### PR TITLE
[codex] Add YoonCompany console cleanup

### DIFF
--- a/doc/plans/2026-05-27-yooncompany-ai-company-console-handoff.md
+++ b/doc/plans/2026-05-27-yooncompany-ai-company-console-handoff.md
@@ -1,0 +1,465 @@
+# YoonCompany AI Company Console Handoff - 2026-05-27
+
+## Purpose
+
+This handoff records the current YoonCompany integration work that turns Paperclip into an AI company operating console:
+
+- Paperclip is the control plane and screen manager.
+- Codex is the main development worker.
+- Hermes is the research/log/sub-worker.
+- YoonCompany uses 6002-style small-unit execution as the default operating discipline.
+
+This document is intended for the next Codex session before continuing the second-stage advanced improvements.
+
+## Current Local Surface
+
+- Workspace: `C:\yooncompany\external\paperclip`
+- Local board: `http://127.0.0.1:3100/YOO/dashboard`
+- API base used for smoke tests: `http://127.0.0.1:3100/api`
+- Company prefix: `YOO`
+- Company id: `a01eddd0-d750-43ea-8858-d1cb087c4de2`
+- Main worker: `Codex Lead Engineer`
+- Hermes worker id: `be227544-1898-4146-847c-19c3c40f98cc`
+
+Use `corepack pnpm ...` for package commands. Do not use bare `pnpm` in this Windows environment unless the PATH issue has been fixed.
+
+## Development Status Snapshot
+
+Current status:
+
+- Stage 1 local advanced-console integration is implemented and smoke-tested.
+- The work is local only. It has not been committed, pushed, opened as a PR, or merged.
+- The local dev board is reachable at `http://127.0.0.1:3100/YOO/dashboard`.
+- The effective API base is `http://127.0.0.1:3100/api`; do not assume `3101` is active.
+- Hermes is connected through Paperclip and can execute a real assigned smoke issue.
+- Hermes model/provider configuration is confirmed as `gpt-5.5` through OpenAI Codex OAuth.
+- Codex remains the intended main development worker; Hermes remains the research/sub-worker.
+- Paperclip is currently the integration screen/control plane, not yet a complete finished product console.
+
+Confirmed complete in this slice:
+
+- Hermes OAuth diagnostic no longer blocks on missing API keys.
+- Hermes E2E assignment path works on a fresh issue.
+- Run-authored Hermes comments no longer cause the observed repeated `issue_commented` follow-up loop.
+- Global YoonCompany question panel opens from the dashboard.
+- Skills detail shows read/apply/connection state.
+- Costs view distinguishes subscription-included runs from API-billed spend.
+- Hermes settings make Telegram readiness explicit instead of implying that Telegram commands are already connected.
+- Quick command plugin creates safer Codex/Hermes task templates.
+
+Not complete yet:
+
+- Full body-text Koreanization across every view.
+- Free-form input inside the global question panel.
+- Automatic current-screen capture/attachment into created issues.
+- Telegram-to-Hermes gateway/bot dispatch.
+- GitHub branch/PR connection workflow inside the UI.
+- Unified Codex/Hermes log and decision search.
+- Backup/restore/update-stability operation flow.
+- Final branch, commit, PR, and merge.
+
+## Completed Work
+
+### 1. Hermes OpenAI Codex OAuth diagnostic
+
+Hermes environment checks now treat OpenAI Codex OAuth as API-key optional.
+
+Changed:
+
+- `server/src/adapters/registry.ts`
+- `server/src/__tests__/adapter-registry.test.ts`
+
+Verified API result:
+
+- `adapterType`: `hermes_local`
+- `status`: `pass`
+- `code`: `hermes_codex_oauth_api_key_not_required`
+- `message`: OpenAI Codex OAuth provider selected; Hermes does not require an LLM API key for this Paperclip run.
+- Model shown: `gpt-5.5`
+
+### 2. Hermes E2E smoke path
+
+Added a repeatable smoke test script:
+
+- `scripts/yooncompany-hermes-e2e-smoke.ps1`
+
+The script:
+
+- resolves the `YOO` company,
+- finds the Hermes agent,
+- creates an assigned smoke issue,
+- invokes the Hermes heartbeat run,
+- waits for completion,
+- verifies run success, issue status `done`, and at least one issue comment.
+
+Latest passing run:
+
+- Issue: `YOO-46`
+- Issue id: `cf4c6b32-9be0-4ca9-ace1-66df84d02d6c`
+- Run id: `8e64d12a-f302-4e0b-ad7d-b94ff117b544`
+- Result: `passed=true`, `runStatus=succeeded`, `issueStatus=done`, `commentCount=1`
+
+Command:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\yooncompany-hermes-e2e-smoke.ps1 -TimeoutSec 420
+```
+
+### 3. Comment wakeup loop fix
+
+Root cause found during E2E:
+
+- Hermes run completed successfully and posted a completion/proposal comment.
+- The comment had `createdByRunId`, but was still attributed as a board/user comment.
+- The issue comment route treated it like a human comment and triggered `issue_commented` automation.
+- That caused repeated Hermes follow-up runs on the same finished issue.
+
+Fix:
+
+- Comments carrying `actor.runId` are treated as run-authored output for implicit reopen/retry/wakeup decisions.
+- Human board comments still wake assigned agents.
+- Run-authored comments no longer implicitly reopen closed work or wake the assignee.
+
+Changed:
+
+- `server/src/routes/issues.ts`
+- `server/src/__tests__/issue-comment-reopen-routes.test.ts`
+
+Regression tests added:
+
+- `does not reopen closed issues from board-authenticated run comments`
+- `does not wake the assignee from board-authenticated run comments`
+
+### 4. Global YoonCompany question panel
+
+Added a fixed bottom-right global assistant panel available across the board UI.
+
+Changed:
+
+- `ui/src/components/YoonCompanyAssistantPanel.tsx`
+- `ui/src/components/Layout.tsx`
+
+Panel actions:
+
+- `Codex에게 묻기`
+- `화면 사용법`
+- `현재 화면 분석`
+- `Hermes 조사`
+
+The panel creates Paperclip issues instead of directly performing risky actions. It includes current route context, document title, Codex 6002 operating guidance, and safe-work constraints.
+
+Verified by browser at:
+
+- `http://127.0.0.1:3100/YOO/dashboard`
+
+Screenshot:
+
+- `C:\Users\USER\AppData\Local\Temp\yooncompany-assistant-panel.png`
+
+### 5. Korean UI and run-status improvements
+
+Changed:
+
+- `ui/src/components/LiveRunWidget.tsx`
+- `ui/src/components/IssueChatThread.tsx`
+- `ui/src/components/ActiveAgentsPanel.tsx`
+
+Improvements:
+
+- localized live-run labels,
+- localized issue run labels,
+- added status badges and liveness/progress descriptions in active agent cards.
+
+### 6. Skills screen state clarity
+
+Changed:
+
+- `ui/src/pages/CompanySkills.tsx`
+
+Added detail-state blocks:
+
+- `읽기`
+- `적용`
+- `연결`
+
+The screen now shows whether a skill is readable, editable/read-only, and attached to any agents.
+
+### 7. Costs subscription/API distinction
+
+Changed:
+
+- `ui/src/pages/Costs.tsx`
+
+Added a `구독/API 과금 구분` panel so GPT Max-style subscription usage is not confused with direct API spend.
+
+Verified text:
+
+- `구독형 포함 실행은 API 과금 지출과 분리해 표시하므로 GPT Max형 사용량을 직접 API 비용으로 오해하지 않습니다.`
+
+### 8. Telegram Hermes readiness label
+
+Changed:
+
+- `ui/src/adapters/hermes-local/config-fields.tsx`
+
+Added an explicit notice:
+
+- Paperclip can run Hermes now.
+- Telegram work commands require a separate Hermes gateway/bot configuration before dispatching work safely.
+
+### 9. YoonCompany quick command plugin
+
+Changed:
+
+- `packages/plugins/examples/plugin-yooncompany-command/src/worker.ts`
+- `packages/plugins/examples/plugin-yooncompany-command/src/ui/index.tsx`
+
+Improvements:
+
+- `new_task` now routes to Codex, not Hermes.
+- Codex templates include 6002 small-unit verified execution guidance.
+- The guide mentions the global right-side question panel.
+- The guide clarifies that GitHub branch/PR organization is a later handoff/organization step.
+
+### 10. Codex 6002 rule hardening follow-up
+
+Changed:
+
+- `ui/src/components/YoonCompanyAssistantPanel.tsx`
+- `ui/src/components/YoonCompanyAssistantPanel.test.tsx`
+- `packages/plugins/examples/plugin-yooncompany-command/src/worker.ts`
+- `packages/plugins/examples/plugin-yooncompany-command/src/ui/index.tsx`
+- `packages/plugins/examples/plugin-yooncompany-command/tests/worker.spec.ts`
+- `packages/plugins/examples/plugin-yooncompany-command/vitest.config.ts`
+
+Improvements:
+
+- Codex issue templates now include the explicit `observe -> plan -> implement -> verify -> risk-report` sequence.
+- The sequence tells Codex to inspect real documents/status/code/logs/screen first, plan small units, implement only the approved scope, verify with real command/browser/API/log evidence, and report files/commands/results/risks/next action.
+- The global panel keeps Codex-created issues in `backlog`.
+- The quick command plugin now also creates assigned issues as `backlog`, not `todo`, so quick actions no longer wake Codex/Hermes immediately.
+- The quick command UI labels were changed from immediate action language to draft language: `작업 초안`, `Codex 질문 초안`, `Hermes 조사 초안`, `새 작업 초안`.
+
+## Verification Completed
+
+Passing:
+
+```powershell
+corepack pnpm --filter @paperclipai/ui typecheck
+corepack pnpm --filter @paperclipai/server exec tsc --noEmit
+corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-routes.test.ts
+corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-registry.test.ts
+corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-comment-reopen-routes.test.ts
+corepack pnpm --filter @yooncompany/paperclip-command-plugin typecheck
+corepack pnpm --filter @yooncompany/paperclip-command-plugin build
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\yooncompany-hermes-e2e-smoke.ps1 -TimeoutSec 420
+```
+
+Also verified:
+
+- Browser DOM and screenshot for global question panel.
+- Skills screen Korean status blocks.
+- Costs screen subscription/API distinction.
+- Hermes adapter diagnostic API returns `pass`.
+
+Known test note:
+
+- Running `adapter-registry.test.ts`, `adapter-routes.test.ts`, and `issue-comment-reopen-routes.test.ts` together once produced an `adapter-routes` beforeEach timeout and cleanup error.
+- Each file passed when run independently.
+- Treat this as a test isolation/timing note, not as a confirmed product regression.
+
+## Problems, Constraints, and Risks
+
+### Fixed in this slice
+
+1. Hermes completion comment loop
+   - Confirmed problem: a Hermes run completed and posted a comment with `createdByRunId`, but the route treated it as a human board comment.
+   - Impact: the finished issue was woken again through `issue_commented`, producing repeated Hermes follow-up runs.
+   - Fix: route decisions now suppress implicit reopen/retry/assignee wakeups when the actor has a run id.
+   - Evidence: fresh smoke issue `YOO-46` ended with one run, one comment, and status `done`.
+
+2. Hermes Codex OAuth warning
+   - Confirmed problem: OpenAI Codex OAuth mode was still surfaced like an API-key-required path.
+   - Fix: Hermes adapter diagnostics normalize the no-API-key warning to an info check in `openai-codex` mode.
+   - Evidence: adapter diagnostic API returns `status=pass` with `hermes_codex_oauth_api_key_not_required`.
+
+### Still open
+
+1. Large dirty worktree
+   - The repo contains many modified files outside this YoonCompany slice.
+   - Risk: an accidental commit could include unrelated changes.
+   - Required control: stage only intended YoonCompany files after reviewing `git status --short` and `git diff`.
+
+2. Grouped server test instability
+   - Observed once when three server test files were run together.
+   - Each test file passed independently.
+   - Current classification: test isolation/timing risk, not confirmed product failure.
+
+3. UI author attribution nuance
+   - Hermes run comments may still display as board/user authored when the request is board-authenticated, but `createdByRunId` is preserved.
+   - Current fix relies on `actor.runId` for wakeup suppression.
+   - Future improvement can clarify UI attribution as "run output" when `createdByRunId` is present.
+
+4. Telegram is not connected
+   - Current state is readiness labeling only.
+   - Real Telegram dispatch requires a gateway/bot, auth checks, command parsing, and safe issue creation.
+
+5. Koreanization is partial
+   - Sidebar and several target surfaces are improved.
+   - 2026-05-27 follow-up: additional issue detail, agent detail, and layout text was wrapped with localized copy.
+   - Some body text and bundled skill content may remain English.
+   - Bundled skill markdown is read-only by design; translate UI chrome first, then decide whether to add translated summaries.
+
+6. Global question panel v2 is still an issue-draft launcher, not an execution surface
+   - 2026-05-27 follow-up: it now accepts custom user text inline.
+   - 2026-05-27 follow-up: it separates Codex development/decision requests from Hermes research/memory requests.
+   - 2026-05-27 follow-up: generated issues default to `backlog` so assignees are not woken until a board operator changes execution status.
+   - It now attaches company, route, page label, visible heading/tab/selection, browser title, and route resource identifiers as text context.
+   - It does not yet attach screenshots or DOM summaries as structured attachments.
+
+7. GitHub workflow is not complete
+   - The UI does not yet guide local folder, branch, PR, and merge state.
+   - Commit, push, PR, and merge remain manual/approval-controlled.
+
+8. Hermes role/permission audit requires approval before mutation
+   - Confirmed by API: Hermes is configured as `Research, memory, and report worker - repo write prohibited`, heartbeat disabled, and `repoWrite=prohibited` metadata is present.
+   - Confirmed by API: Hermes currently has `permissions.canCreateAgents=true`, `permissions.canAssignTasks=true`, and an explicit `tasks:assign` grant.
+   - Confirmed by API: Hermes adapter config includes `toolsets=terminal,memory,session_search,skills,web` and `extraArgs` includes `--yolo`.
+   - Current control: promptTemplate forbids repo writes, deploy, merge, push, delete, DB write, email, external publish, payment, and persistent rule/memory changes.
+   - Risk: prompt-only constraints are weaker than permission/config constraints.
+   - Required approval before action: changing Hermes permissions, grants, adapter config, toolsets, `--yolo`, heartbeat policy, or persistent prompt/rule settings is L3.
+
+9. Browser verification caveat: dashboard quick actions execute immediately
+   - 2026-05-27 follow-up: while validating the UI, clicking the dashboard quick action `Codex에게 묻기` created Paperclip issue `YOO-47` and woke Codex.
+   - Observed result: the created issue used the quick-run template; Codex found no actionable user request and created a pending `ask_user_questions` interaction asking what kind of request should be handled.
+   - No deletion, status edit, or DB cleanup was performed afterward.
+   - 2026-05-27 follow-up: quick command plugin code now creates `backlog` drafts and labels the buttons as drafts, but existing issue `YOO-47` remains as historical data.
+   - Future verification should use the floating button `aria-label="YoonCompany 질문 패널"` for panel v2 checks, and should avoid submitting the final new-issue dialog unless explicitly testing DB writes.
+
+## Current Git/PR Guidance
+
+Commit, push, PR, and merge are not required yet for local continuation.
+
+### 2026-05-27 tree cleanup status
+
+Generated plugin artifacts and workspace links were excluded from the git source set:
+
+- `packages/plugins/examples/plugin-yooncompany-command/node_modules/` is a pnpm workspace link directory required for local typecheck/test. It may exist locally but must stay ignored and unstaged.
+- Local `dist/` is build output. It may be removed during cleanup and regenerated by `corepack pnpm --filter @yooncompany/paperclip-command-plugin build`; in either case it must stay ignored and unstaged.
+- Root `.gitignore` already ignores `dist/` and `node_modules/`, so regenerated build output should remain untracked.
+- Operational caveat: do not remove `dist/` while the plugin is enabled in a running Paperclip instance. During this cleanup, Paperclip observed the transient missing manifest and marked plugin `05834e61-eb70-49ba-a7d2-ed74fb1f16c2` / `yooncompany-command` as `error`.
+- Current plugin files are rebuilt and present again, but lifecycle recovery requires an explicit approval before running `POST /api/plugins/05834e61-eb70-49ba-a7d2-ed74fb1f16c2/enable`.
+
+First PR candidate should include only the YoonCompany console scope:
+
+- `doc/plans/2026-05-27-yooncompany-ai-company-console-handoff.md`
+- `packages/plugins/examples/plugin-yooncompany-command/README.md`
+- `packages/plugins/examples/plugin-yooncompany-command/package.json`
+- `packages/plugins/examples/plugin-yooncompany-command/src/**`
+- `packages/plugins/examples/plugin-yooncompany-command/tests/**`
+- `packages/plugins/examples/plugin-yooncompany-command/tsconfig.json`
+- `packages/plugins/examples/plugin-yooncompany-command/vitest.config.ts`
+- `ui/src/components/YoonCompanyAssistantPanel.tsx`
+- `ui/src/components/YoonCompanyAssistantPanel.test.tsx`
+- Koreanization/i18n files intentionally related to the console slice.
+
+Do not include these in the first console PR without a separate review:
+
+- `pnpm-lock.yaml`
+- broad server route/middleware/service changes
+- broad codex-local adapter changes
+- DB backup changes
+- unrelated UI Koreanization files outside the selected console slice
+- generated `dist/` or `node_modules/`
+
+Recommended order:
+
+1. Keep this as local work until the user confirms the next stage is ready.
+2. Before any PR, review the dirty worktree and separate unrelated changes.
+3. Commit only the YoonCompany integration scope in a dedicated branch.
+4. Open a PR for review.
+5. Merge only after the user approves the final diff and smoke result.
+
+Important:
+
+- The worktree has many pre-existing modified files outside this YoonCompany scope.
+- Do not revert unrelated files.
+- If committing later, stage only the intended YoonCompany integration files.
+
+## Next Improvement Plan
+
+Proceed in small verified units. Do not combine unrelated UI, gateway, and Git workflow changes in one slice.
+
+1. Residual Koreanization
+   - Goal: remove confusing English from main YoonCompany operation screens.
+   - Scope: dashboard, issue detail, agent detail, org, skills, costs, activity, settings.
+   - Verification: browser check on desktop width; confirm no layout overlap.
+
+2. Global question panel v2
+   - Goal: make the panel usable as the default operator entry point.
+   - Scope: add direct text input, task type selector, current route title, and optional current-screen context.
+   - Verification: create a Codex issue and a Hermes issue from the panel without direct execution.
+
+3. Screen context capture
+   - Goal: let Codex answer "what do I do on this screen?" with better context.
+   - Scope: include route, visible page title, selected entity id, and optional screenshot reference.
+   - Verification: created issue body includes screen metadata and does not leak secrets.
+
+4. Codex 6002 rule hardening
+   - Goal: make Codex-created tasks consistently follow small-unit implementation and verification.
+   - Scope: update templates and agent/skill attachment guidance.
+   - 2026-05-27 follow-up: global panel and quick command plugin templates now include the explicit `observe -> plan -> implement -> verify -> risk-report` sequence.
+   - 2026-05-27 follow-up: quick command plugin drafts remain `backlog` even when a target agent is found.
+   - Verification: new Codex task body includes observe-plan-implement-verify-risk-report sequence.
+
+5. Run/progress explanation
+   - Goal: make "running, queued, failed, blocked, completed" understandable to the user.
+   - Scope: timeline labels, failure-cause summaries, liveness reason display.
+   - Verification: inspect active/recent run cards and issue thread run rows.
+
+6. Skills-to-agent operation flow
+   - Goal: make it clear whether bundled/custom skills can be used and which agent uses them.
+   - Scope: attach/detach affordance clarity, read-only explanation, "used by" state.
+   - Verification: skills detail and agent detail both show consistent attachment state.
+
+7. Local/GitHub/PR guidance screen
+   - Goal: prevent confusion between local folder, GitHub repository, branch, PR, and merge.
+   - Scope: project/workspace guidance panel and safe handoff text.
+   - Verification: no mutation of git state unless explicitly approved.
+
+8. Cost reporting v2
+   - Goal: separate subscription usage, direct API spend, and unknown/no-cost runs.
+   - Scope: per-agent mode summary, model/provider labels, clearer empty states.
+   - Verification: costs page shows subscription/API split and does not imply false billing precision.
+
+9. Unified work log and decision search
+   - Goal: search Codex/Hermes runs, comments, decisions, and issue outcomes from one place.
+   - Scope: read-only search first; no automatic mutation.
+   - Verification: search returns issue id, run id, agent, status, and comment/summary snippets.
+
+10. Telegram-to-Hermes gateway
+   - Goal: allow Telegram commands to create safe Paperclip issues for Hermes.
+   - Scope: gateway design, auth, command mapping, rate limits, audit log, dry-run first.
+   - Verification: local dry run creates a Paperclip issue but does not execute work until policy allows.
+
+11. Backup/restore/update stability
+   - Goal: make the local YoonCompany console recoverable before heavier automation.
+   - Scope: database backup, config export, plugin/version notes, restore drill.
+   - Verification: documented restore command or dry-run drill.
+
+12. PR-ready cleanup
+   - Goal: produce a reviewable change set.
+   - Scope: inspect dirty worktree, isolate YoonCompany files, run focused checks, then commit/PR only after user approval.
+   - Verification: staged diff contains only intended files.
+
+## Next Session Start Procedure
+
+Start the next session by reading this file first, then run:
+
+```powershell
+git status --short
+corepack pnpm --filter @paperclipai/ui typecheck
+corepack pnpm --filter @paperclipai/server exec tsc --noEmit
+```
+
+Then continue with the next small improvement, starting from item 1 or item 2 depending on the user's priority.

--- a/packages/plugins/examples/plugin-yooncompany-command/README.md
+++ b/packages/plugins/examples/plugin-yooncompany-command/README.md
@@ -1,0 +1,24 @@
+# YoonCompany Command Plugin
+
+Local Paperclip plugin for the YoonCompany one-person AI company console.
+
+Surfaces:
+
+- dashboardWidget: command strip for queue, approvals, failures, cost, and evolution proposals
+- sidebarPanel: quick actions for Codex, Hermes, new work, and guide
+
+Risk boundary:
+
+- Creates Paperclip issues only.
+- Does not invoke agents automatically.
+- Does not deploy, delete, send email, publish externally, write DB directly, change credentials, or grant Hermes repo write permission.
+
+Install only after WO-08A approval:
+
+```powershell
+pnpm --filter @yooncompany/paperclip-command-plugin build
+Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:3100/api/plugins/install" -ContentType "application/json" -Body (@{
+  packageName = "C:\yooncompany\external\paperclip\packages\plugins\examples\plugin-yooncompany-command"
+  isLocalPath = $true
+} | ConvertTo-Json)
+```

--- a/packages/plugins/examples/plugin-yooncompany-command/package.json
+++ b/packages/plugins/examples/plugin-yooncompany-command/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@yooncompany/paperclip-command-plugin",
+  "version": "0.1.0",
+  "description": "YoonCompany command dashboard and quick-action panel for Paperclip",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-yooncompany-command/src/constants.ts
+++ b/packages/plugins/examples/plugin-yooncompany-command/src/constants.ts
@@ -1,0 +1,18 @@
+export const PLUGIN_ID = "yooncompany-command";
+export const PLUGIN_VERSION = "0.1.0";
+
+export const SLOT_IDS = {
+  dashboardWidget: "yooncompany-command-dashboard-widget",
+  sidebarPanel: "yooncompany-command-sidebar-panel",
+} as const;
+
+export const EXPORT_NAMES = {
+  dashboardWidget: "YoonCompanyCommandWidget",
+  sidebarPanel: "YoonCompanyQuickActionsPanel",
+} as const;
+
+export const ACTION_KEYS = {
+  createGuidedIssue: "create-guided-issue",
+} as const;
+
+export type GuidedIssueKind = "ask_codex" | "ask_hermes" | "new_task";

--- a/packages/plugins/examples/plugin-yooncompany-command/src/index.ts
+++ b/packages/plugins/examples/plugin-yooncompany-command/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-yooncompany-command/src/manifest.ts
+++ b/packages/plugins/examples/plugin-yooncompany-command/src/manifest.ts
@@ -1,0 +1,43 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import { EXPORT_NAMES, PLUGIN_ID, PLUGIN_VERSION, SLOT_IDS } from "./constants.js";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "YoonCompany 운영",
+  description: "Paperclip에서 Codex, Hermes, 승인, 위험, 비용, 진화 작업을 운영하기 위한 명령 패널과 빠른 실행입니다.",
+  author: "YoonCompany",
+  categories: ["ui", "automation"],
+  capabilities: [
+    "companies.read",
+    "issues.read",
+    "issues.create",
+    "issue.comments.create",
+    "agents.read",
+    "ui.dashboardWidget.register",
+    "ui.sidebar.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "dashboardWidget",
+        id: SLOT_IDS.dashboardWidget,
+        displayName: "YoonCompany 운영 현황",
+        exportName: EXPORT_NAMES.dashboardWidget,
+      },
+      {
+        type: "sidebarPanel",
+        id: SLOT_IDS.sidebarPanel,
+        displayName: "YoonCompany 빠른 실행",
+        exportName: EXPORT_NAMES.sidebarPanel,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-yooncompany-command/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-yooncompany-command/src/ui/index.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import {
+  useHostContext,
+  useHostNavigation,
+  usePluginAction,
+  type PluginWidgetProps,
+} from "@paperclipai/plugin-sdk/ui";
+
+const ACTION_KEYS = {
+  createGuidedIssue: "create-guided-issue",
+} as const;
+
+type GuidedIssueKind = "ask_codex" | "ask_hermes" | "new_task";
+
+type DashboardResponse = {
+  agents: {
+    active: number;
+    running: number;
+    paused: number;
+    error: number;
+  };
+  tasks: {
+    open: number;
+    inProgress: number;
+    blocked: number;
+    done: number;
+  };
+  costs: {
+    monthSpendCents: number;
+    monthBudgetCents: number;
+    monthUtilizationPercent: number;
+  };
+  pendingApprovals: number;
+  runActivity: Array<{
+    date: string;
+    succeeded: number;
+    failed: number;
+    other: number;
+    total: number;
+  }>;
+};
+
+type IssueSummary = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  assigneeAgentId: string | null;
+};
+
+type ApprovalSummary = {
+  id: string;
+  status: string;
+  payload?: {
+    proposalId?: unknown;
+    title?: unknown;
+  };
+};
+
+type CommandData = {
+  dashboard: DashboardResponse;
+  issues: IssueSummary[];
+  approvals: ApprovalSummary[];
+};
+
+type CreatedIssueResult = {
+  id: string;
+  identifier?: string | null;
+  route: string;
+};
+
+type GuideItem = {
+  title: string;
+  body: string;
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  background: "var(--card)",
+  color: "var(--card-foreground)",
+  padding: "14px",
+  display: "grid",
+  gap: "12px",
+  minWidth: 0,
+};
+
+const compactPanelStyle: CSSProperties = {
+  ...panelStyle,
+  padding: "12px",
+  fontSize: "12px",
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gap: "8px",
+  gridTemplateColumns: "repeat(auto-fit, minmax(132px, 1fr))",
+};
+
+const metricStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  padding: "10px",
+  minWidth: 0,
+  display: "grid",
+  gap: "4px",
+  textDecoration: "none",
+  color: "inherit",
+};
+
+const labelStyle: CSSProperties = {
+  color: "var(--muted-foreground)",
+  fontSize: "12px",
+  lineHeight: 1.25,
+  overflowWrap: "anywhere",
+};
+
+const valueStyle: CSSProperties = {
+  fontSize: "22px",
+  lineHeight: 1,
+  fontWeight: 700,
+};
+
+const buttonGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "8px",
+  gridTemplateColumns: "repeat(auto-fit, minmax(118px, 1fr))",
+};
+
+const buttonStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  background: "var(--background)",
+  color: "var(--foreground)",
+  cursor: "pointer",
+  minHeight: "36px",
+  padding: "8px",
+  textAlign: "left",
+  font: "inherit",
+  lineHeight: 1.2,
+  overflowWrap: "anywhere",
+};
+
+const secondaryButtonStyle: CSSProperties = {
+  ...buttonStyle,
+  color: "var(--muted-foreground)",
+};
+
+const stackStyle: CSSProperties = {
+  display: "grid",
+  gap: "8px",
+};
+
+const guideItemStyle: CSSProperties = {
+  border: "1px solid var(--border)",
+  padding: "8px",
+  display: "grid",
+  gap: "3px",
+};
+
+const guideTitleStyle: CSSProperties = {
+  color: "var(--foreground)",
+  fontWeight: 600,
+  lineHeight: 1.2,
+};
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(path, {
+    headers: { Accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function latestFailedRuns(dashboard: DashboardResponse): number {
+  const latest = dashboard.runActivity.at(-1);
+  return latest?.failed ?? 0;
+}
+
+function looksLikeEvolutionProposal(issue: IssueSummary): boolean {
+  const haystack = `${issue.title} ${issue.description ?? ""}`.toLowerCase();
+  return haystack.includes("evolution") || haystack.includes("proposal") || haystack.includes("rule");
+}
+
+function pendingProposalCount(issues: IssueSummary[], approvals: ApprovalSummary[]): number {
+  const issueCount = issues.filter((issue) => issue.status !== "done" && looksLikeEvolutionProposal(issue)).length;
+  const approvalCount = approvals.filter((approval) => {
+    if (approval.status !== "pending") return false;
+    const title = typeof approval.payload?.title === "string" ? approval.payload.title : "";
+    const proposalId = typeof approval.payload?.proposalId === "string" ? approval.payload.proposalId : "";
+    return `${title} ${proposalId}`.toLowerCase().includes("proposal");
+  }).length;
+  return issueCount + approvalCount;
+}
+
+function useCommandData(companyId: string | null | undefined) {
+  const [data, setData] = useState<CommandData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!companyId) return;
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const [dashboard, issues, approvals] = await Promise.all([
+          fetchJson<DashboardResponse>(`/api/companies/${companyId}/dashboard`),
+          fetchJson<IssueSummary[]>(
+            `/api/companies/${companyId}/issues?status=todo,in_progress,in_review,blocked&limit=50`,
+          ),
+          fetchJson<ApprovalSummary[]>(`/api/companies/${companyId}/approvals`),
+        ]);
+        if (!cancelled) setData({ dashboard, issues, approvals });
+      } catch (caught) {
+        if (!cancelled) {
+          setError(caught instanceof Error ? caught.message : String(caught));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void load();
+    const timer = window.setInterval(() => {
+      void load();
+    }, 30_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [companyId]);
+
+  return { data, error, loading };
+}
+
+function MetricLink({
+  label,
+  value,
+  to,
+}: {
+  label: string;
+  value: number | string;
+  to: string;
+}) {
+  const hostNavigation = useHostNavigation();
+  return (
+    <a {...hostNavigation.linkProps(to)} style={metricStyle}>
+      <span key="value" style={valueStyle}>{value}</span>
+      <span key="label" style={labelStyle}>{label}</span>
+    </a>
+  );
+}
+
+function CommandMetrics({ data }: { data: CommandData }) {
+  const failedRuns = latestFailedRuns(data.dashboard);
+  const proposals = pendingProposalCount(data.issues, data.approvals);
+  const blocked = data.dashboard.tasks.blocked;
+  const pendingApprovals = data.approvals.filter((approval) => approval.status === "pending").length;
+  const spend = formatCents(data.dashboard.costs.monthSpendCents);
+
+  return (
+    <div style={gridStyle}>
+      <MetricLink key="approvals" label="승인 대기" value={pendingApprovals || data.dashboard.pendingApprovals} to="/inbox" />
+      <MetricLink key="blocked" label="막힌 작업" value={blocked} to="/issues" />
+      <MetricLink key="failed" label="오늘 실패" value={failedRuns} to="/activity" />
+      <MetricLink key="evolution" label="개선 후보" value={proposals} to="/issues" />
+      <MetricLink key="spend" label="월 비용" value={spend} to="/costs" />
+    </div>
+  );
+}
+
+function nextActionText(data: CommandData): string {
+  const pendingApprovals = data.approvals.filter((approval) => approval.status === "pending").length;
+  if (pendingApprovals > 0) return "승인 대기부터 확인";
+  if (data.dashboard.tasks.blocked > 0) return "막힌 작업 복구";
+  if (latestFailedRuns(data.dashboard) > 0) return "실패 실행 확인";
+  if (data.dashboard.tasks.open > 0) return "열린 작업 진행";
+  return "새 작업 생성";
+}
+
+export function YoonCompanyCommandWidget({ context }: PluginWidgetProps) {
+  const companyId = context.companyId;
+  const { data, error, loading } = useCommandData(companyId);
+
+  return (
+    <section aria-label="YoonCompany 운영 현황" style={panelStyle}>
+      <div key="header" style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: "10px", flexWrap: "wrap" }}>
+        <strong key="title">YoonCompany 운영</strong>
+        <span key="status" style={labelStyle}>{data ? nextActionText(data) : loading ? "확인 중" : "대기"}</span>
+      </div>
+      {error ? <div key="error" style={labelStyle}>상태 로드 실패: {error}</div> : null}
+      {data ? <CommandMetrics key="metrics" data={data} /> : <div key="loading" style={labelStyle}>Paperclip 상태를 불러오는 중입니다.</div>}
+    </section>
+  );
+}
+
+function quickActionLabel(kind: GuidedIssueKind): string {
+  if (kind === "ask_codex") return "Codex 질문 초안";
+  if (kind === "ask_hermes") return "Hermes 조사 초안";
+  return "새 작업 초안";
+}
+
+export function YoonCompanyQuickActionsPanel() {
+  const context = useHostContext();
+  const hostNavigation = useHostNavigation();
+  const createGuidedIssue = usePluginAction(ACTION_KEYS.createGuidedIssue);
+  const [busyKind, setBusyKind] = useState<GuidedIssueKind | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showGuide, setShowGuide] = useState(false);
+  const companyId = context.companyId;
+  const disabled = !companyId || busyKind !== null;
+
+  const guideItems = useMemo<GuideItem[]>(
+    () => [
+      {
+        title: "1. 승인 대기",
+        body: "먼저 검토해야 할 실행과 변경 요청을 확인합니다.",
+      },
+      {
+        title: "2. 막힌 작업",
+        body: "작업 상세에서 원인, 담당 직원, 최근 실행 로그를 확인합니다.",
+      },
+      {
+        title: "3. 화면/기능 질문",
+        body: "오른쪽 전역 질문 패널이나 Codex 질문 초안으로 보류 작업을 만들고, 실행 전 6002 검증 기준을 확인합니다.",
+      },
+      {
+        title: "4. 외부 조사",
+        body: "서비스 비교, 가이드, 공개 자료 정리는 Hermes 조사로 만들고 파일 수정 없이 보고만 받습니다.",
+      },
+      {
+        title: "5. 실행 확인",
+        body: "보드에서 상태를 변경해 직원 실행을 시작한 뒤, 대시보드/직원 상세에서 결과, 로그, 비용, 세션을 확인합니다.",
+      },
+    ],
+    [],
+  );
+
+  async function createIssue(kind: GuidedIssueKind) {
+    if (!companyId) return;
+    setBusyKind(kind);
+    setError(null);
+    try {
+      const result = await createGuidedIssue({ companyId, kind }) as CreatedIssueResult;
+      hostNavigation.navigate(result.route);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusyKind(null);
+    }
+  }
+
+  return (
+    <section aria-label="YoonCompany 빠른 실행" style={compactPanelStyle}>
+      <strong key="title">작업 초안</strong>
+      <div key="actions" style={buttonGridStyle}>
+        {(["ask_codex", "ask_hermes", "new_task"] as GuidedIssueKind[]).map((kind) => (
+          <button
+            key={kind}
+            type="button"
+            disabled={disabled}
+            style={{ ...buttonStyle, opacity: disabled ? 0.65 : 1 }}
+            onClick={() => {
+              void createIssue(kind);
+            }}
+          >
+            {busyKind === kind ? "생성 중" : quickActionLabel(kind)}
+          </button>
+        ))}
+        <button
+          key="guide-toggle"
+          type="button"
+          style={secondaryButtonStyle}
+          aria-expanded={showGuide}
+          aria-controls="yooncompany-quick-actions-guide"
+          onClick={() => setShowGuide((value) => !value)}
+        >
+          {showGuide ? "사용법 접기" : "사용법 보기"}
+        </button>
+      </div>
+      {error ? <div key="error" style={labelStyle}>생성 실패: {error}</div> : null}
+      {showGuide ? (
+        <div key="guide" id="yooncompany-quick-actions-guide" style={stackStyle}>
+          {guideItems.map((item) => (
+            <div key={item.title} style={guideItemStyle}>
+              <span style={guideTitleStyle}>{item.title}</span>
+              <span style={labelStyle}>{item.body}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/plugins/examples/plugin-yooncompany-command/src/worker.ts
+++ b/packages/plugins/examples/plugin-yooncompany-command/src/worker.ts
@@ -1,0 +1,175 @@
+import { definePlugin, runWorker, type PluginContext } from "@paperclipai/plugin-sdk";
+import { ACTION_KEYS, type GuidedIssueKind } from "./constants.js";
+
+type CreateGuidedIssueParams = {
+  companyId?: unknown;
+  kind?: unknown;
+};
+
+type AgentCandidate = Awaited<ReturnType<PluginContext["agents"]["list"]>>[number];
+
+const HEALTH_MESSAGE = "YoonCompany command plugin ready";
+
+const CODEX_6002_SEQUENCE = [
+  "6002 실행 순서: observe -> plan -> implement -> verify -> risk-report.",
+  "- Observe: 문서, git status, 실제 코드, 로그, 화면 상태를 먼저 확인한다.",
+  "- Plan: 한 번에 할 작은 단위와 검증 명령을 정한다.",
+  "- Implement: 승인된 범위만 구현하고 기존 변경을 되돌리지 않는다.",
+  "- Verify: typecheck/test/browser/log/API 중 실제 근거를 남긴다.",
+  "- Risk-report: 변경 파일, 실행 명령, 결과, 남은 위험, 다음 행동을 보고한다.",
+];
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseGuidedIssueKind(value: unknown): GuidedIssueKind {
+  if (value === "ask_codex" || value === "ask_hermes" || value === "new_task") {
+    return value;
+  }
+  throw new Error("Unsupported quick action kind");
+}
+
+function matchesCodex(agent: AgentCandidate): boolean {
+  const haystack = `${agent.name} ${agent.title ?? ""} ${agent.adapterType ?? ""}`.toLowerCase();
+  return haystack.includes("codex");
+}
+
+function matchesHermes(agent: AgentCandidate): boolean {
+  const haystack = `${agent.name} ${agent.title ?? ""} ${agent.adapterType ?? ""}`.toLowerCase();
+  return haystack.includes("hermes");
+}
+
+async function findTargetAgent(ctx: PluginContext, companyId: string, kind: GuidedIssueKind) {
+  const agents = await ctx.agents.list({ companyId, limit: 100, offset: 0 });
+  const matcher = kind === "ask_hermes" ? matchesHermes : matchesCodex;
+  return agents.find(matcher) ?? null;
+}
+
+function getIssueTemplate(kind: GuidedIssueKind): {
+  title: string;
+  description: string;
+  priority: "high" | "medium";
+} {
+  if (kind === "ask_codex") {
+    return {
+      title: "Codex에게 질문",
+      priority: "high",
+      description: [
+        "YoonCompany 빠른 실행에서 생성됨.",
+        "",
+        "대상: Codex Lead Engineer.",
+        "모드: 6002.",
+        ...CODEX_6002_SEQUENCE,
+        "",
+        "질문/작업:",
+        "- 화면 사용법, 기능 위치, 개발 질문, 오류 증상을 여기에 적으세요.",
+        "- 관련 화면, 파일, 기대 결과, 검증 방법을 알면 같이 적으세요.",
+        "- 모르면 '현재 화면에서 무엇을 눌러야 하는지 설명하고 필요한 작업을 만들어라'라고 적어도 됩니다.",
+        "",
+        "안전 규칙:",
+        "- 승인 없이 배포, 병합, 삭제, 이메일 발송, 외부 공개, 자격증명 변경, Paperclip DB 직접 쓰기, 영구 규칙 변경 금지.",
+      ].join("\n"),
+    };
+  }
+
+  if (kind === "ask_hermes") {
+    return {
+      title: "Hermes 조사 요청",
+      priority: "medium",
+      description: [
+        "YoonCompany 빠른 실행에서 생성됨.",
+        "",
+        "대상: Hermes Research Worker.",
+        "모드: 조사/보고 전용.",
+        "",
+        "조사 요청:",
+        "- 조사 주제, 비교 대상, 필요한 근거를 여기에 적으세요.",
+        "- 결과는 사실, 근거, 제안으로 분리해서 보고하세요.",
+        "",
+        "강제 규칙:",
+        "- Hermes는 repo 파일 수정, 배포, 병합, push, 삭제, DB 쓰기, 이메일 발송, 외부 공개, 자격증명 변경, 영구 규칙 변경 금지.",
+      ].join("\n"),
+    };
+  }
+
+  return {
+    title: "새 YoonCompany 작업",
+    priority: "medium",
+    description: [
+      "YoonCompany 빠른 실행에서 생성됨.",
+      "",
+      "대상: Codex Lead Engineer.",
+      "모드: 6002.",
+      ...CODEX_6002_SEQUENCE,
+      "",
+      "채울 내용:",
+      "- 목표",
+      "- 범위",
+      "- 완료 기준",
+      "- 검증 방법",
+      "",
+      "실행 규칙:",
+      "- 한 번에 크게 바꾸지 말고 작은 단위로 개발하고 각 단위마다 검증하세요.",
+      "- 확인한 사실, 추정, 남은 검증을 분리해서 보고하세요.",
+      "",
+      "안전 규칙:",
+      "- 위험 작업은 실행 전에 승인으로 넘기세요.",
+    ].join("\n"),
+  };
+}
+
+async function createGuidedIssue(ctx: PluginContext, params: CreateGuidedIssueParams) {
+  const companyId = readString(params.companyId);
+  if (!companyId) throw new Error("companyId is required");
+
+  const kind = parseGuidedIssueKind(params.kind);
+  const targetAgent = await findTargetAgent(ctx, companyId, kind);
+  const template = getIssueTemplate(kind);
+
+  const issue = await ctx.issues.create({
+    companyId,
+    title: template.title,
+    description: template.description,
+    priority: template.priority,
+    status: "backlog",
+    assigneeAgentId: targetAgent?.id,
+  });
+
+  await ctx.issues.createComment(
+    issue.id,
+    [
+      "YoonCompany 운영 플러그인이 생성함.",
+      "",
+      "approval_id: none",
+      "",
+      "이 빠른 실행은 Paperclip 보류 작업만 만들었습니다. 직접 실행, 위험 작업, 외부 작업은 수행하지 않았습니다.",
+      "담당자는 미리 지정되지만 상태는 대기(backlog)로 유지됩니다. 실행하려면 보드에서 상태를 변경하세요.",
+    ].join("\n"),
+    companyId,
+  );
+
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    assigneeAgentId: issue.assigneeAgentId,
+    route: `/issues/${issue.identifier ?? issue.id}`,
+  };
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.actions.register(ACTION_KEYS.createGuidedIssue, async (params) => {
+      return createGuidedIssue(ctx, params);
+    });
+    ctx.logger.info("yooncompany-command plugin setup complete");
+  },
+
+  async onHealth() {
+    return { status: "ok", message: HEALTH_MESSAGE };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-yooncompany-command/tests/worker.spec.ts
+++ b/packages/plugins/examples/plugin-yooncompany-command/tests/worker.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+function agent(overrides: Record<string, unknown>) {
+  const now = new Date();
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Agent",
+    urlKey: "agent",
+    role: "worker",
+    title: null,
+    icon: null,
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("YoonCompany command worker", () => {
+  it("creates Codex quick-action issues as backlog drafts with the 6002 sequence", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      agents: [
+        agent({
+          id: "codex-1",
+          name: "Codex Lead Engineer",
+          title: "Main development worker",
+          adapterType: "codex_local",
+        }),
+      ] as never,
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    const result = await harness.performAction<{ id: string; assigneeAgentId: string | null }>("create-guided-issue", {
+      companyId: "company-1",
+      kind: "ask_codex",
+    });
+
+    expect(result.assigneeAgentId).toBe("codex-1");
+    const issue = await harness.ctx.issues.get(result.id, "company-1");
+    expect(issue).toMatchObject({
+      title: "Codex에게 질문",
+      status: "backlog",
+      assigneeAgentId: "codex-1",
+      priority: "high",
+    });
+    expect(issue?.description).toContain("6002 실행 순서: observe -> plan -> implement -> verify -> risk-report.");
+    expect(issue?.description).toContain("Observe: 문서, git status, 실제 코드, 로그, 화면 상태를 먼저 확인한다.");
+    expect(issue?.description).toContain("Verify: typecheck/test/browser/log/API 중 실제 근거를 남긴다.");
+    expect(issue?.description).toContain("Risk-report: 변경 파일, 실행 명령, 결과, 남은 위험, 다음 행동을 보고한다.");
+  });
+
+  it("keeps Hermes quick-action issues in backlog even when an assignee is found", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      agents: [
+        agent({
+          id: "hermes-1",
+          name: "Hermes Research Worker",
+          title: "Research worker",
+          adapterType: "hermes_local",
+        }),
+      ] as never,
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    const result = await harness.performAction<{ id: string; assigneeAgentId: string | null }>("create-guided-issue", {
+      companyId: "company-1",
+      kind: "ask_hermes",
+    });
+
+    expect(result.assigneeAgentId).toBe("hermes-1");
+    const issue = await harness.ctx.issues.get(result.id, "company-1");
+    expect(issue).toMatchObject({
+      title: "Hermes 조사 요청",
+      status: "backlog",
+      assigneeAgentId: "hermes-1",
+      priority: "medium",
+    });
+    expect(issue?.description).toContain("모드: 조사/보고 전용.");
+    expect(issue?.description).toContain("repo 파일 수정, 배포, 병합, push, 삭제, DB 쓰기");
+  });
+});

--- a/packages/plugins/examples/plugin-yooncompany-command/tsconfig.json
+++ b/packages/plugins/examples/plugin-yooncompany-command/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/examples/plugin-yooncompany-command/vitest.config.ts
+++ b/packages/plugins/examples/plugin-yooncompany-command/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.spec.ts", "tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,31 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/examples/plugin-yooncompany-command:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugins/paperclip-plugin-fake-sandbox:
     dependencies:
       '@paperclipai/plugin-sdk':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,31 +497,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/plugins/examples/plugin-yooncompany-command:
-    dependencies:
-      '@paperclipai/plugin-sdk':
-        specifier: workspace:*
-        version: link:../../sdk
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      '@types/react':
-        specifier: ^19.0.8
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.0.3
-        version: 19.2.3(@types/react@19.2.14)
-      react:
-        specifier: ^19.0.0
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.0.0
-        version: 19.2.4(react@19.2.4)
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
   packages/plugins/paperclip-plugin-fake-sandbox:
     dependencies:
       '@paperclipai/plugin-sdk':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,9 @@ packages:
   # Keep this smoke fixture installable as a local plugin example without
   # forcing PRs to commit pnpm-lock.yaml for a new workspace importer.
   - "!packages/plugins/examples/plugin-orchestration-smoke-example"
+  # Keep this local YoonCompany plugin example installable without forcing
+  # root pnpm-lock.yaml churn for a new workspace importer.
+  - "!packages/plugins/examples/plugin-yooncompany-command"
   - server
   - ui
   - cli

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -45,18 +45,24 @@ function withSuffix(label: string, suffix: string | null): string {
 export interface AdapterDisplayInfo {
   label: string;
   description: string;
+  koreanLabel?: string;
+  koreanDescription?: string;
   icon: ComponentType<{ className?: string }>;
   recommended?: boolean;
   comingSoon?: boolean;
   disabledLabel?: string;
+  koreanDisabledLabel?: string;
   experimental?: boolean;
   hideFromVisualSelection?: boolean;
 }
+
+type AdapterDisplayCopy = (key: string, english: string, korean: string) => string;
 
 const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
   acpx_local: {
     label: "ACPX",
     description: "Experimental local ACPX multi-agent adapter",
+    koreanDescription: "실험적 로컬 ACPX 다중 직원 어댑터",
     icon: Bot,
     experimental: true,
     hideFromVisualSelection: true,
@@ -64,67 +70,81 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
   claude_local: {
     label: "Claude Code",
     description: "Local Claude agent",
+    koreanDescription: "로컬 Claude 직원",
     icon: Sparkles,
     recommended: true,
   },
   codex_local: {
     label: "Codex",
     description: "Local Codex agent",
+    koreanDescription: "로컬 Codex 직원",
     icon: Code,
     recommended: true,
   },
   gemini_local: {
     label: "Gemini CLI",
     description: "Local Gemini agent",
+    koreanDescription: "로컬 Gemini 직원",
     icon: Gem,
   },
   grok_local: {
     label: "Grok Build",
     description: "Local Grok Build agent",
+    koreanDescription: "로컬 Grok Build 직원",
     icon: Bot,
   },
   opencode_local: {
     label: "OpenCode",
     description: "Local multi-provider agent",
+    koreanDescription: "로컬 다중 제공자 직원",
     icon: OpenCodeLogoIcon,
   },
   hermes_local: {
     label: "Hermes Agent",
     description: "Local Hermes CLI agent",
+    koreanLabel: "Hermes 직원",
+    koreanDescription: "로컬 Hermes CLI 직원",
     icon: HermesIcon,
   },
   pi_local: {
     label: "Pi",
     description: "Local Pi agent",
+    koreanDescription: "로컬 Pi 직원",
     icon: Terminal,
   },
   cursor: {
     label: "Cursor",
     description: "Local Cursor agent",
+    koreanDescription: "로컬 Cursor 직원",
     icon: MousePointer2,
   },
   cursor_cloud: {
     label: "Cursor Cloud",
     description: "Managed remote Cursor agent",
+    koreanDescription: "관리형 원격 Cursor 직원",
     icon: MousePointer2,
   },
   openclaw_gateway: {
     label: "OpenClaw Gateway",
     description: "External gateway adapter",
+    koreanDescription: "외부 게이트웨이 어댑터",
     icon: Bot,
     comingSoon: true,
     disabledLabel: "Invite external agents from the add-agent modal",
+    koreanDisabledLabel: "직원 추가 창에서 외부 직원을 초대하세요",
     hideFromVisualSelection: true,
   },
   process: {
     label: "Process",
     description: "Internal process adapter",
+    koreanDescription: "내부 프로세스 어댑터",
     icon: Cpu,
     comingSoon: true,
   },
   http: {
     label: "HTTP",
     description: "Internal HTTP adapter",
+    koreanDescription: "내부 HTTP 어댑터",
     icon: Cpu,
     comingSoon: true,
   },
@@ -169,6 +189,34 @@ export function getAdapterDisplay(type: string): AdapterDisplayInfo {
     label,
     description: suffix ? `External ${suffix} adapter` : "External adapter",
     icon: Cpu,
+  };
+}
+
+export function getLocalizedAdapterDisplay(type: string, copy: AdapterDisplayCopy): AdapterDisplayInfo {
+  const display = getAdapterDisplay(type);
+  const known = adapterDisplayMap[type];
+  const suffix = getTypeSuffix(type);
+  const fallbackKoreanDescription = suffix ? `외부 ${suffix} 어댑터` : "외부 어댑터";
+
+  return {
+    ...display,
+    label: copy(
+      `adapters.${type}.label`,
+      display.label,
+      known?.koreanLabel ?? display.label,
+    ),
+    description: copy(
+      `adapters.${type}.description`,
+      display.description,
+      known?.koreanDescription ?? fallbackKoreanDescription,
+    ),
+    disabledLabel: display.disabledLabel
+      ? copy(
+        `adapters.${type}.disabledLabel`,
+        display.disabledLabel,
+        known?.koreanDisabledLabel ?? display.disabledLabel,
+      )
+      : undefined,
   };
 }
 

--- a/ui/src/adapters/codex-local/config-fields.tsx
+++ b/ui/src/adapters/codex-local/config-fields.tsx
@@ -12,6 +12,7 @@ import {
   isCodexLocalFastModeSupported,
   isCodexLocalManualModel,
 } from "@paperclipai/adapter-codex-local";
+import { useLocalizedCopy } from "../../i18n/ui-copy";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -30,6 +31,7 @@ export function CodexLocalConfigFields({
   models,
   hideInstructionsFile,
 }: AdapterConfigFieldsProps) {
+  const copy = useLocalizedCopy();
   const bypassEnabled =
     config.dangerouslyBypassApprovalsAndSandbox === true || config.dangerouslyBypassSandbox === true;
   const fastModeEnabled = isCreate
@@ -42,15 +44,15 @@ export function CodexLocalConfigFields({
   const fastModeSupported = isCodexLocalFastModeSupported(currentModel);
   const supportedModelsLabel = CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.join(", ");
   const fastModeMessage = fastModeManualModel
-    ? "Fast mode will be passed through for this manual model. If Codex rejects it, turn the toggle off."
+    ? copy("codexLocal.fastMode.manual", "Fast mode will be passed through for this manual model. If Codex rejects it, turn the toggle off.", "수동 모델에는 Fast mode를 그대로 전달합니다. Codex가 거부하면 이 옵션을 끄세요.")
     : fastModeSupported
-      ? "Fast mode consumes credits/tokens much faster than standard Codex runs."
-      : `Fast mode currently only works on ${supportedModelsLabel} or manual model IDs. Paperclip will ignore this toggle until the model is switched.`;
+      ? copy("codexLocal.fastMode.supported", "Fast mode consumes credits/tokens much faster than standard Codex runs.", "Fast mode는 일반 Codex 실행보다 크레딧/토큰을 훨씬 빠르게 사용합니다.")
+      : copy("codexLocal.fastMode.unsupported", `Fast mode currently only works on ${supportedModelsLabel} or manual model IDs. Paperclip will ignore this toggle until the model is switched.`, `Fast mode는 현재 ${supportedModelsLabel} 또는 수동 모델 ID에서만 동작합니다. 모델을 바꾸기 전까지 이 옵션은 무시됩니다.`);
 
   return (
     <>
       {!hideInstructionsFile && (
-        <Field label="Agent instructions file" hint={instructionsFileHint}>
+        <Field label={copy("codexLocal.instructionsFile", "Agent instructions file", "직원 지침 파일")} hint={instructionsFileHint}>
           <div className="flex items-center gap-2">
             <DraftInput
               value={
@@ -76,7 +78,7 @@ export function CodexLocalConfigFields({
         </Field>
       )}
       <ToggleField
-        label="Bypass sandbox"
+        label={copy("codexLocal.bypassSandbox", "Bypass sandbox", "샌드박스 우회")}
         hint={help.dangerouslyBypassSandbox}
         checked={
           isCreate
@@ -94,7 +96,7 @@ export function CodexLocalConfigFields({
         }
       />
       <ToggleField
-        label="Enable search"
+        label={copy("codexLocal.enableSearch", "Enable search", "검색 사용")}
         hint={help.search}
         checked={
           isCreate
@@ -108,7 +110,7 @@ export function CodexLocalConfigFields({
         }
       />
       <ToggleField
-        label="Fast mode"
+        label={copy("codexLocal.fastMode", "Fast mode", "Fast mode")}
         hint={help.fastMode}
         checked={fastModeEnabled}
         onChange={(v) =>

--- a/ui/src/adapters/hermes-local/config-fields.tsx
+++ b/ui/src/adapters/hermes-local/config-fields.tsx
@@ -4,6 +4,7 @@ import {
   DraftInput,
 } from "../../components/agent-config-primitives";
 import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { useLocalizedCopy } from "../../i18n/ui-copy";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -19,31 +20,46 @@ export function HermesLocalConfigFields({
   mark,
   hideInstructionsFile,
 }: AdapterConfigFieldsProps) {
+  const copy = useLocalizedCopy();
   if (hideInstructionsFile) return null;
   return (
-    <Field label="Agent instructions file" hint={instructionsFileHint}>
-      <div className="flex items-center gap-2">
-        <DraftInput
-          value={
-            isCreate
-              ? values!.instructionsFilePath ?? ""
-              : eff(
-                  "adapterConfig",
-                  "instructionsFilePath",
-                  String(config.instructionsFilePath ?? ""),
-                )
-          }
-          onCommit={(v) =>
-            isCreate
-              ? set!({ instructionsFilePath: v })
-              : mark("adapterConfig", "instructionsFilePath", v || undefined)
-          }
-          immediate
-          className={inputClass}
-          placeholder="/absolute/path/to/AGENTS.md"
-        />
-        <ChoosePathButton />
+    <>
+      <Field label={copy("hermesLocal.instructionsFile", "Agent instructions file", "직원 지침 파일")} hint={instructionsFileHint}>
+        <div className="flex items-center gap-2">
+          <DraftInput
+            value={
+              isCreate
+                ? values!.instructionsFilePath ?? ""
+                : eff(
+                    "adapterConfig",
+                    "instructionsFilePath",
+                    String(config.instructionsFilePath ?? ""),
+                  )
+            }
+            onCommit={(v) =>
+              isCreate
+                ? set!({ instructionsFilePath: v })
+                : mark("adapterConfig", "instructionsFilePath", v || undefined)
+            }
+            immediate
+            className={inputClass}
+            placeholder="/absolute/path/to/AGENTS.md"
+          />
+          <ChoosePathButton />
+        </div>
+      </Field>
+      <div className="border border-border bg-muted/20 p-3 text-xs leading-5 text-muted-foreground">
+        <div className="font-medium text-foreground">
+          {copy("hermesLocal.telegram.title", "Telegram command channel", "Telegram 지시 채널")}
+        </div>
+        <div className="mt-1">
+          {copy(
+            "hermesLocal.telegram.description",
+            "Paperclip can run Hermes now. Telegram commands require a separate Hermes gateway/bot configuration before they can dispatch work safely.",
+            "현재 Paperclip에서 Hermes 실행은 가능합니다. Telegram 업무 지시는 별도 Hermes gateway/bot 설정 후 안전하게 작업으로 전달할 수 있습니다.",
+          )}
+        </div>
       </div>
-    </Field>
+    </>
   );
 }

--- a/ui/src/api/heartbeats.test.ts
+++ b/ui/src/api/heartbeats.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockApi = vi.hoisted(() => ({
   get: vi.fn(),
+  post: vi.fn(),
 }));
 
 vi.mock("./client", () => ({
@@ -13,7 +14,9 @@ import { heartbeatsApi } from "./heartbeats";
 describe("heartbeatsApi.liveRunsForCompany", () => {
   beforeEach(() => {
     mockApi.get.mockReset();
+    mockApi.post.mockReset();
     mockApi.get.mockResolvedValue([]);
+    mockApi.post.mockResolvedValue(undefined);
   });
 
   it("keeps the legacy numeric minCount signature", async () => {
@@ -26,5 +29,11 @@ describe("heartbeatsApi.liveRunsForCompany", () => {
     await heartbeatsApi.liveRunsForCompany("company-1", { minCount: 50, limit: 50 });
 
     expect(mockApi.get).toHaveBeenCalledWith("/companies/company-1/live-runs?minCount=50&limit=50");
+  });
+
+  it("sends an operator cancellation reason", async () => {
+    await heartbeatsApi.cancel("run-1", { reason: "manual stop" });
+
+    expect(mockApi.post).toHaveBeenCalledWith("/heartbeat-runs/run-1/cancel", { reason: "manual stop" });
   });
 });

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -93,7 +93,8 @@ export const heartbeatsApi = {
     api.get<{ operationId: string; store: string; logRef: string; content: string; nextOffset?: number }>(
       `/workspace-operations/${operationId}/log?offset=${encodeURIComponent(String(offset))}&limitBytes=${encodeURIComponent(String(limitBytes))}`,
     ),
-  cancel: (runId: string) => api.post<void>(`/heartbeat-runs/${runId}/cancel`, {}),
+  cancel: (runId: string, input?: { reason?: string }) =>
+    api.post<void>(`/heartbeat-runs/${runId}/cancel`, input ?? {}),
   recordWatchdogDecision: (input: WatchdogDecisionInput) =>
     api.post(`/heartbeat-runs/${input.runId}/watchdog-decisions`, {
       decision: input.decision,

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -14,7 +14,9 @@ import {
 import { ExternalLink } from "lucide-react";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
+import { StatusBadge } from "./StatusBadge";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 
 function RunCardRecoveryChip({ action }: { action: IssueRecoveryAction }) {
   const state = deriveActiveRecoveryDisplayState(action);
@@ -50,6 +52,16 @@ function isRunActive(run: LiveRunForIssue): boolean {
   return run.status === "queued" || run.status === "running";
 }
 
+function livenessLabel(run: LiveRunForIssue, copy: ReturnType<typeof useLocalizedCopy>): string | null {
+  if (run.status === "queued") return copy("activeAgents.liveness.queued", "Queued for execution", "실행 대기 중");
+  if (run.status === "running") return copy("activeAgents.liveness.running", "Running now", "현재 실행 중");
+  if (run.livenessState === "needs_followup") return copy("activeAgents.liveness.needsFollowup", "Needs follow-up", "후속 확인 필요");
+  if (run.livenessState === "failed") return copy("activeAgents.liveness.failed", "Recovery needed", "복구 필요");
+  if (run.status === "succeeded") return copy("activeAgents.liveness.succeeded", "Completed successfully", "성공 완료");
+  if (run.status === "cancelled") return copy("activeAgents.liveness.cancelled", "Cancelled", "취소됨");
+  return null;
+}
+
 interface ActiveAgentsPanelProps {
   companyId: string;
   title?: string;
@@ -65,16 +77,20 @@ interface ActiveAgentsPanelProps {
 
 export function ActiveAgentsPanel({
   companyId,
-  title = "Agents",
+  title,
   minRunCount = MIN_DASHBOARD_RUNS,
   fetchLimit,
   cardLimit = DASHBOARD_RUN_CARD_LIMIT,
   gridClassName,
   cardClassName,
-  emptyMessage = "No recent agent runs.",
+  emptyMessage,
   queryScope = "dashboard",
   showMoreLink = true,
 }: ActiveAgentsPanelProps) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
+  const panelTitle = title ?? copy("activeAgents.title", "Agents", "직원");
+  const panelEmptyMessage = emptyMessage ?? copy("activeAgents.empty", "No recent agent runs.", "최근 직원 실행이 없습니다.");
   const { data: liveRuns } = useQuery({
     queryKey: [...queryKeys.liveRuns(companyId), queryScope, { minRunCount, fetchLimit }],
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, { minCount: minRunCount, limit: fetchLimit }),
@@ -118,11 +134,11 @@ export function ActiveAgentsPanel({
   return (
     <div>
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-        {title}
+        {panelTitle}
       </h3>
       {runs.length === 0 ? (
         <div className="rounded-xl border border-border p-4">
-          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+          <p className="text-sm text-muted-foreground">{panelEmptyMessage}</p>
         </div>
       ) : (
         <div className={cn("grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4 xl:grid-cols-4", gridClassName)}>
@@ -136,6 +152,7 @@ export function ActiveAgentsPanel({
               hasOutput={hasOutputForRun(run.id)}
               isActive={isRunActive(run)}
               className={cardClassName}
+              locale={locale}
             />
           ))}
         </div>
@@ -143,7 +160,12 @@ export function ActiveAgentsPanel({
       {showMoreLink && hiddenRunCount > 0 && (
         <div className="mt-3 flex justify-end text-xs text-muted-foreground">
           <Link to="/dashboard/live" className="hover:text-foreground hover:underline">
-            {hiddenRunCount} more active/recent run{hiddenRunCount === 1 ? "" : "s"}
+            {copy(
+              "activeAgents.moreRuns",
+              hiddenRunCount === 1 ? "{{count}} more active/recent run" : "{{count}} more active/recent runs",
+              "활성/최근 실행 {{count}}개 더 보기",
+              { count: hiddenRunCount },
+            )}
           </Link>
         </div>
       )}
@@ -159,6 +181,7 @@ const AgentRunCard = memo(function AgentRunCard({
   hasOutput,
   isActive,
   className,
+  locale,
 }: {
   companyId: string;
   run: LiveRunForIssue;
@@ -167,7 +190,16 @@ const AgentRunCard = memo(function AgentRunCard({
   hasOutput: boolean;
   isActive: boolean;
   className?: string;
+  locale?: string | null;
 }) {
+  const copy = useLocalizedCopy();
+  const runTimeLabel = isActive
+    ? copy("activeAgents.run.liveNow", "Live now", "지금 실행 중")
+    : run.finishedAt
+      ? copy("activeAgents.run.finished", "Finished {{time}}", "{{time}} 완료", { time: relativeTime(run.finishedAt, locale) })
+      : copy("activeAgents.run.started", "Started {{time}}", "{{time}} 시작", { time: relativeTime(run.createdAt, locale) });
+  const progressLabel = livenessLabel(run, copy);
+
   return (
     <div className={cn(
       "flex h-[320px] flex-col overflow-hidden rounded-xl border shadow-sm",
@@ -191,8 +223,14 @@ const AgentRunCard = memo(function AgentRunCard({
               <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
             </div>
             <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
-              <span>{isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}</span>
+              <span>{runTimeLabel}</span>
+              <StatusBadge status={run.status} />
             </div>
+            {progressLabel ? (
+              <div className="mt-1 text-[11px] leading-5 text-muted-foreground">
+                {progressLabel}
+              </div>
+            ) : null}
           </div>
 
           <Link
@@ -231,6 +269,7 @@ const AgentRunCard = memo(function AgentRunCard({
           transcript={transcript}
           hasOutput={hasOutput}
           companyId={companyId}
+          locale={locale}
         />
       </div>
     </div>

--- a/ui/src/components/ActivityCharts.tsx
+++ b/ui/src/components/ActivityCharts.tsx
@@ -1,4 +1,5 @@
 import type { DashboardRunActivityDay, HeartbeatRun } from "@paperclipai/shared";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 /* ---- Utilities ---- */
 
@@ -85,6 +86,7 @@ function resolveRunActivity(props: RunChartProps): DashboardRunActivityDay[] {
 }
 
 export function RunActivityChart(props: RunChartProps) {
+  const copy = useLocalizedCopy();
   const activity = resolveRunActivity(props);
   const days = activity.length > 0 ? activity.map((day) => day.date) : getLast14Days();
   const grouped = new Map(activity.map((day) => [day.date, day]));
@@ -92,7 +94,7 @@ export function RunActivityChart(props: RunChartProps) {
   const maxValue = Math.max(...activity.map(v => v.total), 1);
   const hasData = activity.some(v => v.total > 0);
 
-  if (!hasData) return <p className="text-xs text-muted-foreground">No runs yet</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{copy("charts.noRunsYet", "No runs yet", "아직 실행이 없습니다.")}</p>;
 
   return (
     <div>
@@ -102,7 +104,14 @@ export function RunActivityChart(props: RunChartProps) {
           const total = entry.total;
           const heightPct = (total / maxValue) * 100;
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} runs`}>
+            <div
+              key={day}
+              className="flex-1 h-full flex flex-col justify-end"
+              title={copy("charts.runTooltip", "{{date}}: {{count}} runs", "{{date}}: 실행 {{count}}건", {
+                date: day,
+                count: total,
+              })}
+            >
               {total > 0 ? (
                 <div className="flex flex-col-reverse gap-px overflow-hidden" style={{ height: `${heightPct}%`, minHeight: 2 }}>
                   {entry.succeeded > 0 && <div className="bg-emerald-500" style={{ flex: entry.succeeded }} />}
@@ -131,6 +140,7 @@ const priorityColors: Record<string, string> = {
 const priorityOrder = ["critical", "high", "medium", "low"] as const;
 
 export function PriorityChart({ issues }: { issues: { priority: string; createdAt: Date }[] }) {
+  const copy = useLocalizedCopy();
   const days = getLast14Days();
   const grouped = new Map<string, Record<string, number>>();
   for (const day of days) grouped.set(day, { critical: 0, high: 0, medium: 0, low: 0 });
@@ -144,7 +154,14 @@ export function PriorityChart({ issues }: { issues: { priority: string; createdA
   const maxValue = Math.max(...Array.from(grouped.values()).map(v => Object.values(v).reduce((a, b) => a + b, 0)), 1);
   const hasData = Array.from(grouped.values()).some(v => Object.values(v).reduce((a, b) => a + b, 0) > 0);
 
-  if (!hasData) return <p className="text-xs text-muted-foreground">No issues</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{copy("charts.noIssues", "No issues", "작업이 없습니다.")}</p>;
+
+  const priorityLabels: Record<(typeof priorityOrder)[number], string> = {
+    critical: copy("priority.critical", "Critical", "긴급"),
+    high: copy("priority.high", "High", "높음"),
+    medium: copy("priority.medium", "Medium", "보통"),
+    low: copy("priority.low", "Low", "낮음"),
+  };
 
   return (
     <div>
@@ -154,7 +171,14 @@ export function PriorityChart({ issues }: { issues: { priority: string; createdA
           const total = Object.values(entry).reduce((a, b) => a + b, 0);
           const heightPct = (total / maxValue) * 100;
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} issues`}>
+            <div
+              key={day}
+              className="flex-1 h-full flex flex-col justify-end"
+              title={copy("charts.issueTooltip", "{{date}}: {{count}} issues", "{{date}}: 작업 {{count}}건", {
+                date: day,
+                count: total,
+              })}
+            >
               {total > 0 ? (
                 <div className="flex flex-col-reverse gap-px overflow-hidden" style={{ height: `${heightPct}%`, minHeight: 2 }}>
                   {priorityOrder.map(p => entry[p] > 0 ? (
@@ -169,7 +193,7 @@ export function PriorityChart({ issues }: { issues: { priority: string; createdA
         })}
       </div>
       <DateLabels days={days} />
-      <ChartLegend items={priorityOrder.map(p => ({ color: priorityColors[p], label: p.charAt(0).toUpperCase() + p.slice(1) }))} />
+      <ChartLegend items={priorityOrder.map(p => ({ color: priorityColors[p], label: priorityLabels[p] }))} />
     </div>
   );
 }
@@ -184,17 +208,8 @@ const statusColors: Record<string, string> = {
   backlog: "#64748b",
 };
 
-const statusLabels: Record<string, string> = {
-  todo: "To Do",
-  in_progress: "In Progress",
-  in_review: "In Review",
-  done: "Done",
-  blocked: "Blocked",
-  cancelled: "Cancelled",
-  backlog: "Backlog",
-};
-
 export function IssueStatusChart({ issues }: { issues: { status: string; createdAt: Date }[] }) {
+  const copy = useLocalizedCopy();
   const days = getLast14Days();
   const allStatuses = new Set<string>();
   const grouped = new Map<string, Record<string, number>>();
@@ -211,7 +226,17 @@ export function IssueStatusChart({ issues }: { issues: { status: string; created
   const maxValue = Math.max(...Array.from(grouped.values()).map(v => Object.values(v).reduce((a, b) => a + b, 0)), 1);
   const hasData = allStatuses.size > 0;
 
-  if (!hasData) return <p className="text-xs text-muted-foreground">No issues</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{copy("charts.noIssues", "No issues", "작업이 없습니다.")}</p>;
+
+  const statusLabels: Record<string, string> = {
+    todo: copy("status.todo", "To Do", "할 일"),
+    in_progress: copy("status.inProgress", "In Progress", "진행 중"),
+    in_review: copy("status.inReview", "In Review", "검토 중"),
+    done: copy("status.done", "Done", "완료"),
+    blocked: copy("status.blocked", "Blocked", "막힘"),
+    cancelled: copy("status.cancelled", "Cancelled", "취소"),
+    backlog: copy("status.backlog", "Backlog", "대기"),
+  };
 
   return (
     <div>
@@ -221,7 +246,14 @@ export function IssueStatusChart({ issues }: { issues: { status: string; created
           const total = Object.values(entry).reduce((a, b) => a + b, 0);
           const heightPct = (total / maxValue) * 100;
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${total} issues`}>
+            <div
+              key={day}
+              className="flex-1 h-full flex flex-col justify-end"
+              title={copy("charts.issueTooltip", "{{date}}: {{count}} issues", "{{date}}: 작업 {{count}}건", {
+                date: day,
+                count: total,
+              })}
+            >
               {total > 0 ? (
                 <div className="flex flex-col-reverse gap-px overflow-hidden" style={{ height: `${heightPct}%`, minHeight: 2 }}>
                   {statusOrder.map(s => (entry[s] ?? 0) > 0 ? (
@@ -242,12 +274,13 @@ export function IssueStatusChart({ issues }: { issues: { status: string; created
 }
 
 export function SuccessRateChart(props: RunChartProps) {
+  const copy = useLocalizedCopy();
   const activity = resolveRunActivity(props);
   const days = activity.length > 0 ? activity.map((day) => day.date) : getLast14Days();
   const grouped = new Map(activity.map((day) => [day.date, day]));
 
   const hasData = activity.some(v => v.total > 0);
-  if (!hasData) return <p className="text-xs text-muted-foreground">No runs yet</p>;
+  if (!hasData) return <p className="text-xs text-muted-foreground">{copy("charts.noRunsYet", "No runs yet", "아직 실행이 없습니다.")}</p>;
 
   return (
     <div>
@@ -257,7 +290,21 @@ export function SuccessRateChart(props: RunChartProps) {
           const rate = entry.total > 0 ? entry.succeeded / entry.total : 0;
           const color = entry.total === 0 ? undefined : rate >= 0.8 ? "#10b981" : rate >= 0.5 ? "#eab308" : "#ef4444";
           return (
-            <div key={day} className="flex-1 h-full flex flex-col justify-end" title={`${day}: ${entry.total > 0 ? Math.round(rate * 100) : 0}% (${entry.succeeded}/${entry.total})`}>
+            <div
+              key={day}
+              className="flex-1 h-full flex flex-col justify-end"
+              title={copy(
+                "charts.successTooltip",
+                "{{date}}: {{percent}}% ({{succeeded}}/{{total}})",
+                "{{date}}: {{percent}}% ({{succeeded}}/{{total}})",
+                {
+                  date: day,
+                  percent: entry.total > 0 ? Math.round(rate * 100) : 0,
+                  succeeded: entry.succeeded,
+                  total: entry.total,
+                },
+              )}
+            >
               {entry.total > 0 ? (
                 <div style={{ height: `${rate * 100}%`, minHeight: 2, backgroundColor: color }} />
               ) : (

--- a/ui/src/components/ActivityRow.tsx
+++ b/ui/src/components/ActivityRow.tsx
@@ -7,6 +7,7 @@ import { cn } from "../lib/utils";
 import { formatActivityVerb } from "../lib/activity-format";
 import { deriveProjectUrlKey, type ActivityEvent, type Agent } from "@paperclipai/shared";
 import type { CompanyUserProfile } from "../lib/company-members";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 function entityLink(entityType: string, entityId: string, name?: string | null): string | null {
   switch (entityType) {
@@ -26,10 +27,12 @@ interface ActivityRowProps {
   entityNameMap: Map<string, string>;
   entityTitleMap?: Map<string, string>;
   className?: string;
+  locale?: string | null;
 }
 
-export function ActivityRow({ event, agentMap, userProfileMap, entityNameMap, entityTitleMap, className }: ActivityRowProps) {
-  const verb = formatActivityVerb(event.action, event.details, { agentMap, userProfileMap });
+export function ActivityRow({ event, agentMap, userProfileMap, entityNameMap, entityTitleMap, className, locale }: ActivityRowProps) {
+  const copy = useLocalizedCopy();
+  const verb = formatActivityVerb(event.action, event.details, { agentMap, userProfileMap, locale });
 
   const isHeartbeatEvent = event.entityType === "heartbeat_run";
   const heartbeatAgentId = isHeartbeatEvent
@@ -48,7 +51,14 @@ export function ActivityRow({ event, agentMap, userProfileMap, entityNameMap, en
 
   const actor = event.actorType === "agent" ? agentMap.get(event.actorId) : null;
   const userProfile = event.actorType === "user" ? userProfileMap?.get(event.actorId) : null;
-  const actorName = actor?.name ?? (event.actorType === "system" ? "System" : userProfile?.label ?? (event.actorType === "user" ? "Board" : event.actorId || "Unknown"));
+  const rawActorName = actor?.name ?? (event.actorType === "system" ? "System" : userProfile?.label ?? (event.actorType === "user" ? "Board" : event.actorId || "Unknown"));
+  const actorName = rawActorName === "Board"
+    ? copy("actor.board", "Board", "보드")
+    : rawActorName === "System"
+      ? copy("actor.system", "System", "시스템")
+      : rawActorName === "Unknown"
+        ? copy("actor.unknown", "Unknown", "알 수 없음")
+        : rawActorName;
   const actorAvatarUrl = userProfile?.image ?? null;
 
   const inner = (
@@ -66,7 +76,7 @@ export function ActivityRow({ event, agentMap, userProfileMap, entityNameMap, en
             {entityTitle && <span className="text-muted-foreground"> — {entityTitle}</span>}
           </p>
         </div>
-        <span className="text-xs text-muted-foreground shrink-0">{timeAgo(event.createdAt)}</span>
+        <span className="text-xs text-muted-foreground shrink-0">{timeAgo(event.createdAt, locale)}</span>
       </div>
       <IssueReferenceActivitySummary event={event} />
     </div>

--- a/ui/src/components/AgentActionButtons.tsx
+++ b/ui/src/components/AgentActionButtons.tsx
@@ -1,5 +1,6 @@
 import { Pause, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 export function RunButton({
   onClick,
@@ -33,11 +34,13 @@ export function PauseResumeButton({
   disabled?: boolean;
   size?: "sm" | "default";
 }) {
+  const copy = useLocalizedCopy();
+
   if (isPaused) {
     return (
       <Button variant="outline" size={size} onClick={onResume} disabled={disabled}>
         <Play className="h-3.5 w-3.5 sm:mr-1" />
-        <span className="hidden sm:inline">Resume</span>
+        <span className="hidden sm:inline">{copy("agentActions.resume", "Resume", "재개")}</span>
       </Button>
     );
   }
@@ -45,7 +48,7 @@ export function PauseResumeButton({
   return (
     <Button variant="outline" size={size} onClick={onPause} disabled={disabled}>
       <Pause className="h-3.5 w-3.5 sm:mr-1" />
-      <span className="hidden sm:inline">Pause</span>
+      <span className="hidden sm:inline">{copy("agentActions.pause", "Pause", "일시정지")}</span>
     </Button>
   );
 }

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -53,11 +53,12 @@ import { ReportsToPicker } from "./ReportsToPicker";
 import { EnvVarEditor } from "./EnvVarEditor";
 import { shouldShowLegacyWorkingDirectoryField } from "../lib/legacy-agent-config";
 import { listAdapterOptions, listVisibleAdapterTypes } from "../adapters/metadata";
-import { getAdapterDisplay, getAdapterLabel } from "../adapters/adapter-display-registry";
+import { getAdapterLabel, getLocalizedAdapterDisplay } from "../adapters/adapter-display-registry";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { buildAgentUpdatePatch, type AgentConfigOverlay } from "../lib/agent-config-patch";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { filterAcpxModelsByAgent } from "../lib/acpx-model-filter";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 /* ---- Create mode values ---- */
 
@@ -195,6 +196,7 @@ function clampDelayMsFromSeconds(value: number) {
 
 export function AgentConfigForm(props: AgentConfigFormProps) {
   const { mode, adapterModels: externalModels } = props;
+  const copy = useLocalizedCopy();
   const isCreate = mode === "create";
   const cards = props.sectionLayout === "cards";
   const showAdapterTypeField = props.showAdapterTypeField ?? true;
@@ -531,7 +533,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       const refreshed = await agentsApi.adapterModels(selectedCompanyId, adapterType, { refresh: true });
       queryClient.setQueryData(modelQueryKey, refreshed);
     } catch (error) {
-      setRefreshModelsError(error instanceof Error ? error.message : "Failed to refresh adapter models.");
+      setRefreshModelsError(error instanceof Error ? error.message : copy("agentConfig.models.refreshFailed", "Failed to refresh adapter models.", "어댑터 모델 목록을 새로고침하지 못했습니다."));
     } finally {
       setRefreshingModels(false);
     }
@@ -690,13 +692,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {isDirty && !props.hideInlineSave && (
         <div className="sticky top-0 z-10 flex items-center justify-end px-4 py-2 bg-background/90 backdrop-blur-sm border-b border-primary/20">
           <div className="flex items-center gap-3">
-            <span className="text-xs text-muted-foreground">Unsaved changes</span>
+            <span className="text-xs text-muted-foreground">{copy("agentConfig.unsavedChanges", "Unsaved changes", "저장하지 않은 변경")}</span>
             <Button
               size="sm"
               onClick={handleSave}
               disabled={!isCreate && props.isSaving}
             >
-              {!isCreate && props.isSaving ? "Saving..." : "Save"}
+              {!isCreate && props.isSaving ? copy("common.savingDots", "Saving...", "저장 중...") : copy("common.save", "Save", "저장")}
             </Button>
           </div>
         </div>
@@ -706,42 +708,42 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {!isCreate && (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
-            ? <h3 className="text-sm font-medium mb-3">Identity</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Identity</div>
+            ? <h3 className="text-sm font-medium mb-3">{copy("agentConfig.identity", "Identity", "기본 정보")}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">{copy("agentConfig.identity", "Identity", "기본 정보")}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
-            <Field label="Name" hint={help.name}>
+            <Field label={copy("agentConfig.name", "Name", "이름")} hint={help.name}>
               <DraftInput
                 value={eff("identity", "name", props.agent.name)}
                 onCommit={(v) => mark("identity", "name", v)}
                 immediate
                 className={inputClass}
-                placeholder="Agent name"
+                placeholder={copy("agentConfig.namePlaceholder", "Agent name", "직원 이름")}
               />
             </Field>
-            <Field label="Title" hint={help.title}>
+            <Field label={copy("agentConfig.title", "Title", "직책")} hint={help.title}>
               <DraftInput
                 value={eff("identity", "title", props.agent.title ?? "")}
                 onCommit={(v) => mark("identity", "title", v || null)}
                 immediate
                 className={inputClass}
-                placeholder="e.g. VP of Engineering"
+                placeholder={copy("agentConfig.titlePlaceholder", "e.g. VP of Engineering", "예: 개발 총괄")}
               />
             </Field>
-            <Field label="Reports to" hint={help.reportsTo}>
+            <Field label={copy("agentConfig.reportsTo", "Reports to", "보고 대상")} hint={help.reportsTo}>
               <ReportsToPicker
                 agents={companyAgents}
                 value={eff("identity", "reportsTo", props.agent.reportsTo ?? null)}
                 onChange={(id) => mark("identity", "reportsTo", id)}
                 excludeAgentIds={[props.agent.id]}
-                chooseLabel="Choose manager…"
+                chooseLabel={copy("agentConfig.chooseManager", "Choose manager…", "상위 관리자 선택…")}
               />
             </Field>
-            <Field label="Capabilities" hint={help.capabilities}>
+            <Field label={copy("agentConfig.capabilities", "Capabilities", "역할/능력")} hint={help.capabilities}>
               <MarkdownEditor
                 value={eff("identity", "capabilities", props.agent.capabilities ?? "") ?? ""}
                 onChange={(v) => mark("identity", "capabilities", v || null)}
-                placeholder="Describe what this agent can do..."
+                placeholder={copy("agentConfig.capabilitiesPlaceholder", "Describe what this agent can do...", "이 직원이 할 수 있는 일을 설명하세요...")}
                 contentClassName="min-h-[44px] text-sm font-mono"
                 imageUploadHandler={async (file) => {
                   const asset = await uploadMarkdownImage.mutateAsync({
@@ -754,7 +756,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             </Field>
             {isLocal && !props.hidePromptTemplate && (
               <>
-                <Field label="Prompt Template" hint={help.promptTemplate}>
+                <Field label={copy("agentConfig.promptTemplate", "Prompt Template", "프롬프트 템플릿")} hint={help.promptTemplate}>
                   <MarkdownEditor
                     value={eff(
                       "adapterConfig",
@@ -762,7 +764,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       String(config.promptTemplate ?? ""),
                     )}
                     onChange={(v) => mark("adapterConfig", "promptTemplate", v ?? "")}
-                    placeholder="You are agent {{ agent.name }}. Your role is {{ agent.role }}..."
+                    placeholder={copy("agentConfig.promptTemplatePlaceholder", "You are agent {{ agent.name }}. Your role is {{ agent.role }}...", "당신은 {{ agent.name }}입니다. 역할은 {{ agent.role }}입니다...")}
                     contentClassName="min-h-[88px] text-sm font-mono"
                     imageUploadHandler={async (file) => {
                       const namespace = `agents/${props.agent.id}/prompt-template`;
@@ -772,7 +774,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   />
                 </Field>
                 <div className="rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-                  Prompt template is replayed on every heartbeat. Keep it compact and dynamic to avoid recurring token cost and cache churn.
+                  {copy("agentConfig.promptTemplateWarning", "Prompt template is replayed on every heartbeat. Keep it compact and dynamic to avoid recurring token cost and cache churn.", "프롬프트 템플릿은 매 상태 점검마다 반복됩니다. 반복 토큰 비용과 캐시 낭비를 줄이려면 짧고 동적으로 유지하세요.")}
                 </div>
               </>
             )}
@@ -784,13 +786,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {environmentsEnabled ? (
         <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
           {cards
-            ? <h3 className="text-sm font-medium mb-3">Execution</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Execution</div>
+            ? <h3 className="text-sm font-medium mb-3">{copy("agentConfig.execution", "Execution", "실행")}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">{copy("agentConfig.execution", "Execution", "실행")}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
             <Field
-              label="Default environment"
-              hint="Agent-level default execution target. Project and issue settings can still override this."
+              label={copy("agentConfig.defaultEnvironment", "Default environment", "기본 실행 환경")}
+              hint={copy("agentConfig.defaultEnvironmentHint", "Agent-level default execution target. Project and issue settings can still override this.", "직원 기본 실행 대상입니다. 프로젝트와 작업 설정이 이를 덮어쓸 수 있습니다.")}
             >
               <select
                 className={inputClass}
@@ -804,7 +806,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   mark("identity", "defaultEnvironmentId", nextValue || null);
                 }}
               >
-                <option value="">Company default (Local)</option>
+                <option value="">{copy("agentConfig.companyDefaultLocal", "Company default (Local)", "회사 기본값(Local)")}</option>
                 {runnableEnvironments.map((environment) => (
                   <option key={environment.id} value={environment.id}>
                     {environment.name} · {environment.driver}
@@ -820,8 +822,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
         <div className={cn(cards ? "flex items-center justify-between mb-3" : "px-4 py-2 flex items-center justify-between gap-2")}>
           {cards
-            ? <h3 className="text-sm font-medium">Adapter</h3>
-            : <span className="text-xs font-medium text-muted-foreground">Adapter</span>
+            ? <h3 className="text-sm font-medium">{copy("agentConfig.adapter", "Adapter", "어댑터")}</h3>
+            : <span className="text-xs font-medium text-muted-foreground">{copy("agentConfig.adapter", "Adapter", "어댑터")}</span>
           }
           {showInlineAdapterTestEnvironmentButton && (
             <Button
@@ -832,13 +834,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               onClick={triggerTestEnvironment}
               disabled={testEnvironmentDisabled}
             >
-              {testEnvironment.isPending ? "Testing..." : "Test"}
+              {testEnvironment.isPending ? copy("agentConfig.testing", "Testing...", "테스트 중...") : copy("agentConfig.test", "Test", "테스트")}
             </Button>
           )}
         </div>
         <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
           {showAdapterTypeField && (
-            <Field label="Adapter type" hint={help.adapterType}>
+            <Field label={copy("agentConfig.adapterType", "Adapter type", "어댑터 유형")} hint={help.adapterType}>
               <AdapterTypeDropdown
                 value={adapterType}
                 disabledTypes={disabledTypes}
@@ -899,7 +901,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
               {testEnvironment.error instanceof Error
                 ? testEnvironment.error.message
-                : "Environment test failed"}
+                : copy("agentConfig.environmentTestFailed", "Environment test failed", "환경 테스트 실패")}
             </div>
           )}
 
@@ -909,7 +911,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
 
           {/* Working directory */}
           {showLegacyWorkingDirectoryField && (
-            <Field label="Working directory (deprecated)" hint={help.cwd}>
+            <Field label={copy("agentConfig.workingDirectoryDeprecated", "Working directory (deprecated)", "작업 폴더(구 방식)")} hint={help.cwd}>
               <div className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1.5">
                 <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                 <DraftInput
@@ -941,11 +943,11 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       {isLocal && (
         <div className={cn(!cards && "border-b border-border")}>
           {cards
-            ? <h3 className="text-sm font-medium mb-3">Permissions &amp; Configuration</h3>
-            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Permissions &amp; Configuration</div>
+            ? <h3 className="text-sm font-medium mb-3">{copy("agentConfig.permissionsConfiguration", "Permissions & Configuration", "권한 및 설정")}</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">{copy("agentConfig.permissionsConfiguration", "Permissions & Configuration", "권한 및 설정")}</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
-              <Field label="Command" hint={help.localCommand}>
+              <Field label={copy("agentConfig.command", "Command", "명령")} hint={help.localCommand}>
                 <DraftInput
                   value={
                     isCreate
@@ -981,7 +983,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               </Field>
 
               {supportsModelProfiles && (
-                <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Primary model</div>
+                <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{copy("agentConfig.primaryModel", "Primary model", "기본 모델")}</div>
               )}
               <ModelDropdown
                 models={models}
@@ -1011,22 +1013,22 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     : undefined
                 }
                 refreshingModels={refreshingModels}
-                detectModelLabel="Detect model"
-                emptyDetectHint="No model detected. Select or enter one manually."
+                detectModelLabel={copy("agentConfig.models.detect", "Detect model", "모델 감지")}
+                emptyDetectHint={copy("agentConfig.models.emptyDetectHint", "No model detected. Select or enter one manually.", "감지된 모델이 없습니다. 직접 선택하거나 입력하세요.")}
               />
               {(refreshModelsError || fetchedModelsError) && (
                 <p className="text-xs text-destructive">
                   {refreshModelsError
                     ?? (fetchedModelsError instanceof Error
                       ? fetchedModelsError.message
-                      : "Failed to load adapter models.")}
+                      : copy("agentConfig.models.loadFailed", "Failed to load adapter models.", "어댑터 모델 목록을 불러오지 못했습니다."))}
                 </p>
               )}
               {adapterType === "opencode_local"
                 && currentDefaultEnvironment
                 && currentDefaultEnvironment.driver !== "local" && (
                 <p className="text-xs text-muted-foreground">
-                  Live OpenCode model discovery only runs for Local environments. Using the curated list and manual entry for {currentDefaultEnvironment.name}.
+                  {copy("agentConfig.opencodLocalOnly", "Live OpenCode model discovery only runs for Local environments. Using the curated list and manual entry for", "OpenCode 실시간 모델 감지는 Local 환경에서만 동작합니다. 현재 환경은 기본 목록과 수동 입력을 사용합니다:")} {currentDefaultEnvironment.name}.
                 </p>
               )}
 
@@ -1061,14 +1063,14 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     codexSearchEnabled &&
                     currentThinkingEffort === "minimal" && (
                       <p className="text-xs text-amber-400">
-                        Codex may reject `minimal` thinking when search is enabled.
+                        {copy("agentConfig.codexMinimalSearchWarning", "Codex may reject `minimal` thinking when search is enabled.", "검색이 켜진 상태에서는 Codex가 `minimal` 추론을 거부할 수 있습니다.")}
                       </p>
                     )}
                 </>
               )}
               {!isCreate && typeof config.bootstrapPromptTemplate === "string" && config.bootstrapPromptTemplate && (
                 <>
-                  <Field label="Bootstrap prompt (legacy)" hint={help.bootstrapPrompt}>
+                  <Field label={copy("agentConfig.bootstrapPromptLegacy", "Bootstrap prompt (legacy)", "부트스트랩 프롬프트(구 방식)")} hint={help.bootstrapPrompt}>
                     <MarkdownEditor
                       value={eff(
                         "adapterConfig",
@@ -1078,7 +1080,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       onChange={(v) =>
                         mark("adapterConfig", "bootstrapPromptTemplate", v || undefined)
                       }
-                      placeholder="Optional initial setup prompt for the first run"
+                      placeholder={copy("agentConfig.bootstrapPromptPlaceholder", "Optional initial setup prompt for the first run", "첫 실행에만 사용할 초기 설정 프롬프트")}
                       contentClassName="min-h-[44px] text-sm font-mono"
                       imageUploadHandler={async (file) => {
                         const namespace = `agents/${props.agent.id}/bootstrap-prompt`;
@@ -1088,7 +1090,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     />
                   </Field>
                   <div className="rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-                    Bootstrap prompt is legacy and will be removed in a future release. Consider moving this content into the agent&apos;s prompt template or instructions file instead.
+                    {copy("agentConfig.bootstrapPromptLegacyWarning", "Bootstrap prompt is legacy and will be removed in a future release. Consider moving this content into the agent's prompt template or instructions file instead.", "부트스트랩 프롬프트는 구 방식이며 향후 제거될 수 있습니다. 이 내용은 직원 프롬프트 템플릿이나 지침 파일로 옮기는 것을 권장합니다.")}
                   </div>
                 </>
               )}
@@ -1097,7 +1099,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               )}
               <uiAdapter.ConfigFields {...adapterFieldProps} />
 
-              <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
+              <Field label={copy("agentConfig.extraArgs", "Extra args (comma-separated)", "추가 인자(쉼표로 구분)")} hint={help.extraArgs}>
                 <DraftInput
                   value={
                     isCreate
@@ -1111,11 +1113,11 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   }
                   immediate
                   className={inputClass}
-                  placeholder="e.g. --verbose, --foo=bar"
+                  placeholder={copy("agentConfig.extraArgsPlaceholder", "e.g. --verbose, --foo=bar", "예: --verbose, --foo=bar")}
                 />
               </Field>
 
-              <Field label="Environment variables" hint={help.envVars}>
+              <Field label={copy("agentConfig.environmentVariables", "Environment variables", "환경 변수")} hint={help.envVars}>
                 <EnvVarEditor
                   value={
                     isCreate
@@ -1139,7 +1141,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               {/* Edit-only: timeout + grace period */}
               {!isCreate && (
                 <>
-                  <Field label="Timeout (sec)" hint={help.timeoutSec}>
+                  <Field label={copy("agentConfig.timeoutSec", "Timeout (sec)", "제한 시간(초)")} hint={help.timeoutSec}>
                     <DraftNumberInput
                       value={eff(
                         "adapterConfig",
@@ -1151,7 +1153,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       className={inputClass}
                     />
                   </Field>
-                  <Field label="Interrupt grace period (sec)" hint={help.graceSec}>
+                  <Field label={copy("agentConfig.graceSec", "Interrupt grace period (sec)", "중단 대기 시간(초)")} hint={help.graceSec}>
                     <DraftNumberInput
                       value={eff(
                         "adapterConfig",
@@ -1344,7 +1346,9 @@ function AdapterTypeDropdown({
   disabledTypes: Set<string>;
 }) {
   const [open, setOpen] = useState(false);
-  const selectedDisplay = getAdapterDisplay(value);
+  const copy = useLocalizedCopy();
+  const selectedDisplay = getLocalizedAdapterDisplay(value, copy);
+  const experimentalLabel = copy("common.experimental", "Experimental", "실험");
   const adapterList = useMemo(
     () =>
       listAdapterOptions((type) => adapterLabels[type] ?? getAdapterLabel(type)).filter(
@@ -1360,7 +1364,7 @@ function AdapterTypeDropdown({
           <span className="inline-flex min-w-0 items-center gap-1.5">
             {value === "opencode_local" ? <OpenCodeLogoIcon className="h-3.5 w-3.5" /> : null}
             <span className="truncate">{adapterLabels[value] ?? getAdapterLabel(value)}</span>
-            {selectedDisplay.experimental && <ExperimentalBadge />}
+            {selectedDisplay.experimental && <ExperimentalBadge label={experimentalLabel} />}
           </span>
           <ChevronDown className="h-3 w-3 text-muted-foreground" />
         </button>
@@ -1387,10 +1391,10 @@ function AdapterTypeDropdown({
             <span className="inline-flex items-center gap-1.5">
               {item.value === "opencode_local" ? <OpenCodeLogoIcon className="h-3.5 w-3.5" /> : null}
               <span>{item.label}</span>
-              {item.experimental && <ExperimentalBadge />}
+              {item.experimental && <ExperimentalBadge label={experimentalLabel} />}
             </span>
             {item.comingSoon && (
-              <span className="text-[10px] text-muted-foreground">Coming soon</span>
+              <span className="text-[10px] text-muted-foreground">{copy("common.comingSoon", "Coming soon", "예정")}</span>
             )}
           </button>
         ))}
@@ -1399,10 +1403,10 @@ function AdapterTypeDropdown({
   );
 }
 
-function ExperimentalBadge() {
+function ExperimentalBadge({ label = "Experimental" }: { label?: string }) {
   return (
     <span className="shrink-0 rounded border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-amber-700 dark:text-amber-200">
-      Experimental
+      {label}
     </span>
   );
 }
@@ -1444,6 +1448,7 @@ function ModelDropdown({
   emptyDetectHint?: string;
   defaultLabel?: string;
 }) {
+  const copy = useLocalizedCopy();
   const [modelSearch, setModelSearch] = useState("");
   const [detectingModel, setDetectingModel] = useState(false);
   const selected = models.find((m) => m.id === value);
@@ -1516,7 +1521,7 @@ function ModelDropdown({
   }
 
   return (
-    <Field label="Model" hint={help.model}>
+    <Field label={copy("agentConfig.models.model", "Model", "모델")} hint={help.model}>
       <Popover
         open={open}
         onOpenChange={(nextOpen) => {
@@ -1530,7 +1535,7 @@ function ModelDropdown({
               {selected
                 ? selected.label
                 : value
-                  || (allowDefault ? (defaultLabel ?? "Default") : required ? "Select model (required)" : "Select model")}
+                  || (allowDefault ? (defaultLabel ?? copy("agentConfig.models.default", "Default", "기본값")) : required ? copy("agentConfig.models.selectRequired", "Select model (required)", "모델 선택(필수)") : copy("agentConfig.models.select", "Select model", "모델 선택"))}
             </span>
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           </button>
@@ -1539,7 +1544,9 @@ function ModelDropdown({
           <div className="relative mb-1">
             <input
               className="w-full px-2 py-1.5 pr-6 text-xs bg-transparent outline-none border-b border-border placeholder:text-muted-foreground/50"
-              placeholder={creatable ? "Search models... (type to create)" : "Search models..."}
+              placeholder={creatable
+                ? copy("agentConfig.models.searchCreatable", "Search models... (type to create)", "모델 검색... 직접 입력 가능")
+                : copy("agentConfig.models.search", "Search models...", "모델 검색...")}
               value={modelSearch}
               onChange={(e) => setModelSearch(e.target.value)}
               autoFocus
@@ -1570,7 +1577,11 @@ function ModelDropdown({
                 <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
                 <path d="M3 3v5h5" />
               </svg>
-              {detectingModel ? "Detecting..." : detectedModel ? (detectModelLabel?.replace(/^Detect\b/, "Re-detect") ?? "Re-detect from config") : (detectModelLabel ?? "Detect from config")}
+              {detectingModel
+                ? copy("agentConfig.models.detecting", "Detecting...", "감지 중...")
+                : detectedModel
+                  ? copy("agentConfig.models.redetectFromConfig", "Re-detect from config", "설정에서 다시 감지")
+                  : (detectModelLabel ?? copy("agentConfig.models.detectFromConfig", "Detect from config", "설정에서 감지"))}
             </button>
           )}
           {onRefreshModels && !modelSearch.trim() && (
@@ -1588,7 +1599,9 @@ function ModelDropdown({
                 <path d="M21 12a9 9 0 0 1-15.28 6.36L3 16" />
                 <path d="M8 16H3v5" />
               </svg>
-              {refreshingModels ? "Refreshing..." : "Refresh models"}
+              {refreshingModels
+                ? copy("agentConfig.models.refreshing", "Refreshing...", "새로고침 중...")
+                : copy("agentConfig.models.refresh", "Refresh models", "모델 목록 새로고침")}
             </button>
           )}
           {value && (!models.some((m) => m.id === value) || promotedModelIds.has(value)) && (
@@ -1605,7 +1618,7 @@ function ModelDropdown({
                 {models.find((m) => m.id === value)?.label ?? value}
               </span>
               <span className="shrink-0 ml-auto text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-green-500/15 text-green-400 border border-green-500/20">
-                current
+                {copy("agentConfig.models.current", "current", "현재")}
               </span>
             </button>
           )}
@@ -1624,7 +1637,7 @@ function ModelDropdown({
                 {models.find((m) => m.id === detectedModel)?.label ?? detectedModel}
               </span>
               <span className="shrink-0 ml-auto text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-400 border border-blue-500/20">
-                detected
+                {copy("agentConfig.models.detected", "detected", "감지됨")}
               </span>
             </button>
           )}
@@ -1648,7 +1661,7 @@ function ModelDropdown({
                     {entry?.label ?? candidate}
                   </span>
                   <span className="shrink-0 ml-auto text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-400 border border-sky-500/20">
-                    config
+                    {copy("agentConfig.models.config", "config", "설정")}
                   </span>
                 </button>
               );
@@ -1666,7 +1679,7 @@ function ModelDropdown({
                   onOpenChange(false);
                 }}
               >
-                Default
+                {copy("agentConfig.models.default", "Default", "기본값")}
               </button>
             )}
             {canCreateManualModel && (
@@ -1679,7 +1692,7 @@ function ModelDropdown({
                   setModelSearch("");
                 }}
               >
-                <span>Use manual model</span>
+                <span>{copy("agentConfig.models.useManual", "Use manual model", "수동 모델 사용")}</span>
                 <span className="text-xs font-mono text-muted-foreground">{manualModel}</span>
               </button>
             )}
@@ -1714,8 +1727,8 @@ function ModelDropdown({
               <div className="px-2 py-2 space-y-2">
                 <p className="text-xs text-muted-foreground">
                   {onDetectModel
-                    ? (emptyDetectHint ?? "No model detected yet. Enter a provider/model manually.")
-                    : "No models found."}
+                    ? (emptyDetectHint ?? copy("agentConfig.models.noDetectedYet", "No model detected yet. Enter a provider/model manually.", "아직 감지된 모델이 없습니다. provider/model을 직접 입력하세요."))
+                    : copy("agentConfig.models.noModelsFound", "No models found.", "모델을 찾지 못했습니다.")}
                 </p>
               </div>
             )}
@@ -1747,16 +1760,17 @@ function CheapModelSection({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const copy = useLocalizedCopy();
   const placeholderHint = adapterDefaultModel
-    ? `Adapter default · ${adapterDefaultModel}`
-    : "No adapter default — choose a cheaper model";
+    ? `${copy("agentConfig.cheapModel.adapterDefault", "Adapter default", "어댑터 기본값")} · ${adapterDefaultModel}`
+    : copy("agentConfig.cheapModel.noAdapterDefault", "No adapter default — choose a cheaper model", "어댑터 기본값 없음 - 저비용 모델을 선택하세요");
   return (
     <div className="rounded-md border border-border/70 bg-muted/20 p-3 space-y-3">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Cheap model</div>
+          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{copy("agentConfig.cheapModel.title", "Cheap model", "저비용 모델")}</div>
           <p className="text-xs text-muted-foreground">
-            Used when a run requests the cheap profile (e.g. routine summaries). The primary model stays unchanged.
+            {copy("agentConfig.cheapModel.description", "Used when a run requests the cheap profile (e.g. routine summaries). The primary model stays unchanged.", "저비용 프로필을 요청하는 실행에서 사용합니다. 기본 모델은 그대로 유지됩니다.")}
           </p>
         </div>
         <ToggleSwitch checked={enabled} onCheckedChange={onEnabledChange} />
@@ -1780,12 +1794,12 @@ function CheapModelSection({
       ) : null}
       {enabled && !model && adapterDefaultModel ? (
         <p className="text-[11px] text-muted-foreground">
-          No explicit cheap model selected — runtime falls back to <code>{adapterDefaultModel}</code>.
+          {copy("agentConfig.cheapModel.fallbackPrefix", "No explicit cheap model selected — runtime falls back to", "명시적인 저비용 모델이 없어 런타임이 다음 모델로 대체합니다:")} <code>{adapterDefaultModel}</code>.
         </p>
       ) : null}
       {enabled && !model && !adapterDefaultModel ? (
         <p className="text-[11px] text-amber-500">
-          No cheap model selected and the adapter has no default. Cheap-lane runs will continue on the primary model with a fallback note.
+          {copy("agentConfig.cheapModel.noFallback", "No cheap model selected and the adapter has no default. Cheap-lane runs will continue on the primary model with a fallback note.", "저비용 모델이 선택되지 않았고 어댑터 기본값도 없습니다. 저비용 실행은 안내 문구와 함께 기본 모델로 계속 실행됩니다.")}
         </p>
       ) : null}
     </div>
@@ -1805,14 +1819,24 @@ function ThinkingEffortDropdown({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const copy = useLocalizedCopy();
   const selected = options.find((option) => option.id === value) ?? options[0];
+  const labelFor = (label: string) => ({
+    Auto: copy("agentConfig.thinking.auto", "Auto", "자동"),
+    Minimal: copy("agentConfig.thinking.minimal", "Minimal", "최소"),
+    Low: copy("agentConfig.thinking.low", "Low", "낮음"),
+    Medium: copy("agentConfig.thinking.medium", "Medium", "보통"),
+    High: copy("agentConfig.thinking.high", "High", "높음"),
+    "X-High": copy("agentConfig.thinking.xhigh", "X-High", "매우 높음"),
+    Max: copy("agentConfig.thinking.max", "Max", "최대"),
+  }[label] ?? label);
 
   return (
-    <Field label="Thinking effort" hint={help.thinkingEffort}>
+    <Field label={copy("agentConfig.thinkingEffort", "Thinking effort", "추론 강도")} hint={help.thinkingEffort}>
       <Popover open={open} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>
           <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
-            <span className={cn(!value && "text-muted-foreground")}>{selected?.label ?? "Auto"}</span>
+            <span className={cn(!value && "text-muted-foreground")}>{selected ? labelFor(selected.label) : copy("agentConfig.thinking.auto", "Auto", "자동")}</span>
             <ChevronDown className="h-3 w-3 text-muted-foreground" />
           </button>
         </PopoverTrigger>
@@ -1829,7 +1853,7 @@ function ThinkingEffortDropdown({
                 onOpenChange(false);
               }}
             >
-              <span>{option.label}</span>
+              <span>{labelFor(option.label)}</span>
               {option.id ? <span className="text-xs text-muted-foreground font-mono">{option.id}</span> : null}
             </button>
           ))}

--- a/ui/src/components/ApprovalCard.tsx
+++ b/ui/src/components/ApprovalCard.tsx
@@ -13,6 +13,7 @@ import {
 import { timeAgo } from "../lib/timeAgo";
 import type { Approval, Agent } from "@paperclipai/shared";
 import { cn } from "@/lib/utils";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 
 function statusIcon(status: string) {
   if (status === "approved") return <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />;
@@ -20,6 +21,26 @@ function statusIcon(status: string) {
   if (status === "revision_requested") return <Clock className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />;
   if (status === "pending") return <Clock className="h-3.5 w-3.5 text-yellow-600 dark:text-yellow-400" />;
   return null;
+}
+
+function approvalTypeLabel(type: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    hire_agent: copy("approval.type.hireAgent", "Hire Agent", "직원 채용"),
+    approve_ceo_strategy: copy("approval.type.ceoStrategy", "CEO Strategy", "CEO 전략"),
+    budget_override_required: copy("approval.type.budgetOverride", "Budget Override", "예산 초과 승인"),
+    request_board_approval: copy("approval.type.boardApproval", "Board Approval", "보드 승인"),
+  };
+  return labels[type] ?? typeLabel[type] ?? type;
+}
+
+function approvalStatusLabel(status: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    pending: copy("approval.status.pending", "Pending", "대기"),
+    approved: copy("approval.status.approved", "Approved", "승인됨"),
+    rejected: copy("approval.status.rejected", "Rejected", "거절됨"),
+    revision_requested: copy("approval.status.revisionRequested", "Revision requested", "수정 요청"),
+  };
+  return labels[status] ?? status.replace(/_/g, " ");
 }
 
 export function ApprovalCard({
@@ -41,9 +62,11 @@ export function ApprovalCard({
   isPending?: boolean;
   pendingAction?: "approve" | "reject" | null;
 }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const payload = approval.payload as Record<string, unknown> | null;
   const Icon = typeIcon[approval.type] ?? defaultTypeIcon;
-  const kindLabel = typeLabel[approval.type] ?? approval.type;
+  const kindLabel = approvalTypeLabel(approval.type, copy);
   const subject = approvalSubject(payload);
   const showResolutionButtons =
     Boolean(onApprove && onReject) &&
@@ -69,7 +92,7 @@ export function ApprovalCard({
                 </Badge>
                 {requesterAgent && (
                   <div className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-                    <span>Requested by</span>
+                    <span>{copy("approval.requestedBy", "Requested by", "요청자")}</span>
                     <Identity name={requesterAgent.name} size="sm" className="inline-flex" />
                   </div>
                 )}
@@ -79,7 +102,7 @@ export function ApprovalCard({
                   {subject ?? kindLabel}
                 </h3>
                 <p className="text-xs leading-5 text-muted-foreground">
-                  Approval request created {timeAgo(approval.createdAt)}
+                  {copy("approval.created", "Approval request created {{time}}", "{{time}} 승인 요청 생성", { time: timeAgo(approval.createdAt, locale) })}
                 </p>
               </div>
             </div>
@@ -88,7 +111,7 @@ export function ApprovalCard({
         <div className="shrink-0">
           <div className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background/80 px-2.5 py-1 text-xs text-muted-foreground">
             {statusIcon(approval.status)}
-            <span className="capitalize">{approval.status.replace(/_/g, " ")}</span>
+            <span>{approvalStatusLabel(approval.status, copy)}</span>
           </div>
         </div>
       </div>
@@ -103,7 +126,7 @@ export function ApprovalCard({
 
       {approval.decisionNote && (
         <div className="mt-4 rounded-lg border border-border/60 bg-muted/30 px-3.5 py-3 text-xs leading-5 text-muted-foreground">
-          <span className="font-medium text-foreground">Decision note.</span> {approval.decisionNote}
+          <span className="font-medium text-foreground">{copy("approval.decisionNote", "Decision note.", "결정 메모.")}</span> {approval.decisionNote}
         </div>
       )}
 
@@ -118,7 +141,7 @@ export function ApprovalCard({
                   onClick={onApprove}
                   disabled={isPending}
                 >
-                  {pendingAction === "approve" ? "Approving..." : "Approve"}
+                  {pendingAction === "approve" ? copy("approval.approving", "Approving...", "승인 중...") : copy("approval.approve", "Approve", "승인")}
                 </Button>
                 <Button
                   variant="destructive"
@@ -126,7 +149,7 @@ export function ApprovalCard({
                   onClick={onReject}
                   disabled={isPending}
                 >
-                  {pendingAction === "reject" ? "Rejecting..." : "Reject"}
+                  {pendingAction === "reject" ? copy("approval.rejecting", "Rejecting...", "거절 중...") : copy("approval.reject", "Reject", "거절")}
                 </Button>
               </>
             )}
@@ -137,11 +160,11 @@ export function ApprovalCard({
                 to={detailLink}
                 className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "h-auto px-2 text-xs text-muted-foreground")}
               >
-                View details
+                {copy("common.viewDetails", "View details", "상세 보기")}
               </Link>
             ) : (
               <Button variant="ghost" size="sm" className="h-auto px-2 text-xs text-muted-foreground" onClick={onOpen}>
-                View details
+                {copy("common.viewDetails", "View details", "상세 보기")}
               </Button>
             )
           ) : null}

--- a/ui/src/components/ApprovalPayload.tsx
+++ b/ui/src/components/ApprovalPayload.tsx
@@ -1,5 +1,6 @@
 import { UserPlus, Lightbulb, ShieldAlert, ShieldCheck } from "lucide-react";
 import { formatCents } from "../lib/utils";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 export const typeLabel: Record<string, string> = {
   hire_agent: "Hire Agent",
@@ -56,6 +57,7 @@ function PayloadField({ label, value }: { label: string; value: unknown }) {
 }
 
 function SkillList({ values }: { values: unknown }) {
+  const copy = useLocalizedCopy();
   if (!Array.isArray(values)) return null;
   const items = values
     .filter((value): value is string => typeof value === "string")
@@ -65,7 +67,7 @@ function SkillList({ values }: { values: unknown }) {
 
   return (
     <div className="flex items-start gap-2">
-      <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs pt-0.5">Skills</span>
+      <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs pt-0.5">{copy("approval.payload.skills", "Skills", "스킬")}</span>
       <div className="flex flex-wrap gap-1.5">
         {items.map((item) => (
           <span
@@ -81,24 +83,25 @@ function SkillList({ values }: { values: unknown }) {
 }
 
 export function HireAgentPayload({ payload }: { payload: Record<string, unknown> }) {
+  const copy = useLocalizedCopy();
   return (
     <div className="mt-3 space-y-1.5 text-sm">
       <div className="flex items-center gap-2">
-        <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs">Name</span>
+        <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs">{copy("approval.payload.name", "Name", "이름")}</span>
         <span className="font-medium">{String(payload.name ?? "—")}</span>
       </div>
-      <PayloadField label="Role" value={payload.role} />
-      <PayloadField label="Title" value={payload.title} />
-      <PayloadField label="Icon" value={payload.icon} />
+      <PayloadField label={copy("approval.payload.role", "Role", "역할")} value={payload.role} />
+      <PayloadField label={copy("approval.payload.title", "Title", "직함")} value={payload.title} />
+      <PayloadField label={copy("approval.payload.icon", "Icon", "아이콘")} value={payload.icon} />
       {!!payload.capabilities && (
         <div className="flex items-start gap-2">
-          <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs pt-0.5">Capabilities</span>
+          <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs pt-0.5">{copy("approval.payload.capabilities", "Capabilities", "기능")}</span>
           <span className="text-muted-foreground">{String(payload.capabilities)}</span>
         </div>
       )}
       {!!payload.adapterType && (
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs">Adapter</span>
+          <span className="text-muted-foreground w-20 sm:w-24 shrink-0 text-xs">{copy("approval.payload.adapter", "Adapter", "어댑터")}</span>
           <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
             {String(payload.adapterType)}
           </span>
@@ -110,10 +113,11 @@ export function HireAgentPayload({ payload }: { payload: Record<string, unknown>
 }
 
 export function CeoStrategyPayload({ payload }: { payload: Record<string, unknown> }) {
+  const copy = useLocalizedCopy();
   const plan = payload.plan ?? payload.description ?? payload.strategy ?? payload.text;
   return (
     <div className="mt-3 space-y-1.5 text-sm">
-      <PayloadField label="Title" value={payload.title} />
+      <PayloadField label={copy("approval.payload.title", "Title", "제목")} value={payload.title} />
       {!!plan && (
         <div className="mt-2 rounded-md bg-muted/40 px-3 py-2 text-sm text-muted-foreground whitespace-pre-wrap font-mono text-xs max-h-48 overflow-y-auto">
           {String(plan)}
@@ -129,16 +133,17 @@ export function CeoStrategyPayload({ payload }: { payload: Record<string, unknow
 }
 
 export function BudgetOverridePayload({ payload }: { payload: Record<string, unknown> }) {
+  const copy = useLocalizedCopy();
   const budgetAmount = typeof payload.budgetAmount === "number" ? payload.budgetAmount : null;
   const observedAmount = typeof payload.observedAmount === "number" ? payload.observedAmount : null;
   return (
     <div className="mt-3 space-y-1.5 text-sm">
-      <PayloadField label="Scope" value={payload.scopeName ?? payload.scopeType} />
-      <PayloadField label="Window" value={payload.windowKind} />
-      <PayloadField label="Metric" value={payload.metric} />
+      <PayloadField label={copy("approval.payload.scope", "Scope", "범위")} value={payload.scopeName ?? payload.scopeType} />
+      <PayloadField label={copy("approval.payload.window", "Window", "기간")} value={payload.windowKind} />
+      <PayloadField label={copy("approval.payload.metric", "Metric", "지표")} value={payload.metric} />
       {(budgetAmount !== null || observedAmount !== null) ? (
         <div className="rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-          Limit {budgetAmount !== null ? formatCents(budgetAmount) : "—"} · Observed {observedAmount !== null ? formatCents(observedAmount) : "—"}
+          {copy("approval.payload.limit", "Limit", "한도")} {budgetAmount !== null ? formatCents(budgetAmount) : "—"} · {copy("approval.payload.observed", "Observed", "관측")} {observedAmount !== null ? formatCents(observedAmount) : "—"}
         </div>
       ) : null}
       {!!payload.guidance && (
@@ -162,6 +167,7 @@ export function BoardApprovalPayload({
 }
 
 function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unknown> }) {
+  const copy = useLocalizedCopy();
   const risks = Array.isArray(payload.risks)
     ? payload.risks
         .filter((value): value is string => typeof value === "string")
@@ -178,33 +184,33 @@ function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unkn
     <div className="mt-4 space-y-3.5 text-sm">
       {title && (
         <div className="space-y-1">
-          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">Title</p>
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">{copy("approval.payload.title", "Title", "제목")}</p>
           <p className="font-medium leading-6 text-foreground">{title}</p>
         </div>
       )}
       {summary && (
         <div className="space-y-1">
-          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">Summary</p>
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">{copy("approval.payload.summary", "Summary", "요약")}</p>
           <p className="leading-6 text-foreground/90">{summary}</p>
         </div>
       )}
       {recommendedAction && (
         <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3.5 py-3">
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-amber-700 dark:text-amber-300">
-            Recommended action
+            {copy("approval.payload.recommendedAction", "Recommended action", "권장 조치")}
           </p>
           <p className="mt-1 leading-6 text-foreground">{recommendedAction}</p>
         </div>
       )}
       {nextActionOnApproval && (
         <div className="rounded-lg border border-border/60 bg-background/60 px-3.5 py-3">
-          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">On approval</p>
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">{copy("approval.payload.onApproval", "On approval", "승인 시")}</p>
           <p className="mt-1 leading-6 text-foreground">{nextActionOnApproval}</p>
         </div>
       )}
       {risks.length > 0 && (
         <div className="space-y-1.5">
-          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">Risks</p>
+          <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">{copy("approval.payload.risks", "Risks", "위험")}</p>
           <ul className="space-y-1 text-sm text-muted-foreground">
             {risks.map((risk) => (
               <li key={risk} className="flex items-start gap-2">
@@ -218,7 +224,7 @@ function BoardApprovalPayloadContent({ payload }: { payload: Record<string, unkn
       {proposedComment && (
         <div className="space-y-1.5">
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-            Proposed comment
+            {copy("approval.payload.proposedComment", "Proposed comment", "제안 댓글")}
           </p>
           <pre className="max-h-48 overflow-auto rounded-lg border border-border/60 bg-muted/50 px-3.5 py-3 font-mono text-xs leading-5 text-muted-foreground whitespace-pre-wrap">
             {proposedComment}

--- a/ui/src/components/BlockedInboxView.tsx
+++ b/ui/src/components/BlockedInboxView.tsx
@@ -22,6 +22,7 @@ import { IssueRow } from "./IssueRow";
 import { Identity } from "./Identity";
 import { StatusIcon } from "./StatusIcon";
 import { Button } from "@/components/ui/button";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 interface BlockedInboxViewProps {
   companyId: string;
@@ -58,6 +59,7 @@ export function BlockedInboxView({
   showIdentifierColumn,
   showUpdatedColumn,
 }: BlockedInboxViewProps) {
+  const copy = useLocalizedCopy();
   const [collapsedVariants, setCollapsedVariants] = useState<Set<string>>(() => new Set());
 
   const {
@@ -136,7 +138,7 @@ export function BlockedInboxView({
 
   if (error) {
     const message =
-      error instanceof Error ? error.message : "Couldn't load the Blocked tab.";
+      error instanceof Error ? error.message : copy("inbox.blocked.loadFailed", "Couldn't load the Blocked tab.", "막힘 탭을 불러오지 못했습니다.");
     return (
       <div
         data-testid="blocked-inbox-error"
@@ -146,9 +148,9 @@ export function BlockedInboxView({
         <div className="flex items-start gap-2">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
           <div className="flex-1 space-y-1">
-            <p className="text-sm font-medium">Couldn't load the Blocked tab.</p>
+            <p className="text-sm font-medium">{copy("inbox.blocked.loadFailed", "Couldn't load the Blocked tab.", "막힘 탭을 불러오지 못했습니다.")}</p>
             <p className="text-xs opacity-80">
-              Other Inbox tabs still work. {message}
+              {copy("inbox.blocked.otherTabsWork", "Other Inbox tabs still work.", "다른 받은함 탭은 계속 사용할 수 있습니다.")} {message}
             </p>
           </div>
           <Button
@@ -159,7 +161,7 @@ export function BlockedInboxView({
             onClick={() => void refetch()}
             disabled={isFetching}
           >
-            {isFetching ? "Trying…" : "Try again"}
+            {isFetching ? copy("common.trying", "Trying...", "시도 중...") : copy("common.tryAgain", "Try again", "다시 시도")}
           </Button>
         </div>
       </div>
@@ -176,9 +178,9 @@ export function BlockedInboxView({
           <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
         </span>
         <div className="space-y-1">
-          <p className="text-sm font-medium text-foreground">No work is stopped.</p>
+          <p className="text-sm font-medium text-foreground">{copy("inbox.blocked.emptyTitle", "No work is stopped.", "멈춘 작업이 없습니다.")}</p>
           <p className="text-xs text-muted-foreground">
-            Issues that need a decision, recovery, or external action will appear here.
+            {copy("inbox.blocked.emptyBody", "Issues that need a decision, recovery, or external action will appear here.", "결정, 복구, 외부 조치가 필요한 작업이 여기에 표시됩니다.")}
           </p>
         </div>
       </div>
@@ -192,7 +194,7 @@ export function BlockedInboxView({
           data-testid="blocked-inbox-no-search-results"
           className="rounded-lg border border-border/70 bg-card/40 px-4 py-6 text-center text-sm text-muted-foreground"
         >
-          No stopped items match your search.
+          {copy("inbox.blocked.noSearchResults", "No stopped items match your search.", "검색과 일치하는 멈춘 항목이 없습니다.")}
         </div>
       </div>
     );

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { Identity } from "./Identity";
 import { agentUrl, projectUrl } from "../lib/utils";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 const SEARCH_ALL_VALUE = "__paperclip-search-all__";
 
@@ -41,6 +42,7 @@ export function buildFullSearchPath(query: string) {
 }
 
 export function CommandPalette() {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
@@ -121,7 +123,7 @@ export function CommandPalette() {
         if (v && isMobile) setSidebarOpen(false);
       }}>
       <CommandInput
-        placeholder="Search issues, agents, projects..."
+        placeholder={copy("commandPalette.placeholder", "Search issues, agents, projects...", "작업, 직원, 프로젝트 검색...")}
         value={query}
         onValueChange={setQuery}
         onKeyDown={(event) => {
@@ -135,17 +137,18 @@ export function CommandPalette() {
         <CommandEmpty>
           {showSearchAll ? (
             <span>
-              No quick issue matches. Press{" "}
+              {copy("commandPalette.noQuickMatchesPrefix", "No quick issue matches. Press", "빠른 작업 결과가 없습니다.")}
+              {" "}
               <kbd className="rounded border border-border bg-muted px-1 py-0.5 text-[10px]">↵</kbd>{" "}
-              to <span className="font-medium">search all</span> or keep typing to refine.
+              {copy("commandPalette.noQuickMatchesSuffix", "to search all or keep typing to refine.", "전체 검색을 열거나 계속 입력해 좁히세요.")}
             </span>
           ) : (
-            "No results found."
+            copy("commandPalette.noResults", "No results found.", "검색 결과가 없습니다.")
           )}
         </CommandEmpty>
 
         {showSearchAll ? (
-          <CommandGroup heading="Search">
+          <CommandGroup heading={copy("commandPalette.group.search", "Search", "검색")}>
             <CommandItem
               value={`${SEARCH_ALL_VALUE} ${searchQuery}`}
               onSelect={goFullSearch}
@@ -154,10 +157,10 @@ export function CommandPalette() {
             >
               <Search className="mr-2 h-4 w-4" />
               <span className="flex-1 truncate">
-                Search all for <span className="font-semibold">&ldquo;{searchQuery}&rdquo;</span>
+                {copy("commandPalette.searchAllFor", "Search all for", "전체 검색")} <span className="font-semibold">&ldquo;{searchQuery}&rdquo;</span>
               </span>
               <span className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground">
-                <span>open full search</span>
+                <span>{copy("commandPalette.openFullSearch", "open full search", "전체 검색 열기")}</span>
                 <kbd className="rounded border border-border bg-background px-1 py-0.5 text-[10px]">↵</kbd>
               </span>
             </CommandItem>
@@ -166,7 +169,7 @@ export function CommandPalette() {
 
         {showSearchAll ? <CommandSeparator /> : null}
 
-        <CommandGroup heading="Actions">
+        <CommandGroup heading={copy("commandPalette.group.actions", "Actions", "작업")}>
           <CommandItem
             onSelect={() => {
               setOpen(false);
@@ -174,7 +177,7 @@ export function CommandPalette() {
             }}
           >
             <SquarePen className="mr-2 h-4 w-4" />
-            Create new issue
+            {copy("commandPalette.createIssue", "Create new issue", "새 작업 만들기")}
             <span className="ml-auto text-xs text-muted-foreground">C</span>
           </CommandItem>
           <CommandItem
@@ -184,55 +187,55 @@ export function CommandPalette() {
             }}
           >
             <Plus className="mr-2 h-4 w-4" />
-            Create new agent
+            {copy("commandPalette.createAgent", "Create new agent", "새 직원 만들기")}
           </CommandItem>
           <CommandItem onSelect={() => go("/projects")}>
             <Plus className="mr-2 h-4 w-4" />
-            Create new project
+            {copy("commandPalette.createProject", "Create new project", "새 프로젝트 만들기")}
           </CommandItem>
         </CommandGroup>
 
         <CommandSeparator />
 
-        <CommandGroup heading="Pages">
+        <CommandGroup heading={copy("commandPalette.group.pages", "Pages", "페이지")}>
           <CommandItem onSelect={() => go("/dashboard")}>
             <LayoutDashboard className="mr-2 h-4 w-4" />
-            Dashboard
+            {copy("sidebar.nav.dashboard", "Dashboard", "대시보드")}
           </CommandItem>
           <CommandItem onSelect={() => go("/inbox")}>
             <Inbox className="mr-2 h-4 w-4" />
-            Inbox
+            {copy("sidebar.nav.inbox", "Inbox", "받은함")}
           </CommandItem>
           <CommandItem onSelect={() => go("/issues")}>
             <CircleDot className="mr-2 h-4 w-4" />
-            Issues
+            {copy("sidebar.nav.issues", "Issues", "작업")}
           </CommandItem>
           <CommandItem onSelect={() => go("/projects")}>
             <Hexagon className="mr-2 h-4 w-4" />
-            Projects
+            {copy("sidebar.nav.projects", "Projects", "프로젝트")}
           </CommandItem>
           <CommandItem onSelect={() => go("/goals")}>
             <Target className="mr-2 h-4 w-4" />
-            Goals
+            {copy("sidebar.nav.goals", "Goals", "목표")}
           </CommandItem>
           <CommandItem onSelect={() => go("/agents")}>
             <Bot className="mr-2 h-4 w-4" />
-            Agents
+            {copy("sidebar.nav.agents", "Agents", "직원")}
           </CommandItem>
           <CommandItem onSelect={() => go("/costs")}>
             <DollarSign className="mr-2 h-4 w-4" />
-            Costs
+            {copy("sidebar.nav.costs", "Costs", "비용")}
           </CommandItem>
           <CommandItem onSelect={() => go("/activity")}>
             <History className="mr-2 h-4 w-4" />
-            Activity
+            {copy("sidebar.nav.activity", "Activity", "활동")}
           </CommandItem>
         </CommandGroup>
 
         {visibleIssues.length > 0 && (
           <>
             <CommandSeparator />
-            <CommandGroup heading="Issues">
+            <CommandGroup heading={copy("commandPalette.group.issues", "Issues", "작업")}>
               {visibleIssues.slice(0, 10).map((issue) => (
                 <CommandItem
                   key={issue.id}
@@ -261,7 +264,7 @@ export function CommandPalette() {
         {agents.length > 0 && (
           <>
             <CommandSeparator />
-            <CommandGroup heading="Agents">
+            <CommandGroup heading={copy("commandPalette.group.agents", "Agents", "직원")}>
               {agents.slice(0, 10).map((agent) => (
                 <CommandItem key={agent.id} onSelect={() => go(agentUrl(agent))}>
                   <Bot className="mr-2 h-4 w-4" />
@@ -276,7 +279,7 @@ export function CommandPalette() {
         {projects.length > 0 && (
           <>
             <CommandSeparator />
-            <CommandGroup heading="Projects">
+            <CommandGroup heading={copy("commandPalette.group.projects", "Projects", "프로젝트")}>
               {projects.slice(0, 10).map((project) => (
                 <CommandItem key={project.id} onSelect={() => go(projectUrl(project))}>
                   <Hexagon className="mr-2 h-4 w-4" />

--- a/ui/src/components/GoalTree.tsx
+++ b/ui/src/components/GoalTree.tsx
@@ -4,6 +4,7 @@ import { StatusBadge } from "./StatusBadge";
 import { ChevronRight } from "lucide-react";
 import { cn } from "../lib/utils";
 import { useState } from "react";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 interface GoalTreeProps {
   goals: Goal[];
@@ -22,8 +23,15 @@ interface GoalNodeProps {
 
 function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalNodeProps) {
   const [expanded, setExpanded] = useState(true);
+  const copy = useLocalizedCopy();
   const hasChildren = children.length > 0;
   const link = goalLink?.(goal);
+  const levelLabels: Record<string, string> = {
+    company: copy("goal.level.company", "Company", "회사"),
+    team: copy("goal.level.team", "Team", "팀"),
+    agent: copy("goal.level.agent", "Agent", "직원"),
+    task: copy("goal.level.task", "Task", "작업"),
+  };
 
   const inner = (
     <>
@@ -43,7 +51,7 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
       ) : (
         <span className="w-4" />
       )}
-      <span className="text-xs text-muted-foreground capitalize">{goal.level}</span>
+      <span className="text-xs text-muted-foreground">{levelLabels[goal.level] ?? goal.level}</span>
       <span className="flex-1 truncate">{goal.title}</span>
       <StatusBadge status={goal.status} />
     </>
@@ -92,11 +100,12 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
 }
 
 export function GoalTree({ goals, goalLink, onSelect }: GoalTreeProps) {
+  const copy = useLocalizedCopy();
   const goalIds = new Set(goals.map((g) => g.id));
   const roots = goals.filter((g) => !g.parentId || !goalIds.has(g.parentId));
 
   if (goals.length === 0) {
-    return <p className="text-sm text-muted-foreground">No goals.</p>;
+    return <p className="text-sm text-muted-foreground">{copy("goalTree.empty", "No goals.", "목표가 없습니다.")}</p>;
   }
 
   return (

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -137,6 +137,8 @@ import { AlertTriangle, ArrowRight, Brain, Check, ChevronDown, ClipboardList, Co
 import { IssueBlockedNotice } from "./IssueBlockedNotice";
 import { IssueAssignedBacklogNotice } from "./IssueAssignedBacklogNotice";
 import { IssueRecoveryActionCard, type RecoveryResolveOutcome } from "./IssueRecoveryActionCard";
+import { useCurrentLocale } from "@/i18n/ui-copy";
+import { isKoreanLocale } from "@/i18n/locale-utils";
 
 interface IssueChatMessageContext {
   feedbackDataSharingPreference: FeedbackDataSharingPreference;
@@ -174,6 +176,7 @@ interface IssueChatMessageContext {
   ) => Promise<void> | void;
   issueStatus?: string;
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
+  locale?: string | null;
 }
 
 const IssueChatCtx = createContext<IssueChatMessageContext>({
@@ -181,6 +184,7 @@ const IssueChatCtx = createContext<IssueChatMessageContext>({
   feedbackTermsUrl: null,
   issueStatus: undefined,
   successfulRunHandoff: null,
+  locale: "en",
 });
 
 export function resolveAssistantMessageFoldedState(args: {
@@ -234,7 +238,7 @@ function findCoTSegmentIndex(
   return -1;
 }
 
-function useLiveElapsed(startMs: number | null | undefined, active: boolean): string | null {
+function useLiveElapsed(startMs: number | null | undefined, active: boolean, locale?: string | null): string | null {
   const [, rerender] = useState(0);
   useEffect(() => {
     if (!active || !startMs) return;
@@ -242,7 +246,7 @@ function useLiveElapsed(startMs: number | null | undefined, active: boolean): st
     return () => clearInterval(interval);
   }, [active, startMs]);
   if (!active || !startMs) return null;
-  return formatDurationWords(Date.now() - startMs);
+  return formatDurationWords(Date.now() - startMs, locale);
 }
 
 function useStableEvent<T extends (...args: never[]) => unknown>(callback: T | undefined): T | undefined {
@@ -347,6 +351,7 @@ interface IssueChatThreadProps {
   emptyMessage?: string;
   footer?: ReactNode;
   variant?: "full" | "embedded";
+  locale?: string | null;
   enableLiveTranscriptPolling?: boolean;
   transcriptsByRunId?: ReadonlyMap<string, readonly IssueChatTranscriptEntry[]>;
   hasOutputForRun?: (runId: string) => boolean;
@@ -626,11 +631,11 @@ function isUnassignedReassignValue(value: string): boolean {
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
-function commentDateLabel(date: Date | string | undefined): string {
+function commentDateLabel(date: Date | string | undefined, locale?: string | null): string {
   if (!date) return "";
   const then = new Date(date).getTime();
-  if (Date.now() - then < WEEK_MS) return timeAgo(date);
-  return formatShortDate(date);
+  if (Date.now() - then < WEEK_MS) return timeAgo(date, locale);
+  return formatShortDate(date, locale);
 }
 
 const IssueChatTextPart = memo(function IssueChatTextPart({ text, recessed }: { text: string; recessed?: boolean }) {
@@ -685,8 +690,20 @@ export function SuccessfulRunHandoffCommentCallout({
   );
 }
 
-function humanizeValue(value: string | null) {
-  if (!value) return "None";
+function humanizeValue(value: string | null, locale?: string | null) {
+  if (!value) return isKoreanLocale(locale) ? "없음" : "None";
+  if (isKoreanLocale(locale)) {
+    const labels: Record<string, string> = {
+      backlog: "대기",
+      todo: "할 일",
+      in_progress: "진행 중",
+      in_review: "검토 중",
+      blocked: "막힘",
+      done: "완료",
+      cancelled: "취소",
+    };
+    if (labels[value]) return labels[value];
+  }
   return value.replace(/_/g, " ");
 }
 
@@ -695,14 +712,15 @@ function formatTimelineAssigneeLabel(
   agentMap?: Map<string, Agent>,
   currentUserId?: string | null,
   userLabelMap?: ReadonlyMap<string, string> | null,
+  locale?: string | null,
 ) {
   if (assignee.agentId) {
     return agentMap?.get(assignee.agentId)?.name ?? assignee.agentId.slice(0, 8);
   }
   if (assignee.userId) {
-    return formatAssigneeUserLabel(assignee.userId, currentUserId, userLabelMap) ?? "Board";
+    return formatAssigneeUserLabel(assignee.userId, currentUserId, userLabelMap) ?? (isKoreanLocale(locale) ? "보드" : "Board");
   }
-  return "Unassigned";
+  return isKoreanLocale(locale) ? "미지정" : "Unassigned";
 }
 
 function initialsForName(name: string) {
@@ -750,7 +768,20 @@ export function resolveIssueChatHumanAuthor(args: {
   };
 }
 
-function formatRunStatusLabel(status: string) {
+function formatRunStatusLabel(status: string, locale?: string | null) {
+  if (isKoreanLocale(locale)) {
+    const labels: Record<string, string> = {
+      succeeded: "성공",
+      failed: "실패",
+      error: "오류",
+      timed_out: "시간 초과",
+      running: "실행 중",
+      queued: "대기 중",
+      pending: "대기 중",
+      cancelled: "취소됨",
+    };
+    return labels[status] ?? status.replace(/_/g, " ");
+  }
   switch (status) {
     case "timed_out":
       return "timed out";
@@ -812,7 +843,7 @@ function IssueChatChainOfThought({
   message: ThreadMessage;
   cotParts: readonly IssueChatCoTPart[];
 }) {
-  const { agentMap } = useContext(IssueChatCtx);
+  const { agentMap, locale } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const runAgentId = typeof custom.runAgentId === "string" ? custom.runAgentId : null;
   const authorAgentId = typeof custom.authorAgentId === "string" ? custom.authorAgentId : null;
@@ -840,7 +871,7 @@ function IssueChatChainOfThought({
     ? (custom.chainOfThoughtSegments as SegmentTiming[])
     : [];
   const segmentTiming = myIndex >= 0 ? rawSegments[myIndex] ?? null : null;
-  const liveElapsed = useLiveElapsed(segmentTiming?.startMs, isActive);
+  const liveElapsed = useLiveElapsed(segmentTiming?.startMs, isActive, locale);
 
   useEffect(() => {
     if (isActive) setExpanded(true);
@@ -849,15 +880,15 @@ function IssueChatChainOfThought({
   let headerVerb: string;
   let headerSuffix: string | null = null;
   if (isActive) {
-    headerVerb = "Working";
-    if (liveElapsed) headerSuffix = `for ${liveElapsed}`;
+    headerVerb = isKoreanLocale(locale) ? "작업 중" : "Working";
+    if (liveElapsed) headerSuffix = isKoreanLocale(locale) ? `${liveElapsed} 동안` : `for ${liveElapsed}`;
   } else if (segmentTiming) {
     const durationMs = segmentTiming.endMs - segmentTiming.startMs;
-    const durationText = formatDurationWords(durationMs);
-    headerVerb = "Worked";
-    if (durationText) headerSuffix = `for ${durationText}`;
+    const durationText = formatDurationWords(durationMs, locale);
+    headerVerb = isKoreanLocale(locale) ? "작업함" : "Worked";
+    if (durationText) headerSuffix = isKoreanLocale(locale) ? `${durationText} 동안` : `for ${durationText}`;
   } else {
-    headerVerb = "Worked";
+    headerVerb = isKoreanLocale(locale) ? "작업함" : "Worked";
   }
 
   const toolSummary = toolCountSummary(toolParts);
@@ -1273,6 +1304,7 @@ function IssueChatUserMessage({
     onCancelQueued,
     currentUserId,
     userProfileMap,
+    locale,
   } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
@@ -1371,11 +1403,11 @@ function IssueChatUserMessage({
                 href={anchorId ? `#${anchorId}` : undefined}
                 className="text-[11px] text-muted-foreground hover:text-foreground hover:underline"
               >
-                {message.createdAt ? commentDateLabel(message.createdAt) : ""}
+                {message.createdAt ? commentDateLabel(message.createdAt, locale) : ""}
               </a>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">
-              {message.createdAt ? formatDateTime(message.createdAt) : ""}
+              {message.createdAt ? formatDateTime(message.createdAt, locale) : ""}
             </TooltipContent>
           </Tooltip>
           <button
@@ -1437,10 +1469,13 @@ function IssueChatAssistantMessage({
     onVote,
     agentMap,
     onStopRun,
-    stopRunLabel = "Stop run",
-    stoppingRunLabel = "Stopping...",
+    stopRunLabel: configuredStopRunLabel,
+    stoppingRunLabel: configuredStoppingRunLabel,
     stopRunVariant = "stop",
+    locale,
   } = useContext(IssueChatCtx);
+  const stopRunLabel = configuredStopRunLabel ?? (isKoreanLocale(locale) ? "실행 중지" : "Stop run");
+  const stoppingRunLabel = configuredStoppingRunLabel ?? (isKoreanLocale(locale) ? "중지 중..." : "Stopping...");
   const custom = message.metadata.custom as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
   const authorName = typeof custom.authorName === "string"
@@ -1520,7 +1555,7 @@ function IssueChatAssistantMessage({
               <span className="ml-auto flex items-center gap-1.5">
                 {message.createdAt ? (
                   <span className="text-[11px] text-muted-foreground/50">
-                    {commentDateLabel(message.createdAt)}
+                    {commentDateLabel(message.createdAt, locale)}
                   </span>
                 ) : null}
                 <ChevronDown className={cn("h-3.5 w-3.5 text-muted-foreground/40 transition-transform", !folded && "rotate-180")} />
@@ -1531,13 +1566,13 @@ function IssueChatAssistantMessage({
               <span className="text-sm font-medium text-foreground">{authorName}</span>
               {followUpRequested ? (
                 <Badge variant="outline" className="text-[10px] uppercase tracking-[0.14em]">
-                  Follow-up
+                  {isKoreanLocale(locale) ? "후속" : "Follow-up"}
                 </Badge>
               ) : null}
               {isRunning ? (
                 <span className="inline-flex items-center gap-1 rounded-full border border-cyan-400/40 bg-cyan-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-cyan-700 dark:text-cyan-200">
                   <Loader2 className="h-3 w-3 animate-spin" />
-                  Running
+                  {isKoreanLocale(locale) ? "실행 중" : "Running"}
                 </span>
               ) : null}
             </div>
@@ -1577,8 +1612,8 @@ function IssueChatAssistantMessage({
                 <button
                   type="button"
                   className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  title="Copy message"
-                  aria-label="Copy message"
+                  title={isKoreanLocale(locale) ? "메시지 복사" : "Copy message"}
+                  aria-label={isKoreanLocale(locale) ? "메시지 복사" : "Copy message"}
                   onClick={() => {
                     void navigator.clipboard.writeText(copyText).then(() => {
                       setCopied(true);
@@ -1602,11 +1637,11 @@ function IssueChatAssistantMessage({
                       href={anchorId ? `#${anchorId}` : undefined}
                       className="text-[11px] text-muted-foreground hover:text-foreground hover:underline"
                     >
-                      {message.createdAt ? commentDateLabel(message.createdAt) : ""}
+                      {message.createdAt ? commentDateLabel(message.createdAt, locale) : ""}
                     </a>
                   </TooltipTrigger>
                   <TooltipContent side="bottom" className="text-xs">
-                    {message.createdAt ? formatDateTime(message.createdAt) : ""}
+                    {message.createdAt ? formatDateTime(message.createdAt, locale) : ""}
                   </TooltipContent>
                 </Tooltip>
                 <DropdownMenu>
@@ -1615,8 +1650,8 @@ function IssueChatAssistantMessage({
                       variant="ghost"
                       size="icon-xs"
                       className="text-muted-foreground hover:text-foreground"
-                      title="More actions"
-                      aria-label="More actions"
+                      title={isKoreanLocale(locale) ? "추가 작업" : "More actions"}
+                      aria-label={isKoreanLocale(locale) ? "추가 작업" : "More actions"}
                     >
                       <MoreHorizontal className="h-3.5 w-3.5" />
                     </Button>
@@ -1628,7 +1663,7 @@ function IssueChatAssistantMessage({
                       }}
                     >
                       <Copy className="mr-2 h-3.5 w-3.5" />
-                      Copy message
+                      {isKoreanLocale(locale) ? "메시지 복사" : "Copy message"}
                     </DropdownMenuItem>
                     {canStopRun && onStopRun && runId ? (
                       <DropdownMenuItem
@@ -1654,7 +1689,7 @@ function IssueChatAssistantMessage({
                       <DropdownMenuItem asChild>
                         <Link to={runHref} target="_blank" rel="noreferrer noopener">
                           <Search className="mr-2 h-3.5 w-3.5" />
-                          View run
+                          {isKoreanLocale(locale) ? "실행 보기" : "View run"}
                         </Link>
                       </DropdownMenuItem>
                     ) : null}
@@ -1905,6 +1940,7 @@ function ExpiredRequestConfirmationActivity({
     onAcceptInteraction,
     onRejectInteraction,
     onCancelInteraction,
+    locale,
   } = useContext(IssueChatCtx);
   const [expanded, setExpanded] = useState(false);
   const hasResolvedActor = Boolean(interaction.resolvedByAgentId || interaction.resolvedByUserId);
@@ -1930,12 +1966,12 @@ function ExpiredRequestConfirmationActivity({
     <div className="min-w-0 flex-1">
       <div className={cn("flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs", isCurrentUser && "justify-end")}>
         <span className="font-medium text-foreground">{actorName}</span>
-        <span className="text-muted-foreground">updated this task</span>
+        <span className="text-muted-foreground">{isKoreanLocale(locale) ? "이 작업을 수정함" : "updated this task"}</span>
         <a
           href={anchorId ? `#${anchorId}` : undefined}
           className="text-xs text-muted-foreground transition-colors hover:text-foreground hover:underline"
         >
-          {timeAgo(message.createdAt)}
+          {timeAgo(message.createdAt, locale)}
         </a>
         <button
           type="button"
@@ -1945,7 +1981,9 @@ function ExpiredRequestConfirmationActivity({
           onClick={() => setExpanded((current) => !current)}
         >
           <ChevronDown className={cn("h-3 w-3 transition-transform", expanded && "rotate-180")} />
-          {expanded ? "Hide confirmation" : "Expired confirmation"}
+          {expanded
+            ? (isKoreanLocale(locale) ? "확인 숨기기" : "Hide confirmation")
+            : (isKoreanLocale(locale) ? "만료된 확인" : "Expired confirmation")}
         </button>
       </div>
       {expanded ? (
@@ -2188,6 +2226,7 @@ function StaleDispositionWarningRow({
   runAgentId?: string | null;
 }) {
   const [open, setOpen] = useState(false);
+  const { locale } = useContext(IssueChatCtx);
   const detailsId = useId();
   const sections = mapCommentMetadataToSystemNoticeSections(metadata, { runAgentId });
 
@@ -2209,7 +2248,7 @@ function StaleDispositionWarningRow({
             <span className="ml-auto flex items-center gap-1.5">
               {message.createdAt ? (
                 <span data-testid="stale-disposition-warning-time" className="text-[11px] text-muted-foreground/50">
-                  {commentDateLabel(message.createdAt)}
+                  {commentDateLabel(message.createdAt, locale)}
                 </span>
               ) : null}
               <ChevronDown className={cn("h-3.5 w-3.5 text-muted-foreground/40 transition-transform", open && "rotate-180")} />
@@ -2231,7 +2270,7 @@ function SystemNoticeCommentRow({
   message: ThreadMessage;
   anchorId?: string;
 }) {
-  const { onImageClick, agentMap, issueStatus, successfulRunHandoff } = useContext(IssueChatCtx);
+  const { onImageClick, agentMap, issueStatus, successfulRunHandoff, locale } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const presentation = isIssueCommentPresentation(custom.presentation) ? custom.presentation : null;
   const commentMetadata = isIssueCommentMetadata(custom.commentMetadata) ? custom.commentMetadata : null;
@@ -2318,11 +2357,11 @@ function SystemNoticeCommentRow({
                 href={anchorId ? `#${anchorId}` : undefined}
                 className="text-[11px] text-muted-foreground hover:text-foreground hover:underline"
               >
-                {message.createdAt ? commentDateLabel(message.createdAt) : ""}
+                {message.createdAt ? commentDateLabel(message.createdAt, locale) : ""}
               </a>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">
-              {message.createdAt ? formatDateTime(message.createdAt) : ""}
+              {message.createdAt ? formatDateTime(message.createdAt, locale) : ""}
             </TooltipContent>
           </Tooltip>
           {anchorId ? (
@@ -2360,6 +2399,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
     onRejectInteraction,
     onSubmitInteractionAnswers,
     onCancelInteraction,
+    locale,
   } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
@@ -2432,38 +2472,40 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
         <div className={cn("flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-xs", isCurrentUser && "justify-end")}>
           <span className="font-medium text-foreground">{actorName}</span>
           <span className="text-muted-foreground">
-            {custom.followUpRequested === true ? "requested follow-up" : "updated this task"}
+            {custom.followUpRequested === true
+              ? (isKoreanLocale(locale) ? "후속 확인을 요청함" : "requested follow-up")
+              : (isKoreanLocale(locale) ? "이 작업을 수정함" : "updated this task")}
           </span>
           <a
             href={anchorId ? `#${anchorId}` : undefined}
             className="text-xs text-muted-foreground transition-colors hover:text-foreground hover:underline"
           >
-            {timeAgo(message.createdAt)}
+            {timeAgo(message.createdAt, locale)}
           </a>
         </div>
 
         {statusChange ? (
           <div className={cn("flex flex-wrap items-center gap-1.5 text-xs", isCurrentUser && "justify-end")}>
             <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Status
+              {isKoreanLocale(locale) ? "상태" : "Status"}
             </span>
-            <span className="text-muted-foreground">{humanizeValue(statusChange.from)}</span>
+            <span className="text-muted-foreground">{humanizeValue(statusChange.from, locale)}</span>
             <ArrowRight className="h-3 w-3 text-muted-foreground" />
-            <span className="font-medium text-foreground">{humanizeValue(statusChange.to)}</span>
+            <span className="font-medium text-foreground">{humanizeValue(statusChange.to, locale)}</span>
           </div>
         ) : null}
 
         {assigneeChange ? (
           <div className={cn("flex flex-wrap items-center gap-1.5 text-xs", isCurrentUser && "justify-end")}>
             <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Assignee
+              {isKoreanLocale(locale) ? "담당자" : "Assignee"}
             </span>
             <span className="text-muted-foreground">
-              {formatTimelineAssigneeLabel(assigneeChange.from, agentMap, currentUserId, userLabelMap)}
+              {formatTimelineAssigneeLabel(assigneeChange.from, agentMap, currentUserId, userLabelMap, locale)}
             </span>
             <ArrowRight className="h-3 w-3 text-muted-foreground" />
             <span className="font-medium text-foreground">
-              {formatTimelineAssigneeLabel(assigneeChange.to, agentMap, currentUserId, userLabelMap)}
+              {formatTimelineAssigneeLabel(assigneeChange.to, agentMap, currentUserId, userLabelMap, locale)}
             </span>
           </div>
         ) : null}
@@ -2532,7 +2574,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
               <Link to={`/agents/${runAgentId}`} className="font-medium text-foreground transition-colors hover:underline">
                 {displayedRunAgentName}
               </Link>
-              <span className="text-muted-foreground">run</span>
+              <span className="text-muted-foreground">{isKoreanLocale(locale) ? "실행" : "run"}</span>
               <Link
                 to={`/agents/${runAgentId}/runs/${runId}`}
                 className="inline-flex items-center rounded-md border border-border bg-accent/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
@@ -2540,13 +2582,13 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
                 {runId.slice(0, 8)}
               </Link>
               <span className={cn("font-medium", runStatusClass(runStatus))}>
-                {formatRunStatusLabel(runStatus)}
+                {formatRunStatusLabel(runStatus, locale)}
               </span>
               <a
                 href={anchorId ? `#${anchorId}` : undefined}
                 className="text-xs text-muted-foreground transition-colors hover:text-foreground hover:underline"
               >
-                {timeAgo(message.createdAt)}
+                {timeAgo(message.createdAt, locale)}
               </a>
             </div>
           </div>
@@ -3116,6 +3158,8 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
 }, forwardedRef) {
   const api = useAui();
   const toastActions = useOptionalToastActions();
+  const locale = useCurrentLocale();
+  const korean = isKoreanLocale(locale);
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [attaching, setAttaching] = useState(false);
@@ -3207,8 +3251,8 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
       && !unassignedConfirmed
     ) {
       toastActions?.pushToast({
-        title: "No assignee selected",
-        body: "Pick an assignee or click Send again to post without one.",
+        title: korean ? "담당자가 선택되지 않음" : "No assignee selected",
+        body: korean ? "담당자를 선택하거나 보내기를 다시 눌러 담당자 없이 게시하세요." : "Pick an assignee or click Send again to post without one.",
         tone: "warn",
         dedupeKey: `issue-chat-no-assignee:${draftKey ?? ""}`,
       });
@@ -3417,9 +3461,11 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
               <Paperclip className="h-4 w-4" />
             </span>
             <div className="min-w-0">
-              <div className="text-sm font-medium text-foreground">Drop to upload</div>
+              <div className="text-sm font-medium text-foreground">{korean ? "놓아서 업로드" : "Drop to upload"}</div>
               <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
-                Images insert into the reply. Other files are added to this issue.
+                {korean
+                  ? "이미지는 답장에 삽입되고 다른 파일은 이 작업에 첨부됩니다."
+                  : "Images insert into the reply. Other files are added to this issue."}
               </div>
             </div>
           </div>
@@ -3430,7 +3476,7 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
         ref={editorRef}
         value={body}
         onChange={setBody}
-        placeholder="Reply"
+        placeholder={korean ? "답장" : "Reply"}
         mentions={mentions}
         onSubmit={handleSubmit}
         imageUploadHandler={onImageUpload}
@@ -3454,12 +3500,12 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
             const sizeLabel = formatAttachmentSize(attachment.size);
             const statusLabel =
               attachment.status === "uploading"
-                ? "Uploading to issue"
+                ? (korean ? "작업에 업로드 중" : "Uploading to issue")
                 : attachment.status === "error"
-                  ? attachment.error ?? "Upload failed"
+                  ? attachment.error ?? (korean ? "업로드 실패" : "Upload failed")
                   : attachment.inline
-                    ? "Inserted inline"
-                    : "Attached to issue";
+                    ? (korean ? "본문에 삽입됨" : "Inserted inline")
+                    : (korean ? "작업에 첨부됨" : "Attached to issue");
             return (
               <div
                 key={attachment.id}
@@ -3505,7 +3551,7 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
                 size="icon-sm"
                 onClick={() => attachInputRef.current?.click()}
                 disabled={attaching}
-                title="Attach file"
+                title={korean ? "파일 첨부" : "Attach file"}
               >
                 <Paperclip className="h-4 w-4" />
               </Button>
@@ -3518,7 +3564,7 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
                   variant="ghost"
                   size="icon-sm"
                   data-testid="issue-chat-composer-work-mode-menu"
-                  title="More composer options"
+                  title={korean ? "작성 옵션 더 보기" : "More composer options"}
                 >
                   <MoreHorizontal className="h-4 w-4" />
                 </Button>
@@ -3542,7 +3588,9 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
                   ) : (
                     <ClipboardList className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-300" aria-hidden />
                   )}
-                  <span>{isPlanning ? "Switch to standard" : "Switch to planning"}</span>
+                  <span>{isPlanning
+                    ? (korean ? "표준 모드로 전환" : "Switch to standard")
+                    : (korean ? "계획 모드로 전환" : "Switch to planning")}</span>
                 </button>
               </PopoverContent>
             </Popover>
@@ -3553,12 +3601,14 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
               data-testid="issue-chat-composer-work-mode-toggle"
               data-pending-work-mode={pendingWorkMode}
               aria-pressed
-              title="Planning mode is on for this submission. Click to switch to Standard."
+              title={korean
+                ? "이번 전송은 계획 모드입니다. 표준으로 전환하려면 클릭하세요."
+                : "Planning mode is on for this submission. Click to switch to Standard."}
               onClick={() => setPendingWorkMode("standard")}
               className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/60 bg-amber-500/15 px-2 py-1 text-xs text-amber-800 transition-colors hover:bg-amber-500/25 dark:border-amber-500/50 dark:bg-amber-500/15 dark:text-amber-200 dark:hover:bg-amber-500/25"
             >
               <ClipboardList className="h-3.5 w-3.5" aria-hidden />
-              <span>Planning</span>
+              <span>{korean ? "계획" : "Planning"}</span>
             </button>
           ) : null}
         </div>
@@ -3567,14 +3617,14 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
           <InlineEntitySelector
             value={reassignTarget}
             options={reassignOptions}
-            placeholder="Assignee"
-            noneLabel="No assignee"
-            searchPlaceholder="Search assignees..."
-            emptyMessage="No assignees found."
+            placeholder={korean ? "담당자" : "Assignee"}
+            noneLabel={korean ? "담당자 없음" : "No assignee"}
+            searchPlaceholder={korean ? "담당자 검색..." : "Search assignees..."}
+            emptyMessage={korean ? "담당자를 찾을 수 없습니다." : "No assignees found."}
             onChange={setReassignTarget}
             className="h-8 text-xs"
             renderTriggerValue={(option) => {
-              if (!option) return <span className="text-muted-foreground">Assignee</span>;
+              if (!option) return <span className="text-muted-foreground">{korean ? "담당자" : "Assignee"}</span>;
               const agentId = option.id.startsWith("agent:") ? option.id.slice("agent:".length) : null;
               const agent = agentId ? agentMap?.get(agentId) : null;
               return (
@@ -3603,7 +3653,7 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
         ) : null}
 
         <Button size="sm" disabled={!canSubmit} onClick={() => void handleSubmit()}>
-          {submitting ? "Posting..." : "Send"}
+          {submitting ? (korean ? "게시 중..." : "Posting...") : (korean ? "보내기" : "Send")}
         </Button>
       </div>
     </div>
@@ -3658,6 +3708,7 @@ export function IssueChatThread({
   emptyMessage,
   footer,
   variant = "full",
+  locale: localeProp,
   enableLiveTranscriptPolling = true,
   transcriptsByRunId,
   hasOutputForRun: hasOutputForRunOverride,
@@ -3679,6 +3730,8 @@ export function IssueChatThread({
   onResumeFromBacklog,
   resumeFromBacklogPending = false,
 }: IssueChatThreadProps) {
+  const currentLocale = useCurrentLocale();
+  const locale = localeProp ?? currentLocale;
   const location = useLocation();
   const lastScrolledHashRef = useRef<string | null>(null);
   const virtualizedThreadRef = useRef<VirtualizedIssueChatThreadListHandle | null>(null);
@@ -3766,6 +3819,7 @@ export function IssueChatThread({
         agentMap,
         currentUserId,
         userLabelMap,
+        locale,
       }),
     [
       comments,
@@ -3782,6 +3836,7 @@ export function IssueChatThread({
       agentMap,
       currentUserId,
       userLabelMap,
+      locale,
     ],
   );
   const stableMessagesRef = useRef<readonly ThreadMessage[]>([]);
@@ -4157,6 +4212,7 @@ export function IssueChatThread({
       onCancelInteraction: stableOnCancelInteraction,
       issueStatus,
       successfulRunHandoff,
+      locale,
     }),
     [
       feedbackDataSharingPreference,
@@ -4179,14 +4235,15 @@ export function IssueChatThread({
       stableOnCancelInteraction,
       issueStatus,
       successfulRunHandoff,
+      locale,
     ],
   );
 
   const resolvedShowJumpToLatest = showJumpToLatest ?? variant === "full";
   const resolvedEmptyMessage = emptyMessage
     ?? (variant === "embedded"
-      ? "No run output yet."
-      : "This issue conversation is empty. Start with a message below.");
+      ? (isKoreanLocale(locale) ? "아직 실행 출력이 없습니다." : "No run output yet.")
+      : (isKoreanLocale(locale) ? "아직 대화가 없습니다. 아래에 메시지를 입력하세요." : "This issue conversation is empty. Start with a message below."));
   const previousErrorBoundaryMessagesRef = useRef<readonly ThreadMessage[] | null>(null);
   const errorBoundaryResetVersionRef = useRef(0);
   if (previousErrorBoundaryMessagesRef.current !== messages) {
@@ -4206,7 +4263,7 @@ export function IssueChatThread({
               onClick={handleJumpToLatest}
               className="text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
-              Jump to latest
+              {isKoreanLocale(locale) ? "최신으로 이동" : "Jump to latest"}
             </button>
           </div>
         ) : null}

--- a/ui/src/components/IssueColumns.tsx
+++ b/ui/src/components/IssueColumns.tsx
@@ -17,35 +17,44 @@ import { formatAssigneeUserLabel } from "../lib/assignees";
 import type { InboxIssueColumn } from "../lib/inbox";
 import { cn } from "../lib/utils";
 import { timeAgo } from "../lib/timeAgo";
+import { isKoreanLocale } from "@/i18n/locale-utils";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 import { Identity } from "./Identity";
 import { StatusIcon } from "./StatusIcon";
 
 export const issueTrailingColumns: InboxIssueColumn[] = ["assignee", "project", "workspace", "parent", "labels", "updated"];
 
-const issueColumnLabels: Record<InboxIssueColumn, string> = {
-  status: "Status",
-  id: "ID",
-  assignee: "Assignee",
-  project: "Project",
-  workspace: "Workspace",
-  parent: "Parent issue",
-  labels: "Tags",
-  updated: "Last updated",
-};
+function issueColumnLabel(column: InboxIssueColumn, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<InboxIssueColumn, string> = {
+    status: copy("issueColumns.status", "Status", "상태"),
+    id: copy("issueColumns.id", "ID", "ID"),
+    assignee: copy("issueColumns.assignee", "Assignee", "담당자"),
+    project: copy("issueColumns.project", "Project", "프로젝트"),
+    workspace: copy("issueColumns.workspace", "Workspace", "작업공간"),
+    parent: copy("issueColumns.parent", "Parent issue", "상위 작업"),
+    labels: copy("issueColumns.labels", "Tags", "태그"),
+    updated: copy("issueColumns.updated", "Last updated", "최근 수정"),
+  };
+  return labels[column];
+}
 
-const issueColumnDescriptions: Record<InboxIssueColumn, string> = {
-  status: "Issue state chip on the left edge.",
-  id: "Ticket identifier like PAP-1009.",
-  assignee: "Assigned agent or board user.",
-  project: "Linked project pill with its color.",
-  workspace: "Execution or project workspace used for the issue.",
-  parent: "Parent issue identifier and title.",
-  labels: "Issue labels and tags.",
-  updated: "Latest visible activity time.",
-};
+function issueColumnDescription(column: InboxIssueColumn, copy: ReturnType<typeof useLocalizedCopy>) {
+  const descriptions: Record<InboxIssueColumn, string> = {
+    status: copy("issueColumns.statusDesc", "Issue state chip on the left edge.", "왼쪽 상태 표시 칩입니다."),
+    id: copy("issueColumns.idDesc", "Ticket identifier like PAP-1009.", "PAP-1009 같은 작업 식별자입니다."),
+    assignee: copy("issueColumns.assigneeDesc", "Assigned agent or board user.", "배정된 직원 또는 보드 사용자입니다."),
+    project: copy("issueColumns.projectDesc", "Linked project pill with its color.", "연결된 프로젝트와 색상 표시입니다."),
+    workspace: copy("issueColumns.workspaceDesc", "Execution or project workspace used for the issue.", "작업에 사용된 실행/프로젝트 작업공간입니다."),
+    parent: copy("issueColumns.parentDesc", "Parent issue identifier and title.", "상위 작업 식별자와 제목입니다."),
+    labels: copy("issueColumns.labelsDesc", "Issue labels and tags.", "작업 라벨과 태그입니다."),
+    updated: copy("issueColumns.updatedDesc", "Latest visible activity time.", "최근 표시 가능한 활동 시간입니다."),
+  };
+  return descriptions[column];
+}
 
-export function issueActivityText(issue: Issue): string {
-  return `Updated ${timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt)}`;
+export function issueActivityText(issue: Issue, locale?: string | null): string {
+  const value = timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt, locale);
+  return isKoreanLocale(locale) ? `${value} 수정` : `Updated ${value}`;
 }
 
 function issueTrailingGridTemplate(columns: InboxIssueColumn[]): string {
@@ -76,6 +85,8 @@ export function IssueColumnPicker({
   title: string;
   iconOnly?: boolean;
 }) {
+  const copy = useLocalizedCopy();
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -84,17 +95,17 @@ export function IssueColumnPicker({
           variant={iconOnly ? "outline" : "ghost"}
           size={iconOnly ? "icon" : "sm"}
           className={iconOnly ? "h-8 w-8 shrink-0" : "hidden h-8 shrink-0 px-2 text-xs sm:inline-flex"}
-          title="Columns"
+          title={copy("issueColumns.columns", "Columns", "열")}
         >
           <Columns3 className={iconOnly ? "h-3.5 w-3.5" : "mr-1 h-3.5 w-3.5"} />
-          {!iconOnly && "Columns"}
+          {!iconOnly && copy("issueColumns.columns", "Columns", "열")}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[300px] rounded-xl border-border/70 p-1.5 shadow-xl shadow-black/10">
         <DropdownMenuLabel className="px-2 pb-1 pt-1.5">
           <div className="space-y-1">
             <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-              Desktop issue rows
+              {copy("issueColumns.desktopRows", "Desktop issue rows", "데스크톱 작업 행")}
             </div>
             <div className="text-sm font-medium text-foreground">
               {title}
@@ -112,10 +123,10 @@ export function IssueColumnPicker({
           >
             <span className="flex flex-col gap-0.5">
               <span className="text-sm font-medium text-foreground">
-                {issueColumnLabels[column]}
+                {issueColumnLabel(column, copy)}
               </span>
               <span className="text-xs leading-relaxed text-muted-foreground">
-                {issueColumnDescriptions[column]}
+                {issueColumnDescription(column, copy)}
               </span>
             </span>
           </DropdownMenuCheckboxItem>
@@ -125,7 +136,7 @@ export function IssueColumnPicker({
           onSelect={onResetColumns}
           className="rounded-lg px-3 py-2 text-sm"
         >
-          Reset defaults
+          {copy("issueColumns.resetDefaults", "Reset defaults", "기본값 복원")}
           <span className="ml-auto text-xs text-muted-foreground">status, id, updated</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
@@ -148,6 +159,8 @@ export function InboxIssueMetaLeading({
   statusSlot?: ReactNode;
   checklistStepNumber?: number | string | null;
 }) {
+  const copy = useLocalizedCopy();
+
   return (
     <>
       {showStatus ? (
@@ -187,7 +200,7 @@ export function InboxIssueMetaLeading({
               "text-blue-600 dark:text-blue-400",
             )}
           >
-            Live
+            {copy("common.live", "Live", "실행 중")}
           </span>
         </span>
       )}
@@ -226,8 +239,10 @@ export function InboxIssueTrailingColumns({
   assigneeContent?: ReactNode;
   onFilterWorkspace?: (workspaceId: string) => void;
 }) {
-  const activityText = timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt);
-  const userLabel = assigneeUserName ?? formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? "User";
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
+  const activityText = timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt, locale);
+  const userLabel = assigneeUserName ?? formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? copy("common.user", "User", "사용자");
 
   return (
     <span
@@ -267,7 +282,7 @@ export function InboxIssueTrailingColumns({
 
           return (
             <span key={column} className="min-w-0 truncate text-xs text-muted-foreground">
-              Unassigned
+              {copy("issues.group.unassigned", "Unassigned", "미지정")}
             </span>
           );
         }
@@ -292,7 +307,7 @@ export function InboxIssueTrailingColumns({
 
           return (
             <span key={column} className="min-w-0 truncate text-xs text-muted-foreground">
-              No project
+              {copy("issues.group.noProject", "No project", "프로젝트 없음")}
             </span>
           );
         }
@@ -349,7 +364,7 @@ export function InboxIssueTrailingColumns({
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="top" sideOffset={6}>
-                    Filter by workspace
+                    {copy("issues.workspace.filter", "Filter by workspace", "작업공간으로 필터")}
                   </TooltipContent>
                 </Tooltip>
               ) : (
@@ -369,7 +384,7 @@ export function InboxIssueTrailingColumns({
               {parentIdentifier ? (
                 <span className="font-mono">{parentIdentifier}</span>
               ) : (
-                <span className="italic">Sub-issue</span>
+                <span className="italic">{copy("issues.subIssue", "Sub-issue", "하위 작업")}</span>
               )}
             </span>
           );

--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@paperclipai/shared";
 import { isSystemIssueDocumentKey } from "@paperclipai/shared";
 import { useLocation } from "@/lib/router";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 import { ApiError } from "../api/client";
 import { issuesApi } from "../api/issues";
 import { useAutosaveIndicator } from "../hooks/useAutosaveIndicator";
@@ -169,6 +170,7 @@ export function IssueDocumentsSection({
 }) {
   const queryClient = useQueryClient();
   const location = useLocation();
+  const copy = useLocalizedCopy();
   const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [draft, setDraft] = useState<DraftState | null>(null);
@@ -734,19 +736,21 @@ export function IssueDocumentsSection({
           {extraActions}
           <Button variant="outline" size="sm" onClick={beginNewDocument} className="shrink-0">
             <Plus className="mr-1.5 h-3.5 w-3.5" />
-            <span className="hidden sm:inline">New document</span>
-            <span className="sm:hidden">New</span>
+            <span className="hidden sm:inline">{copy("issueDocuments.new", "New document", "새 문서")}</span>
+            <span className="sm:hidden">{copy("issueDocuments.newShort", "New", "새로 만들기")}</span>
           </Button>
         </div>
       ) : (
         <div className="flex flex-wrap items-center gap-2 min-w-0">
-          <h3 className="w-full text-sm font-medium text-muted-foreground shrink-0 sm:w-auto">Documents</h3>
+          <h3 className="w-full text-sm font-medium text-muted-foreground shrink-0 sm:w-auto">
+            {copy("issueDocuments.title", "Documents", "문서")}
+          </h3>
           <div className="flex flex-wrap items-center gap-2 min-w-0 sm:ml-auto">
             {extraActions}
             <Button variant="outline" size="sm" onClick={beginNewDocument} className="shrink-0">
               <Plus className="mr-1.5 h-3.5 w-3.5" />
-              <span className="hidden sm:inline">New document</span>
-              <span className="sm:hidden">New</span>
+              <span className="hidden sm:inline">{copy("issueDocuments.new", "New document", "새 문서")}</span>
+              <span className="sm:hidden">{copy("issueDocuments.newShort", "New", "새로 만들기")}</span>
             </Button>
           </div>
         </div>
@@ -766,7 +770,7 @@ export function IssueDocumentsSection({
             onChange={(event) =>
               setDraft((current) => current ? { ...current, key: event.target.value.toLowerCase() } : current)
             }
-            placeholder="Document key"
+            placeholder={copy("issueDocuments.keyPlaceholder", "Document key", "문서 키")}
           />
           {newDocumentKeyError && (
             <p className="text-xs text-destructive">{newDocumentKeyError}</p>
@@ -777,7 +781,7 @@ export function IssueDocumentsSection({
               onChange={(event) =>
                 setDraft((current) => current ? { ...current, title: event.target.value } : current)
               }
-              placeholder="Optional title"
+              placeholder={copy("issueDocuments.titlePlaceholder", "Optional title", "선택 제목")}
             />
           )}
           <MarkdownEditor
@@ -785,7 +789,7 @@ export function IssueDocumentsSection({
             onChange={(body) =>
               setDraft((current) => current ? { ...current, body } : current)
             }
-            placeholder="Markdown body"
+            placeholder={copy("issueDocuments.bodyPlaceholder", "Markdown body", "마크다운 본문")}
             bordered={false}
             className="bg-transparent"
             contentClassName="min-h-[220px] text-[15px] leading-7"
@@ -796,14 +800,16 @@ export function IssueDocumentsSection({
           <div className="flex items-center justify-end gap-2">
             <Button variant="outline" size="sm" onClick={cancelDraft}>
               <X className="mr-1.5 h-3.5 w-3.5" />
-              Cancel
+              {copy("common.cancel", "Cancel", "취소")}
             </Button>
             <Button
               size="sm"
               onClick={() => void commitDraft(draft, { clearAfterSave: false, trackAutosave: false })}
               disabled={upsertDocument.isPending}
             >
-              {upsertDocument.isPending ? "Saving..." : "Create document"}
+              {upsertDocument.isPending
+                ? copy("common.saving", "Saving...", "저장 중...")
+                : copy("issueDocuments.create", "Create document", "문서 만들기")}
             </Button>
           </div>
         </div>

--- a/ui/src/components/IssueFiltersPopover.tsx
+++ b/ui/src/components/IssueFiltersPopover.tsx
@@ -7,6 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Bot, Filter, HardDrive, Search, User, X } from "lucide-react";
 import { PriorityIcon } from "./PriorityIcon";
 import { StatusIcon } from "./StatusIcon";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 import {
   defaultIssueFilterState,
   issueFilterArraysEqual,
@@ -47,6 +48,25 @@ type CreatorOption = {
   searchText?: string;
 };
 
+function issueFilterValueLabel(value: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    all: copy("issues.quickFilter.all", "All", "전체"),
+    active: copy("issues.quickFilter.active", "Active", "활성"),
+    backlog: copy("status.backlog", "Backlog", "대기"),
+    done: copy("status.done", "Done", "완료"),
+    todo: copy("status.todo", "Todo", "할 일"),
+    in_progress: copy("status.inProgress", "In progress", "진행 중"),
+    in_review: copy("status.inReview", "In review", "검토 중"),
+    blocked: copy("status.blocked", "Blocked", "막힘"),
+    cancelled: copy("status.cancelled", "Cancelled", "취소"),
+    critical: copy("priority.critical", "Critical", "긴급"),
+    high: copy("priority.high", "High", "높음"),
+    medium: copy("priority.medium", "Medium", "보통"),
+    low: copy("priority.low", "Low", "낮음"),
+  };
+  return labels[value.toLowerCase()] ?? issueFilterLabel(value);
+}
+
 export function IssueFiltersPopover({
   state,
   onChange,
@@ -74,6 +94,7 @@ export function IssueFiltersPopover({
   workspaces?: WorkspaceOption[];
   creators?: CreatorOption[];
 }) {
+  const copy = useLocalizedCopy();
   const [creatorSearch, setCreatorSearch] = useState("");
   const creatorOptions = creators ?? [];
   const creatorOptionById = useMemo(
@@ -108,9 +129,15 @@ export function IssueFiltersPopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant={buttonVariant} size={iconOnly ? "icon" : "sm"} className={`text-xs ${iconOnly ? "relative h-8 w-8 shrink-0" : ""} ${activeFilterCount > 0 ? "text-blue-600 dark:text-blue-400" : ""}`} title={iconOnly ? (activeFilterCount > 0 ? `Filters: ${activeFilterCount}` : "Filter") : undefined}>
+        <Button
+          variant={buttonVariant}
+          size={iconOnly ? "icon" : "sm"}
+          className={`text-xs ${iconOnly ? "relative h-8 w-8 shrink-0" : ""} ${activeFilterCount > 0 ? "text-blue-600 dark:text-blue-400" : ""}`}
+          title={iconOnly ? (activeFilterCount > 0 ? copy("issues.filter.count", "Filters: {{count}}", "필터: {{count}}개", { count: activeFilterCount }) : copy("issues.filter.title", "Filter", "필터")) : undefined}
+          aria-label={iconOnly ? copy("issues.filter.title", "Filter", "필터") : undefined}
+        >
           <Filter className={iconOnly ? "h-3.5 w-3.5" : "h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1"} />
-          {!iconOnly && <span className="hidden sm:inline">{activeFilterCount > 0 ? `Filters: ${activeFilterCount}` : "Filter"}</span>}
+          {!iconOnly && <span className="hidden sm:inline">{activeFilterCount > 0 ? copy("issues.filter.count", "Filters: {{count}}", "필터: {{count}}개", { count: activeFilterCount }) : copy("issues.filter.title", "Filter", "필터")}</span>}
           {!iconOnly && activeFilterCount > 0 ? <span className="ml-0.5 text-[10px] font-medium sm:hidden">{activeFilterCount}</span> : null}
           {iconOnly && activeFilterCount > 0 ? <span className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-blue-600 text-[9px] font-bold text-white">{activeFilterCount}</span> : null}
           {!iconOnly && activeFilterCount > 0 ? (
@@ -130,20 +157,20 @@ export function IssueFiltersPopover({
       >
         <div className="space-y-3 p-3">
           <div className="flex items-center justify-between">
-            <span className="text-sm font-medium">Filters</span>
+            <span className="text-sm font-medium">{copy("issues.filters.title", "Filters", "필터")}</span>
             {activeFilterCount > 0 ? (
               <button
                 type="button"
                 className="text-xs text-muted-foreground hover:text-foreground"
                 onClick={() => onChange(defaultIssueFilterState)}
               >
-                Clear
+                {copy("common.clear", "Clear", "초기화")}
               </button>
             ) : null}
           </div>
 
           <div className="space-y-1.5">
-            <span className="text-xs text-muted-foreground">Quick filters</span>
+            <span className="text-xs text-muted-foreground">{copy("issues.filters.quick", "Quick filters", "빠른 필터")}</span>
             <div className="flex flex-wrap gap-1.5">
               {issueQuickFilterPresets.map((preset) => {
                 const isActive = issueFilterArraysEqual(state.statuses, preset.statuses);
@@ -158,7 +185,7 @@ export function IssueFiltersPopover({
                     }`}
                     onClick={() => onChange({ statuses: isActive ? [] : [...preset.statuses] })}
                   >
-                    {preset.label}
+                    {issueFilterValueLabel(preset.label, copy)}
                   </button>
                 );
               })}
@@ -170,7 +197,7 @@ export function IssueFiltersPopover({
           <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
             <div className="min-w-0 space-y-3">
               <div className="space-y-1">
-                <span className="text-xs text-muted-foreground">Status</span>
+                <span className="text-xs text-muted-foreground">{copy("issues.filters.status", "Status", "상태")}</span>
                 <div className="space-y-0.5">
                   {issueStatusOrder.map((status) => (
                     <label key={status} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -179,14 +206,14 @@ export function IssueFiltersPopover({
                         onCheckedChange={() => onChange({ statuses: toggleIssueFilterValue(state.statuses, status) })}
                       />
                       <StatusIcon status={status} />
-                      <span className="text-sm">{issueFilterLabel(status)}</span>
+                      <span className="text-sm">{issueFilterValueLabel(status, copy)}</span>
                     </label>
                   ))}
                 </div>
               </div>
 
               <div className="space-y-1">
-                <span className="text-xs text-muted-foreground">Priority</span>
+                <span className="text-xs text-muted-foreground">{copy("issues.filters.priority", "Priority", "우선순위")}</span>
                 <div className="space-y-0.5">
                   {issuePriorityOrder.map((priority) => (
                     <label key={priority} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -195,7 +222,7 @@ export function IssueFiltersPopover({
                         onCheckedChange={() => onChange({ priorities: toggleIssueFilterValue(state.priorities, priority) })}
                       />
                       <PriorityIcon priority={priority} />
-                      <span className="text-sm">{issueFilterLabel(priority)}</span>
+                      <span className="text-sm">{issueFilterValueLabel(priority, copy)}</span>
                     </label>
                   ))}
                 </div>
@@ -204,14 +231,14 @@ export function IssueFiltersPopover({
 
             <div className="min-w-0 space-y-3">
               <div className="space-y-1">
-                <span className="text-xs text-muted-foreground">Assignee</span>
+                <span className="text-xs text-muted-foreground">{copy("issues.filters.assignee", "Assignee", "담당자")}</span>
                 <div className="max-h-32 space-y-0.5 overflow-y-auto">
                   <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                     <Checkbox
                       checked={state.assignees.includes("__unassigned")}
                       onCheckedChange={() => onChange({ assignees: toggleIssueFilterValue(state.assignees, "__unassigned") })}
                     />
-                    <span className="text-sm">No assignee</span>
+                    <span className="text-sm">{copy("issues.assignee.none", "No assignee", "담당자 없음")}</span>
                   </label>
                   {currentUserId ? (
                     <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -220,7 +247,7 @@ export function IssueFiltersPopover({
                         onCheckedChange={() => onChange({ assignees: toggleIssueFilterValue(state.assignees, "__me") })}
                       />
                       <User className="h-3.5 w-3.5 text-muted-foreground" />
-                      <span className="text-sm">Me</span>
+                      <span className="text-sm">{copy("common.me", "Me", "나")}</span>
                     </label>
                   ) : null}
                   {(agents ?? []).map((agent) => (
@@ -237,7 +264,7 @@ export function IssueFiltersPopover({
 
               {creatorOptions.length > 0 ? (
                 <div className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Creator</span>
+                  <span className="text-xs text-muted-foreground">{copy("issues.filters.creator", "Creator", "생성자")}</span>
                   {selectedCreatorOptions.length > 0 ? (
                     <div className="flex flex-wrap gap-1">
                       {selectedCreatorOptions.map((creator) => (
@@ -248,7 +275,7 @@ export function IssueFiltersPopover({
                             type="button"
                             className="rounded-full p-0.5 hover:bg-accent"
                             onClick={() => onChange({ creators: state.creators.filter((value) => value !== creator.id) })}
-                            aria-label={`Remove creator ${creator.label}`}
+                            aria-label={copy("issues.creator.remove", "Remove creator {{label}}", "생성자 {{label}} 제거", { label: creator.label })}
                           >
                             <X className="h-3 w-3" />
                           </button>
@@ -261,7 +288,7 @@ export function IssueFiltersPopover({
                     <Input
                       value={creatorSearch}
                       onChange={(event) => setCreatorSearch(event.target.value)}
-                      placeholder="Search creators..."
+                      placeholder={copy("issues.creator.search", "Search creators...", "생성자 검색...")}
                       className="h-8 pl-7 text-xs"
                     />
                   </div>
@@ -283,7 +310,7 @@ export function IssueFiltersPopover({
                         </button>
                       );
                     }) : (
-                      <div className="px-2 py-1 text-xs text-muted-foreground">No creators match.</div>
+                      <div className="px-2 py-1 text-xs text-muted-foreground">{copy("issues.creator.noMatch", "No creators match.", "일치하는 생성자가 없습니다.")}</div>
                     )}
                   </div>
                 </div>
@@ -291,7 +318,7 @@ export function IssueFiltersPopover({
 
               {projects && projects.length > 0 ? (
                 <div className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Project</span>
+                  <span className="text-xs text-muted-foreground">{copy("issues.filters.project", "Project", "프로젝트")}</span>
                   <div className="max-h-32 space-y-0.5 overflow-y-auto">
                     {projects.map((project) => (
                       <label key={project.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -310,7 +337,7 @@ export function IssueFiltersPopover({
             <div className="min-w-0 space-y-3">
               {labels && labels.length > 0 ? (
                 <div className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Labels</span>
+                  <span className="text-xs text-muted-foreground">{copy("issues.filters.labels", "Labels", "라벨")}</span>
                   <div className="max-h-32 space-y-0.5 overflow-y-auto">
                     {labels.map((label) => (
                       <label key={label.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -328,7 +355,7 @@ export function IssueFiltersPopover({
 
               {workspaces && workspaces.length > 0 ? (
                 <div className="space-y-1">
-                  <span className="text-xs text-muted-foreground">Workspace</span>
+                  <span className="text-xs text-muted-foreground">{copy("issues.filters.workspace", "Workspace", "작업공간")}</span>
                   <div className="max-h-32 space-y-0.5 overflow-y-auto">
                     {workspaces.map((workspace) => (
                       <label key={workspace.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -345,13 +372,13 @@ export function IssueFiltersPopover({
               ) : null}
 
               <div className="space-y-1">
-                <span className="text-xs text-muted-foreground">Visibility</span>
+                <span className="text-xs text-muted-foreground">{copy("issues.filters.visibility", "Visibility", "표시")}</span>
                 <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                   <Checkbox
                     checked={state.liveOnly}
                     onCheckedChange={(checked) => onChange({ liveOnly: checked === true })}
                   />
-                  <span className="text-sm">Live runs only</span>
+                  <span className="text-sm">{copy("issues.filters.liveOnly", "Live runs only", "실행 중인 작업만")}</span>
                 </label>
                 {enableRoutineVisibilityFilter ? (
                   <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
@@ -359,7 +386,7 @@ export function IssueFiltersPopover({
                       checked={state.hideRoutineExecutions}
                       onCheckedChange={(checked) => onChange({ hideRoutineExecutions: checked === true })}
                     />
-                    <span className="text-sm">Hide routine runs</span>
+                    <span className="text-sm">{copy("issues.filters.hideRoutineRuns", "Hide routine runs", "루틴 실행 숨기기")}</span>
                   </label>
                 ) : null}
               </div>

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -15,6 +15,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IssueProperties } from "./IssueProperties";
+import { i18n } from "@/i18n";
 
 const mockAgentsApi = vi.hoisted(() => ({
   list: vi.fn(),
@@ -363,7 +364,8 @@ function renderProperties(container: HTMLDivElement, props: ComponentProps<typeo
 describe("IssueProperties", () => {
   let container: HTMLDivElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     container = document.createElement("div");
     document.body.appendChild(container);
     mockAgentsApi.list.mockResolvedValue([]);
@@ -380,7 +382,8 @@ describe("IssueProperties", () => {
     mockAuthApi.getSession.mockResolvedValue({ user: { id: "user-1" } });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await i18n.changeLanguage("en");
     document.body.innerHTML = "";
   });
 
@@ -643,6 +646,45 @@ describe("IssueProperties", () => {
     expect(container.textContent).toMatch(/CreatedApr 6, 2026, \d{1,2}:34 (AM|PM)/);
     expect(container.textContent).toMatch(/StartedApr 6, 2026, \d{1,2}:35 (AM|PM)/);
     expect(container.textContent).toMatch(/CompletedApr 6, 2026, \d{1,2}:36 (AM|PM)/);
+
+    act(() => root.unmount());
+  });
+
+  it("renders core issue property labels in Korean when the locale is Korean", async () => {
+    await i18n.changeLanguage("ko");
+    const root = renderProperties(container, {
+      issue: createIssue({
+        createdAt: new Date(2026, 3, 6, 12, 34),
+        startedAt: new Date(2026, 3, 6, 12, 35),
+        completedAt: new Date(2026, 3, 6, 12, 36),
+      }),
+      childIssues: [],
+      onAddSubIssue: vi.fn(),
+      onUpdate: vi.fn(),
+    });
+    await flush();
+
+    expect(container.textContent).toContain("상태");
+    expect(container.textContent).toContain("우선순위");
+    expect(container.textContent).toContain("태그 없음");
+    expect(container.textContent).toContain("담당자");
+    expect(container.textContent).toContain("담당자 없음");
+    expect(container.textContent).toContain("프로젝트 없음");
+    expect(container.textContent).toContain("상위 작업 없음");
+    expect(container.textContent).toContain("하위 작업");
+    expect(container.textContent).toContain("하위 작업 추가");
+    expect(container.textContent).toContain("없음");
+    expect(container.textContent).toContain("예약 없음");
+    expect(container.textContent).toContain("생성자");
+    expect(container.textContent).toContain("시작");
+    expect(container.textContent).toContain("완료");
+    expect(container.textContent).toContain("생성");
+    expect(container.textContent).toContain("수정");
+    expect(container.textContent).not.toContain("Sub-issues");
+    expect(container.textContent).not.toContain("Add sub-issue");
+    expect(container.textContent).not.toContain("No project");
+    expect(container.textContent).not.toContain("Unassigned");
+    expect(container.textContent).not.toContain("Not scheduled");
 
     act(() => root.unmount());
   });

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -52,6 +52,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { User, Hexagon, ArrowUpRight, Tag, Plus, GitBranch, FolderOpen, Check, ExternalLink, X, Clock, RotateCcw, Loader2, CheckCircle2 } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 
 function TruncatedCopyable({ value, icon: Icon }: { value: string; icon: React.ComponentType<{ className?: string }> }) {
   const [copied, setCopied] = useState(false);
@@ -382,6 +383,8 @@ export function IssueProperties({
   onUpdate,
   inline,
 }: IssuePropertiesProps) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const { selectedCompanyId } = useCompany();
   const queryClient = useQueryClient();
   const companyId = issue.companyId ?? selectedCompanyId;
@@ -495,7 +498,7 @@ export function IssueProperties({
   };
 
   const projectName = (id: string | null) => {
-    if (!id) return id?.slice(0, 8) ?? "None";
+    if (!id) return id?.slice(0, 8) ?? copy("common.none", "None", "없음");
     const project = orderedProjects.find((p) => p.id === id);
     return project?.name ?? id.slice(0, 8);
   };
@@ -812,16 +815,16 @@ export function IssueProperties({
       return agentName(value.slice("agent:".length)) ?? value.slice("agent:".length, "agent:".length + 8);
     }
     if (value.startsWith("user:")) {
-      return userLabel(value.slice("user:".length)) ?? "User";
+      return userLabel(value.slice("user:".length)) ?? copy("issueProperties.user", "User", "사용자");
     }
     return value;
   };
   const reviewerTrigger = reviewerValues.length > 0
     ? <span className="text-sm break-words min-w-0">{reviewerValues.map((value) => executionParticipantLabel(value)).join(", ")}</span>
-    : <span className="text-sm text-muted-foreground">None</span>;
+    : <span className="text-sm text-muted-foreground">{copy("common.none", "None", "없음")}</span>;
   const approverTrigger = approverValues.length > 0
     ? <span className="text-sm break-words min-w-0">{approverValues.map((value) => executionParticipantLabel(value)).join(", ")}</span>
-    : <span className="text-sm text-muted-foreground">None</span>;
+    : <span className="text-sm text-muted-foreground">{copy("common.none", "None", "없음")}</span>;
   const nextRunnableExecutionStage = (() => {
     if (issue.executionState?.status === "changes_requested" && issue.executionState.currentStageType) {
       return issue.executionState.currentStageType;
@@ -910,15 +913,19 @@ export function IssueProperties({
   };
   const currentMonitorLabel = (() => {
     if (issue.executionPolicy?.monitor?.nextCheckAt) {
-      return `Next check ${formatDate(new Date(issue.executionPolicy.monitor.nextCheckAt))}`;
+      return copy("issueProperties.monitor.nextCheckAt", "Next check {{date}}", "{{date}} 확인 예정", {
+        date: formatDate(new Date(issue.executionPolicy.monitor.nextCheckAt), locale),
+      });
     }
     if (issue.executionState?.monitor?.status === "cleared") {
-      return "Cleared";
+      return copy("issueProperties.monitor.cleared", "Cleared", "해제됨");
     }
     if (issue.monitorLastTriggeredAt) {
-      return `Last triggered ${timeAgo(issue.monitorLastTriggeredAt)}`;
+      return copy("issueProperties.monitor.lastTriggered", "Last triggered {{time}}", "{{time}} 마지막 실행", {
+        time: timeAgo(issue.monitorLastTriggeredAt, locale),
+      });
     }
-    return "Not scheduled";
+    return copy("issueProperties.monitor.notScheduled", "Not scheduled", "예약 없음");
   })();
   const monitorNextCheckAt = issue.executionPolicy?.monitor?.nextCheckAt ?? null;
   const monitorTrigger = (
@@ -933,11 +940,15 @@ export function IssueProperties({
         )}
         title={monitorNextCheckAt ? currentMonitorLabel : undefined}
       >
-        {monitorNextCheckAt ? `Next check ${formatMonitorOffset(monitorNextCheckAt)}` : currentMonitorLabel}
+        {monitorNextCheckAt
+          ? copy("issueProperties.monitor.nextCheckRelative", "Next check {{time}}", "{{time}} 후 확인", {
+            time: formatMonitorOffset(monitorNextCheckAt),
+          })
+          : currentMonitorLabel}
       </span>
       {monitorNextCheckAt ? (
         <span className="text-xs text-muted-foreground" title={currentMonitorLabel}>
-          {formatDate(new Date(monitorNextCheckAt))}
+          {formatDate(new Date(monitorNextCheckAt), locale)}
         </span>
       ) : null}
     </span>
@@ -1193,7 +1204,7 @@ export function IssueProperties({
   ) : (
     <>
       <Tag className="h-3.5 w-3.5 text-muted-foreground" />
-      <span className="text-sm text-muted-foreground">No labels</span>
+      <span className="text-sm text-muted-foreground">{copy("issueProperties.labels.none", "No labels", "태그 없음")}</span>
     </>
   );
   const labelsExtra = (issue.labelIds ?? []).length > 0 ? (
@@ -1201,8 +1212,8 @@ export function IssueProperties({
       type="button"
       className="inline-flex items-center justify-center h-5 w-5 rounded hover:bg-accent/50 transition-colors text-muted-foreground hover:text-foreground"
       onClick={() => setLabelsOpen(true)}
-      aria-label="Add label"
-      title="Add label"
+      aria-label={copy("issueProperties.labels.add", "Add label", "태그 추가")}
+      title={copy("issueProperties.labels.add", "Add label", "태그 추가")}
     >
       <Plus className="h-3 w-3" />
     </button>
@@ -1212,7 +1223,7 @@ export function IssueProperties({
     <>
       <input
         className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-        placeholder="Search labels..."
+        placeholder={copy("issueProperties.labels.search", "Search labels...", "태그 검색...")}
         value={labelSearch}
         onChange={(e) => setLabelSearch(e.target.value)}
         autoFocus={!inline}
@@ -1251,7 +1262,7 @@ export function IssueProperties({
           />
           <input
             className="flex-1 px-2 py-1.5 text-xs bg-transparent outline-none rounded placeholder:text-muted-foreground/50"
-            placeholder="New label"
+            placeholder={copy("issueProperties.labels.new", "New label", "새 태그")}
             value={newLabelName}
             onChange={(e) => setNewLabelName(e.target.value)}
           />
@@ -1267,7 +1278,9 @@ export function IssueProperties({
           }
         >
           <Plus className="h-3 w-3" />
-          {createLabel.isPending ? "Creating…" : "Create label"}
+          {createLabel.isPending
+            ? copy("issueProperties.labels.creating", "Creating...", "생성 중...")
+            : copy("issueProperties.labels.create", "Create label", "태그 만들기")}
         </button>
       </div>
     </>
@@ -1283,19 +1296,19 @@ export function IssueProperties({
   ) : (
     <>
       <User className="h-3.5 w-3.5 text-muted-foreground" />
-      <span className="text-sm text-muted-foreground">Unassigned</span>
+      <span className="text-sm text-muted-foreground">{copy("issueProperties.assignee.unassigned", "Unassigned", "미지정")}</span>
     </>
   );
 
   const assigneePickerOptions = orderItemsBySelectedAndRecent(
     [
-      { id: "", kind: "none" as const, label: "No assignee", searchText: "" },
+      { id: "", kind: "none" as const, label: copy("issueProperties.assignee.none", "No assignee", "담당자 없음"), searchText: "" },
       ...(currentUserId
         ? [{
             id: `user:${currentUserId}`,
             kind: "user" as const,
             userId: currentUserId,
-            label: "Assign to me",
+            label: copy("issueProperties.assignee.assignMe", "Assign to me", "나에게 배정"),
             searchText: userLabel(currentUserId) ?? "",
           }]
         : []),
@@ -1304,7 +1317,9 @@ export function IssueProperties({
             id: `user:${issue.createdByUserId}`,
             kind: "user" as const,
             userId: issue.createdByUserId,
-            label: creatorUserLabel ? `Assign to ${creatorUserLabel}` : "Assign to requester",
+            label: creatorUserLabel
+              ? copy("issueProperties.assignee.assignUser", "Assign to {{name}}", "{{name}}에게 배정", { name: creatorUserLabel })
+              : copy("issueProperties.assignee.assignRequester", "Assign to requester", "요청자에게 배정"),
             searchText: creatorUserLabel ?? "requester",
           }]
         : []),
@@ -1331,7 +1346,7 @@ export function IssueProperties({
     <>
       <input
         className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-        placeholder="Search assignees..."
+        placeholder={copy("issueProperties.assignee.search", "Search assignees...", "담당자 검색...")}
         value={assigneeSearch}
         onChange={(e) => setAssigneeSearch(e.target.value)}
         autoFocus={!inline}
@@ -1385,7 +1400,9 @@ export function IssueProperties({
     <>
       <input
         className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-        placeholder={`Search ${stageType === "review" ? "reviewers" : "approvers"}...`}
+        placeholder={stageType === "review"
+          ? copy("issueProperties.reviewers.search", "Search reviewers...", "검토자 검색...")
+          : copy("issueProperties.approvers.search", "Search approvers...", "승인자 검색...")}
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         autoFocus={!inline}
@@ -1398,7 +1415,9 @@ export function IssueProperties({
           )}
           onClick={onClear}
         >
-          No {stageType === "review" ? "reviewers" : "approvers"}
+          {stageType === "review"
+            ? copy("issueProperties.reviewers.none", "No reviewers", "검토자 없음")
+            : copy("issueProperties.approvers.none", "No approvers", "승인자 없음")}
         </button>
         {currentUserId && (
           <button
@@ -1409,7 +1428,7 @@ export function IssueProperties({
             onClick={() => toggleExecutionParticipant(stageType, `user:${currentUserId}`)}
           >
             <User className="h-3 w-3 shrink-0 text-muted-foreground" />
-            Assign to me
+            {copy("issueProperties.assignee.assignMe", "Assign to me", "나에게 배정")}
           </button>
         )}
         {issue.createdByUserId && issue.createdByUserId !== currentUserId && (
@@ -1421,7 +1440,7 @@ export function IssueProperties({
             onClick={() => toggleExecutionParticipant(stageType, `user:${issue.createdByUserId}`)}
           >
             <User className="h-3 w-3 shrink-0 text-muted-foreground" />
-            {creatorUserLabel ? creatorUserLabel : "Requester"}
+            {creatorUserLabel ?? copy("issueProperties.assignee.requester", "Requester", "요청자")}
           </button>
         )}
         {otherUserOptions
@@ -1478,12 +1497,12 @@ export function IssueProperties({
   ) : (
     <>
       <Hexagon className="h-3.5 w-3.5 text-muted-foreground" />
-      <span className="text-sm text-muted-foreground">No project</span>
+      <span className="text-sm text-muted-foreground">{copy("issueProperties.project.none", "No project", "프로젝트 없음")}</span>
     </>
   );
   const projectPickerOptions = orderItemsBySelectedAndRecent(
     [
-      { id: "", kind: "none" as const, name: "No project", color: null as string | null },
+      { id: "", kind: "none" as const, name: copy("issueProperties.project.none", "No project", "프로젝트 없음"), color: null as string | null },
       ...orderedProjects.map((project) => ({
         id: project.id,
         kind: "project" as const,
@@ -1500,7 +1519,7 @@ export function IssueProperties({
     <>
       <input
         className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-        placeholder="Search projects..."
+        placeholder={copy("issueProperties.project.search", "Search projects...", "프로젝트 검색...")}
         value={projectSearch}
         onChange={(e) => setProjectSearch(e.target.value)}
         autoFocus={!inline}
@@ -1590,7 +1609,7 @@ export function IssueProperties({
       {parentTitle}
     </span>
   ) : (
-    <span className="text-sm text-muted-foreground">No parent</span>
+    <span className="text-sm text-muted-foreground">{copy("issueProperties.parent.none", "No parent", "상위 작업 없음")}</span>
   );
   const parentLink = issue.parentId ? (
     <Link
@@ -1621,7 +1640,7 @@ export function IssueProperties({
     <>
       <input
         className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-        placeholder="Search issues..."
+        placeholder={copy("issueProperties.issues.search", "Search issues...", "작업 검색...")}
         value={parentSearch}
         onChange={(e) => setParentSearch(e.target.value)}
         autoFocus={!inline}
@@ -1637,7 +1656,7 @@ export function IssueProperties({
             setParentOpen(false);
           }}
         >
-          No parent
+          {copy("issueProperties.parent.none", "No parent", "상위 작업 없음")}
         </button>
         {parentOptions.map((candidate) => (
           <button
@@ -1693,11 +1712,11 @@ export function IssueProperties({
     <>
       <input
         className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-        placeholder="Search issues..."
+        placeholder={copy("issueProperties.issues.search", "Search issues...", "작업 검색...")}
         value={blockedBySearch}
         onChange={(e) => setBlockedBySearch(e.target.value)}
         autoFocus={!inline}
-        aria-label="Search issues to add as blockers"
+        aria-label={copy("issueProperties.blockers.searchAria", "Search issues to add as blockers", "차단 작업으로 추가할 작업 검색")}
       />
       <div className="max-h-48 overflow-y-auto overscroll-contain">
         <button
@@ -1711,7 +1730,7 @@ export function IssueProperties({
             setBlockedBySearch("");
           }}
         >
-          No blockers
+          {copy("issueProperties.blockers.none", "No blockers", "차단 작업 없음")}
         </button>
         {blockerOptions.map((candidate) => {
           const selected = blockedByIds.includes(candidate.id);
@@ -1734,9 +1753,9 @@ export function IssueProperties({
           );
         })}
         {blockerOptionsLoading ? (
-          <div className="px-2 py-2 text-xs text-muted-foreground">Searching issues...</div>
+          <div className="px-2 py-2 text-xs text-muted-foreground">{copy("issueProperties.issues.searching", "Searching issues...", "작업 검색 중...")}</div>
         ) : blockerOptions.length === 0 ? (
-          <div className="px-2 py-2 text-xs text-muted-foreground">No matching issues.</div>
+          <div className="px-2 py-2 text-xs text-muted-foreground">{copy("issueProperties.issues.noMatches", "No matching issues.", "일치하는 작업이 없습니다.")}</div>
         ) : null}
       </div>
     </>
@@ -1748,14 +1767,14 @@ export function IssueProperties({
       onClick={onClick}
     >
       <Plus className="h-3 w-3" />
-      Add blocker
+      {copy("issueProperties.blockers.add", "Add blocker", "차단 작업 추가")}
     </button>
   );
 
   return (
     <div className="space-y-4">
       <div className="space-y-1">
-        <PropertyRow label="Status">
+        <PropertyRow label={copy("issueProperties.status", "Status", "상태")}>
           <StatusIcon
             status={issue.status}
             blockerAttention={issue.blockerAttention}
@@ -1764,7 +1783,7 @@ export function IssueProperties({
           />
         </PropertyRow>
 
-        <PropertyRow label="Priority">
+        <PropertyRow label={copy("issueProperties.priority", "Priority", "우선순위")}>
           <PriorityIcon
             priority={issue.priority}
             onChange={(priority) => onUpdate({ priority })}
@@ -1774,7 +1793,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Labels"
+          label={copy("issueProperties.labels", "Labels", "태그")}
           open={labelsOpen}
           onOpenChange={(open) => { setLabelsOpen(open); if (!open) setLabelSearch(""); }}
           triggerContent={labelsTrigger}
@@ -1787,7 +1806,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Assignee"
+          label={copy("issueProperties.assignee", "Assignee", "담당자")}
           open={assigneeOpen}
           onOpenChange={(open) => { setAssigneeOpen(open); if (!open) setAssigneeSearch(""); }}
           triggerContent={assigneeTrigger}
@@ -1808,7 +1827,7 @@ export function IssueProperties({
         {showAssigneeAdapterOptions ? (
           <PropertyPicker
             inline={inline}
-            label="Model"
+            label={copy("issueProperties.model", "Model", "모델")}
             open={assigneeOptionsOpen}
             onOpenChange={setAssigneeOptionsOpen}
             triggerContent={assigneeOptionsTrigger}
@@ -1832,7 +1851,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Project"
+          label={copy("issueProperties.project", "Project", "프로젝트")}
           open={projectOpen}
           onOpenChange={(open) => { setProjectOpen(open); if (!open) setProjectSearch(""); }}
           triggerContent={projectTrigger}
@@ -1853,7 +1872,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Parent"
+          label={copy("issueProperties.parent", "Parent", "상위 작업")}
           open={parentOpen}
           onOpenChange={(open) => {
             setParentOpen(open);
@@ -1869,7 +1888,7 @@ export function IssueProperties({
 
         {inline ? (
           <div>
-            <PropertyRow label="Blocked by">
+            <PropertyRow label={copy("issueProperties.blockedBy", "Blocked by", "막고 있는 작업")}>
               {(issue.blockedBy ?? []).map((relation) => (
                 <RemovableIssueReferencePill key={relation.id} issue={relation} onRemove={removeBlockedBy} />
               ))}
@@ -1882,7 +1901,7 @@ export function IssueProperties({
             )}
           </div>
         ) : (
-          <PropertyRow label="Blocked by">
+          <PropertyRow label={copy("issueProperties.blockedBy", "Blocked by", "막고 있는 작업")}>
             {(issue.blockedBy ?? []).map((relation) => (
               <RemovableIssueReferencePill key={relation.id} issue={relation} onRemove={removeBlockedBy} />
             ))}
@@ -1903,7 +1922,7 @@ export function IssueProperties({
           </PropertyRow>
         )}
 
-        <PropertyRow label="Blocking">
+        <PropertyRow label={copy("issueProperties.blocking", "Blocking", "막는 작업")}>
           {blockingIssues.length > 0 ? (
             <div className="flex flex-wrap gap-1">
               {blockingIssues.map((relation) => (
@@ -1913,7 +1932,7 @@ export function IssueProperties({
           ) : null}
         </PropertyRow>
 
-        <PropertyRow label="Sub-issues">
+        <PropertyRow label={copy("issueProperties.subIssues", "Sub-issues", "하위 작업")}>
           <div className="flex flex-wrap items-center gap-1.5">
             {childIssues.length > 0
               ? childIssues.map((child) => (
@@ -1927,14 +1946,14 @@ export function IssueProperties({
                 onClick={onAddSubIssue}
               >
                 <Plus className="h-3 w-3" />
-              Add sub-issue
+                {copy("issueProperties.subIssues.add", "Add sub-issue", "하위 작업 추가")}
               </button>
             ) : null}
           </div>
         </PropertyRow>
 
         {relatedTasks.length > 0 ? (
-          <PropertyRow label="Related Tasks">
+          <PropertyRow label={copy("issueProperties.relatedTasks", "Related Tasks", "관련 작업")}>
             <div className="flex flex-wrap gap-1">
               {relatedTasks.map((related) => (
                 <IssueReferencePill key={related.id} issue={related} />
@@ -1945,7 +1964,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Reviewers"
+          label={copy("issueProperties.reviewers", "Reviewers", "검토자")}
           open={reviewersOpen}
           onOpenChange={(open) => { setReviewersOpen(open); if (!open) setReviewerSearch(""); }}
           triggerContent={reviewerTrigger}
@@ -1964,7 +1983,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Approvers"
+          label={copy("issueProperties.approvers", "Approvers", "승인자")}
           open={approversOpen}
           onOpenChange={(open) => { setApproversOpen(open); if (!open) setApproverSearch(""); }}
           triggerContent={approverTrigger}
@@ -1982,7 +2001,7 @@ export function IssueProperties({
         {nextRunnableExecutionStage === "approval" && approverValues.length > 0 ? runExecutionButton("approval") : null}
 
         {currentExecutionLabel && (
-          <PropertyRow label="Execution">
+          <PropertyRow label={copy("issueProperties.execution", "Execution", "실행")}>
             <span className="text-sm">{currentExecutionLabel}</span>
           </PropertyRow>
         )}
@@ -1990,7 +2009,7 @@ export function IssueProperties({
         {showScheduledRetryRow && scheduledRetryContent ? (
           <PropertyPicker
             inline={inline}
-            label="Scheduled retry"
+            label={copy("issueProperties.scheduledRetry", "Scheduled retry", "예약 재시도")}
             open={scheduledRetryOpen}
             onOpenChange={setScheduledRetryOpen}
             triggerContent={scheduledRetryTrigger}
@@ -2004,7 +2023,7 @@ export function IssueProperties({
 
         <PropertyPicker
           inline={inline}
-          label="Monitor"
+          label={copy("issueProperties.monitor", "Monitor", "모니터")}
           open={monitorOpen}
           onOpenChange={setMonitorOpen}
           triggerContent={monitorTrigger}
@@ -2016,7 +2035,7 @@ export function IssueProperties({
         </PropertyPicker>
 
         {issue.requestDepth > 0 && (
-          <PropertyRow label="Depth">
+          <PropertyRow label={copy("issueProperties.depth", "Depth", "깊이")}>
             <span className="text-sm font-mono">{issue.requestDepth}</span>
           </PropertyRow>
         )}
@@ -2027,7 +2046,7 @@ export function IssueProperties({
           <Separator />
           <div className="space-y-1">
             {liveWorkspaceService?.url && (
-              <PropertyRow label="Service">
+              <PropertyRow label={copy("issueProperties.service", "Service", "서비스")}>
                 <a
                   href={liveWorkspaceService.url}
                   target="_blank"
@@ -2040,18 +2059,18 @@ export function IssueProperties({
               </PropertyRow>
             )}
             {showWorkspaceDetailLink && issue.executionWorkspaceId && (
-              <PropertyRow label="Workspace">
+              <PropertyRow label={copy("issueProperties.workspace", "Workspace", "작업공간")}>
                 <Link
                   to={`/execution-workspaces/${issue.executionWorkspaceId}`}
                   className="text-sm text-primary hover:underline inline-flex items-center gap-1"
                 >
-                  View workspace
+                  {copy("issueProperties.workspace.view", "View workspace", "작업공간 보기")}
                   <ExternalLink className="h-3 w-3" />
                 </Link>
               </PropertyRow>
             )}
             {issue.currentExecutionWorkspace?.branchName && (
-              <PropertyRow label="Branch">
+              <PropertyRow label={copy("issueProperties.branch", "Branch", "브랜치")}>
                 <TruncatedCopyable
                   value={issue.currentExecutionWorkspace.branchName}
                   icon={GitBranch}
@@ -2059,7 +2078,7 @@ export function IssueProperties({
               </PropertyRow>
             )}
             {issue.currentExecutionWorkspace?.cwd && (
-              <PropertyRow label="Folder">
+              <PropertyRow label={copy("issueProperties.folder", "Folder", "폴더")}>
                 <TruncatedCopyable
                   value={issue.currentExecutionWorkspace.cwd}
                   icon={FolderOpen}
@@ -2074,7 +2093,7 @@ export function IssueProperties({
 
       <div className="space-y-1">
         {(issue.createdByAgentId || issue.createdByUserId) && (
-          <PropertyRow label="Created by">
+          <PropertyRow label={copy("issueProperties.createdBy", "Created by", "생성자")}>
             {issue.createdByAgentId ? (
               <Link
                 to={`/agents/${issue.createdByAgentId}`}
@@ -2085,26 +2104,26 @@ export function IssueProperties({
             ) : (
               <>
                 <User className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-sm">{creatorUserLabel ?? "User"}</span>
+                <span className="text-sm">{creatorUserLabel ?? copy("issueProperties.user", "User", "사용자")}</span>
               </>
             )}
           </PropertyRow>
         )}
         {issue.startedAt && (
-          <PropertyRow label="Started">
-            <span className="text-sm">{formatDateTime(issue.startedAt)}</span>
+          <PropertyRow label={copy("issueProperties.started", "Started", "시작")}>
+            <span className="text-sm">{formatDateTime(issue.startedAt, locale)}</span>
           </PropertyRow>
         )}
         {issue.completedAt && (
-          <PropertyRow label="Completed">
-            <span className="text-sm">{formatDateTime(issue.completedAt)}</span>
+          <PropertyRow label={copy("issueProperties.completed", "Completed", "완료")}>
+            <span className="text-sm">{formatDateTime(issue.completedAt, locale)}</span>
           </PropertyRow>
         )}
-        <PropertyRow label="Created">
-          <span className="text-sm">{formatDateTime(issue.createdAt)}</span>
+        <PropertyRow label={copy("issueProperties.created", "Created", "생성")}>
+          <span className="text-sm">{formatDateTime(issue.createdAt, locale)}</span>
         </PropertyRow>
-        <PropertyRow label="Updated">
-          <span className="text-sm">{timeAgo(issue.updatedAt)}</span>
+        <PropertyRow label={copy("issueProperties.updated", "Updated", "수정")}>
+          <span className="text-sm">{timeAgo(issue.updatedAt, locale)}</span>
         </PropertyRow>
       </div>
     </div>

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -12,6 +12,7 @@ import { deriveActiveRecoveryDisplayState, RECOVERY_CHIP_DEFAULT_TONE } from "..
 import { StatusIcon } from "./StatusIcon";
 import { productivityReviewTriggerLabel } from "./ProductivityReviewBadge";
 import { hasAssignedBacklogBlocker } from "../lib/issue-blockers";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 type UnreadState = "hidden" | "visible" | "fading";
 
@@ -60,6 +61,7 @@ export function IssueRow({
   archiveDisabled,
   className,
 }: IssueRowProps) {
+  const copy = useLocalizedCopy();
   const issuePathId = issue.identifier ?? issue.id;
   const identifier = issue.identifier ?? issue.id.slice(0, 8);
   const showUnreadSlot = unreadState !== null;
@@ -73,8 +75,8 @@ export function IssueRow({
         "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-300",
         selected ? "border-muted-foreground text-muted-foreground" : null,
       )}
-      title={`Productivity review: ${productivityReviewTriggerLabel(productivityReview.trigger)}`}
-      aria-label="Productivity review open"
+      title={copy("issueRow.productivityReviewTitle", "Productivity review: {{trigger}}", "생산성 검토: {{trigger}}", { trigger: productivityReviewTriggerLabel(productivityReview.trigger) })}
+      aria-label={copy("issueRow.productivityReviewOpen", "Productivity review open", "생산성 검토 열림")}
     >
       <Eye className="h-2.5 w-2.5" aria-hidden />
     </span>
@@ -91,10 +93,10 @@ export function IssueRow({
     <span
       data-testid="issue-row-parked-blocker"
       className="ml-1.5 inline-flex shrink-0 items-center gap-0.5 rounded-full border border-amber-500/60 bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300"
-      title="Blocked by parked work — at least one assigned blocker is in backlog and will not wake its assignee."
+      title={copy("issueRow.parkedBlockerTitle", "Blocked by parked work - at least one assigned blocker is in backlog and will not wake its assignee.", "대기 작업에 의해 막힘 - 배정된 차단 작업 중 하나 이상이 대기 상태라 담당자를 깨우지 않습니다.")}
     >
       <Flag className="h-2.5 w-2.5" aria-hidden />
-      Blocked by parked work
+      {copy("issueRow.parkedBlocker", "Blocked by parked work", "대기 작업에 의해 막힘")}
     </span>
   ) : null;
 
@@ -188,7 +190,7 @@ export function IssueRow({
                 "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
                 selected ? "hover:bg-muted/80" : "hover:bg-blue-500/20",
               )}
-              aria-label="Mark as read"
+              aria-label={copy("issueRow.markAsRead", "Mark as read", "읽음 표시")}
             >
               <span
                 className={cn(
@@ -215,7 +217,7 @@ export function IssueRow({
               }}
               disabled={archiveDisabled}
               className="inline-flex h-4 w-4 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-30"
-              aria-label="Dismiss from inbox"
+              aria-label={copy("issueRow.dismissFromInbox", "Dismiss from inbox", "받은함에서 숨기기")}
             >
               <X className="h-3.5 w-3.5" />
             </button>

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -56,6 +56,7 @@ import { IssueGroupHeader } from "./IssueGroupHeader";
 import { IssueFiltersPopover } from "./IssueFiltersPopover";
 import { IssueRow } from "./IssueRow";
 import { PageSkeleton } from "./PageSkeleton";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
@@ -95,15 +96,6 @@ function findIssuesScrollContainer(element: HTMLElement | null): HTMLElement | n
   return null;
 }
 const boardIssueStatuses = ISSUE_STATUSES;
-const issueStatusLabels: Record<IssueStatus, string> = {
-  backlog: "Backlog",
-  todo: "Todo",
-  in_progress: "In progress",
-  in_review: "In review",
-  done: "Done",
-  blocked: "Blocked",
-  cancelled: "Cancelled",
-};
 const progressSegmentClasses: Record<IssueStatus, string> = {
   backlog: "bg-muted-foreground/40",
   todo: "bg-blue-500",
@@ -113,6 +105,23 @@ const progressSegmentClasses: Record<IssueStatus, string> = {
   blocked: "bg-red-500",
   cancelled: "bg-neutral-400",
 };
+
+function localizedIssueFilterLabel(value: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    backlog: copy("status.backlog", "Backlog", "대기"),
+    todo: copy("status.todo", "Todo", "할 일"),
+    in_progress: copy("status.inProgress", "In progress", "진행 중"),
+    in_review: copy("status.inReview", "In review", "검토 중"),
+    done: copy("status.done", "Done", "완료"),
+    blocked: copy("status.blocked", "Blocked", "막힘"),
+    cancelled: copy("status.cancelled", "Cancelled", "취소"),
+    critical: copy("priority.critical", "Critical", "긴급"),
+    high: copy("priority.high", "High", "높음"),
+    medium: copy("priority.medium", "Medium", "보통"),
+    low: copy("priority.low", "Low", "낮음"),
+  };
+  return labels[value] ?? issueFilterLabel(value);
+}
 
 /* ── View state ── */
 
@@ -424,6 +433,7 @@ function IssueSearchInput({
   value: string;
   onDebouncedChange?: (search: string) => void;
 }) {
+  const copy = useLocalizedCopy();
   const [draftValue, setDraftValue] = useState(value);
   const lastCommittedValueRef = useRef(value);
 
@@ -470,9 +480,9 @@ function IssueSearchInput({
             e.currentTarget.blur();
           }
         }}
-        placeholder="Search issues..."
+        placeholder={copy("issues.search.placeholder", "Search issues...", "작업 검색...")}
         className="pl-7 text-xs sm:text-sm"
-        aria-label="Search issues"
+        aria-label={copy("issues.search.aria", "Search issues", "작업 검색")}
         data-page-search-target="true"
       />
     </div>
@@ -488,6 +498,8 @@ function SubIssueProgressSummaryStrip({
   issueLinkState?: unknown;
   parentIssueIdForCostSummary?: string;
 }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const target = summary.target;
   const targetIssue = target?.issue ?? null;
   const targetPathId = targetIssue?.identifier ?? targetIssue?.id ?? "";
@@ -517,35 +529,31 @@ function SubIssueProgressSummaryStrip({
         <div className="min-w-0 flex-1 space-y-2">
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
             <span className="font-medium text-foreground">
-              {summary.doneCount}/{summary.totalCount} done
+              {copy("issues.subIssues.doneCount", "{{done}}/{{total}} done", "{{done}}/{{total}} 완료", { done: summary.doneCount, total: summary.totalCount })}
             </span>
             <span className="text-muted-foreground">
-              {summary.inProgressCount} in progress
+              {copy("issues.subIssues.inProgressCount", "{{count}} in progress", "{{count}}개 진행 중", { count: summary.inProgressCount })}
             </span>
             <span className="text-muted-foreground">
-              {summary.blockedCount} blocked
+              {copy("issues.subIssues.blockedCount", "{{count}} blocked", "{{count}}개 막힘", { count: summary.blockedCount })}
             </span>
             {showCostSummary && (
               <>
                 <span
                   className="text-muted-foreground tabular-nums"
-                  title={`${costSummary.runCount.toLocaleString()} run${
-                    costSummary.runCount === 1 ? "" : "s"
-                  } across ${costSummary.issueCount} sub-issue${
-                    costSummary.issueCount === 1 ? "" : "s"
-                  }`}
+                  title={`${costSummary.runCount.toLocaleString(locale)} ${copy("issues.subIssues.runs", "runs", "실행")} / ${costSummary.issueCount.toLocaleString(locale)} ${copy("issues.subIssues.subIssues", "sub-issues", "하위 작업")}`}
                 >
-                  {formatTokens(totalTokens)} tokens
+                  {formatTokens(totalTokens)} {copy("common.tokens", "tokens", "토큰")}
                 </span>
                 <span className="text-muted-foreground tabular-nums">
-                  {formatDurationMs(costSummary.runtimeMs)} runtime
+                  {formatDurationMs(costSummary.runtimeMs, locale)} {copy("common.runtime", "runtime", "실행 시간")}
                 </span>
               </>
             )}
           </div>
           <div
             role="progressbar"
-            aria-label="Sub-issues completion progress"
+            aria-label={copy("issues.subIssues.progress", "Sub-issues completion progress", "하위 작업 완료 진행률")}
             aria-valuemin={0}
             aria-valuenow={summary.doneCount}
             aria-valuemax={summary.totalCount}
@@ -556,7 +564,7 @@ function SubIssueProgressSummaryStrip({
                 key={status}
                 className={cn("h-full", progressSegmentClasses[status])}
                 style={{ width: `${(count / summary.totalCount) * 100}%` }}
-                title={`${issueStatusLabels[status]}: ${count}`}
+                title={`${localizedIssueFilterLabel(status, copy)}: ${count.toLocaleString(locale)}`}
                 aria-hidden="true"
               />
             ))}
@@ -567,7 +575,7 @@ function SubIssueProgressSummaryStrip({
           {target && targetIssue ? (
             <>
               <div className="text-xs font-medium text-muted-foreground">
-                {target.kind === "next" ? "Next up" : "Waiting on blockers"}
+                {target.kind === "next" ? copy("issues.subIssues.nextUp", "Next up", "다음 작업") : copy("issues.subIssues.waitingOnBlockers", "Waiting on blockers", "차단 작업 대기")}
               </div>
               <Link
                 to={createIssueDetailPath(targetPathId)}
@@ -582,11 +590,11 @@ function SubIssueProgressSummaryStrip({
               </Link>
             </>
           ) : summary.totalCount === 0 ? (
-            <div className="text-sm font-medium text-foreground">No active sub-issues</div>
+            <div className="text-sm font-medium text-foreground">{copy("issues.subIssues.noneActive", "No active sub-issues", "활성 하위 작업 없음")}</div>
           ) : summary.doneCount === summary.totalCount ? (
-            <div className="text-sm font-medium text-foreground">All sub-issues done</div>
+            <div className="text-sm font-medium text-foreground">{copy("issues.subIssues.allDone", "All sub-issues done", "모든 하위 작업 완료")}</div>
           ) : (
-            <div className="text-sm font-medium text-foreground">No actionable sub-issues</div>
+            <div className="text-sm font-medium text-foreground">{copy("issues.subIssues.noneActionable", "No actionable sub-issues", "진행 가능한 하위 작업 없음")}</div>
           )}
         </div>
       </div>
@@ -626,6 +634,8 @@ export function IssuesList({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialogActions();
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const { data: session } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -861,7 +871,7 @@ export function IssuesList({
     if (currentUserId) {
       options.set(`user:${currentUserId}`, {
         id: `user:${currentUserId}`,
-        label: currentUserId === "local-board" ? "Board" : "Me",
+        label: currentUserId === "local-board" ? copy("common.board", "Board", "보드") : copy("common.me", "Me", "나"),
         kind: "user",
         searchText: currentUserId === "local-board" ? "board me human local-board" : `me board human ${currentUserId}`,
       });
@@ -912,7 +922,7 @@ export function IssuesList({
       if (a.kind !== b.kind) return a.kind === "user" ? -1 : 1;
       return a.label.localeCompare(b.label);
     });
-  }, [agents, currentUserId, issues]);
+  }, [agents, copy, currentUserId, issues]);
 
   const visibleIssueColumnSet = useMemo(() => new Set(visibleIssueColumns), [visibleIssueColumns]);
   const availableIssueColumns = useMemo(
@@ -1069,13 +1079,13 @@ export function IssuesList({
       const groups = groupBy(filtered, (i) => i.status);
       return issueStatusOrder
         .filter((s) => groups[s]?.length)
-        .map((s) => ({ key: s, label: issueFilterLabel(s), items: groups[s]! }));
+        .map((s) => ({ key: s, label: localizedIssueFilterLabel(s, copy), items: groups[s]! }));
     }
     if (viewState.groupBy === "priority") {
       const groups = groupBy(filtered, (i) => i.priority);
       return issuePriorityOrder
         .filter((p) => groups[p]?.length)
-        .map((p) => ({ key: p, label: issueFilterLabel(p), items: groups[p]! }));
+        .map((p) => ({ key: p, label: localizedIssueFilterLabel(p, copy), items: groups[p]! }));
     }
     if (viewState.groupBy === "workspace") {
       const groups = groupBy(
@@ -1091,7 +1101,7 @@ export function IssuesList({
         })
         .map((key) => ({
           key,
-          label: key === "__no_workspace" ? "No Workspace" : (workspaceNameMap.get(key) ?? key.slice(0, 8)),
+          label: key === "__no_workspace" ? copy("issues.group.noWorkspace", "No Workspace", "작업공간 없음") : (workspaceNameMap.get(key) ?? key.slice(0, 8)),
           items: groups[key]!,
         }));
     }
@@ -1107,7 +1117,7 @@ export function IssuesList({
         })
         .map((key) => ({
           key,
-          label: key === "__no_project" ? "No Project" : (projectById.get(key)?.name ?? key.slice(0, 8)),
+          label: key === "__no_project" ? copy("issues.group.noProject", "No Project", "프로젝트 없음") : (projectById.get(key)?.name ?? key.slice(0, 8)),
           items: groups[key]!,
         }));
     }
@@ -1122,7 +1132,7 @@ export function IssuesList({
         })
         .map((key) => ({
           key,
-          label: key === "__no_parent" ? "No Parent" : (issueTitleMap.get(key) ?? key.slice(0, 8)),
+          label: key === "__no_parent" ? copy("issues.group.noParent", "No Parent", "상위 작업 없음") : (issueTitleMap.get(key) ?? key.slice(0, 8)),
           items: groups[key]!,
         }));
     }
@@ -1135,14 +1145,15 @@ export function IssuesList({
       key,
       label:
         key === "__unassigned"
-          ? "Unassigned"
+          ? copy("issues.group.unassigned", "Unassigned", "미지정")
           : key.startsWith("__user:")
-            ? (formatAssigneeUserLabel(key.slice("__user:".length), currentUserId, companyUserLabelMap) ?? "User")
+            ? (formatAssigneeUserLabel(key.slice("__user:".length), currentUserId, companyUserLabelMap) ?? copy("common.user", "User", "사용자"))
             : (agentName(key) ?? key.slice(0, 8)),
       items: groups[key]!,
     }));
   }, [
     filtered,
+    copy,
     issueFilterWorkspaceContext,
     viewState.groupBy,
     agents,
@@ -1289,8 +1300,12 @@ export function IssuesList({
     viewState.groupBy,
   ]);
 
-  const createActionLabel = createIssueLabel ? `Create ${createIssueLabel}` : "Create Issue";
-  const createButtonLabel = createIssueLabel ? `New ${createIssueLabel}` : "New Issue";
+  const createActionLabel = createIssueLabel
+    ? copy("issues.createLabeled", "Create {{label}}", "{{label}} 만들기", { label: createIssueLabel })
+    : copy("issues.create", "Create Issue", "작업 만들기");
+  const createButtonLabel = createIssueLabel
+    ? copy("issues.newLabeled", "New {{label}}", "새 {{label}}", { label: createIssueLabel })
+    : copy("issues.new", "New Issue", "새 작업");
   const openCreateIssueDialog = useCallback((group?: { key: string; items: Issue[] }) => {
     openNewIssue(newIssueDefaults(group));
   }, [newIssueDefaults, openNewIssue]);
@@ -1353,14 +1368,16 @@ export function IssuesList({
             <button
               className={`p-1.5 transition-colors ${viewState.viewMode === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => updateView({ viewMode: "list" })}
-              title="List view"
+              title={copy("issues.view.list", "List view", "목록 보기")}
+              aria-label={copy("issues.view.list", "List view", "목록 보기")}
             >
               <List className="h-3.5 w-3.5" />
             </button>
             <button
               className={`p-1.5 transition-colors ${viewState.viewMode === "board" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => updateView({ viewMode: "board" })}
-              title="Board view"
+              title={copy("issues.view.board", "Board view", "보드 보기")}
+              aria-label={copy("issues.view.board", "Board view", "보드 보기")}
             >
               <Columns3 className="h-3.5 w-3.5" />
             </button>
@@ -1373,7 +1390,9 @@ export function IssuesList({
               size="icon"
               className={cn("hidden h-8 w-8 shrink-0 sm:inline-flex", viewState.nestingEnabled && "bg-accent")}
               onClick={() => updateView({ nestingEnabled: !viewState.nestingEnabled })}
-              title={viewState.nestingEnabled ? "Disable parent-child nesting" : "Enable parent-child nesting"}
+              title={viewState.nestingEnabled
+                ? copy("issues.nesting.disable", "Disable parent-child nesting", "상위/하위 접기 해제")
+                : copy("issues.nesting.enable", "Enable parent-child nesting", "상위/하위 접기 사용")}
             >
               <ListTree className="h-3.5 w-3.5" />
             </Button>
@@ -1387,7 +1406,7 @@ export function IssuesList({
                 size="icon"
                 className={cn("h-8 w-8 shrink-0", boardCompactCards && "bg-accent")}
                 onClick={() => updateView({ boardCardDensity: boardCompactCards ? "comfortable" : "compact" })}
-                title={boardCompactCards ? "Use comfortable cards" : "Use compact cards"}
+                title={boardCompactCards ? copy("issues.board.comfortableCards", "Use comfortable cards", "여유 있는 카드 사용") : copy("issues.board.compactCards", "Use compact cards", "촘촘한 카드 사용")}
               >
                 <ChevronsDownUp className="h-3.5 w-3.5" />
               </Button>
@@ -1397,7 +1416,7 @@ export function IssuesList({
                 size="icon"
                 className={cn("h-8 w-8 shrink-0", boardCollapsedStatuses.length > 0 && "bg-accent")}
                 onClick={() => updateView({ boardColdLaneMode: boardCollapsedStatuses.length > 0 ? "expanded" : "collapsed" })}
-                title={boardCollapsedStatuses.length > 0 ? "Expand cold lanes" : "Collapse cold lanes"}
+                title={boardCollapsedStatuses.length > 0 ? copy("issues.board.expandCold", "Expand cold lanes", "비활성 열 펼치기") : copy("issues.board.collapseCold", "Collapse cold lanes", "비활성 열 접기")}
               >
                 <PanelTopClose className="h-3.5 w-3.5" />
               </Button>
@@ -1411,7 +1430,7 @@ export function IssuesList({
                       "h-8 shrink-0 gap-1.5 px-2",
                       viewState.boardColumnPageSize !== KANBAN_COLUMN_DEFAULT_PAGE_SIZE && "bg-accent",
                     )}
-                    title="Cards per column"
+                    title={copy("issues.board.cardsPerColumn", "Cards per column", "열당 카드 수")}
                   >
                     <ListCollapse className="h-3.5 w-3.5" />
                     <span className="min-w-4 text-xs tabular-nums">{viewState.boardColumnPageSize}</span>
@@ -1431,7 +1450,7 @@ export function IssuesList({
                         )}
                         onClick={() => updateView({ boardColumnPageSize: pageSize })}
                       >
-                        <span>{pageSize} per column</span>
+                        <span>{copy("issues.board.perColumn", "{{count}} per column", "열당 {{count}}개", { count: pageSize })}</span>
                         {viewState.boardColumnPageSize === pageSize && <Check className="h-3.5 w-3.5" />}
                       </button>
                     ))}
@@ -1449,7 +1468,7 @@ export function IssuesList({
                   boardColumnPageSize: KANBAN_COLUMN_DEFAULT_PAGE_SIZE,
                 })}
                 disabled={!boardDensityCustomized}
-                title="Reset board density"
+                title={copy("issues.board.resetDensity", "Reset board density", "보드 밀도 초기화")}
               >
                 <RotateCcw className="h-3.5 w-3.5" />
               </Button>
@@ -1461,7 +1480,7 @@ export function IssuesList({
             visibleColumnSet={visibleIssueColumnSet}
             onToggleColumn={toggleIssueColumn}
             onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
-            title="Choose which issue columns stay visible"
+            title={copy("issues.columns.title", "Choose which issue columns stay visible", "표시할 작업 열 선택")}
             iconOnly
           />
 
@@ -1483,19 +1502,19 @@ export function IssuesList({
           {viewState.viewMode === "list" && (
             <Popover>
               <PopoverTrigger asChild>
-                <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" title="Sort">
+                <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" title={copy("issues.sort.title", "Sort", "정렬")}>
                   <ArrowUpDown className="h-3.5 w-3.5" />
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-48 p-0">
                 <div className="p-2 space-y-0.5">
                   {([
-                    ["workflow", "Workflow"],
-                    ["status", "Status"],
-                    ["priority", "Priority"],
-                    ["title", "Title"],
-                    ["created", "Created"],
-                    ["updated", "Updated"],
+                    ["workflow", copy("issues.sort.workflow", "Workflow", "흐름")],
+                    ["status", copy("issues.sort.status", "Status", "상태")],
+                    ["priority", copy("issues.sort.priority", "Priority", "우선순위")],
+                    ["title", copy("issues.sort.titleField", "Title", "제목")],
+                    ["created", copy("issues.sort.created", "Created", "생성일")],
+                    ["updated", copy("issues.sort.updated", "Updated", "수정일")],
                   ] as const).map(([field, label]) => (
                     <button
                       key={field}
@@ -1527,20 +1546,20 @@ export function IssuesList({
           {viewState.viewMode === "list" && (
             <Popover>
               <PopoverTrigger asChild>
-                <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" title="Group">
+                <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" title={copy("issues.group.title", "Group", "그룹")}>
                   <Layers className="h-3.5 w-3.5" />
                 </Button>
               </PopoverTrigger>
               <PopoverContent align="end" className="w-44 p-0">
                 <div className="p-2 space-y-0.5">
                   {([
-                    ["status", "Status"],
-                    ["priority", "Priority"],
-                    ["assignee", "Assignee"],
-                    ["project", "Project"],
-                    ["workspace", "Workspace"],
-                    ["parent", "Parent Issue"],
-                    ["none", "None"],
+                    ["status", copy("issues.group.status", "Status", "상태")],
+                    ["priority", copy("issues.group.priority", "Priority", "우선순위")],
+                    ["assignee", copy("issues.group.assignee", "Assignee", "담당자")],
+                    ["project", copy("issues.group.project", "Project", "프로젝트")],
+                    ["workspace", copy("issues.group.workspace", "Workspace", "작업공간")],
+                    ["parent", copy("issues.group.parent", "Parent Issue", "상위 작업")],
+                    ["none", copy("issues.group.none", "None", "없음")],
                   ] as const).map(([value, label]) => (
                     <button
                       key={value}
@@ -1564,18 +1583,18 @@ export function IssuesList({
       {error && <p className="text-sm text-destructive">{error.message}</p>}
       {!searchWithinLoadedIssues && normalizedIssueSearch.length > 0 && searchedIssues.length === ISSUE_SEARCH_RESULT_LIMIT && (
         <p className="text-xs text-muted-foreground">
-          Showing up to {ISSUE_SEARCH_RESULT_LIMIT} matches. Refine the search to narrow further.
+          {copy("issues.search.limitReached", "Showing up to {{count}} matches. Refine the search to narrow further.", "{{count}}개까지 표시 중입니다. 검색어를 더 좁혀 주세요.", { count: ISSUE_SEARCH_RESULT_LIMIT })}
         </p>
       )}
       {boardColumnLimitReached && (
         <p className="text-xs text-muted-foreground">
-          Some board columns are showing up to {ISSUE_BOARD_COLUMN_RESULT_LIMIT} issues. Refine filters or search to reveal the rest.
+          {copy("issues.board.limitReached", "Some board columns are showing up to {{count}} issues. Refine filters or search to reveal the rest.", "일부 보드 열은 {{count}}개까지만 표시 중입니다. 나머지는 필터나 검색을 좁혀 확인하세요.", { count: ISSUE_BOARD_COLUMN_RESULT_LIMIT })}
         </p>
       )}
       {!isLoading && filtered.length === 0 && viewState.viewMode === "list" && (
         <EmptyState
           icon={CircleDot}
-          message="No issues match the current filters or search."
+          message={copy("issues.emptyFiltered", "No issues match the current filters or search.", "현재 필터나 검색과 일치하는 작업이 없습니다.")}
           action={createActionLabel}
           onAction={() => openCreateIssueDialog()}
         />
@@ -1748,18 +1767,18 @@ export function IssuesList({
                           <>
                             {hasChildren && !isExpanded ? (
                               <span className="ml-1.5 text-xs text-muted-foreground">
-                                ({totalDescendants} sub-task{totalDescendants !== 1 ? "s" : ""})
+                                ({copy("issues.subTaskCount", "{{count}} sub-task", "하위 작업 {{count}}개", { count: totalDescendants })})
                               </span>
                             ) : null}
                             {issueBadge ? (
                               issueBadge === "Paused" ? (
                                 <span
                                   className={cn("ml-1.5 inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium", statusBadge.paused)}
-                                  aria-label="Paused"
-                                  title="Paused"
+                                  aria-label={copy("status.paused", "Paused", "일시정지")}
+                                  title={copy("status.paused", "Paused", "일시정지")}
                                 >
                                   <CircleSlash2 className="h-3 w-3" />
-                                  Paused
+                                  {copy("status.paused", "Paused", "일시정지")}
                                 </span>
                               ) : (
                                 <span className="ml-1.5 inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300">
@@ -1770,11 +1789,11 @@ export function IssuesList({
                             {isSuccessfulRunHandoffRequired(issue) ? (
                               <span
                                 className="ml-1.5 inline-flex items-center gap-1 rounded-full border border-amber-400/45 bg-amber-50/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:border-amber-300/35 dark:bg-amber-400/10 dark:text-amber-300"
-                                aria-label="Needs next step"
-                                title="This issue needs a next step"
+                                aria-label={copy("issues.nextStep.aria", "Needs next step", "다음 단계 필요")}
+                                title={copy("issues.nextStep.title", "This issue needs a next step", "이 작업은 다음 단계가 필요합니다.")}
                               >
                                 <CircleDot className="h-3 w-3" />
-                                Needs next step
+                                {copy("issues.nextStep", "Needs next step", "다음 단계 필요")}
                               </span>
                             ) : null}
                           </>
@@ -1819,7 +1838,7 @@ export function IssuesList({
                             />
                           </>
                         )}
-                        mobileMeta={issueActivityText(issue).toLowerCase()}
+                        mobileMeta={issueActivityText(issue, locale).toLowerCase()}
                         desktopTrailing={(
                           visibleTrailingIssueColumns.length > 0 ? (
                             <InboxIssueTrailingColumns
@@ -1857,7 +1876,7 @@ export function IssuesList({
                                         <Identity name={agentName(issue.assigneeAgentId)!} size="sm" className="min-w-0" />
                                       ) : issue.assigneeUserId ? (
                                         <Identity
-                                          name={assigneeUserLabel ?? "User"}
+                                          name={assigneeUserLabel ?? copy("common.user", "User", "사용자")}
                                           avatarUrl={assigneeUserProfile?.image ?? null}
                                           size="sm"
                                           className="min-w-0"
@@ -1867,7 +1886,7 @@ export function IssuesList({
                                           <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-dashed border-muted-foreground/35 bg-muted/30">
                                             <User className="h-3.5 w-3.5" />
                                           </span>
-                                          Assignee
+                                          {copy("issues.assignee", "Assignee", "담당자")}
                                         </span>
                                       )}
                                     </button>
@@ -1880,7 +1899,7 @@ export function IssuesList({
                                   >
                                     <input
                                       className="mb-1 w-full border-b border-border bg-transparent px-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground/50"
-                                      placeholder="Search assignees..."
+                                      placeholder={copy("issues.assignee.search", "Search assignees...", "담당자 검색...")}
                                       value={assigneeSearch}
                                       onChange={(e) => setAssigneeSearch(e.target.value)}
                                       autoFocus
@@ -1897,7 +1916,7 @@ export function IssuesList({
                                           assignIssue(issue.id, null, null);
                                         }}
                                       >
-                                        No assignee
+                                        {copy("issues.assignee.none", "No assignee", "담당자 없음")}
                                       </button>
                                       {currentUserId && (
                                         <button
@@ -1912,7 +1931,7 @@ export function IssuesList({
                                           }}
                                         >
                                           <User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                                          <span>Me</span>
+                                          <span>{copy("common.me", "Me", "나")}</span>
                                         </button>
                                       )}
                                       {(agents ?? [])
@@ -1959,10 +1978,13 @@ export function IssuesList({
             <div className="py-2" data-testid="issues-load-more-sentinel">
               <p className="text-xs text-muted-foreground">
                 {isLoadingMoreIssues
-                  ? "Loading more issues..."
+                  ? copy("issues.loadMore.loading", "Loading more issues...", "작업을 더 불러오는 중...")
                   : remainingIssueRowCount > 0
-                    ? `Rendering ${Math.min(renderedIssueRowLimit, filtered.length)} of ${filtered.length} issues`
-                    : "Scroll to load more issues"}
+                    ? copy("issues.loadMore.rendering", "Rendering {{visible}} of {{total}} issues", "{{total}}개 중 {{visible}}개 표시 중", {
+                      visible: Math.min(renderedIssueRowLimit, filtered.length).toLocaleString(locale),
+                      total: filtered.length.toLocaleString(locale),
+                    })
+                    : copy("issues.loadMore.scroll", "Scroll to load more issues", "스크롤하면 작업을 더 불러옵니다.")}
               </p>
             </div>
           )}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -15,6 +15,7 @@ import { NewAgentDialog } from "./NewAgentDialog";
 import { KeyboardShortcutsCheatsheet } from "./KeyboardShortcutsCheatsheet";
 import { ToastViewport } from "./ToastViewport";
 import { MobileBottomNav } from "./MobileBottomNav";
+import { YoonCompanyAssistantPanel } from "./YoonCompanyAssistantPanel";
 import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
 import { ResizableSidebarPane } from "./ResizableSidebarPane";
@@ -37,6 +38,7 @@ import {
   resetNavigationScroll,
   shouldResetScrollOnNavigation,
 } from "../lib/navigation-scroll";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import { queryKeys } from "../lib/queryKeys";
 import { scheduleMainContentFocus } from "../lib/main-content-focus";
 import { cn } from "../lib/utils";
@@ -63,6 +65,7 @@ function readRememberedInstanceSettingsPath(): string {
 }
 
 export function Layout() {
+  const copy = useLocalizedCopy();
   const { sidebarOpen, setSidebarOpen, toggleSidebar, isMobile } = useSidebar();
   const { openNewIssue, openOnboarding } = useDialogActions();
   const { togglePanelVisible } = usePanel();
@@ -359,7 +362,7 @@ export function Layout() {
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[200] focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        Skip to Main Content
+        {copy("layout.skipToMain", "Skip to Main Content", "본문으로 건너뛰기")}
       </a>
       <WorktreeBanner />
       <DevRestartBanner devServer={health?.devServer} />
@@ -369,7 +372,7 @@ export function Layout() {
             type="button"
             className="fixed inset-0 z-40 bg-black/50"
             onClick={() => setSidebarOpen(false)}
-            aria-label="Close sidebar"
+            aria-label={copy("layout.closeSidebar", "Close sidebar", "사이드바 닫기")}
           />
         )}
 
@@ -461,6 +464,7 @@ export function Layout() {
       <NewGoalDialog />
       <NewAgentDialog />
       <KeyboardShortcutsCheatsheet open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+      <YoonCompanyAssistantPanel />
       <ToastViewport />
       </div>
     </GeneralSettingsProvider>

--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -9,6 +9,7 @@ import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
 import { StatusBadge } from "./StatusBadge";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 interface LiveRunWidgetProps {
   issueId: string;
@@ -25,6 +26,7 @@ function isRunActive(status: string): boolean {
 }
 
 export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const [cancellingRunIds, setCancellingRunIds] = useState(new Set<string>());
 
@@ -74,7 +76,7 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
   const handleCancelRun = async (runId: string) => {
     setCancellingRunIds((prev) => new Set(prev).add(runId));
     try {
-      await heartbeatsApi.cancel(runId);
+      await heartbeatsApi.cancel(runId, { reason: "Stopped from live run widget" });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.liveRuns(issueId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.activeRun(issueId) });
     } finally {
@@ -92,10 +94,14 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
     <div className="overflow-hidden rounded-xl border border-cyan-500/25 bg-background/80 shadow-[0_18px_50px_rgba(6,182,212,0.08)]">
       <div className="border-b border-border/60 bg-cyan-500/[0.04] px-4 py-3">
         <div className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-300">
-          Live Runs
+          {copy("liveRunWidget.title", "Live Runs", "실시간 실행")}
         </div>
         <div className="mt-1 text-xs text-muted-foreground">
-          Uses the shared chat-style run surface from issue activity.
+          {copy(
+            "liveRunWidget.description",
+            "Shows the current execution, output, cancellation state, and run detail link.",
+            "현재 실행, 출력, 중지 상태, 실행 상세 링크를 보여줍니다.",
+          )}
         </div>
       </div>
 
@@ -130,14 +136,16 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
                       className="inline-flex items-center gap-1 rounded-full border border-red-500/20 bg-red-500/[0.06] px-2.5 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-500/[0.12] dark:text-red-300 disabled:opacity-50"
                     >
                       <Square className="h-2.5 w-2.5" fill="currentColor" />
-                      {cancellingRunIds.has(run.id) ? "Stopping…" : "Stop"}
+                      {cancellingRunIds.has(run.id)
+                        ? copy("liveRunWidget.stopping", "Stopping...", "중지 중...")
+                        : copy("liveRunWidget.stop", "Stop", "중지")}
                     </button>
                   )}
                   <Link
                     to={`/agents/${run.agentId}/runs/${run.id}`}
                     className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background/70 px-2.5 py-1 text-[11px] font-medium text-cyan-700 transition-colors hover:border-cyan-500/30 hover:text-cyan-600 dark:text-cyan-300"
                   >
-                    Open run
+                    {copy("liveRunWidget.openRun", "Open run", "실행 열기")}
                     <ExternalLink className="h-3 w-3" />
                   </Link>
                 </div>

--- a/ui/src/components/MembershipAction.tsx
+++ b/ui/src/components/MembershipAction.tsx
@@ -3,6 +3,7 @@ import { Loader2, LogIn, LogOut } from "lucide-react";
 import type { ResourceMembershipState } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
 import { cn } from "../lib/utils";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 interface MembershipActionProps {
   state: ResourceMembershipState;
@@ -23,11 +24,18 @@ export function MembershipAction({
   onJoin,
   onLeave,
 }: MembershipActionProps) {
+  const copy = useLocalizedCopy();
   const isLeft = state === "left";
   const label = pending
-    ? pendingState === "left" ? "Leaving..." : "Joining..."
-    : isLeft ? "Join" : "Leave";
-  const ariaLabel = `${isLeft ? "Join" : "Leave"} ${resourceName}`;
+    ? pendingState === "left"
+      ? copy("membership.leaving", "Leaving...", "나가는 중...")
+      : copy("membership.joining", "Joining...", "참여 중...")
+    : isLeft
+      ? copy("membership.join", "Join", "참여")
+      : copy("membership.leave", "Leave", "나가기");
+  const ariaLabel = isLeft
+    ? copy("membership.joinResource", "Join {{resourceName}}", "{{resourceName}} 참여", { resourceName })
+    : copy("membership.leaveResource", "Leave {{resourceName}}", "{{resourceName}} 나가기", { resourceName });
   const Icon = pending ? Loader2 : isLeft ? LogIn : LogOut;
 
   function handleClick(event: MouseEvent<HTMLButtonElement>) {

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -12,6 +12,7 @@ import { useDialogActions } from "../context/DialogContext";
 import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
 import { cn } from "../lib/utils";
 import { useInboxBadge } from "../hooks/useInboxBadge";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 interface MobileBottomNavProps {
   visible: boolean;
@@ -35,6 +36,7 @@ interface MobileNavActionItem {
 type MobileNavItem = MobileNavLinkItem | MobileNavActionItem;
 
 export function MobileBottomNav({ visible }: MobileBottomNavProps) {
+  const copy = useLocalizedCopy();
   const location = useLocation();
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialogActions();
@@ -42,19 +44,19 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
 
   const items = useMemo<MobileNavItem[]>(
     () => [
-      { type: "link", to: "/dashboard", label: "Home", icon: House },
-      { type: "link", to: "/issues", label: "Issues", icon: CircleDot },
-      { type: "action", label: "Create", icon: SquarePen, onClick: () => openNewIssue() },
-      { type: "link", to: "/agents/all", label: "Agents", icon: Users },
+      { type: "link", to: "/dashboard", label: copy("mobileNav.home", "Home", "홈"), icon: House },
+      { type: "link", to: "/issues", label: copy("mobileNav.issues", "Issues", "작업"), icon: CircleDot },
+      { type: "action", label: copy("mobileNav.create", "Create", "생성"), icon: SquarePen, onClick: () => openNewIssue() },
+      { type: "link", to: "/agents/all", label: copy("mobileNav.agents", "Agents", "직원"), icon: Users },
       {
         type: "link",
         to: "/inbox",
-        label: "Inbox",
+        label: copy("mobileNav.inbox", "Inbox", "받은함"),
         icon: Inbox,
         badge: inboxBadge.inbox,
       },
     ],
-    [openNewIssue, inboxBadge.inbox],
+    [copy, openNewIssue, inboxBadge.inbox],
   );
 
   return (
@@ -63,7 +65,7 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
         "fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-transform duration-200 ease-out md:hidden pb-[env(safe-area-inset-bottom)]",
         visible ? "translate-y-0" : "translate-y-full",
       )}
-      aria-label="Mobile navigation"
+      aria-label={copy("mobileNav.aria", "Mobile navigation", "모바일 내비게이션")}
     >
       <div className="grid h-16 grid-cols-5 px-1">
         {items.map((item) => {

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -24,9 +24,10 @@ import { cn } from "@/lib/utils";
 import { buildAgentOnboardingPrompt } from "@/lib/agent-onboarding-prompt";
 import { listUIAdapters } from "../adapters";
 import { isVisualAdapterChoice } from "../adapters/metadata";
-import { getAdapterDisplay } from "../adapters/adapter-display-registry";
+import { getLocalizedAdapterDisplay } from "../adapters/adapter-display-registry";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { useToast } from "../context/ToastContext";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 /**
  * Adapter types that are suitable for agent creation (excludes internal
@@ -41,6 +42,7 @@ function isAgentAdapterType(type: string): boolean {
 }
 
 export function NewAgentDialog() {
+  const copy = useLocalizedCopy();
   const { newAgentOpen, closeNewAgent, openNewIssue } = useDialog();
   const { selectedCompanyId } = useCompany();
   const { pushToast } = useToast();
@@ -97,7 +99,7 @@ export function NewAgentDialog() {
     // Sort: recommended first, then alphabetical
     return registered
       .map((a) => {
-        const display = getAdapterDisplay(a.type);
+        const display = getLocalizedAdapterDisplay(a.type, copy);
         return {
           value: a.type,
           label: display.label,
@@ -113,14 +115,14 @@ export function NewAgentDialog() {
         if (!a.recommended && b.recommended) return 1;
         return a.label.localeCompare(b.label);
       });
-  }, [disabledTypes, serverAdapters]);
+  }, [copy, disabledTypes, serverAdapters]);
 
   function handleAskCeo() {
     closeNewAgent();
     openNewIssue({
       assigneeAgentId: ceoAgent?.id,
-      title: "Create a new agent",
-      description: "(type in what kind of agent you want here)",
+      title: copy("newAgent.askCeoTitle", "Create a new agent", "새 직원 만들기"),
+      description: copy("newAgent.askCeoDescription", "(type in what kind of agent you want here)", "(원하는 직원 종류를 여기에 입력하세요)"),
     });
   }
 
@@ -149,7 +151,7 @@ export function NewAgentDialog() {
     }
 
     pushToast({
-      title: "Clipboard unavailable",
+      title: copy("newAgent.clipboardUnavailable", "Clipboard unavailable", "클립보드 사용 불가"),
       body: unavailableBody,
       tone: "warn",
     });
@@ -195,19 +197,21 @@ export function NewAgentDialog() {
       setLatestAgentPrompt(prompt);
       setLatestAgentPromptCopied(false);
       setMode("prompt");
-      const copied = await copyText(prompt, "Copy the agent onboarding prompt manually from the field below.");
+      const copied = await copyText(prompt, copy("newAgent.copyPromptManual", "Copy the agent onboarding prompt manually from the field below.", "아래 필드에서 직원 온보딩 프롬프트를 직접 복사하세요."));
 
       await queryClient.invalidateQueries({ queryKey: inviteHistoryQueryKey });
       pushToast({
-        title: "Agent invite created",
-        body: copied ? "Agent onboarding prompt ready below and copied to clipboard." : "Agent onboarding prompt ready below.",
+        title: copy("newAgent.inviteCreated", "Agent invite created", "직원 초대 생성됨"),
+        body: copied
+          ? copy("newAgent.promptReadyCopied", "Agent onboarding prompt ready below and copied to clipboard.", "직원 온보딩 프롬프트가 아래에 준비되었고 클립보드에 복사되었습니다.")
+          : copy("newAgent.promptReady", "Agent onboarding prompt ready below.", "직원 온보딩 프롬프트가 아래에 준비되었습니다."),
         tone: "success",
       });
     },
     onError: (error) => {
       pushToast({
-        title: "Failed to create agent invite",
-        body: error instanceof Error ? error.message : "Unknown error",
+        title: copy("newAgent.inviteFailed", "Failed to create agent invite", "직원 초대 생성 실패"),
+        body: error instanceof Error ? error.message : copy("common.unknownError", "Unknown error", "알 수 없는 오류"),
         tone: "error",
       });
     },
@@ -232,7 +236,7 @@ export function NewAgentDialog() {
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
-          <span className="text-sm text-muted-foreground">Add a new agent</span>
+          <span className="text-sm text-muted-foreground">{copy("newAgent.header", "Add a new agent", "새 직원 추가")}</span>
           <Button
             variant="ghost"
             size="icon-xs"
@@ -255,28 +259,31 @@ export function NewAgentDialog() {
                   <Bot className="h-6 w-6 text-foreground" />
                 </div>
                 <p className="text-sm text-muted-foreground">
-                  Ask a leader to propose the hire, configure a runtime yourself,
-                  or send an onboarding prompt to an external agent.
+                  {copy(
+                    "newAgent.choiceHelp",
+                    "Ask a leader to propose the hire, configure a runtime yourself, or send an onboarding prompt to an external agent.",
+                    "리더에게 채용 제안을 맡기거나, 런타임을 직접 설정하거나, 외부 직원에게 온보딩 프롬프트를 보냅니다.",
+                  )}
                 </p>
               </div>
 
               <Button className="w-full" size="lg" onClick={handleAskCeo}>
                 <Bot className="h-4 w-4 mr-2" />
-                Ask the CEO to create a new agent
+                {copy("newAgent.askCeo", "Ask the CEO to create a new agent", "CEO에게 새 직원 생성을 요청")}
               </Button>
 
               <div className="grid gap-2">
                 <Button variant="outline" className="w-full" onClick={handleAdvancedConfig}>
                   <Settings2 className="h-4 w-4 mr-2" />
-                  Configure a runtime manually
+                  {copy("newAgent.configureRuntime", "Configure a runtime manually", "런타임 직접 설정")}
                 </Button>
                 <div className="space-y-1">
                   <Button variant="outline" className="w-full" onClick={handleInviteExternalAgent}>
                     <MailPlus className="h-4 w-4 mr-2" />
-                    Invite an external agent
+                    {copy("newAgent.inviteExternal", "Invite an external agent", "외부 직원 초대")}
                   </Button>
                   <p className="text-xs text-muted-foreground text-center">
-                    (OpenClaw, Hermes, or any agent that can call the invite API.)
+                    {copy("newAgent.externalHint", "(OpenClaw, Hermes, or any agent that can call the invite API.)", "(OpenClaw, Hermes 또는 초대 API를 호출할 수 있는 직원)")}
                   </p>
                 </div>
               </div>
@@ -289,10 +296,10 @@ export function NewAgentDialog() {
                   onClick={() => setMode("choices")}
                 >
                   <ArrowLeft className="h-3.5 w-3.5" />
-                  Back
+                  {copy("common.back", "Back", "뒤로")}
                 </button>
                 <p className="text-sm text-muted-foreground">
-                  Choose the runtime Paperclip should start or resume directly.
+                  {copy("newAgent.runtimeHelp", "Choose the runtime Paperclip should start or resume directly.", "Paperclip이 직접 시작하거나 재개할 런타임을 선택하세요.")}
                 </p>
               </div>
 
@@ -312,7 +319,7 @@ export function NewAgentDialog() {
                   >
                     {opt.recommended && (
                       <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
-                        Recommended
+                        {copy("common.recommended", "Recommended", "추천")}
                       </span>
                     )}
                     <opt.icon className="h-4 w-4" />
@@ -332,29 +339,37 @@ export function NewAgentDialog() {
                   onClick={() => setMode("choices")}
                 >
                   <ArrowLeft className="h-3.5 w-3.5" />
-                  Back
+                  {copy("common.back", "Back", "뒤로")}
                 </button>
                 <div className="space-y-1">
-                  <h2 className="text-sm font-semibold">Invite an external agent</h2>
+                  <h2 className="text-sm font-semibold">{copy("newAgent.inviteExternal", "Invite an external agent", "외부 직원 초대")}</h2>
                   <p className="text-sm text-muted-foreground">
-                    Generate a one-time onboarding prompt that any compatible agent can use to request access, wait for approval, and claim its Paperclip API key.
+                    {copy(
+                      "newAgent.inviteHelp",
+                      "Generate a one-time onboarding prompt that any compatible agent can use to request access, wait for approval, and claim its Paperclip API key.",
+                      "호환 직원이 접근을 요청하고 승인을 기다린 뒤 Paperclip API 키를 받을 수 있는 일회성 온보딩 프롬프트를 생성합니다.",
+                    )}
                   </p>
                 </div>
               </div>
 
               <label className="block space-y-2">
-                <span className="text-sm font-medium">Optional message for the agent</span>
+                <span className="text-sm font-medium">{copy("newAgent.optionalMessage", "Optional message for the agent", "직원에게 보낼 선택 메시지")}</span>
                 <Textarea
                   value={agentMessage}
                   onChange={(event) => setAgentMessage(event.target.value)}
                   className="min-h-24 resize-y"
-                  placeholder="Add onboarding context, expected role, or first instructions."
+                  placeholder={copy("newAgent.optionalMessagePlaceholder", "Add onboarding context, expected role, or first instructions.", "온보딩 맥락, 기대 역할, 첫 지시를 입력하세요.")}
                   maxLength={4000}
                 />
               </label>
 
               <div className="rounded-lg border border-border px-4 py-3 text-sm text-muted-foreground">
-                Agent invites create a join request first. A company admin still approves the request before the agent can claim its API key.
+                {copy(
+                  "newAgent.inviteApprovalHelp",
+                  "Agent invites create a join request first. A company admin still approves the request before the agent can claim its API key.",
+                  "직원 초대는 먼저 가입 요청을 만듭니다. 직원이 API 키를 받기 전 회사 관리자가 요청을 승인해야 합니다.",
+                )}
               </div>
 
               <div>
@@ -362,7 +377,7 @@ export function NewAgentDialog() {
                   onClick={() => createAgentInviteMutation.mutate()}
                   disabled={!selectedCompanyId || createAgentInviteMutation.isPending}
                 >
-                  {createAgentInviteMutation.isPending ? "Generating…" : "Generate onboarding prompt"}
+                  {createAgentInviteMutation.isPending ? copy("newAgent.generating", "Generating...", "생성 중...") : copy("newAgent.generatePrompt", "Generate onboarding prompt", "온보딩 프롬프트 생성")}
                 </Button>
               </div>
             </div>
@@ -374,20 +389,20 @@ export function NewAgentDialog() {
                   onClick={() => setMode("invite")}
                 >
                   <ArrowLeft className="h-3.5 w-3.5" />
-                  Back
+                  {copy("common.back", "Back", "뒤로")}
                 </button>
                 <div className="space-y-1">
                   <div className="flex items-center justify-between gap-3">
-                    <h2 className="text-sm font-semibold">Agent onboarding prompt</h2>
+                    <h2 className="text-sm font-semibold">{copy("newAgent.onboardingPrompt", "Agent onboarding prompt", "직원 온보딩 프롬프트")}</h2>
                     {latestAgentPromptCopied ? (
                       <div className="inline-flex items-center gap-1 text-xs font-medium text-foreground">
                         <Check className="h-3.5 w-3.5" />
-                        Copied
+                        {copy("common.copied", "Copied", "복사됨")}
                       </div>
                     ) : null}
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    Send this prompt to the external agent that should join this company.
+                    {copy("newAgent.sendPromptHelp", "Send this prompt to the external agent that should join this company.", "이 회사에 합류할 외부 직원에게 이 프롬프트를 보내세요.")}
                   </p>
                 </div>
               </div>
@@ -403,11 +418,11 @@ export function NewAgentDialog() {
                 disabled={!latestAgentPrompt}
                 onClick={async () => {
                   if (!latestAgentPrompt) return;
-                  const copied = await copyText(latestAgentPrompt, "Copy the agent onboarding prompt manually from the field above.");
+                  const copied = await copyText(latestAgentPrompt, copy("newAgent.copyPromptManualAbove", "Copy the agent onboarding prompt manually from the field above.", "위 필드에서 직원 온보딩 프롬프트를 직접 복사하세요."));
                   setLatestAgentPromptCopied(copied);
                 }}
               >
-                {latestAgentPromptCopied ? "Copied prompt" : "Copy prompt"}
+                {latestAgentPromptCopied ? copy("newAgent.copiedPrompt", "Copied prompt", "프롬프트 복사됨") : copy("newAgent.copyPrompt", "Copy prompt", "프롬프트 복사")}
               </Button>
             </div>
           )}

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -23,20 +23,15 @@ import {
   Layers,
 } from "lucide-react";
 import { cn } from "../lib/utils";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import { MarkdownEditor, type MarkdownEditorRef } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
-
-const levelLabels: Record<string, string> = {
-  company: "Company",
-  team: "Team",
-  agent: "Agent",
-  task: "Task",
-};
 
 export function NewGoalDialog() {
   const { newGoalOpen, newGoalDefaults, closeNewGoal } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
   const queryClient = useQueryClient();
+  const copy = useLocalizedCopy();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("planned");
@@ -70,7 +65,7 @@ export function NewGoalDialog() {
 
   const uploadDescriptionImage = useMutation({
     mutationFn: async (file: File) => {
-      if (!selectedCompanyId) throw new Error("No company selected");
+      if (!selectedCompanyId) throw new Error(copy("newGoal.error.noCompany", "No company selected", "선택된 회사가 없습니다."));
       return assetsApi.uploadImage(selectedCompanyId, file, "goals/drafts");
     },
   });
@@ -103,6 +98,18 @@ export function NewGoalDialog() {
   }
 
   const currentParent = (goals ?? []).find((g) => g.id === appliedParentId);
+  const levelLabels: Record<string, string> = {
+    company: copy("goal.level.company", "Company", "회사"),
+    team: copy("goal.level.team", "Team", "팀"),
+    agent: copy("goal.level.agent", "Agent", "직원"),
+    task: copy("goal.level.task", "Task", "작업"),
+  };
+  const statusLabels: Record<string, string> = {
+    planned: copy("goal.status.planned", "Planned", "계획됨"),
+    active: copy("goal.status.active", "Active", "활성"),
+    achieved: copy("goal.status.achieved", "Achieved", "달성"),
+    cancelled: copy("goal.status.cancelled", "Cancelled", "취소"),
+  };
 
   return (
     <Dialog
@@ -128,7 +135,11 @@ export function NewGoalDialog() {
               </span>
             )}
             <span className="text-muted-foreground/60">&rsaquo;</span>
-            <span>{newGoalDefaults.parentId ? "New sub-goal" : "New goal"}</span>
+            <span>
+              {newGoalDefaults.parentId
+                ? copy("newGoal.subTitle", "New sub-goal", "새 하위 목표")
+                : copy("newGoal.title", "New goal", "새 목표")}
+            </span>
           </div>
           <div className="flex items-center gap-1">
             <Button
@@ -136,6 +147,9 @@ export function NewGoalDialog() {
               size="icon-xs"
               className="text-muted-foreground"
               onClick={() => setExpanded(!expanded)}
+              aria-label={expanded
+                ? copy("newGoal.collapse", "Collapse dialog", "창 축소")
+                : copy("newGoal.expand", "Expand dialog", "창 확대")}
             >
               {expanded ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
             </Button>
@@ -144,6 +158,7 @@ export function NewGoalDialog() {
               size="icon-xs"
               className="text-muted-foreground"
               onClick={() => { reset(); closeNewGoal(); }}
+              aria-label={copy("common.close", "Close", "닫기")}
             >
               <span className="text-lg leading-none">&times;</span>
             </Button>
@@ -154,7 +169,7 @@ export function NewGoalDialog() {
         <div className="px-4 pt-4 pb-2 shrink-0">
           <input
             className="w-full text-lg font-semibold bg-transparent outline-none placeholder:text-muted-foreground/50"
-            placeholder="Goal title"
+            placeholder={copy("newGoal.title.placeholder", "Goal title", "목표 제목")}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             onKeyDown={(e) => {
@@ -173,7 +188,7 @@ export function NewGoalDialog() {
             ref={descriptionEditorRef}
             value={description}
             onChange={setDescription}
-            placeholder="Add description..."
+            placeholder={copy("newGoal.description.placeholder", "Add description...", "설명 추가...")}
             bordered={false}
             contentClassName={cn("text-sm text-muted-foreground", expanded ? "min-h-[220px]" : "min-h-[120px]")}
             imageUploadHandler={async (file) => {
@@ -202,7 +217,7 @@ export function NewGoalDialog() {
                   )}
                   onClick={() => { setStatus(s); setStatusOpen(false); }}
                 >
-                  {s}
+                  {statusLabels[s] ?? s}
                 </button>
               ))}
             </PopoverContent>
@@ -237,7 +252,7 @@ export function NewGoalDialog() {
             <PopoverTrigger asChild>
               <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent/50 transition-colors">
                 <Target className="h-3 w-3 text-muted-foreground" />
-                {currentParent ? currentParent.title : "Parent goal"}
+                {currentParent ? currentParent.title : copy("newGoal.parent", "Parent goal", "상위 목표")}
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-48 p-1" align="start">
@@ -248,7 +263,7 @@ export function NewGoalDialog() {
                 )}
                 onClick={() => { setParentId(""); setParentOpen(false); }}
               >
-                No parent
+                {copy("newGoal.parent.none", "No parent", "상위 목표 없음")}
               </button>
               {(goals ?? []).map((g) => (
                 <button
@@ -273,7 +288,11 @@ export function NewGoalDialog() {
             disabled={!title.trim() || createGoal.isPending}
             onClick={handleSubmit}
           >
-            {createGoal.isPending ? "Creating…" : newGoalDefaults.parentId ? "Create sub-goal" : "Create goal"}
+            {createGoal.isPending
+              ? copy("newGoal.creating", "Creating…", "만드는 중...")
+              : newGoalDefaults.parentId
+                ? copy("newGoal.createSubGoal", "Create sub-goal", "하위 목표 만들기")
+                : copy("newGoal.create", "Create goal", "목표 만들기")}
           </Button>
         </div>
       </DialogContent>

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -67,6 +67,7 @@ import { issueStatusText, issueStatusTextDefault, priorityColor, priorityColorDe
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { AgentIcon } from "./AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 const DRAFT_KEY = "paperclip:issue-draft";
 const DEBOUNCE_MS = 800;
@@ -251,6 +252,65 @@ const EXECUTION_WORKSPACE_MODES = [
   { value: "reuse_existing", label: "Reuse existing workspace" },
 ] as const;
 
+function executionWorkspaceModeLabel(mode: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  if (mode === "shared_workspace") return copy("newIssue.workspace.projectDefault", "Project default", "프로젝트 기본값");
+  if (mode === "isolated_workspace") return copy("newIssue.workspace.newIsolated", "New isolated workspace", "새 격리 작업공간");
+  if (mode === "reuse_existing") return copy("newIssue.workspace.reuseExisting", "Reuse existing workspace", "기존 작업공간 재사용");
+  return mode;
+}
+
+function issueModelLaneLabel(lane: IssueModelLane, copy: ReturnType<typeof useLocalizedCopy>) {
+  if (lane === "primary") return copy("newIssue.modelLane.primary", "Primary", "기본");
+  if (lane === "cheap") return copy("newIssue.modelLane.cheap", "Cheap", "저비용");
+  return copy("newIssue.modelLane.custom", "Custom", "직접 설정");
+}
+
+function thinkingEffortLabel(value: string, fallback: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    "": copy("common.default", "Default", "기본값"),
+    minimal: copy("thinkingEffort.minimal", "Minimal", "최소"),
+    low: copy("thinkingEffort.low", "Low", "낮음"),
+    medium: copy("thinkingEffort.medium", "Medium", "보통"),
+    high: copy("thinkingEffort.high", "High", "높음"),
+    xhigh: copy("thinkingEffort.xhigh", "X-High", "매우 높음"),
+    max: copy("thinkingEffort.max", "Max", "최대"),
+  };
+  return labels[value] ?? fallback;
+}
+
+function issueStatusLabel(value: string, fallback: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    backlog: copy("status.backlog", "Backlog", "대기"),
+    todo: copy("status.todo", "Todo", "할 일"),
+    in_progress: copy("status.inProgress", "In Progress", "진행 중"),
+    in_review: copy("status.inReview", "In Review", "검토 중"),
+    done: copy("status.done", "Done", "완료"),
+  };
+  return labels[value] ?? fallback;
+}
+
+function issueStatusDescription(value: string, description: string | undefined, copy: ReturnType<typeof useLocalizedCopy>) {
+  if (value === "backlog") return copy("newIssue.status.backlogDesc", "Parked - assignee will not be woken", "보류 - 담당자를 깨우지 않습니다.");
+  if (value === "todo") return copy("newIssue.status.todoDesc", "Executable - assignee will be woken", "실행 가능 - 담당자를 깨웁니다.");
+  return description;
+}
+
+function priorityLabel(value: string, fallback: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    critical: copy("priority.critical", "Critical", "긴급"),
+    high: copy("priority.high", "High", "높음"),
+    medium: copy("priority.medium", "Medium", "보통"),
+    low: copy("priority.low", "Low", "낮음"),
+  };
+  return labels[value] ?? fallback;
+}
+
+function workModeLabel(value: IssueWorkMode, fallback: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  if (value === "standard") return copy("newIssue.workMode.standard", "Standard", "표준");
+  if (value === "planning") return copy("newIssue.workMode.planning", "Planning", "계획");
+  return fallback;
+}
+
 function defaultProjectWorkspaceIdForProject(project: { workspaces?: Array<{ id: string; isPrimary: boolean }>; executionWorkspacePolicy?: { defaultProjectWorkspaceId?: string | null } | null } | null | undefined) {
   if (!project) return "";
   return project.executionWorkspacePolicy?.defaultProjectWorkspaceId
@@ -305,6 +365,7 @@ const IssueTitleTextarea = memo(function IssueTitleTextarea({
   projectSelectorRef: RefObject<HTMLButtonElement | null>;
   onChange: (value: string) => void;
 }) {
+  const copy = useLocalizedCopy();
   const [draftValue, setDraftValue] = useState(value);
 
   useEffect(() => {
@@ -314,7 +375,7 @@ const IssueTitleTextarea = memo(function IssueTitleTextarea({
   return (
     <textarea
       className="w-full text-lg font-semibold bg-transparent outline-none resize-none overflow-hidden placeholder:text-muted-foreground/50"
-      placeholder="Issue title"
+      placeholder={copy("newIssue.titlePlaceholder", "Issue title", "작업 제목")}
       rows={1}
       value={draftValue}
       onChange={(e) => {
@@ -368,6 +429,7 @@ const IssueDescriptionEditor = memo(function IssueDescriptionEditor({
   imageUploadHandler: (file: File) => Promise<string>;
   onChange: (value: string) => void;
 }) {
+  const copy = useLocalizedCopy();
   const [draftValue, setDraftValue] = useState(value);
 
   useEffect(() => {
@@ -382,7 +444,7 @@ const IssueDescriptionEditor = memo(function IssueDescriptionEditor({
         setDraftValue(nextValue);
         onChange(nextValue);
       }}
-      placeholder="Add description..."
+      placeholder={copy("newIssue.descriptionPlaceholder", "Add description...", "설명을 입력하세요...")}
       bordered={false}
       mentions={mentions}
       contentClassName={cn("text-sm text-muted-foreground pb-12", expanded ? "min-h-[220px]" : "min-h-[120px]")}
@@ -402,6 +464,7 @@ function issueExecutionWorkspaceModeForExistingWorkspace(mode: string | null | u
 }
 
 export function NewIssueDialog() {
+  const copy = useLocalizedCopy();
   const { newIssueOpen, newIssueDefaults, closeNewIssue } = useDialog();
   const { companies, selectedCompanyId, selectedCompany } = useCompany();
   const queryClient = useQueryClient();
@@ -1096,12 +1159,12 @@ export function NewIssueDialog() {
     && !isUsingParentExecutionWorkspace;
   const assigneeOptionsTitle =
     assigneeAdapterType === "claude_local"
-      ? "Claude options"
+      ? copy("newIssue.options.claude", "Claude options", "Claude 옵션")
       : assigneeAdapterType === "codex_local"
-        ? "Codex options"
+        ? copy("newIssue.options.codex", "Codex options", "Codex 옵션")
         : assigneeAdapterType === "opencode_local"
-          ? "OpenCode options"
-        : "Agent options";
+          ? copy("newIssue.options.opencode", "OpenCode options", "OpenCode 옵션")
+        : copy("newIssue.options.agent", "Agent options", "직원 옵션");
   const thinkingEffortOptions =
     assigneeAdapterType === "codex_local"
       ? ISSUE_THINKING_EFFORT_OPTIONS.codex_local
@@ -1142,7 +1205,9 @@ export function NewIssueDialog() {
   const hasSavedDraft = Boolean(savedDraft?.title.trim() || savedDraft?.description.trim());
   const canDiscardDraft = hasDraft || hasSavedDraft;
   const createIssueErrorMessage =
-    createIssue.error instanceof Error ? createIssue.error.message : "Failed to create issue. Try again.";
+    createIssue.error instanceof Error
+      ? createIssue.error.message
+      : copy("newIssue.createFailed", "Failed to create issue. Try again.", "작업 생성에 실패했습니다. 다시 시도하세요.");
   const stagedDocuments = stagedFiles.filter((file) => file.kind === "document");
   const stagedAttachments = stagedFiles.filter((file) => file.kind === "attachment");
 
@@ -1291,7 +1356,7 @@ export function NewIssueDialog() {
               </PopoverContent>
             </Popover>
             <span className="text-muted-foreground/60">&rsaquo;</span>
-            <span>{isSubIssueMode ? "New sub-issue" : "New issue"}</span>
+            <span>{isSubIssueMode ? copy("newIssue.header.subIssue", "New sub-issue", "새 하위 작업") : copy("newIssue.header.issue", "New issue", "새 작업")}</span>
           </div>
           <div className="flex items-center gap-1">
             <Button
@@ -1333,17 +1398,17 @@ export function NewIssueDialog() {
           <div className="px-4 pb-2">
             <div className="overflow-x-auto overscroll-x-contain">
               <div className="inline-flex items-center gap-2 text-sm text-muted-foreground flex-wrap sm:flex-nowrap sm:min-w-max">
-              <span className="w-6 shrink-0 text-center">For</span>
+              <span className="w-6 shrink-0 text-center">{copy("newIssue.for", "For", "대상")}</span>
               <InlineEntitySelector
                 ref={assigneeSelectorRef}
                 value={assigneeValue}
                 options={assigneeOptions}
                 recentOptionIds={recentAssigneeOptionIds}
-                placeholder="Assignee"
+                placeholder={copy("newIssue.assignee", "Assignee", "담당자")}
                 disablePortal
-                noneLabel="No assignee"
-                searchPlaceholder="Search assignees..."
-                emptyMessage="No assignees found."
+                noneLabel={copy("newIssue.noAssignee", "No assignee", "담당자 없음")}
+                searchPlaceholder={copy("newIssue.searchAssignees", "Search assignees...", "담당자 검색...")}
+                emptyMessage={copy("newIssue.noAssigneesFound", "No assignees found.", "담당자를 찾을 수 없습니다.")}
                 onChange={(value) => {
                   const nextAssignee = parseAssigneeValue(value);
                   if (nextAssignee.assigneeAgentId) {
@@ -1373,7 +1438,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     )
                   ) : (
-                    <span className="text-muted-foreground">Assignee</span>
+                    <span className="text-muted-foreground">{copy("newIssue.assignee", "Assignee", "담당자")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1389,17 +1454,17 @@ export function NewIssueDialog() {
                   );
                 }}
               />
-              <span>in</span>
+              <span>{copy("newIssue.inProject", "in", "프로젝트")}</span>
               <InlineEntitySelector
                 ref={projectSelectorRef}
                 value={projectId}
                 options={projectOptions}
                 recentOptionIds={recentProjectIds}
-                placeholder="Project"
+                placeholder={copy("newIssue.project", "Project", "프로젝트")}
                 disablePortal
-                noneLabel="No project"
-                searchPlaceholder="Search projects..."
-                emptyMessage="No projects found."
+                noneLabel={copy("newIssue.noProject", "No project", "프로젝트 없음")}
+                searchPlaceholder={copy("newIssue.searchProjects", "Search projects...", "프로젝트 검색...")}
+                emptyMessage={copy("newIssue.noProjectsFound", "No projects found.", "프로젝트를 찾을 수 없습니다.")}
                 onChange={handleProjectChange}
                 onConfirm={() => {
                   descriptionEditorRef.current?.focus();
@@ -1414,7 +1479,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     </>
                   ) : (
-                    <span className="text-muted-foreground">Project</span>
+                    <span className="text-muted-foreground">{copy("newIssue.project", "Project", "프로젝트")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1438,7 +1503,7 @@ export function NewIssueDialog() {
                   <button
                     type="button"
                     className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent/50 transition-colors"
-                    title="Add reviewer or approver"
+                    title={copy("newIssue.addReviewerApprover", "Add reviewer or approver", "검토자 또는 승인자 추가")}
                   >
                     <MoreHorizontal className="h-4 w-4" />
                   </button>
@@ -1456,7 +1521,7 @@ export function NewIssueDialog() {
                     }}
                   >
                     <Eye className="h-3 w-3" />
-                    Reviewer
+                    {copy("newIssue.reviewer", "Reviewer", "검토자")}
                   </button>
                   <button
                     className={cn(
@@ -1470,7 +1535,7 @@ export function NewIssueDialog() {
                     }}
                   >
                     <ShieldCheck className="h-3 w-3" />
-                    Approver
+                    {copy("newIssue.approver", "Approver", "승인자")}
                   </button>
                 </PopoverContent>
               </Popover>
@@ -1485,11 +1550,11 @@ export function NewIssueDialog() {
                 value={reviewerValue}
                 options={assigneeOptions}
                 recentOptionIds={recentAssigneeOptionIds}
-                placeholder="Reviewer"
+                placeholder={copy("newIssue.reviewer", "Reviewer", "검토자")}
                 disablePortal
-                noneLabel="No reviewer"
-                searchPlaceholder="Search reviewers..."
-                emptyMessage="No reviewers found."
+                noneLabel={copy("newIssue.noReviewer", "No reviewer", "검토자 없음")}
+                searchPlaceholder={copy("newIssue.searchReviewers", "Search reviewers...", "검토자 검색...")}
+                emptyMessage={copy("newIssue.noReviewersFound", "No reviewers found.", "검토자를 찾을 수 없습니다.")}
                 onChange={setReviewerValue}
                 renderTriggerValue={(option) =>
                   option ? (
@@ -1503,7 +1568,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     </>
                   ) : (
-                    <span className="text-muted-foreground">Reviewer</span>
+                    <span className="text-muted-foreground">{copy("newIssue.reviewer", "Reviewer", "검토자")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1530,11 +1595,11 @@ export function NewIssueDialog() {
                 value={approverValue}
                 options={assigneeOptions}
                 recentOptionIds={recentAssigneeOptionIds}
-                placeholder="Approver"
+                placeholder={copy("newIssue.approver", "Approver", "승인자")}
                 disablePortal
-                noneLabel="No approver"
-                searchPlaceholder="Search approvers..."
-                emptyMessage="No approvers found."
+                noneLabel={copy("newIssue.noApprover", "No approver", "승인자 없음")}
+                searchPlaceholder={copy("newIssue.searchApprovers", "Search approvers...", "승인자 검색...")}
+                emptyMessage={copy("newIssue.noApproversFound", "No approvers found.", "승인자를 찾을 수 없습니다.")}
                 onChange={setApproverValue}
                 renderTriggerValue={(option) =>
                   option ? (
@@ -1548,7 +1613,7 @@ export function NewIssueDialog() {
                       <span className="truncate">{option.label}</span>
                     </>
                   ) : (
-                    <span className="text-muted-foreground">Approver</span>
+                    <span className="text-muted-foreground">{copy("newIssue.approver", "Approver", "승인자")}</span>
                   )
                 }
                 renderOption={(option) => {
@@ -1573,7 +1638,7 @@ export function NewIssueDialog() {
             <div className="max-w-full rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground">
               <div className="flex items-center gap-1.5">
                 <ListTree className="h-3.5 w-3.5 shrink-0" />
-                <span className="shrink-0">Sub-issue of</span>
+                <span className="shrink-0">{copy("newIssue.subIssueOf", "Sub-issue of", "상위 작업")}</span>
                 <span className="font-medium text-foreground">{parentIssueLabel}</span>
               </div>
               {newIssueDefaults.parentTitle ? (
@@ -1588,9 +1653,13 @@ export function NewIssueDialog() {
           {currentProject && currentProjectSupportsExecutionWorkspace && (
             <div className="px-4 py-3 space-y-2">
             <div className="space-y-1.5">
-              <div className="text-xs font-medium">Execution workspace</div>
+              <div className="text-xs font-medium">{copy("newIssue.executionWorkspace", "Execution workspace", "실행 작업공간")}</div>
               <div className="text-[11px] text-muted-foreground">
-                Control whether this issue runs in the shared workspace, a new isolated workspace, or an existing one.
+                {copy(
+                  "newIssue.executionWorkspaceHelp",
+                  "Control whether this issue runs in the shared workspace, a new isolated workspace, or an existing one.",
+                  "이 작업을 공유 작업공간, 새 격리 작업공간, 기존 작업공간 중 어디서 실행할지 정합니다.",
+                )}
               </div>
               <select
                 className="w-full rounded border border-border bg-transparent px-2 py-1.5 text-xs outline-none"
@@ -1604,7 +1673,7 @@ export function NewIssueDialog() {
               >
                 {EXECUTION_WORKSPACE_MODES.map((option) => (
                   <option key={option.value} value={option.value}>
-                    {option.label}
+                    {executionWorkspaceModeLabel(option.value, copy)}
                   </option>
                 ))}
               </select>
@@ -1614,7 +1683,7 @@ export function NewIssueDialog() {
                   value={selectedExecutionWorkspaceId}
                   onChange={(e) => setSelectedExecutionWorkspaceId(e.target.value)}
                 >
-                  <option value="">Choose an existing workspace</option>
+                  <option value="">{copy("newIssue.chooseExistingWorkspace", "Choose an existing workspace", "기존 작업공간 선택")}</option>
                   {deduplicatedReusableWorkspaces.map((workspace) => (
                     <option key={workspace.id} value={workspace.id}>
                       {workspace.name} · {workspace.status} · {workspace.branchName ?? workspace.cwd ?? workspace.id.slice(0, 8)}
@@ -1624,12 +1693,20 @@ export function NewIssueDialog() {
               )}
               {executionWorkspaceMode === "reuse_existing" && selectedReusableExecutionWorkspace && (
                 <div className="text-[11px] text-muted-foreground">
-                  Reusing {selectedReusableExecutionWorkspace.name} from {selectedReusableExecutionWorkspace.branchName ?? selectedReusableExecutionWorkspace.cwd ?? "existing execution workspace"}.
+                  {copy("newIssue.reusingWorkspace", "Reusing {{name}} from {{source}}.", "{{source}}의 {{name}} 재사용.", {
+                    name: selectedReusableExecutionWorkspace.name,
+                    source: selectedReusableExecutionWorkspace.branchName ?? selectedReusableExecutionWorkspace.cwd ?? copy("newIssue.existingExecutionWorkspace", "existing execution workspace", "기존 실행 작업공간"),
+                  })}
                 </div>
               )}
               {showParentWorkspaceWarning ? (
                 <div className="rounded-md border border-amber-300/60 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-900 dark:border-amber-800/70 dark:bg-amber-950/30 dark:text-amber-100">
-                  Warning: this sub-issue will no longer use the parent issue workspace{parentExecutionWorkspaceLabel ? ` (${parentExecutionWorkspaceLabel})` : ""}.
+                  {copy(
+                    "newIssue.parentWorkspaceWarning",
+                    "Warning: this sub-issue will no longer use the parent issue workspace{{workspace}}.",
+                    "경고: 이 하위 작업은 더 이상 상위 작업공간{{workspace}}을 사용하지 않습니다.",
+                    { workspace: parentExecutionWorkspaceLabel ? ` (${parentExecutionWorkspaceLabel})` : "" },
+                  )}
                 </div>
               ) : null}
             </div>
@@ -1648,11 +1725,11 @@ export function NewIssueDialog() {
             {assigneeOptionsOpen && (
               <div className="mt-2 rounded-md border border-border p-3 bg-muted/20 space-y-3">
                 <div className="space-y-1.5">
-                  <div className="text-xs text-muted-foreground">Model lane</div>
+                  <div className="text-xs text-muted-foreground">{copy("newIssue.modelLane", "Model lane", "모델 경로")}</div>
                   <div
                     className="flex w-full overflow-hidden rounded-md border border-border"
                     role="radiogroup"
-                    aria-label="Model lane"
+                    aria-label={copy("newIssue.modelLane", "Model lane", "모델 경로")}
                   >
                     {(["primary", ...(assigneeSupportsCheapLane ? (["cheap"] as const) : ([] as const)), "custom"] as const).map((lane) => (
                       <button
@@ -1666,49 +1743,45 @@ export function NewIssueDialog() {
                         )}
                         onClick={() => setAssigneeModelLane(lane)}
                       >
-                        {lane === "primary"
-                          ? "Primary"
-                          : lane === "cheap"
-                            ? "Cheap"
-                            : "Custom"}
+                        {issueModelLaneLabel(lane, copy)}
                       </button>
                     ))}
                   </div>
                   {assigneeModelLane === "cheap" && (
                     <p className="text-[11px] text-muted-foreground">
-                      Sends <code>modelProfile: "cheap"</code>{" "}
+                      {copy("newIssue.cheapLaneSends", "Sends", "전송")} <code>modelProfile: "cheap"</code>{" "}
                       {assigneeCheapProfile?.adapterConfig && typeof (assigneeCheapProfile.adapterConfig as Record<string, unknown>).model === "string"
-                        ? <>· adapter default <code>{String((assigneeCheapProfile.adapterConfig as Record<string, unknown>).model)}</code></>
+                          ? <>· {copy("newIssue.adapterDefault", "adapter default", "어댑터 기본값")} <code>{String((assigneeCheapProfile.adapterConfig as Record<string, unknown>).model)}</code></>
                         : assigneeCheapProfile
-                          ? <>· uses the agent's configured cheap profile</>
-                          : <>· falls back to the primary model if no cheap profile is configured</>}
+                          ? <>· {copy("newIssue.cheapProfileConfigured", "uses the agent's configured cheap profile", "직원에 설정된 저비용 프로필 사용")}</>
+                          : <>· {copy("newIssue.cheapProfileFallback", "falls back to the primary model if no cheap profile is configured", "저비용 프로필이 없으면 기본 모델로 실행")}</>}
                     </p>
                   )}
                   {assigneeModelLane === "primary" && (
-                    <p className="text-[11px] text-muted-foreground">Runs on the agent's primary model.</p>
+                    <p className="text-[11px] text-muted-foreground">{copy("newIssue.primaryLaneHelp", "Runs on the agent's primary model.", "직원의 기본 모델로 실행합니다.")}</p>
                   )}
                   {assigneeModelLane === "custom" && (
-                    <p className="text-[11px] text-muted-foreground">Override the model and effort for this issue only.</p>
+                    <p className="text-[11px] text-muted-foreground">{copy("newIssue.customLaneHelp", "Override the model and effort for this issue only.", "이 작업에만 모델과 추론 강도를 덮어씁니다.")}</p>
                   )}
                 </div>
                 {assigneeModelLane === "custom" && (
                   <div className="space-y-1.5">
-                    <div className="text-xs text-muted-foreground">Model</div>
+                    <div className="text-xs text-muted-foreground">{copy("newIssue.model", "Model", "모델")}</div>
                     <InlineEntitySelector
                       value={assigneeModelOverride}
                       options={modelOverrideOptions}
-                      placeholder="Default model"
+                      placeholder={copy("newIssue.defaultModel", "Default model", "기본 모델")}
                       disablePortal
-                      noneLabel="Default model"
-                      searchPlaceholder="Search models..."
-                      emptyMessage="No models found."
+                      noneLabel={copy("newIssue.defaultModel", "Default model", "기본 모델")}
+                      searchPlaceholder={copy("newIssue.searchModels", "Search models...", "모델 검색...")}
+                      emptyMessage={copy("newIssue.noModelsFound", "No models found.", "모델을 찾을 수 없습니다.")}
                       onChange={setAssigneeModelOverride}
                     />
                   </div>
                 )}
                 {assigneeModelLane === "custom" && (
                   <div className="space-y-1.5">
-                    <div className="text-xs text-muted-foreground">Thinking effort</div>
+                    <div className="text-xs text-muted-foreground">{copy("newIssue.thinkingEffort", "Thinking effort", "추론 강도")}</div>
                     <div className="flex items-center gap-1.5 flex-wrap">
                       {thinkingEffortOptions.map((option) => (
                         <button
@@ -1719,7 +1792,7 @@ export function NewIssueDialog() {
                           )}
                           onClick={() => setAssigneeThinkingEffort(option.value)}
                         >
-                          {option.label}
+                          {thinkingEffortLabel(option.value, option.label, copy)}
                         </button>
                       ))}
                     </div>
@@ -1727,7 +1800,7 @@ export function NewIssueDialog() {
                 )}
                 {assigneeAdapterType === "claude_local" && assigneeModelLane === "custom" && (
                   <div className="flex items-center justify-between rounded-md border border-border px-2 py-1.5">
-                    <div className="text-xs text-muted-foreground">Enable Chrome (--chrome)</div>
+                    <div className="text-xs text-muted-foreground">{copy("newIssue.enableChrome", "Enable Chrome (--chrome)", "Chrome 사용 (--chrome)")}</div>
                     <ToggleSwitch
                       checked={assigneeChrome}
                       onCheckedChange={() => setAssigneeChrome((value) => !value)}
@@ -1766,7 +1839,7 @@ export function NewIssueDialog() {
               <div className="mt-4 space-y-3 rounded-lg border border-border/70 p-3">
               {stagedDocuments.length > 0 ? (
                 <div className="space-y-2">
-                  <div className="text-xs font-medium text-muted-foreground">Documents</div>
+                  <div className="text-xs font-medium text-muted-foreground">{copy("newIssue.documents", "Documents", "문서")}</div>
                   <div className="space-y-2">
                     {stagedDocuments.map((file) => (
                       <div key={file.id} className="flex items-start justify-between gap-3 rounded-md border border-border/70 px-3 py-2">
@@ -1790,7 +1863,7 @@ export function NewIssueDialog() {
                           className="shrink-0 text-muted-foreground"
                           onClick={() => removeStagedFile(file.id)}
                           disabled={createIssue.isPending}
-                          title="Remove document"
+                          title={copy("newIssue.removeDocument", "Remove document", "문서 제거")}
                         >
                           <X className="h-3.5 w-3.5" />
                         </Button>
@@ -1802,7 +1875,7 @@ export function NewIssueDialog() {
 
               {stagedAttachments.length > 0 ? (
                 <div className="space-y-2">
-                  <div className="text-xs font-medium text-muted-foreground">Attachments</div>
+                  <div className="text-xs font-medium text-muted-foreground">{copy("newIssue.attachments", "Attachments", "첨부파일")}</div>
                   <div className="space-y-2">
                     {stagedAttachments.map((file) => (
                       <div key={file.id} className="flex items-start justify-between gap-3 rounded-md border border-border/70 px-3 py-2">
@@ -1821,7 +1894,7 @@ export function NewIssueDialog() {
                           className="shrink-0 text-muted-foreground"
                           onClick={() => removeStagedFile(file.id)}
                           disabled={createIssue.isPending}
-                          title="Remove attachment"
+                          title={copy("newIssue.removeAttachment", "Remove attachment", "첨부파일 제거")}
                         >
                           <X className="h-3.5 w-3.5" />
                         </Button>
@@ -1842,7 +1915,7 @@ export function NewIssueDialog() {
             <PopoverTrigger asChild>
               <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent/50 transition-colors">
                 <CircleDot className={cn("h-3 w-3", currentStatus.color)} />
-                {currentStatus.label}
+                {issueStatusLabel(currentStatus.value, currentStatus.label, copy)}
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-56 p-1" align="start">
@@ -1857,9 +1930,9 @@ export function NewIssueDialog() {
                 >
                   <CircleDot className={cn("h-3 w-3 mt-0.5 shrink-0", s.color)} />
                   <span className="flex flex-col text-left leading-tight">
-                    <span>{s.label}</span>
-                    {s.description ? (
-                      <span className="text-[10px] text-muted-foreground">{s.description}</span>
+                    <span>{issueStatusLabel(s.value, s.label, copy)}</span>
+                    {issueStatusDescription(s.value, s.description, copy) ? (
+                      <span className="text-[10px] text-muted-foreground">{issueStatusDescription(s.value, s.description, copy)}</span>
                     ) : null}
                   </span>
                 </button>
@@ -1878,12 +1951,12 @@ export function NewIssueDialog() {
                 {currentPriority ? (
                   <>
                     <currentPriority.icon className={cn("h-3 w-3", currentPriority.color)} />
-                    {currentPriority.label}
+                    {priorityLabel(currentPriority.value, currentPriority.label, copy)}
                   </>
                 ) : (
                   <>
                     <Minus className="h-3 w-3 text-muted-foreground" />
-                    Priority
+                    {copy("newIssue.priority", "Priority", "우선순위")}
                   </>
                 )}
               </button>
@@ -1899,7 +1972,7 @@ export function NewIssueDialog() {
                   onClick={() => { setPriority(p.value); setPriorityOpen(false); }}
                 >
                   <p.icon className={cn("h-3 w-3", p.color)} />
-                  {p.label}
+                  {priorityLabel(p.value, p.label, copy)}
                 </button>
               ))}
             </PopoverContent>
@@ -1925,7 +1998,7 @@ export function NewIssueDialog() {
             disabled={createIssue.isPending}
           >
             <Paperclip className="h-3 w-3" />
-            Upload
+            {copy("newIssue.upload", "Upload", "업로드")}
           </button>
 
           {/* Work mode chip */}
@@ -1942,7 +2015,7 @@ export function NewIssueDialog() {
                 )}
               >
                 <CurrentWorkModeIcon className="h-3 w-3" />
-                {currentWorkMode.label}
+                {workModeLabel(currentWorkMode.value, currentWorkMode.label, copy)}
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-36 p-1" align="start">
@@ -1963,7 +2036,7 @@ export function NewIssueDialog() {
                     }}
                   >
                     <Icon className="h-3 w-3" />
-                    {option.label}
+                    {workModeLabel(option.value, option.label, copy)}
                   </button>
                 );
               })}
@@ -1984,7 +2057,7 @@ export function NewIssueDialog() {
             <PopoverContent className="w-44 p-1" align="start" data-testid="new-issue-more-menu">
               <div className="sm:hidden">
                 <div className="px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
-                  Priority
+                  {copy("newIssue.priority", "Priority", "우선순위")}
                 </div>
                 {priorities.map((p) => (
                   <button
@@ -2001,18 +2074,18 @@ export function NewIssueDialog() {
                     }}
                   >
                     <p.icon className={cn("h-3 w-3", p.color)} />
-                    {p.label}
+                    {priorityLabel(p.value, p.label, copy)}
                   </button>
                 ))}
                 <div className="my-1 border-t border-border" />
               </div>
               <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
                 <Calendar className="h-3 w-3" />
-                Start date
+                {copy("newIssue.startDate", "Start date", "시작일")}
               </button>
               <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
                 <Calendar className="h-3 w-3" />
-                Due date
+                {copy("newIssue.dueDate", "Due date", "마감일")}
               </button>
             </PopoverContent>
           </Popover>
@@ -2025,7 +2098,13 @@ export function NewIssueDialog() {
           >
             <Flag className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-300" />
             <span className="leading-snug">
-              Assigning implies executable intent — leave status as <span className="font-medium">Backlog</span> only to deliberately park this. The assignee will not be woken until status moves to <span className="font-medium">Todo</span> or <span className="font-medium">In Progress</span>.
+              {copy("newIssue.assignedBacklogNotePrefix", "Assigning implies executable intent - leave status as", "담당자 배정은 실행 의도를 뜻합니다. 일부러 보류하려면 상태를")}
+              {" "}<span className="font-medium">{copy("status.backlog", "Backlog", "대기")}</span>{" "}
+              {copy("newIssue.assignedBacklogNoteMiddle", "only to deliberately park this. The assignee will not be woken until status moves to", "로 유지하세요. 상태가")}
+              {" "}<span className="font-medium">{copy("status.todo", "Todo", "할 일")}</span>{" "}
+              {copy("newIssue.assignedBacklogNoteOr", "or", "또는")}
+              {" "}<span className="font-medium">{copy("status.inProgress", "In Progress", "진행 중")}</span>{" "}
+              {copy("newIssue.assignedBacklogNoteSuffix", "before the assignee is woken.", "으로 바뀌기 전까지 담당자는 깨워지지 않습니다.")}
             </span>
           </div>
         ) : null}
@@ -2039,14 +2118,14 @@ export function NewIssueDialog() {
             onClick={discardDraft}
             disabled={createIssue.isPending || !canDiscardDraft}
           >
-            Discard Draft
+            {copy("newIssue.discardDraft", "Discard Draft", "초안 버리기")}
           </Button>
           <div className="flex items-center gap-3">
             <div className="min-h-5 text-right">
               {createIssue.isPending ? (
                 <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                   <Loader2 className="h-3 w-3 animate-spin" />
-                  Creating issue...
+                  {copy("newIssue.creatingIssue", "Creating issue...", "작업 생성 중...")}
                 </span>
               ) : createIssue.isError ? (
                 <span className="text-xs text-destructive">{createIssueErrorMessage}</span>
@@ -2061,7 +2140,13 @@ export function NewIssueDialog() {
             >
               <span className="inline-flex items-center justify-center gap-1.5">
                 {createIssue.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-                <span>{createIssue.isPending ? "Creating..." : isSubIssueMode ? "Create Sub-Issue" : "Create Issue"}</span>
+                <span>
+                  {createIssue.isPending
+                    ? copy("newIssue.creating", "Creating...", "생성 중...")
+                    : isSubIssueMode
+                      ? copy("newIssue.createSubIssue", "Create Sub-Issue", "하위 작업 생성")
+                      : copy("newIssue.createIssue", "Create Issue", "작업 생성")}
+                </span>
               </span>
             </Button>
           </div>

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -35,22 +35,24 @@ import {
 } from "@/components/ui/tooltip";
 import { PROJECT_COLORS } from "@paperclipai/shared";
 import { cn } from "../lib/utils";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
 import { ChoosePathButton } from "./PathInstructionsModal";
 
 const projectStatuses = [
-  { value: "backlog", label: "Backlog" },
-  { value: "planned", label: "Planned" },
-  { value: "in_progress", label: "In Progress" },
-  { value: "completed", label: "Completed" },
-  { value: "cancelled", label: "Cancelled" },
+  { value: "backlog", key: "backlog", english: "Backlog", korean: "대기" },
+  { value: "planned", key: "planned", english: "Planned", korean: "계획됨" },
+  { value: "in_progress", key: "inProgress", english: "In Progress", korean: "진행 중" },
+  { value: "completed", key: "completed", english: "Completed", korean: "완료" },
+  { value: "cancelled", key: "cancelled", english: "Cancelled", korean: "취소" },
 ];
 
 export function NewProjectDialog() {
   const { newProjectOpen, closeNewProject } = useDialog();
   const { selectedCompanyId, selectedCompany } = useCompany();
   const queryClient = useQueryClient();
+  const copy = useLocalizedCopy();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("planned");
@@ -97,7 +99,7 @@ export function NewProjectDialog() {
 
   const uploadDescriptionImage = useMutation({
     mutationFn: async (file: File) => {
-      if (!selectedCompanyId) throw new Error("No company selected");
+      if (!selectedCompanyId) throw new Error(copy("newProject.error.noCompany", "No company selected", "선택된 회사가 없습니다."));
       return assetsApi.uploadImage(selectedCompanyId, file, "projects/drafts");
     },
   });
@@ -130,7 +132,7 @@ export function NewProjectDialog() {
   const deriveWorkspaceNameFromPath = (value: string) => {
     const normalized = value.trim().replace(/[\\/]+$/, "");
     const segments = normalized.split(/[\\/]/).filter(Boolean);
-    return segments[segments.length - 1] ?? "Local folder";
+    return segments[segments.length - 1] ?? copy("newProject.workspace.localFolder", "Local folder", "로컬 폴더");
   };
 
   const deriveWorkspaceNameFromRepo = (value: string) => {
@@ -138,9 +140,9 @@ export function NewProjectDialog() {
       const parsed = new URL(value);
       const segments = parsed.pathname.split("/").filter(Boolean);
       const repo = segments[segments.length - 1]?.replace(/\.git$/i, "") ?? "";
-      return repo || "GitHub repo";
+      return repo || copy("newProject.workspace.githubRepo", "GitHub repo", "GitHub 저장소");
     } catch {
-      return "GitHub repo";
+      return copy("newProject.workspace.githubRepo", "GitHub repo", "GitHub 저장소");
     }
   };
 
@@ -150,11 +152,19 @@ export function NewProjectDialog() {
     const repoUrl = workspaceRepoUrl.trim();
 
     if (localPath && !isAbsolutePath(localPath)) {
-      setWorkspaceError("Local folder must be a full absolute path.");
+      setWorkspaceError(copy(
+        "newProject.error.localPath",
+        "Local folder must be a full absolute path.",
+        "로컬 폴더는 전체 절대 경로여야 합니다.",
+      ));
       return;
     }
     if (repoUrl && !looksLikeRepoUrl(repoUrl)) {
-      setWorkspaceError("Repo must use a valid GitHub or GitHub Enterprise repo URL.");
+      setWorkspaceError(copy(
+        "newProject.error.repoUrl",
+        "Repo must use a valid GitHub or GitHub Enterprise repo URL.",
+        "저장소는 유효한 GitHub 또는 GitHub Enterprise 저장소 URL이어야 합니다.",
+      ));
       return;
     }
 
@@ -224,7 +234,7 @@ export function NewProjectDialog() {
               </span>
             )}
             <span className="text-muted-foreground/60">&rsaquo;</span>
-            <span>New project</span>
+            <span>{copy("newProject.title", "New project", "새 프로젝트")}</span>
           </div>
           <div className="flex items-center gap-1">
             <Button
@@ -232,6 +242,9 @@ export function NewProjectDialog() {
               size="icon-xs"
               className="text-muted-foreground"
               onClick={() => setExpanded(!expanded)}
+              aria-label={expanded
+                ? copy("newProject.collapse", "Collapse dialog", "창 축소")
+                : copy("newProject.expand", "Expand dialog", "창 확대")}
             >
               {expanded ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
             </Button>
@@ -240,6 +253,7 @@ export function NewProjectDialog() {
               size="icon-xs"
               className="text-muted-foreground"
               onClick={() => { reset(); closeNewProject(); }}
+              aria-label={copy("common.close", "Close", "닫기")}
             >
               <span className="text-lg leading-none">&times;</span>
             </Button>
@@ -250,7 +264,7 @@ export function NewProjectDialog() {
         <div className="px-4 pt-4 pb-2 shrink-0">
           <input
             className="w-full text-lg font-semibold bg-transparent outline-none placeholder:text-muted-foreground/50"
-            placeholder="Project name"
+            placeholder={copy("newProject.name.placeholder", "Project name", "프로젝트 이름")}
             value={name}
             onChange={(e) => setName(e.target.value)}
             onKeyDown={(e) => {
@@ -269,7 +283,7 @@ export function NewProjectDialog() {
             ref={descriptionEditorRef}
             value={description}
             onChange={setDescription}
-            placeholder="Add description..."
+            placeholder={copy("newProject.description.placeholder", "Add description...", "설명 추가...")}
             bordered={false}
             mentions={mentionOptions}
             contentClassName={cn("text-sm text-muted-foreground", expanded ? "min-h-[220px]" : "min-h-[120px]")}
@@ -283,14 +297,18 @@ export function NewProjectDialog() {
         <div className="px-4 pt-3 pb-3 space-y-3 border-t border-border">
           <div>
             <div className="mb-1 flex items-center gap-1.5">
-              <label className="block text-xs text-muted-foreground">Repo URL</label>
-              <span className="text-xs text-muted-foreground/50">optional</span>
+              <label className="block text-xs text-muted-foreground">{copy("newProject.repoUrl", "Repo URL", "저장소 URL")}</label>
+              <span className="text-xs text-muted-foreground/50">{copy("common.optional", "optional", "선택")}</span>
               <Tooltip delayDuration={300}>
                 <TooltipTrigger asChild>
                   <HelpCircle className="h-3 w-3 text-muted-foreground/50 cursor-help" />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="max-w-[240px] text-xs">
-                  Link a GitHub repository so agents can clone, read, and push code for this project.
+                  {copy(
+                    "newProject.repoUrl.help",
+                    "Link a GitHub repository so agents can clone, read, and push code for this project.",
+                    "직원이 이 프로젝트의 코드를 clone, 읽기, push할 수 있도록 GitHub 저장소를 연결합니다.",
+                  )}
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -304,14 +322,18 @@ export function NewProjectDialog() {
 
           <div>
             <div className="mb-1 flex items-center gap-1.5">
-              <label className="block text-xs text-muted-foreground">Local folder</label>
-              <span className="text-xs text-muted-foreground/50">optional</span>
+              <label className="block text-xs text-muted-foreground">{copy("newProject.localFolder", "Local folder", "로컬 폴더")}</label>
+              <span className="text-xs text-muted-foreground/50">{copy("common.optional", "optional", "선택")}</span>
               <Tooltip delayDuration={300}>
                 <TooltipTrigger asChild>
                   <HelpCircle className="h-3 w-3 text-muted-foreground/50 cursor-help" />
                 </TooltipTrigger>
                 <TooltipContent side="top" className="max-w-[240px] text-xs">
-                  Set an absolute path on this machine where local agents will read and write files for this project.
+                  {copy(
+                    "newProject.localFolder.help",
+                    "Set an absolute path on this machine where local agents will read and write files for this project.",
+                    "이 프로젝트에서 로컬 직원이 파일을 읽고 쓸 이 PC의 절대 경로를 지정합니다.",
+                  )}
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -350,7 +372,7 @@ export function NewProjectDialog() {
                   )}
                   onClick={() => { setStatus(s.value); setStatusOpen(false); }}
                 >
-                  {s.label}
+                  {copy(`newProject.status.${s.key}`, s.english, s.korean)}
                 </button>
               ))}
             </PopoverContent>
@@ -366,7 +388,7 @@ export function NewProjectDialog() {
               <button
                 className="text-muted-foreground hover:text-foreground"
                 onClick={() => setGoalIds((prev) => prev.filter((id) => id !== goal.id))}
-                aria-label={`Remove goal ${goal.title}`}
+                aria-label={copy("newProject.goal.remove", "Remove goal {{title}}", "{{title}} 목표 제거", { title: goal.title })}
                 type="button"
               >
                 <X className="h-3 w-3" />
@@ -381,7 +403,9 @@ export function NewProjectDialog() {
                 disabled={selectedGoals.length > 0 && availableGoals.length === 0}
               >
                 {selectedGoals.length > 0 ? <Plus className="h-3 w-3 text-muted-foreground" /> : <Target className="h-3 w-3 text-muted-foreground" />}
-                {selectedGoals.length > 0 ? "+ Goal" : "Goal"}
+                {selectedGoals.length > 0
+                  ? copy("newProject.goal.addAnother", "+ Goal", "+ 목표")
+                  : copy("newProject.goal", "Goal", "목표")}
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-56 p-1" align="start">
@@ -390,7 +414,7 @@ export function NewProjectDialog() {
                   className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground"
                   onClick={() => setGoalOpen(false)}
                 >
-                  No goal
+                  {copy("newProject.goal.none", "No goal", "목표 없음")}
                 </button>
               )}
               {availableGoals.map((g) => (
@@ -407,7 +431,7 @@ export function NewProjectDialog() {
               ))}
               {selectedGoals.length > 0 && availableGoals.length === 0 && (
                 <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                  All goals already selected.
+                  {copy("newProject.goal.allSelected", "All goals already selected.", "모든 목표가 이미 선택되었습니다.")}
                 </div>
               )}
             </PopoverContent>
@@ -429,7 +453,9 @@ export function NewProjectDialog() {
         {/* Footer */}
         <div className="flex items-center justify-between px-4 py-2.5 border-t border-border">
           {createProject.isError ? (
-            <p className="text-xs text-destructive">Failed to create project.</p>
+            <p className="text-xs text-destructive">
+              {copy("newProject.error.createFailed", "Failed to create project.", "프로젝트를 만들지 못했습니다.")}
+            </p>
           ) : (
             <span />
           )}
@@ -438,7 +464,9 @@ export function NewProjectDialog() {
             disabled={!name.trim() || createProject.isPending}
             onClick={handleSubmit}
           >
-            {createProject.isPending ? "Creating…" : "Create project"}
+            {createProject.isPending
+              ? copy("newProject.creating", "Creating…", "만드는 중...")
+              : copy("newProject.create", "Create project", "프로젝트 만들기")}
           </Button>
         </div>
       </DialogContent>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -28,7 +28,8 @@ import { listUIAdapters } from "../adapters";
 import { isVisualAdapterChoice } from "../adapters/metadata";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
-import { getAdapterDisplay } from "../adapters/adapter-display-registry";
+import { getLocalizedAdapterDisplay } from "../adapters/adapter-display-registry";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { parseOnboardingGoalInput } from "../lib/onboarding-goal";
 import {
@@ -70,6 +71,7 @@ const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the
 - break the roadmap into concrete tasks and start delegating work`;
 
 export function OnboardingWizard() {
+  const copy = useLocalizedCopy();
   const { onboardingOpen, onboardingOptions, closeOnboarding } = useDialog();
   const { companies, setSelectedCompanyId, loading: companiesLoading } = useCompany();
   const queryClient = useQueryClient();
@@ -213,13 +215,13 @@ export function OnboardingWizard() {
         !disabledTypes.has(a.type) &&
         isVisualAdapterChoice(a.type)
       )
-      .map((a) => ({ ...getAdapterDisplay(a.type), type: a.type }));
+      .map((a) => ({ ...getLocalizedAdapterDisplay(a.type, copy), type: a.type }));
 
     return {
       recommendedAdapters: all.filter((a) => a.recommended),
       moreAdapters: all.filter((a) => !a.recommended),
     };
-  }, [disabledTypes]);
+  }, [copy, disabledTypes]);
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
     claude_local: "claude",
     codex_local: "codex",
@@ -738,7 +740,7 @@ export function OnboardingWizard() {
                   {/* Adapter type radio cards */}
                   <div>
                     <label className="text-xs text-muted-foreground mb-2 block">
-                      Adapter type
+                      {copy("onboarding.adapterType", "Adapter type", "직원 런타임")}
                     </label>
                     <div className="grid grid-cols-2 gap-2">
                       {recommendedAdapters.map((opt) => (
@@ -768,7 +770,7 @@ export function OnboardingWizard() {
                         >
                           {opt.recommended && (
                             <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
-                              Recommended
+                              {copy("common.recommended", "Recommended", "추천")}
                             </span>
                           )}
                           <opt.icon className="h-4 w-4" />
@@ -790,7 +792,7 @@ export function OnboardingWizard() {
                           showMoreAdapters ? "rotate-0" : "-rotate-90"
                         )}
                       />
-                      More Agent Adapter Types
+                      {copy("onboarding.moreAdapters", "More Agent Adapter Types", "다른 직원 런타임")}
                     </button>
 
                     {showMoreAdapters && (
@@ -830,7 +832,7 @@ export function OnboardingWizard() {
                             <span className="font-medium">{opt.label}</span>
                             <span className="text-muted-foreground text-[10px]">
                               {opt.comingSoon
-                                ? opt.disabledLabel ?? "Coming soon"
+                                ? opt.disabledLabel ?? copy("common.comingSoon", "Coming soon", "예정")
                                 : opt.description}
                             </span>
                           </button>
@@ -844,7 +846,7 @@ export function OnboardingWizard() {
                     <div className="space-y-3">
                       <div>
                         <label className="text-xs text-muted-foreground mb-1 block">
-                          Model
+                          {copy("common.model", "Model", "모델")}
                         </label>
                         <Popover
                           open={modelOpen}

--- a/ui/src/components/PriorityIcon.tsx
+++ b/ui/src/components/PriorityIcon.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/utils";
 import { priorityColor, priorityColorDefault } from "../lib/status-colors";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 const priorityConfig: Record<string, { icon: typeof ArrowUp; color: string; label: string }> = {
   critical: { icon: AlertTriangle, color: priorityColor.critical ?? priorityColorDefault, label: "Critical" },
@@ -14,6 +15,21 @@ const priorityConfig: Record<string, { icon: typeof ArrowUp; color: string; labe
 
 const allPriorities = ["critical", "high", "medium", "low"];
 
+function priorityLabel(priority: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  switch (priority) {
+    case "critical":
+      return copy("priority.critical", "Critical", "긴급");
+    case "high":
+      return copy("priority.high", "High", "높음");
+    case "medium":
+      return copy("priority.medium", "Medium", "보통");
+    case "low":
+      return copy("priority.low", "Low", "낮음");
+    default:
+      return priority.replace(/_/g, " ");
+  }
+}
+
 interface PriorityIconProps {
   priority: string;
   onChange?: (priority: string) => void;
@@ -22,9 +38,11 @@ interface PriorityIconProps {
 }
 
 export function PriorityIcon({ priority, onChange, className, showLabel }: PriorityIconProps) {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(false);
   const config = priorityConfig[priority] ?? priorityConfig.medium!;
   const Icon = config.icon;
+  const label = priorityLabel(priority, copy);
 
   const icon = (
     <span
@@ -39,12 +57,12 @@ export function PriorityIcon({ priority, onChange, className, showLabel }: Prior
     </span>
   );
 
-  if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{icon}<span className="text-sm">{config.label}</span></span> : icon;
+  if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{icon}<span className="text-sm">{label}</span></span> : icon;
 
   const trigger = showLabel ? (
     <button className="inline-flex items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors">
       {icon}
-      <span className="text-sm">{config.label}</span>
+      <span className="text-sm">{label}</span>
     </button>
   ) : icon;
 
@@ -67,7 +85,7 @@ export function PriorityIcon({ priority, onChange, className, showLabel }: Prior
               }}
             >
               <PIcon className={cn("h-3.5 w-3.5", c.color)} />
-              {c.label}
+              {priorityLabel(p, copy)}
             </Button>
           );
         })}

--- a/ui/src/components/PropertiesPanel.tsx
+++ b/ui/src/components/PropertiesPanel.tsx
@@ -2,8 +2,10 @@ import { X } from "lucide-react";
 import { usePanel } from "../context/PanelContext";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 export function PropertiesPanel() {
+  const copy = useLocalizedCopy();
   const { panelContent, panelVisible, setPanelVisible } = usePanel();
 
   if (!panelContent) return null;
@@ -15,7 +17,7 @@ export function PropertiesPanel() {
     >
       <div className="w-80 flex-1 flex flex-col min-w-[320px] min-h-0">
         <div className="flex items-center justify-between px-4 py-2 border-b border-border">
-          <span className="text-sm font-medium">Properties</span>
+          <span className="text-sm font-medium">{copy("propertiesPanel.title", "Properties", "속성")}</span>
           <Button variant="ghost" size="icon-xs" onClick={() => setPanelVisible(false)}>
             <X className="h-4 w-4" />
           </Button>

--- a/ui/src/components/RunChatSurface.tsx
+++ b/ui/src/components/RunChatSurface.tsx
@@ -3,6 +3,7 @@ import type { TranscriptEntry } from "../adapters";
 import type { LiveRunForIssue } from "../api/heartbeats";
 import { IssueChatThread } from "./IssueChatThread";
 import type { IssueChatLinkedRun } from "../lib/issue-chat-messages";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 
 const EMPTY_COMMENTS: [] = [];
 const EMPTY_TIMELINE_EVENTS: [] = [];
@@ -19,6 +20,7 @@ interface RunChatSurfaceProps {
   transcript: TranscriptEntry[];
   hasOutput: boolean;
   companyId?: string | null;
+  locale?: string | null;
 }
 
 export const RunChatSurface = memo(function RunChatSurface({
@@ -26,7 +28,11 @@ export const RunChatSurface = memo(function RunChatSurface({
   transcript,
   hasOutput,
   companyId,
+  locale: localeProp,
 }: RunChatSurfaceProps) {
+  const currentLocale = useCurrentLocale();
+  const copy = useLocalizedCopy();
+  const locale = localeProp ?? currentLocale;
   const active = isRunActive(run);
   const liveRuns = useMemo(() => (active ? [run] : EMPTY_LIVE_RUNS), [active, run]);
   const linkedRuns = useMemo<IssueChatLinkedRun[]>(
@@ -60,11 +66,14 @@ export const RunChatSurface = memo(function RunChatSurface({
       showComposer={false}
       showJumpToLatest={false}
       variant="embedded"
-      emptyMessage={active ? "Waiting for run output..." : "No run output captured."}
+      emptyMessage={active
+        ? copy("runChat.waitingForOutput", "Waiting for run output...", "실행 출력을 기다리는 중...")
+        : copy("runChat.noOutputCaptured", "No run output captured.", "저장된 실행 출력이 없습니다.")}
       enableLiveTranscriptPolling={false}
       transcriptsByRunId={transcriptsByRunId}
       hasOutputForRun={(runId) => runId === run.id && hasOutput}
       includeSucceededRunsWithoutOutput
+      locale={locale}
     />
   );
 });

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -29,8 +29,10 @@ import { Button } from "@/components/ui/button";
 import { PluginSlotOutlet } from "@/plugins/slots";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 export function Sidebar() {
+  const copy = useLocalizedCopy();
   const { openNewIssue } = useDialogActions();
   const { selectedCompanyId, selectedCompany } = useCompany();
   const inboxBadge = useInboxBadge(selectedCompanyId);
@@ -62,8 +64,8 @@ export function Sidebar() {
           variant="ghost"
           size="icon-sm"
           className="text-muted-foreground shrink-0"
-          aria-label="Open search"
-          title="Open search"
+          aria-label={copy("sidebar.search.open", "Open search", "검색 열기")}
+          title={copy("sidebar.search.open", "Open search", "검색 열기")}
         >
           <NavLink to="/search">
             <Search className="h-4 w-4" />
@@ -80,12 +82,12 @@ export function Sidebar() {
             className="flex items-center gap-2.5 px-3 py-2 pointer-coarse:py-1.5 text-[13px] font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
           >
             <SquarePen className="h-4 w-4 shrink-0" />
-            <span className="truncate">New Issue</span>
+            <span className="truncate">{copy("sidebar.nav.newIssue", "New Issue", "새 작업")}</span>
           </button>
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem to="/dashboard" label={copy("sidebar.nav.dashboard", "Dashboard", "대시보드")} icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
-            label="Inbox"
+            label={copy("sidebar.nav.inbox", "Inbox", "받은함")}
             icon={Inbox}
             badge={inboxBadge.inbox}
             badgeTone={inboxBadge.failedRuns > 0 ? "danger" : "default"}
@@ -93,12 +95,12 @@ export function Sidebar() {
           />
         </div>
 
-        <SidebarSection label="Work">
-          <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
-          <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+        <SidebarSection label={copy("sidebar.section.work", "Work", "업무")}>
+          <SidebarNavItem to="/issues" label={copy("sidebar.nav.issues", "Issues", "작업")} icon={CircleDot} />
+          <SidebarNavItem to="/routines" label={copy("sidebar.nav.routines", "Routines", "루틴")} icon={Repeat} />
+          <SidebarNavItem to="/goals" label={copy("sidebar.nav.goals", "Goals", "목표")} icon={Target} />
           {showWorkspacesLink ? (
-            <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
+            <SidebarNavItem to="/workspaces" label={copy("sidebar.nav.workspaces", "Workspaces", "작업공간")} icon={GitBranch} />
           ) : null}
           <PluginSlotOutlet
             slotTypes={["sidebar"]}
@@ -119,12 +121,12 @@ export function Sidebar() {
 
         <SidebarAgents />
 
-        <SidebarSection label="Company">
-          <SidebarNavItem to="/org" label="Org" icon={Network} />
-          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
-          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
-          <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+        <SidebarSection label={copy("sidebar.section.company", "Company", "회사")}>
+          <SidebarNavItem to="/org" label={copy("sidebar.nav.org", "Org", "조직")} icon={Network} />
+          <SidebarNavItem to="/skills" label={copy("sidebar.nav.skills", "Skills", "스킬")} icon={Boxes} />
+          <SidebarNavItem to="/costs" label={copy("sidebar.nav.costs", "Costs", "비용")} icon={DollarSign} />
+          <SidebarNavItem to="/activity" label={copy("sidebar.nav.activity", "Activity", "활동")} icon={History} />
+          <SidebarNavItem to="/company/settings" label={copy("sidebar.nav.settings", "Settings", "설정")} icon={Settings} />
         </SidebarSection>
 
         <PluginSlotOutlet

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -43,12 +43,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { Agent } from "@paperclipai/shared";
-
-const AGENT_SORT_CHOICES: SidebarSectionRadioChoice[] = [
-  { value: "top", label: "Top" },
-  { value: "alphabetical", label: "Alphabetical" },
-  { value: "recent", label: "Recent" },
-];
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 function agentTimestamp(agent: Agent, field: "lastHeartbeatAt" | "updatedAt" | "createdAt"): number {
   const raw = agent[field];
@@ -211,6 +206,7 @@ function SidebarAgentItem({
 }
 
 export function SidebarAgents() {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(true);
   const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(() => new Set());
   const queryClient = useQueryClient();
@@ -275,6 +271,14 @@ export function SidebarAgents() {
   const sortedAgents = useMemo(
     () => sortAgents(orderedAgents, sortMode),
     [orderedAgents, sortMode],
+  );
+  const agentSortChoices = useMemo<SidebarSectionRadioChoice[]>(
+    () => [
+      { value: "top", label: copy("sidebar.sort.top", "Top", "상단 고정") },
+      { value: "alphabetical", label: copy("sidebar.sort.alphabetical", "Alphabetical", "가나다순") },
+      { value: "recent", label: copy("sidebar.sort.recent", "Recent", "최근순") },
+    ],
+    [copy],
   );
 
   const agentMatch = location.pathname.match(/^\/(?:[^/]+\/)?agents\/([^/]+)(?:\/([^/]+))?/);
@@ -387,21 +391,21 @@ export function SidebarAgents() {
 
   return (
     <SidebarSection
-      label="Agents"
+      label={copy("sidebar.section.agents", "Agents", "직원")}
       collapsible={{ open, onOpenChange: setOpen }}
       headerAction={{
-        ariaLabel: "New agent",
+        ariaLabel: copy("sidebar.agents.new", "New agent", "새 직원"),
         icon: Plus,
         onClick: openNewAgent,
       }}
       menu={{
-        ariaLabel: "Agents section actions",
+        ariaLabel: copy("sidebar.agents.actions", "Agents section actions", "직원 섹션 작업"),
         actions: [
-          { type: "item", label: "Browse agents", icon: Users, href: "/agents/all" },
+          { type: "item", label: copy("sidebar.agents.browse", "Browse agents", "직원 둘러보기"), icon: Users, href: "/agents/all" },
           { type: "separator" },
         ],
-        radioLabel: "Agent sort",
-        radioChoices: AGENT_SORT_CHOICES,
+        radioLabel: copy("sidebar.agents.sort", "Agent sort", "직원 정렬"),
+        radioChoices: agentSortChoices,
         radioValue: sortMode,
         onRadioValueChange: persistSortMode,
       }}

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PluginSlotMount, usePluginSlots } from "@/plugins/slots";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 import {
   getProjectSortModeStorageKey,
   PROJECT_SORT_MODE_UPDATED_EVENT,
@@ -44,11 +45,6 @@ import type { Project } from "@paperclipai/shared";
 
 type ProjectSidebarSlot = ReturnType<typeof usePluginSlots>["slots"][number];
 
-const PROJECT_SORT_CHOICES: SidebarSectionRadioChoice[] = [
-  { value: "top", label: "Top" },
-  { value: "alphabetical", label: "Alphabetical" },
-  { value: "recent", label: "Recent" },
-];
 const REORDER_POINTER_MEDIA = "(hover: hover) and (pointer: fine)";
 
 type ProjectItemProps = {
@@ -228,6 +224,7 @@ function SortableProjectItem(props: ProjectItemProps) {
 }
 
 export function SidebarProjects() {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(true);
   const { selectedCompany, selectedCompanyId } = useCompany();
   const { openNewProject } = useDialogActions();
@@ -282,6 +279,14 @@ export function SidebarProjects() {
   );
   const isTopMode = sortMode === "top";
   const canReorderProjects = isTopMode && !isMobile && fineReorderPointer;
+  const projectSortChoices = useMemo<SidebarSectionRadioChoice[]>(
+    () => [
+      { value: "top", label: copy("sidebar.sort.top", "Top", "상단 고정") },
+      { value: "alphabetical", label: copy("sidebar.sort.alphabetical", "Alphabetical", "가나다순") },
+      { value: "recent", label: copy("sidebar.sort.recent", "Recent", "최근순") },
+    ],
+    [copy],
+  );
 
   const projectMatch = location.pathname.match(/^\/(?:[^/]+\/)?projects\/([^/]+)/);
   const activeProjectRef = projectMatch?.[1] ?? null;
@@ -383,21 +388,21 @@ export function SidebarProjects() {
 
   return (
     <SidebarSection
-      label="Projects"
+      label={copy("sidebar.section.projects", "Projects", "프로젝트")}
       collapsible={{ open, onOpenChange: setOpen }}
       headerAction={{
-        ariaLabel: "New project",
+        ariaLabel: copy("sidebar.projects.new", "New project", "새 프로젝트"),
         icon: Plus,
         onClick: openNewProject,
       }}
       menu={{
-        ariaLabel: "Projects section actions",
+        ariaLabel: copy("sidebar.projects.actions", "Projects section actions", "프로젝트 섹션 작업"),
         actions: [
-          { type: "item", label: "Browse projects", icon: FolderOpen, href: "/projects" },
+          { type: "item", label: copy("sidebar.projects.browse", "Browse projects", "프로젝트 둘러보기"), icon: FolderOpen, href: "/projects" },
           { type: "separator" },
         ],
-        radioLabel: "Project sort",
-        radioChoices: PROJECT_SORT_CHOICES,
+        radioLabel: copy("sidebar.projects.sort", "Project sort", "프로젝트 정렬"),
+        radioChoices: projectSortChoices,
         radioValue: sortMode,
         onRadioValueChange: persistSortMode,
       }}

--- a/ui/src/components/SidebarSection.tsx
+++ b/ui/src/components/SidebarSection.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 type SidebarSectionIcon = ComponentType<{ className?: string }>;
 
@@ -68,6 +69,7 @@ function SidebarSectionHeader({
   label,
   menu,
 }: Pick<SidebarSectionProps, "collapsible" | "headerAction" | "label" | "menu">) {
+  const copy = useLocalizedCopy();
   const { isMobile } = useSidebar();
   const [menuOpen, setMenuOpen] = useState(false);
   const hasMenu = Boolean(
@@ -159,7 +161,11 @@ function SidebarSectionHeader({
               type="button"
               data-slot="icon-button"
               className="absolute -left-4 flex h-5 w-5 items-center justify-center rounded-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-              aria-label={collapsible.open ? `Collapse ${label}` : `Expand ${label}`}
+              aria-label={
+                collapsible.open
+                  ? copy("sidebar.section.collapse", "Collapse {{label}}", "{{label}} 접기", { label })
+                  : copy("sidebar.section.expand", "Expand {{label}}", "{{label}} 펼치기", { label })
+              }
             >
               <ChevronRight className={caretClassName} aria-hidden="true" />
             </button>

--- a/ui/src/components/StatusBadge.tsx
+++ b/ui/src/components/StatusBadge.tsx
@@ -1,7 +1,36 @@
 import { cn } from "../lib/utils";
 import { statusBadge, statusBadgeDefault } from "../lib/status-colors";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 export function StatusBadge({ status }: { status: string }) {
+  const copy = useLocalizedCopy();
+  const labels: Record<string, string> = {
+    active: copy("status.active", "active", "활성"),
+    idle: copy("status.idle", "idle", "대기"),
+    paused: copy("status.paused", "paused", "일시정지"),
+    error: copy("status.error", "error", "오류"),
+    approved: copy("status.approved", "approved", "승인됨"),
+    rejected: copy("status.rejected", "rejected", "반려됨"),
+    revision_requested: copy("status.revisionRequested", "revision requested", "수정 요청"),
+    pending_approval: copy("status.pendingApproval", "pending approval", "승인 대기"),
+    running: copy("status.running", "running", "실행 중"),
+    queued: copy("status.queued", "queued", "대기 중"),
+    scheduled_retry: copy("status.scheduledRetry", "scheduled retry", "재시도 예약"),
+    achieved: copy("status.achieved", "achieved", "달성"),
+    succeeded: copy("status.succeeded", "succeeded", "성공"),
+    failed: copy("status.failed", "failed", "실패"),
+    timed_out: copy("status.timedOut", "timed out", "시간 초과"),
+    cancelled: copy("status.cancelled", "cancelled", "취소"),
+    backlog: copy("status.backlog", "backlog", "대기"),
+    planned: copy("status.planned", "planned", "계획됨"),
+    todo: copy("status.todo", "todo", "할 일"),
+    in_progress: copy("status.inProgress", "in progress", "진행 중"),
+    in_review: copy("status.inReview", "in review", "검토 중"),
+    done: copy("status.done", "done", "완료"),
+    completed: copy("status.completed", "completed", "완료"),
+    blocked: copy("status.blocked", "blocked", "막힘"),
+  };
+
   return (
     <span
       className={cn(
@@ -9,7 +38,7 @@ export function StatusBadge({ status }: { status: string }) {
         statusBadge[status] ?? statusBadgeDefault
       )}
     >
-      {status.replace(/_/g, " ")}
+      {labels[status] ?? status.replace(/_/g, " ")}
     </span>
   );
 }

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -4,10 +4,23 @@ import { cn } from "../lib/utils";
 import { issueStatusIcon, issueStatusIconDefault } from "../lib/status-colors";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 const allStatuses = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "blocked"];
 
-function statusLabel(status: string): string {
+function statusLabel(status: string, copy?: ReturnType<typeof useLocalizedCopy>): string {
+  if (copy) {
+    const labels: Record<string, string> = {
+      backlog: copy("status.backlog", "Backlog", "대기"),
+      todo: copy("status.todo", "To Do", "할 일"),
+      in_progress: copy("status.inProgress", "In Progress", "진행 중"),
+      in_review: copy("status.inReview", "In Review", "검토 중"),
+      done: copy("status.done", "Done", "완료"),
+      cancelled: copy("status.cancelled", "Cancelled", "취소"),
+      blocked: copy("status.blocked", "Blocked", "막힘"),
+    };
+    if (labels[status]) return labels[status];
+  }
   return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
@@ -62,6 +75,7 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
 }
 
 export function StatusIcon({ status, blockerAttention, onChange, className, showLabel }: StatusIconProps) {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
   const isStalledBlocked = status === "blocked" && blockerAttention?.state === "stalled";
@@ -73,7 +87,7 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
       ? "text-amber-600 border-amber-600 dark:text-amber-400 dark:border-amber-400"
       : issueStatusIcon[status] ?? issueStatusIconDefault;
   const isDone = status === "done";
-  const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status);
+  const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status, copy);
   const blockerAttentionState = isCoveredBlocked
     ? "covered"
     : isStalledBlocked
@@ -109,12 +123,12 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
     </span>
   );
 
-  if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{circle}<span className="text-sm">{statusLabel(status)}</span></span> : circle;
+  if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{circle}<span className="text-sm">{statusLabel(status, copy)}</span></span> : circle;
 
   const trigger = showLabel ? (
     <button className="inline-flex items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors">
       {circle}
-      <span className="text-sm">{statusLabel(status)}</span>
+      <span className="text-sm">{statusLabel(status, copy)}</span>
     </button>
   ) : circle;
 
@@ -134,7 +148,7 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
             }}
           >
             <StatusIcon status={s} />
-            {statusLabel(s)}
+            {statusLabel(s, copy)}
           </Button>
         ))}
       </PopoverContent>

--- a/ui/src/components/YoonCompanyAssistantPanel.test.tsx
+++ b/ui/src/components/YoonCompanyAssistantPanel.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Agent } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { YoonCompanyAssistantPanel } from "./YoonCompanyAssistantPanel";
+
+const mockOpenNewIssue = vi.hoisted(() => vi.fn());
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+  useLocation: () => ({
+    pathname: "/YOO/agents/hermes-research-worker",
+    search: "?tab=runs",
+    hash: "#latest",
+  }),
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({
+    selectedCompanyId: "company-1",
+    selectedCompany: {
+      id: "company-1",
+      name: "YoonCompany",
+      issuePrefix: "YOO",
+    },
+  }),
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialogActions: () => ({ openNewIssue: mockOpenNewIssue }),
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeAgent(overrides: Partial<Agent>): Agent {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Agent",
+    urlKey: "agent",
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(textarea, value);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("YoonCompanyAssistantPanel", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | null;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    document.title = "직원 상세 • YoonCompany • Paperclip";
+    document.body.innerHTML = "<main><h1>직원 상세</h1></main>";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    mockOpenNewIssue.mockClear();
+    mockAgentsApi.list.mockResolvedValue([
+      makeAgent({
+        id: "codex-1",
+        name: "Codex Lead Engineer",
+        adapterType: "codex_local",
+      }),
+      makeAgent({
+        id: "hermes-1",
+        name: "Hermes Research Worker",
+        title: "Research worker",
+        adapterType: "hermes_local",
+      }),
+    ]);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    document.body.innerHTML = "";
+  });
+
+  it("creates a backlog Hermes issue draft with current screen context and user input", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <YoonCompanyAssistantPanel />
+        </QueryClientProvider>,
+      );
+    });
+    await flush();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="YoonCompany 질문 패널"]')?.click();
+    });
+    await flush();
+
+    const hermesTarget = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Hermes 조사/기억"));
+    await act(async () => {
+      hermesTarget?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    await act(async () => {
+      setTextareaValue(textarea!, "현재 Hermes 권한과 조사 역할을 비교해줘");
+    });
+    await flush();
+
+    const createButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("조사 이슈 초안 만들기"));
+    expect(createButton).toBeDefined();
+    expect((createButton as HTMLButtonElement).disabled).toBe(false);
+    await act(async () => {
+      (createButton as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(mockOpenNewIssue).toHaveBeenCalledWith(expect.objectContaining({
+      status: "backlog",
+      assigneeAgentId: "hermes-1",
+      title: "Hermes 조사: 현재 Hermes 권한과 조사 역할을 비교해줘",
+    }));
+    const defaults = mockOpenNewIssue.mock.calls[0]?.[0] as { description?: string };
+    expect(defaults.description).toContain("직접 실행 아님");
+    expect(defaults.description).toContain("회사: YoonCompany (YOO)");
+    expect(defaults.description).toContain("현재 직원: hermes-research-worker");
+    expect(defaults.description).toContain("화면 제목: 직원 상세");
+    expect(defaults.description).toContain("현재 Hermes 권한과 조사 역할을 비교해줘");
+  });
+
+  it("creates a backlog Codex issue draft with the 6002 execution sequence", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <YoonCompanyAssistantPanel />
+        </QueryClientProvider>,
+      );
+    });
+    await flush();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="YoonCompany 질문 패널"]')?.click();
+    });
+    await flush();
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    await act(async () => {
+      setTextareaValue(textarea!, "이 화면의 다음 개발 작업을 작은 단위로 진행해줘");
+    });
+    await flush();
+
+    const createButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("개발 이슈 초안 만들기"));
+    expect(createButton).toBeDefined();
+    await act(async () => {
+      (createButton as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(mockOpenNewIssue).toHaveBeenCalledWith(expect.objectContaining({
+      status: "backlog",
+      assigneeAgentId: "codex-1",
+      title: "Codex 질문: 이 화면의 다음 개발 작업을 작은 단위로 진행해줘",
+    }));
+    const defaults = mockOpenNewIssue.mock.calls[0]?.[0] as { description?: string };
+    expect(defaults.description).toContain("6002 실행 순서: observe -> plan -> implement -> verify -> risk-report.");
+    expect(defaults.description).toContain("Observe: 실제 문서, git status, 코드, 로그, 화면 상태를 먼저 확인하라.");
+    expect(defaults.description).toContain("Verify: typecheck/test/browser/log/API 중 실제 근거를 남겨라.");
+    expect(defaults.description).toContain("Risk-report: 변경 파일, 실행 명령, 결과, 남은 위험, 다음 행동을 보고하라.");
+  });
+});

--- a/ui/src/components/YoonCompanyAssistantPanel.tsx
+++ b/ui/src/components/YoonCompanyAssistantPanel.tsx
@@ -1,0 +1,374 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useLocation } from "@/lib/router";
+import type { Agent } from "@paperclipai/shared";
+import {
+  Bot,
+  ClipboardList,
+  DollarSign,
+  GitBranch,
+  HelpCircle,
+  MessageSquareText,
+  PanelRightOpen,
+  Radio,
+  SearchCheck,
+  Send,
+  X,
+} from "lucide-react";
+import { agentsApi } from "../api/agents";
+import { useCompany } from "../context/CompanyContext";
+import { useDialogActions } from "../context/DialogContext";
+import { queryKeys } from "../lib/queryKeys";
+import { cn } from "../lib/utils";
+
+function findAgent(agents: Agent[] | undefined, keyword: "codex" | "hermes") {
+  return agents?.find((agent) => {
+    const haystack = `${agent.name} ${agent.title ?? ""} ${agent.adapterType}`.toLowerCase();
+    return haystack.includes(keyword);
+  }) ?? null;
+}
+
+function pageLabel(pathname: string): string {
+  if (pathname.includes("/dashboard")) return "대시보드";
+  if (pathname.includes("/issues")) return "작업";
+  if (pathname.includes("/agents")) return "직원";
+  if (pathname.includes("/skills")) return "스킬";
+  if (pathname.includes("/org")) return "조직";
+  if (pathname.includes("/costs")) return "비용";
+  if (pathname.includes("/activity")) return "활동";
+  if (pathname.includes("/company/settings")) return "회사 설정";
+  if (pathname.includes("/projects")) return "프로젝트";
+  return "현재 화면";
+}
+
+function routeResourceContext(pathname: string): string[] {
+  const segments = pathname.split("/").filter(Boolean);
+  const [, section, resourceId] = segments;
+  if (!section || !resourceId) return [];
+  if (section === "issues") return [`현재 이슈: ${resourceId}`];
+  if (section === "agents") return [`현재 직원: ${resourceId}`];
+  if (section === "projects") return [`현재 프로젝트: ${resourceId}`];
+  if (section === "goals") return [`현재 목표: ${resourceId}`];
+  if (section === "approvals") return [`현재 승인: ${resourceId}`];
+  return [];
+}
+
+function readVisibleScreenContext() {
+  if (typeof document === "undefined") return [];
+  const mainHeading = document.querySelector("main h1")?.textContent?.trim();
+  const activeTab = document.querySelector('[role="tab"][aria-selected="true"]')?.textContent?.trim();
+  const selectedText = window.getSelection()?.toString().trim();
+  return [
+    mainHeading ? `화면 제목: ${mainHeading}` : null,
+    activeTab ? `선택 탭: ${activeTab}` : null,
+    selectedText ? `선택 텍스트: ${selectedText.slice(0, 500)}` : null,
+  ].filter(Boolean) as string[];
+}
+
+function pageContext(
+  pathname: string,
+  search: string,
+  hash: string,
+  company: { id: string; name: string; issuePrefix?: string | null } | null,
+) {
+  const route = `${pathname}${search}${hash}`;
+  return [
+    company ? `회사: ${company.name} (${company.issuePrefix ?? "prefix 없음"})` : null,
+    company ? `회사 ID: ${company.id}` : null,
+    `현재 화면: ${pageLabel(pathname)}`,
+    `경로: ${route}`,
+    ...routeResourceContext(pathname),
+    ...readVisibleScreenContext(),
+    typeof document === "undefined" ? null : `브라우저 제목: ${document.title}`,
+  ].filter(Boolean).join("\n");
+}
+
+function requestBlock(userRequest: string) {
+  const trimmed = userRequest.trim();
+  if (!trimmed) return [];
+  return ["", "사용자 입력:", trimmed];
+}
+
+function titleFromInput(prefix: string, fallback: string, userRequest: string) {
+  const firstLine = userRequest.trim().split(/\r?\n/).find(Boolean);
+  if (!firstLine) return fallback;
+  return `${prefix}: ${firstLine.slice(0, 48)}`;
+}
+
+const CODEX_6002_SEQUENCE = [
+  "6002 실행 순서: observe -> plan -> implement -> verify -> risk-report.",
+  "- Observe: 실제 문서, git status, 코드, 로그, 화면 상태를 먼저 확인하라.",
+  "- Plan: 작은 단위 작업과 검증 방법을 먼저 정리하라.",
+  "- Implement: 승인된 범위 안에서만 구현하고 기존 변경을 되돌리지 마라.",
+  "- Verify: typecheck/test/browser/log/API 중 실제 근거를 남겨라.",
+  "- Risk-report: 변경 파일, 실행 명령, 결과, 남은 위험, 다음 행동을 보고하라.",
+];
+
+function codexDescription(kind: "ask" | "guide" | "analyze", context: string, userRequest = "") {
+  const intent = kind === "guide"
+    ? "현재 화면 사용법과 다음 클릭 위치를 설명하고, 필요하면 작업으로 쪼개라."
+    : kind === "analyze"
+      ? "현재 화면의 상태, 위험, 다음 개선 후보를 6002 기준으로 분석하라."
+      : "질문에 답하고 필요한 경우 작은 작업 단위와 검증 방법을 제안하라.";
+
+  return [
+    "YoonCompany 전역 질문 패널 v2에서 생성됨.",
+    "생성 방식: Paperclip 이슈 초안/보류 생성. 직접 실행 아님.",
+    "",
+    "대상: Codex Lead Engineer.",
+    "모드: 6002.",
+    "",
+    context,
+    "",
+    "요청:",
+    `- ${intent}`,
+    ...requestBlock(userRequest),
+    "",
+    ...CODEX_6002_SEQUENCE,
+    "",
+    "- 확인한 사실, 추정, 남은 검증을 분리하라.",
+    "- 코드 변경이 필요하면 작은 단위로 계획하고 검증하라.",
+    "",
+    "안전 규칙:",
+    "- 승인 없이 배포, 병합, 삭제, 외부 공개, 자격증명 변경, Paperclip DB 직접 쓰기 금지.",
+  ].join("\n");
+}
+
+function hermesDescription(context: string, userRequest = "") {
+  return [
+    "YoonCompany 전역 질문 패널 v2에서 생성됨.",
+    "생성 방식: Paperclip 이슈 초안/보류 생성. 직접 실행 아님.",
+    "",
+    "대상: Hermes Research Worker.",
+    "모드: 조사/보고 전용.",
+    "",
+    context,
+    "",
+    "조사 요청:",
+    "- 공개 자료, 로그, 메모리를 확인해 사실/근거/제안을 분리 보고하라.",
+    ...requestBlock(userRequest),
+    "- repo 파일 수정, 배포, 병합, push, 삭제, DB 쓰기 금지.",
+  ].join("\n");
+}
+
+function ActionButton({
+  icon: Icon,
+  title,
+  body,
+  disabled,
+  onClick,
+}: {
+  icon: typeof MessageSquareText;
+  title: string;
+  body: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="grid grid-cols-[auto_1fr] gap-3 border border-border bg-background p-3 text-left text-sm transition-colors hover:bg-accent/50 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <Icon className="mt-0.5 h-4 w-4 text-muted-foreground" />
+      <span className="min-w-0">
+        <span className="block font-medium">{title}</span>
+        <span className="mt-1 block text-xs leading-5 text-muted-foreground">{body}</span>
+      </span>
+    </button>
+  );
+}
+
+function StatusLine({ icon: Icon, label, value }: { icon: typeof GitBranch; label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[auto_1fr] gap-2 text-xs leading-5">
+      <Icon className="mt-0.5 h-3.5 w-3.5 text-muted-foreground" />
+      <div className="min-w-0">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground"> · {value}</span>
+      </div>
+    </div>
+  );
+}
+
+export function YoonCompanyAssistantPanel() {
+  const { selectedCompanyId, selectedCompany } = useCompany();
+  const { openNewIssue } = useDialogActions();
+  const location = useLocation();
+  const [open, setOpen] = useState(false);
+  const [target, setTarget] = useState<"codex" | "hermes">("codex");
+  const [requestText, setRequestText] = useState("");
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId ?? "__none__"),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    staleTime: 30_000,
+  });
+
+  const codexAgent = useMemo(() => findAgent(agents, "codex"), [agents]);
+  const hermesAgent = useMemo(() => findAgent(agents, "hermes"), [agents]);
+  const context = pageContext(location.pathname, location.search, location.hash, selectedCompany);
+  const disabled = !selectedCompanyId;
+
+  function openCodex(kind: "ask" | "guide" | "analyze", userRequest = "") {
+    openNewIssue({
+      title: titleFromInput(
+        "Codex 질문",
+        kind === "guide" ? "현재 화면 사용법 질문" : kind === "analyze" ? "현재 화면 6002 분석" : "Codex에게 질문",
+        userRequest,
+      ),
+      description: codexDescription(kind, context, userRequest),
+      priority: "high",
+      status: "backlog",
+      assigneeAgentId: codexAgent?.id,
+    });
+    setOpen(false);
+  }
+
+  function openHermes(userRequest = "") {
+    openNewIssue({
+      title: titleFromInput("Hermes 조사", "Hermes 조사 요청", userRequest),
+      description: hermesDescription(context, userRequest),
+      priority: "medium",
+      status: "backlog",
+      assigneeAgentId: hermesAgent?.id,
+    });
+    setOpen(false);
+  }
+
+  function openCustomRequest() {
+    if (target === "hermes") {
+      openHermes(requestText);
+    } else {
+      openCodex("ask", requestText);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={cn(
+          "fixed bottom-4 right-4 z-[80] inline-flex h-11 w-11 items-center justify-center border border-border bg-background text-foreground shadow-lg transition-colors hover:bg-accent",
+          open && "bg-accent",
+        )}
+        aria-label="YoonCompany 질문 패널"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {open ? <X className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+      </button>
+
+      {open ? (
+        <aside className="fixed bottom-20 right-4 z-[80] max-h-[min(720px,calc(100dvh-7rem))] w-[min(390px,calc(100vw-2rem))] overflow-y-auto border border-border bg-background p-4 shadow-xl">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-sm font-semibold">YoonCompany 질문</div>
+              <div className="mt-1 text-xs text-muted-foreground">{pageLabel(location.pathname)}에서 바로 작업을 만듭니다.</div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center border border-border text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="질문 패널 닫기"
+              onClick={() => setOpen(false)}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          <div className="grid gap-2">
+            <div className="grid gap-2 border border-border bg-muted/20 p-3">
+              <div className="grid grid-cols-2 gap-1">
+                <button
+                  type="button"
+                  className={cn(
+                    "border border-border px-2.5 py-2 text-xs font-medium transition-colors hover:bg-accent",
+                    target === "codex" && "bg-accent text-foreground",
+                  )}
+                  onClick={() => setTarget("codex")}
+                >
+                  Codex 개발/결정
+                </button>
+                <button
+                  type="button"
+                  className={cn(
+                    "border border-border px-2.5 py-2 text-xs font-medium transition-colors hover:bg-accent",
+                    target === "hermes" && "bg-accent text-foreground",
+                  )}
+                  onClick={() => setTarget("hermes")}
+                >
+                  Hermes 조사/기억
+                </button>
+              </div>
+              <textarea
+                value={requestText}
+                onChange={(event) => setRequestText(event.target.value)}
+                rows={4}
+                placeholder="현재 화면 맥락과 함께 전달할 내용을 입력"
+                className="min-h-24 resize-y border border-border bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-foreground"
+              />
+              <button
+                type="button"
+                disabled={disabled || !requestText.trim()}
+                onClick={openCustomRequest}
+                className="inline-flex items-center justify-center gap-2 border border-border bg-foreground px-3 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Send className="h-3.5 w-3.5" />
+                {target === "hermes" ? "조사 이슈 초안 만들기" : "개발 이슈 초안 만들기"}
+              </button>
+            </div>
+            <ActionButton
+              icon={MessageSquareText}
+              title="Codex에게 묻기"
+              body="개발, 설정, 오류, 의사결정을 보류 이슈로 정리합니다."
+              disabled={disabled}
+              onClick={() => openCodex("ask")}
+            />
+            <ActionButton
+              icon={HelpCircle}
+              title="화면 사용법"
+              body="현재 화면에서 무엇을 눌러야 하는지 Codex 작업으로 묻습니다."
+              disabled={disabled}
+              onClick={() => openCodex("guide")}
+            />
+            <ActionButton
+              icon={SearchCheck}
+              title="현재 화면 분석"
+              body="상태, 위험, 다음 개선을 6002 검증 기준으로 분석합니다."
+              disabled={disabled}
+              onClick={() => openCodex("analyze")}
+            />
+            <ActionButton
+              icon={ClipboardList}
+              title="Hermes 조사"
+              body="파일 수정 없이 공개 자료, 로그, 메모리 조사 보류 이슈를 만듭니다."
+              disabled={disabled}
+              onClick={() => openHermes()}
+            />
+          </div>
+
+          <div className="mt-4 grid gap-2 border-t border-border pt-4">
+            <StatusLine icon={Bot} label="메인 직원" value={codexAgent ? `${codexAgent.name} · 6002 우선` : "Codex 직원 미확인"} />
+            <StatusLine icon={Radio} label="외부 지시" value="Telegram은 미연결, Hermes gateway 설정 후 연결 가능" />
+            <StatusLine icon={DollarSign} label="비용" value="구독형 포함 실행과 API 과금은 비용 화면에서 구분" />
+            <StatusLine icon={GitBranch} label="프로젝트" value="로컬 변경 후 GitHub 브랜치/PR 단위로 정리" />
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2 text-xs">
+            <Link to="/dashboard/live" className="border border-border px-2.5 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground">
+              진행 확인
+            </Link>
+            <Link to="/costs" className="border border-border px-2.5 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground">
+              비용 보기
+            </Link>
+            <Link to="/skills" className="border border-border px-2.5 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground">
+              스킬 보기
+            </Link>
+          </div>
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/ui/src/components/access/CompanySettingsNav.tsx
+++ b/ui/src/components/access/CompanySettingsNav.tsx
@@ -1,14 +1,15 @@
 import { PageTabBar } from "@/components/PageTabBar";
 import { Tabs } from "@/components/ui/tabs";
 import { useLocation, useNavigate } from "@/lib/router";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 
 const items = [
-  { value: "general", label: "General", href: "/company/settings" },
-  { value: "environments", label: "Environments", href: "/company/settings/environments" },
-  { value: "cloud-upstream", label: "Cloud upstream", href: "/company/settings/cloud-upstream" },
-  { value: "members", label: "Members", href: "/company/settings/members" },
-  { value: "invites", label: "Invites", href: "/company/settings/invites" },
-  { value: "secrets", label: "Secrets", href: "/company/settings/secrets" },
+  { value: "general", labelKey: "general", english: "General", korean: "일반", href: "/company/settings" },
+  { value: "environments", labelKey: "environments", english: "Environments", korean: "환경", href: "/company/settings/environments" },
+  { value: "cloud-upstream", labelKey: "cloudUpstream", english: "Cloud upstream", korean: "클라우드 연동", href: "/company/settings/cloud-upstream" },
+  { value: "members", labelKey: "members", english: "Members", korean: "멤버", href: "/company/settings/members" },
+  { value: "invites", labelKey: "invites", english: "Invites", korean: "초대", href: "/company/settings/invites" },
+  { value: "secrets", labelKey: "secrets", english: "Secrets", korean: "시크릿", href: "/company/settings/secrets" },
 ] as const;
 
 type CompanySettingsTab = (typeof items)[number]["value"];
@@ -40,6 +41,7 @@ export function getCompanySettingsTab(pathname: string): CompanySettingsTab {
 export function CompanySettingsNav() {
   const location = useLocation();
   const navigate = useNavigate();
+  const copy = useLocalizedCopy();
   const activeTab = getCompanySettingsTab(location.pathname);
 
   function handleTabChange(value: string) {
@@ -51,7 +53,10 @@ export function CompanySettingsNav() {
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange}>
       <PageTabBar
-        items={items.map(({ value, label }) => ({ value, label }))}
+        items={items.map(({ value, labelKey, english, korean }) => ({
+          value,
+          label: copy(`companySettings.nav.${labelKey}`, english, korean),
+        }))}
         value={activeTab}
         onValueChange={handleTabChange}
         align="start"

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { HelpCircle, ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "../lib/utils";
 import { AGENT_ROLE_LABELS } from "@paperclipai/shared";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 /* ---- Help text for (?) tooltips ---- */
 export const help: Record<string, string> = {
@@ -386,6 +387,7 @@ export function DraftNumberInput({
  * type the path due to browser security limitations.
  */
 export function ChoosePathButton() {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(false);
   return (
     <>
@@ -394,54 +396,53 @@ export function ChoosePathButton() {
         className="inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 transition-colors shrink-0"
         onClick={() => setOpen(true)}
       >
-        Choose
+        {copy("agentConfig.choosePath.choose", "Choose", "선택")}
       </button>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Specify path manually</DialogTitle>
+            <DialogTitle>{copy("agentConfig.choosePath.title", "Specify path manually", "경로 직접 입력")}</DialogTitle>
             <DialogDescription>
-              Browser security blocks apps from reading full local paths via a file picker.
-              Copy the absolute path and paste it into the input.
+              {copy("agentConfig.choosePath.description", "Browser security blocks apps from reading full local paths via a file picker. Copy the absolute path and paste it into the input.", "브라우저 보안 때문에 앱이 파일 선택기에서 전체 로컬 경로를 읽을 수 없습니다. 절대 경로를 복사해서 입력란에 붙여 넣으세요.")}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 text-sm">
             <section className="space-y-1.5">
-              <p className="font-medium">macOS (Finder)</p>
+              <p className="font-medium">{copy("agentConfig.choosePath.macos", "macOS (Finder)", "macOS(Finder)")}</p>
               <ol className="list-decimal space-y-1 pl-5 text-muted-foreground">
-                <li>Find the folder in Finder.</li>
-                <li>Hold <kbd>Option</kbd> and right-click the folder.</li>
-                <li>Click "Copy &lt;folder name&gt; as Pathname".</li>
-                <li>Paste the result into the path input.</li>
+                <li>{copy("agentConfig.choosePath.macosStep1", "Find the folder in Finder.", "Finder에서 폴더를 찾습니다.")}</li>
+                <li>{copy("agentConfig.choosePath.macosStep2", "Hold Option and right-click the folder.", "Option 키를 누른 상태에서 폴더를 우클릭합니다.")}</li>
+                <li>{copy("agentConfig.choosePath.macosStep3", "Click Copy <folder name> as Pathname.", "경로명으로 복사 메뉴를 클릭합니다.")}</li>
+                <li>{copy("agentConfig.choosePath.macosStep4", "Paste the result into the path input.", "복사한 값을 경로 입력란에 붙여 넣습니다.")}</li>
               </ol>
               <p className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
                 /Users/yourname/Documents/project
               </p>
             </section>
             <section className="space-y-1.5">
-              <p className="font-medium">Windows (File Explorer)</p>
+              <p className="font-medium">{copy("agentConfig.choosePath.windows", "Windows (File Explorer)", "Windows(파일 탐색기)")}</p>
               <ol className="list-decimal space-y-1 pl-5 text-muted-foreground">
-                <li>Find the folder in File Explorer.</li>
-                <li>Hold <kbd>Shift</kbd> and right-click the folder.</li>
-                <li>Click "Copy as path".</li>
-                <li>Paste the result into the path input.</li>
+                <li>{copy("agentConfig.choosePath.windowsStep1", "Find the folder in File Explorer.", "파일 탐색기에서 폴더를 찾습니다.")}</li>
+                <li>{copy("agentConfig.choosePath.windowsStep2", "Hold Shift and right-click the folder.", "Shift 키를 누른 상태에서 폴더를 우클릭합니다.")}</li>
+                <li>{copy("agentConfig.choosePath.windowsStep3", "Click Copy as path.", "경로로 복사를 클릭합니다.")}</li>
+                <li>{copy("agentConfig.choosePath.windowsStep4", "Paste the result into the path input.", "복사한 값을 경로 입력란에 붙여 넣습니다.")}</li>
               </ol>
               <p className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
                 C:\Users\yourname\Documents\project
               </p>
             </section>
             <section className="space-y-1.5">
-              <p className="font-medium">Terminal fallback (macOS/Linux)</p>
+              <p className="font-medium">{copy("agentConfig.choosePath.terminal", "Terminal fallback (macOS/Linux)", "터미널 대체 방법(macOS/Linux)")}</p>
               <ol className="list-decimal space-y-1 pl-5 text-muted-foreground">
-                <li>Run <code>cd /path/to/folder</code>.</li>
-                <li>Run <code>pwd</code>.</li>
-                <li>Copy the output and paste it into the path input.</li>
+                <li>{copy("agentConfig.choosePath.terminalStep1", "Run cd /path/to/folder.", "cd /path/to/folder 명령을 실행합니다.")}</li>
+                <li>{copy("agentConfig.choosePath.terminalStep2", "Run pwd.", "pwd 명령을 실행합니다.")}</li>
+                <li>{copy("agentConfig.choosePath.terminalStep3", "Copy the output and paste it into the path input.", "출력값을 복사해서 경로 입력란에 붙여 넣습니다.")}</li>
               </ol>
             </section>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)}>
-              OK
+              {copy("common.ok", "OK", "확인")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/ui/src/components/ui/command.tsx
+++ b/ui/src/components/ui/command.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { useLocalizedCopy } from "@/i18n/ui-copy"
 
 function Command({
   className,
@@ -31,8 +32,8 @@ function Command({
 }
 
 function CommandDialog({
-  title = "Command Palette",
-  description = "Search for a command to run...",
+  title,
+  description,
   children,
   className,
   showCloseButton = true,
@@ -43,11 +44,15 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
 }) {
+  const copy = useLocalizedCopy()
+  const dialogTitle = title ?? copy("commandDialog.title", "Command Palette", "명령 팔레트")
+  const dialogDescription = description ?? copy("commandDialog.description", "Search for a command to run...", "실행할 명령을 검색하세요...")
+
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
+        <DialogTitle>{dialogTitle}</DialogTitle>
+        <DialogDescription>{dialogDescription}</DialogDescription>
       </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}
@@ -62,7 +67,7 @@ function CommandDialog({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-0 right-2 flex h-12 items-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{copy("common.close", "Close", "닫기")}</span>
           </DialogPrimitive.Close>
         )}
       </DialogContent>

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -3,9 +3,49 @@ import { initReactI18next, useTranslation as useReactI18nextTranslation } from "
 
 import { DEFAULT_LOCALE, i18nextResources, supportedLocales } from "./locales";
 
+export const LOCALE_STORAGE_KEY = "paperclip.locale";
+
+function normalizeSupportedLocale(candidate: string | null | undefined) {
+  if (!candidate) return null;
+  const normalized = candidate.trim();
+  if (!normalized) return null;
+
+  if (supportedLocales.includes(normalized)) return normalized;
+
+  const base = normalized.split("-")[0];
+  if (base && supportedLocales.includes(base)) return base;
+
+  return null;
+}
+
+function resolveInitialLocale() {
+  const envLocale = normalizeSupportedLocale(import.meta.env?.VITE_PAPERCLIP_LOCALE);
+  if (envLocale) return envLocale;
+
+  if (typeof window !== "undefined") {
+    try {
+      const storedLocale = normalizeSupportedLocale(window.localStorage.getItem(LOCALE_STORAGE_KEY));
+      if (storedLocale) return storedLocale;
+    } catch {
+      // Ignore storage access errors and fall through to browser language.
+    }
+
+    const browserLocales = [
+      ...(Array.isArray(window.navigator.languages) ? window.navigator.languages : []),
+      window.navigator.language,
+    ];
+    for (const locale of browserLocales) {
+      const supportedLocale = normalizeSupportedLocale(locale);
+      if (supportedLocale) return supportedLocale;
+    }
+  }
+
+  return DEFAULT_LOCALE;
+}
+
 const i18nextOptions: InitOptions = {
   resources: i18nextResources,
-  lng: DEFAULT_LOCALE,
+  lng: resolveInitialLocale(),
   fallbackLng: DEFAULT_LOCALE,
   supportedLngs: supportedLocales,
   defaultNS: "translation",

--- a/ui/src/i18n/locale-utils.ts
+++ b/ui/src/i18n/locale-utils.ts
@@ -1,0 +1,4 @@
+export function isKoreanLocale(locale: string | null | undefined) {
+  const normalized = locale?.toLowerCase();
+  return normalized === "ko" || normalized?.startsWith("ko-") === true;
+}

--- a/ui/src/i18n/ui-copy.ts
+++ b/ui/src/i18n/ui-copy.ts
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+import type { TOptions } from "i18next";
+
+import { useTranslation } from "./index";
+import { isKoreanLocale } from "./locale-utils";
+
+export function useCurrentLocale() {
+  const { i18n } = useTranslation();
+  return i18n.resolvedLanguage ?? i18n.language;
+}
+
+export function useLocalizedCopy() {
+  const { t, i18n } = useTranslation();
+  const korean = isKoreanLocale(i18n.resolvedLanguage ?? i18n.language);
+
+  return useCallback(
+    (key: string, english: string, koreanText: string, options: TOptions = {}) =>
+      String(t(key, { ...options, defaultValue: korean ? koreanText : english })),
+    [korean, t],
+  );
+}

--- a/ui/src/lib/activity-format.ts
+++ b/ui/src/lib/activity-format.ts
@@ -1,5 +1,6 @@
 import type { Agent } from "@paperclipai/shared";
 import type { CompanyUserProfile } from "./company-members";
+import { isKoreanLocale } from "@/i18n/locale-utils";
 
 type ActivityDetails = Record<string, unknown> | null | undefined;
 
@@ -19,6 +20,7 @@ interface ActivityFormatOptions {
   agentMap?: Map<string, Agent>;
   userProfileMap?: Map<string, CompanyUserProfile>;
   currentUserId?: string | null;
+  locale?: string | null;
 }
 
 const ACTIVITY_ROW_VERBS: Record<string, string> = {
@@ -78,6 +80,69 @@ const ACTIVITY_ROW_VERBS: Record<string, string> = {
   "company.updated": "updated company",
   "company.archived": "archived",
   "company.budget_updated": "updated budget for",
+  "asset.created": "created asset",
+  "issue.read_marked": "marked issue read",
+};
+
+const ACTIVITY_ROW_VERBS_KO: Record<string, string> = {
+  "issue.created": "작업 생성",
+  "issue.updated": "작업 수정",
+  "issue.checked_out": "작업 체크아웃",
+  "issue.released": "작업 해제",
+  "issue.comment_added": "댓글 작성",
+  "issue.comment_cancelled": "대기 댓글 취소",
+  "issue.attachment_added": "파일 첨부",
+  "issue.attachment_removed": "첨부 제거",
+  "issue.document_created": "문서 생성",
+  "issue.document_updated": "문서 수정",
+  "issue.document_locked": "문서 잠금",
+  "issue.document_unlocked": "문서 잠금 해제",
+  "issue.document_deleted": "문서 삭제",
+  "issue.monitor_scheduled": "모니터 예약",
+  "issue.monitor_triggered": "모니터 실행",
+  "issue.monitor_cleared": "모니터 해제",
+  "issue.monitor_skipped": "모니터 건너뜀",
+  "issue.monitor_exhausted": "모니터 한도 소진",
+  "issue.monitor_recovery_wake_queued": "모니터 복구 실행 대기",
+  "issue.monitor_recovery_issue_created": "모니터 복구 작업 생성",
+  "issue.monitor_escalated_to_board": "모니터 보드 에스컬레이션",
+  "issue.commented": "댓글 작성",
+  "issue.deleted": "작업 삭제",
+  "issue.successful_run_handoff_required": "다음 단계 누락 표시",
+  "issue.successful_run_handoff_resolved": "다음 단계 선택 기록",
+  "issue.successful_run_handoff_escalated": "다음 단계 누락 에스컬레이션",
+  "issue.recovery_action_opened": "복구 작업 열기",
+  "issue.recovery_action_resolved": "복구 작업 해결",
+  "issue.recovery_action_escalated": "복구 작업 에스컬레이션",
+  "agent.created": "직원 생성",
+  "agent.updated": "직원 수정",
+  "agent.paused": "직원 일시정지",
+  "agent.resumed": "직원 재개",
+  "agent.terminated": "직원 종료",
+  "agent.key_created": "직원 API 키 생성",
+  "agent.budget_updated": "직원 예산 수정",
+  "agent.runtime_session_reset": "직원 세션 초기화",
+  "heartbeat.invoked": "상태 점검 실행",
+  "heartbeat.cancelled": "상태 점검 취소",
+  "heartbeat.output_stale_source_resolved": "오래된 실행 자동 정리",
+  "heartbeat.output_stale_recovery_recursion_refused": "복구 반복 거부",
+  "approval.created": "승인 요청",
+  "approval.approved": "승인",
+  "approval.rejected": "반려",
+  "project.created": "프로젝트 생성",
+  "project.updated": "프로젝트 수정",
+  "project.deleted": "프로젝트 삭제",
+  "goal.created": "목표 생성",
+  "goal.updated": "목표 수정",
+  "goal.deleted": "목표 삭제",
+  "cost.reported": "비용 보고",
+  "cost.recorded": "비용 기록",
+  "company.created": "회사 생성",
+  "company.updated": "회사 수정",
+  "company.archived": "회사 보관",
+  "company.budget_updated": "회사 예산 수정",
+  "asset.created": "자산 생성",
+  "issue.read_marked": "작업 읽음 표시",
 };
 
 const ISSUE_ACTIVITY_LABELS: Record<string, string> = {
@@ -129,8 +194,24 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function humanizeValue(value: unknown): string {
+function humanizeValue(value: unknown, locale?: string | null): string {
   if (typeof value !== "string") return String(value ?? "none");
+  if (isKoreanLocale(locale)) {
+    const labels: Record<string, string> = {
+      backlog: "대기",
+      todo: "할 일",
+      in_progress: "진행 중",
+      in_review: "검토 중",
+      done: "완료",
+      cancelled: "취소",
+      blocked: "막힘",
+      critical: "긴급",
+      high: "높음",
+      medium: "보통",
+      low: "낮음",
+    };
+    return labels[value] ?? value.replace(/_/g, " ");
+  }
   return value.replace(/_/g, " ");
 }
 
@@ -189,20 +270,31 @@ function formatChangedEntityLabel(
   return `${labels.length} ${plural}`;
 }
 
-function formatIssueUpdatedVerb(details: ActivityDetails): string | null {
+function formatIssueUpdatedVerb(details: ActivityDetails, locale?: string | null): string | null {
   if (!details) return null;
   const previous = asRecord(details._previous) ?? {};
+  const korean = isKoreanLocale(locale);
   if (details.status !== undefined) {
     const from = previous.status;
+    if (korean) {
+      return from
+        ? `상태를 ${humanizeValue(from, locale)}에서 ${humanizeValue(details.status, locale)}로 변경`
+        : `상태를 ${humanizeValue(details.status, locale)}로 변경`;
+    }
     return from
-      ? `changed status from ${humanizeValue(from)} to ${humanizeValue(details.status)} on`
-      : `changed status to ${humanizeValue(details.status)} on`;
+      ? `changed status from ${humanizeValue(from, locale)} to ${humanizeValue(details.status, locale)} on`
+      : `changed status to ${humanizeValue(details.status, locale)} on`;
   }
   if (details.priority !== undefined) {
     const from = previous.priority;
+    if (korean) {
+      return from
+        ? `우선순위를 ${humanizeValue(from, locale)}에서 ${humanizeValue(details.priority, locale)}으로 변경`
+        : `우선순위를 ${humanizeValue(details.priority, locale)}으로 변경`;
+    }
     return from
-      ? `changed priority from ${humanizeValue(from)} to ${humanizeValue(details.priority)} on`
-      : `changed priority to ${humanizeValue(details.priority)} on`;
+      ? `changed priority from ${humanizeValue(from, locale)} to ${humanizeValue(details.priority, locale)} on`
+      : `changed priority to ${humanizeValue(details.priority, locale)} on`;
   }
   return null;
 }
@@ -299,7 +391,7 @@ export function formatActivityVerb(
   options: ActivityFormatOptions = {},
 ): string {
   if (action === "issue.updated") {
-    const issueUpdatedVerb = formatIssueUpdatedVerb(details);
+    const issueUpdatedVerb = formatIssueUpdatedVerb(details, options.locale);
     if (issueUpdatedVerb) return issueUpdatedVerb;
   }
 
@@ -310,6 +402,10 @@ export function formatActivityVerb(
     forIssueDetail: false,
   });
   if (structuredChange) return structuredChange;
+
+  if (isKoreanLocale(options.locale)) {
+    return ACTIVITY_ROW_VERBS_KO[action] ?? action.replace(/[._]/g, " ");
+  }
 
   return ACTIVITY_ROW_VERBS[action] ?? action.replace(/[._]/g, " ");
 }

--- a/ui/src/lib/issue-chat-messages.test.ts
+++ b/ui/src/lib/issue-chat-messages.test.ts
@@ -861,6 +861,37 @@ describe("buildIssueChatMessages", () => {
     });
   });
 
+  it("labels historical run duration in Korean when locale is Korean", () => {
+    const messages = buildIssueChatMessages({
+      comments: [],
+      timelineEvents: [],
+      linkedRuns: [
+        {
+          runId: "run-cancelled",
+          status: "cancelled",
+          agentId: "agent-1",
+          agentName: "CodexCoder",
+          createdAt: new Date("2026-04-06T12:01:00.000Z"),
+          startedAt: new Date("2026-04-06T12:01:00.000Z"),
+          finishedAt: new Date("2026-04-06T12:01:19.000Z"),
+        },
+      ],
+      liveRuns: [],
+      transcriptsByRunId: new Map([
+        ["run-cancelled", [{ kind: "assistant", ts: "2026-04-06T12:01:05.000Z", text: "작업 로그" }]],
+      ]),
+      hasOutputForRun: (runId) => runId === "run-cancelled",
+      currentUserId: "user-1",
+      locale: "ko-KR",
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.metadata.custom).toMatchObject({
+      chainOfThoughtLabel: "19초 후 취소됨",
+      runStatus: "cancelled",
+    });
+  });
+
   it("can keep succeeded runs without transcript output for embedded run feeds", () => {
     const messages = buildIssueChatMessages({
       comments: [],

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -18,6 +18,7 @@ import type { IssueTimelineEvent } from "./issue-timeline-events";
 import {
   summarizeNotice,
 } from "./transcriptPresentation";
+import { isKoreanLocale } from "@/i18n/locale-utils";
 
 type JsonValue = null | string | number | boolean | JsonValue[] | { [key: string]: JsonValue };
 type JsonObject = { [key: string]: JsonValue };
@@ -371,7 +372,20 @@ function authorNameForComment(
   return formatAssigneeUserLabel(authorUserId, currentUserId, userLabelMap) ?? "You";
 }
 
-function formatStatusLabel(status: string) {
+function formatStatusLabel(status: string, locale?: string | null) {
+  if (isKoreanLocale(locale)) {
+    const labels: Record<string, string> = {
+      succeeded: "성공",
+      failed: "실패",
+      error: "오류",
+      timed_out: "시간 초과",
+      cancelled: "취소됨",
+      queued: "대기 중",
+      running: "실행 중",
+      pending: "대기 중",
+    };
+    return labels[status] ?? status.replace(/_/g, " ");
+  }
   return status.replace(/_/g, " ");
 }
 
@@ -565,18 +579,25 @@ function computeSegmentTimings(entries: readonly IssueChatTranscriptEntry[]): Se
   return timings;
 }
 
-export function formatDurationWords(ms: number | null) {
+export function formatDurationWords(ms: number | null, locale?: string | null) {
   if (ms === null || !Number.isFinite(ms) || ms <= 0) return null;
   const totalSeconds = Math.max(1, Math.round(ms / 1000));
+  const korean = isKoreanLocale(locale);
   if (totalSeconds < 60) {
+    if (korean) return `${totalSeconds}초`;
     return `${totalSeconds} second${totalSeconds === 1 ? "" : "s"}`;
   }
   const totalMinutes = Math.round(totalSeconds / 60);
   if (totalMinutes < 60) {
+    if (korean) return `${totalMinutes}분`;
     return `${totalMinutes} minute${totalMinutes === 1 ? "" : "s"}`;
   }
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
+  if (korean) {
+    if (minutes === 0) return `${hours}시간`;
+    return `${hours}시간 ${minutes}분`;
+  }
   if (minutes === 0) {
     return `${hours} hour${hours === 1 ? "" : "s"}`;
   }
@@ -589,41 +610,54 @@ function runDurationLabel(run: {
   startedAt: Date | string | null;
   finishedAt?: Date | string | null;
   resultJson?: Record<string, unknown> | null;
-}) {
+}, locale?: string | null) {
   const start = run.startedAt ?? run.createdAt;
   const end = run.finishedAt ?? null;
   const durationMs = end ? Math.max(0, toTimestamp(end) - toTimestamp(start)) : null;
-  const durationText = formatDurationWords(durationMs);
+  const durationText = formatDurationWords(durationMs, locale);
   const stopReason = typeof run.resultJson?.stopReason === "string" ? run.resultJson.stopReason : null;
+  const korean = isKoreanLocale(locale);
   switch (run.status) {
     case "succeeded":
+      if (korean) return durationText ? `${durationText} 작업함` : "작업 완료";
       return durationText ? `Worked for ${durationText}` : "Finished work";
     case "failed":
     case "error":
+      if (korean) return durationText ? `${durationText} 후 실패` : "실행 실패";
       return durationText ? `Failed after ${durationText}` : "Run failed";
     case "timed_out":
+      if (korean) return durationText ? `${durationText} 후 시간 초과` : "시간 초과";
       return durationText ? `Timed out after ${durationText}` : "Run timed out";
     case "cancelled":
       if (stopReason === "paused") {
+        if (korean) return durationText ? `${durationText} 후 보드 일시정지` : "보드 일시정지";
         return durationText ? `Paused by board after ${durationText}` : "Paused by board";
       }
+      if (korean) return durationText ? `${durationText} 후 취소됨` : "실행 취소됨";
       return durationText ? `Cancelled after ${durationText}` : "Run cancelled";
     case "queued":
+      if (korean) return "대기 중";
       return "Queued";
     case "running":
+      if (korean) return "작업 중...";
       return "Working...";
     default:
-      return formatStatusLabel(run.status);
+      return formatStatusLabel(run.status, locale);
   }
 }
 
-function createHistoricalRunMessage(run: IssueChatLinkedRun, agentMap?: Map<string, Agent>) {
+function createHistoricalRunMessage(run: IssueChatLinkedRun, agentMap?: Map<string, Agent>, locale?: string | null) {
   const agentName = run.agentName ?? agentMap?.get(run.agentId)?.name ?? run.agentId.slice(0, 8);
   const message: ThreadSystemMessage = {
     id: `run:${run.runId}`,
     role: "system",
     createdAt: toDate(runTimestamp(run)),
-    content: [{ type: "text", text: `${agentName} run ${run.runId.slice(0, 8)} ${formatStatusLabel(run.status)}` }],
+    content: [{
+      type: "text",
+      text: isKoreanLocale(locale)
+        ? `${agentName} 실행 ${run.runId.slice(0, 8)} ${formatStatusLabel(run.status, locale)}`
+        : `${agentName} run ${run.runId.slice(0, 8)} ${formatStatusLabel(run.status)}`,
+    }],
     metadata: {
       custom: {
         kind: "run",
@@ -643,12 +677,13 @@ function createHistoricalTranscriptMessage(args: {
   transcript: readonly IssueChatTranscriptEntry[];
   hasOutput: boolean;
   agentMap?: Map<string, Agent>;
+  locale?: string | null;
 }) {
-  const { run, transcript, hasOutput, agentMap } = args;
+  const { run, transcript, hasOutput, agentMap, locale } = args;
   const agentName = run.agentName ?? agentMap?.get(run.agentId)?.name ?? run.agentId.slice(0, 8);
   const compactedTranscript = compactIssueChatTranscript(transcript);
   const { parts, notices, segments } = buildAssistantPartsFromTranscript(compactedTranscript);
-  const waitingText = hasOutput ? "" : "Run finished";
+  const waitingText = hasOutput ? "" : isKoreanLocale(locale) ? "실행이 끝났습니다." : "Run finished";
   const content = parts.length > 0
     ? parts
     : waitingText
@@ -670,7 +705,7 @@ function createHistoricalTranscriptMessage(args: {
       runStatus: run.status,
       notices,
       waitingText,
-      chainOfThoughtLabel: runDurationLabel(run),
+      chainOfThoughtLabel: runDurationLabel(run, locale),
       chainOfThoughtSegments: segments,
     }),
   };
@@ -839,16 +874,17 @@ function normalizeLiveRuns(
 function createLiveRunMessage(args: {
   run: LiveRunForIssue;
   transcript: readonly IssueChatTranscriptEntry[];
+  locale?: string | null;
 }) {
-  const { run, transcript } = args;
+  const { run, transcript, locale } = args;
   const compactedTranscript = compactIssueChatTranscript(transcript);
   const { parts, notices, segments } = buildAssistantPartsFromTranscript(compactedTranscript);
   const waitingText =
     run.status === "queued"
-      ? "Queued..."
+      ? isKoreanLocale(locale) ? "대기 중..." : "Queued..."
       : parts.length > 0
         ? ""
-        : "Working...";
+        : isKoreanLocale(locale) ? "작업 중..." : "Working...";
 
   const content = parts;
 
@@ -867,7 +903,7 @@ function createLiveRunMessage(args: {
       adapterType: run.adapterType,
       notices,
       waitingText,
-      chainOfThoughtLabel: runDurationLabel(run),
+      chainOfThoughtLabel: runDurationLabel(run, locale),
       chainOfThoughtSegments: segments,
     }),
   };
@@ -890,6 +926,7 @@ export function buildIssueChatMessages(args: {
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
   userLabelMap?: ReadonlyMap<string, string> | null;
+  locale?: string | null;
 }) {
   const {
     comments,
@@ -907,6 +944,7 @@ export function buildIssueChatMessages(args: {
     agentMap,
     currentUserId,
     userLabelMap,
+    locale,
   } = args;
 
   const orderedMessages: MessageWithOrder[] = [];
@@ -961,6 +999,7 @@ export function buildIssueChatMessages(args: {
           transcript,
           hasOutput: hasRunOutput,
           agentMap,
+          locale,
         }),
       });
       continue;
@@ -969,7 +1008,7 @@ export function buildIssueChatMessages(args: {
     orderedMessages.push({
       createdAtMs: toTimestamp(runTimestamp(run)),
       order: 2,
-      message: createHistoricalRunMessage(run, agentMap),
+      message: createHistoricalRunMessage(run, agentMap, locale),
     });
   }
 
@@ -980,6 +1019,7 @@ export function buildIssueChatMessages(args: {
       message: createLiveRunMessage({
         run,
         transcript: transcriptsByRunId?.get(run.id) ?? [],
+        locale,
       }),
     });
   }

--- a/ui/src/lib/time-format.test.ts
+++ b/ui/src/lib/time-format.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { timeAgo } from "./timeAgo";
+import { formatDurationMs, relativeTime } from "./utils";
+
+describe("runtime time formatting", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps English as the default relative time language", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-24T12:00:00.000Z"));
+
+    expect(timeAgo("2026-04-24T11:58:00.000Z")).toBe("2m ago");
+    expect(relativeTime("2026-04-24T10:00:00.000Z")).toBe("2h ago");
+  });
+
+  it("formats relative time and compact durations in Korean when requested", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-24T12:00:00.000Z"));
+
+    expect(timeAgo("2026-04-24T11:58:00.000Z", "ko")).toBe("2분 전");
+    expect(relativeTime("2026-04-24T10:00:00.000Z", "ko-KR")).toBe("2시간 전");
+    expect(formatDurationMs(65_000, "ko")).toBe("1분 5초");
+  });
+});

--- a/ui/src/lib/timeAgo.ts
+++ b/ui/src/lib/timeAgo.ts
@@ -1,31 +1,34 @@
+import { isKoreanLocale } from "@/i18n/locale-utils";
+
 const MINUTE = 60;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 const MONTH = 30 * DAY;
 
-export function timeAgo(date: Date | string): string {
+export function timeAgo(date: Date | string, locale?: string | null): string {
   const now = Date.now();
   const then = new Date(date).getTime();
   const seconds = Math.round((now - then) / 1000);
+  const korean = isKoreanLocale(locale);
 
-  if (seconds < MINUTE) return "just now";
+  if (seconds < MINUTE) return korean ? "방금 전" : "just now";
   if (seconds < HOUR) {
     const m = Math.floor(seconds / MINUTE);
-    return `${m}m ago`;
+    return korean ? `${m}분 전` : `${m}m ago`;
   }
   if (seconds < DAY) {
     const h = Math.floor(seconds / HOUR);
-    return `${h}h ago`;
+    return korean ? `${h}시간 전` : `${h}h ago`;
   }
   if (seconds < WEEK) {
     const d = Math.floor(seconds / DAY);
-    return `${d}d ago`;
+    return korean ? `${d}일 전` : `${d}d ago`;
   }
   if (seconds < MONTH) {
     const w = Math.floor(seconds / WEEK);
-    return `${w}w ago`;
+    return korean ? `${w}주 전` : `${w}w ago`;
   }
   const mo = Math.floor(seconds / MONTH);
-  return `${mo}mo ago`;
+  return korean ? `${mo}개월 전` : `${mo}mo ago`;
 }

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { deriveAgentUrlKey, deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "@paperclipai/shared";
 import type { BillingType, FinanceDirection, FinanceEventKind } from "@paperclipai/shared";
+import { isKoreanLocale } from "@/i18n/locale-utils";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -29,16 +30,20 @@ export function formatNumber(n: number): string {
   return n.toLocaleString("en-US");
 }
 
-export function formatDate(date: Date | string): string {
-  return new Date(date).toLocaleDateString("en-US", {
+function dateLocale(locale?: string | null) {
+  return isKoreanLocale(locale) ? "ko-KR" : "en-US";
+}
+
+export function formatDate(date: Date | string, locale?: string | null): string {
+  return new Date(date).toLocaleDateString(dateLocale(locale), {
     month: "short",
     day: "numeric",
     year: "numeric",
   });
 }
 
-export function formatDateTime(date: Date | string): string {
-  return new Date(date).toLocaleString("en-US", {
+export function formatDateTime(date: Date | string, locale?: string | null): string {
+  return new Date(date).toLocaleString(dateLocale(locale), {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -47,25 +52,26 @@ export function formatDateTime(date: Date | string): string {
   });
 }
 
-export function formatShortDate(date: Date | string): string {
-  return new Date(date).toLocaleString("en-US", {
+export function formatShortDate(date: Date | string, locale?: string | null): string {
+  return new Date(date).toLocaleString(dateLocale(locale), {
     month: "short",
     day: "numeric",
   });
 }
 
-export function relativeTime(date: Date | string): string {
+export function relativeTime(date: Date | string, locale?: string | null): string {
   const now = Date.now();
   const then = new Date(date).getTime();
   const diffSec = Math.round((now - then) / 1000);
-  if (diffSec < 60) return "just now";
+  const korean = isKoreanLocale(locale);
+  if (diffSec < 60) return korean ? "방금 전" : "just now";
   const diffMin = Math.round(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 60) return korean ? `${diffMin}분 전` : `${diffMin}m ago`;
   const diffHr = Math.round(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffHr < 24) return korean ? `${diffHr}시간 전` : `${diffHr}h ago`;
   const diffDay = Math.round(diffHr / 24);
-  if (diffDay < 30) return `${diffDay}d ago`;
-  return formatDate(date);
+  if (diffDay < 30) return korean ? `${diffDay}일 전` : `${diffDay}d ago`;
+  return formatDate(date, locale);
 }
 
 export function formatTokens(n: number): string {
@@ -76,20 +82,26 @@ export function formatTokens(n: number): string {
 }
 
 /** Humanize a millisecond duration into a compact `1h 2m`, `45m 12s`, `12s` string. */
-export function formatDurationMs(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) return "0s";
+export function formatDurationMs(ms: number, locale?: string | null): string {
+  const korean = isKoreanLocale(locale);
+  if (!Number.isFinite(ms) || ms <= 0) return korean ? "0초" : "0s";
   const totalSeconds = Math.round(ms / 1000);
-  if (totalSeconds < 60) return `${totalSeconds}s`;
+  if (totalSeconds < 60) return korean ? `${totalSeconds}초` : `${totalSeconds}s`;
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
-  if (minutes < 60) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  if (minutes < 60) {
+    if (korean) return seconds > 0 ? `${minutes}분 ${seconds}초` : `${minutes}분`;
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
   if (hours < 24) {
+    if (korean) return remainingMinutes > 0 ? `${hours}시간 ${remainingMinutes}분` : `${hours}시간`;
     return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
   }
   const days = Math.floor(hours / 24);
   const remainingHours = hours % 24;
+  if (korean) return remainingHours > 0 ? `${days}일 ${remainingHours}시간` : `${days}일`;
   return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
 }
 

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -11,6 +11,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { EmptyState } from "../components/EmptyState";
 import { ActivityRow } from "../components/ActivityRow";
 import { PageSkeleton } from "../components/PageSkeleton";
+import { useCurrentLocale, useLocalizedCopy } from "../i18n/ui-copy";
 import {
   Select,
   SelectContent,
@@ -43,14 +44,33 @@ function activityEntityTitle(event: ActivityEvent) {
   return null;
 }
 
+function entityTypeLabel(type: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    agent: copy("activity.entity.agent", "Agent", "직원"),
+    approval: copy("activity.entity.approval", "Approval", "승인"),
+    asset: copy("activity.entity.asset", "Asset", "자산"),
+    comment: copy("activity.entity.comment", "Comment", "댓글"),
+    company: copy("activity.entity.company", "Company", "회사"),
+    goal: copy("activity.entity.goal", "Goal", "목표"),
+    issue: copy("activity.entity.issue", "Issue", "작업"),
+    project: copy("activity.entity.project", "Project", "프로젝트"),
+    run: copy("activity.entity.run", "Run", "실행"),
+    skill: copy("activity.entity.skill", "Skill", "스킬"),
+    routine: copy("activity.entity.routine", "Routine", "루틴"),
+  };
+  return labels[type] ?? type.charAt(0).toUpperCase() + type.slice(1);
+}
+
 export function Activity() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const [filter, setFilter] = useState("all");
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Activity" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("activity.breadcrumb", "Activity", "활동") }]);
+  }, [copy, setBreadcrumbs]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: [...queryKeys.activity(selectedCompanyId!), { limit: ACTIVITY_PAGE_LIMIT }],
@@ -101,7 +121,7 @@ export function Activity() {
   }, [data]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={History} message="Select a company to view activity." />;
+    return <EmptyState icon={History} message={copy("activity.noCompany", "Select a company to view activity.", "활동을 보려면 회사를 선택하세요.")} />;
   }
 
   if (isLoading) {
@@ -122,13 +142,13 @@ export function Activity() {
       <div className="flex items-center justify-end">
         <Select value={filter} onValueChange={setFilter}>
           <SelectTrigger className="w-[140px] h-8 text-xs">
-            <SelectValue placeholder="Filter by type" />
+            <SelectValue placeholder={copy("activity.filter.placeholder", "Filter by type", "유형 필터")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="all">{copy("activity.filter.all", "All types", "전체 유형")}</SelectItem>
             {entityTypes.map((type) => (
               <SelectItem key={type} value={type}>
-                {type.charAt(0).toUpperCase() + type.slice(1)}
+                {entityTypeLabel(type, copy)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -138,7 +158,7 @@ export function Activity() {
       {error && <p className="text-sm text-destructive">{error.message}</p>}
 
       {filtered && filtered.length === 0 && (
-        <EmptyState icon={History} message="No activity yet." />
+        <EmptyState icon={History} message={copy("activity.empty", "No activity yet.", "아직 활동이 없습니다.")} />
       )}
 
       {filtered && filtered.length > 0 && (
@@ -151,6 +171,7 @@ export function Activity() {
               userProfileMap={userProfileMap}
               entityNameMap={entityNameMap}
               entityTitleMap={entityTitleMap}
+              locale={locale}
             />
           ))}
         </div>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -47,7 +47,7 @@ import { SourceResolvedFoldCallout } from "../components/SourceResolvedFoldCallo
 import { SourceResolvedFoldBadge } from "../components/SourceResolvedFoldBadge";
 import { readSourceResolvedWatchdogFold } from "../lib/source-resolved-watchdog-fold";
 import { buildSameOriginWebSocketUrl } from "../lib/websocket-url";
-import { formatCents, formatDate, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
+import { formatCents, formatDate, formatDurationMs, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { cn } from "../lib/utils";
 import { describeRunRetryState } from "../lib/runRetryState";
 import { buildDuplicateAgentPayload, duplicateAgentName, type DuplicateInstructionsBundle } from "../lib/duplicate-agent-payload";
@@ -113,6 +113,7 @@ import {
   arraysEqual,
   isReadOnlyUnmanagedSkillEntry,
 } from "../lib/agent-skills-state";
+import { useCurrentLocale, useLocalizedCopy } from "../i18n/ui-copy";
 
 async function loadDuplicateInstructionsBundle(
   agentId: string,
@@ -215,12 +216,15 @@ function formatEnvForDisplay(envValue: unknown, censorUsernameInLogs: boolean): 
     .join("\n");
 }
 
-const sourceLabels: Record<string, string> = {
-  timer: "Timer",
-  assignment: "Assignment",
-  on_demand: "On-demand",
-  automation: "Automation",
-};
+function sourceLabel(source: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    timer: copy("agentDetail.source.timer", "Timer", "예약"),
+    assignment: copy("agentDetail.source.assignment", "Assignment", "배정"),
+    on_demand: copy("agentDetail.source.onDemand", "On-demand", "수동 실행"),
+    automation: copy("agentDetail.source.automation", "Automation", "자동화"),
+  };
+  return labels[source] ?? source;
+}
 
 const LIVE_SCROLL_BOTTOM_TOLERANCE_PX = 32;
 type ScrollContainer = Window | HTMLElement;
@@ -350,6 +354,7 @@ export function RunInvocationCard({
   payload: Record<string, unknown>;
   censorUsernameInLogs: boolean;
 }) {
+  const copy = useLocalizedCopy();
   const rawCommandLine = [
     typeof payload.command === "string" ? payload.command : null,
     ...(Array.isArray(payload.commandArgs)
@@ -369,29 +374,29 @@ export function RunInvocationCard({
 
   return (
     <div className="rounded-lg border border-border bg-background/60 p-3 space-y-2">
-      <div className="text-xs font-medium text-muted-foreground">Invocation</div>
+      <div className="text-xs font-medium text-muted-foreground">{copy("agentDetail.invocation.title", "Invocation", "실행 호출")}</div>
       {typeof payload.adapterType === "string" && (
-        <div className="text-xs"><span className="text-muted-foreground">Adapter: </span>{payload.adapterType}</div>
+        <div className="text-xs"><span className="text-muted-foreground">{copy("agentDetail.invocation.adapter", "Adapter", "어댑터")}: </span>{payload.adapterType}</div>
       )}
       {typeof payload.cwd === "string" && (
-        <div className="text-xs break-all"><span className="text-muted-foreground">Working dir: </span><span className="font-mono">{payload.cwd}</span></div>
+        <div className="text-xs break-all"><span className="text-muted-foreground">{copy("agentDetail.invocation.workingDir", "Working dir", "작업 폴더")}: </span><span className="font-mono">{payload.cwd}</span></div>
       )}
       {hasAdvancedDetails && (
         <Collapsible>
           <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors group">
             <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
-            Details
+            {copy("agentDetail.invocation.details", "Details", "상세")}
           </CollapsibleTrigger>
           <CollapsibleContent className="pt-2 space-y-2">
             {commandLine && (
               <div className="text-xs break-all">
-                <span className="text-muted-foreground">Command: </span>
+                <span className="text-muted-foreground">{copy("agentDetail.invocation.command", "Command", "명령")}: </span>
                 <span className="font-mono">{commandLine}</span>
               </div>
             )}
             {Array.isArray(payload.commandNotes) && payload.commandNotes.length > 0 && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Command notes</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy("agentDetail.invocation.commandNotes", "Command notes", "명령 메모")}</div>
                 <ul className="list-disc pl-5 space-y-1">
                   {payload.commandNotes
                     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
@@ -405,7 +410,7 @@ export function RunInvocationCard({
             )}
             {payload.prompt !== undefined && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Prompt</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy("agentDetail.invocation.prompt", "Prompt", "프롬프트")}</div>
                 <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap">
                   {typeof payload.prompt === "string"
                     ? redactPathText(payload.prompt, censorUsernameInLogs)
@@ -415,7 +420,7 @@ export function RunInvocationCard({
             )}
             {payload.context !== undefined && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Context</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy("agentDetail.invocation.context", "Context", "컨텍스트")}</div>
                 <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap">
                   {JSON.stringify(redactPathValue(payload.context, censorUsernameInLogs), null, 2)}
                 </pre>
@@ -423,7 +428,7 @@ export function RunInvocationCard({
             )}
             {payload.env !== undefined && (
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Environment</div>
+                <div className="text-xs text-muted-foreground mb-1">{copy("agentDetail.invocation.environment", "Environment", "환경 변수")}</div>
                 <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap font-mono">
                   {formatEnvForDisplay(payload.env, censorUsernameInLogs)}
                 </pre>
@@ -456,16 +461,16 @@ function parseStoredLogContent(content: string): RunLogChunk[] {
   return parsed;
 }
 
-function workspaceOperationPhaseLabel(phase: WorkspaceOperation["phase"]) {
+function workspaceOperationPhaseLabel(phase: WorkspaceOperation["phase"], copy: ReturnType<typeof useLocalizedCopy>) {
   switch (phase) {
     case "worktree_prepare":
-      return "Worktree setup";
+      return copy("agentDetail.workspace.phase.worktreePrepare", "Worktree setup", "작업트리 준비");
     case "workspace_provision":
-      return "Provision";
+      return copy("agentDetail.workspace.phase.provision", "Provision", "작업공간 준비");
     case "workspace_teardown":
-      return "Teardown";
+      return copy("agentDetail.workspace.phase.teardown", "Teardown", "작업공간 정리");
     case "worktree_cleanup":
-      return "Worktree cleanup";
+      return copy("agentDetail.workspace.phase.worktreeCleanup", "Worktree cleanup", "작업트리 정리");
     default:
       return phase;
   }
@@ -487,6 +492,14 @@ function workspaceOperationStatusTone(status: WorkspaceOperation["status"]) {
 }
 
 function WorkspaceOperationStatusBadge({ status }: { status: WorkspaceOperation["status"] }) {
+  const copy = useLocalizedCopy();
+  const labels: Record<string, string> = {
+    succeeded: copy("status.succeeded", "succeeded", "성공"),
+    failed: copy("status.failed", "failed", "실패"),
+    running: copy("status.running", "running", "실행 중"),
+    skipped: copy("status.skipped", "skipped", "건너뜀"),
+  };
+
   return (
     <span
       className={cn(
@@ -494,7 +507,7 @@ function WorkspaceOperationStatusBadge({ status }: { status: WorkspaceOperation[
         workspaceOperationStatusTone(status),
       )}
     >
-      {status.replace("_", " ")}
+      {labels[status] ?? status.replace("_", " ")}
     </span>
   );
 }
@@ -506,6 +519,8 @@ function WorkspaceOperationLogViewer({
   operation: WorkspaceOperation;
   censorUsernameInLogs: boolean;
 }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const [open, setOpen] = useState(false);
   const { data: logData, isLoading, error } = useQuery({
     queryKey: ["workspace-operation-log", operation.id],
@@ -526,25 +541,27 @@ function WorkspaceOperationLogViewer({
         className="text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
         onClick={() => setOpen((value) => !value)}
       >
-        {open ? "Hide full log" : "Show full log"}
+        {open
+          ? copy("agentDetail.workspace.hideFullLog", "Hide full log", "전체 로그 숨기기")
+          : copy("agentDetail.workspace.showFullLog", "Show full log", "전체 로그 보기")}
       </button>
       {open && (
         <div className="rounded-md border border-border bg-background/70 p-2">
-          {isLoading && <div className="text-xs text-muted-foreground">Loading log...</div>}
+          {isLoading && <div className="text-xs text-muted-foreground">{copy("agentDetail.workspace.loadingLog", "Loading log...", "로그 불러오는 중...")}</div>}
           {error && (
             <div className="text-xs text-destructive">
-              {error instanceof Error ? error.message : "Failed to load workspace operation log"}
+              {error instanceof Error ? error.message : copy("agentDetail.workspace.loadLogFailed", "Failed to load workspace operation log", "작업공간 작업 로그를 불러오지 못했습니다.")}
             </div>
           )}
           {!isLoading && !error && chunks.length === 0 && (
-            <div className="text-xs text-muted-foreground">No persisted log lines.</div>
+            <div className="text-xs text-muted-foreground">{copy("agentDetail.workspace.noLogLines", "No persisted log lines.", "저장된 로그 줄이 없습니다.")}</div>
           )}
           {chunks.length > 0 && (
             <div className="max-h-64 overflow-y-auto rounded bg-neutral-100 p-2 font-mono text-xs dark:bg-neutral-950">
               {chunks.map((chunk, index) => (
                 <div key={`${chunk.ts}-${index}`} className="flex gap-2">
                   <span className="shrink-0 text-neutral-500">
-                    {new Date(chunk.ts).toLocaleTimeString("en-US", { hour12: false })}
+                    {new Date(chunk.ts).toLocaleTimeString(locale, { hour12: false })}
                   </span>
                   <span
                     className={cn(
@@ -576,12 +593,14 @@ function WorkspaceOperationsSection({
   operations: WorkspaceOperation[];
   censorUsernameInLogs: boolean;
 }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   if (operations.length === 0) return null;
 
   return (
     <div className="rounded-lg border border-border bg-background/60 p-3 space-y-3">
       <div className="text-xs font-medium text-muted-foreground">
-        Workspace ({operations.length})
+        {copy("agentDetail.workspace.title", "Workspace", "작업공간")} ({operations.length})
       </div>
       <div className="space-y-3">
         {operations.map((operation) => {
@@ -589,22 +608,22 @@ function WorkspaceOperationsSection({
           return (
             <div key={operation.id} className="rounded-md border border-border/70 bg-background/70 p-3 space-y-2">
               <div className="flex flex-wrap items-center gap-2">
-                <div className="text-sm font-medium">{workspaceOperationPhaseLabel(operation.phase)}</div>
+                <div className="text-sm font-medium">{workspaceOperationPhaseLabel(operation.phase, copy)}</div>
                 <WorkspaceOperationStatusBadge status={operation.status} />
                 <div className="text-[11px] text-muted-foreground">
-                  {relativeTime(operation.startedAt)}
-                  {operation.finishedAt && ` to ${relativeTime(operation.finishedAt)}`}
+                  {relativeTime(operation.startedAt, locale)}
+                  {operation.finishedAt && <> &rarr; {relativeTime(operation.finishedAt, locale)}</>}
                 </div>
               </div>
               {operation.command && (
                 <div className="text-xs break-all">
-                  <span className="text-muted-foreground">Command: </span>
+                  <span className="text-muted-foreground">{copy("agentDetail.invocation.command", "Command", "명령")}: </span>
                   <span className="font-mono">{operation.command}</span>
                 </div>
               )}
               {operation.cwd && (
                 <div className="text-xs break-all">
-                  <span className="text-muted-foreground">Working dir: </span>
+                  <span className="text-muted-foreground">{copy("agentDetail.invocation.workingDir", "Working dir", "작업 폴더")}: </span>
                   <span className="font-mono">{operation.cwd}</span>
                 </div>
               )}
@@ -615,30 +634,32 @@ function WorkspaceOperationsSection({
                 || asNonEmptyString(metadata?.cleanupAction)) && (
                 <div className="grid gap-1 text-xs sm:grid-cols-2">
                   {asNonEmptyString(metadata?.branchName) && (
-                    <div><span className="text-muted-foreground">Branch: </span><span className="font-mono">{metadata?.branchName as string}</span></div>
+                    <div><span className="text-muted-foreground">{copy("agentDetail.workspace.branch", "Branch", "브랜치")}: </span><span className="font-mono">{metadata?.branchName as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.baseRef) && (
-                    <div><span className="text-muted-foreground">Base ref: </span><span className="font-mono">{metadata?.baseRef as string}</span></div>
+                    <div><span className="text-muted-foreground">{copy("agentDetail.workspace.baseRef", "Base ref", "기준 ref")}: </span><span className="font-mono">{metadata?.baseRef as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.worktreePath) && (
-                    <div className="break-all"><span className="text-muted-foreground">Worktree: </span><span className="font-mono">{metadata?.worktreePath as string}</span></div>
+                    <div className="break-all"><span className="text-muted-foreground">{copy("agentDetail.workspace.worktree", "Worktree", "작업트리")}: </span><span className="font-mono">{metadata?.worktreePath as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.repoRoot) && (
-                    <div className="break-all"><span className="text-muted-foreground">Repo root: </span><span className="font-mono">{metadata?.repoRoot as string}</span></div>
+                    <div className="break-all"><span className="text-muted-foreground">{copy("agentDetail.workspace.repoRoot", "Repo root", "저장소 루트")}: </span><span className="font-mono">{metadata?.repoRoot as string}</span></div>
                   )}
                   {asNonEmptyString(metadata?.cleanupAction) && (
-                    <div><span className="text-muted-foreground">Cleanup: </span><span className="font-mono">{metadata?.cleanupAction as string}</span></div>
+                    <div><span className="text-muted-foreground">{copy("agentDetail.workspace.cleanup", "Cleanup", "정리")}: </span><span className="font-mono">{metadata?.cleanupAction as string}</span></div>
                   )}
                 </div>
               )}
               {typeof metadata?.created === "boolean" && (
                 <div className="text-xs text-muted-foreground">
-                  {metadata.created ? "Created by this run" : "Reused existing workspace"}
+                  {metadata.created
+                    ? copy("agentDetail.workspace.createdByRun", "Created by this run", "이 실행에서 생성됨")
+                    : copy("agentDetail.workspace.reusedExisting", "Reused existing workspace", "기존 작업공간 재사용")}
                 </div>
               )}
               {operation.stderrExcerpt && operation.stderrExcerpt.trim() && (
                 <div>
-                  <div className="mb-1 text-xs text-red-700 dark:text-red-300">stderr excerpt</div>
+                  <div className="mb-1 text-xs text-red-700 dark:text-red-300">{copy("agentDetail.run.stderrExcerpt", "stderr excerpt", "stderr 발췌")}</div>
                   <pre className="rounded-md bg-red-50 p-2 text-xs whitespace-pre-wrap break-all text-red-800 dark:bg-neutral-950 dark:text-red-100">
                     {redactPathText(operation.stderrExcerpt, censorUsernameInLogs)}
                   </pre>
@@ -646,7 +667,7 @@ function WorkspaceOperationsSection({
               )}
               {operation.stdoutExcerpt && operation.stdoutExcerpt.trim() && (
                 <div>
-                  <div className="mb-1 text-xs text-muted-foreground">stdout excerpt</div>
+                  <div className="mb-1 text-xs text-muted-foreground">{copy("agentDetail.run.stdoutExcerpt", "stdout excerpt", "stdout 발췌")}</div>
                   <pre className="rounded-md bg-neutral-100 p-2 text-xs whitespace-pre-wrap break-all dark:bg-neutral-950">
                     {redactPathText(operation.stdoutExcerpt, censorUsernameInLogs)}
                   </pre>
@@ -678,6 +699,7 @@ export function AgentDetail() {
   const { openNewIssue } = useDialogActions();
   const { pushToast } = useToastActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [actionError, setActionError] = useState<string | null>(null);
@@ -964,7 +986,7 @@ export function AgentDetail() {
 
   useEffect(() => {
     const crumbs: { label: string; href?: string }[] = [
-      { label: "Agents", href: "/agents" },
+      { label: copy("agentDetail.breadcrumb.agents", "Agents", "직원"), href: "/agents" },
     ];
     const agentName = agent?.name ?? routeAgentRef ?? "Agent";
     if (activeView === "dashboard" && !urlRunId) {
@@ -972,24 +994,24 @@ export function AgentDetail() {
     } else {
       crumbs.push({ label: agentName, href: `/agents/${canonicalAgentRef}/dashboard` });
       if (urlRunId) {
-        crumbs.push({ label: "Runs", href: `/agents/${canonicalAgentRef}/runs` });
-        crumbs.push({ label: `Run ${urlRunId.slice(0, 8)}` });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.runs", "Runs", "실행 기록"), href: `/agents/${canonicalAgentRef}/runs` });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.run", `Run ${urlRunId.slice(0, 8)}`, `실행 ${urlRunId.slice(0, 8)}`) });
       } else if (activeView === "instructions") {
-        crumbs.push({ label: "Instructions" });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.instructions", "Instructions", "지침") });
       } else if (activeView === "configuration") {
-        crumbs.push({ label: "Configuration" });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.configuration", "Configuration", "설정") });
       // } else if (activeView === "skills") { // TODO: bring back later
       //   crumbs.push({ label: "Skills" });
       } else if (activeView === "runs") {
-        crumbs.push({ label: "Runs" });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.runs", "Runs", "실행 기록") });
       } else if (activeView === "budget") {
-        crumbs.push({ label: "Budget" });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.budget", "Budget", "예산") });
       } else {
-        crumbs.push({ label: "Dashboard" });
+        crumbs.push({ label: copy("agentDetail.breadcrumb.dashboard", "Dashboard", "대시보드") });
       }
     }
     setBreadcrumbs(crumbs);
-  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId]);
+  }, [setBreadcrumbs, agent, routeAgentRef, canonicalAgentRef, activeView, urlRunId, copy]);
 
   useEffect(() => {
     closePanel();
@@ -1033,7 +1055,7 @@ export function AgentDetail() {
       {showLeftAgentNotice ? (
         <div className="flex items-center gap-3 border border-yellow-300/35 bg-yellow-300/10 px-3 py-2 text-sm text-yellow-100">
           <p className="min-w-0 flex-1">
-            You left this agent. It no longer appears in your sidebar.
+            {copy("agentDetail.leftNotice.body", "You left this agent. It no longer appears in your sidebar.", "이 직원을 떠났습니다. 이제 사이드바에 표시되지 않습니다.")}
           </p>
           <MembershipAction
             compact
@@ -1057,7 +1079,7 @@ export function AgentDetail() {
           <button
             type="button"
             className="h-6 w-6 shrink-0 text-yellow-100/70 hover:text-yellow-100"
-            aria-label="Dismiss agent membership notice"
+            aria-label={copy("agentDetail.leftNotice.dismiss", "Dismiss agent membership notice", "직원 멤버십 알림 닫기")}
             onClick={() => setDismissedLeftAgentIds((current) => new Set(current).add(agent.id))}
           >
             ×
@@ -1090,12 +1112,12 @@ export function AgentDetail() {
             onClick={() => openNewIssue({ assigneeAgentId: agent.id })}
           >
             <Plus className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">Assign Task</span>
+            <span className="hidden sm:inline">{copy("agentDetail.actions.assignTask", "Assign Task", "작업 배정")}</span>
           </Button>
           <RunButton
             onClick={() => agentAction.mutate("invoke")}
             disabled={agentAction.isPending || isPendingApproval}
-            label="Run Heartbeat"
+            label={copy("agentDetail.actions.runHeartbeat", "Run Heartbeat", "상태 점검 실행")}
           />
           <PauseResumeButton
             isPaused={agent.status === "paused"}
@@ -1113,7 +1135,9 @@ export function AgentDetail() {
                 <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
               </span>
-              <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">Live</span>
+              <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
+                {copy("agentDetail.live", "Live", "실행 중")}
+              </span>
             </Link>
           )}
 
@@ -1135,7 +1159,7 @@ export function AgentDetail() {
                 ) : (
                   <Copy className="h-3 w-3" />
                 )}
-                Duplicate Agent
+                {copy("agentDetail.menu.duplicateAgent", "Duplicate Agent", "직원 복제")}
               </button>
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
@@ -1145,7 +1169,7 @@ export function AgentDetail() {
                 }}
               >
                 <Copy className="h-3 w-3" />
-                Copy Agent ID
+                {copy("agentDetail.menu.copyAgentId", "Copy Agent ID", "직원 ID 복사")}
               </button>
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
@@ -1155,7 +1179,7 @@ export function AgentDetail() {
                 }}
               >
                 <RotateCcw className="h-3 w-3" />
-                Reset Sessions
+                {copy("agentDetail.menu.resetSessions", "Reset Sessions", "세션 초기화")}
               </button>
               <button
                 className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
@@ -1165,7 +1189,7 @@ export function AgentDetail() {
                 }}
               >
                 <Trash2 className="h-3 w-3" />
-                Terminate
+                {copy("agentDetail.menu.terminate", "Terminate", "종료")}
               </button>
             </PopoverContent>
           </Popover>
@@ -1179,12 +1203,12 @@ export function AgentDetail() {
         >
           <PageTabBar
             items={[
-              { value: "dashboard", label: "Dashboard" },
-              { value: "instructions", label: "Instructions" },
-              { value: "skills", label: "Skills" },
-              { value: "configuration", label: "Configuration" },
-              { value: "runs", label: "Runs" },
-              { value: "budget", label: "Budget" },
+              { value: "dashboard", label: copy("agentDetail.tabs.dashboard", "Dashboard", "대시보드") },
+              { value: "instructions", label: copy("agentDetail.tabs.instructions", "Instructions", "지침") },
+              { value: "skills", label: copy("agentDetail.tabs.skills", "Skills", "스킬") },
+              { value: "configuration", label: copy("agentDetail.tabs.configuration", "Configuration", "설정") },
+              { value: "runs", label: copy("agentDetail.tabs.runs", "Runs", "실행 기록") },
+              { value: "budget", label: copy("agentDetail.tabs.budget", "Budget", "예산") },
             ]}
             value={activeView}
             onValueChange={(value) => navigate(`/agents/${canonicalAgentRef}/${value}`)}
@@ -1195,7 +1219,7 @@ export function AgentDetail() {
       {actionError && <p className="text-sm text-destructive">{actionError}</p>}
       {isPendingApproval && (
         <div className="flex flex-wrap items-center gap-3 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/30 dark:text-amber-200">
-          <span>This agent is pending board approval and cannot be invoked yet.</span>
+          <span>{copy("agentDetail.pending.body", "This agent is pending board approval and cannot be invoked yet.", "이 직원은 보드 승인을 기다리는 중이라 아직 실행할 수 없습니다.")}</span>
           <Button
             variant="outline"
             size="sm"
@@ -1203,7 +1227,7 @@ export function AgentDetail() {
             disabled={agentAction.isPending}
           >
             <CheckCircle2 className="h-3.5 w-3.5 sm:mr-1" />
-            <span>Approve agent</span>
+            <span>{copy("agentDetail.pending.approve", "Approve agent", "직원 승인")}</span>
           </Button>
         </div>
       )}
@@ -1218,14 +1242,14 @@ export function AgentDetail() {
               onClick={() => cancelConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              Cancel
+              {copy("common.cancel", "Cancel", "취소")}
             </Button>
             <Button
               size="sm"
               onClick={() => saveConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              {configSaving ? "Saving…" : "Save"}
+              {configSaving ? copy("common.saving", "Saving…", "저장 중…") : copy("common.save", "Save", "저장")}
             </Button>
           </div>
         </div>
@@ -1244,14 +1268,14 @@ export function AgentDetail() {
               onClick={() => cancelConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              Cancel
+              {copy("common.cancel", "Cancel", "취소")}
             </Button>
             <Button
               size="sm"
               onClick={() => saveConfigActionRef.current?.()}
               disabled={configSaving}
             >
-              {configSaving ? "Saving…" : "Save"}
+              {configSaving ? copy("common.saving", "Saving…", "저장 중…") : copy("common.save", "Save", "저장")}
             </Button>
           </div>
         </div>
@@ -1338,20 +1362,22 @@ function SummaryRow({ label, children }: { label: string; children: React.ReactN
 }
 
 function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: string }) {
-  if (runs.length === 0) return null;
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
+  const run = useMemo(() => {
+    if (runs.length === 0) return null;
+    const sorted = [...runs].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+    const liveRun = sorted.find((r) => r.status === "running" || r.status === "queued");
+    return liveRun ?? sorted[0] ?? null;
+  }, [runs]);
 
-  const sorted = [...runs].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
-
-  const liveRun = sorted.find((r) => r.status === "running" || r.status === "queued");
-  const run = liveRun ?? sorted[0];
-  const isLive = run.status === "running" || run.status === "queued";
-  const statusInfo = runStatusIcons[run.status] ?? { icon: Clock, color: "text-neutral-400" };
-  const StatusIcon = statusInfo.icon;
-  const summaryRaw = run.resultJson
-    ? String((run.resultJson as Record<string, unknown>).summary ?? (run.resultJson as Record<string, unknown>).result ?? "")
-    : run.error ?? "";
+  const summaryRaw = run
+    ? run.resultJson
+      ? String((run.resultJson as Record<string, unknown>).summary ?? (run.resultJson as Record<string, unknown>).result ?? "")
+      : run.error ?? ""
+    : "";
 
   // Extract a clean 2-3 line excerpt: first non-empty, non-header, non-list-mark lines
   const summary = useMemo(() => {
@@ -1371,6 +1397,12 @@ function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: strin
     return excerpt.join(" ");
   }, [summaryRaw]);
 
+  if (!run) return null;
+
+  const isLive = run.status === "running" || run.status === "queued";
+  const statusInfo = runStatusIcons[run.status] ?? { icon: Clock, color: "text-neutral-400" };
+  const StatusIcon = statusInfo.icon;
+
   return (
     <div className="space-y-3">
       <div className="flex w-full items-center justify-between">
@@ -1381,13 +1413,15 @@ function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: strin
               <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-400" />
             </span>
           )}
-          {isLive ? "Live Run" : "Latest Run"}
+          {isLive
+            ? copy("agentDetail.latestRun.live", "Live Run", "실행 중")
+            : copy("agentDetail.latestRun.latest", "Latest Run", "최근 실행")}
         </h3>
         <Link
           to={`/agents/${agentId}/runs/${run.id}`}
           className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors no-underline"
         >
-          View details &rarr;
+          {copy("agentDetail.latestRun.viewDetails", "View details", "자세히 보기")} &rarr;
         </Link>
       </div>
 
@@ -1409,9 +1443,9 @@ function LatestRunCard({ runs, agentId }: { runs: HeartbeatRun[]; agentId: strin
               : run.invocationSource === "on_demand" ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300"
               : "bg-muted text-muted-foreground"
           )}>
-            {sourceLabels[run.invocationSource] ?? run.invocationSource}
+            {sourceLabel(run.invocationSource, copy)}
           </span>
-          <span className="ml-auto text-xs text-muted-foreground">{relativeTime(run.createdAt)}</span>
+          <span className="ml-auto text-xs text-muted-foreground">{relativeTime(run.createdAt, locale)}</span>
         </div>
 
         {summary && (
@@ -1441,6 +1475,7 @@ function AgentOverview({
   agentId: string;
   agentRouteId: string;
 }) {
+  const copy = useLocalizedCopy();
   return (
     <div className="space-y-8">
       {/* Latest Run */}
@@ -1448,16 +1483,16 @@ function AgentOverview({
 
       {/* Charts */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <ChartCard title="Run Activity" subtitle="Last 14 days">
+        <ChartCard title={copy("agentDetail.overview.runActivity", "Run Activity", "실행 활동")} subtitle={copy("agentDetail.overview.last14Days", "Last 14 days", "최근 14일")}>
           <RunActivityChart runs={runs} />
         </ChartCard>
-        <ChartCard title="Issues by Priority" subtitle="Last 14 days">
+        <ChartCard title={copy("agentDetail.overview.issuesByPriority", "Issues by Priority", "우선순위별 작업")} subtitle={copy("agentDetail.overview.last14Days", "Last 14 days", "최근 14일")}>
           <PriorityChart issues={assignedIssues} />
         </ChartCard>
-        <ChartCard title="Issues by Status" subtitle="Last 14 days">
+        <ChartCard title={copy("agentDetail.overview.issuesByStatus", "Issues by Status", "상태별 작업")} subtitle={copy("agentDetail.overview.last14Days", "Last 14 days", "최근 14일")}>
           <IssueStatusChart issues={assignedIssues} />
         </ChartCard>
-        <ChartCard title="Success Rate" subtitle="Last 14 days">
+        <ChartCard title={copy("agentDetail.overview.successRate", "Success Rate", "성공률")} subtitle={copy("agentDetail.overview.last14Days", "Last 14 days", "최근 14일")}>
           <SuccessRateChart runs={runs} />
         </ChartCard>
       </div>
@@ -1465,16 +1500,18 @@ function AgentOverview({
       {/* Recent Issues */}
       <div className="space-y-3">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium">Recent Issues</h3>
+          <h3 className="text-sm font-medium">{copy("agentDetail.overview.recentIssues", "Recent Issues", "최근 작업")}</h3>
           <Link
             to={`/issues?participantAgentId=${agentId}`}
             className="text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            See All &rarr;
+            {copy("agentDetail.overview.seeAll", "See All", "전체 보기")} &rarr;
           </Link>
         </div>
         {assignedIssues.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No recent issues.</p>
+          <p className="text-sm text-muted-foreground">
+            {copy("agentDetail.overview.noRecentIssues", "No recent issues.", "최근 작업이 없습니다.")}
+          </p>
         ) : (
           <div className="border border-border rounded-lg">
             {assignedIssues.slice(0, 10).map((issue) => (
@@ -1488,7 +1525,7 @@ function AgentOverview({
             ))}
             {assignedIssues.length > 10 && (
               <div className="px-3 py-2 text-xs text-muted-foreground text-center border-t border-border">
-                +{assignedIssues.length - 10} more issues
+                +{assignedIssues.length - 10} {copy("agentDetail.overview.moreIssues", "more issues", "개 작업 더 있음")}
               </div>
             )}
           </div>
@@ -1497,7 +1534,7 @@ function AgentOverview({
 
       {/* Costs */}
       <div className="space-y-3">
-        <h3 className="text-sm font-medium">Costs</h3>
+        <h3 className="text-sm font-medium">{copy("agentDetail.overview.costs", "Costs", "비용")}</h3>
         <CostsSection runtimeState={runtimeState} runs={runs} />
       </div>
     </div>
@@ -1513,6 +1550,8 @@ function CostsSection({
   runtimeState?: AgentRuntimeState;
   runs: HeartbeatRun[];
 }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const runsWithCost = runs
     .filter((r) => {
       const metrics = runMetrics(r);
@@ -1526,19 +1565,19 @@ function CostsSection({
         <div className="border border-border rounded-lg p-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 tabular-nums">
             <div>
-              <span className="text-xs text-muted-foreground block">Input tokens</span>
+              <span className="text-xs text-muted-foreground block">{copy("agentDetail.costs.inputTokens", "Input tokens", "입력 토큰")}</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalInputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Output tokens</span>
+              <span className="text-xs text-muted-foreground block">{copy("agentDetail.costs.outputTokens", "Output tokens", "출력 토큰")}</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalOutputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Cached tokens</span>
+              <span className="text-xs text-muted-foreground block">{copy("agentDetail.costs.cachedTokens", "Cached tokens", "캐시 토큰")}</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalCachedInputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Total cost</span>
+              <span className="text-xs text-muted-foreground block">{copy("agentDetail.costs.totalCost", "Total cost", "총 비용")}</span>
               <span className="text-lg font-semibold">{formatCents(runtimeState.totalCostCents)}</span>
             </div>
           </div>
@@ -1549,11 +1588,11 @@ function CostsSection({
           <table className="w-full text-xs">
             <thead>
               <tr className="border-b border-border bg-accent/20">
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Date</th>
-                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Run</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Input</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Output</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Cost</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">{copy("agentDetail.costs.date", "Date", "날짜")}</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">{copy("agentDetail.costs.run", "Run", "실행")}</th>
+                <th className="text-right px-3 py-2 font-medium text-muted-foreground">{copy("agentDetail.costs.input", "Input", "입력")}</th>
+                <th className="text-right px-3 py-2 font-medium text-muted-foreground">{copy("agentDetail.costs.output", "Output", "출력")}</th>
+                <th className="text-right px-3 py-2 font-medium text-muted-foreground">{copy("agentDetail.costs.cost", "Cost", "비용")}</th>
               </tr>
             </thead>
             <tbody>
@@ -1561,7 +1600,7 @@ function CostsSection({
                 const metrics = runMetrics(run);
                 return (
                   <tr key={run.id} className="border-b border-border last:border-b-0">
-                    <td className="px-3 py-2">{formatDate(run.createdAt)}</td>
+                    <td className="px-3 py-2">{formatDate(run.createdAt, locale)}</td>
                     <td className="px-3 py-2 font-mono">{run.id.slice(0, 8)}</td>
                     <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.input)}</td>
                     <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.output)}</td>
@@ -1603,6 +1642,7 @@ function AgentConfigurePage({
   onSavingChange: (saving: boolean) => void;
   updatePermissions: { mutate: (permissions: AgentPermissionUpdate) => void; isPending: boolean };
 }) {
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const [revisionsOpen, setRevisionsOpen] = useState(false);
 
@@ -1634,7 +1674,7 @@ function AgentConfigurePage({
         hideInstructionsFile
       />
       <div>
-        <h3 className="text-sm font-medium mb-3">API Keys</h3>
+        <h3 className="text-sm font-medium mb-3">{copy("agentDetail.configuration.apiKeys", "API Keys", "API 키")}</h3>
         <KeysTab agentId={agentId} companyId={companyId} />
       </div>
 
@@ -1648,13 +1688,15 @@ function AgentConfigurePage({
             ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
             : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
           }
-          Configuration Revisions
+          {copy("agentDetail.configuration.revisions", "Configuration Revisions", "설정 변경 이력")}
           <span className="text-xs font-normal text-muted-foreground">{configRevisions?.length ?? 0}</span>
         </button>
         {revisionsOpen && (
           <div className="mt-3">
             {(configRevisions ?? []).length === 0 ? (
-              <p className="text-sm text-muted-foreground">No configuration revisions yet.</p>
+              <p className="text-sm text-muted-foreground">
+                {copy("agentDetail.configuration.noRevisions", "No configuration revisions yet.", "아직 설정 변경 이력이 없습니다.")}
+              </p>
             ) : (
               <div className="space-y-2">
                 {(configRevisions ?? []).slice(0, 10).map((revision) => (
@@ -1674,12 +1716,12 @@ function AgentConfigurePage({
                         onClick={() => rollbackConfig.mutate(revision.id)}
                         disabled={rollbackConfig.isPending}
                       >
-                        Restore
+                        {copy("agentDetail.configuration.restore", "Restore", "복원")}
                       </Button>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Changed:{" "}
-                      {revision.changedKeys.length > 0 ? revision.changedKeys.join(", ") : "no tracked changes"}
+                      {copy("agentDetail.configuration.changed", "Changed", "변경")}:{ " "}
+                      {revision.changedKeys.length > 0 ? revision.changedKeys.join(", ") : copy("agentDetail.configuration.noTrackedChanges", "no tracked changes", "추적된 변경 없음")}
                     </p>
                   </div>
                 ))}
@@ -1715,6 +1757,7 @@ function ConfigurationTab({
   hidePromptTemplate?: boolean;
   hideInstructionsFile?: boolean;
 }) {
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const { pushToast } = useToastActions();
   const [awaitingRefreshAfterSave, setAwaitingRefreshAfterSave] = useState(false);
@@ -1747,8 +1790,8 @@ function ConfigurationTab({
           ? err.message
           : err instanceof Error
             ? err.message
-            : "Could not save agent";
-      pushToast({ title: "Save failed", body: message, tone: "error" });
+            : copy("agentDetail.configuration.couldNotSave", "Could not save agent", "직원 설정을 저장하지 못했습니다.");
+      pushToast({ title: copy("agentDetail.configuration.saveFailed", "Save failed", "저장 실패"), body: message, tone: "error" });
     },
   });
 
@@ -1770,14 +1813,14 @@ function ConfigurationTab({
   const taskAssignLocked = agent.role === "ceo" || canCreateAgents;
   const taskAssignHint =
     taskAssignSource === "ceo_role"
-      ? "Enabled automatically for CEO agents."
+      ? copy("agentDetail.permissions.hintCeo", "Enabled automatically for CEO agents.", "CEO 직원은 자동으로 활성화됩니다.")
       : taskAssignSource === "agent_creator"
-        ? "Enabled automatically while this agent can create new agents."
+        ? copy("agentDetail.permissions.hintCreator", "Enabled automatically while this agent can create new agents.", "이 직원이 새 직원을 만들 수 있는 동안 자동으로 활성화됩니다.")
         : taskAssignSource === "explicit_grant"
-          ? "Enabled via explicit company permission grant."
+          ? copy("agentDetail.permissions.hintExplicit", "Enabled via explicit company permission grant.", "명시적인 회사 권한 부여로 활성화되었습니다.")
           : taskAssignSource === "simple_default"
-            ? "Enabled by simple company-wide task assignment defaults."
-            : "Disabled unless explicitly granted.";
+            ? copy("agentDetail.permissions.hintDefault", "Enabled by simple company-wide task assignment defaults.", "회사 전체 기본 작업 배정 규칙으로 활성화되었습니다.")
+            : copy("agentDetail.permissions.hintDisabled", "Disabled unless explicitly granted.", "명시적으로 허용하지 않으면 비활성화됩니다.");
 
   return (
     <div className="space-y-6">
@@ -1797,13 +1840,13 @@ function ConfigurationTab({
       />
 
       <div>
-        <h3 className="text-sm font-medium mb-3">Permissions</h3>
+        <h3 className="text-sm font-medium mb-3">{copy("agentDetail.permissions.title", "Permissions", "권한")}</h3>
         <div className="border border-border rounded-lg p-4 space-y-4">
           <div className="flex items-center justify-between gap-4 text-sm">
             <div className="space-y-1">
-              <div>Can create new agents</div>
+              <div>{copy("agentDetail.permissions.canCreateAgents", "Can create new agents", "새 직원 생성 가능")}</div>
               <p className="text-xs text-muted-foreground">
-                Lets this agent create or hire agents and implicitly assign tasks.
+                {copy("agentDetail.permissions.canCreateAgentsHint", "Lets this agent create or hire agents and implicitly assign tasks.", "이 직원이 새 직원을 만들거나 고용하고 작업을 자동으로 배정할 수 있게 합니다.")}
               </p>
             </div>
             <ToggleSwitch
@@ -1819,7 +1862,7 @@ function ConfigurationTab({
           </div>
           <div className="flex items-center justify-between gap-4 text-sm">
             <div className="space-y-1">
-              <div>Can assign tasks</div>
+              <div>{copy("agentDetail.permissions.canAssignTasks", "Can assign tasks", "작업 배정 가능")}</div>
               <p className="text-xs text-muted-foreground">
                 {taskAssignHint}
               </p>
@@ -1858,6 +1901,7 @@ function PromptsTab({
   onCancelActionChange: (cancel: (() => void) | null) => void;
   onSavingChange: (saving: boolean) => void;
 }) {
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const { selectedCompanyId } = useCompany();
   const { isMobile } = useSidebar();
@@ -2363,7 +2407,7 @@ function PromptsTab({
           isMobile && !showFilePanel && "hidden",
         )}>
           <div className="flex items-center justify-between">
-            <h4 className="text-sm font-medium">Files</h4>
+            <h4 className="text-sm font-medium">{copy("agentDetail.instructions.files", "Files", "파일")}</h4>
             <div className="flex items-center gap-1">
               {!showNewFileInput && (
                 <Button
@@ -2421,7 +2465,7 @@ function PromptsTab({
                     setShowNewFileInput(false);
                   }}
                 >
-                  Create
+                  {copy("common.create", "Create", "생성")}
                 </Button>
                 <Button
                   type="button"
@@ -2433,7 +2477,7 @@ function PromptsTab({
                     setNewFilePath("");
                   }}
                 >
-                  Cancel
+                  {copy("common.cancel", "Cancel", "취소")}
                 </Button>
               </div>
             </div>
@@ -2465,18 +2509,18 @@ function PromptsTab({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="ml-3 shrink-0 rounded border border-amber-500/40 bg-amber-500/10 text-amber-200 px-1.5 py-0.5 text-[10px] uppercase tracking-wide cursor-help">
-                        virtual file
+                        {copy("agentDetail.instructions.virtualFile", "virtual file", "가상 파일")}
                       </span>
                     </TooltipTrigger>
                     <TooltipContent side="right" sideOffset={4}>
-                      Legacy inline prompt — this deprecated virtual file preserves the old promptTemplate content
+                      {copy("agentDetail.instructions.virtualFileTooltip", "Legacy inline prompt — this deprecated virtual file preserves the old promptTemplate content", "레거시 인라인 프롬프트 - 이 deprecated 가상 파일은 이전 promptTemplate 내용을 보존합니다.")}
                     </TooltipContent>
                   </Tooltip>
                 );
               }
               return (
                 <span className="ml-3 shrink-0 rounded border border-border text-muted-foreground px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
-                  {file.isEntryFile ? "entry" : `${file.size}b`}
+                  {file.isEntryFile ? copy("agentDetail.instructions.entryFile", "entry", "진입점") : `${file.size}b`}
                 </span>
               );
             }}
@@ -2510,9 +2554,9 @@ function PromptsTab({
                 <p className="text-xs text-muted-foreground">
                   {selectedFileExists
                     ? selectedFileSummary?.deprecated
-                      ? "Deprecated virtual file"
-                      : `${selectedFileDetail?.language ?? "text"} file`
-                    : "New file in this bundle"}
+                      ? copy("agentDetail.instructions.deprecatedVirtualFile", "Deprecated virtual file", "Deprecated 가상 파일")
+                      : copy("agentDetail.instructions.languageFile", "{{language}} file", "{{language}} 파일", { language: selectedFileDetail?.language ?? "text" })
+                    : copy("agentDetail.instructions.newFile", "New file in this bundle", "이 번들의 새 파일")}
                 </p>
               </div>
             </div>
@@ -2520,9 +2564,9 @@ function PromptsTab({
               {!fileLoading && (
                 <CopyText
                   text={displayValue}
-                  ariaLabel="Copy instructions file as markdown"
-                  title="Copy as markdown"
-                  copiedLabel="Copied"
+                  ariaLabel={copy("agentDetail.instructions.copyMarkdownAria", "Copy instructions file as markdown", "지침 파일을 마크다운으로 복사")}
+                  title={copy("agentDetail.instructions.copyMarkdown", "Copy as markdown", "마크다운으로 복사")}
+                  copiedLabel={copy("common.copied", "Copied", "복사됨")}
                   className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground"
                 >
                   <Copy className="h-3.5 w-3.5" />
@@ -2534,7 +2578,7 @@ function PromptsTab({
                   size="sm"
                   variant="outline"
                   onClick={() => {
-                    if (confirm(`Delete ${selectedOrEntryFile}?`)) {
+                    if (confirm(copy("agentDetail.instructions.deleteFileConfirm", "Delete {{file}}?", "{{file}} 파일을 삭제할까요?", { file: selectedOrEntryFile }))) {
                       deleteFile.mutate(selectedOrEntryFile, {
                         onSuccess: () => {
                           setSelectedFile(currentEntryFile);
@@ -2545,7 +2589,7 @@ function PromptsTab({
                   }}
                   disabled={deleteFile.isPending}
                 >
-                  Delete
+                  {copy("common.delete", "Delete", "삭제")}
                 </Button>
               )}
             </div>
@@ -2657,6 +2701,7 @@ export function AgentSkillsTab({
   };
 
   const queryClient = useQueryClient();
+  const copy = useLocalizedCopy();
   const [skillDraft, setSkillDraft] = useState<string[]>([]);
   const [lastSavedSkills, setLastSavedSkills] = useState<string[]>([]);
   const [unmanagedOpen, setUnmanagedOpen] = useState(false);
@@ -2808,15 +2853,15 @@ export function AgentSkillsTab({
   const skillApplicationLabel = useMemo(() => {
     switch (skillSnapshot?.mode) {
       case "persistent":
-        return "Kept in the workspace";
+        return copy("agentSkills.mode.persistent", "Kept in the workspace", "작업공간에 유지");
       case "ephemeral":
-        return "Applied when the agent runs";
+        return copy("agentSkills.mode.ephemeral", "Applied when the agent runs", "직원 실행 시 적용");
       case "unsupported":
-        return "Tracked only";
+        return copy("agentSkills.mode.unsupported", "Tracked only", "추적만 가능");
       default:
-        return "Unknown";
+        return copy("common.unknown", "Unknown", "알 수 없음");
     }
-  }, [skillSnapshot?.mode]);
+  }, [copy, skillSnapshot?.mode]);
   const unsupportedSkillMessage = useMemo(() => {
     if (skillSnapshot?.mode !== "unsupported") return null;
     if (
@@ -2824,18 +2869,30 @@ export function AgentSkillsTab({
       typeof agent.adapterConfig.agent === "string" &&
       agent.adapterConfig.agent === "custom"
     ) {
-      return "Paperclip cannot manage skills for custom ACP commands yet.";
+      return copy(
+        "agentSkills.unsupported.customAcp",
+        "Paperclip cannot manage skills for custom ACP commands yet.",
+        "아직 Paperclip은 사용자 지정 ACP 명령의 스킬을 관리할 수 없습니다.",
+      );
     }
     if (agent.adapterType === "openclaw_gateway") {
-      return "Paperclip cannot manage OpenClaw skills here. Visit your OpenClaw instance to manage this agent's skills.";
+      return copy(
+        "agentSkills.unsupported.openclaw",
+        "Paperclip cannot manage OpenClaw skills here. Visit your OpenClaw instance to manage this agent's skills.",
+        "여기서는 OpenClaw 스킬을 관리할 수 없습니다. OpenClaw 인스턴스에서 이 직원의 스킬을 관리하세요.",
+      );
     }
-    return "Paperclip cannot manage skills for this adapter yet. Manage them in the adapter directly.";
-  }, [agent.adapterConfig.agent, agent.adapterType, skillSnapshot?.mode]);
+    return copy(
+      "agentSkills.unsupported.default",
+      "Paperclip cannot manage skills for this adapter yet. Manage them in the adapter directly.",
+      "아직 이 어댑터의 스킬은 Paperclip에서 관리할 수 없습니다. 어댑터에서 직접 관리하세요.",
+    );
+  }, [agent.adapterConfig.agent, agent.adapterType, copy, skillSnapshot?.mode]);
   const hasUnsavedChanges = !arraysEqual(skillDraft, lastSavedSkills);
   const saveStatusLabel = syncSkills.isPending
-    ? "Saving changes..."
+    ? copy("agentSkills.savingChanges", "Saving changes...", "변경 저장 중...")
     : hasUnsavedChanges
-      ? "Saving soon..."
+      ? copy("agentSkills.savingSoon", "Saving soon...", "곧 저장...")
       : null;
 
   return (
@@ -2845,7 +2902,7 @@ export function AgentSkillsTab({
           to="/skills"
           className="text-sm font-medium text-foreground underline-offset-4 no-underline transition-colors hover:text-foreground/70 hover:underline"
         >
-          View company skills library
+          {copy("agentSkills.viewLibrary", "View company skills library", "회사 스킬 라이브러리 보기")}
         </Link>
         {saveStatusLabel ? (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -2892,7 +2949,7 @@ export function AgentSkillsTab({
                         to={skill.linkTo}
                         className="shrink-0 text-xs text-muted-foreground no-underline hover:text-foreground"
                       >
-                        View
+                        {copy("common.view", "View", "보기")}
                       </Link>
                     ) : null}
                   </div>
@@ -2905,7 +2962,9 @@ export function AgentSkillsTab({
                     <p className="mt-1 text-xs text-muted-foreground">{skill.originLabel}</p>
                   )}
                   {skill.readOnly && skill.locationLabel && (
-                    <p className="mt-1 text-xs text-muted-foreground">Location: {skill.locationLabel}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {copy("agentSkills.location", "Location: {{location}}", "위치: {{location}}", { location: skill.locationLabel })}
+                    </p>
                   )}
                   {skill.detail && (
                     <p className="mt-1 text-xs text-muted-foreground">{skill.detail}</p>
@@ -2954,7 +3013,7 @@ export function AgentSkillsTab({
                         <span>{checkbox}</span>
                       </TooltipTrigger>
                       <TooltipContent side="top">
-                        {unsupportedSkillMessage ?? "Manage skills in the adapter directly."}
+                        {unsupportedSkillMessage ?? copy("agentSkills.manageInAdapter", "Manage skills in the adapter directly.", "어댑터에서 직접 스킬을 관리하세요.")}
                       </TooltipContent>
                     </Tooltip>
                   ) : (
@@ -2969,7 +3028,11 @@ export function AgentSkillsTab({
               return (
                 <section className="border-y border-border">
                   <div className="px-3 py-6 text-sm text-muted-foreground">
-                    Import skills into the company library first, then attach them here.
+                    {copy(
+                      "agentSkills.empty",
+                      "Import skills into the company library first, then attach them here.",
+                      "먼저 회사 스킬 라이브러리로 스킬을 가져온 뒤 여기에서 연결하세요.",
+                    )}
                   </div>
                 </section>
               );
@@ -2987,7 +3050,7 @@ export function AgentSkillsTab({
                   <section className="border-y border-border">
                     <div className="border-b border-border bg-muted/40 px-3 py-2">
                       <span className="text-xs font-medium text-muted-foreground">
-                        Required by Paperclip
+                        {copy("agentSkills.required", "Required by Paperclip", "Paperclip 필수 스킬")}
                       </span>
                     </div>
                     {requiredSkillRows.map(renderSkillRow)}
@@ -3004,7 +3067,12 @@ export function AgentSkillsTab({
                       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setUnmanagedOpen((v) => !v); } }}
                     >
                       <span className="text-xs font-medium text-muted-foreground">
-                        ({unmanagedSkillRows.length}) User-installed skills, not managed by Paperclip
+                        {copy(
+                          "agentSkills.unmanaged",
+                          "({{count}}) User-installed skills, not managed by Paperclip",
+                          "사용자 설치 스킬 {{count}}개, Paperclip 관리 아님",
+                          { count: unmanagedSkillRows.length },
+                        )}
                       </span>
                       {unmanagedOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
                     </div>
@@ -3017,7 +3085,9 @@ export function AgentSkillsTab({
 
           {desiredOnlyMissingSkills.length > 0 && (
             <div className="rounded-xl border border-amber-300/60 bg-amber-50/60 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/20 dark:text-amber-200">
-              <div className="font-medium">Requested skills missing from the company library</div>
+              <div className="font-medium">
+                {copy("agentSkills.missing.title", "Requested skills missing from the company library", "요청된 스킬이 회사 라이브러리에 없습니다.")}
+              </div>
               <div className="mt-1 text-xs">
                 {desiredOnlyMissingSkills.join(", ")}
               </div>
@@ -3027,22 +3097,22 @@ export function AgentSkillsTab({
           <section className="border-t border-border pt-4">
             <div className="grid gap-2 text-sm sm:grid-cols-2">
               <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2">
-                <span className="text-muted-foreground">Adapter</span>
+                <span className="text-muted-foreground">{copy("agentSkills.adapter", "Adapter", "어댑터")}</span>
                 <span className="font-medium">{adapterLabels[agent.adapterType] ?? agent.adapterType}</span>
               </div>
               <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2">
-                <span className="text-muted-foreground">Skills applied</span>
+                <span className="text-muted-foreground">{copy("agentSkills.applied", "Skills applied", "스킬 적용 방식")}</span>
                 <span>{skillApplicationLabel}</span>
               </div>
               <div className="flex items-center justify-between gap-3 border-b border-border/60 py-2">
-                <span className="text-muted-foreground">Selected skills</span>
+                <span className="text-muted-foreground">{copy("agentSkills.selected", "Selected skills", "선택된 스킬")}</span>
                 <span>{skillDraft.length}</span>
               </div>
             </div>
 
             {syncSkills.isError && (
               <p className="mt-3 text-xs text-destructive">
-                {syncSkills.error instanceof Error ? syncSkills.error.message : "Failed to update skills"}
+                {syncSkills.error instanceof Error ? syncSkills.error.message : copy("agentSkills.updateFailed", "Failed to update skills", "스킬을 업데이트하지 못했습니다.")}
               </p>
             )}
           </section>
@@ -3055,6 +3125,8 @@ export function AgentSkillsTab({
 /* ---- Runs Tab ---- */
 
 function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelected: boolean; agentId: string }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const statusInfo = runStatusIcons[run.status] ?? { icon: Clock, color: "text-neutral-400" };
   const StatusIcon = statusInfo.icon;
   const metrics = runMetrics(run);
@@ -3083,11 +3155,11 @@ function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelect
             : run.invocationSource === "on_demand" ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300"
             : "bg-muted text-muted-foreground"
         )}>
-          {sourceLabels[run.invocationSource] ?? run.invocationSource}
+          {sourceLabel(run.invocationSource, copy)}
         </span>
         {sourceResolvedFold ? <SourceResolvedFoldBadge showIcon={false} className="shrink-0 text-[10px] py-0" /> : null}
         <span className="ml-auto text-[11px] text-muted-foreground shrink-0">
-          {relativeTime(run.createdAt)}
+          {relativeTime(run.createdAt, locale)}
         </span>
       </div>
       {summary && (
@@ -3122,10 +3194,11 @@ function RunsTab({
   adapterType: string;
   adapterConfig: Record<string, unknown>;
 }) {
+  const copy = useLocalizedCopy();
   const { isMobile } = useSidebar();
 
   if (runs.length === 0) {
-    return <p className="text-sm text-muted-foreground">No runs yet.</p>;
+    return <p className="text-sm text-muted-foreground">{copy("agentDetail.runs.empty", "No runs yet.", "아직 실행이 없습니다.")}</p>;
   }
 
   // Sort by created descending
@@ -3190,6 +3263,8 @@ function RunsTab({
 /* ---- Run Detail (expanded) ---- */
 
 function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }: { run: HeartbeatRun; agentRouteId: string; adapterType: string; adapterConfig: Record<string, unknown> }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { data: hydratedRun } = useQuery({
@@ -3207,7 +3282,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   }, [run.id]);
 
   const cancelRun = useMutation({
-    mutationFn: () => heartbeatsApi.cancel(run.id),
+    mutationFn: () => heartbeatsApi.cancel(run.id, { reason: "Cancelled from agent run detail" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
     },
@@ -3326,8 +3401,8 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   }, [isRunning, run.startedAt]);
 
   const timeFormat: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false };
-  const startTime = run.startedAt ? new Date(run.startedAt).toLocaleTimeString("en-US", timeFormat) : null;
-  const endTime = run.finishedAt ? new Date(run.finishedAt).toLocaleTimeString("en-US", timeFormat) : null;
+  const startTime = run.startedAt ? new Date(run.startedAt).toLocaleTimeString(locale, timeFormat) : null;
+  const endTime = run.finishedAt ? new Date(run.finishedAt).toLocaleTimeString(locale, timeFormat) : null;
   const durationSec = run.startedAt && run.finishedAt
     ? Math.round((new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()) / 1000)
     : null;
@@ -3356,7 +3431,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   onClick={() => cancelRun.mutate()}
                   disabled={cancelRun.isPending}
                 >
-                  {cancelRun.isPending ? "Cancelling…" : "Cancel"}
+                  {cancelRun.isPending
+                    ? copy("agentDetail.run.canceling", "Cancelling...", "취소 중...")
+                    : copy("common.cancel", "Cancel", "취소")}
                 </Button>
               )}
               {canResumeLostRun && (
@@ -3368,7 +3445,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   disabled={resumeRun.isPending}
                 >
                   <RotateCcw className="h-3.5 w-3.5 mr-1" />
-                  {resumeRun.isPending ? "Resuming…" : "Resume"}
+                  {resumeRun.isPending
+                    ? copy("agentDetail.run.resuming", "Resuming...", "재개 중...")
+                    : copy("agentDetail.run.resume", "Resume", "재개")}
                 </Button>
               )}
               {canRetryRun && !canResumeLostRun && (
@@ -3380,7 +3459,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   disabled={retryRun.isPending}
                 >
                   <RotateCcw className="h-3.5 w-3.5 mr-1" />
-                  {retryRun.isPending ? "Retrying…" : "Retry"}
+                  {retryRun.isPending
+                    ? copy("agentDetail.run.retrying", "Retrying...", "재시도 중...")
+                    : copy("agentDetail.run.retry", "Retry", "재시도")}
                 </Button>
               )}
             </div>
@@ -3407,12 +3488,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
             })()}
             {resumeRun.isError && (
               <div className="text-xs text-destructive">
-                {resumeRun.error instanceof Error ? resumeRun.error.message : "Failed to resume run"}
+                {resumeRun.error instanceof Error ? resumeRun.error.message : copy("agentDetail.run.resumeFailed", "Failed to resume run", "실행을 재개하지 못했습니다.")}
               </div>
             )}
             {retryRun.isError && (
               <div className="text-xs text-destructive">
-                {retryRun.error instanceof Error ? retryRun.error.message : "Failed to retry run"}
+                {retryRun.error instanceof Error ? retryRun.error.message : copy("agentDetail.run.retryFailed", "Failed to retry run", "실행을 재시도하지 못했습니다.")}
               </div>
             )}
             {startTime && (
@@ -3423,12 +3504,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   {endTime}
                 </div>
                 <div className="text-[11px] text-muted-foreground">
-                  {relativeTime(run.startedAt!)}
-                  {run.finishedAt && <> &rarr; {relativeTime(run.finishedAt)}</>}
+                  {relativeTime(run.startedAt!, locale)}
+                  {run.finishedAt && <> &rarr; {relativeTime(run.finishedAt, locale)}</>}
                 </div>
                 {displayDurationSec !== null && (
                   <div className="text-xs text-muted-foreground">
-                    Duration: {displayDurationSec >= 60 ? `${Math.floor(displayDurationSec / 60)}m ${displayDurationSec % 60}s` : `${displayDurationSec}s`}
+                    {copy("agentDetail.run.duration", "Duration", "소요 시간")}: {formatDurationMs(displayDurationSec * 1000, locale)}
                   </div>
                 )}
               </div>
@@ -3448,18 +3529,20 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   onClick={() => runClaudeLogin.mutate()}
                   disabled={runClaudeLogin.isPending}
                 >
-                  {runClaudeLogin.isPending ? "Running claude login..." : "Login to Claude Code"}
+                  {runClaudeLogin.isPending
+                    ? copy("agentDetail.run.claudeLoginRunning", "Running claude login...", "Claude 로그인 실행 중...")
+                    : copy("agentDetail.run.claudeLogin", "Login to Claude Code", "Claude Code 로그인")}
                 </Button>
                 {runClaudeLogin.isError && (
                   <p className="text-xs text-destructive">
                     {runClaudeLogin.error instanceof Error
                       ? runClaudeLogin.error.message
-                      : "Failed to run Claude login"}
+                      : copy("agentDetail.run.claudeLoginFailed", "Failed to run Claude login", "Claude 로그인을 실행하지 못했습니다.")}
                   </p>
                 )}
                 {claudeLoginResult?.loginUrl && (
                   <p className="text-xs">
-                    Login URL:
+                    {copy("agentDetail.run.loginUrl", "Login URL", "로그인 URL")}:
                     <a
                       href={claudeLoginResult.loginUrl}
                       className="text-blue-600 underline underline-offset-2 ml-1 break-all dark:text-blue-400"
@@ -3488,8 +3571,8 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
             )}
             {hasNonZeroExit && (
               <div className="text-xs text-red-600 dark:text-red-400">
-                Exit code {run.exitCode}
-                {run.signal && <span className="text-muted-foreground ml-1">(signal: {run.signal})</span>}
+                {copy("agentDetail.run.exitCode", "Exit code", "종료 코드")} {run.exitCode}
+                {run.signal && <span className="text-muted-foreground ml-1">({copy("agentDetail.run.signal", "signal", "시그널")}: {run.signal})</span>}
               </div>
             )}
             {retryState && (
@@ -3522,19 +3605,19 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
           {hasMetrics && (
             <div className="border-t sm:border-t-0 sm:border-l border-border p-4 grid grid-cols-2 gap-x-4 sm:gap-x-8 gap-y-3 content-center tabular-nums">
               <div>
-                <div className="text-xs text-muted-foreground">Input</div>
+                <div className="text-xs text-muted-foreground">{copy("agentDetail.costs.input", "Input", "입력")}</div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.input)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Output</div>
+                <div className="text-xs text-muted-foreground">{copy("agentDetail.costs.output", "Output", "출력")}</div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.output)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Cached</div>
+                <div className="text-xs text-muted-foreground">{copy("agentDetail.costs.cached", "Cached", "캐시")}</div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.cached)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Cost</div>
+                <div className="text-xs text-muted-foreground">{copy("agentDetail.costs.cost", "Cost", "비용")}</div>
                 <div className="text-sm font-medium font-mono">{metrics.cost > 0 ? `$${metrics.cost.toFixed(4)}` : "-"}</div>
               </div>
             </div>
@@ -3549,20 +3632,20 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
               onClick={() => setSessionOpen((v) => !v)}
             >
               <ChevronRight className={cn("h-3 w-3 transition-transform", sessionOpen && "rotate-90")} />
-              Session
-              {sessionChanged && <span className="text-yellow-400 ml-1">(changed)</span>}
+              {copy("agentDetail.run.session", "Session", "세션")}
+              {sessionChanged && <span className="text-yellow-400 ml-1">({copy("agentDetail.run.changed", "changed", "변경됨")})</span>}
             </button>
             {sessionOpen && (
               <div className="px-4 pb-3 space-y-1 text-xs">
                 {run.sessionIdBefore && (
                   <div className="flex items-center gap-2">
-                    <span className="text-muted-foreground w-12">{sessionChanged ? "Before" : "ID"}</span>
+                    <span className="text-muted-foreground w-12">{sessionChanged ? copy("agentDetail.run.before", "Before", "이전") : "ID"}</span>
                     <CopyText text={run.sessionIdBefore} className="font-mono" />
                   </div>
                 )}
                 {sessionChanged && run.sessionIdAfter && (
                   <div className="flex items-center gap-2">
-                    <span className="text-muted-foreground w-12">After</span>
+                    <span className="text-muted-foreground w-12">{copy("agentDetail.run.after", "After", "이후")}</span>
                     <CopyText text={run.sessionIdAfter} className="font-mono" />
                   </div>
                 )}
@@ -3575,21 +3658,26 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                       onClick={() => {
                         const issueCount = touchedIssueIds.length;
                         const confirmed = window.confirm(
-                          `Clear session for ${issueCount} issue${issueCount === 1 ? "" : "s"} touched by this run?`,
+                          copy(
+                            "agentDetail.run.clearSessionConfirm",
+                            `Clear session for ${issueCount} issue${issueCount === 1 ? "" : "s"} touched by this run?`,
+                            `이 실행이 건드린 작업 ${issueCount}개의 세션을 초기화할까요?`,
+                            { count: issueCount },
+                          ),
                         );
                         if (!confirmed) return;
                         clearSessionsForTouchedIssues.mutate();
                       }}
                     >
                       {clearSessionsForTouchedIssues.isPending
-                        ? "clearing session..."
-                        : "clear session for these issues"}
+                        ? copy("agentDetail.run.clearingSession", "clearing session...", "세션 초기화 중...")
+                        : copy("agentDetail.run.clearSession", "clear session for these issues", "이 작업들의 세션 초기화")}
                     </button>
                     {clearSessionsForTouchedIssues.isError && (
                       <p className="text-[11px] text-destructive mt-1">
                         {clearSessionsForTouchedIssues.error instanceof Error
                           ? clearSessionsForTouchedIssues.error.message
-                          : "Failed to clear sessions"}
+                          : copy("agentDetail.run.clearSessionFailed", "Failed to clear sessions", "세션을 초기화하지 못했습니다.")}
                       </p>
                     )}
                   </div>
@@ -3603,7 +3691,9 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
       {/* Issues touched by this run */}
       {touchedIssues && touchedIssues.length > 0 && (
         <div className="space-y-2">
-          <span className="text-xs font-medium text-muted-foreground">Issues Touched ({touchedIssues.length})</span>
+          <span className="text-xs font-medium text-muted-foreground">
+            {copy("agentDetail.run.issuesTouched", "Issues Touched", "관련 작업")} ({touchedIssues.length})
+          </span>
           <div className="border border-border rounded-lg divide-y divide-border">
             {touchedIssues.map((issue) => (
               <Link
@@ -3625,7 +3715,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
       {/* stderr excerpt for failed runs */}
       {run.stderrExcerpt && (
         <div className="space-y-1">
-          <span className="text-xs font-medium text-red-600 dark:text-red-400">stderr</span>
+          <span className="text-xs font-medium text-red-600 dark:text-red-400">{copy("agentDetail.run.stderr", "stderr", "stderr")}</span>
           <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-red-700 dark:text-red-300 overflow-x-auto whitespace-pre-wrap">{run.stderrExcerpt}</pre>
         </div>
       )}
@@ -3633,7 +3723,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
       {/* stdout excerpt when no log is available */}
       {run.stdoutExcerpt && !run.logRef && (
         <div className="space-y-1">
-          <span className="text-xs font-medium text-muted-foreground">stdout</span>
+          <span className="text-xs font-medium text-muted-foreground">{copy("agentDetail.run.stdout", "stdout", "stdout")}</span>
           <pre className="bg-neutral-100 dark:bg-neutral-950 rounded-md p-3 text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap">{run.stdoutExcerpt}</pre>
         </div>
       )}
@@ -3655,6 +3745,8 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
 /* ---- Log Viewer ---- */
 
 function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: string }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const [events, setEvents] = useState<HeartbeatRunEvent[]>([]);
   const [logLines, setLogLines] = useState<Array<{ ts: string; stream: "stdout" | "stderr" | "system"; chunk: string }>>([]);
   const [loading, setLoading] = useState(true);
@@ -3843,7 +3935,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
             setLogLoading(false);
             return;
           }
-          setLogError(err instanceof Error ? err.message : "Failed to load run log");
+          setLogError(err instanceof Error ? err.message : copy("agentDetail.logs.loadRunLogFailed", "Failed to load run log", "실행 로그를 불러오지 못했습니다."));
         }
       } finally {
         if (!cancelled) setLogLoading(false);
@@ -3867,7 +3959,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
       setLogOffset(next);
       setHasMoreLog(result.nextOffset !== undefined);
     } catch (err) {
-      setLogError(err instanceof Error ? err.message : "Failed to load more run log");
+      setLogError(err instanceof Error ? err.message : copy("agentDetail.logs.loadMoreRunLogFailed", "Failed to load more run log", "추가 실행 로그를 불러오지 못했습니다."));
     } finally {
       setLoadingMoreLog(false);
     }
@@ -4056,11 +4148,11 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   }, [run.id]);
 
   if (loading && logLoading) {
-    return <p className="text-xs text-muted-foreground">Loading run logs...</p>;
+    return <p className="text-xs text-muted-foreground">{copy("agentDetail.logs.loading", "Loading run logs...", "실행 로그 불러오는 중...")}</p>;
   }
 
   if (events.length === 0 && logLines.length === 0 && !logError) {
-    return <p className="text-xs text-muted-foreground">No log events.</p>;
+    return <p className="text-xs text-muted-foreground">{copy("agentDetail.logs.empty", "No log events.", "로그 이벤트가 없습니다.")}</p>;
   }
 
   const levelColors: Record<string, string> = {
@@ -4087,7 +4179,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-muted-foreground">
-          Transcript ({transcript.length})
+          {copy("agentDetail.logs.transcript", "Transcript", "작업 기록")} ({transcript.length})
         </span>
         <div className="flex items-center gap-2">
           <div className="inline-flex rounded-lg border border-border/70 bg-background/70 p-0.5">
@@ -4103,7 +4195,9 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
                 )}
                 onClick={() => setTranscriptMode(mode)}
               >
-                {mode}
+                {mode === "nice"
+                  ? copy("agentDetail.logs.niceMode", "nice", "정리")
+                  : copy("agentDetail.logs.rawMode", "raw", "원문")}
               </button>
             ))}
           </div>
@@ -4119,7 +4213,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
                 lastMetricsRef.current = readScrollMetrics(container);
               }}
             >
-              Jump to live
+              {copy("agentDetail.logs.jumpToLive", "Jump to live", "실시간 위치로 이동")}
             </Button>
           )}
           {isLive && (
@@ -4128,7 +4222,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
                 <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-400" />
               </span>
-              Live
+              {copy("agentDetail.live", "Live", "실행 중")}
             </span>
           )}
         </div>
@@ -4138,7 +4232,9 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           entries={transcript}
           mode={transcriptMode}
           streaming={isLive}
-          emptyMessage={run.logRef ? "Waiting for transcript..." : "No persisted transcript for this run."}
+          emptyMessage={run.logRef
+            ? copy("agentDetail.logs.waitingTranscript", "Waiting for transcript...", "작업 기록을 기다리는 중...")
+            : copy("agentDetail.logs.noPersistedTranscript", "No persisted transcript for this run.", "이 실행에 저장된 작업 기록이 없습니다.")}
         />
         {hasMoreLog && (
           <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/60 pt-3">
@@ -4149,12 +4245,14 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
               onClick={loadMorePersistedLog}
               disabled={loadingMoreLog}
             >
-              {loadingMoreLog ? "Loading..." : "Load more log"}
+              {loadingMoreLog
+                ? copy("agentDetail.logs.loadingMore", "Loading...", "불러오는 중...")
+                : copy("agentDetail.logs.loadMore", "Load more log", "로그 더 보기")}
             </Button>
             <span className="text-xs text-muted-foreground">
-              Showing the first {Math.round(logOffset / 1024).toLocaleString("en-US")} KB
+              {copy("agentDetail.logs.showingFirst", "Showing the first", "처음")} {Math.round(logOffset / 1024).toLocaleString(locale)} KB
               {typeof run.logBytes === "number" && run.logBytes > 0
-                ? ` of ${Math.round(run.logBytes / 1024).toLocaleString("en-US")} KB`
+                ? ` / ${Math.round(run.logBytes / 1024).toLocaleString(locale)} KB`
                 : ""}
             </span>
           </div>
@@ -4169,16 +4267,16 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
       {(run.status === "failed" || run.status === "timed_out") && (
         <div className="rounded-lg border border-red-300 dark:border-red-500/30 bg-red-50 dark:bg-red-950/20 p-3 space-y-2">
-          <div className="text-xs font-medium text-red-700 dark:text-red-300">Failure details</div>
+          <div className="text-xs font-medium text-red-700 dark:text-red-300">{copy("agentDetail.logs.failureDetails", "Failure details", "실패 상세")}</div>
           {run.error && (
             <div className="text-xs text-red-600 dark:text-red-200">
-              <span className="text-red-700 dark:text-red-300">Error: </span>
+              <span className="text-red-700 dark:text-red-300">{copy("agentDetail.logs.error", "Error", "오류")}: </span>
               {redactPathText(run.error, censorUsernameInLogs)}
             </div>
           )}
           {run.stderrExcerpt && run.stderrExcerpt.trim() && (
             <div>
-              <div className="text-xs text-red-700 dark:text-red-300 mb-1">stderr excerpt</div>
+              <div className="text-xs text-red-700 dark:text-red-300 mb-1">{copy("agentDetail.run.stderrExcerpt", "stderr excerpt", "stderr 발췌")}</div>
               <pre className="bg-red-50 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap text-red-800 dark:text-red-100">
                 {redactPathText(run.stderrExcerpt, censorUsernameInLogs)}
               </pre>
@@ -4186,7 +4284,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           )}
           {run.resultJson && (
             <div>
-              <div className="text-xs text-red-700 dark:text-red-300 mb-1">adapter result JSON</div>
+              <div className="text-xs text-red-700 dark:text-red-300 mb-1">{copy("agentDetail.logs.adapterResultJson", "adapter result JSON", "어댑터 결과 JSON")}</div>
               <pre className="bg-red-50 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap text-red-800 dark:text-red-100">
                 {JSON.stringify(redactPathValue(run.resultJson, censorUsernameInLogs), null, 2)}
               </pre>
@@ -4194,7 +4292,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           )}
           {run.stdoutExcerpt && run.stdoutExcerpt.trim() && !run.resultJson && (
             <div>
-              <div className="text-xs text-red-700 dark:text-red-300 mb-1">stdout excerpt</div>
+              <div className="text-xs text-red-700 dark:text-red-300 mb-1">{copy("agentDetail.run.stdoutExcerpt", "stdout excerpt", "stdout 발췌")}</div>
               <pre className="bg-red-50 dark:bg-neutral-950 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap text-red-800 dark:text-red-100">
                 {redactPathText(run.stdoutExcerpt, censorUsernameInLogs)}
               </pre>
@@ -4205,7 +4303,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
       {events.length > 0 && (
         <div>
-          <div className="mb-2 text-xs font-medium text-muted-foreground">Events ({events.length})</div>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">{copy("agentDetail.logs.events", "Events", "이벤트")} ({events.length})</div>
           <div className="bg-neutral-100 dark:bg-neutral-950 rounded-lg p-3 font-mono text-xs space-y-0.5">
             {events.map((evt) => {
               const color = evt.color
@@ -4216,7 +4314,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
               return (
                 <div key={evt.id} className="flex gap-2">
                   <span className="text-neutral-400 dark:text-neutral-600 shrink-0 select-none w-16">
-                    {new Date(evt.createdAt).toLocaleTimeString("en-US", { hour12: false })}
+                    {new Date(evt.createdAt).toLocaleTimeString(locale, { hour12: false })}
                   </span>
                   <span className={cn("shrink-0 w-14", evt.stream ? (streamColors[evt.stream] ?? "text-neutral-500") : "text-neutral-500")}>
                     {evt.stream ? `[${evt.stream}]` : ""}
@@ -4241,6 +4339,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 /* ---- Keys Tab ---- */
 
 function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }) {
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const [newKeyName, setNewKeyName] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
@@ -4285,7 +4384,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       {newToken && (
         <div className="border border-yellow-300 dark:border-yellow-600/40 bg-yellow-50 dark:bg-yellow-500/5 rounded-lg p-4 space-y-2">
           <p className="text-sm font-medium text-yellow-700 dark:text-yellow-400">
-            API key created — copy it now, it will not be shown again.
+            {copy("agentDetail.keys.createdWarning", "API key created — copy it now, it will not be shown again.", "API 키가 생성되었습니다. 다시 표시되지 않으니 지금 복사하세요.")}
           </p>
           <div className="flex items-center gap-2">
             <code className="flex-1 bg-neutral-100 dark:bg-neutral-950 rounded px-3 py-1.5 text-xs font-mono text-green-700 dark:text-green-300 truncate">
@@ -4295,7 +4394,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
               variant="ghost"
               size="icon-sm"
               onClick={() => setTokenVisible((v) => !v)}
-              title={tokenVisible ? "Hide" : "Show"}
+              title={tokenVisible ? copy("common.hide", "Hide", "숨기기") : copy("common.show", "Show", "표시")}
             >
               {tokenVisible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </Button>
@@ -4303,11 +4402,11 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
               variant="ghost"
               size="icon-sm"
               onClick={copyToken}
-              title="Copy"
+              title={copy("common.copy", "Copy", "복사")}
             >
               <Copy className="h-3.5 w-3.5" />
             </Button>
-            {copied && <span className="text-xs text-green-400">Copied!</span>}
+            {copied && <span className="text-xs text-green-400">{copy("common.copiedBang", "Copied!", "복사됨!")}</span>}
           </div>
           <Button
             variant="ghost"
@@ -4315,7 +4414,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
             className="text-muted-foreground text-xs"
             onClick={() => setNewToken(null)}
           >
-            Dismiss
+            {copy("common.dismiss", "Dismiss", "닫기")}
           </Button>
         </div>
       )}
@@ -4324,14 +4423,14 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       <div className="border border-border rounded-lg p-4 space-y-3">
         <h3 className="text-xs font-medium text-muted-foreground flex items-center gap-2">
           <Key className="h-3.5 w-3.5" />
-          Create API Key
+          {copy("agentDetail.keys.createTitle", "Create API Key", "API 키 생성")}
         </h3>
         <p className="text-xs text-muted-foreground">
-          API keys allow this agent to authenticate calls to the Paperclip server.
+          {copy("agentDetail.keys.createHelp", "API keys allow this agent to authenticate calls to the Paperclip server.", "API 키를 사용하면 이 직원이 Paperclip 서버 호출을 인증할 수 있습니다.")}
         </p>
         <div className="flex items-center gap-2">
           <Input
-            placeholder="Key name (e.g. production)"
+            placeholder={copy("agentDetail.keys.namePlaceholder", "Key name (e.g. production)", "키 이름(예: production)")}
             value={newKeyName}
             onChange={(e) => setNewKeyName(e.target.value)}
             className="h-8 text-sm"
@@ -4345,22 +4444,22 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
             disabled={createKey.isPending}
           >
             <Plus className="h-3.5 w-3.5 mr-1" />
-            Create
+            {copy("common.create", "Create", "생성")}
           </Button>
         </div>
       </div>
 
       {/* Active keys */}
-      {isLoading && <p className="text-sm text-muted-foreground">Loading keys...</p>}
+      {isLoading && <p className="text-sm text-muted-foreground">{copy("agentDetail.keys.loading", "Loading keys...", "키를 불러오는 중...")}</p>}
 
       {!isLoading && activeKeys.length === 0 && !newToken && (
-        <p className="text-sm text-muted-foreground">No active API keys.</p>
+        <p className="text-sm text-muted-foreground">{copy("agentDetail.keys.emptyActive", "No active API keys.", "활성 API 키가 없습니다.")}</p>
       )}
 
       {activeKeys.length > 0 && (
         <div>
           <h3 className="text-xs font-medium text-muted-foreground mb-2">
-            Active Keys
+            {copy("agentDetail.keys.active", "Active Keys", "활성 키")}
           </h3>
           <div className="border border-border rounded-lg divide-y divide-border">
             {activeKeys.map((key: AgentKey) => (
@@ -4368,7 +4467,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                 <div>
                   <span className="text-sm font-medium">{key.name}</span>
                   <span className="text-xs text-muted-foreground ml-3">
-                    Created {formatDate(key.createdAt)}
+                    {copy("agentDetail.keys.created", "Created", "생성됨")} {formatDate(key.createdAt)}
                   </span>
                 </div>
                 <Button
@@ -4378,7 +4477,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                   onClick={() => revokeKey.mutate(key.id)}
                   disabled={revokeKey.isPending}
                 >
-                  Revoke
+                  {copy("agentDetail.keys.revoke", "Revoke", "폐기")}
                 </Button>
               </div>
             ))}
@@ -4390,7 +4489,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
       {revokedKeys.length > 0 && (
         <div>
           <h3 className="text-xs font-medium text-muted-foreground mb-2">
-            Revoked Keys
+            {copy("agentDetail.keys.revokedKeys", "Revoked Keys", "폐기된 키")}
           </h3>
           <div className="border border-border rounded-lg divide-y divide-border opacity-50">
             {revokedKeys.map((key: AgentKey) => (
@@ -4398,7 +4497,7 @@ function KeysTab({ agentId, companyId }: { agentId: string; companyId?: string }
                 <div>
                   <span className="text-sm line-through">{key.name}</span>
                   <span className="text-xs text-muted-foreground ml-3">
-                    Revoked {key.revokedAt ? formatDate(key.revokedAt) : ""}
+                    {copy("agentDetail.keys.revoked", "Revoked", "폐기됨")} {key.revokedAt ? formatDate(key.revokedAt) : ""}
                   </span>
                 </div>
               </div>

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -16,6 +16,7 @@ import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { relativeTime, cn, agentRouteRef, agentUrl } from "../lib/utils";
 import { PageTabBar } from "../components/PageTabBar";
+import { useCurrentLocale, useLocalizedCopy } from "../i18n/ui-copy";
 import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Bot, Plus, List, GitBranch, SlidersHorizontal } from "lucide-react";
@@ -54,6 +55,24 @@ function getConfiguredModel(agent: Agent): string | null {
   return model.length > 0 ? model : null;
 }
 
+function agentRoleLabel(role: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const labels: Record<string, string> = {
+    ceo: copy("agentRole.ceo", "CEO", "대표"),
+    cto: copy("agentRole.cto", "CTO", "기술 책임자"),
+    cmo: copy("agentRole.cmo", "CMO", "마케팅 책임자"),
+    cfo: copy("agentRole.cfo", "CFO", "재무 책임자"),
+    security: copy("agentRole.security", "Security", "보안"),
+    engineer: copy("agentRole.engineer", "Engineer", "엔지니어"),
+    designer: copy("agentRole.designer", "Designer", "디자이너"),
+    pm: copy("agentRole.pm", "PM", "PM"),
+    qa: copy("agentRole.qa", "QA", "QA"),
+    devops: copy("agentRole.devops", "DevOps", "DevOps"),
+    researcher: copy("agentRole.researcher", "Researcher", "조사원"),
+    general: copy("agentRole.general", "General", "일반"),
+  };
+  return labels[role] ?? roleLabels[role] ?? role;
+}
+
 function filterOrgTree(nodes: OrgNode[], tab: FilterTab, showTerminated: boolean): OrgNode[] {
   return nodes
     .reduce<OrgNode[]>((acc, node) => {
@@ -70,6 +89,8 @@ export function Agents() {
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const navigate = useNavigate();
   const location = useLocation();
   const { isMobile } = useSidebar();
@@ -124,11 +145,11 @@ export function Agents() {
   }, [agents]);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Agents" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("agents.breadcrumb", "Agents", "직원") }]);
+  }, [copy, setBreadcrumbs]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Bot} message="Select a company to view agents." />;
+    return <EmptyState icon={Bot} message={copy("agents.noCompany", "Select a company to view agents.", "직원을 보려면 회사를 선택하세요.")} />;
   }
 
   if (isLoading) {
@@ -144,10 +165,10 @@ export function Agents() {
         <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
           <PageTabBar
             items={[
-              { value: "all", label: "All" },
-              { value: "active", label: "Active" },
-              { value: "paused", label: "Paused" },
-              { value: "error", label: "Error" },
+              { value: "all", label: copy("agents.tabs.all", "All", "전체") },
+              { value: "active", label: copy("agents.tabs.active", "Active", "활성") },
+              { value: "paused", label: copy("agents.tabs.paused", "Paused", "일시정지") },
+              { value: "error", label: copy("agents.tabs.error", "Error", "오류") },
             ]}
             value={tab}
             onValueChange={(v) => navigate(`/agents/${v}`)}
@@ -164,7 +185,7 @@ export function Agents() {
               onClick={() => setFiltersOpen(!filtersOpen)}
             >
               <SlidersHorizontal className="h-3 w-3" />
-              Filters
+              {copy("agents.filters", "Filters", "필터")}
               {showTerminated && <span className="ml-0.5 px-1 bg-foreground/10 rounded text-[10px]">1</span>}
             </button>
             {filtersOpen && (
@@ -179,7 +200,7 @@ export function Agents() {
                   )}>
                     {showTerminated && <span className="text-background text-[10px] leading-none">&#10003;</span>}
                   </span>
-                  Show terminated
+                  {copy("agents.showTerminated", "Show terminated", "종료된 직원 표시")}
                 </button>
               </div>
             )}
@@ -192,6 +213,8 @@ export function Agents() {
                   "p-1.5 transition-colors",
                   effectiveView === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
                 )}
+                aria-label={copy("agents.view.list", "List view", "목록 보기")}
+                title={copy("agents.view.list", "List view", "목록 보기")}
                 onClick={() => setView("list")}
               >
                 <List className="h-3.5 w-3.5" />
@@ -201,6 +224,8 @@ export function Agents() {
                   "p-1.5 transition-colors",
                   effectiveView === "org" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
                 )}
+                aria-label={copy("agents.view.org", "Org chart view", "조직도 보기")}
+                title={copy("agents.view.org", "Org chart view", "조직도 보기")}
                 onClick={() => setView("org")}
               >
                 <GitBranch className="h-3.5 w-3.5" />
@@ -209,13 +234,13 @@ export function Agents() {
           )}
           <Button size="sm" variant="outline" onClick={openNewAgent}>
             <Plus className="h-3.5 w-3.5 mr-1.5" />
-            New Agent
+            {copy("agents.newAgent", "New Agent", "새 직원")}
           </Button>
         </div>
       </div>
 
       {filtered.length > 0 && (
-        <p className="text-xs text-muted-foreground">{filtered.length} agent{filtered.length !== 1 ? "s" : ""}</p>
+        <p className="text-xs text-muted-foreground">{copy("agents.count", "{{count}} agent", "{{count}}명", { count: filtered.length })}</p>
       )}
 
       {error && <p className="text-sm text-destructive">{error.message}</p>}
@@ -223,8 +248,8 @@ export function Agents() {
       {agents && agents.length === 0 && (
         <EmptyState
           icon={Bot}
-          message="Create your first agent to get started."
-          action="New Agent"
+          message={copy("agents.empty", "Create your first agent to get started.", "첫 직원을 만들어 시작하세요.")}
+          action={copy("agents.newAgent", "New Agent", "새 직원")}
           onAction={openNewAgent}
         />
       )}
@@ -237,7 +262,7 @@ export function Agents() {
               <EntityRow
                 key={agent.id}
                 title={agent.name}
-                subtitle={`${roleLabels[agent.role] ?? agent.role}${agent.title ? ` - ${agent.title}` : ""}`}
+                subtitle={`${agentRoleLabel(agent.role, copy)}${agent.title ? ` - ${agent.title}` : ""}`}
                 to={agentUrl(agent)}
                 className={cn(
                   "group",
@@ -282,7 +307,7 @@ export function Agents() {
                         {getConfiguredModel(agent) ?? "—"}
                       </span>
                       <span className="text-xs text-muted-foreground w-16 text-right">
-                        {agent.lastHeartbeatAt ? relativeTime(agent.lastHeartbeatAt) : "—"}
+                        {agent.lastHeartbeatAt ? relativeTime(agent.lastHeartbeatAt, locale) : "—"}
                       </span>
                       <span className="w-20 flex justify-end">
                         <StatusBadge status={agent.status} />
@@ -326,7 +351,7 @@ export function Agents() {
 
       {effectiveView === "list" && agents && agents.length > 0 && filtered.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">
-          No agents match the selected filter.
+          {copy("agents.noFilterResults", "No agents match the selected filter.", "선택한 필터와 일치하는 직원이 없습니다.")}
         </p>
       )}
 
@@ -350,13 +375,13 @@ export function Agents() {
 
       {effectiveView === "org" && orgTree && orgTree.length > 0 && filteredOrg.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">
-          No agents match the selected filter.
+          {copy("agents.noFilterResults", "No agents match the selected filter.", "선택한 필터와 일치하는 직원이 없습니다.")}
         </p>
       )}
 
       {effectiveView === "org" && orgTree && orgTree.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-8">
-          No organizational hierarchy defined.
+          {copy("agents.noOrg", "No organizational hierarchy defined.", "정의된 조직도가 없습니다.")}
         </p>
       )}
     </div>
@@ -380,6 +405,8 @@ function OrgTreeNode({
   memberships: ReturnType<typeof useResourceMemberships>["data"];
   membershipMutation: ReturnType<typeof useResourceMembershipMutation>;
 }) {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const agent = agentMap.get(node.id);
   const membershipState = resourceMembershipState(memberships, "agent", node.id);
   const pending = membershipMutation.isPending &&
@@ -404,7 +431,7 @@ function OrgTreeNode({
         <div className="flex-1 min-w-0">
           <span className="text-sm font-medium">{node.name}</span>
           <span className="text-xs text-muted-foreground ml-2">
-            {roleLabels[node.role] ?? node.role}
+            {agentRoleLabel(node.role, copy)}
             {agent?.title ? ` - ${agent.title}` : ""}
           </span>
         </div>
@@ -440,7 +467,7 @@ function OrgTreeNode({
                   {getConfiguredModel(agent) ?? "—"}
                 </span>
                 <span className="text-xs text-muted-foreground w-16 text-right">
-                  {agent.lastHeartbeatAt ? relativeTime(agent.lastHeartbeatAt) : "—"}
+                  {agent.lastHeartbeatAt ? relativeTime(agent.lastHeartbeatAt, locale) : "—"}
                 </span>
               </>
             )}
@@ -497,6 +524,11 @@ function LiveRunIndicator({
   runId: string;
   liveCount: number;
 }) {
+  const copy = useLocalizedCopy();
+  const label = liveCount > 1
+    ? copy("agents.liveWithCount", "Live ({{count}})", "실행 중 ({{count}})", { count: liveCount })
+    : copy("agents.live", "Live", "실행 중");
+
   return (
     <Link
       to={`/agents/${agentRef}/runs/${runId}`}
@@ -508,7 +540,7 @@ function LiveRunIndicator({
         <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
       </span>
       <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
-        Live{liveCount > 1 ? ` (${liveCount})` : ""}
+        {label}
       </span>
     </Link>
   );

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -8,18 +8,21 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "../components/StatusBadge";
 import { Identity } from "../components/Identity";
-import { approvalLabel, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer } from "../components/ApprovalPayload";
+import { approvalSubject, typeIcon, defaultTypeIcon, ApprovalPayloadRenderer } from "../components/ApprovalPayload";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { CheckCircle2, ChevronRight, Sparkles } from "lucide-react";
 import type { ApprovalComment } from "@paperclipai/shared";
 import { MarkdownBody } from "../components/MarkdownBody";
+import { useCurrentLocale, useLocalizedCopy } from "../i18n/ui-copy";
 
 export function ApprovalDetail() {
   const { approvalId } = useParams<{ approvalId: string }>();
   const { selectedCompanyId, setSelectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -65,10 +68,10 @@ export function ApprovalDetail() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Approvals", href: "/approvals" },
-      { label: approval?.id?.slice(0, 8) ?? approvalId ?? "Approval" },
+      { label: copy("approvals.breadcrumb", "Approvals", "승인"), href: "/approvals" },
+      { label: approval?.id?.slice(0, 8) ?? approvalId ?? copy("approvalDetail.breadcrumb", "Approval", "승인 상세") },
     ]);
-  }, [setBreadcrumbs, approval, approvalId]);
+  }, [copy, setBreadcrumbs, approval, approvalId]);
 
   const refresh = () => {
     if (!approvalId) return;
@@ -91,7 +94,7 @@ export function ApprovalDetail() {
       refresh();
       navigate(`/approvals/${approvalId}?resolved=approved`, { replace: true });
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Approve failed"),
+    onError: (err) => setError(err instanceof Error ? err.message : copy("approvalDetail.error.approve", "Approve failed", "승인에 실패했습니다.")),
   });
 
   const rejectMutation = useMutation({
@@ -100,7 +103,7 @@ export function ApprovalDetail() {
       setError(null);
       refresh();
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Reject failed"),
+    onError: (err) => setError(err instanceof Error ? err.message : copy("approvalDetail.error.reject", "Reject failed", "반려에 실패했습니다.")),
   });
 
   const revisionMutation = useMutation({
@@ -109,7 +112,7 @@ export function ApprovalDetail() {
       setError(null);
       refresh();
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Revision request failed"),
+    onError: (err) => setError(err instanceof Error ? err.message : copy("approvalDetail.error.revision", "Revision request failed", "수정 요청에 실패했습니다.")),
   });
 
   const resubmitMutation = useMutation({
@@ -118,7 +121,7 @@ export function ApprovalDetail() {
       setError(null);
       refresh();
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Resubmit failed"),
+    onError: (err) => setError(err instanceof Error ? err.message : copy("approvalDetail.error.resubmit", "Resubmit failed", "재제출 표시를 실패했습니다.")),
   });
 
   const addCommentMutation = useMutation({
@@ -128,7 +131,7 @@ export function ApprovalDetail() {
       setError(null);
       refresh();
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Comment failed"),
+    onError: (err) => setError(err instanceof Error ? err.message : copy("approvalDetail.error.comment", "Comment failed", "댓글 작성에 실패했습니다.")),
   });
 
   const deleteAgentMutation = useMutation({
@@ -138,17 +141,26 @@ export function ApprovalDetail() {
       refresh();
       navigate("/approvals");
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Delete failed"),
+    onError: (err) => setError(err instanceof Error ? err.message : copy("approvalDetail.error.delete", "Delete failed", "삭제에 실패했습니다.")),
   });
 
   if (isLoading) return <PageSkeleton variant="detail" />;
-  if (!approval) return <p className="text-sm text-muted-foreground">Approval not found.</p>;
+  if (!approval) return <p className="text-sm text-muted-foreground">{copy("approvalDetail.notFound", "Approval not found.", "승인 요청을 찾을 수 없습니다.")}</p>;
 
   const payload = approval.payload as Record<string, unknown>;
   const linkedAgentId = typeof payload.agentId === "string" ? payload.agentId : null;
   const isActionable = approval.status === "pending" || approval.status === "revision_requested";
   const isBudgetApproval = approval.type === "budget_override_required";
   const TypeIcon = typeIcon[approval.type] ?? defaultTypeIcon;
+  const approvalTypeLabels: Record<string, string> = {
+    hire_agent: copy("approval.type.hireAgent", "Hire Agent", "직원 고용"),
+    approve_ceo_strategy: copy("approval.type.ceoStrategy", "CEO Strategy", "CEO 전략"),
+    budget_override_required: copy("approval.type.budgetOverride", "Budget Override", "예산 초과 승인"),
+    request_board_approval: copy("approval.type.boardApproval", "Board Approval", "보드 승인"),
+  };
+  const approvalTitleBase = approvalTypeLabels[approval.type] ?? approval.type;
+  const approvalTitleSubject = approvalSubject(payload);
+  const approvalTitle = approvalTitleSubject ? `${approvalTitleBase}: ${approvalTitleSubject}` : approvalTitleBase;
   const showApprovedBanner = searchParams.get("resolved") === "approved" && approval.status === "approved";
   const primaryLinkedIssue = linkedIssues?.[0] ?? null;
   const resolvedCta =
@@ -156,17 +168,17 @@ export function ApprovalDetail() {
       ? {
           label:
             (linkedIssues?.length ?? 0) > 1
-              ? "Review linked issues"
-              : "Review linked issue",
+              ? copy("approvalDetail.cta.reviewLinkedIssues", "Review linked issues", "연결 작업 검토")
+              : copy("approvalDetail.cta.reviewLinkedIssue", "Review linked issue", "연결 작업 검토"),
           to: `/issues/${primaryLinkedIssue.identifier ?? primaryLinkedIssue.id}`,
         }
       : linkedAgentId
         ? {
-            label: "Open hired agent",
+            label: copy("approvalDetail.cta.openHiredAgent", "Open hired agent", "고용된 직원 열기"),
             to: `/agents/${linkedAgentId}`,
           }
         : {
-            label: "Back to approvals",
+            label: copy("approvalDetail.cta.back", "Back to approvals", "승인 목록으로"),
             to: "/approvals",
           };
 
@@ -181,9 +193,15 @@ export function ApprovalDetail() {
                 <Sparkles className="h-3 w-3 text-green-500 dark:text-green-200 absolute -right-2 -top-1 animate-pulse" />
               </div>
               <div>
-                <p className="text-sm text-green-800 dark:text-green-100 font-medium">Approval confirmed</p>
+                <p className="text-sm text-green-800 dark:text-green-100 font-medium">
+                  {copy("approvalDetail.approvedBanner.title", "Approval confirmed", "승인이 완료되었습니다.")}
+                </p>
                 <p className="text-xs text-green-700 dark:text-green-200/90">
-                  Requesting agent was notified to review this approval and linked issues.
+                  {copy(
+                    "approvalDetail.approvedBanner.body",
+                    "Requesting agent was notified to review this approval and linked issues.",
+                    "요청한 직원에게 이 승인과 연결 작업을 확인하라고 알렸습니다.",
+                  )}
                 </p>
               </div>
             </div>
@@ -203,7 +221,7 @@ export function ApprovalDetail() {
           <div className="flex items-center gap-2">
             <TypeIcon className="h-5 w-5 text-muted-foreground shrink-0" />
             <div>
-              <h2 className="text-lg font-semibold">{approvalLabel(approval.type, approval.payload as Record<string, unknown> | null)}</h2>
+              <h2 className="text-lg font-semibold">{approvalTitle}</h2>
               <p className="text-xs text-muted-foreground font-mono">{approval.id}</p>
             </div>
           </div>
@@ -212,7 +230,7 @@ export function ApprovalDetail() {
         <div className="text-sm space-y-1">
           {approval.requestedByAgentId && (
             <div className="flex items-center gap-2">
-              <span className="text-muted-foreground text-xs">Requested by</span>
+              <span className="text-muted-foreground text-xs">{copy("approvalDetail.requestedBy", "Requested by", "요청자")}</span>
               <Identity
                 name={agentNameById.get(approval.requestedByAgentId) ?? approval.requestedByAgentId.slice(0, 8)}
                 size="sm"
@@ -226,7 +244,7 @@ export function ApprovalDetail() {
             onClick={() => setShowRawPayload((v) => !v)}
           >
             <ChevronRight className={`h-3 w-3 transition-transform ${showRawPayload ? "rotate-90" : ""}`} />
-            See full request
+            {copy("approvalDetail.rawRequest", "See full request", "전체 요청 보기")}
           </button>
           {showRawPayload && (
             <pre className="text-xs bg-muted/40 rounded-md p-3 overflow-x-auto">
@@ -234,13 +252,15 @@ export function ApprovalDetail() {
             </pre>
           )}
           {approval.decisionNote && (
-            <p className="text-xs text-muted-foreground">Decision note: {approval.decisionNote}</p>
+            <p className="text-xs text-muted-foreground">
+              {copy("approvalDetail.decisionNote", "Decision note: {{note}}", "결정 메모: {{note}}", { note: approval.decisionNote })}
+            </p>
           )}
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
         {linkedIssues && linkedIssues.length > 0 && (
           <div className="pt-2 border-t border-border/60">
-            <p className="text-xs text-muted-foreground mb-1.5">Linked Issues</p>
+            <p className="text-xs text-muted-foreground mb-1.5">{copy("approvalDetail.linkedIssues", "Linked Issues", "연결 작업")}</p>
             <div className="space-y-1.5">
               {linkedIssues.map((issue) => (
                 <Link
@@ -256,7 +276,11 @@ export function ApprovalDetail() {
               ))}
             </div>
             <p className="text-[11px] text-muted-foreground mt-2">
-              Linked issues remain open until the requesting agent follows up and closes them.
+              {copy(
+                "approvalDetail.linkedIssues.note",
+                "Linked issues remain open until the requesting agent follows up and closes them.",
+                "연결 작업은 요청한 직원이 후속 처리하고 닫을 때까지 열린 상태로 남습니다.",
+              )}
             </p>
           </div>
         )}
@@ -269,7 +293,7 @@ export function ApprovalDetail() {
                 onClick={() => approveMutation.mutate()}
                 disabled={approveMutation.isPending}
               >
-                Approve
+                {copy("approvalDetail.action.approve", "Approve", "승인")}
               </Button>
               <Button
                 variant="destructive"
@@ -277,13 +301,17 @@ export function ApprovalDetail() {
                 onClick={() => rejectMutation.mutate()}
                 disabled={rejectMutation.isPending}
               >
-                Reject
+                {copy("approvalDetail.action.reject", "Reject", "반려")}
               </Button>
             </>
           )}
           {isBudgetApproval && approval.status === "pending" && (
             <p className="text-sm text-muted-foreground">
-              Resolve this budget stop from the budget controls on <Link to="/costs" className="underline underline-offset-2">/costs</Link>.
+              {copy("approvalDetail.budgetStop.prefix", "Resolve this budget stop from the budget controls on", "이 예산 중지는")}
+              {" "}
+              <Link to="/costs" className="underline underline-offset-2">/costs</Link>
+              {" "}
+              {copy("approvalDetail.budgetStop.suffix", ".", "예산 관리에서 해제하세요.")}
             </p>
           )}
           {approval.status === "pending" && (
@@ -293,7 +321,7 @@ export function ApprovalDetail() {
               onClick={() => revisionMutation.mutate()}
               disabled={revisionMutation.isPending}
             >
-              Request revision
+              {copy("approvalDetail.action.requestRevision", "Request revision", "수정 요청")}
             </Button>
           )}
           {approval.status === "revision_requested" && (
@@ -303,7 +331,7 @@ export function ApprovalDetail() {
               onClick={() => resubmitMutation.mutate()}
               disabled={resubmitMutation.isPending}
             >
-              Mark resubmitted
+              {copy("approvalDetail.action.markResubmitted", "Mark resubmitted", "재제출 표시")}
             </Button>
           )}
           {approval.status === "rejected" && approval.type === "hire_agent" && linkedAgentId && (
@@ -312,19 +340,25 @@ export function ApprovalDetail() {
               variant="outline"
               className="text-destructive border-destructive/40"
               onClick={() => {
-                if (!window.confirm("Delete this disapproved agent? This cannot be undone.")) return;
+                if (!window.confirm(copy(
+                  "approvalDetail.confirmDeleteAgent",
+                  "Delete this disapproved agent? This cannot be undone.",
+                  "반려된 이 직원을 삭제할까요? 이 작업은 되돌릴 수 없습니다.",
+                ))) return;
                 deleteAgentMutation.mutate(linkedAgentId);
               }}
               disabled={deleteAgentMutation.isPending}
             >
-              Delete disapproved agent
+              {copy("approvalDetail.action.deleteAgent", "Delete disapproved agent", "반려된 직원 삭제")}
             </Button>
           )}
         </div>
       </div>
 
       <div className="border border-border rounded-lg p-4 space-y-3">
-        <h3 className="text-sm font-medium">Comments ({comments?.length ?? 0})</h3>
+        <h3 className="text-sm font-medium">
+          {copy("approvalDetail.comments.title", "Comments ({{count}})", "댓글 {{count}}개", { count: comments?.length ?? 0 })}
+        </h3>
         <div className="space-y-2">
           {(comments ?? []).map((comment: ApprovalComment) => (
             <div key={comment.id} className="border border-border/60 rounded-md p-3">
@@ -337,10 +371,10 @@ export function ApprovalDetail() {
                     />
                   </Link>
                 ) : (
-                  <Identity name="Board" size="sm" />
+                  <Identity name={copy("approvalDetail.board", "Board", "보드")} size="sm" />
                 )}
                 <span className="text-xs text-muted-foreground">
-                  {new Date(comment.createdAt).toLocaleString()}
+                  {new Date(comment.createdAt).toLocaleString(locale)}
                 </span>
               </div>
               <MarkdownBody className="text-sm">{comment.body}</MarkdownBody>
@@ -350,7 +384,7 @@ export function ApprovalDetail() {
         <Textarea
           value={commentBody}
           onChange={(e) => setCommentBody(e.target.value)}
-          placeholder="Add a comment..."
+          placeholder={copy("approvalDetail.comment.placeholder", "Add a comment...", "댓글 추가...")}
           rows={3}
         />
         <div className="flex justify-end">
@@ -359,7 +393,9 @@ export function ApprovalDetail() {
             onClick={() => addCommentMutation.mutate()}
             disabled={!commentBody.trim() || addCommentMutation.isPending}
           >
-            {addCommentMutation.isPending ? "Posting…" : "Post comment"}
+            {addCommentMutation.isPending
+              ? copy("approvalDetail.comment.posting", "Posting…", "게시 중...")
+              : copy("approvalDetail.comment.post", "Post comment", "댓글 게시")}
           </Button>
         </div>
       </div>

--- a/ui/src/pages/Approvals.tsx
+++ b/ui/src/pages/Approvals.tsx
@@ -12,12 +12,14 @@ import { Tabs } from "@/components/ui/tabs";
 import { ShieldCheck } from "lucide-react";
 import { ApprovalCard } from "../components/ApprovalCard";
 import { PageSkeleton } from "../components/PageSkeleton";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 type StatusFilter = "pending" | "all";
 
 export function Approvals() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
@@ -26,8 +28,8 @@ export function Approvals() {
   const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Approvals" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("approvals.breadcrumb", "Approvals", "승인") }]);
+  }, [copy, setBreadcrumbs]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.approvals.list(selectedCompanyId!),
@@ -49,7 +51,7 @@ export function Approvals() {
       navigate(`/approvals/${id}?resolved=approved`);
     },
     onError: (err) => {
-      setActionError(err instanceof Error ? err.message : "Failed to approve");
+      setActionError(err instanceof Error ? err.message : copy("approvals.error.approve", "Failed to approve", "승인하지 못했습니다."));
     },
   });
 
@@ -60,7 +62,7 @@ export function Approvals() {
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals.list(selectedCompanyId!) });
     },
     onError: (err) => {
-      setActionError(err instanceof Error ? err.message : "Failed to reject");
+      setActionError(err instanceof Error ? err.message : copy("approvals.error.reject", "Failed to reject", "반려하지 못했습니다."));
     },
   });
 
@@ -75,7 +77,7 @@ export function Approvals() {
   ).length;
 
   if (!selectedCompanyId) {
-    return <p className="text-sm text-muted-foreground">Select a company first.</p>;
+    return <p className="text-sm text-muted-foreground">{copy("approvals.noCompany", "Select a company first.", "먼저 회사를 선택하세요.")}</p>;
   }
 
   if (isLoading) {
@@ -87,7 +89,7 @@ export function Approvals() {
       <div className="flex items-center justify-between">
         <Tabs value={statusFilter} onValueChange={(v) => navigate(`/approvals/${v}`)}>
           <PageTabBar items={[
-            { value: "pending", label: <>Pending{pendingCount > 0 && (
+            { value: "pending", label: <>{copy("approvals.tab.pending", "Pending", "대기")}{pendingCount > 0 && (
               <span className={cn(
                 "ml-1.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
                 "bg-yellow-500/20 text-yellow-500"
@@ -95,7 +97,7 @@ export function Approvals() {
                 {pendingCount}
               </span>
             )}</> },
-            { value: "all", label: "All" },
+            { value: "all", label: copy("approvals.tab.all", "All", "전체") },
           ]} />
         </Tabs>
       </div>
@@ -107,7 +109,9 @@ export function Approvals() {
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <ShieldCheck className="h-8 w-8 text-muted-foreground/30 mb-3" />
           <p className="text-sm text-muted-foreground">
-            {statusFilter === "pending" ? "No pending approvals." : "No approvals yet."}
+            {statusFilter === "pending"
+              ? copy("approvals.empty.pending", "No pending approvals.", "대기 중인 승인이 없습니다.")
+              : copy("approvals.empty.all", "No approvals yet.", "아직 승인 요청이 없습니다.")}
           </p>
         </div>
       )}

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -17,6 +17,7 @@ import {
   Field,
   ToggleField,
 } from "../components/agent-config-primitives";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 const BYTES_PER_MIB = 1024 * 1024;
 const DEFAULT_COMPANY_ATTACHMENT_MAX_MIB = DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES / BYTES_PER_MIB;
@@ -30,6 +31,7 @@ export function CompanySettings() {
   } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+  const copy = useLocalizedCopy();
   const { data: experimentalSettings } = useQuery({
     queryKey: queryKeys.instance.experimentalSettings,
     queryFn: () => instanceSettingsApi.getExperimental(),
@@ -147,15 +149,19 @@ export function CompanySettings() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
-      { label: "Settings" }
+      { label: selectedCompany?.name ?? copy("common.company", "Company", "회사"), href: "/dashboard" },
+      { label: copy("companySettings.breadcrumb", "Settings", "설정") }
     ]);
-  }, [setBreadcrumbs, selectedCompany?.name]);
+  }, [copy, setBreadcrumbs, selectedCompany?.name]);
 
   if (!selectedCompany) {
     return (
       <div className="text-sm text-muted-foreground">
-        No company selected. Select a company from the switcher above.
+        {copy(
+          "companySettings.noCompany",
+          "No company selected. Select a company from the switcher above.",
+          "선택된 회사가 없습니다. 위의 전환기에서 회사를 선택하세요.",
+        )}
       </div>
     );
   }
@@ -173,16 +179,19 @@ export function CompanySettings() {
     <div className="max-w-2xl space-y-6">
       <div className="flex items-center gap-2">
         <Settings className="h-5 w-5 text-muted-foreground" />
-        <h1 className="text-lg font-semibold">Company Settings</h1>
+        <h1 className="text-lg font-semibold">{copy("companySettings.title", "Company Settings", "회사 설정")}</h1>
       </div>
 
       {/* General */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          General
+          {copy("companySettings.section.general", "General", "일반")}
         </div>
         <div className="space-y-3 rounded-md border border-border px-4 py-4">
-          <Field label="Company name" hint="The display name for your company.">
+          <Field
+            label={copy("companySettings.companyName", "Company name", "회사 이름")}
+            hint={copy("companySettings.companyName.hint", "The display name for your company.", "회사에 표시할 이름입니다.")}
+          >
             <input
               className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
               type="text"
@@ -191,14 +200,14 @@ export function CompanySettings() {
             />
           </Field>
           <Field
-            label="Description"
-            hint="Optional description shown in the company profile."
+            label={copy("companySettings.description", "Description", "설명")}
+            hint={copy("companySettings.description.hint", "Optional description shown in the company profile.", "회사 프로필에 표시되는 선택 설명입니다.")}
           >
             <input
               className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
               type="text"
               value={description}
-              placeholder="Optional company description"
+              placeholder={copy("companySettings.description.placeholder", "Optional company description", "선택 회사 설명")}
               onChange={(e) => setDescription(e.target.value)}
             />
           </Field>
@@ -208,7 +217,7 @@ export function CompanySettings() {
       {/* Appearance */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Appearance
+          {copy("companySettings.section.appearance", "Appearance", "표시")}
         </div>
         <div className="space-y-3 rounded-md border border-border px-4 py-4">
           <div className="flex items-start gap-4">
@@ -222,8 +231,8 @@ export function CompanySettings() {
             </div>
             <div className="flex-1 space-y-3">
               <Field
-                label="Logo"
-                hint="Upload a PNG, JPEG, WEBP, GIF, or SVG logo image."
+                label={copy("companySettings.logo", "Logo", "로고")}
+                hint={copy("companySettings.logo.hint", "Upload a PNG, JPEG, WEBP, GIF, or SVG logo image.", "PNG, JPEG, WEBP, GIF 또는 SVG 로고 이미지를 업로드합니다.")}
               >
                 <div className="space-y-2">
                   <input
@@ -240,7 +249,9 @@ export function CompanySettings() {
                         onClick={handleClearLogo}
                         disabled={clearLogoMutation.isPending}
                       >
-                        {clearLogoMutation.isPending ? "Removing..." : "Remove logo"}
+                        {clearLogoMutation.isPending
+                          ? copy("companySettings.logo.removing", "Removing...", "삭제 중...")
+                          : copy("companySettings.logo.remove", "Remove logo", "로고 삭제")}
                       </Button>
                     </div>
                   )}
@@ -249,7 +260,7 @@ export function CompanySettings() {
                       {logoUploadError ??
                         (logoUploadMutation.error instanceof Error
                           ? logoUploadMutation.error.message
-                          : "Logo upload failed")}
+                          : copy("companySettings.logo.uploadFailed", "Logo upload failed", "로고 업로드 실패"))}
                     </span>
                   )}
                   {clearLogoMutation.isError && (
@@ -258,13 +269,15 @@ export function CompanySettings() {
                     </span>
                   )}
                   {logoUploadMutation.isPending && (
-                    <span className="text-xs text-muted-foreground">Uploading logo...</span>
+                    <span className="text-xs text-muted-foreground">
+                      {copy("companySettings.logo.uploading", "Uploading logo...", "로고 업로드 중...")}
+                    </span>
                   )}
                 </div>
               </Field>
               <Field
-                label="Brand color"
-                hint="Sets the hue for the company icon. Leave empty for auto-generated color."
+                label={copy("companySettings.brandColor", "Brand color", "브랜드 색상")}
+                hint={copy("companySettings.brandColor.hint", "Sets the hue for the company icon. Leave empty for auto-generated color.", "회사 아이콘 색조를 설정합니다. 비워두면 자동 생성 색상을 사용합니다.")}
               >
                 <div className="flex items-center gap-2">
                   <input
@@ -282,7 +295,7 @@ export function CompanySettings() {
                         setBrandColor(v);
                       }
                     }}
-                    placeholder="Auto"
+                    placeholder={copy("companySettings.brandColor.auto", "Auto", "자동")}
                     className="w-28 rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm font-mono outline-none"
                   />
                   {brandColor && (
@@ -292,14 +305,19 @@ export function CompanySettings() {
                       onClick={() => setBrandColor("")}
                       className="text-xs text-muted-foreground"
                     >
-                      Clear
+                      {copy("common.clear", "Clear", "비우기")}
                     </Button>
                   )}
                 </div>
               </Field>
               <Field
-                label="Attachment size limit"
-                hint={`Accepted range: 1-${MAX_COMPANY_ATTACHMENT_MAX_MIB} MiB.`}
+                label={copy("companySettings.attachmentLimit", "Attachment size limit", "첨부파일 크기 제한")}
+                hint={copy(
+                  "companySettings.attachmentLimit.hint",
+                  "Accepted range: 1-{{max}} MiB.",
+                  "허용 범위: 1-{{max}} MiB.",
+                  { max: MAX_COMPANY_ATTACHMENT_MAX_MIB },
+                )}
               >
                 <div className="flex flex-col gap-1.5">
                   <div className="flex items-center gap-2">
@@ -316,7 +334,12 @@ export function CompanySettings() {
                   </div>
                   {!attachmentMaxValid && (
                     <span className="text-xs text-destructive">
-                      Enter a whole number from 1 to {MAX_COMPANY_ATTACHMENT_MAX_MIB}.
+                      {copy(
+                        "companySettings.attachmentLimit.invalid",
+                        "Enter a whole number from 1 to {{max}}.",
+                        "1부터 {{max}}까지의 정수를 입력하세요.",
+                        { max: MAX_COMPANY_ATTACHMENT_MAX_MIB },
+                      )}
                     </span>
                   )}
                 </div>
@@ -334,16 +357,18 @@ export function CompanySettings() {
             onClick={handleSaveGeneral}
             disabled={generalMutation.isPending || !companyName.trim() || !attachmentMaxValid}
           >
-            {generalMutation.isPending ? "Saving..." : "Save changes"}
+            {generalMutation.isPending
+              ? copy("common.savingDots", "Saving...", "저장 중...")
+              : copy("companySettings.saveChanges", "Save changes", "변경사항 저장")}
           </Button>
           {generalMutation.isSuccess && (
-            <span className="text-xs text-muted-foreground">Saved</span>
+            <span className="text-xs text-muted-foreground">{copy("common.saved", "Saved", "저장됨")}</span>
           )}
           {generalMutation.isError && (
             <span className="text-xs text-destructive">
               {generalMutation.error instanceof Error
                   ? generalMutation.error.message
-                  : "Failed to save"}
+                  : copy("companySettings.saveFailed", "Failed to save", "저장 실패")}
             </span>
           )}
         </div>
@@ -352,12 +377,12 @@ export function CompanySettings() {
       {/* Hiring */}
       <div className="space-y-4" data-testid="company-settings-team-section">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Hiring
+          {copy("companySettings.section.hiring", "Hiring", "채용")}
         </div>
         <div className="rounded-md border border-border px-4 py-3">
           <ToggleField
-            label="Require board approval for new hires"
-            hint="New agent hires stay pending until approved by board."
+            label={copy("companySettings.requireApproval", "Require board approval for new hires", "새 직원 고용에 보드 승인 필요")}
+            hint={copy("companySettings.requireApproval.hint", "New agent hires stay pending until approved by board.", "새 직원 고용은 보드 승인 전까지 대기 상태로 유지됩니다.")}
             checked={!!selectedCompany.requireBoardApprovalForNewAgents}
             onChange={(v) => settingsMutation.mutate(v)}
             toggleTestId="company-settings-team-approval-toggle"
@@ -368,32 +393,35 @@ export function CompanySettings() {
       {/* Import / Export */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          Company Packages
+          {copy("companySettings.section.packages", "Company Packages", "회사 패키지")}
         </div>
         <div className="rounded-md border border-border px-4 py-4">
           <p className="text-sm text-muted-foreground">
-            Import and export have moved to dedicated pages accessible from the{" "}
-            <a href="/org" className="underline hover:text-foreground">Org Chart</a> header.
+            {copy("companySettings.packages.note.prefix", "Import and export have moved to dedicated pages accessible from the", "가져오기와 내보내기는")}
+            {" "}
+            <a href="/org" className="underline hover:text-foreground">{copy("org.breadcrumb", "Org Chart", "조직도")}</a>
+            {" "}
+            {copy("companySettings.packages.note.suffix", "header.", "상단에서 접근하는 전용 페이지로 이동했습니다.")}
           </p>
           <div className="mt-3 flex flex-wrap items-center gap-2">
             {cloudSyncEnabled ? (
               <Button size="sm" asChild>
                 <a href="/company/settings/cloud-upstream">
                   <CloudUpload className="mr-1.5 h-3.5 w-3.5" />
-                  Send to Paperclip Cloud
+                  {copy("companySettings.cloud.send", "Send to Paperclip Cloud", "Paperclip Cloud로 보내기")}
                 </a>
               </Button>
             ) : null}
             <Button size="sm" variant="outline" asChild>
               <a href="/company/export">
                 <Download className="mr-1.5 h-3.5 w-3.5" />
-                Export
+                {copy("common.export", "Export", "내보내기")}
               </a>
             </Button>
             <Button size="sm" variant="outline" asChild>
               <a href="/company/import">
                 <Upload className="mr-1.5 h-3.5 w-3.5" />
-                Import
+                {copy("common.import", "Import", "가져오기")}
               </a>
             </Button>
           </div>
@@ -403,12 +431,15 @@ export function CompanySettings() {
       {/* Danger Zone */}
       <div className="space-y-4">
         <div className="text-xs font-medium text-destructive uppercase tracking-wide">
-          Danger Zone
+          {copy("companySettings.section.danger", "Danger Zone", "위험 구역")}
         </div>
         <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-4">
           <p className="text-sm text-muted-foreground">
-            Archive this company to hide it from the sidebar. This persists in
-            the database.
+            {copy(
+              "companySettings.archive.note",
+              "Archive this company to hide it from the sidebar. This persists in the database.",
+              "이 회사를 보관 처리하면 사이드바에서 숨겨집니다. 이 상태는 데이터베이스에 유지됩니다.",
+            )}
           </p>
           <div className="flex items-center gap-2">
             <Button
@@ -421,7 +452,12 @@ export function CompanySettings() {
               onClick={() => {
                 if (!selectedCompanyId) return;
                 const confirmed = window.confirm(
-                  `Archive company "${selectedCompany.name}"? It will be hidden from the sidebar.`
+                  copy(
+                    "companySettings.archive.confirm",
+                    "Archive company \"{{name}}\"? It will be hidden from the sidebar.",
+                    "\"{{name}}\" 회사를 보관 처리할까요? 사이드바에서 숨겨집니다.",
+                    { name: selectedCompany.name },
+                  )
                 );
                 if (!confirmed) return;
                 const nextCompanyId =
@@ -437,16 +473,16 @@ export function CompanySettings() {
               }}
             >
               {archiveMutation.isPending
-                ? "Archiving..."
+                ? copy("companySettings.archive.archiving", "Archiving...", "보관 처리 중...")
                 : selectedCompany.status === "archived"
-                ? "Already archived"
-                : "Archive company"}
+                ? copy("companySettings.archive.already", "Already archived", "이미 보관됨")
+                : copy("companySettings.archive.action", "Archive company", "회사 보관")}
             </Button>
             {archiveMutation.isError && (
               <span className="text-xs text-destructive">
                 {archiveMutation.error instanceof Error
                   ? archiveMutation.error.message
-                  : "Failed to archive company"}
+                  : copy("companySettings.archive.failed", "Failed to archive company", "회사 보관 처리 실패")}
               </span>
             )}
           </div>

--- a/ui/src/pages/CompanySkills.tsx
+++ b/ui/src/pages/CompanySkills.tsx
@@ -22,6 +22,7 @@ import { MarkdownEditor } from "../components/MarkdownEditor";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { CopyText } from "../components/CopyText";
 import { Identity } from "../components/Identity";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import {
   Dialog,
   DialogContent,
@@ -180,15 +181,26 @@ function middleTruncate(value: string, maxLength = 72) {
   return `${value.slice(0, edgeLength)}...${value.slice(value.length - edgeLength)}`;
 }
 
-function formatProjectScanSummary(result: CompanySkillProjectScanResult) {
+type LocalizedCopyFn = ReturnType<typeof useLocalizedCopy>;
+
+function formatProjectScanSummary(result: CompanySkillProjectScanResult, copy: LocalizedCopyFn) {
   const parts = [
-    `${result.discovered} found`,
-    `${result.imported.length} imported`,
-    `${result.updated.length} updated`,
+    copy("skills.scan.found", "{{count}} found", "{{count}}개 발견", { count: result.discovered }),
+    copy("skills.scan.imported", "{{count}} imported", "{{count}}개 가져옴", { count: result.imported.length }),
+    copy("skills.scan.updated", "{{count}} updated", "{{count}}개 업데이트", { count: result.updated.length }),
   ];
-  if (result.conflicts.length > 0) parts.push(`${result.conflicts.length} conflicts`);
-  if (result.skipped.length > 0) parts.push(`${result.skipped.length} skipped`);
-  return `${parts.join(", ")} across ${result.scannedWorkspaces} workspace${result.scannedWorkspaces === 1 ? "" : "s"}.`;
+  if (result.conflicts.length > 0) {
+    parts.push(copy("skills.scan.conflicts", "{{count}} conflicts", "충돌 {{count}}개", { count: result.conflicts.length }));
+  }
+  if (result.skipped.length > 0) {
+    parts.push(copy("skills.scan.skipped", "{{count}} skipped", "{{count}}개 건너뜀", { count: result.skipped.length }));
+  }
+  return copy(
+    "skills.scan.summary",
+    "{{summary}} across {{count}} workspace.",
+    "작업공간 {{count}}개에서 {{summary}}.",
+    { summary: parts.join(", "), count: result.scannedWorkspaces },
+  );
 }
 
 function fileIcon(kind: CompanySkillFileInventoryEntry["kind"]) {
@@ -262,6 +274,7 @@ function NewSkillForm({
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
   const [description, setDescription] = useState("");
+  const copy = useLocalizedCopy();
 
   return (
     <div className="border-b border-border px-4 py-4">
@@ -269,7 +282,7 @@ function NewSkillForm({
         <Input
           value={name}
           onChange={(event) => setName(event.target.value)}
-          placeholder="Skill name"
+          placeholder={copy("skills.new.name", "Skill name", "스킬 이름")}
           className="h-9 rounded-none border-0 border-b border-border px-0 shadow-none focus-visible:ring-0"
         />
         <Input
@@ -281,19 +294,21 @@ function NewSkillForm({
         <Textarea
           value={description}
           onChange={(event) => setDescription(event.target.value)}
-          placeholder="Short description"
+          placeholder={copy("skills.new.description", "Short description", "짧은 설명")}
           className="min-h-20 rounded-none border-0 border-b border-border px-0 shadow-none focus-visible:ring-0"
         />
         <div className="flex items-center justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel} disabled={isPending}>
-            Cancel
+            {copy("common.cancel", "Cancel", "취소")}
           </Button>
           <Button
             size="sm"
             onClick={() => onCreate({ name, slug: slug || null, description: description || null })}
             disabled={isPending || name.trim().length === 0}
           >
-            {isPending ? "Creating..." : "Create skill"}
+            {isPending
+              ? copy("skills.new.creating", "Creating...", "만드는 중...")
+              : copy("skills.new.create", "Create skill", "스킬 만들기")}
           </Button>
         </div>
       </div>
@@ -412,6 +427,7 @@ function SkillList({
   onSelectSkill: (skillId: string) => void;
   onSelectPath: (skillId: string, path: string) => void;
 }) {
+  const copy = useLocalizedCopy();
   const filteredSkills = skills.filter((skill) => {
     const haystack = `${skill.name} ${skill.key} ${skill.slug} ${skill.sourceLabel ?? ""}`.toLowerCase();
     return haystack.includes(skillFilter.toLowerCase());
@@ -420,7 +436,7 @@ function SkillList({
   if (filteredSkills.length === 0) {
     return (
       <div className="px-4 py-6 text-sm text-muted-foreground">
-        No skills match this filter.
+        {copy("skills.list.noMatches", "No skills match this filter.", "이 필터와 일치하는 스킬이 없습니다.")}
       </div>
     );
   }
@@ -465,7 +481,9 @@ function SkillList({
                 type="button"
                 className="flex h-9 w-9 shrink-0 items-center justify-center self-center rounded-sm text-muted-foreground opacity-80 transition-[background-color,color,opacity] hover:bg-accent hover:text-foreground group-hover:opacity-100"
                 onClick={() => onToggleSkill(skill.id)}
-                aria-label={expanded ? `Collapse ${skill.name}` : `Expand ${skill.name}`}
+                aria-label={expanded
+                  ? copy("skills.list.collapse", "Collapse {{name}}", "{{name}} 접기", { name: skill.name })
+                  : copy("skills.list.expand", "Expand {{name}}", "{{name}} 펼치기", { name: skill.name })}
               >
                 {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
               </button>
@@ -539,6 +557,7 @@ function SkillPane({
   onSave: () => void;
   savePending: boolean;
 }) {
+  const copy = useLocalizedCopy();
   if (!detail) {
     if (loading) {
       return <PageSkeleton variant="detail" />;
@@ -546,7 +565,7 @@ function SkillPane({
     return (
       <EmptyState
         icon={Boxes}
-        message="Select a skill to inspect its files."
+        message={copy("skills.detail.empty", "Select a skill to inspect its files.", "파일을 확인할 스킬을 선택하세요.")}
       />
     );
   }
@@ -558,10 +577,24 @@ function SkillPane({
   const currentPin = shortRef(detail.sourceRef);
   const latestPin = shortRef(updateStatus?.latestRef);
   const displaySourcePath = detail.sourcePath ? middleTruncate(detail.sourcePath) : null;
+  const editableReason = detail.editableReason?.includes("Bundled Paperclip skills are read-only")
+    ? copy("skills.detail.bundledReadOnly", "Bundled Paperclip skills are read-only.", "기본 제공 Paperclip 스킬은 읽기 전용입니다.")
+    : detail.editableReason;
   const removeBlocked = usedBy.length > 0;
   const removeDisabledReason = removeBlocked
-    ? "Detach this skill from all agents before removing it."
+    ? copy("skills.detail.removeBlocked", "Detach this skill from all agents before removing it.", "삭제하기 전에 모든 직원에서 이 스킬 연결을 해제하세요.")
     : null;
+  const applicationStatus = detail.editable
+    ? copy("skills.detail.applyEditable", "Editable company skill", "회사 스킬로 편집/적용 가능")
+    : copy("skills.detail.applyReadOnly", "Read-only source skill", "읽기 전용 출처 스킬");
+  const connectionStatus = usedBy.length === 0
+    ? copy("skills.detail.connectionNone", "Not attached to any agent", "연결된 직원 없음")
+    : copy(
+        "skills.detail.connectionCount",
+        usedBy.length === 1 ? "Attached to {{count}} agent" : "Attached to {{count}} agents",
+        "직원 {{count}}명에 연결됨",
+        { count: usedBy.length },
+      );
 
   return (
     <div className="min-w-0">
@@ -585,7 +618,7 @@ function SkillPane({
               title={removeDisabledReason ?? undefined}
             >
               <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-              {deletePending ? "Removing..." : "Remove"}
+              {deletePending ? copy("skills.remove.removing", "Removing...", "삭제 중...") : copy("common.remove", "Remove", "삭제")}
             </Button>
             {detail.editable ? (
               <button
@@ -593,10 +626,12 @@ function SkillPane({
                 onClick={() => setEditMode(!editMode)}
               >
                 <Pencil className="h-3.5 w-3.5" />
-                {editMode ? "Stop editing" : "Edit"}
+                {editMode
+                  ? copy("skills.detail.stopEditing", "Stop editing", "편집 중지")
+                  : copy("common.edit", "Edit", "편집")}
               </button>
             ) : (
-              <div className="text-sm text-muted-foreground">{detail.editableReason}</div>
+              <div className="text-sm text-muted-foreground">{editableReason}</div>
             )}
           </div>
         </div>
@@ -604,7 +639,7 @@ function SkillPane({
         <div className="mt-4 space-y-3 border-t border-border pt-4 text-sm">
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
             <div className="flex min-w-0 items-center gap-2">
-              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Source</span>
+              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{copy("skills.detail.source", "Source", "출처")}</span>
               <span className="flex min-w-0 items-center gap-2">
                 <SourceIcon className="h-3.5 w-3.5 text-muted-foreground" />
                 {detail.sourcePath && displaySourcePath ? (
@@ -617,9 +652,9 @@ function SkillPane({
                     </span>
                     <CopyText
                       text={detail.sourcePath}
-                      copiedLabel="Copied path"
-                      ariaLabel="Copy source path"
-                      title="Copy source path"
+                      copiedLabel={copy("skills.detail.copiedPath", "Copied path", "경로 복사됨")}
+                      ariaLabel={copy("skills.detail.copySourcePath", "Copy source path", "출처 경로 복사")}
+                      title={copy("skills.detail.copySourcePath", "Copy source path", "출처 경로 복사")}
                       className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-sm border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                     >
                       <Copy className="h-3.5 w-3.5" />
@@ -632,10 +667,12 @@ function SkillPane({
             </div>
             {detail.sourceType === "github" && (
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Pin</span>
-                <span className="font-mono text-xs">{currentPin ?? "untracked"}</span>
+                <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{copy("skills.detail.pin", "Pin", "고정")}</span>
+                <span className="font-mono text-xs">{currentPin ?? copy("skills.detail.untracked", "untracked", "추적 안 함")}</span>
                 {updateStatus?.trackingRef && (
-                  <span className="text-xs text-muted-foreground">tracking {updateStatus.trackingRef}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {copy("skills.detail.tracking", "tracking {{ref}}", "{{ref}} 추적 중", { ref: updateStatus.trackingRef })}
+                  </span>
                 )}
                 <Button
                   variant="ghost"
@@ -644,7 +681,7 @@ function SkillPane({
                   disabled={checkUpdatesPending || updateStatusLoading}
                 >
                   <RefreshCw className={cn("mr-1.5 h-3.5 w-3.5", (checkUpdatesPending || updateStatusLoading) && "animate-spin")} />
-                  Check for updates
+                  {copy("skills.detail.checkUpdates", "Check for updates", "업데이트 확인")}
                 </Button>
                 {updateStatus?.supported && updateStatus.hasUpdate && (
                   <Button
@@ -653,11 +690,11 @@ function SkillPane({
                     disabled={installUpdatePending}
                   >
                     <RefreshCw className={cn("mr-1.5 h-3.5 w-3.5", installUpdatePending && "animate-spin")} />
-                    Install update{latestPin ? ` ${latestPin}` : ""}
+                    {copy("skills.detail.installUpdate", "Install update", "업데이트 설치")}{latestPin ? ` ${latestPin}` : ""}
                   </Button>
                 )}
                 {updateStatus?.supported && !updateStatus.hasUpdate && !updateStatusLoading && (
-                  <span className="text-xs text-muted-foreground">Up to date</span>
+                  <span className="text-xs text-muted-foreground">{copy("skills.detail.upToDate", "Up to date", "최신 상태")}</span>
                 )}
                 {!updateStatus?.supported && updateStatus?.reason && (
                   <span className="text-xs text-muted-foreground">{updateStatus.reason}</span>
@@ -665,18 +702,18 @@ function SkillPane({
               </div>
             )}
             <div className="flex items-center gap-2">
-              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Key</span>
+              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{copy("skills.detail.key", "Key", "키")}</span>
               <span className="font-mono text-xs">{detail.key}</span>
             </div>
             <div className="flex items-center gap-2">
-              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Mode</span>
-              <span>{detail.editable ? "Editable" : "Read only"}</span>
+              <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{copy("skills.detail.mode", "Mode", "모드")}</span>
+              <span>{detail.editable ? copy("skills.detail.editable", "Editable", "편집 가능") : copy("skills.detail.readOnly", "Read only", "읽기 전용")}</span>
             </div>
           </div>
           <div className="flex flex-wrap items-start gap-x-3 gap-y-1">
-            <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Used by</span>
+            <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">{copy("skills.detail.usedBy", "Used by", "사용 중인 직원")}</span>
             {usedBy.length === 0 ? (
-              <span className="text-muted-foreground">No agents attached</span>
+              <span className="text-muted-foreground">{copy("skills.detail.noAgents", "No agents attached", "연결된 직원 없음")}</span>
             ) : (
               <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
                 {usedBy.map((agent) => (
@@ -690,6 +727,30 @@ function SkillPane({
                 ))}
               </div>
             )}
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-3">
+            <div className="flex items-start gap-2 border border-border/70 bg-background/70 p-3">
+              <Eye className="mt-0.5 h-3.5 w-3.5 text-muted-foreground" />
+              <div className="min-w-0">
+                <div className="text-xs font-medium">{copy("skills.detail.readState", "Read", "읽기")}</div>
+                <div className="mt-1 text-xs text-muted-foreground">{copy("skills.detail.readAvailable", "SKILL.md and files can be inspected here.", "SKILL.md와 파일 내용을 여기서 확인할 수 있습니다.")}</div>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 border border-border/70 bg-background/70 p-3">
+              <Boxes className="mt-0.5 h-3.5 w-3.5 text-muted-foreground" />
+              <div className="min-w-0">
+                <div className="text-xs font-medium">{copy("skills.detail.applyState", "Apply", "적용")}</div>
+                <div className="mt-1 text-xs text-muted-foreground">{applicationStatus}</div>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 border border-border/70 bg-background/70 p-3">
+              <Link2 className="mt-0.5 h-3.5 w-3.5 text-muted-foreground" />
+              <div className="min-w-0">
+                <div className="text-xs font-medium">{copy("skills.detail.connectionState", "Connection", "연결")}</div>
+                <div className="mt-1 text-xs text-muted-foreground">{connectionStatus}</div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -708,7 +769,7 @@ function SkillPane({
                 >
                   <span className="flex items-center gap-1.5">
                     <Eye className="h-3.5 w-3.5" />
-                    View
+                    {copy("skills.detail.view", "View", "보기")}
                   </span>
                 </button>
                 <button
@@ -717,7 +778,7 @@ function SkillPane({
                 >
                   <span className="flex items-center gap-1.5">
                     <Code2 className="h-3.5 w-3.5" />
-                    Code
+                    {copy("skills.detail.code", "Code", "코드")}
                   </span>
                 </button>
               </div>
@@ -725,11 +786,11 @@ function SkillPane({
             {editMode && file?.editable && (
               <>
                 <Button variant="ghost" size="sm" onClick={() => setEditMode(false)} disabled={savePending}>
-                  Cancel
+                  {copy("common.cancel", "Cancel", "취소")}
                 </Button>
                 <Button size="sm" onClick={onSave} disabled={savePending}>
                   <Save className="mr-1.5 h-3.5 w-3.5" />
-                  {savePending ? "Saving..." : "Save"}
+                  {savePending ? copy("common.savingDots", "Saving...", "저장 중...") : copy("common.save", "Save", "저장")}
                 </Button>
               </>
             )}
@@ -741,7 +802,7 @@ function SkillPane({
         {fileLoading ? (
           <PageSkeleton variant="detail" />
         ) : !file ? (
-          <div className="text-sm text-muted-foreground">Select a file to inspect.</div>
+          <div className="text-sm text-muted-foreground">{copy("skills.detail.selectFile", "Select a file to inspect.", "확인할 파일을 선택하세요.")}</div>
         ) : editMode && file.editable ? (
           file.markdown ? (
             <MarkdownEditor
@@ -776,6 +837,7 @@ export function CompanySkills() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { pushToast } = useToastActions();
+  const copy = useLocalizedCopy();
   const [skillFilter, setSkillFilter] = useState("");
   const [source, setSource] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
@@ -797,10 +859,10 @@ export function CompanySkills() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Skills", href: "/skills" },
-      ...(routeSkillId ? [{ label: "Detail" }] : []),
+      { label: copy("skills.breadcrumb", "Skills", "스킬"), href: "/skills" },
+      ...(routeSkillId ? [{ label: copy("skills.breadcrumb.detail", "Detail", "상세") }] : []),
     ]);
-  }, [routeSkillId, setBreadcrumbs]);
+  }, [copy, routeSkillId, setBreadcrumbs]);
 
   const skillsQuery = useQuery({
     queryKey: queryKeys.companySkills.list(selectedCompanyId ?? ""),
@@ -909,19 +971,24 @@ export function CompanySkills() {
       if (result.imported[0]) navigate(skillRoute(result.imported[0].id));
       pushToast({
         tone: "success",
-        title: "Skills imported",
-        body: `${result.imported.length} skill${result.imported.length === 1 ? "" : "s"} added.`,
+        title: copy("skills.toast.imported", "Skills imported", "스킬 가져오기 완료"),
+        body: copy(
+          "skills.toast.importedBody",
+          result.imported.length === 1 ? "{{count}} skill added." : "{{count}} skills added.",
+          "스킬 {{count}}개가 추가되었습니다.",
+          { count: result.imported.length },
+        ),
       });
       if (result.warnings[0]) {
-        pushToast({ tone: "warn", title: "Import warnings", body: result.warnings[0] });
+        pushToast({ tone: "warn", title: copy("skills.toast.importWarnings", "Import warnings", "가져오기 경고"), body: result.warnings[0] });
       }
       setSource("");
     },
     onError: (error) => {
       pushToast({
         tone: "error",
-        title: "Skill import failed",
-        body: error instanceof Error ? error.message : "Failed to import skill source.",
+        title: copy("skills.toast.importFailed", "Skill import failed", "스킬 가져오기 실패"),
+        body: error instanceof Error ? error.message : copy("skills.toast.importFailedBody", "Failed to import skill source.", "스킬 출처를 가져오지 못했습니다."),
       });
     },
   });
@@ -934,15 +1001,20 @@ export function CompanySkills() {
       setCreateOpen(false);
       pushToast({
         tone: "success",
-        title: "Skill created",
-        body: `${skill.name} is now editable in the Paperclip workspace.`,
+        title: copy("skills.toast.created", "Skill created", "스킬 생성됨"),
+        body: copy(
+          "skills.toast.createdBody",
+          "{{name}} is now editable in the Paperclip workspace.",
+          "{{name}} 스킬을 Paperclip 작업공간에서 편집할 수 있습니다.",
+          { name: skill.name },
+        ),
       });
     },
     onError: (error) => {
       pushToast({
         tone: "error",
-        title: "Skill creation failed",
-        body: error instanceof Error ? error.message : "Failed to create skill.",
+        title: copy("skills.toast.createFailed", "Skill creation failed", "스킬 생성 실패"),
+        body: error instanceof Error ? error.message : copy("skills.toast.createFailedBody", "Failed to create skill.", "스킬을 만들지 못했습니다."),
       });
     },
   });
@@ -950,28 +1022,28 @@ export function CompanySkills() {
   const scanProjects = useMutation({
     mutationFn: () => companySkillsApi.scanProjects(selectedCompanyId!),
     onMutate: () => {
-      setScanStatusMessage("Scanning project workspaces for skills...");
+      setScanStatusMessage(copy("skills.scan.scanning", "Scanning project workspaces for skills...", "프로젝트 작업공간에서 스킬을 찾는 중..."));
     },
     onSuccess: async (result) => {
-      setScanStatusMessage("Refreshing skills list...");
+      setScanStatusMessage(copy("skills.scan.refreshing", "Refreshing skills list...", "스킬 목록 새로고침 중..."));
       await queryClient.invalidateQueries({ queryKey: queryKeys.companySkills.list(selectedCompanyId!) });
-      const summary = formatProjectScanSummary(result);
+      const summary = formatProjectScanSummary(result, copy);
       setScanStatusMessage(summary);
       pushToast({
         tone: "success",
-        title: "Project skill scan complete",
+        title: copy("skills.toast.scanComplete", "Project skill scan complete", "프로젝트 스킬 스캔 완료"),
         body: summary,
       });
       if (result.conflicts[0]) {
         pushToast({
           tone: "warn",
-          title: "Skill conflicts found",
+          title: copy("skills.toast.conflicts", "Skill conflicts found", "스킬 충돌 발견"),
           body: result.conflicts[0].reason,
         });
       } else if (result.warnings[0]) {
         pushToast({
           tone: "warn",
-          title: "Scan warnings",
+          title: copy("skills.toast.scanWarnings", "Scan warnings", "스캔 경고"),
           body: result.warnings[0],
         });
       }
@@ -980,8 +1052,8 @@ export function CompanySkills() {
       setScanStatusMessage(null);
       pushToast({
         tone: "error",
-        title: "Project skill scan failed",
-        body: error instanceof Error ? error.message : "Failed to scan project workspaces.",
+        title: copy("skills.toast.scanFailed", "Project skill scan failed", "프로젝트 스킬 스캔 실패"),
+        body: error instanceof Error ? error.message : copy("skills.toast.scanFailedBody", "Failed to scan project workspaces.", "프로젝트 작업공간에서 스킬을 스캔하지 못했습니다."),
       });
     },
   });
@@ -1003,15 +1075,15 @@ export function CompanySkills() {
       setEditMode(false);
       pushToast({
         tone: "success",
-        title: "Skill saved",
+        title: copy("skills.toast.saved", "Skill saved", "스킬 저장됨"),
         body: result.path,
       });
     },
     onError: (error) => {
       pushToast({
         tone: "error",
-        title: "Save failed",
-        body: error instanceof Error ? error.message : "Failed to save skill file.",
+        title: copy("skills.toast.saveFailed", "Save failed", "저장 실패"),
+        body: error instanceof Error ? error.message : copy("skills.toast.saveFailedBody", "Failed to save skill file.", "스킬 파일을 저장하지 못했습니다."),
       });
     },
   });
@@ -1028,15 +1100,17 @@ export function CompanySkills() {
       navigate(skillRoute(skill.id, selectedPath));
       pushToast({
         tone: "success",
-        title: "Skill updated",
-        body: skill.sourceRef ? `Pinned to ${shortRef(skill.sourceRef)}` : skill.name,
+        title: copy("skills.toast.updated", "Skill updated", "스킬 업데이트됨"),
+        body: skill.sourceRef
+          ? copy("skills.toast.pinnedTo", "Pinned to {{ref}}", "{{ref}}에 고정됨", { ref: shortRef(skill.sourceRef) })
+          : skill.name,
       });
     },
     onError: (error) => {
       pushToast({
         tone: "error",
-        title: "Update failed",
-        body: error instanceof Error ? error.message : "Failed to install skill update.",
+        title: copy("skills.toast.updateFailed", "Update failed", "업데이트 실패"),
+        body: error instanceof Error ? error.message : copy("skills.toast.updateFailedBody", "Failed to install skill update.", "스킬 업데이트를 설치하지 못했습니다."),
       });
     },
   });
@@ -1066,21 +1140,26 @@ export function CompanySkills() {
       navigate("/skills", { replace: true });
       pushToast({
         tone: "success",
-        title: "Skill removed",
-        body: `${skill.name} was removed from the company skill library.`,
+        title: copy("skills.toast.removed", "Skill removed", "스킬 삭제됨"),
+        body: copy(
+          "skills.toast.removedBody",
+          "{{name}} was removed from the company skill library.",
+          "{{name}} 스킬이 회사 스킬 라이브러리에서 삭제되었습니다.",
+          { name: skill.name },
+        ),
       });
     },
     onError: (error) => {
       pushToast({
         tone: "error",
-        title: "Remove failed",
-        body: error instanceof Error ? error.message : "Failed to remove skill.",
+        title: copy("skills.toast.removeFailed", "Remove failed", "삭제 실패"),
+        body: error instanceof Error ? error.message : copy("skills.toast.removeFailedBody", "Failed to remove skill.", "스킬을 삭제하지 못했습니다."),
       });
     },
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Boxes} message="Select a company to manage skills." />;
+    return <EmptyState icon={Boxes} message={copy("skills.noCompany", "Select a company to manage skills.", "스킬을 관리하려면 회사를 선택하세요.")} />;
   }
 
   function handleAddSkillSource() {
@@ -1097,44 +1176,55 @@ export function CompanySkills() {
       <Dialog open={deleteOpen} onOpenChange={closeDeleteDialog}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Remove skill</DialogTitle>
+            <DialogTitle>{copy("skills.remove.title", "Remove skill", "스킬 삭제")}</DialogTitle>
             <DialogDescription>
-              Remove this skill from the company library. If any agents still use it, removal will be blocked until it is detached.
+              {copy(
+                "skills.remove.description",
+                "Remove this skill from the company library. If any agents still use it, removal will be blocked until it is detached.",
+                "회사 라이브러리에서 이 스킬을 삭제합니다. 아직 사용하는 직원이 있으면 연결 해제 전까지 삭제가 차단됩니다.",
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 text-sm">
             <p>
               {deleteTargetDetail
-                ? `You are about to remove ${deleteTargetDetail.name}.`
-                : "You are about to remove this skill."}
+                ? copy("skills.remove.confirmNamed", "You are about to remove {{name}}.", "{{name}} 스킬을 삭제하려고 합니다.", { name: deleteTargetDetail.name })
+                : copy("skills.remove.confirm", "You are about to remove this skill.", "이 스킬을 삭제하려고 합니다.")}
             </p>
             {deleteTargetDetail?.usedByAgents?.length ? (
               <div className="rounded-md border border-border px-3 py-3 text-muted-foreground">
-                Currently used by {deleteTargetDetail.usedByAgents.map((agent) => agent.name).join(", ")}.
+                {copy(
+                  "skills.remove.currentlyUsedBy",
+                  "Currently used by {{agents}}.",
+                  "현재 {{agents}} 직원이 사용 중입니다.",
+                  { agents: deleteTargetDetail.usedByAgents.map((agent) => agent.name).join(", ") },
+                )}
               </div>
             ) : null}
             {(deleteTargetDetail?.usedByAgents.length ?? 0) > 0 ? (
               <p className="text-muted-foreground">
-                Detach this skill from all agents to enable removal.
+                {copy("skills.remove.detachFirst", "Detach this skill from all agents to enable removal.", "삭제하려면 먼저 모든 직원에서 이 스킬 연결을 해제하세요.")}
               </p>
             ) : null}
           </div>
           <DialogFooter>
             {(deleteTargetDetail?.usedByAgents.length ?? 0) > 0 ? (
               <Button variant="ghost" onClick={() => closeDeleteDialog(false)}>
-                Close
+                {copy("common.close", "Close", "닫기")}
               </Button>
             ) : (
               <>
                 <Button variant="ghost" onClick={() => closeDeleteDialog(false)} disabled={deleteSkill.isPending}>
-                  Cancel
+                  {copy("common.cancel", "Cancel", "취소")}
                 </Button>
                 <Button
                   variant="destructive"
                   onClick={() => deleteSkill.mutate()}
                   disabled={deleteSkill.isPending || !deleteTargetSkillId}
                 >
-                  {deleteSkill.isPending ? "Removing..." : "Remove skill"}
+                  {deleteSkill.isPending
+                    ? copy("skills.remove.removing", "Removing...", "삭제 중...")
+                    : copy("skills.remove.action", "Remove skill", "스킬 삭제")}
                 </Button>
               </>
             )}
@@ -1145,9 +1235,13 @@ export function CompanySkills() {
       <Dialog open={emptySourceHelpOpen} onOpenChange={setEmptySourceHelpOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Add a skill source</DialogTitle>
+            <DialogTitle>{copy("skills.addSource.title", "Add a skill source", "스킬 출처 추가")}</DialogTitle>
             <DialogDescription>
-              Paste a local path, GitHub URL, or `skills.sh` command into the field first.
+              {copy(
+                "skills.addSource.description",
+                "Paste a local path, GitHub URL, or `skills.sh` command into the field first.",
+                "먼저 로컬 경로, GitHub URL 또는 `skills.sh` 명령을 입력란에 붙여넣으세요.",
+              )}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 text-sm">
@@ -1158,9 +1252,9 @@ export function CompanySkills() {
               className="flex items-start justify-between rounded-md border border-border px-3 py-3 text-foreground no-underline transition-colors hover:bg-accent/40"
             >
               <span>
-                <span className="block font-medium">Browse skills.sh</span>
+                <span className="block font-medium">{copy("skills.addSource.browseSkillsSh", "Browse skills.sh", "skills.sh 둘러보기")}</span>
                 <span className="mt-1 block text-muted-foreground">
-                  Find install commands and paste one here.
+                  {copy("skills.addSource.browseHelp", "Find install commands and paste one here.", "설치 명령을 찾아 여기에 붙여넣으세요.")}
                 </span>
               </span>
               <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
@@ -1172,9 +1266,13 @@ export function CompanySkills() {
               className="flex items-start justify-between rounded-md border border-border px-3 py-3 text-foreground no-underline transition-colors hover:bg-accent/40"
             >
               <span>
-                <span className="block font-medium">Search GitHub</span>
+                <span className="block font-medium">{copy("skills.addSource.searchGithub", "Search GitHub", "GitHub 검색")}</span>
                 <span className="mt-1 block text-muted-foreground">
-                  Look for repositories with `SKILL.md`, then paste the repo URL here.
+                  {copy(
+                    "skills.addSource.githubHelp",
+                    "Look for repositories with `SKILL.md`, then paste the repo URL here.",
+                    "`SKILL.md`가 있는 저장소를 찾은 뒤 저장소 URL을 여기에 붙여넣으세요.",
+                  )}
                 </span>
               </span>
               <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
@@ -1189,9 +1287,9 @@ export function CompanySkills() {
           <div className="border-b border-border px-4 py-3">
             <div className="flex items-center justify-between gap-2">
               <div>
-                <h1 className="text-base font-semibold">Skills</h1>
+                <h1 className="text-base font-semibold">{copy("skills.title", "Skills", "스킬")}</h1>
                 <p className="text-xs text-muted-foreground">
-                  {skillsQuery.data?.length ?? 0} available
+                  {copy("skills.available", "{{count}} available", "{{count}}개 사용 가능", { count: skillsQuery.data?.length ?? 0 })}
                 </p>
               </div>
               <div className="flex items-center gap-1">
@@ -1200,11 +1298,18 @@ export function CompanySkills() {
                   size="icon-sm"
                   onClick={() => scanProjects.mutate()}
                   disabled={scanProjects.isPending}
-                  title="Scan project workspaces for skills"
+                  title={copy("skills.scan.action", "Scan project workspaces for skills", "프로젝트 작업공간에서 스킬 찾기")}
+                  aria-label={copy("skills.scan.action", "Scan project workspaces for skills", "프로젝트 작업공간에서 스킬 찾기")}
                 >
                   <RefreshCw className={cn("h-4 w-4", scanProjects.isPending && "animate-spin")} />
                 </Button>
-                <Button variant="ghost" size="icon-sm" onClick={() => setCreateOpen((value) => !value)}>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setCreateOpen((value) => !value)}
+                  aria-label={copy("skills.new.open", "Create skill", "스킬 만들기")}
+                  title={copy("skills.new.open", "Create skill", "스킬 만들기")}
+                >
                   <Plus className="h-4 w-4" />
                 </Button>
               </div>
@@ -1215,7 +1320,7 @@ export function CompanySkills() {
               <input
                 value={skillFilter}
                 onChange={(event) => setSkillFilter(event.target.value)}
-                placeholder="Filter skills"
+                placeholder={copy("skills.filter.placeholder", "Filter skills", "스킬 필터")}
                 className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
               />
             </div>
@@ -1224,7 +1329,11 @@ export function CompanySkills() {
               <input
                 value={source}
                 onChange={(event) => setSource(event.target.value)}
-                placeholder="Paste path, GitHub URL, or skills.sh command"
+                placeholder={copy(
+                  "skills.source.placeholder",
+                  "Paste path, GitHub URL, or skills.sh command",
+                  "경로, GitHub URL 또는 skills.sh 명령 붙여넣기",
+                )}
                 className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
               />
               <Button
@@ -1233,7 +1342,7 @@ export function CompanySkills() {
                 onClick={handleAddSkillSource}
                 disabled={importSkill.isPending}
               >
-                {importSkill.isPending ? <RefreshCw className="h-4 w-4 animate-spin" /> : "Add"}
+                {importSkill.isPending ? <RefreshCw className="h-4 w-4 animate-spin" /> : copy("common.add", "Add", "추가")}
               </Button>
             </div>
             {scanStatusMessage && (

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -27,6 +27,7 @@ import { StatusBadge } from "../components/StatusBadge";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useCompany } from "../context/CompanyContext";
 import { useDateRange, PRESET_KEYS, PRESET_LABELS } from "../hooks/useDateRange";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import { queryKeys } from "../lib/queryKeys";
 import { billingTypeDisplayName, cn, formatCents, formatTokens, providerDisplayName } from "../lib/utils";
 import { Button } from "@/components/ui/button";
@@ -108,37 +109,47 @@ function FinanceSummaryCard({
   estimatedDebitCents: number;
   eventCount: number;
 }) {
+  const copy = useLocalizedCopy();
   return (
     <Card>
       <CardHeader className="px-5 pt-5 pb-2">
-        <CardTitle className="text-base">Finance ledger</CardTitle>
+        <CardTitle className="text-base">{copy("costs.financeLedger", "Finance ledger", "재무 장부")}</CardTitle>
         <CardDescription>
-          Account-level charges that do not map to a single inference request.
+          {copy(
+            "costs.financeLedger.description",
+            "Account-level charges that do not map to a single inference request.",
+            "단일 추론 요청에 직접 매핑되지 않는 계정 단위 비용입니다.",
+          )}
         </CardDescription>
       </CardHeader>
       <CardContent className="grid gap-3 px-5 pb-5 pt-2 sm:grid-cols-2 xl:grid-cols-4">
         <MetricTile
-          label="Debits"
+          label={copy("costs.debits", "Debits", "차감")}
           value={formatCents(debitCents)}
-          subtitle={`${eventCount} total event${eventCount === 1 ? "" : "s"} in range`}
+          subtitle={copy(
+            "costs.finance.eventsInRange",
+            eventCount === 1 ? "{{count}} total event in range" : "{{count}} total events in range",
+            "범위 내 총 이벤트 {{count}}건",
+            { count: eventCount },
+          )}
           icon={ArrowUpRight}
         />
         <MetricTile
-          label="Credits"
+          label={copy("costs.credits", "Credits", "크레딧")}
           value={formatCents(creditCents)}
-          subtitle="Refunds, offsets, and credit returns"
+          subtitle={copy("costs.credits.subtitle", "Refunds, offsets, and credit returns", "환불, 상계, 크레딧 반환")}
           icon={ArrowDownLeft}
         />
         <MetricTile
-          label="Net"
+          label={copy("costs.net", "Net", "순액")}
           value={formatCents(netCents)}
-          subtitle="Debit minus credit for the selected period"
+          subtitle={copy("costs.net.subtitle", "Debit minus credit for the selected period", "선택 기간의 차감액에서 크레딧을 뺀 값")}
           icon={ReceiptText}
         />
         <MetricTile
-          label="Estimated"
+          label={copy("costs.estimated", "Estimated", "추정")}
           value={formatCents(estimatedDebitCents)}
-          subtitle="Estimated debits that are not yet invoice-authoritative"
+          subtitle={copy("costs.estimated.subtitle", "Estimated debits that are not yet invoice-authoritative", "아직 청구서 기준으로 확정되지 않은 추정 차감액")}
           icon={Coins}
         />
       </CardContent>
@@ -149,6 +160,7 @@ function FinanceSummaryCard({
 export function Costs() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
 
   const [mainTab, setMainTab] = useState<"overview" | "budgets" | "providers" | "billers" | "finance">("overview");
@@ -168,8 +180,8 @@ export function Costs() {
   } = useDateRange();
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Costs" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("costs.breadcrumb", "Costs", "비용") }]);
+  }, [copy, setBreadcrumbs]);
 
   const [today, setToday] = useState(() => new Date().toDateString());
   const todayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -436,6 +448,17 @@ export function Costs() {
 
   const providers = useMemo(() => Array.from(byProvider.keys()), [byProvider]);
   const billers = useMemo(() => Array.from(byBiller.keys()), [byBiller]);
+  const billingModeSummary = useMemo(() => {
+    let apiRunCount = 0;
+    let subscriptionRunCount = 0;
+    let subscriptionTokens = 0;
+    for (const row of spendData?.byAgent ?? []) {
+      apiRunCount += row.apiRunCount;
+      subscriptionRunCount += row.subscriptionRunCount;
+      subscriptionTokens += row.subscriptionCachedInputTokens + row.subscriptionInputTokens + row.subscriptionOutputTokens;
+    }
+    return { apiRunCount, subscriptionRunCount, subscriptionTokens };
+  }, [spendData?.byAgent]);
 
   const effectiveProvider =
     activeProvider === "all" || providers.includes(activeProvider) ? activeProvider : "all";
@@ -463,8 +486,8 @@ export function Costs() {
       {
         value: "all",
         label: (
-          <span className="flex items-center gap-1.5">
-            <span>All providers</span>
+            <span className="flex items-center gap-1.5">
+            <span>{copy("costs.allProviders", "All providers", "전체 제공자")}</span>
             {providerKeys.length > 0 ? (
               <>
                 <span className="font-mono text-xs text-muted-foreground">{formatTokens(allTokens)}</span>
@@ -479,7 +502,7 @@ export function Costs() {
         label: <ProviderTabLabel provider={provider} rows={byProvider.get(provider) ?? []} />,
       })),
     ];
-  }, [byProvider]);
+  }, [byProvider, copy]);
 
   const billerTabItems = useMemo(() => {
     const billerKeys = Array.from(byBiller.keys());
@@ -495,8 +518,8 @@ export function Costs() {
       {
         value: "all",
         label: (
-          <span className="flex items-center gap-1.5">
-            <span>All billers</span>
+            <span className="flex items-center gap-1.5">
+            <span>{copy("costs.allBillers", "All billers", "전체 청구자")}</span>
             {billerKeys.length > 0 ? (
               <>
                 <span className="font-mono text-xs text-muted-foreground">{formatTokens(allTokens)}</span>
@@ -511,7 +534,7 @@ export function Costs() {
         label: <BillerTabLabel biller={biller} rows={byBiller.get(biller) ?? []} />,
       })),
     ];
-  }, [byBiller]);
+  }, [byBiller, copy]);
 
   const inferenceTokenTotal =
     (spendData?.byAgent ?? []).reduce(
@@ -522,6 +545,14 @@ export function Costs() {
   const topFinanceEvents = (financeData?.events ?? []) as FinanceEvent[];
   const budgetPolicies = budgetData?.policies ?? [];
   const activeBudgetIncidents = budgetData?.activeIncidents ?? [];
+  const presetLabels = {
+    mtd: copy("costs.preset.mtd", PRESET_LABELS.mtd, "이번 달"),
+    "7d": copy("costs.preset.7d", PRESET_LABELS["7d"], "최근 7일"),
+    "30d": copy("costs.preset.30d", PRESET_LABELS["30d"], "최근 30일"),
+    ytd: copy("costs.preset.ytd", PRESET_LABELS.ytd, "올해"),
+    all: copy("costs.preset.all", PRESET_LABELS.all, "전체"),
+    custom: copy("costs.preset.custom", PRESET_LABELS.custom, "직접 선택"),
+  };
   const budgetPoliciesByScope = useMemo(() => ({
     company: budgetPolicies.filter((policy) => policy.scopeType === "company"),
     agent: budgetPolicies.filter((policy) => policy.scopeType === "agent"),
@@ -529,7 +560,7 @@ export function Costs() {
   }), [budgetPolicies]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={DollarSign} message="Select a company to view costs." />;
+    return <EmptyState icon={DollarSign} message={copy("costs.noCompany", "Select a company to view costs.", "비용을 보려면 회사를 선택하세요.")} />;
   }
 
   const showCustomPrompt = preset === "custom" && !customReady;
@@ -541,9 +572,13 @@ export function Costs() {
       <div className="space-y-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
-                <h1 className="text-3xl font-semibold tracking-tight">Costs</h1>
+                <h1 className="text-3xl font-semibold tracking-tight">{copy("costs.title", "Costs", "비용")}</h1>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                  Inference spend, platform fees, credits, and live quota windows.
+                  {copy(
+                    "costs.subtitle",
+                    "Inference spend, platform fees, credits, and live quota windows.",
+                    "추론 지출, 플랫폼 비용, 크레딧, 실시간 quota 구간을 관리합니다.",
+                  )}
                 </p>
             </div>
 
@@ -555,7 +590,7 @@ export function Costs() {
                   size="sm"
                   onClick={() => setPreset(key)}
                 >
-                  {PRESET_LABELS[key]}
+                  {presetLabels[key]}
                 </Button>
               ))}
             </div>
@@ -569,7 +604,7 @@ export function Costs() {
                 onChange={(event) => setCustomFrom(event.target.value)}
                 className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
               />
-              <span className="text-sm text-muted-foreground">to</span>
+              <span className="text-sm text-muted-foreground">{copy("costs.dateRange.to", "to", "까지")}</span>
               <input
                 type="date"
                 value={customTo}
@@ -581,54 +616,97 @@ export function Costs() {
 
           <div className="grid gap-3 lg:grid-cols-4">
             <MetricTile
-              label="Inference spend"
+              label={copy("costs.inferenceSpend", "Inference spend", "추론 지출")}
               value={formatCents(spendData?.summary.spendCents ?? 0)}
-              subtitle={`${formatTokens(inferenceTokenTotal)} tokens across request-scoped events`}
+              subtitle={copy(
+                "costs.inferenceSpend.subtitle",
+                "{{tokens}} tokens across request-scoped events",
+                "요청 단위 이벤트 토큰 {{tokens}}",
+                { tokens: formatTokens(inferenceTokenTotal) },
+              )}
               icon={DollarSign}
             />
             <MetricTile
-              label="Budget"
+              label={copy("costs.budget", "Budget", "예산")}
               value={activeBudgetIncidents.length > 0 ? String(activeBudgetIncidents.length) : (
                 spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
                   ? `${spendData.summary.utilizationPercent}%`
-                  : "Open"
+                  : copy("costs.budget.open", "Open", "열림")
               )}
               subtitle={
                 activeBudgetIncidents.length > 0
-                  ? `${budgetData?.pausedAgentCount ?? 0} agents paused · ${budgetData?.pausedProjectCount ?? 0} projects paused`
+                  ? copy(
+                    "costs.budget.paused",
+                    "{{agents}} agents paused · {{projects}} projects paused",
+                    "직원 {{agents}}명 일시정지 · 프로젝트 {{projects}}개 일시정지",
+                    { agents: budgetData?.pausedAgentCount ?? 0, projects: budgetData?.pausedProjectCount ?? 0 },
+                  )
                   : spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
                     ? `${formatCents(spendData.summary.spendCents)} of ${formatCents(spendData.summary.budgetCents)}`
-                    : "No monthly cap configured"
+                    : copy("costs.budget.noCap", "No monthly cap configured", "월 한도 미설정")
               }
               icon={Coins}
             />
             <MetricTile
-              label="Finance net"
+              label={copy("costs.financeNet", "Finance net", "재무 순액")}
               value={formatCents(financeData?.summary.netCents ?? 0)}
-              subtitle={`${formatCents(financeData?.summary.debitCents ?? 0)} debits · ${formatCents(financeData?.summary.creditCents ?? 0)} credits`}
+              subtitle={copy(
+                "costs.financeNet.subtitle",
+                "{{debits}} debits · {{credits}} credits",
+                "차감 {{debits}} · 크레딧 {{credits}}",
+                { debits: formatCents(financeData?.summary.debitCents ?? 0), credits: formatCents(financeData?.summary.creditCents ?? 0) },
+              )}
               icon={ReceiptText}
             />
             <MetricTile
-              label="Finance events"
+              label={copy("costs.financeEvents", "Finance events", "재무 이벤트")}
               value={String(financeData?.summary.eventCount ?? 0)}
-              subtitle={`${formatCents(financeData?.summary.estimatedDebitCents ?? 0)} estimated in range`}
+              subtitle={copy(
+                "costs.financeEvents.subtitle",
+                "{{amount}} estimated in range",
+                "범위 내 추정 {{amount}}",
+                { amount: formatCents(financeData?.summary.estimatedDebitCents ?? 0) },
+              )}
               icon={ArrowUpRight}
             />
+          </div>
+
+          <div className="grid gap-3 border border-border p-4 md:grid-cols-[1fr_auto] md:items-center">
+            <div className="min-w-0">
+              <div className="text-sm font-medium">{copy("costs.billingMode.title", "Billing mode split", "구독/API 과금 구분")}</div>
+              <div className="mt-1 text-sm text-muted-foreground">
+                {copy(
+                  "costs.billingMode.description",
+                  "Subscription-included runs are counted separately from API-billed spend so GPT Max-style usage is not mistaken for direct API charges.",
+                  "구독형 포함 실행은 API 과금 지출과 분리해 표시하므로 GPT Max형 사용량을 직접 API 비용으로 오해하지 않습니다.",
+                )}
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              <span className="border border-border px-3 py-2">
+                {copy("costs.billingMode.subscription", "Subscription {{count}} runs", "구독형 {{count}}회", { count: billingModeSummary.subscriptionRunCount })}
+                {" · "}
+                {formatTokens(billingModeSummary.subscriptionTokens)}
+              </span>
+              <span className="border border-border px-3 py-2">
+                {copy("costs.billingMode.api", "API {{count}} runs", "API {{count}}회", { count: billingModeSummary.apiRunCount })}
+              </span>
+            </div>
           </div>
       </div>
 
       <Tabs value={mainTab} onValueChange={(value) => setMainTab(value as typeof mainTab)}>
         <TabsList variant="line" className="justify-start">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="budgets">Budgets</TabsTrigger>
-          <TabsTrigger value="providers">Providers</TabsTrigger>
-          <TabsTrigger value="billers">Billers</TabsTrigger>
-          <TabsTrigger value="finance">Finance</TabsTrigger>
+          <TabsTrigger value="overview">{copy("costs.tab.overview", "Overview", "개요")}</TabsTrigger>
+          <TabsTrigger value="budgets">{copy("costs.tab.budgets", "Budgets", "예산")}</TabsTrigger>
+          <TabsTrigger value="providers">{copy("costs.tab.providers", "Providers", "제공자")}</TabsTrigger>
+          <TabsTrigger value="billers">{copy("costs.tab.billers", "Billers", "청구자")}</TabsTrigger>
+          <TabsTrigger value="finance">{copy("costs.tab.finance", "Finance", "재무")}</TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{copy("costs.customPrompt", "Select a start and end date to load data.", "데이터를 불러올 시작일과 종료일을 선택하세요.")}</p>
           ) : showOverviewLoading ? (
             <PageSkeleton variant="costs" />
           ) : overviewError ? (
@@ -657,9 +735,13 @@ export function Costs() {
               <div className="grid gap-4 xl:grid-cols-[1.3fr,1fr]">
                 <Card>
                   <CardHeader className="px-5 pt-5 pb-2">
-                    <CardTitle className="text-base">Inference ledger</CardTitle>
+                    <CardTitle className="text-base">{copy("costs.inferenceLedger", "Inference ledger", "추론 장부")}</CardTitle>
                     <CardDescription>
-                      Request-scoped inference spend for the selected period.
+                      {copy(
+                        "costs.inferenceLedger.description",
+                        "Request-scoped inference spend for the selected period.",
+                        "선택 기간의 요청 단위 추론 지출입니다.",
+                      )}
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4 px-5 pb-5 pt-2">
@@ -670,12 +752,12 @@ export function Costs() {
                         </div>
                         <div className="mt-1 text-sm text-muted-foreground">
                           {spendData?.summary.budgetCents && spendData.summary.budgetCents > 0
-                            ? `Budget ${formatCents(spendData.summary.budgetCents)}`
-                            : "Unlimited budget"}
+                            ? copy("costs.inferenceLedger.budget", "Budget {{amount}}", "예산 {{amount}}", { amount: formatCents(spendData.summary.budgetCents) })
+                            : copy("costs.inferenceLedger.unlimited", "Unlimited budget", "무제한 예산")}
                         </div>
                       </div>
                       <div className="border border-border px-4 py-3 text-right">
-                        <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">usage</div>
+                        <div className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">{copy("costs.usage", "usage", "사용량")}</div>
                         <div className="mt-1 text-lg font-medium tabular-nums">
                           {formatTokens(inferenceTokenTotal)}
                         </div>
@@ -697,7 +779,12 @@ export function Costs() {
                           />
                         </div>
                         <div className="text-xs text-muted-foreground">
-                          {spendData.summary.utilizationPercent}% of monthly budget consumed in this range.
+                          {copy(
+                            "costs.inferenceLedger.utilization",
+                            "{{percent}}% of monthly budget consumed in this range.",
+                            "이 범위에서 월 예산의 {{percent}}%를 사용했습니다.",
+                            { percent: spendData.summary.utilizationPercent },
+                          )}
                         </div>
                       </div>
                     ) : null}
@@ -716,12 +803,14 @@ export function Costs() {
               <div className="grid gap-4 xl:grid-cols-[1.25fr,0.95fr]">
                 <Card>
                   <CardHeader className="px-5 pt-5 pb-2">
-                    <CardTitle className="text-base">By agent</CardTitle>
-                    <CardDescription>What each agent consumed in the selected period.</CardDescription>
+                    <CardTitle className="text-base">{copy("costs.byAgent", "By agent", "직원별")}</CardTitle>
+                    <CardDescription>
+                      {copy("costs.byAgent.description", "What each agent consumed in the selected period.", "선택 기간 동안 각 직원이 사용한 비용입니다.")}
+                    </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-2 px-5 pb-5 pt-2">
                     {(spendData?.byAgent.length ?? 0) === 0 ? (
-                      <p className="text-sm text-muted-foreground">No cost events yet.</p>
+                      <p className="text-sm text-muted-foreground">{copy("costs.empty.costEvents", "No cost events yet.", "아직 비용 이벤트가 없습니다.")}</p>
                     ) : (
                       spendData?.byAgent.map((row) => {
                         const modelRows = agentModelRows.get(row.agentId) ?? [];
@@ -747,15 +836,20 @@ export function Costs() {
                               <div className="text-right text-sm tabular-nums">
                                 <div className="font-medium">{formatCents(row.costCents)}</div>
                                 <div className="text-xs text-muted-foreground">
-                                  in {formatTokens(row.inputTokens + row.cachedInputTokens)} · out {formatTokens(row.outputTokens)}
+                                  {copy("costs.tokens.inOut", "in {{input}} · out {{output}}", "입력 {{input}} · 출력 {{output}}", {
+                                    input: formatTokens(row.inputTokens + row.cachedInputTokens),
+                                    output: formatTokens(row.outputTokens),
+                                  })}
                                 </div>
                                 {(row.apiRunCount > 0 || row.subscriptionRunCount > 0) ? (
                                   <div className="text-xs text-muted-foreground">
-                                    {row.apiRunCount > 0 ? `${row.apiRunCount} api` : "0 api"}
+                                    {row.apiRunCount > 0
+                                      ? copy("costs.runCount.api", "{{count}} api", "API {{count}}회", { count: row.apiRunCount })
+                                      : copy("costs.runCount.api", "{{count}} api", "API {{count}}회", { count: 0 })}
                                     {" · "}
                                     {row.subscriptionRunCount > 0
-                                      ? `${row.subscriptionRunCount} subscription`
-                                      : "0 subscription"}
+                                      ? copy("costs.runCount.subscription", "{{count}} subscription", "구독 {{count}}회", { count: row.subscriptionRunCount })
+                                      : copy("costs.runCount.subscription", "{{count}} subscription", "구독 {{count}}회", { count: 0 })}
                                   </div>
                                 ) : null}
                               </div>
@@ -804,19 +898,19 @@ export function Costs() {
                 <div className="space-y-4">
                   <Card>
                     <CardHeader className="px-5 pt-5 pb-2">
-                      <CardTitle className="text-base">By project</CardTitle>
-                      <CardDescription>Run costs attributed through project-linked issues.</CardDescription>
+                      <CardTitle className="text-base">{copy("costs.byProject", "By project", "프로젝트별")}</CardTitle>
+                      <CardDescription>{copy("costs.byProject.description", "Run costs attributed through project-linked issues.", "프로젝트와 연결된 작업을 통해 귀속된 실행 비용입니다.")}</CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-2 px-5 pb-5 pt-2">
                       {(spendData?.byProject.length ?? 0) === 0 ? (
-                        <p className="text-sm text-muted-foreground">No project-attributed run costs yet.</p>
+                        <p className="text-sm text-muted-foreground">{copy("costs.empty.projectCosts", "No project-attributed run costs yet.", "아직 프로젝트 귀속 실행 비용이 없습니다.")}</p>
                       ) : (
                         spendData?.byProject.map((row, index) => (
                           <div
                             key={row.projectId ?? `unattributed-${index}`}
                             className="flex items-center justify-between gap-3 border border-border px-3 py-2 text-sm"
                           >
-                            <span className="truncate">{row.projectName ?? row.projectId ?? "Unattributed"}</span>
+                            <span className="truncate">{row.projectName ?? row.projectId ?? copy("costs.unattributed", "Unattributed", "미귀속")}</span>
                             <span className="font-medium tabular-nums">{formatCents(row.costCents)}</span>
                           </div>
                         ))
@@ -824,7 +918,14 @@ export function Costs() {
                     </CardContent>
                   </Card>
 
-                  <FinanceTimelineCard rows={topFinanceEvents.slice(0, 6)} emptyMessage="No finance events yet. Add account-level charges once biller invoices or credits land." />
+                  <FinanceTimelineCard
+                    rows={topFinanceEvents.slice(0, 6)}
+                    emptyMessage={copy(
+                      "costs.empty.financeTimeline",
+                      "No finance events yet. Add account-level charges once biller invoices or credits land.",
+                      "아직 재무 이벤트가 없습니다. 청구자 인보이스나 크레딧이 반영되면 계정 단위 비용을 추가하세요.",
+                    )}
+                  />
                 </div>
               </div>
             </>
@@ -840,34 +941,38 @@ export function Costs() {
             <>
               <Card className="border-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))]">
                 <CardHeader className="px-5 pt-5 pb-3">
-                  <CardTitle className="text-base">Budget control plane</CardTitle>
+                  <CardTitle className="text-base">{copy("costs.budgetControl", "Budget control plane", "예산 제어판")}</CardTitle>
                   <CardDescription>
-                    Hard-stop spend limits for agents and projects. Provider subscription quota stays separate and appears under Providers.
+                    {copy(
+                      "costs.budgetControl.description",
+                      "Hard-stop spend limits for agents and projects. Provider subscription quota stays separate and appears under Providers.",
+                      "직원과 프로젝트의 강제 중지 지출 한도입니다. 제공자 구독 quota는 별도로 Providers 아래에 표시됩니다.",
+                    )}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="grid gap-3 px-5 pb-5 pt-0 md:grid-cols-4">
                   <MetricTile
-                    label="Active incidents"
+                    label={copy("costs.activeIncidents", "Active incidents", "활성 사고")}
                     value={String(activeBudgetIncidents.length)}
-                    subtitle="Open soft or hard threshold crossings"
+                    subtitle={copy("costs.activeIncidents.subtitle", "Open soft or hard threshold crossings", "열려 있는 소프트/하드 한도 초과")}
                     icon={ReceiptText}
                   />
                   <MetricTile
-                    label="Pending approvals"
+                    label={copy("costs.pendingApprovals", "Pending approvals", "대기 승인")}
                     value={String(budgetData?.pendingApprovalCount ?? 0)}
-                    subtitle="Budget override approvals awaiting board action"
+                    subtitle={copy("costs.pendingApprovals.subtitle", "Budget override approvals awaiting board action", "보드 처리를 기다리는 예산 초과 승인")}
                     icon={ArrowUpRight}
                   />
                   <MetricTile
-                    label="Paused agents"
+                    label={copy("costs.pausedAgents", "Paused agents", "일시정지 직원")}
                     value={String(budgetData?.pausedAgentCount ?? 0)}
-                    subtitle="Agent heartbeats blocked by budget"
+                    subtitle={copy("costs.pausedAgents.subtitle", "Agent heartbeats blocked by budget", "예산으로 차단된 직원 상태 점검")}
                     icon={Coins}
                   />
                   <MetricTile
-                    label="Paused projects"
+                    label={copy("costs.pausedProjects", "Paused projects", "일시정지 프로젝트")}
                     value={String(budgetData?.pausedProjectCount ?? 0)}
-                    subtitle="Project execution blocked by budget"
+                    subtitle={copy("costs.pausedProjects.subtitle", "Project execution blocked by budget", "예산으로 차단된 프로젝트 실행")}
                     icon={DollarSign}
                   />
                 </CardContent>
@@ -876,9 +981,13 @@ export function Costs() {
               {activeBudgetIncidents.length > 0 ? (
                 <div className="space-y-3">
                   <div>
-                    <h2 className="text-lg font-semibold">Active incidents</h2>
+                    <h2 className="text-lg font-semibold">{copy("costs.activeIncidents", "Active incidents", "활성 사고")}</h2>
                     <p className="text-sm text-muted-foreground">
-                      Resolve hard stops here by raising the budget or explicitly keeping the scope paused.
+                      {copy(
+                        "costs.activeIncidents.description",
+                        "Resolve hard stops here by raising the budget or explicitly keeping the scope paused.",
+                        "예산을 올리거나 범위를 명시적으로 일시정지 상태로 유지해 강제 중지를 처리합니다.",
+                      )}
                     </p>
                   </div>
                   <div className="grid gap-4 xl:grid-cols-2">
@@ -907,13 +1016,19 @@ export function Costs() {
                   return (
                     <section key={scopeType} className="space-y-3">
                       <div>
-                        <h2 className="text-lg font-semibold capitalize">{scopeType} budgets</h2>
+                        <h2 className="text-lg font-semibold capitalize">
+                          {scopeType === "company"
+                            ? copy("costs.budgetScope.company", "Company budgets", "회사 예산")
+                            : scopeType === "agent"
+                              ? copy("costs.budgetScope.agent", "Agent budgets", "직원 예산")
+                              : copy("costs.budgetScope.project", "Project budgets", "프로젝트 예산")}
+                        </h2>
                         <p className="text-sm text-muted-foreground">
                           {scopeType === "company"
-                            ? "Company-wide monthly policy."
+                            ? copy("costs.budgetScope.companyHelp", "Company-wide monthly policy.", "회사 전체 월간 정책입니다.")
                             : scopeType === "agent"
-                              ? "Recurring monthly spend policies for individual agents."
-                              : "Lifetime spend policies for execution-bound projects."}
+                              ? copy("costs.budgetScope.agentHelp", "Recurring monthly spend policies for individual agents.", "개별 직원의 반복 월간 지출 정책입니다.")
+                              : copy("costs.budgetScope.projectHelp", "Lifetime spend policies for execution-bound projects.", "실행 연결 프로젝트의 누적 지출 정책입니다.")}
                         </p>
                       </div>
                       <div className="grid gap-4 xl:grid-cols-2">
@@ -939,7 +1054,11 @@ export function Costs() {
                 {budgetPolicies.length === 0 ? (
                   <Card>
                     <CardContent className="px-5 py-8 text-sm text-muted-foreground">
-                      No budget policies yet. Set agent and project budgets from their detail pages, or use the existing company monthly budget control.
+                      {copy(
+                        "costs.empty.budgetPolicies",
+                        "No budget policies yet. Set agent and project budgets from their detail pages, or use the existing company monthly budget control.",
+                        "아직 예산 정책이 없습니다. 직원/프로젝트 상세에서 예산을 설정하거나 기존 회사 월간 예산 제어를 사용하세요.",
+                      )}
                     </CardContent>
                   </Card>
                 ) : null}
@@ -950,7 +1069,7 @@ export function Costs() {
 
         <TabsContent value="providers" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{copy("costs.customPrompt", "Select a start and end date to load data.", "데이터를 불러올 시작일과 종료일을 선택하세요.")}</p>
           ) : (
             <>
               <Tabs value={effectiveProvider} onValueChange={setActiveProvider}>
@@ -958,7 +1077,7 @@ export function Costs() {
 
                 <TabsContent value="all" className="mt-4">
                   {providers.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">No cost events in this period.</p>
+                    <p className="text-sm text-muted-foreground">{copy("costs.empty.periodCosts", "No cost events in this period.", "이 기간에는 비용 이벤트가 없습니다.")}</p>
                   ) : (
                     <div className="grid gap-4 md:grid-cols-2">
                       {providers.map((provider) => (
@@ -1005,7 +1124,7 @@ export function Costs() {
 
         <TabsContent value="billers" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{copy("costs.customPrompt", "Select a start and end date to load data.", "데이터를 불러올 시작일과 종료일을 선택하세요.")}</p>
           ) : (
             <>
               <Tabs value={effectiveBiller} onValueChange={setActiveBiller}>
@@ -1013,7 +1132,7 @@ export function Costs() {
 
                 <TabsContent value="all" className="mt-4">
                   {billers.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">No billable events in this period.</p>
+                    <p className="text-sm text-muted-foreground">{copy("costs.empty.billablePeriod", "No billable events in this period.", "이 기간에는 청구 가능 이벤트가 없습니다.")}</p>
                   ) : (
                     <div className="grid gap-4 md:grid-cols-2">
                       {billers.map((biller) => {
@@ -1058,7 +1177,7 @@ export function Costs() {
 
         <TabsContent value="finance" className="mt-4 space-y-4">
           {showCustomPrompt ? (
-            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+            <p className="text-sm text-muted-foreground">{copy("costs.customPrompt", "Select a start and end date to load data.", "데이터를 불러올 시작일과 종료일을 선택하세요.")}</p>
           ) : financeLoading ? (
             <PageSkeleton variant="costs" />
           ) : financeError ? (
@@ -1077,12 +1196,18 @@ export function Costs() {
                 <div className="space-y-4">
                   <Card>
                     <CardHeader className="px-5 pt-5 pb-2">
-                      <CardTitle className="text-base">By biller</CardTitle>
-                      <CardDescription>Account-level financial events grouped by who charged or credited them.</CardDescription>
+                      <CardTitle className="text-base">{copy("costs.byBiller", "By biller", "청구자별")}</CardTitle>
+                      <CardDescription>
+                        {copy(
+                          "costs.byBiller.description",
+                          "Account-level financial events grouped by who charged or credited them.",
+                          "비용을 청구하거나 크레딧을 준 주체별 계정 단위 재무 이벤트입니다.",
+                        )}
+                      </CardDescription>
                     </CardHeader>
                     <CardContent className="grid gap-4 px-5 pb-5 pt-2 md:grid-cols-2">
                       {(financeData?.byBiller.length ?? 0) === 0 ? (
-                        <p className="text-sm text-muted-foreground">No finance events yet.</p>
+                        <p className="text-sm text-muted-foreground">{copy("costs.empty.financeEvents", "No finance events yet.", "아직 재무 이벤트가 없습니다.")}</p>
                       ) : (
                         financeData?.byBiller.map((row) => <FinanceBillerCard key={row.biller} row={row} />)
                       )}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRa
 import { PageSkeleton } from "../components/PageSkeleton";
 import type { Agent, Issue } from "@paperclipai/shared";
 import { PluginSlotOutlet } from "@/plugins/slots";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 
 const DASHBOARD_ACTIVITY_LIMIT = 10;
 
@@ -35,6 +36,8 @@ function getRecentIssues(issues: Issue[]): Issue[] {
 }
 
 export function Dashboard() {
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const { selectedCompanyId, companies } = useCompany();
   const { openOnboarding } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -50,8 +53,8 @@ export function Dashboard() {
   });
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Dashboard" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("dashboard.title", "Dashboard", "대시보드") }]);
+  }, [copy, setBreadcrumbs]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.dashboard(selectedCompanyId!),
@@ -176,14 +179,25 @@ export function Dashboard() {
       return (
         <EmptyState
           icon={LayoutDashboard}
-          message="Welcome to Paperclip. Set up your first company and agent to get started."
-          action="Get Started"
+          message={copy(
+            "dashboard.empty.welcome",
+            "Welcome to Paperclip. Set up your first company and agent to get started.",
+            "Paperclip에 오신 것을 환영합니다. 첫 회사와 직원을 설정해 시작하세요.",
+          )}
+          action={copy("dashboard.empty.getStarted", "Get Started", "시작하기")}
           onAction={openOnboarding}
         />
       );
     }
     return (
-      <EmptyState icon={LayoutDashboard} message="Create or select a company to view the dashboard." />
+      <EmptyState
+        icon={LayoutDashboard}
+        message={copy(
+          "dashboard.empty.selectCompany",
+          "Create or select a company to view the dashboard.",
+          "대시보드를 보려면 회사를 만들거나 선택하세요.",
+        )}
+      />
     );
   }
 
@@ -202,14 +216,14 @@ export function Dashboard() {
           <div className="flex items-center gap-2.5">
             <Bot className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
             <p className="text-sm text-amber-900 dark:text-amber-100">
-              You have no agents.
+              {copy("dashboard.noAgents.message", "You have no agents.", "아직 직원이 없습니다.")}
             </p>
           </div>
           <button
             onClick={() => openOnboarding({ initialStep: 2, companyId: selectedCompanyId! })}
             className="text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100 underline underline-offset-2 shrink-0"
           >
-            Create one here
+            {copy("dashboard.noAgents.action", "Create one here", "여기서 만들기")}
           </button>
         </div>
       )}
@@ -224,15 +238,29 @@ export function Dashboard() {
                 <PauseCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-300" />
                 <div>
                   <p className="text-sm font-medium text-red-50">
-                    {data.budgets.activeIncidents} active budget incident{data.budgets.activeIncidents === 1 ? "" : "s"}
+                    {copy(
+                      "dashboard.budget.activeIncidents",
+                      data.budgets.activeIncidents === 1 ? "{{count}} active budget incident" : "{{count}} active budget incidents",
+                      "활성 예산 사고 {{count}}건",
+                      { count: data.budgets.activeIncidents },
+                    )}
                   </p>
                   <p className="text-xs text-red-100/70">
-                    {data.budgets.pausedAgents} agents paused · {data.budgets.pausedProjects} projects paused · {data.budgets.pendingApprovals} pending budget approvals
+                    {copy(
+                      "dashboard.budget.summary",
+                      "{{agents}} agents paused, {{projects}} projects paused, {{approvals}} pending budget approvals",
+                      "직원 {{agents}}명 일시정지, 프로젝트 {{projects}}개 일시정지, 예산 승인 {{approvals}}건 대기",
+                      {
+                        agents: data.budgets.pausedAgents,
+                        projects: data.budgets.pausedProjects,
+                        approvals: data.budgets.pendingApprovals,
+                      },
+                    )}
                   </p>
                 </div>
               </div>
               <Link to="/costs" className="text-sm underline underline-offset-2 text-red-100">
-                Open budgets
+                {copy("dashboard.budget.open", "Open budgets", "예산 열기")}
               </Link>
             </div>
           ) : null}
@@ -241,67 +269,94 @@ export function Dashboard() {
             <MetricCard
               icon={Bot}
               value={data.agents.active + data.agents.running + data.agents.paused + data.agents.error}
-              label="Agents Enabled"
+              label={copy("dashboard.metrics.agentsEnabled", "Agents Enabled", "활성 직원")}
               to="/agents"
               description={
                 <span>
-                  {data.agents.running} running{", "}
-                  {data.agents.paused} paused{", "}
-                  {data.agents.error} errors
+                  {copy(
+                    "dashboard.metrics.agentsDescription",
+                    "{{running}} running, {{paused}} paused, {{errors}} errors",
+                    "실행 {{running}}, 일시정지 {{paused}}, 오류 {{errors}}",
+                    {
+                      running: data.agents.running,
+                      paused: data.agents.paused,
+                      errors: data.agents.error,
+                    },
+                  )}
                 </span>
               }
             />
             <MetricCard
               icon={CircleDot}
               value={data.tasks.inProgress}
-              label="Tasks In Progress"
+              label={copy("dashboard.metrics.tasksInProgress", "Tasks In Progress", "진행 중 작업")}
               to="/issues"
               description={
                 <span>
-                  {data.tasks.open} open{", "}
-                  {data.tasks.blocked} blocked
+                  {copy(
+                    "dashboard.metrics.tasksDescription",
+                    "{{open}} open, {{blocked}} blocked",
+                    "열림 {{open}}, 막힘 {{blocked}}",
+                    {
+                      open: data.tasks.open,
+                      blocked: data.tasks.blocked,
+                    },
+                  )}
                 </span>
               }
             />
             <MetricCard
               icon={DollarSign}
               value={formatCents(data.costs.monthSpendCents)}
-              label="Month Spend"
+              label={copy("dashboard.metrics.monthSpend", "Month Spend", "이번 달 지출")}
               to="/costs"
               description={
                 <span>
                   {data.costs.monthBudgetCents > 0
-                    ? `${data.costs.monthUtilizationPercent}% of ${formatCents(data.costs.monthBudgetCents)} budget`
-                    : "Unlimited budget"}
+                    ? copy(
+                      "dashboard.metrics.monthBudget",
+                      "{{percent}}% of {{budget}} budget",
+                      "예산 {{budget}} 중 {{percent}}%",
+                      {
+                        percent: data.costs.monthUtilizationPercent,
+                        budget: formatCents(data.costs.monthBudgetCents),
+                      },
+                    )
+                    : copy("dashboard.metrics.unlimitedBudget", "Unlimited budget", "무제한 예산")}
                 </span>
               }
             />
             <MetricCard
               icon={ShieldCheck}
               value={data.pendingApprovals + data.budgets.pendingApprovals}
-              label="Pending Approvals"
+              label={copy("dashboard.metrics.pendingApprovals", "Pending Approvals", "승인 대기")}
               to="/approvals"
               description={
                 <span>
                   {data.budgets.pendingApprovals > 0
-                    ? `${data.budgets.pendingApprovals} budget overrides awaiting board review`
-                    : "Awaiting board review"}
+                    ? copy(
+                      "dashboard.metrics.budgetApprovals",
+                      "{{count}} budget overrides awaiting board review",
+                      "예산 예외 승인 {{count}}건 대기",
+                      { count: data.budgets.pendingApprovals },
+                    )
+                    : copy("dashboard.metrics.awaitingReview", "Awaiting board review", "검토 대기 중")}
                 </span>
               }
             />
           </div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            <ChartCard title="Run Activity" subtitle="Last 14 days">
+            <ChartCard title={copy("dashboard.charts.runActivity", "Run Activity", "실행 활동")} subtitle={copy("dashboard.charts.last14Days", "Last 14 days", "최근 14일")}>
               <RunActivityChart activity={data.runActivity} />
             </ChartCard>
-            <ChartCard title="Issues by Priority" subtitle="Last 14 days">
+            <ChartCard title={copy("dashboard.charts.issuesByPriority", "Issues by Priority", "우선순위별 작업")} subtitle={copy("dashboard.charts.last14Days", "Last 14 days", "최근 14일")}>
               <PriorityChart issues={issues ?? []} />
             </ChartCard>
-            <ChartCard title="Issues by Status" subtitle="Last 14 days">
+            <ChartCard title={copy("dashboard.charts.issuesByStatus", "Issues by Status", "상태별 작업")} subtitle={copy("dashboard.charts.last14Days", "Last 14 days", "최근 14일")}>
               <IssueStatusChart issues={issues ?? []} />
             </ChartCard>
-            <ChartCard title="Success Rate" subtitle="Last 14 days">
+            <ChartCard title={copy("dashboard.charts.successRate", "Success Rate", "성공률")} subtitle={copy("dashboard.charts.last14Days", "Last 14 days", "최근 14일")}>
               <SuccessRateChart activity={data.runActivity} />
             </ChartCard>
           </div>
@@ -318,7 +373,7 @@ export function Dashboard() {
             {recentActivity.length > 0 && (
               <div className="min-w-0">
                 <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                  Recent Activity
+                  {copy("dashboard.recentActivity", "Recent Activity", "최근 활동")}
                 </h3>
                 <div className="border border-border divide-y divide-border overflow-hidden">
                   {recentActivity.map((event) => (
@@ -330,6 +385,7 @@ export function Dashboard() {
                       entityNameMap={entityNameMap}
                       entityTitleMap={entityTitleMap}
                       className={animatedActivityIds.has(event.id) ? "activity-row-enter" : undefined}
+                      locale={locale}
                     />
                   ))}
                 </div>
@@ -339,11 +395,13 @@ export function Dashboard() {
             {/* Recent Tasks */}
             <div className="min-w-0">
               <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-                Recent Tasks
+                {copy("dashboard.recentTasks", "Recent Tasks", "최근 작업")}
               </h3>
               {recentIssues.length === 0 ? (
                 <div className="border border-border p-4">
-                  <p className="text-sm text-muted-foreground">No tasks yet.</p>
+                  <p className="text-sm text-muted-foreground">
+                    {copy("dashboard.noTasks", "No tasks yet.", "아직 작업이 없습니다.")}
+                  </p>
                 </div>
               ) : (
                 <div className="border border-border divide-y divide-border overflow-hidden">
@@ -377,7 +435,7 @@ export function Dashboard() {
                             })()}
                             <span className="text-xs text-muted-foreground sm:hidden">&middot;</span>
                             <span className="text-xs text-muted-foreground shrink-0 sm:order-last">
-                              {timeAgo(issue.updatedAt)}
+                              {timeAgo(issue.updatedAt, locale)}
                             </span>
                           </span>
                         </span>

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -10,15 +10,17 @@ import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { Button } from "@/components/ui/button";
 import { Target, Plus } from "lucide-react";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 export function Goals() {
   const { selectedCompanyId } = useCompany();
   const { openNewGoal } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Goals" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("goals.breadcrumb", "Goals", "목표") }]);
+  }, [copy, setBreadcrumbs]);
 
   const { data: goals, isLoading, error } = useQuery({
     queryKey: queryKeys.goals.list(selectedCompanyId!),
@@ -27,7 +29,12 @@ export function Goals() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Target} message="Select a company to view goals." />;
+    return (
+      <EmptyState
+        icon={Target}
+        message={copy("goals.noCompany", "Select a company to view goals.", "목표를 보려면 회사를 선택하세요.")}
+      />
+    );
   }
 
   if (isLoading) {
@@ -41,8 +48,8 @@ export function Goals() {
       {goals && goals.length === 0 && (
         <EmptyState
           icon={Target}
-          message="No goals yet."
-          action="Add Goal"
+          message={copy("goals.empty", "No goals yet.", "아직 목표가 없습니다.")}
+          action={copy("goals.add", "Add Goal", "목표 추가")}
           onAction={() => openNewGoal()}
         />
       )}
@@ -52,7 +59,7 @@ export function Goals() {
           <div className="flex items-center justify-start">
             <Button size="sm" variant="outline" onClick={() => openNewGoal()}>
               <Plus className="h-3.5 w-3.5 mr-1.5" />
-              New Goal
+              {copy("goals.new", "New Goal", "새 목표")}
             </Button>
           </div>
           <GoalTree goals={goals} goalLink={(goal) => `/goals/${goal.id}`} />

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -1927,7 +1927,7 @@ export function Inbox() {
           <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             type="search"
-            placeholder={copy("inbox.search", "Search inbox...", "받은함 검색...")}
+            placeholder={copy("inbox.search", "Search inbox…", "받은함 검색...")}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={(e) => {
@@ -1975,7 +1975,7 @@ export function Inbox() {
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="search"
-              placeholder={copy("inbox.search", "Search inbox...", "받은함 검색...")}
+              placeholder={copy("inbox.search", "Search inbox…", "받은함 검색...")}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -156,6 +156,7 @@ import {
   type InboxWorkItemGroupBy,
 } from "../lib/inbox";
 import { useDismissedInboxAlerts, useInboxDismissals, useReadInboxItems } from "../hooks/useInboxBadge";
+import { useCurrentLocale, useLocalizedCopy } from "@/i18n/ui-copy";
 
 export { InboxIssueMetaLeading, InboxIssueTrailingColumns } from "../components/IssueColumns";
 export { IssueGroupHeader as InboxGroupHeader } from "../components/IssueGroupHeader";
@@ -663,6 +664,8 @@ function JoinRequestInboxRow({
 export function Inbox() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const { openNewIssue } = useDialogActions();
   const { isMobile } = useSidebar();
   const navigate = useNavigate();
@@ -703,11 +706,11 @@ export function Inbox() {
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
-        "Inbox",
+        copy("inbox.breadcrumb", "Inbox", "받은함"),
         `${location.pathname}${location.search}${location.hash}`,
         "inbox",
       ),
-    [location.pathname, location.search, location.hash],
+    [copy, location.pathname, location.search, location.hash],
   );
 
   const { data: session } = useQuery({
@@ -741,8 +744,8 @@ export function Inbox() {
   });
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Inbox" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("inbox.breadcrumb", "Inbox", "받은함") }]);
+  }, [copy, setBreadcrumbs]);
 
   useEffect(() => {
     saveLastInboxTab(tab);
@@ -882,7 +885,7 @@ export function Inbox() {
     if (currentUserId) {
       options.set(`user:${currentUserId}`, {
         id: `user:${currentUserId}`,
-        label: currentUserId === "local-board" ? "Board" : "Me",
+        label: currentUserId === "local-board" ? copy("common.board", "Board", "보드") : copy("common.me", "Me", "나"),
         kind: "user",
         searchText: currentUserId === "local-board" ? "board me human local-board" : `me board human ${currentUserId}`,
       });
@@ -934,7 +937,7 @@ export function Inbox() {
       if (a.kind !== b.kind) return a.kind === "user" ? -1 : 1;
       return a.label.localeCompare(b.label);
     });
-  }, [agents, currentUserId, mineIssues, touchedIssues]);
+  }, [agents, copy, currentUserId, mineIssues, touchedIssues]);
   const issuesToRender = useMemo(
     () => {
       if (tab === "mine") return visibleMineIssues;
@@ -1866,7 +1869,7 @@ export function Inbox() {
   }, [selectedIndex]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={InboxIcon} message="Select a company to view inbox." />;
+    return <EmptyState icon={InboxIcon} message={copy("inbox.noCompany", "Select a company to view inbox.", "받은함을 보려면 회사를 선택하세요.")} />;
   }
 
   const hasRunFailures = failedRuns.length > 0;
@@ -1924,7 +1927,7 @@ export function Inbox() {
           <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             type="search"
-            placeholder="Search inbox…"
+            placeholder={copy("inbox.search", "Search inbox...", "받은함 검색...")}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={(e) => {
@@ -1954,15 +1957,15 @@ export function Inbox() {
             items={[
               {
                 value: "mine",
-                label: "Mine",
+                label: copy("inbox.tabs.mine", "Mine", "내 작업"),
               },
               {
                 value: "recent",
-                label: "Recent",
+                label: copy("inbox.tabs.recent", "Recent", "최근"),
               },
-              { value: "unread", label: "Unread" },
-              { value: "blocked", label: "Blocked" },
-              { value: "all", label: "All" },
+              { value: "unread", label: copy("inbox.tabs.unread", "Unread", "읽지 않음") },
+              { value: "blocked", label: copy("inbox.tabs.blocked", "Blocked", "막힘") },
+              { value: "all", label: copy("inbox.tabs.all", "All", "전체") },
             ]}
           />
         </Tabs>
@@ -1972,7 +1975,7 @@ export function Inbox() {
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="search"
-              placeholder="Search inbox…"
+              placeholder={copy("inbox.search", "Search inbox...", "받은함 검색...")}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
@@ -2019,14 +2022,14 @@ export function Inbox() {
                     variant="outline"
                     size="icon"
                     className={cn("h-8 w-8 shrink-0", blockedGroupBy !== "none" && "bg-accent")}
-                    title="Group"
+                    title={copy("issues.group.title", "Group", "그룹")}
                   >
                     <Layers className="h-3.5 w-3.5" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent align="end" className="w-44 p-0">
                   <div className="space-y-0.5 p-2">
-                    {BLOCKED_GROUP_OPTIONS.map(([value, label]) => (
+                    {BLOCKED_GROUP_OPTIONS.map(([value]) => (
                       <button
                         key={value}
                         type="button"
@@ -2036,7 +2039,7 @@ export function Inbox() {
                         )}
                         onClick={() => setBlockedGroupBy(value)}
                       >
-                        <span>{label}</span>
+                        <span>{value === "blocker_type" ? copy("inbox.blocked.group.blockerType", "Blocker type", "차단 유형") : copy("issues.group.none", "None", "없음")}</span>
                         {blockedGroupBy === value ? <Check className="h-3.5 w-3.5" /> : null}
                       </button>
                     ))}
@@ -2048,7 +2051,7 @@ export function Inbox() {
                 visibleColumnSet={visibleIssueColumnSet}
                 onToggleColumn={toggleIssueColumn}
                 onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
-                title="Choose which inbox columns stay visible"
+                title={copy("inbox.columns.title", "Choose which inbox columns stay visible", "표시할 받은함 열 선택")}
                 iconOnly
               />
               <Popover>
@@ -2058,14 +2061,14 @@ export function Inbox() {
                     variant="outline"
                     size="icon"
                     className="h-8 w-8 shrink-0"
-                    title="Sort"
+                    title={copy("issues.sort.title", "Sort", "정렬")}
                   >
                     <ArrowUpDown className="h-3.5 w-3.5" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent align="end" className="w-48 p-0">
                   <div className="space-y-0.5 p-2">
-                    {BLOCKED_SORT_OPTIONS.map(([value, label]) => (
+                    {BLOCKED_SORT_OPTIONS.map(([value]) => (
                       <button
                         key={value}
                         type="button"
@@ -2075,7 +2078,13 @@ export function Inbox() {
                         )}
                         onClick={() => setBlockedSortBy(value)}
                       >
-                        <span>{label}</span>
+                        <span>
+                          {value === "urgency"
+                            ? copy("inbox.blocked.sort.urgency", "Most urgent", "긴급순")
+                            : value === "most_recent"
+                              ? copy("inbox.blocked.sort.mostRecent", "Most recent", "최근순")
+                              : copy("inbox.blocked.sort.longestStopped", "Longest stopped", "오래 멈춘 순")}
+                        </span>
                         {blockedSortBy === value ? <Check className="h-3.5 w-3.5" /> : null}
                       </button>
                     ))}
@@ -2091,7 +2100,9 @@ export function Inbox() {
                 size="icon"
                 className={cn("hidden h-8 w-8 shrink-0 sm:inline-flex", nestingEnabled && "bg-accent")}
                 onClick={toggleNesting}
-                title={nestingEnabled ? "Disable parent-child nesting" : "Enable parent-child nesting"}
+                title={nestingEnabled
+                  ? copy("issues.nesting.disable", "Disable parent-child nesting", "상위/하위 접기 해제")
+                  : copy("issues.nesting.enable", "Enable parent-child nesting", "상위/하위 접기 사용")}
               >
                 <ListTree className="h-3.5 w-3.5" />
               </Button>
@@ -2116,7 +2127,7 @@ export function Inbox() {
                     variant="outline"
                     size="icon"
                     className={cn("h-8 w-8 shrink-0", groupBy !== "none" && "bg-accent")}
-                    title="Group"
+                    title={copy("issues.group.title", "Group", "그룹")}
                   >
                     <Layers className="h-3.5 w-3.5" />
                   </Button>
@@ -2124,11 +2135,11 @@ export function Inbox() {
                 <PopoverContent align="end" className="w-40 p-2">
                   <div className="space-y-0.5">
                     {([
-                      ["none", "None"],
-                      ["type", "Type"],
-                      ["assignee", "Assignee"],
-                      ["project", "Project"],
-                      ...(isolatedWorkspacesEnabled ? ([["workspace", "Workspace"]] as const) : []),
+                      ["none", copy("issues.group.none", "None", "없음")],
+                      ["type", copy("inbox.group.type", "Type", "유형")],
+                      ["assignee", copy("issues.group.assignee", "Assignee", "담당자")],
+                      ["project", copy("issues.group.project", "Project", "프로젝트")],
+                      ...(isolatedWorkspacesEnabled ? ([["workspace", copy("issues.group.workspace", "Workspace", "작업공간")]] as const) : []),
                     ] as const).map(([value, label]) => (
                       <button
                         key={value}
@@ -2151,7 +2162,7 @@ export function Inbox() {
                 visibleColumnSet={visibleIssueColumnSet}
                 onToggleColumn={toggleIssueColumn}
                 onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
-                title="Choose which inbox columns stay visible"
+                title={copy("inbox.columns.title", "Choose which inbox columns stay visible", "표시할 받은함 열 선택")}
                 iconOnly
               />
               {canMarkAllRead && (
@@ -2164,19 +2175,19 @@ export function Inbox() {
                     onClick={() => setShowMarkAllReadConfirm(true)}
                     disabled={markAllReadMutation.isPending}
                   >
-                    {markAllReadMutation.isPending ? "Marking…" : "Mark all as read"}
+                    {markAllReadMutation.isPending ? copy("inbox.marking", "Marking...", "표시 중...") : copy("inbox.markAllRead", "Mark all as read", "모두 읽음 표시")}
                   </Button>
                   <Dialog open={showMarkAllReadConfirm} onOpenChange={setShowMarkAllReadConfirm}>
                     <DialogContent className="sm:max-w-md">
                       <DialogHeader>
-                        <DialogTitle>Mark all as read?</DialogTitle>
+                        <DialogTitle>{copy("inbox.markAllReadConfirmTitle", "Mark all as read?", "모두 읽음으로 표시할까요?")}</DialogTitle>
                         <DialogDescription>
-                          This will mark {unreadIssueIds.length} unread {unreadIssueIds.length === 1 ? "item" : "items"} as read.
+                          {copy("inbox.markAllReadConfirmBody", "This will mark {{count}} unread items as read.", "읽지 않은 항목 {{count}}개를 읽음으로 표시합니다.", { count: unreadIssueIds.length })}
                         </DialogDescription>
                       </DialogHeader>
                       <DialogFooter>
                         <Button variant="outline" onClick={() => setShowMarkAllReadConfirm(false)}>
-                          Cancel
+                          {copy("common.cancel", "Cancel", "취소")}
                         </Button>
                         <Button
                           onClick={() => {
@@ -2184,7 +2195,7 @@ export function Inbox() {
                             markAllReadMutation.mutate(unreadIssueIds);
                           }}
                         >
-                          Mark all as read
+                          {copy("inbox.markAllRead", "Mark all as read", "모두 읽음 표시")}
                         </Button>
                       </DialogFooter>
                     </DialogContent>
@@ -2204,15 +2215,15 @@ export function Inbox() {
             onValueChange={(value) => updateAllCategoryFilter(value as InboxCategoryFilter)}
           >
             <SelectTrigger className="h-8 w-[170px] text-xs">
-              <SelectValue placeholder="Category" />
+              <SelectValue placeholder={copy("inbox.category", "Category", "카테고리")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="everything">All categories</SelectItem>
-              <SelectItem value="issues_i_touched">My recent issues</SelectItem>
-              <SelectItem value="join_requests">Join requests</SelectItem>
-              <SelectItem value="approvals">Approvals</SelectItem>
-              <SelectItem value="failed_runs">Failed runs</SelectItem>
-              <SelectItem value="alerts">Alerts</SelectItem>
+              <SelectItem value="everything">{copy("inbox.category.all", "All categories", "전체 카테고리")}</SelectItem>
+              <SelectItem value="issues_i_touched">{copy("inbox.category.myRecentIssues", "My recent issues", "내 최근 작업")}</SelectItem>
+              <SelectItem value="join_requests">{copy("inbox.category.joinRequests", "Join requests", "가입 요청")}</SelectItem>
+              <SelectItem value="approvals">{copy("inbox.category.approvals", "Approvals", "승인")}</SelectItem>
+              <SelectItem value="failed_runs">{copy("inbox.category.failedRuns", "Failed runs", "실패 실행")}</SelectItem>
+              <SelectItem value="alerts">{copy("inbox.category.alerts", "Alerts", "알림")}</SelectItem>
             </SelectContent>
           </Select>
 
@@ -2222,12 +2233,12 @@ export function Inbox() {
               onValueChange={(value) => updateAllApprovalFilter(value as InboxApprovalFilter)}
             >
               <SelectTrigger className="h-8 w-[170px] text-xs">
-                <SelectValue placeholder="Approval status" />
+                <SelectValue placeholder={copy("inbox.approvalStatus", "Approval status", "승인 상태")} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All approval statuses</SelectItem>
-                <SelectItem value="actionable">Needs action</SelectItem>
-                <SelectItem value="resolved">Resolved</SelectItem>
+                <SelectItem value="all">{copy("inbox.approvalStatus.all", "All approval statuses", "전체 승인 상태")}</SelectItem>
+                <SelectItem value="actionable">{copy("inbox.approvalStatus.actionable", "Needs action", "조치 필요")}</SelectItem>
+                <SelectItem value="resolved">{copy("inbox.approvalStatus.resolved", "Resolved", "처리됨")}</SelectItem>
               </SelectContent>
             </Select>
           )}
@@ -2265,14 +2276,14 @@ export function Inbox() {
           icon={searchQuery.trim() ? Search : InboxIcon}
           message={
             searchQuery.trim()
-              ? "No inbox items match your search."
+              ? copy("inbox.empty.search", "No inbox items match your search.", "검색과 일치하는 받은함 항목이 없습니다.")
               : tab === "mine"
-              ? "Inbox zero."
+              ? copy("inbox.empty.mine", "Inbox zero.", "받은함이 비었습니다.")
               : tab === "unread"
-              ? "No new inbox items."
+              ? copy("inbox.empty.unread", "No new inbox items.", "새 받은함 항목이 없습니다.")
               : tab === "recent"
-                ? "No recent inbox items."
-                : "No inbox items match these filters."
+                ? copy("inbox.empty.recent", "No recent inbox items.", "최근 받은함 항목이 없습니다.")
+                : copy("inbox.empty.filtered", "No inbox items match these filters.", "이 필터와 일치하는 받은함 항목이 없습니다.")
           }
         />
       )}
@@ -2354,7 +2365,7 @@ export function Inbox() {
                           ({childCount} sub-task{childCount !== 1 ? "s" : ""})
                         </span>
                       ) : undefined}
-                      mobileMeta={issueActivityText(issue).toLowerCase()}
+                      mobileMeta={issueActivityText(issue, locale).toLowerCase()}
                       mobileLeading={
                         depth === 0 && hasChildren && collapseParentId ? (
                           <button

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -102,6 +102,7 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { formatIssueActivityAction } from "@/lib/activity-format";
+import { useLocalizedCopy } from "@/i18n/ui-copy";
 import { buildIssuePropertiesPanelKey } from "../lib/issue-properties-panel-key";
 import { buildIssueSiblingNavigation, shouldRenderRichSubIssuesSection } from "../lib/issue-detail-subissues";
 import { filterIssueDescendants } from "../lib/issue-tree";
@@ -192,10 +193,43 @@ const LEAF_WORK_CONTROL_MODE_HELP_TEXT: Partial<Record<IssueTreeControlMode, str
   pause: "Pause active execution on this issue until an explicit resume.",
   resume: "Release the active pause hold so this issue can continue.",
 };
+const TREE_CONTROL_MODE_LABEL_KO: Record<IssueTreeControlMode, string> = {
+  pause: "하위 작업 일시정지",
+  resume: "하위 작업 재개",
+  cancel: "하위 작업 취소",
+  restore: "하위 작업 복원",
+};
+const LEAF_WORK_CONTROL_MODE_LABEL_KO: Partial<Record<IssueTreeControlMode, string>> = {
+  pause: "작업 일시정지",
+  resume: "작업 재개",
+};
+const TREE_CONTROL_MODE_HELP_TEXT_KO: Record<IssueTreeControlMode, string> = {
+  pause: "명시적으로 재개할 때까지 이 이슈와 하위 이슈의 실행을 일시정지합니다.",
+  resume: "활성 하위 작업 일시정지 보류를 해제해 보류된 작업을 계속할 수 있게 합니다.",
+  cancel: "이 하위 작업의 미완료 이슈를 취소하고 가능한 경우 대기/실행 중인 작업을 중단합니다.",
+  restore: "이 하위 작업 작업으로 취소된 이슈를 복원해 작업을 다시 진행할 수 있게 합니다.",
+};
+const LEAF_WORK_CONTROL_MODE_HELP_TEXT_KO: Partial<Record<IssueTreeControlMode, string>> = {
+  pause: "명시적으로 재개할 때까지 이 이슈의 실행을 일시정지합니다.",
+  resume: "활성 일시정지 보류를 해제해 이 이슈가 계속 진행될 수 있게 합니다.",
+};
+type LocalizedCopy = ReturnType<typeof useLocalizedCopy>;
 function issueTreeControlLabel(mode: IssueTreeControlMode, scope: "leaf" | "subtree") {
   return scope === "leaf"
     ? LEAF_WORK_CONTROL_MODE_LABEL[mode] ?? TREE_CONTROL_MODE_LABEL[mode]
     : TREE_CONTROL_MODE_LABEL[mode];
+}
+
+function localizedIssueTreeControlLabel(
+  mode: IssueTreeControlMode,
+  scope: "leaf" | "subtree",
+  copy: LocalizedCopy,
+) {
+  const english = issueTreeControlLabel(mode, scope);
+  const korean = scope === "leaf"
+    ? LEAF_WORK_CONTROL_MODE_LABEL_KO[mode] ?? TREE_CONTROL_MODE_LABEL_KO[mode]
+    : TREE_CONTROL_MODE_LABEL_KO[mode];
+  return copy(`issueDetail.treeControl.${scope}.${mode}.label`, english, korean);
 }
 
 function issueTreeControlHelpText(mode: IssueTreeControlMode, scope: "leaf" | "subtree") {
@@ -204,13 +238,45 @@ function issueTreeControlHelpText(mode: IssueTreeControlMode, scope: "leaf" | "s
     : TREE_CONTROL_MODE_HELP_TEXT[mode];
 }
 
-function treeControlPreviewErrorCopy(error: unknown): string {
+function localizedIssueTreeControlHelpText(
+  mode: IssueTreeControlMode,
+  scope: "leaf" | "subtree",
+  copy: LocalizedCopy,
+) {
+  const english = issueTreeControlHelpText(mode, scope);
+  const korean = scope === "leaf"
+    ? LEAF_WORK_CONTROL_MODE_HELP_TEXT_KO[mode] ?? TREE_CONTROL_MODE_HELP_TEXT_KO[mode]
+    : TREE_CONTROL_MODE_HELP_TEXT_KO[mode];
+  return copy(`issueDetail.treeControl.${scope}.${mode}.help`, english, korean);
+}
+
+function treeControlPreviewErrorCopy(error: unknown, copy: LocalizedCopy): string {
   if (error instanceof ApiError) {
-    if (error.status === 403) return "Only board users can preview subtree controls.";
-    if (error.status === 409) return "Preview is stale because subtree hold state changed. Retry to refresh.";
-    if (error.status === 422) return "This subtree action is currently invalid for the selected issues.";
+    if (error.status === 403) {
+      return copy(
+        "issueDetail.treeControl.previewError.forbidden",
+        "Only board users can preview subtree controls.",
+        "보드 사용자만 하위 작업 제어 미리보기를 볼 수 있습니다.",
+      );
+    }
+    if (error.status === 409) {
+      return copy(
+        "issueDetail.treeControl.previewError.stale",
+        "Preview is stale because subtree hold state changed. Retry to refresh.",
+        "하위 작업 보류 상태가 바뀌어 미리보기가 오래되었습니다. 다시 시도해 새로고침하세요.",
+      );
+    }
+    if (error.status === 422) {
+      return copy(
+        "issueDetail.treeControl.previewError.invalid",
+        "This subtree action is currently invalid for the selected issues.",
+        "선택한 이슈에는 현재 이 하위 작업 제어를 적용할 수 없습니다.",
+      );
+    }
   }
-  return error instanceof Error ? error.message : "Unable to load preview.";
+  return error instanceof Error
+    ? error.message
+    : copy("issueDetail.treeControl.previewError.default", "Unable to load preview.", "미리보기를 불러올 수 없습니다.");
 }
 
 export function canBoardResolveRecoveryAction(
@@ -437,6 +503,7 @@ function IssueDetailLoadingState({
 }: {
   headerSeed: ReturnType<typeof readIssueDetailHeaderSeed>;
 }) {
+  const copy = useLocalizedCopy();
   const identifier = headerSeed?.identifier ?? headerSeed?.id.slice(0, 8) ?? null;
 
   return (
@@ -468,7 +535,7 @@ function IssueDetailLoadingState({
               ) : (
                 <span className="inline-flex items-center gap-1 text-xs text-muted-foreground opacity-50 px-1 -mx-1 py-0.5">
                   <Hexagon className="h-3 w-3 shrink-0" />
-                  No project
+                  {copy("issueDetail.project.none", "No project", "프로젝트 없음")}
                 </span>
               )}
             </>
@@ -535,6 +602,7 @@ function InboxMobileToolbar({
   onHide,
 }: InboxMobileToolbarProps) {
   const navigate = useNavigate();
+  const copy = useLocalizedCopy();
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -552,7 +620,7 @@ function InboxMobileToolbar({
             navigate(backHref);
           }
         }}
-        aria-label="Back to inbox"
+        aria-label={copy("issueDetail.inboxToolbar.back", "Back to inbox", "받은함으로 돌아가기")}
       >
         <ArrowLeft className="h-5 w-5" />
       </Button>
@@ -564,7 +632,7 @@ function InboxMobileToolbar({
             size="icon-sm"
             onClick={onArchive}
             disabled={archivePending}
-            aria-label="Archive from inbox"
+            aria-label={copy("issueDetail.inboxToolbar.archive", "Archive from inbox", "받은함에서 보관")}
           >
             <Archive className="h-5 w-5" />
           </Button>
@@ -572,7 +640,7 @@ function InboxMobileToolbar({
 
         <Popover open={menuOpen} onOpenChange={setMenuOpen}>
           <PopoverTrigger asChild>
-            <Button variant="ghost" size="icon-sm" aria-label="More actions">
+            <Button variant="ghost" size="icon-sm" aria-label={copy("issueDetail.inboxToolbar.more", "More actions", "더 보기")}>
               <MoreVertical className="h-5 w-5" />
             </Button>
           </PopoverTrigger>
@@ -582,14 +650,14 @@ function InboxMobileToolbar({
               onClick={() => { onCopy(); setMenuOpen(false); }}
             >
               <Copy className="h-3 w-3" />
-              Copy as markdown
+              {copy("issueDetail.inboxToolbar.copyMarkdown", "Copy as markdown", "마크다운으로 복사")}
             </button>
             <button
               className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
               onClick={() => { onProperties(); setMenuOpen(false); }}
             >
               <SlidersHorizontal className="h-3 w-3" />
-              Properties
+              {copy("issueDetail.properties", "Properties", "속성")}
             </button>
             {issueIdProp && (
               <button
@@ -597,7 +665,7 @@ function InboxMobileToolbar({
                 onClick={() => { onHide(); setMenuOpen(false); }}
               >
                 <EyeOff className="h-3 w-3" />
-                Hide this issue
+                {copy("issueDetail.inboxToolbar.hide", "Hide this issue", "이 작업 숨기기")}
               </button>
             )}
           </PopoverContent>
@@ -992,6 +1060,7 @@ function IssueDetailActivityTab({
   checkingMonitorNow,
   handoffFocusSignal = 0,
 }: IssueDetailActivityTabProps) {
+  const copy = useLocalizedCopy();
   const { data: activity, isLoading: activityLoading } = useQuery({
     queryKey: queryKeys.issues.activity(issueId),
     queryFn: () => activityApi.forIssue(issueId),
@@ -1103,13 +1172,19 @@ function IssueDetailActivityTab({
     <>
       {shouldShowCostSummary && (
         <div className="mb-3 px-3 py-2 rounded-lg border border-border">
-          <div className="text-sm font-medium text-muted-foreground mb-1">Cost Summary</div>
+          <div className="text-sm font-medium text-muted-foreground mb-1">
+            {copy("issueDetail.costSummary.title", "Cost Summary", "비용 요약")}
+          </div>
           {!issueCostSummary.hasCost && !issueCostSummary.hasTokens && !hasIssueTreeCost ? (
-            <div className="text-xs text-muted-foreground">No cost data yet.</div>
+            <div className="text-xs text-muted-foreground">
+              {copy("issueDetail.costSummary.empty", "No cost data yet.", "아직 비용 데이터가 없습니다.")}
+            </div>
           ) : (
             <div className="space-y-1 text-xs text-muted-foreground tabular-nums">
               <div className="flex flex-wrap gap-3">
-                <span className="font-medium text-foreground">This issue</span>
+                <span className="font-medium text-foreground">
+                  {copy("issueDetail.costSummary.thisIssue", "This issue", "이 이슈")}
+                </span>
                 {issueCostSummary.hasCost ? (
                   <span className="font-medium text-foreground">
                     ${issueCostSummary.cost.toFixed(4)}
@@ -1117,26 +1192,28 @@ function IssueDetailActivityTab({
                 ) : null}
                 {issueCostSummary.hasTokens ? (
                   <span>
-                    Tokens {formatTokens(issueCostSummary.totalTokens)}
+                    {copy("issueDetail.costSummary.tokens", "Tokens", "토큰")} {formatTokens(issueCostSummary.totalTokens)}
                     {issueCostSummary.cached > 0
-                      ? ` (in ${formatTokens(issueCostSummary.input)}, out ${formatTokens(issueCostSummary.output)}, cached ${formatTokens(issueCostSummary.cached)})`
-                      : ` (in ${formatTokens(issueCostSummary.input)}, out ${formatTokens(issueCostSummary.output)})`}
+                      ? ` (${copy("issueDetail.costSummary.in", "in", "입력")} ${formatTokens(issueCostSummary.input)}, ${copy("issueDetail.costSummary.out", "out", "출력")} ${formatTokens(issueCostSummary.output)}, ${copy("issueDetail.costSummary.cached", "cached", "캐시")} ${formatTokens(issueCostSummary.cached)})`
+                      : ` (${copy("issueDetail.costSummary.in", "in", "입력")} ${formatTokens(issueCostSummary.input)}, ${copy("issueDetail.costSummary.out", "out", "출력")} ${formatTokens(issueCostSummary.output)})`}
                   </span>
                 ) : null}
                 {issueCostSummary.hasRuntime ? (
                   <span>
-                    Runtime {formatDurationMs(issueCostSummary.runtimeMs)}
-                    {` (${issueCostSummary.runCount} run${issueCostSummary.runCount === 1 ? "" : "s"})`}
+                    {copy("issueDetail.costSummary.runtime", "Runtime", "실행 시간")} {formatDurationMs(issueCostSummary.runtimeMs)}
+                    {` (${issueCostSummary.runCount}${copy("issueDetail.costSummary.runsSuffix", " run", "회 실행")}${issueCostSummary.runCount === 1 ? "" : copy("issueDetail.costSummary.runPluralSuffix", "s", "")})`}
                   </span>
                 ) : null}
                 {!issueCostSummary.hasCost && !issueCostSummary.hasTokens && !issueCostSummary.hasRuntime ? (
-                  <span>No direct cost data.</span>
+                  <span>
+                    {copy("issueDetail.costSummary.noDirect", "No direct cost data.", "직접 비용 데이터가 없습니다.")}
+                  </span>
                 ) : null}
               </div>
               {hasIssueTreeCost && issueTreeCostSummary ? (
                 <div className="flex flex-wrap gap-3">
                   <span className="font-medium text-foreground">
-                    Including sub-issues {(issueTreeCostSummary.costCents / 100).toLocaleString(undefined, {
+                    {copy("issueDetail.costSummary.includingSubIssues", "Including sub-issues", "하위 이슈 포함")} {(issueTreeCostSummary.costCents / 100).toLocaleString(undefined, {
                       style: "currency",
                       currency: "USD",
                       minimumFractionDigits: 4,
@@ -1144,18 +1221,20 @@ function IssueDetailActivityTab({
                     })}
                   </span>
                   <span>
-                    Tokens {formatTokens(issueTreeCostTokens)}
+                    {copy("issueDetail.costSummary.tokens", "Tokens", "토큰")} {formatTokens(issueTreeCostTokens)}
                     {issueTreeCostSummary.cachedInputTokens > 0
-                      ? ` (in ${formatTokens(issueTreeCostSummary.inputTokens)}, out ${formatTokens(issueTreeCostSummary.outputTokens)}, cached ${formatTokens(issueTreeCostSummary.cachedInputTokens)})`
-                      : ` (in ${formatTokens(issueTreeCostSummary.inputTokens)}, out ${formatTokens(issueTreeCostSummary.outputTokens)})`}
+                      ? ` (${copy("issueDetail.costSummary.in", "in", "입력")} ${formatTokens(issueTreeCostSummary.inputTokens)}, ${copy("issueDetail.costSummary.out", "out", "출력")} ${formatTokens(issueTreeCostSummary.outputTokens)}, ${copy("issueDetail.costSummary.cached", "cached", "캐시")} ${formatTokens(issueTreeCostSummary.cachedInputTokens)})`
+                      : ` (${copy("issueDetail.costSummary.in", "in", "입력")} ${formatTokens(issueTreeCostSummary.inputTokens)}, ${copy("issueDetail.costSummary.out", "out", "출력")} ${formatTokens(issueTreeCostSummary.outputTokens)})`}
                   </span>
                   {issueTreeCostSummary.runCount > 0 ? (
                     <span>
-                      Runtime {formatDurationMs(issueTreeCostSummary.runtimeMs)}
-                      {` (${issueTreeCostSummary.runCount} run${issueTreeCostSummary.runCount === 1 ? "" : "s"})`}
+                      {copy("issueDetail.costSummary.runtime", "Runtime", "실행 시간")} {formatDurationMs(issueTreeCostSummary.runtimeMs)}
+                      {` (${issueTreeCostSummary.runCount}${copy("issueDetail.costSummary.runsSuffix", " run", "회 실행")}${issueTreeCostSummary.runCount === 1 ? "" : copy("issueDetail.costSummary.runPluralSuffix", "s", "")})`}
                     </span>
                   ) : null}
-                  <span>{issueTreeCostSummary.issueCount} issue{issueTreeCostSummary.issueCount === 1 ? "" : "s"}</span>
+                  <span>
+                    {issueTreeCostSummary.issueCount}{copy("issueDetail.costSummary.issueSuffix", " issue", "개 이슈")}{issueTreeCostSummary.issueCount === 1 ? "" : copy("issueDetail.costSummary.issuePluralSuffix", "s", "")}
+                  </span>
                 </div>
               ) : null}
             </div>
@@ -1235,6 +1314,7 @@ export function IssueDetail() {
   const location = useLocation();
   const { pushToast } = useToastActions();
   const { isMobile } = useSidebar();
+  const copy = useLocalizedCopy();
   const [moreOpen, setMoreOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [mobilePropsOpen, setMobilePropsOpen] = useState(false);
@@ -1363,8 +1443,9 @@ export function IssueDetail() {
     }
   }, [hasLiveRuns, locallyQueuedCommentRunIds.size]);
   const sourceBreadcrumb = useMemo(
-    () => readIssueDetailBreadcrumb(issueId, location.state, location.search) ?? { label: "Issues", href: "/issues" },
-    [issueId, location.state, location.search],
+    () => readIssueDetailBreadcrumb(issueId, location.state, location.search)
+      ?? { label: copy("issueDetail.breadcrumb.issues", "Issues", "작업"), href: "/issues" },
+    [copy, issueId, location.state, location.search],
   );
 
   const { data: rawChildIssues = [], isLoading: childIssuesLoading } = useQuery({
@@ -1827,23 +1908,29 @@ export function IssueDetail() {
       return { kind: "create" as const, hold: created.hold, preview: created.preview };
     },
     onSuccess: async (result) => {
-      const modeLabel = issueTreeControlLabel(result.hold.mode, treeControlScope);
+      const modeLabel = localizedIssueTreeControlLabel(result.hold.mode, treeControlScope, copy);
       const cancelCount = result.preview?.totals.activeRuns ?? 0;
       pushToast({
         title: result.kind === "release"
-          ? treeControlScope === "leaf" ? "Work resumed" : "Subtree resumed"
-          : result.hold.mode === "pause"
-            ? treeControlScope === "leaf" ? "Work paused" : "Subtree paused"
-            : `${modeLabel} applied`,
-        body: result.kind === "release"
-          ? (result.hold.releaseReason?.trim() || (treeControlScope === "leaf" ? "Active issue pause released." : "Active subtree pause released."))
+          ? treeControlScope === "leaf"
+            ? copy("issueDetail.treeControl.toast.workResumed", "Work resumed", "작업이 재개되었습니다")
+            : copy("issueDetail.treeControl.toast.subtreeResumed", "Subtree resumed", "하위 작업이 재개되었습니다")
           : result.hold.mode === "pause"
             ? treeControlScope === "leaf"
-              ? `Work paused. ${cancelCount} run${cancelCount === 1 ? "" : "s"} cancelled.`
-              : `Subtree paused. ${cancelCount} run${cancelCount === 1 ? "" : "s"} cancelled.`
+              ? copy("issueDetail.treeControl.toast.workPaused", "Work paused", "작업이 일시정지되었습니다")
+              : copy("issueDetail.treeControl.toast.subtreePaused", "Subtree paused", "하위 작업이 일시정지되었습니다")
+            : `${modeLabel} applied`,
+        body: result.kind === "release"
+          ? (result.hold.releaseReason?.trim() || (treeControlScope === "leaf"
+            ? copy("issueDetail.treeControl.toast.issuePauseReleased", "Active issue pause released.", "활성 이슈 일시정지가 해제되었습니다.")
+            : copy("issueDetail.treeControl.toast.subtreePauseReleased", "Active subtree pause released.", "활성 하위 작업 일시정지가 해제되었습니다.")))
+          : result.hold.mode === "pause"
+            ? treeControlScope === "leaf"
+              ? `${copy("issueDetail.treeControl.toast.workPaused", "Work paused", "작업이 일시정지되었습니다")}. ${cancelCount}${copy("issueDetail.treeControl.toast.cancelledRunsSuffix", " run", "개 실행")} ${copy("issueDetail.treeControl.toast.cancelled", "cancelled", "취소됨")}.`
+              : `${copy("issueDetail.treeControl.toast.subtreePaused", "Subtree paused", "하위 작업이 일시정지되었습니다")}. ${cancelCount}${copy("issueDetail.treeControl.toast.cancelledRunsSuffix", " run", "개 실행")} ${copy("issueDetail.treeControl.toast.cancelled", "cancelled", "취소됨")}.`
             : result.hold.reason?.trim()
               ? result.hold.reason
-              : "Subtree control applied.",
+              : copy("issueDetail.treeControl.toast.applied", "Subtree control applied.", "하위 작업 제어가 적용되었습니다."),
       });
       setTreeControlOpen(false);
       setTreeControlReason("");
@@ -3146,15 +3233,15 @@ export function IssueDetail() {
   const treeControlPrimaryButtonLabel =
     treeControlMode === "pause"
       ? treeControlScope === "leaf"
-        ? "Pause work"
-        : "Pause and stop work"
+        ? copy("issueDetail.treeControl.primary.pauseWork", "Pause work", "작업 일시정지")
+        : copy("issueDetail.treeControl.primary.pauseAndStop", "Pause and stop work", "일시정지하고 실행 중단")
       : treeControlMode === "cancel"
-        ? `Cancel ${previewAffectedIssueCount} issues`
+        ? copy("issueDetail.treeControl.primary.cancelIssues", "Cancel {{count}} issues", "{{count}}개 이슈 취소", { count: previewAffectedIssueCount })
       : treeControlMode === "restore"
-          ? `Restore ${previewAffectedIssueCount} issues`
+          ? copy("issueDetail.treeControl.primary.restoreIssues", "Restore {{count}} issues", "{{count}}개 이슈 복원", { count: previewAffectedIssueCount })
           : treeControlScope === "leaf"
-            ? "Resume work"
-            : "Resume subtree";
+            ? copy("issueDetail.treeControl.primary.resumeWork", "Resume work", "작업 재개")
+            : copy("issueDetail.treeControl.primary.resumeSubtree", "Resume subtree", "하위 작업 재개");
   const treePreviewAffectedIssueRows = treePreviewDisplayIssues.map((candidate) => ({
     candidate,
     issue: {
@@ -3208,10 +3295,10 @@ export function IssueDetail() {
         )}
       >
         <Paperclip className="h-3.5 w-3.5 mr-1.5" />
-        {uploadAttachment.isPending || importMarkdownDocument.isPending ? "Uploading..." : (
+        {uploadAttachment.isPending || importMarkdownDocument.isPending ? copy("issueDetail.attachments.uploading", "Uploading...", "업로드 중...") : (
           <>
-            <span className="hidden sm:inline">Upload attachment</span>
-            <span className="sm:hidden">Upload</span>
+            <span className="hidden sm:inline">{copy("issueDetail.attachments.upload", "Upload attachment", "첨부파일 업로드")}</span>
+            <span className="sm:hidden">{copy("issueDetail.attachments.uploadShort", "Upload", "업로드")}</span>
           </>
         )}
       </Button>
@@ -3250,7 +3337,7 @@ export function IssueDetail() {
       {issue.hiddenAt && (
         <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           <EyeOff className="h-4 w-4 shrink-0" />
-          This issue is hidden
+          {copy("issueDetail.hidden", "This issue is hidden", "이 이슈는 숨김 상태입니다")}
         </div>
       )}
       {activePauseHold && (
@@ -3259,19 +3346,21 @@ export function IssueDetail() {
             <div className="space-y-2">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="font-medium">
-                  {childIssues.length === 0 ? "Paused by board." : "Subtree pause is active."}
+                  {childIssues.length === 0
+                    ? copy("issueDetail.pauseBanner.pausedByBoard", "Paused by board.", "보드가 작업을 일시정지했습니다.")
+                    : copy("issueDetail.pauseBanner.subtreeActive", "Subtree pause is active.", "하위 작업 일시정지가 활성화되었습니다.")}
                 </span>
                 <span className="text-xs text-amber-900/80 dark:text-amber-100/80">
                   {childIssues.length === 0
-                    ? "Issue execution is held until resume. Human comments can still wake the assignee for triage."
-                    : "Root and descendant execution is held until resume. Human comments can still wake assignees for triage."}
+                    ? copy("issueDetail.pauseBanner.leafHelp", "Issue execution is held until resume. Human comments can still wake the assignee for triage.", "재개할 때까지 이슈 실행이 보류됩니다. 사람 댓글은 분류를 위해 담당자를 깨울 수 있습니다.")
+                    : copy("issueDetail.pauseBanner.subtreeHelp", "Root and descendant execution is held until resume. Human comments can still wake assignees for triage.", "재개할 때까지 루트와 하위 이슈 실행이 보류됩니다. 사람 댓글은 분류를 위해 담당자를 깨울 수 있습니다.")}
                 </span>
               </div>
               <div className="text-xs text-amber-900/80 dark:text-amber-100/80">
                 {childIssues.length === 0
-                  ? "1 issue held"
-                  : `${heldDescendantCount} descendant${heldDescendantCount === 1 ? "" : "s"} held`}
-                {activeRootPauseHold?.createdAt ? ` · started ${relativeTime(activeRootPauseHold.createdAt)}` : ""}
+                  ? copy("issueDetail.pauseBanner.oneIssueHeld", "1 issue held", "이슈 1개 보류 중")
+                  : copy("issueDetail.pauseBanner.descendantsHeld", "{{count}} descendant{{suffix}} held", "하위 이슈 {{count}}개 보류 중", { count: heldDescendantCount, suffix: heldDescendantCount === 1 ? "" : "s" })}
+                {activeRootPauseHold?.createdAt ? ` · ${copy("issueDetail.pauseBanner.started", "started", "시작")} ${relativeTime(activeRootPauseHold.createdAt)}` : ""}
               </div>
               {canShowSubtreeControls || canResumeLeafWork ? (
                 <div className="flex flex-wrap items-center gap-2">
@@ -3283,7 +3372,9 @@ export function IssueDetail() {
                       setTreeControlOpen(true);
                     }}
                   >
-                    {childIssues.length === 0 ? "Resume work" : "Resume subtree"}
+                    {childIssues.length === 0
+                      ? copy("issueDetail.treeControl.primary.resumeWork", "Resume work", "작업 재개")
+                      : copy("issueDetail.treeControl.primary.resumeSubtree", "Resume subtree", "하위 작업 재개")}
                   </Button>
                   <Button
                     variant="outline"
@@ -3294,7 +3385,7 @@ export function IssueDetail() {
                       setTreeControlOpen(true);
                     }}
                   >
-                    View affected ({childIssues.length === 0 ? 1 : heldDescendantCount})
+                    {copy("issueDetail.treeControl.viewAffected", "View affected", "영향 범위 보기")} ({childIssues.length === 0 ? 1 : heldDescendantCount})
                   </Button>
                   {canShowSubtreeControls ? (
                     <Button
@@ -3307,7 +3398,7 @@ export function IssueDetail() {
                         setTreeControlOpen(true);
                       }}
                     >
-                      Cancel subtree...
+                      {copy("issueDetail.treeControl.cancelSubtreeEllipsis", "Cancel subtree...", "하위 작업 취소...")}
                     </Button>
                   ) : null}
                 </div>
@@ -3315,7 +3406,7 @@ export function IssueDetail() {
             </div>
           ) : (
             <div className="text-xs">
-              This issue is paused by ancestor{" "}
+              {copy("issueDetail.pauseBanner.pausedByAncestor", "This issue is paused by ancestor", "상위 이슈 때문에 이 이슈가 일시정지되었습니다")}{" "}
               {activePauseHoldRoot?.identifier ? (
                 <Link to={createIssueDetailPath(activePauseHoldRoot.identifier)} className="underline">
                   {activePauseHoldRoot.identifier}
@@ -3323,7 +3414,7 @@ export function IssueDetail() {
               ) : (
                 activePauseHold.rootIssueId.slice(0, 8)
               )}
-              . Resume from the root issue to deliver deferred work.
+              . {copy("issueDetail.pauseBanner.resumeFromRoot", "Resume from the root issue to deliver deferred work.", "보류된 작업을 전달하려면 루트 이슈에서 재개하세요.")}
             </div>
           )}
         </div>
@@ -3372,16 +3463,16 @@ export function IssueDetail() {
               title="This task is a productivity review."
             >
               <Eye className="h-3 w-3" />
-              Productivity review
+              {copy("issueDetail.badge.productivityReview", "Productivity review", "생산성 리뷰")}
             </span>
           ) : null}
 
           {issue.workMode === "planning" ? (
             <span
               className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300 shrink-0"
-              title="This issue is in planning mode."
+              title={copy("issueDetail.badge.planningTitle", "This issue is in planning mode.", "이 이슈는 계획 모드입니다.")}
             >
-              Planning
+              {copy("issueDetail.badge.planning", "Planning", "계획")}
             </span>
           ) : null}
 
@@ -3389,10 +3480,10 @@ export function IssueDetail() {
             <span
               data-testid="issue-detail-parked-blocker"
               className="inline-flex items-center gap-1 rounded-full border border-amber-500/60 bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300 shrink-0"
-              title="Blocked by parked work — at least one assigned blocker is in backlog and will not wake its assignee."
+              title={copy("issueDetail.badge.parkedBlockerTitle", "Blocked by parked work — at least one assigned blocker is in backlog and will not wake its assignee.", "보류 작업에 의해 막힘 - 배정된 blocker 중 하나 이상이 backlog에 있어 담당자를 깨우지 않습니다.")}
             >
               <Flag className="h-3 w-3" />
-              Blocked by parked work
+              {copy("issueDetail.badge.parkedBlocker", "Blocked by parked work", "보류 작업에 의해 막힘")}
             </span>
           ) : null}
 
@@ -3407,7 +3498,7 @@ export function IssueDetail() {
           ) : (
             <span className="inline-flex items-center gap-1 text-xs text-muted-foreground opacity-50 px-1 -mx-1 py-0.5">
               <Hexagon className="h-3 w-3 shrink-0" />
-              No project
+              {copy("issueDetail.project.none", "No project", "프로젝트 없음")}
             </span>
           )}
 
@@ -3438,7 +3529,7 @@ export function IssueDetail() {
                 variant="ghost"
                 size="icon-xs"
                 onClick={copyIssueToClipboard}
-                title="Copy issue as markdown"
+                title={copy("issueDetail.actions.copyMarkdown", "Copy issue as markdown", "작업을 마크다운으로 복사")}
               >
                 {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
               </Button>
@@ -3446,7 +3537,7 @@ export function IssueDetail() {
                 variant="ghost"
                 size="icon-xs"
                 onClick={() => setMobilePropsOpen(true)}
-                title="Properties"
+                title={copy("issueDetail.properties", "Properties", "속성")}
               >
                 <SlidersHorizontal className="h-4 w-4" />
               </Button>
@@ -3462,8 +3553,8 @@ export function IssueDetail() {
                   if (!archivePending && issue?.id) archiveFromInbox.mutate(issue.id);
                 }}
                 disabled={archivePending}
-                title="Archive from inbox"
-                aria-label="Archive from inbox"
+                title={copy("issueDetail.inboxToolbar.archive", "Archive from inbox", "받은함에서 보관")}
+                aria-label={copy("issueDetail.inboxToolbar.archive", "Archive from inbox", "받은함에서 보관")}
               >
                 <Archive className="h-4 w-4" />
               </Button>
@@ -3472,7 +3563,7 @@ export function IssueDetail() {
               variant="ghost"
               size="icon-xs"
               onClick={copyIssueToClipboard}
-              title="Copy issue as markdown"
+              title={copy("issueDetail.actions.copyMarkdown", "Copy issue as markdown", "작업을 마크다운으로 복사")}
             >
               {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
             </Button>
@@ -3484,7 +3575,7 @@ export function IssueDetail() {
                 panelVisible ? "opacity-0 pointer-events-none w-0 overflow-hidden" : "opacity-100",
               )}
               onClick={() => setPanelVisible(true)}
-              title="Show properties"
+              title={copy("issueDetail.actions.showProperties", "Show properties", "속성 보기")}
             >
               <SlidersHorizontal className="h-4 w-4" />
             </Button>
@@ -3519,7 +3610,7 @@ export function IssueDetail() {
                   }}
                 >
                   <PauseCircle className="h-3 w-3" />
-                  Pause work...
+                  {copy("issueDetail.treeControl.pauseWorkEllipsis", "Pause work...", "작업 일시정지...")}
                 </button>
               ) : null}
               {canResumeLeafWork ? (
@@ -3533,7 +3624,7 @@ export function IssueDetail() {
                   }}
                 >
                   <PlayCircle className="h-3 w-3" />
-                  Resume work
+                  {copy("issueDetail.treeControl.primary.resumeWork", "Resume work", "작업 재개")}
                 </button>
               ) : null}
               {canShowSubtreeControls ? (
@@ -3548,7 +3639,7 @@ export function IssueDetail() {
                     }}
                   >
                     <PauseCircle className="h-3 w-3" />
-                    Pause subtree...
+                    {copy("issueDetail.treeControl.pauseSubtreeEllipsis", "Pause subtree...", "하위 작업 일시정지...")}
                   </button>
                   {canResumeSubtree ? (
                     <button
@@ -3561,7 +3652,7 @@ export function IssueDetail() {
                       }}
                     >
                       <PlayCircle className="h-3 w-3" />
-                      Resume subtree
+                      {copy("issueDetail.treeControl.primary.resumeSubtree", "Resume subtree", "하위 작업 재개")}
                     </button>
                   ) : null}
                   <button
@@ -3574,7 +3665,7 @@ export function IssueDetail() {
                     }}
                   >
                     <XCircle className="h-3 w-3" />
-                    Cancel subtree...
+                    {copy("issueDetail.treeControl.cancelSubtreeEllipsis", "Cancel subtree...", "하위 작업 취소...")}
                   </button>
                   {canRestoreSubtree ? (
                     <button
@@ -3588,7 +3679,7 @@ export function IssueDetail() {
                       }}
                     >
                       <Repeat className="h-3 w-3" />
-                      Restore subtree...
+                      {copy("issueDetail.treeControl.restoreSubtreeEllipsis", "Restore subtree...", "하위 작업 복원...")}
                     </button>
                   ) : null}
                 </>
@@ -3604,7 +3695,7 @@ export function IssueDetail() {
                 }}
               >
                 <EyeOff className="h-3 w-3" />
-                Hide this Issue
+                {copy("issueDetail.actions.hideIssue", "Hide this Issue", "이 이슈 숨기기")}
               </button>
             </PopoverContent>
             </Popover>
@@ -3681,7 +3772,9 @@ export function IssueDetail() {
       {showRichSubIssuesSection ? (
         <div className="space-y-3">
           <div className="flex items-center justify-between gap-2">
-            <h3 className="text-sm font-medium text-muted-foreground">Sub-issues</h3>
+            <h3 className="text-sm font-medium text-muted-foreground">
+              {copy("issueDetail.subIssues.title", "Sub-issues", "하위 작업")}
+            </h3>
           </div>
           <IssuesList
             issues={childIssues}
@@ -3697,7 +3790,7 @@ export function IssueDetail() {
             searchFilters={{ descendantOf: issue.id, includeBlockedBy: true }}
             searchWithinLoadedIssues
             baseCreateIssueDefaults={buildSubIssueDefaultsForViewer(issue, currentUserId)}
-            createIssueLabel="Sub-issue"
+            createIssueLabel={copy("issueDetail.subIssues.createLabel", "Sub-issue", "하위 작업")}
             defaultSortField="workflow"
             showProgressSummary
             parentIssueIdForCostSummary={issue.id}
@@ -3708,7 +3801,7 @@ export function IssueDetail() {
         <div className="flex flex-wrap items-center justify-end gap-2 min-w-0">
           <Button variant="outline" size="sm" onClick={openNewSubIssue} className="shrink-0 shadow-none">
             <Plus className="mr-1.5 h-3.5 w-3.5" />
-            New Sub-issue
+            {copy("issueDetail.subIssues.new", "New Sub-issue", "새 하위 작업")}
           </Button>
         </div>
       )}
@@ -3760,7 +3853,9 @@ export function IssueDetail() {
         onDrop={(evt) => void handleAttachmentDrop(evt)}
       >
         <div className="flex items-center justify-between gap-2">
-          <h3 className="text-sm font-medium text-muted-foreground">Attachments</h3>
+          <h3 className="text-sm font-medium text-muted-foreground">
+            {copy("issueDetail.attachments.title", "Attachments", "첨부파일")}
+          </h3>
           {attachmentUploadButton}
         </div>
 
@@ -3792,7 +3887,9 @@ export function IssueDetail() {
                     className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-black/60"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <p className="text-xs text-white font-medium">Delete?</p>
+                    <p className="text-xs text-white font-medium">
+                      {copy("issueDetail.attachments.confirmDelete", "Delete?", "삭제할까요?")}
+                    </p>
                     <div className="flex gap-1.5">
                       <button
                         type="button"
@@ -3804,7 +3901,7 @@ export function IssueDetail() {
                         }}
                         disabled={deleteAttachment.isPending}
                       >
-                        Yes
+                        {copy("common.yes", "Yes", "예")}
                       </button>
                       <button
                         type="button"
@@ -3814,7 +3911,7 @@ export function IssueDetail() {
                           setConfirmDeleteId(null);
                         }}
                       >
-                        No
+                        {copy("common.no", "No", "아니요")}
                       </button>
                     </div>
                   </div>
@@ -3826,7 +3923,7 @@ export function IssueDetail() {
                       e.stopPropagation();
                       setConfirmDeleteId(attachment.id);
                     }}
-                    title="Delete attachment"
+                    title={copy("issueDetail.attachments.deleteAttachment", "Delete attachment", "첨부 삭제")}
                   >
                     <Trash2 className="h-3.5 w-3.5" />
                   </button>
@@ -3889,15 +3986,15 @@ export function IssueDetail() {
         <TabsList variant="line" className="w-full justify-start gap-1">
           <TabsTrigger value="chat" className="gap-1.5">
             <MessageSquare className="h-3.5 w-3.5" />
-            Chat
+            {copy("issueDetail.tabs.chat", "Chat", "채팅")}
           </TabsTrigger>
           <TabsTrigger value="activity" className="gap-1.5">
             <ActivityIcon className="h-3.5 w-3.5" />
-            Activity
+            {copy("issueDetail.tabs.activity", "Activity", "활동")}
           </TabsTrigger>
           <TabsTrigger value="related-work" className="gap-1.5">
             <ListTree className="h-3.5 w-3.5" />
-            Related work
+            {copy("issueDetail.tabs.relatedWork", "Related work", "관련 작업")}
           </TabsTrigger>
           {issuePluginTabItems.map((item) => (
             <TabsTrigger key={item.value} value={item.value}>
@@ -4030,26 +4127,26 @@ export function IssueDetail() {
       <Dialog open={treeControlOpen} onOpenChange={setTreeControlOpen}>
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-[560px]">
           <DialogHeader className="border-b border-border/60 px-6 pb-4 pr-12 pt-6">
-            <DialogTitle>{issueTreeControlLabel(treeControlMode, treeControlScope)}</DialogTitle>
+            <DialogTitle>{localizedIssueTreeControlLabel(treeControlMode, treeControlScope, copy)}</DialogTitle>
             <DialogDescription>
-              {issueTreeControlHelpText(treeControlMode, treeControlScope)}
+              {localizedIssueTreeControlHelpText(treeControlMode, treeControlScope, copy)}
             </DialogDescription>
           </DialogHeader>
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-6 py-4">
             {treeControlMode === "cancel" ? (
               <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                Cancelling a subtree is destructive. Non-terminal issues will be marked cancelled, and running or queued work will be interrupted where possible.
+                {copy("issueDetail.treeControl.cancelWarning", "Cancelling a subtree is destructive. Non-terminal issues will be marked cancelled, and running or queued work will be interrupted where possible.", "하위 작업 취소는 파괴적 작업입니다. 완료되지 않은 이슈는 취소 상태가 되고, 실행 중이거나 대기 중인 작업은 가능한 경우 중단됩니다.")}
               </div>
             ) : null}
 
             <div className="space-y-1.5">
               <label className="text-xs text-muted-foreground">
-                Reason (optional)
+                {copy("issueDetail.treeControl.reasonLabel", "Reason (optional)", "사유(선택)")}
               </label>
               <Textarea
                 value={treeControlReason}
                 onChange={(event) => setTreeControlReason(event.target.value)}
-                placeholder="Explain why this subtree control is being applied..."
+                placeholder={copy("issueDetail.treeControl.reasonPlaceholder", "Explain why this subtree control is being applied...", "이 하위 작업 제어를 적용하는 이유를 적어주세요...")}
                 className="min-h-[88px]"
               />
             </div>
@@ -4065,11 +4162,13 @@ export function IssueDetail() {
                     onChange={(event) => setTreeControlWakeAgentsOnResume(event.target.checked)}
                   />
                   <span>
-                    <span className="block font-medium">Wake affected agents ({previewAffectedAgentCount})</span>
+                    <span className="block font-medium">
+                      {copy("issueDetail.treeControl.wakeAgents", "Wake affected agents", "영향받은 직원 깨우기")} ({previewAffectedAgentCount})
+                    </span>
                     <span className="text-xs text-muted-foreground">
                       {previewAffectedAgentCount === 0
-                        ? "No assigned agents are eligible to wake from this preview."
-                        : "Wake assigned agents after this operation completes."}
+                        ? copy("issueDetail.treeControl.noAgentsToWake", "No assigned agents are eligible to wake from this preview.", "이 미리보기에서 깨울 수 있는 배정 직원이 없습니다.")
+                        : copy("issueDetail.treeControl.wakeAgentsHelp", "Wake assigned agents after this operation completes.", "이 작업이 완료되면 배정된 직원을 깨웁니다.")}
                     </span>
                   </span>
                 </label>
@@ -4096,7 +4195,9 @@ export function IssueDetail() {
                   checked={treeControlCancelConfirmed}
                   onChange={(event) => setTreeControlCancelConfirmed(event.target.checked)}
                 />
-                <span>I understand this will cancel {previewAffectedIssueCount} issues.</span>
+                <span>
+                  {copy("issueDetail.treeControl.cancelConfirm", "I understand this will cancel {{count}} issues.", "{{count}}개 이슈가 취소됨을 이해했습니다.", { count: previewAffectedIssueCount })}
+                </span>
               </label>
             ) : null}
 
@@ -4110,7 +4211,7 @@ export function IssueDetail() {
                 </div>
               ) : treeControlPreviewError ? (
                 <div className="space-y-2">
-                  <p className="text-xs text-destructive">{treeControlPreviewErrorCopy(treeControlPreviewError)}</p>
+                  <p className="text-xs text-destructive">{treeControlPreviewErrorCopy(treeControlPreviewError, copy)}</p>
                   <Button
                     variant="outline"
                     size="sm"
@@ -4118,7 +4219,7 @@ export function IssueDetail() {
                       void refetchTreeControlPreview();
                     }}
                   >
-                    Retry preview
+                    {copy("issueDetail.treeControl.retryPreview", "Retry preview", "미리보기 다시 시도")}
                   </Button>
                 </div>
               ) : treeControlPreview ? (
@@ -4150,7 +4251,9 @@ export function IssueDetail() {
                             </span>
                             <span className="min-w-0 flex-1 truncate">{candidate.title}</span>
                             {candidate.skipped && candidate.skipReason === "terminal_status" ? (
-                              <span className="shrink-0 text-xs text-muted-foreground">Complete</span>
+                              <span className="shrink-0 text-xs text-muted-foreground">
+                                {copy("issueDetail.treeControl.complete", "Complete", "완료")}
+                              </span>
                             ) : null}
                           </Link>
                         </div>
@@ -4159,20 +4262,24 @@ export function IssueDetail() {
                   ) : null}
                 </div>
               ) : (
-                <p className="text-xs text-muted-foreground">Preview unavailable.</p>
+                <p className="text-xs text-muted-foreground">
+                  {copy("issueDetail.treeControl.previewUnavailable", "Preview unavailable.", "미리보기를 사용할 수 없습니다.")}
+                </p>
               )}
             </div>
           </div>
           <DialogFooter className="border-t border-border/60 bg-background px-6 py-4">
             <Button variant="outline" onClick={() => setTreeControlOpen(false)} disabled={executeTreeControl.isPending}>
-              Close
+              {copy("common.close", "Close", "닫기")}
             </Button>
             <Button
               onClick={() => executeTreeControl.mutate()}
               disabled={executeTreeControl.isPending || !canApplyTreeControl}
               variant={treeControlMode === "cancel" ? "destructive" : "default"}
             >
-              {executeTreeControl.isPending ? "Applying..." : treeControlPrimaryButtonLabel}
+              {executeTreeControl.isPending
+                ? copy("issueDetail.treeControl.applying", "Applying...", "적용 중...")
+                : treeControlPrimaryButtonLabel}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -4182,7 +4289,7 @@ export function IssueDetail() {
       <Sheet open={mobilePropsOpen} onOpenChange={setMobilePropsOpen}>
         <SheetContent side="bottom" className="max-h-[85dvh] pb-[env(safe-area-inset-bottom)]">
           <SheetHeader>
-            <SheetTitle className="text-sm">Properties</SheetTitle>
+            <SheetTitle className="text-sm">{copy("issueDetail.properties", "Properties", "속성")}</SheetTitle>
           </SheetHeader>
           <ScrollArea className="flex-1 overflow-y-auto">
             <div className="px-4 pb-4">

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -12,6 +12,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import { CircleDot } from "lucide-react";
 import type { Issue } from "@paperclipai/shared";
 
@@ -58,6 +59,7 @@ export function buildIssuesSearchUrl(currentHref: string, search: string): strin
 export function Issues() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -108,16 +110,16 @@ export function Issues() {
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
-        "Issues",
+        copy("issues.breadcrumb", "Issues", "작업"),
         `${location.pathname}${location.search}${location.hash}`,
         "issues",
       ),
-    [location.pathname, location.search, location.hash],
+    [copy, location.pathname, location.search, location.hash],
   );
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Issues" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("issues.breadcrumb", "Issues", "작업") }]);
+  }, [copy, setBreadcrumbs]);
 
   const issuePageSize = workspaceIdFilter ? WORKSPACE_FILTER_ISSUE_LIMIT : ISSUES_PAGE_SIZE;
 
@@ -175,7 +177,7 @@ export function Issues() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={CircleDot} message="Select a company to view issues." />;
+    return <EmptyState icon={CircleDot} message={copy("issues.noCompany", "Select a company to view issues.", "작업을 보려면 회사를 선택하세요.")} />;
   }
 
   return (

--- a/ui/src/pages/Org.tsx
+++ b/ui/src/pages/Org.tsx
@@ -10,33 +10,49 @@ import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { ChevronRight, GitBranch } from "lucide-react";
 import { cn } from "../lib/utils";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 function OrgTree({
   nodes,
   depth = 0,
   hrefFn,
+  copy,
 }: {
   nodes: OrgNode[];
   depth?: number;
   hrefFn: (id: string) => string;
+  copy: ReturnType<typeof useLocalizedCopy>;
 }) {
   return (
     <div>
       {nodes.map((node) => (
-        <OrgTreeNode key={node.id} node={node} depth={depth} hrefFn={hrefFn} />
+        <OrgTreeNode key={node.id} node={node} depth={depth} hrefFn={hrefFn} copy={copy} />
       ))}
     </div>
   );
+}
+
+function orgRoleLabel(role: string, copy: ReturnType<typeof useLocalizedCopy>) {
+  const normalized = role.trim().toLowerCase();
+  if (normalized === "ceo") return copy("org.role.ceo", "CEO", "대표");
+  if (normalized === "engineer") return copy("org.role.engineer", "Engineer", "개발자");
+  if (normalized === "researcher") return copy("org.role.researcher", "Researcher", "조사원");
+  if (normalized === "manager") return copy("org.role.manager", "Manager", "관리자");
+  if (normalized === "designer") return copy("org.role.designer", "Designer", "디자이너");
+  if (normalized === "operator") return copy("org.role.operator", "Operator", "운영자");
+  return role;
 }
 
 function OrgTreeNode({
   node,
   depth,
   hrefFn,
+  copy,
 }: {
   node: OrgNode;
   depth: number;
   hrefFn: (id: string) => string;
+  copy: ReturnType<typeof useLocalizedCopy>;
 }) {
   const [expanded, setExpanded] = useState(true);
   const hasChildren = node.reports.length > 0;
@@ -79,11 +95,11 @@ function OrgTreeNode({
           )}
         />
         <span className="font-medium flex-1">{node.name}</span>
-        <span className="text-xs text-muted-foreground">{node.role}</span>
+        <span className="text-xs text-muted-foreground">{orgRoleLabel(node.role, copy)}</span>
         <StatusBadge status={node.status} />
       </Link>
       {hasChildren && expanded && (
-        <OrgTree nodes={node.reports} depth={depth + 1} hrefFn={hrefFn} />
+        <OrgTree nodes={node.reports} depth={depth + 1} hrefFn={hrefFn} copy={copy} />
       )}
     </div>
   );
@@ -92,10 +108,11 @@ function OrgTreeNode({
 export function Org() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Org Chart" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("org.breadcrumb", "Org Chart", "조직도") }]);
+  }, [copy, setBreadcrumbs]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: queryKeys.org(selectedCompanyId!),
@@ -104,7 +121,12 @@ export function Org() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={GitBranch} message="Select a company to view org chart." />;
+    return (
+      <EmptyState
+        icon={GitBranch}
+        message={copy("org.noCompany", "Select a company to view org chart.", "조직도를 보려면 회사를 선택하세요.")}
+      />
+    );
   }
 
   if (isLoading) {
@@ -118,13 +140,17 @@ export function Org() {
       {data && data.length === 0 && (
         <EmptyState
           icon={GitBranch}
-          message="No agents in the organization. Create agents to build your org chart."
+          message={copy(
+            "org.empty",
+            "No agents in the organization. Create agents to build your org chart.",
+            "조직에 직원이 없습니다. 직원을 만들어 조직도를 구성하세요.",
+          )}
         />
       )}
 
       {data && data.length > 0 && (
         <div className="border border-border py-1">
-          <OrgTree nodes={data} hrefFn={(id) => `/agents/${id}`} />
+          <OrgTree nodes={data} hrefFn={(id) => `/agents/${id}`} copy={copy} />
         </div>
       )}
     </div>

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -12,6 +12,7 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { Download, Maximize2, Minus, Network, Plus, Upload } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent } from "@paperclipai/shared";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 // Layout constants
 const CARD_W = 200;
@@ -173,6 +174,7 @@ const defaultDotColor = "#a3a3a3";
 export function OrgChart() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
   const navigate = useNavigate();
 
   const { data: orgTree, isLoading } = useQuery({
@@ -194,8 +196,8 @@ export function OrgChart() {
   }, [agents]);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Org Chart" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("org.breadcrumb", "Org Chart", "조직도") }]);
+  }, [copy, setBreadcrumbs]);
 
   // Layout computation
   const layout = useMemo(() => layoutForest(orgTree ?? []), [orgTree]);
@@ -429,7 +431,12 @@ export function OrgChart() {
   }, [pan, zoom]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Network} message="Select a company to view the org chart." />;
+    return (
+      <EmptyState
+        icon={Network}
+        message={copy("orgChart.noCompany", "Select a company to view the org chart.", "조직도를 보려면 회사를 선택하세요.")}
+      />
+    );
   }
 
   if (isLoading) {
@@ -437,7 +444,12 @@ export function OrgChart() {
   }
 
   if (orgTree && orgTree.length === 0) {
-    return <EmptyState icon={Network} message="No organizational hierarchy defined." />;
+    return (
+      <EmptyState
+        icon={Network}
+        message={copy("orgChart.empty", "No organizational hierarchy defined.", "정의된 조직 계층이 없습니다.")}
+      />
+    );
   }
 
   return (
@@ -446,13 +458,13 @@ export function OrgChart() {
         <Link to="/company/import">
           <Button variant="outline" size="sm">
             <Upload className="mr-1.5 h-3.5 w-3.5" />
-            Import company
+            {copy("orgChart.import", "Import company", "회사 가져오기")}
           </Button>
         </Link>
         <Link to="/company/export">
           <Button variant="outline" size="sm">
             <Download className="mr-1.5 h-3.5 w-3.5" />
-            Export company
+            {copy("orgChart.export", "Export company", "회사 내보내기")}
           </Button>
         </Link>
       </div>
@@ -488,8 +500,8 @@ export function OrgChart() {
                 });
               }
             }}
-            title="Zoom in"
-            aria-label="Zoom in"
+            title={copy("orgChart.zoomIn", "Zoom in", "확대")}
+            aria-label={copy("orgChart.zoomIn", "Zoom in", "확대")}
           >
             <Plus className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
           </button>
@@ -504,16 +516,16 @@ export function OrgChart() {
                 });
               }
             }}
-            title="Zoom out"
-            aria-label="Zoom out"
+            title={copy("orgChart.zoomOut", "Zoom out", "축소")}
+            aria-label={copy("orgChart.zoomOut", "Zoom out", "축소")}
           >
             <Minus className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
           </button>
           <button
             className="flex size-9 items-center justify-center rounded border border-border bg-background text-[10px] transition-colors hover:bg-accent sm:size-7"
             onClick={fitToScreen}
-            title="Fit to screen"
-            aria-label="Fit chart to screen"
+            title={copy("orgChart.fit", "Fit to screen", "화면에 맞춤")}
+            aria-label={copy("orgChart.fitAria", "Fit chart to screen", "조직도를 화면에 맞춤")}
           >
             <Maximize2 className="h-4 w-4 sm:h-3.5 sm:w-3.5" />
           </button>

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -27,6 +27,7 @@ import { MembershipAction } from "../components/MembershipAction";
 import { buildProjectWorkspaceSummaries } from "../lib/project-workspaces-tab";
 import { collectLiveIssueIds } from "../lib/liveIssueIds";
 import { projectRouteRef } from "../lib/utils";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 import { Button } from "@/components/ui/button";
 import { Tabs } from "@/components/ui/tabs";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
@@ -72,6 +73,7 @@ function OverviewContent({
   onUpdate: (data: Record<string, unknown>) => void;
   imageUploadHandler?: (file: File) => Promise<string>;
 }) {
+  const copy = useLocalizedCopy();
   return (
     <div className="space-y-6">
       <InlineEditor
@@ -80,21 +82,21 @@ function OverviewContent({
         nullable
         as="p"
         className="text-sm text-muted-foreground"
-        placeholder="Add a description..."
+        placeholder={copy("projectDetail.overview.addDescription", "Add a description...", "설명 추가...")}
         multiline
         imageUploadHandler={imageUploadHandler}
       />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
         <div>
-          <span className="text-muted-foreground">Status</span>
+          <span className="text-muted-foreground">{copy("projectDetail.overview.status", "Status", "상태")}</span>
           <div className="mt-1">
             <StatusBadge status={project.status} />
           </div>
         </div>
         {project.targetDate && (
           <div>
-            <span className="text-muted-foreground">Target Date</span>
+            <span className="text-muted-foreground">{copy("projectDetail.overview.targetDate", "Target Date", "목표일")}</span>
             <p>{project.targetDate}</p>
           </div>
         )}
@@ -112,6 +114,7 @@ function ColorPicker({
   currentColor: string;
   onSelect: (color: string) => void;
 }) {
+  const copy = useLocalizedCopy();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -132,7 +135,7 @@ function ColorPicker({
         onClick={() => setOpen(!open)}
         className="shrink-0 h-5 w-5 rounded-md cursor-pointer hover:ring-2 hover:ring-foreground/20 transition-[box-shadow]"
         style={{ backgroundColor: currentColor }}
-        aria-label="Change project color"
+        aria-label={copy("projectDetail.color.change", "Change project color", "프로젝트 색상 변경")}
       />
       {open && (
         <div className="absolute top-full left-0 mt-2 p-2 bg-popover border border-border rounded-lg shadow-lg z-50 w-max">
@@ -150,7 +153,7 @@ function ColorPicker({
                     : "hover:ring-2 hover:ring-foreground/30"
                 }`}
                 style={{ backgroundColor: color }}
-                aria-label={`Select color ${color}`}
+                aria-label={copy("projectDetail.color.select", "Select color {{color}}", "{{color}} 색상 선택", { color })}
               />
             ))}
           </div>
@@ -288,6 +291,7 @@ export function ProjectDetail() {
   const { closePanel } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { pushToast } = useToastActions();
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
@@ -404,20 +408,28 @@ export function ProjectDetail() {
         projectLookupRef,
         { archivedAt: archived ? new Date().toISOString() : null },
         resolvedCompanyId ?? lookupCompanyId,
-      ),
+    ),
     onSuccess: (updatedProject, archived) => {
       invalidateProject();
-      const name = updatedProject?.name ?? project?.name ?? "Project";
+      const name = updatedProject?.name ?? project?.name ?? copy("common.project", "Project", "프로젝트");
       if (archived) {
-        pushToast({ title: `"${name}" has been archived`, tone: "success" });
+        pushToast({
+          title: copy("projectDetail.toast.archived", "\"{{name}}\" has been archived", "\"{{name}}\" 프로젝트가 보관되었습니다.", { name }),
+          tone: "success",
+        });
         navigate("/dashboard");
       } else {
-        pushToast({ title: `"${name}" has been unarchived`, tone: "success" });
+        pushToast({
+          title: copy("projectDetail.toast.unarchived", "\"{{name}}\" has been unarchived", "\"{{name}}\" 프로젝트 보관이 해제되었습니다.", { name }),
+          tone: "success",
+        });
       }
     },
     onError: (_, archived) => {
       pushToast({
-        title: archived ? "Failed to archive project" : "Failed to unarchive project",
+        title: archived
+          ? copy("projectDetail.toast.archiveFailed", "Failed to archive project", "프로젝트를 보관하지 못했습니다.")
+          : copy("projectDetail.toast.unarchiveFailed", "Failed to unarchive project", "프로젝트 보관 해제를 실패했습니다."),
         tone: "error",
       });
     },
@@ -425,7 +437,7 @@ export function ProjectDetail() {
 
   const uploadImage = useMutation({
     mutationFn: async (file: File) => {
-      if (!resolvedCompanyId) throw new Error("No company selected");
+      if (!resolvedCompanyId) throw new Error(copy("projectDetail.error.noCompany", "No company selected", "선택된 회사가 없습니다."));
       return assetsApi.uploadImage(resolvedCompanyId, file, `projects/${projectLookupRef || "draft"}`);
     },
   });
@@ -440,10 +452,10 @@ export function ProjectDetail() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Projects", href: "/projects" },
-      { label: project?.name ?? routeProjectRef ?? "Project" },
+      { label: copy("projects.breadcrumb", "Projects", "프로젝트"), href: "/projects" },
+      { label: project?.name ?? routeProjectRef ?? copy("common.project", "Project", "프로젝트") },
     ]);
-  }, [setBreadcrumbs, project, routeProjectRef]);
+  }, [copy, setBreadcrumbs, project, routeProjectRef]);
 
   useEffect(() => {
     if (!project) return;
@@ -551,7 +563,7 @@ export function ProjectDetail() {
       companyId: resolvedCompanyId ?? "",
       scopeType: "project",
       scopeId: project?.id ?? routeProjectRef,
-      scopeName: project?.name ?? "Project",
+      scopeName: project?.name ?? copy("common.project", "Project", "프로젝트"),
       metric: "billed_cents",
       windowKind: "lifetime",
       amount: 0,
@@ -568,7 +580,7 @@ export function ProjectDetail() {
       windowStart: new Date(),
       windowEnd: new Date(),
     } satisfies BudgetPolicySummary;
-  }, [budgetOverview?.policies, project, resolvedCompanyId, routeProjectRef]);
+  }, [budgetOverview?.policies, copy, project, resolvedCompanyId, routeProjectRef]);
 
   const budgetMutation = useMutation({
     mutationFn: (amount: number) =>
@@ -665,7 +677,7 @@ export function ProjectDetail() {
       {showLeftProjectNotice ? (
         <div className="flex items-center gap-3 border border-yellow-300/35 bg-yellow-300/10 px-3 py-2 text-sm text-yellow-100">
           <p className="min-w-0 flex-1">
-            You left this project. It no longer appears in your sidebar.
+            {copy("projectDetail.leftNotice", "You left this project. It no longer appears in your sidebar.", "이 프로젝트에서 나갔습니다. 더 이상 사이드바에 표시되지 않습니다.")}
           </p>
           <MembershipAction
             compact
@@ -689,7 +701,7 @@ export function ProjectDetail() {
           <button
             type="button"
             className="h-6 w-6 shrink-0 text-yellow-100/70 hover:text-yellow-100"
-            aria-label="Dismiss project membership notice"
+            aria-label={copy("projectDetail.leftNotice.dismiss", "Dismiss project membership notice", "프로젝트 참여 알림 닫기")}
             onClick={() => setDismissedLeftProjectIds((current) => new Set(current).add(project.id))}
           >
             ×
@@ -713,13 +725,13 @@ export function ProjectDetail() {
           {project.pauseReason === "budget" ? (
             <div className="inline-flex items-center gap-2 rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-red-200">
               <span className="h-2 w-2 rounded-full bg-red-400" />
-              Paused by budget hard stop
+              {copy("projectDetail.pausedByBudget", "Paused by budget hard stop", "예산 강제 중지로 일시정지")}
             </div>
           ) : null}
           {project.managedByPlugin ? (
             <div className="inline-flex items-center gap-2 rounded-full border border-border bg-muted px-3 py-1 text-[11px] font-medium text-muted-foreground">
               <span className="h-2 w-2 rounded-full" style={{ backgroundColor: project.color ?? "#6366f1" }} />
-              Managed by {project.managedByPlugin.pluginDisplayName}
+              {copy("projectDetail.managedBy", "Managed by {{name}}", "{{name}}에서 관리", { name: project.managedByPlugin.pluginDisplayName })}
             </div>
           ) : null}
         </div>
@@ -759,12 +771,12 @@ export function ProjectDetail() {
       <Tabs value={activeTab ?? "list"} onValueChange={(value) => handleTabChange(value as ProjectTab)}>
         <PageTabBar
           items={[
-            { value: "list", label: "Issues" },
-            { value: "overview", label: "Overview" },
-            ...(project.managedByPlugin ? [{ value: "plugin-operations", label: "Plugin operations" }] : []),
-            ...(showWorkspacesTab ? [{ value: "workspaces", label: "Workspaces" }] : []),
-            { value: "configuration", label: "Configuration" },
-            { value: "budget", label: "Budget" },
+            { value: "list", label: copy("projectDetail.tabs.issues", "Issues", "작업") },
+            { value: "overview", label: copy("projectDetail.tabs.overview", "Overview", "개요") },
+            ...(project.managedByPlugin ? [{ value: "plugin-operations", label: copy("projectDetail.tabs.pluginOperations", "Plugin operations", "플러그인 작업") }] : []),
+            ...(showWorkspacesTab ? [{ value: "workspaces", label: copy("projectDetail.tabs.workspaces", "Workspaces", "작업공간") }] : []),
+            { value: "configuration", label: copy("projectDetail.tabs.configuration", "Configuration", "설정") },
+            { value: "budget", label: copy("projectDetail.tabs.budget", "Budget", "예산") },
             ...pluginTabItems.map((item) => ({
               value: item.value,
               label: item.label,
@@ -812,7 +824,7 @@ export function ProjectDetail() {
             />
           )
         ) : (
-          <p className="text-sm text-muted-foreground">Loading workspaces...</p>
+          <p className="text-sm text-muted-foreground">{copy("projectDetail.workspaces.loading", "Loading workspaces...", "작업공간 불러오는 중...")}</p>
         )
       ) : null}
 

--- a/ui/src/pages/Projects.tsx
+++ b/ui/src/pages/Projects.tsx
@@ -12,6 +12,7 @@ import { MembershipAction } from "../components/MembershipAction";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { formatDate, projectUrl } from "../lib/utils";
+import { useCurrentLocale, useLocalizedCopy } from "../i18n/ui-copy";
 import {
   resourceMembershipState,
   useResourceMembershipMutation,
@@ -24,11 +25,11 @@ import { ArrowUpDown, Check, Hexagon, Plus } from "lucide-react";
 type ProjectSortField = "name" | "updated" | "created" | "targetDate";
 type ProjectSortDir = "asc" | "desc";
 
-const PROJECT_SORT_OPTIONS: Array<{ field: ProjectSortField; label: string }> = [
-  { field: "name", label: "Name" },
-  { field: "updated", label: "Updated" },
-  { field: "created", label: "Created" },
-  { field: "targetDate", label: "Target date" },
+const PROJECT_SORT_OPTIONS: Array<{ field: ProjectSortField; key: string; english: string; korean: string }> = [
+  { field: "name", key: "name", english: "Name", korean: "이름" },
+  { field: "updated", key: "updated", english: "Updated", korean: "최근 수정" },
+  { field: "created", key: "created", english: "Created", korean: "생성일" },
+  { field: "targetDate", key: "targetDate", english: "Target date", korean: "목표일" },
 ];
 
 function compareProjectNames(left: Project, right: Project) {
@@ -76,12 +77,14 @@ export function Projects() {
   const { selectedCompanyId } = useCompany();
   const { openNewProject } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
+  const locale = useCurrentLocale();
   const [sortField, setSortField] = useState<ProjectSortField>("name");
   const [sortDir, setSortDir] = useState<ProjectSortDir>("asc");
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Projects" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("projects.breadcrumb", "Projects", "프로젝트") }]);
+  }, [copy, setBreadcrumbs]);
 
   const { data: allProjects, isLoading, error } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
@@ -112,10 +115,25 @@ export function Projects() {
 
     return groups;
   }, [membershipsQuery.data, sortedProjects]);
-  const sortLabel = PROJECT_SORT_OPTIONS.find((option) => option.field === sortField)?.label ?? "Name";
+  const currentSortOption = PROJECT_SORT_OPTIONS.find((option) => option.field === sortField) ?? {
+    field: "name",
+    key: "name",
+    english: "Name",
+    korean: "이름",
+  };
+  const sortLabel = copy(
+    `projects.sort.${currentSortOption.key}`,
+    currentSortOption.english,
+    currentSortOption.korean,
+  );
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Hexagon} message="Select a company to view projects." />;
+    return (
+      <EmptyState
+        icon={Hexagon}
+        message={copy("projects.noCompany", "Select a company to view projects.", "프로젝트를 보려면 회사를 선택하세요.")}
+      />
+    );
   }
 
   if (isLoading) {
@@ -127,46 +145,51 @@ export function Projects() {
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <Popover>
           <PopoverTrigger asChild>
-            <Button variant="ghost" size="sm" className="w-fit text-xs" title="Sort">
+            <Button variant="ghost" size="sm" className="w-fit text-xs" title={copy("projects.sort.title", "Sort", "정렬")}>
               <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-              <span>Sort: {sortLabel}</span>
+              <span>{copy("projects.sort.prefix", "Sort: {{label}}", "정렬: {{label}}", { label: sortLabel })}</span>
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-44 p-0">
             <div className="p-2 space-y-0.5">
-              {PROJECT_SORT_OPTIONS.map((option) => (
-                <button
-                  key={option.field}
-                  type="button"
-                  className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
-                    sortField === option.field
-                      ? "bg-accent/50 text-foreground"
-                      : "text-muted-foreground hover:bg-accent/50"
-                  }`}
-                  onClick={() => {
-                    if (sortField === option.field) {
-                      setSortDir((current) => (current === "asc" ? "desc" : "asc"));
-                      return;
-                    }
-                    setSortField(option.field);
-                    setSortDir(option.field === "name" || option.field === "targetDate" ? "asc" : "desc");
-                  }}
-                >
-                  <span>{option.label}</span>
-                  {sortField === option.field ? (
-                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                      <Check className="h-3 w-3" />
-                      {sortDir === "asc" ? "Asc" : "Desc"}
-                    </span>
-                  ) : null}
-                </button>
-              ))}
+              {PROJECT_SORT_OPTIONS.map((option) => {
+                const optionLabel = copy(`projects.sort.${option.key}`, option.english, option.korean);
+                return (
+                  <button
+                    key={option.field}
+                    type="button"
+                    className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
+                      sortField === option.field
+                        ? "bg-accent/50 text-foreground"
+                        : "text-muted-foreground hover:bg-accent/50"
+                    }`}
+                    onClick={() => {
+                      if (sortField === option.field) {
+                        setSortDir((current) => (current === "asc" ? "desc" : "asc"));
+                        return;
+                      }
+                      setSortField(option.field);
+                      setSortDir(option.field === "name" || option.field === "targetDate" ? "asc" : "desc");
+                    }}
+                  >
+                    <span>{optionLabel}</span>
+                    {sortField === option.field ? (
+                      <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <Check className="h-3 w-3" />
+                        {sortDir === "asc"
+                          ? copy("projects.sort.asc", "Asc", "오름차순")
+                          : copy("projects.sort.desc", "Desc", "내림차순")}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
             </div>
           </PopoverContent>
         </Popover>
         <Button size="sm" variant="outline" onClick={openNewProject}>
           <Plus className="h-4 w-4 mr-1" />
-          Add Project
+          {copy("projects.add", "Add Project", "프로젝트 추가")}
         </Button>
       </div>
 
@@ -175,8 +198,8 @@ export function Projects() {
       {!isLoading && projects.length === 0 && (
         <EmptyState
           icon={Hexagon}
-          message="No projects yet."
-          action="Add Project"
+          message={copy("projects.empty", "No projects yet.", "아직 프로젝트가 없습니다.")}
+          action={copy("projects.add", "Add Project", "프로젝트 추가")}
           onAction={openNewProject}
         />
       )}
@@ -184,17 +207,30 @@ export function Projects() {
       {projects.length > 0 && (
         <div className="space-y-6">
           {([
-            ["My Projects", groupedProjects.mine],
-            ["Other Projects", groupedProjects.other],
-          ] as const).map(([label, sectionProjects]) => {
+            [
+              copy("projects.group.mine", "My Projects", "내 프로젝트"),
+              groupedProjects.mine,
+              "mine",
+            ],
+            [
+              copy("projects.group.other", "Other Projects", "다른 프로젝트"),
+              groupedProjects.other,
+              "other",
+            ],
+          ] as const).map(([label, sectionProjects, sectionKey]) => {
             if (sectionProjects.length === 0) return null;
 
             return (
-              <section key={label} className="space-y-2">
+              <section key={sectionKey} className="space-y-2">
                 <div className="flex items-center justify-between">
                   <h2 className="text-sm font-medium">{label}</h2>
                   <span className="text-xs text-muted-foreground">
-                    {sectionProjects.length} project{sectionProjects.length === 1 ? "" : "s"}
+                    {copy(
+                      "projects.count",
+                      sectionProjects.length === 1 ? "{{count}} project" : "{{count}} projects",
+                      "{{count}}개 프로젝트",
+                      { count: sectionProjects.length },
+                    )}
                   </span>
                 </div>
                 <div className="border border-border">
@@ -215,7 +251,7 @@ export function Projects() {
                           <div className="flex items-center gap-3">
                             {project.targetDate && (
                               <span className="text-xs text-muted-foreground">
-                                {formatDate(project.targetDate)}
+                                {formatDate(project.targetDate, locale)}
                               </span>
                             )}
                             <StatusBadge status={project.status} />

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
+import { useLocalizedCopy } from "../i18n/ui-copy";
 
 const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
@@ -202,6 +203,7 @@ function buildRoutinesTabHref(tab: RoutinesTab) {
 export function Routines() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const copy = useLocalizedCopy();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -241,8 +243,8 @@ export function Routines() {
   const [routineViewState, setRoutineViewState] = useState<RoutineViewState>(() => getRoutineViewState(routineViewStateKey));
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Routines" }]);
-  }, [setBreadcrumbs]);
+    setBreadcrumbs([{ label: copy("routines.breadcrumb", "Routines", "루틴") }]);
+  }, [copy, setBreadcrumbs]);
 
   useEffect(() => {
     setRoutineViewState(getRoutineViewState(routineViewStateKey));
@@ -310,10 +312,10 @@ export function Routines() {
       setAdvancedOpen(false);
       await queryClient.invalidateQueries({ queryKey: queryKeys.routines.list(selectedCompanyId!) });
       pushToast({
-        title: "Routine created",
+        title: copy("routines.toast.created", "Routine created", "루틴 생성됨"),
         body: routine.assigneeAgentId
-          ? "Add the first trigger to turn it into a live workflow."
-          : "Draft saved. Add a default agent before enabling automation.",
+          ? copy("routines.toast.createdWithAgent", "Add the first trigger to turn it into a live workflow.", "첫 트리거를 추가하면 실행 가능한 워크플로가 됩니다.")
+          : copy("routines.toast.createdDraft", "Draft saved. Add a default agent before enabling automation.", "초안이 저장되었습니다. 자동화를 켜기 전에 기본 직원을 추가하세요."),
         tone: "success",
       });
       navigate(`/routines/${routine.id}?tab=triggers`);
@@ -343,8 +345,8 @@ export function Routines() {
     },
     onError: (mutationError) => {
       pushToast({
-        title: "Failed to update routine",
-        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not update the routine.",
+        title: copy("routines.toast.updateFailed", "Failed to update routine", "루틴 업데이트 실패"),
+        body: mutationError instanceof Error ? mutationError.message : copy("routines.toast.updateFailedBody", "Paperclip could not update the routine.", "Paperclip이 루틴을 업데이트하지 못했습니다."),
         tone: "error",
       });
     },
@@ -378,8 +380,8 @@ export function Routines() {
     },
     onError: (mutationError) => {
       pushToast({
-        title: "Routine run failed",
-        body: mutationError instanceof Error ? mutationError.message : "Paperclip could not start the routine run.",
+        title: copy("routines.toast.runFailed", "Routine run failed", "루틴 실행 실패"),
+        body: mutationError instanceof Error ? mutationError.message : copy("routines.toast.runFailedBody", "Paperclip could not start the routine run.", "Paperclip이 루틴 실행을 시작하지 못했습니다."),
         tone: "error",
       });
     },
@@ -428,14 +430,63 @@ export function Routines() {
   const recentRunsIssueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
-        "Recent Runs",
+        copy("routines.tab.runs", "Recent Runs", "최근 실행"),
         buildRoutinesTabHref("runs"),
         "issues",
       ),
-    [],
+    [copy],
   );
   const currentAssignee = draft.assigneeAgentId ? agentById.get(draft.assigneeAgentId) ?? null : null;
   const currentProject = draft.projectId ? projectById.get(draft.projectId) ?? null : null;
+  const routineSortLabels: Record<RoutineSortField, string> = {
+    updated: copy("routines.sort.updated", "Updated", "최근 수정"),
+    created: copy("routines.sort.created", "Created", "생성일"),
+    lastRun: copy("routines.sort.lastRun", "Last run", "마지막 실행"),
+    title: copy("routines.sort.title", "Title", "제목"),
+  };
+  const routineGroupLabels: Record<RoutineGroupBy, string> = {
+    project: copy("routines.group.project", "Project", "프로젝트"),
+    assignee: copy("routines.group.assignee", "Agent", "직원"),
+    none: copy("routines.group.none", "None", "없음"),
+  };
+  const concurrencyPolicyLabels: Record<string, string> = {
+    coalesce_if_active: copy("routines.policy.concurrency.coalesce", "Coalesce if active", "실행 중이면 후속 1건만 유지"),
+    always_enqueue: copy("routines.policy.concurrency.always", "Always enqueue", "항상 대기열에 추가"),
+    skip_if_active: copy("routines.policy.concurrency.skip", "Skip if active", "실행 중이면 건너뛰기"),
+  };
+  const localizedConcurrencyDescriptions: Record<string, string> = {
+    coalesce_if_active: copy(
+      "routines.policy.concurrency.coalesceHelp",
+      concurrencyPolicyDescriptions.coalesce_if_active,
+      "이미 실행 중이면 후속 실행 하나만 대기열에 유지합니다.",
+    ),
+    always_enqueue: copy(
+      "routines.policy.concurrency.alwaysHelp",
+      concurrencyPolicyDescriptions.always_enqueue,
+      "루틴이 실행 중이어도 모든 트리거 발생을 대기열에 추가합니다.",
+    ),
+    skip_if_active: copy(
+      "routines.policy.concurrency.skipHelp",
+      concurrencyPolicyDescriptions.skip_if_active,
+      "이전 실행이 끝나지 않았으면 새 트리거 발생을 버립니다.",
+    ),
+  };
+  const catchUpPolicyLabels: Record<string, string> = {
+    skip_missed: copy("routines.policy.catchup.skip", "Skip missed", "놓친 실행 무시"),
+    enqueue_missed_with_cap: copy("routines.policy.catchup.enqueue", "Enqueue missed with cap", "놓친 실행 제한 추가"),
+  };
+  const localizedCatchUpDescriptions: Record<string, string> = {
+    skip_missed: copy(
+      "routines.policy.catchup.skipHelp",
+      catchUpPolicyDescriptions.skip_missed,
+      "스케줄러나 루틴이 일시정지된 동안 놓친 실행 구간을 무시합니다.",
+    ),
+    enqueue_missed_with_cap: copy(
+      "routines.policy.catchup.enqueueHelp",
+      catchUpPolicyDescriptions.enqueue_missed_with_cap,
+      "복구 후 놓친 스케줄 구간을 제한된 묶음으로 따라잡습니다.",
+    ),
+  };
 
   function updateRoutineView(patch: Partial<RoutineViewState>) {
     setRoutineViewState((current) => {
@@ -459,8 +510,8 @@ export function Routines() {
   function handleToggleEnabled(routine: RoutineListItem, enabled: boolean) {
     if (!enabled && !routine.assigneeAgentId) {
       pushToast({
-        title: "Default agent required",
-        body: "Set a default agent before enabling routine automation.",
+        title: copy("routines.toast.defaultAgentRequired", "Default agent required", "기본 직원 필요"),
+        body: copy("routines.toast.defaultAgentRequiredBody", "Set a default agent before enabling routine automation.", "루틴 자동화를 켜기 전에 기본 직원을 지정하세요."),
         tone: "warn",
       });
       return;
@@ -478,8 +529,21 @@ export function Routines() {
     });
   }
 
+  function routineGroupDisplayLabel(group: RoutineGroup) {
+    if (group.key === "__no_project") return copy("routines.group.noProject", "No project", "프로젝트 없음");
+    if (group.key === "__unassigned") return copy("routines.group.unassigned", "Unassigned", "미지정");
+    if (group.label === "Unknown project") return copy("routines.group.unknownProject", "Unknown project", "알 수 없는 프로젝트");
+    if (group.label === "Unknown agent") return copy("routines.group.unknownAgent", "Unknown agent", "알 수 없는 직원");
+    return group.label;
+  }
+
   if (!selectedCompanyId) {
-    return <EmptyState icon={Repeat} message="Select a company to view routines." />;
+    return (
+      <EmptyState
+        icon={Repeat}
+        message={copy("routines.noCompany", "Select a company to view routines.", "루틴을 보려면 회사를 선택하세요.")}
+      />
+    );
   }
 
   if (isLoading) {
@@ -491,15 +555,19 @@ export function Routines() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">
-            Routines
+            {copy("routines.title", "Routines", "루틴")}
           </h1>
           <p className="text-sm text-muted-foreground">
-            Recurring work definitions that materialize into auditable execution issues.
+            {copy(
+              "routines.subtitle",
+              "Recurring work definitions that materialize into auditable execution issues.",
+              "반복 업무를 감사 가능한 실행 작업으로 전환하는 정의입니다.",
+            )}
           </p>
         </div>
         <Button onClick={() => setComposerOpen(true)}>
           <Plus className="mr-2 h-4 w-4" />
-          Create routine
+          {copy("routines.create", "Create routine", "루틴 만들기")}
         </Button>
       </div>
 
@@ -509,31 +577,31 @@ export function Routines() {
           value={activeTab}
           onValueChange={handleTabChange}
           items={[
-            { value: "routines", label: "Routines" },
-            { value: "runs", label: "Recent Runs" },
+            { value: "routines", label: copy("routines.tab.routines", "Routines", "루틴") },
+            { value: "runs", label: copy("routines.tab.runs", "Recent Runs", "최근 실행") },
           ]}
         />
         <TabsContent value="routines" className="space-y-4">
           <div className="flex items-center justify-between gap-3">
             <p className="text-sm text-muted-foreground">
-              {(routines ?? []).length} routine{(routines ?? []).length === 1 ? "" : "s"}
+              {copy(
+                "routines.count",
+                (routines ?? []).length === 1 ? "{{count}} routine" : "{{count}} routines",
+                "루틴 {{count}}개",
+                { count: (routines ?? []).length },
+              )}
             </p>
             <div className="flex items-center gap-1">
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-xs" title="Sort">
+                  <Button variant="ghost" size="sm" className="text-xs" title={copy("routines.sort.title", "Sort", "정렬")}>
                     <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                    <span className="hidden sm:inline">Sort</span>
+                    <span className="hidden sm:inline">{copy("routines.sort.title", "Sort", "정렬")}</span>
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent align="end" className="w-44 p-0">
                   <div className="p-2 space-y-0.5">
-                    {([
-                      ["updated", "Updated"],
-                      ["created", "Created"],
-                      ["lastRun", "Last run"],
-                      ["title", "Title"],
-                    ] as const).map(([field, label]) => (
+                    {(["updated", "created", "lastRun", "title"] as const).map((field) => (
                       <button
                         key={field}
                         className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
@@ -549,10 +617,12 @@ export function Routines() {
                           );
                         }}
                       >
-                        <span>{label}</span>
+                        <span>{routineSortLabels[field]}</span>
                         {routineViewState.sortField === field ? (
                           <span className="text-xs text-muted-foreground">
-                            {routineViewState.sortDir === "asc" ? "Asc" : "Desc"}
+                            {routineViewState.sortDir === "asc"
+                              ? copy("routines.sort.asc", "Asc", "오름차순")
+                              : copy("routines.sort.desc", "Desc", "내림차순")}
                           </span>
                         ) : null}
                       </button>
@@ -562,18 +632,14 @@ export function Routines() {
               </Popover>
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-xs" title="Group">
+                  <Button variant="ghost" size="sm" className="text-xs" title={copy("routines.group.title", "Group", "그룹")}>
                     <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
-                    <span className="hidden sm:inline">Group</span>
+                    <span className="hidden sm:inline">{copy("routines.group.title", "Group", "그룹")}</span>
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent align="end" className="w-44 p-0">
                   <div className="p-2 space-y-0.5">
-                    {([
-                      ["project", "Project"],
-                      ["assignee", "Agent"],
-                      ["none", "None"],
-                    ] as const).map(([value, label]) => (
+                    {(["project", "assignee", "none"] as const).map((value) => (
                       <button
                         key={value}
                         className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm ${
@@ -583,7 +649,7 @@ export function Routines() {
                         }`}
                         onClick={() => updateRoutineView({ groupBy: value, collapsedGroups: [] })}
                       >
-                        <span>{label}</span>
+                        <span>{routineGroupLabels[value]}</span>
                         {routineViewState.groupBy === value ? <Check className="h-3.5 w-3.5" /> : null}
                       </button>
                     ))}
@@ -622,9 +688,15 @@ export function Routines() {
         >
           <div className="shrink-0 flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-5 py-3">
             <div>
-              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">New routine</p>
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                {copy("routines.composer.eyebrow", "New routine", "새 루틴")}
+              </p>
               <p className="text-sm text-muted-foreground">
-                Define the recurring work first. Default project and agent are optional for draft routines.
+                {copy(
+                  "routines.composer.subtitle",
+                  "Define the recurring work first. Default project and agent are optional for draft routines.",
+                  "반복 업무부터 정의하세요. 초안 루틴에서는 기본 프로젝트와 직원은 선택입니다.",
+                )}
               </p>
             </div>
             <Button
@@ -636,7 +708,7 @@ export function Routines() {
               }}
               disabled={createRoutine.isPending}
             >
-              Cancel
+              {copy("common.cancel", "Cancel", "취소")}
             </Button>
           </div>
 
@@ -645,7 +717,7 @@ export function Routines() {
               <textarea
                 ref={titleInputRef}
                 className="w-full resize-none overflow-hidden bg-transparent text-xl font-semibold outline-none placeholder:text-muted-foreground/50"
-                placeholder="Routine title"
+                placeholder={copy("routines.composer.titlePlaceholder", "Routine title", "루틴 제목")}
                 rows={1}
                 value={draft.title}
                 onChange={(event) => {
@@ -678,16 +750,16 @@ export function Routines() {
             <div className="px-5 pb-3">
               <div className="overflow-x-auto overscroll-x-contain">
                 <div className="inline-flex min-w-full flex-wrap items-center gap-2 text-sm text-muted-foreground sm:min-w-max sm:flex-nowrap">
-                  <span>For</span>
+                  <span>{copy("routines.composer.for", "For", "담당")}</span>
                   <InlineEntitySelector
                     ref={assigneeSelectorRef}
                     value={draft.assigneeAgentId}
                     options={assigneeOptions}
                     recentOptionIds={recentAssigneeIds}
-                    placeholder="Assignee"
-                    noneLabel="No assignee"
-                    searchPlaceholder="Search assignees..."
-                    emptyMessage="No assignees found."
+                    placeholder={copy("routines.assignee.placeholder", "Assignee", "담당 직원")}
+                    noneLabel={copy("routines.assignee.none", "No assignee", "담당 직원 없음")}
+                    searchPlaceholder={copy("routines.assignee.search", "Search assignees...", "담당 직원 검색...")}
+                    emptyMessage={copy("routines.assignee.empty", "No assignees found.", "직원을 찾지 못했습니다.")}
                     onChange={(assigneeAgentId) => {
                       if (assigneeAgentId) trackRecentAssignee(assigneeAgentId);
                       setDraft((current) => ({ ...current, assigneeAgentId }));
@@ -710,7 +782,7 @@ export function Routines() {
                           <span className="truncate">{option.label}</span>
                         )
                       ) : (
-                        <span className="text-muted-foreground">Assignee</span>
+                        <span className="text-muted-foreground">{copy("routines.assignee.placeholder", "Assignee", "담당 직원")}</span>
                       )
                     }
                     renderOption={(option) => {
@@ -724,16 +796,16 @@ export function Routines() {
                       );
                     }}
                   />
-                  <span>in</span>
+                  <span>{copy("routines.composer.in", "in", "프로젝트")}</span>
                   <InlineEntitySelector
                     ref={projectSelectorRef}
                     value={draft.projectId}
                     options={projectOptions}
                     recentOptionIds={recentProjectIds}
-                    placeholder="Project"
-                    noneLabel="No project"
-                    searchPlaceholder="Search projects..."
-                    emptyMessage="No projects found."
+                    placeholder={copy("routines.project.placeholder", "Project", "프로젝트")}
+                    noneLabel={copy("routines.project.none", "No project", "프로젝트 없음")}
+                    searchPlaceholder={copy("routines.project.search", "Search projects...", "프로젝트 검색...")}
+                    emptyMessage={copy("routines.project.empty", "No projects found.", "프로젝트를 찾지 못했습니다.")}
                     onChange={(projectId) => {
                       if (projectId) trackRecentProject(projectId);
                       setDraft((current) => ({ ...current, projectId }));
@@ -749,7 +821,7 @@ export function Routines() {
                           <span className="truncate">{option.label}</span>
                         </>
                       ) : (
-                        <span className="text-muted-foreground">Project</span>
+                        <span className="text-muted-foreground">{copy("routines.project.placeholder", "Project", "프로젝트")}</span>
                       )
                     }
                     renderOption={(option) => {
@@ -775,7 +847,7 @@ export function Routines() {
                 ref={descriptionEditorRef}
                 value={draft.description}
                 onChange={(description) => setDraft((current) => ({ ...current, description }))}
-                placeholder="Add instructions..."
+                placeholder={copy("routines.composer.instructionsPlaceholder", "Add instructions...", "지시사항 추가...")}
                 bordered={false}
                 contentClassName="min-h-[160px] text-sm text-muted-foreground"
                 mentions={mentionOptions}
@@ -791,15 +863,25 @@ export function Routines() {
               <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
                 <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
                   <div>
-                    <p className="text-sm font-medium">Advanced delivery settings</p>
-                    <p className="text-sm text-muted-foreground">Keep policy controls secondary to the work definition.</p>
+                    <p className="text-sm font-medium">
+                      {copy("routines.advanced.title", "Advanced delivery settings", "고급 실행 설정")}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {copy(
+                        "routines.advanced.subtitle",
+                        "Keep policy controls secondary to the work definition.",
+                        "정책 제어는 업무 정의보다 보조 설정으로 유지합니다.",
+                      )}
+                    </p>
                   </div>
                   {advancedOpen ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
                 </CollapsibleTrigger>
                 <CollapsibleContent className="pt-3">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div className="space-y-2">
-                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Concurrency</p>
+                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                        {copy("routines.advanced.concurrency", "Concurrency", "동시 실행")}
+                      </p>
                       <Select
                         value={draft.concurrencyPolicy}
                         onValueChange={(concurrencyPolicy) => setDraft((current) => ({ ...current, concurrencyPolicy }))}
@@ -809,14 +891,16 @@ export function Routines() {
                         </SelectTrigger>
                         <SelectContent>
                           {concurrencyPolicies.map((value) => (
-                            <SelectItem key={value} value={value}>{value.replaceAll("_", " ")}</SelectItem>
+                            <SelectItem key={value} value={value}>{concurrencyPolicyLabels[value] ?? value.replaceAll("_", " ")}</SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
-                      <p className="text-xs text-muted-foreground">{concurrencyPolicyDescriptions[draft.concurrencyPolicy]}</p>
+                      <p className="text-xs text-muted-foreground">{localizedConcurrencyDescriptions[draft.concurrencyPolicy]}</p>
                     </div>
                     <div className="space-y-2">
-                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Catch-up</p>
+                      <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                        {copy("routines.advanced.catchup", "Catch-up", "놓친 실행 처리")}
+                      </p>
                       <Select
                         value={draft.catchUpPolicy}
                         onValueChange={(catchUpPolicy) => setDraft((current) => ({ ...current, catchUpPolicy }))}
@@ -826,11 +910,11 @@ export function Routines() {
                         </SelectTrigger>
                         <SelectContent>
                           {catchUpPolicies.map((value) => (
-                            <SelectItem key={value} value={value}>{value.replaceAll("_", " ")}</SelectItem>
+                            <SelectItem key={value} value={value}>{catchUpPolicyLabels[value] ?? value.replaceAll("_", " ")}</SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
-                      <p className="text-xs text-muted-foreground">{catchUpPolicyDescriptions[draft.catchUpPolicy]}</p>
+                      <p className="text-xs text-muted-foreground">{localizedCatchUpDescriptions[draft.catchUpPolicy]}</p>
                     </div>
                   </div>
                 </CollapsibleContent>
@@ -840,7 +924,11 @@ export function Routines() {
 
           <div className="shrink-0 flex flex-col gap-3 border-t border-border/60 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-sm text-muted-foreground">
-              After creation, Paperclip takes you straight to trigger setup. Draft routines stay paused until you add a default agent.
+              {copy(
+                "routines.composer.footerHint",
+                "After creation, Paperclip takes you straight to trigger setup. Draft routines stay paused until you add a default agent.",
+                "생성 후 바로 트리거 설정으로 이동합니다. 기본 직원을 추가하기 전까지 초안 루틴은 일시정지 상태로 남습니다.",
+              )}
             </div>
             <div className="flex flex-col gap-2 sm:items-end">
               <Button
@@ -851,11 +939,15 @@ export function Routines() {
                 }
               >
                 <Plus className="mr-2 h-4 w-4" />
-                {createRoutine.isPending ? "Creating..." : "Create routine"}
+                {createRoutine.isPending
+                  ? copy("routines.creating", "Creating...", "만드는 중...")
+                  : copy("routines.create", "Create routine", "루틴 만들기")}
               </Button>
               {createRoutine.isError ? (
                 <p className="text-sm text-destructive">
-                  {createRoutine.error instanceof Error ? createRoutine.error.message : "Failed to create routine"}
+                  {createRoutine.error instanceof Error
+                    ? createRoutine.error.message
+                    : copy("routines.error.create", "Failed to create routine", "루틴을 만들지 못했습니다.")}
                 </p>
               ) : null}
             </div>
@@ -866,7 +958,7 @@ export function Routines() {
       {error ? (
         <Card>
           <CardContent className="pt-6 text-sm text-destructive">
-            {error instanceof Error ? error.message : "Failed to load routines"}
+            {error instanceof Error ? error.message : copy("routines.error.load", "Failed to load routines", "루틴을 불러오지 못했습니다.")}
           </CardContent>
         </Card>
       ) : null}
@@ -877,7 +969,11 @@ export function Routines() {
             <div className="py-12">
               <EmptyState
                 icon={Repeat}
-                message="No routines yet. Use Create routine to define the first recurring workflow."
+                message={copy(
+                  "routines.empty",
+                  "No routines yet. Use Create routine to define the first recurring workflow.",
+                  "아직 루틴이 없습니다. 루틴 만들기로 첫 반복 워크플로를 정의하세요.",
+                )}
               />
             </div>
           ) : (
@@ -899,7 +995,7 @@ export function Routines() {
                       <CollapsibleTrigger className="flex items-center gap-1.5">
                         <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-90" />
                         <span className="text-sm font-semibold uppercase tracking-wide">
-                          {group.label}
+                          {routineGroupDisplayLabel(group)}
                         </span>
                       </CollapsibleTrigger>
                       <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Add the YoonCompany console cleanup slice for the Paperclip UI surface.
- Localize remaining YoonCompany console copy to Korean across assistant, issue, run, plugin, and settings surfaces.
- Add the YoonCompany command plugin as a standalone local plugin example, not a root workspace package, to respect the repository lockfile policy.

## Scope Control
- This PR intentionally includes only the YoonCompany console cleanup scope.
- Existing server/adapter/db safety changes were split into separate PRs.
- The YoonCompany plugin remains present as a local plugin example; it is excluded from root workspace importer resolution like existing standalone plugin examples so PR-authored root `pnpm-lock.yaml` churn is not required.
- No merge was performed by this branch.

## Validation
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @paperclipai/ui typecheck`
- `corepack pnpm --dir packages/plugins/examples/plugin-yooncompany-command exec tsc --noEmit`
- Prior browser check: `http://127.0.0.1:3100/YOO/dashboard` showed restored draft labels for Codex/Hermes/YoonCompany tasks.

## Operational Notes
- Local plugin `yooncompany-command` was re-enabled through the Paperclip API during local validation and reported `ready`.
- Dangerous actions not executed: deploy, DB direct write, delete, email send, external publish beyond fork push and draft PR.