### PR TITLE
[codex] Improve Codex local Windows link fallback

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -4,6 +4,22 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { prepareManagedCodexHome } from "./codex-home.js";
 
+async function canCreateFileSymlink(root: string): Promise<boolean> {
+  const source = path.join(root, "symlink-probe-source");
+  const target = path.join(root, "symlink-probe-target");
+  await fs.writeFile(source, "probe", "utf8");
+
+  try {
+    await fs.symlink(source, target);
+    return (await fs.lstat(target)).isSymbolicLink();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM" && process.platform === "win32") {
+      return false;
+    }
+    throw error;
+  }
+}
+
 describe("codex managed home", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -24,14 +40,60 @@ describe("codex managed home", () => {
     const sharedAuth = path.join(sharedCodexHome, "auth.json");
     const managedAuth = path.join(managedCodexHome, "auth.json");
 
+    try {
+      if (!(await canCreateFileSymlink(root))) return;
+
+      await fs.mkdir(sharedCodexHome, { recursive: true });
+      await fs.writeFile(sharedAuth, '{"token":"shared"}\n', "utf8");
+
+      const originalSymlink = fs.symlink.bind(fs);
+      vi.spyOn(fs, "symlink").mockImplementationOnce(async (source, target, type) => {
+        await originalSymlink(source, target, type);
+        const error = new Error("file already exists") as NodeJS.ErrnoException;
+        error.code = "EEXIST";
+        throw error;
+      });
+
+      await expect(
+        prepareManagedCodexHome(
+          {
+            CODEX_HOME: sharedCodexHome,
+            PAPERCLIP_HOME: paperclipHome,
+            PAPERCLIP_INSTANCE_ID: "default",
+          },
+          async () => {},
+          "company-1",
+        ),
+      ).resolves.toBe(managedCodexHome);
+
+      expect((await fs.lstat(managedAuth)).isSymbolicLink()).toBe(true);
+      expect(await fs.realpath(managedAuth)).toBe(await fs.realpath(sharedAuth));
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to copying auth.json when Windows blocks file symlinks", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-home-"));
+    const sharedCodexHome = path.join(root, "shared-codex-home");
+    const paperclipHome = path.join(root, "paperclip-home");
+    const managedCodexHome = path.join(
+      paperclipHome,
+      "instances",
+      "default",
+      "companies",
+      "company-1",
+      "codex-home",
+    );
+    const sharedAuth = path.join(sharedCodexHome, "auth.json");
+    const managedAuth = path.join(managedCodexHome, "auth.json");
+
     await fs.mkdir(sharedCodexHome, { recursive: true });
     await fs.writeFile(sharedAuth, '{"token":"shared"}\n', "utf8");
 
-    const originalSymlink = fs.symlink.bind(fs);
-    vi.spyOn(fs, "symlink").mockImplementationOnce(async (source, target, type) => {
-      await originalSymlink(source, target, type);
-      const error = new Error("file already exists") as NodeJS.ErrnoException;
-      error.code = "EEXIST";
+    vi.spyOn(fs, "symlink").mockImplementationOnce(async () => {
+      const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+      error.code = "EPERM";
       throw error;
     });
 
@@ -48,8 +110,8 @@ describe("codex managed home", () => {
         ),
       ).resolves.toBe(managedCodexHome);
 
-      expect((await fs.lstat(managedAuth)).isSymbolicLink()).toBe(true);
-      expect(await fs.realpath(managedAuth)).toBe(await fs.realpath(sharedAuth));
+      expect((await fs.lstat(managedAuth)).isSymbolicLink()).toBe(false);
+      expect(await fs.readFile(managedAuth, "utf8")).toBe(await fs.readFile(sharedAuth, "utf8"));
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -91,6 +91,7 @@ describe("codex managed home", () => {
     await fs.mkdir(sharedCodexHome, { recursive: true });
     await fs.writeFile(sharedAuth, '{"token":"shared"}\n', "utf8");
 
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     vi.spyOn(fs, "symlink").mockImplementationOnce(async () => {
       const error = new Error("operation not permitted") as NodeJS.ErrnoException;
       error.code = "EPERM";

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -61,6 +61,10 @@ async function createExpectedSymlink(target: string, source: string): Promise<vo
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "EEXIST" && await isExpectedSymlink(target, source)) return;
+    if (code === "EPERM" && process.platform === "win32") {
+      await fs.copyFile(source, target);
+      return;
+    }
     throw error;
   }
 }

--- a/packages/adapters/codex-local/src/server/execute.skills.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.skills.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensureCodexSkillsInjected } from "./execute.js";
+
+describe("codex skill injection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to copying skill directories when Windows blocks links", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-skills-"));
+    const source = path.join(root, "source", "paperclip-test");
+    const skillsHome = path.join(root, "codex-home", "skills");
+    const target = path.join(skillsHome, "paperclip-test");
+
+    await fs.mkdir(source, { recursive: true });
+    await fs.writeFile(path.join(source, "SKILL.md"), "# Test skill\n", "utf8");
+
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.spyOn(fs, "symlink").mockImplementationOnce(async () => {
+      const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    });
+
+    try {
+      await ensureCodexSkillsInjected(async () => {}, {
+        skillsHome,
+        skillsEntries: [
+          {
+            key: "paperclipai/paperclip/paperclip-test",
+            runtimeName: "paperclip-test",
+            source,
+          },
+        ],
+        desiredSkillNames: ["paperclipai/paperclip/paperclip-test"],
+      });
+
+      expect((await fs.lstat(target)).isDirectory()).toBe(true);
+      expect(await fs.readFile(path.join(target, "SKILL.md"), "utf8")).toBe("# Test skill\n");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -164,6 +164,18 @@ function resolveCodexSkillsDir(codexHome: string): string {
   return path.join(codexHome, "skills");
 }
 
+async function linkCodexSkill(source: string, target: string): Promise<void> {
+  try {
+    await fs.symlink(source, target, process.platform === "win32" ? "junction" : "dir");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM" && process.platform === "win32") {
+      await fs.cp(source, target, { recursive: true });
+      return;
+    }
+    throw error;
+  }
+}
+
 type EnsureCodexSkillsInjectedOptions = {
   skillsHome?: string;
   skillsEntries?: Array<{ key: string; runtimeName: string; source: string }>;
@@ -230,7 +242,7 @@ export async function ensureCodexSkillsInjected(
 
   const skillsHome = options.skillsHome ?? resolveCodexSkillsDir(resolveSharedCodexHomeDir());
   await fs.mkdir(skillsHome, { recursive: true });
-  const linkSkill = options.linkSkill;
+  const linkSkill = options.linkSkill ?? linkCodexSkill;
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.runtimeName);
 
@@ -247,11 +259,7 @@ export async function ensureCodexSkillsInjected(
           (await isLikelyPaperclipRuntimeSkillPath(resolvedLinkedPath, entry.runtimeName))
         ) {
           await fs.unlink(target);
-          if (linkSkill) {
-            await linkSkill(entry.source, target);
-          } else {
-            await fs.symlink(entry.source, target);
-          }
+          await linkSkill(entry.source, target);
           await onLog(
             "stdout",
             `[paperclip] Repaired Codex skill "${entry.runtimeName}" into ${skillsHome}\n`,


### PR DESCRIPTION
## Summary
- Add Windows fallbacks for Codex local managed-home auth linking and runtime skill injection.
- Copy `auth.json` when Windows blocks file symlink creation with `EPERM`.
- Use directory junctions for Codex skill links on Windows, with a recursive copy fallback when links are blocked.

## Why
Paperclip local Codex runs can fail on Windows machines where symlink creation is not allowed. This keeps the local runtime usable without requiring elevated shell permissions or developer-mode symlink support.

## Scope Control
- This PR is based directly on `paperclipai/paperclip:master`.
- It intentionally excludes the YoonCompany console cleanup PR and all remaining dirty server/db/Hermes changes.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond the requested fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `corepack pnpm exec vitest run packages/adapters/codex-local/src/server/codex-home.test.ts packages/adapters/codex-local/src/server/execute.skills.test.ts`
- `corepack pnpm --filter @paperclipai/adapter-codex-local build`
- `git diff --check`
- `git diff --cached --check`

## Browser Verification
Not applicable: this is a Codex local adapter filesystem/runtime fallback with no UI surface.