### PR TITLE
[codex] Improve Hermes Paperclip context integration

### DIFF
--- a/scripts/yooncompany-hermes-e2e-smoke.ps1
+++ b/scripts/yooncompany-hermes-e2e-smoke.ps1
@@ -1,0 +1,133 @@
+param(
+  [string]$ApiBase = "http://127.0.0.1:3100/api",
+  [string]$CompanyPrefix = "YOO",
+  [int]$TimeoutSec = 420,
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Invoke-PaperclipJson {
+  param(
+    [ValidateSet("GET", "POST", "PATCH")]
+    [string]$Method,
+    [string]$Path,
+    [object]$Body = $null
+  )
+
+  $uri = "$ApiBase$Path"
+  if ($null -eq $Body) {
+    return Invoke-RestMethod -Method $Method -Uri $uri -TimeoutSec 30
+  }
+
+  return Invoke-RestMethod `
+    -Method $Method `
+    -Uri $uri `
+    -ContentType "application/json" `
+    -Body ($Body | ConvertTo-Json -Depth 12) `
+    -TimeoutSec 30
+}
+
+function First-NonEmptyString {
+  param(
+    [object]$First,
+    [object]$Second
+  )
+  if ($First -is [string] -and $First.Trim().Length -gt 0) {
+    return $First
+  }
+  return $Second
+}
+
+$companies = Invoke-PaperclipJson -Method GET -Path "/companies"
+$company = @($companies | Where-Object { $_.issuePrefix -eq $CompanyPrefix } | Select-Object -First 1)[0]
+if (-not $company) {
+  throw "Company prefix '$CompanyPrefix' was not found."
+}
+
+$agents = Invoke-PaperclipJson -Method GET -Path "/companies/$($company.id)/agents"
+$hermes = @(
+  $agents |
+    Where-Object { $_.adapterType -eq "hermes_local" -or $_.name -match "Hermes" } |
+    Select-Object -First 1
+)[0]
+if (-not $hermes) {
+  throw "Hermes agent was not found in company '$($company.name)'."
+}
+
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$issueBody = @{
+  title = "Hermes E2E smoke $stamp"
+  description = @"
+YoonCompany Hermes E2E smoke test.
+
+Expected behavior:
+- Hermes receives this assigned issue through Paperclip.
+- Hermes posts one concise proposal/comment.
+- Hermes marks the issue done.
+- Hermes does not edit repo files.
+
+verification:
+- run status succeeded
+- issue status done
+- at least one issue comment exists
+"@
+  priority = "medium"
+  status = "todo"
+  assigneeAgentId = $hermes.id
+}
+
+if ($DryRun) {
+  [pscustomobject]@{
+    company = $company.name
+    companyId = $company.id
+    hermes = $hermes.name
+    hermesId = $hermes.id
+    issue = $issueBody
+    dryRun = $true
+  } | ConvertTo-Json -Depth 8
+  exit 0
+}
+
+$issue = Invoke-PaperclipJson -Method POST -Path "/companies/$($company.id)/issues" -Body $issueBody
+$issueLabel = First-NonEmptyString -First $issue.identifier -Second $issue.id
+Write-Host "Created issue $issueLabel"
+
+$run = Invoke-PaperclipJson -Method POST -Path "/agents/$($hermes.id)/heartbeat/invoke" -Body @{
+  reason = "YoonCompany Hermes E2E smoke"
+  triggerDetail = "manual"
+  forceFreshSession = $true
+  payload = @{
+    issueId = $issue.id
+  }
+}
+Write-Host "Started run $($run.id)"
+
+$deadline = (Get-Date).AddSeconds($TimeoutSec)
+do {
+  Start-Sleep -Seconds 5
+  $run = Invoke-PaperclipJson -Method GET -Path "/heartbeat-runs/$($run.id)"
+  Write-Host "status=$($run.status) lastOutputSeq=$($run.lastOutputSeq)"
+} while ($run.status -in @("queued", "running") -and (Get-Date) -lt $deadline)
+
+$finalIssue = Invoke-PaperclipJson -Method GET -Path "/issues/$($issue.id)"
+$comments = @(Invoke-PaperclipJson -Method GET -Path "/issues/$($issue.id)/comments")
+
+$passed = $run.status -eq "succeeded" -and $finalIssue.status -eq "done" -and $comments.Count -gt 0
+$summary = [pscustomobject]@{
+  passed = $passed
+  issueId = $issue.id
+  identifier = $issue.identifier
+  runId = $run.id
+  runStatus = $run.status
+  exitCode = $run.exitCode
+  issueStatus = $finalIssue.status
+  commentCount = $comments.Count
+  result = First-NonEmptyString -First $run.resultJson.summary -Second $run.resultJson.result
+}
+
+$summary | ConvertTo-Json -Depth 8
+if (-not $passed) {
+  exit 1
+}

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -10,14 +10,18 @@ const hermesExecuteMock = vi.hoisted(() =>
   })),
 );
 
-vi.mock("hermes-paperclip-adapter/server", () => ({
-  execute: hermesExecuteMock,
-  testEnvironment: async () => ({
+const hermesTestEnvironmentMock = vi.hoisted(() =>
+  vi.fn(async () => ({
     adapterType: "hermes_local",
-    status: "pass",
+    status: "pass" as const,
     checks: [],
     testedAt: new Date(0).toISOString(),
-  }),
+  })),
+);
+
+vi.mock("hermes-paperclip-adapter/server", () => ({
+  execute: hermesExecuteMock,
+  testEnvironment: hermesTestEnvironmentMock,
   sessionCodec: null,
   listSkills: async () => [],
   syncSkills: async () => ({ entries: [] }),
@@ -61,6 +65,12 @@ describe("server adapter registry", () => {
     unregisterServerAdapter("external_test");
     unregisterServerAdapter("claude_local");
     setOverridePaused("claude_local", false);
+    hermesTestEnvironmentMock.mockImplementation(async () => ({
+      adapterType: "hermes_local",
+      status: "pass",
+      checks: [],
+      testedAt: new Date(0).toISOString(),
+    }));
   });
 
   afterEach(() => {
@@ -68,6 +78,7 @@ describe("server adapter registry", () => {
     unregisterServerAdapter("claude_local");
     setOverridePaused("claude_local", false);
     hermesExecuteMock.mockClear();
+    hermesTestEnvironmentMock.mockClear();
   });
 
   it("registers external adapters and exposes them through lookup helpers", async () => {
@@ -259,6 +270,65 @@ describe("server adapter registry", () => {
       detectCommand: "opencode",
       installCommand: expectedOpenCodeInstall,
     });
+    expect(findActiveServerAdapter("hermes_local")?.getRuntimeCommandSpec?.({})).toEqual({
+      command: "hermes",
+      detectCommand: "hermes",
+      installCommand: null,
+    });
+  });
+
+  it("uses Hermes-specific command aliases for runtime command detection", () => {
+    expect(findActiveServerAdapter("hermes_local")?.getRuntimeCommandSpec?.({
+      command: "agent-hermes",
+    })).toEqual({
+      command: "agent-hermes",
+      detectCommand: "agent-hermes",
+      installCommand: null,
+    });
+    expect(findActiveServerAdapter("hermes_local")?.getRuntimeCommandSpec?.({
+      command: "agent-hermes",
+      hermesCommand: "C:\\Tools\\Hermes\\hermes.exe",
+    })).toEqual({
+      command: "C:\\Tools\\Hermes\\hermes.exe",
+      detectCommand: "C:\\Tools\\Hermes\\hermes.exe",
+      installCommand: null,
+    });
+  });
+
+  it("treats Hermes OpenAI Codex OAuth as API-key optional in environment diagnostics", async () => {
+    hermesTestEnvironmentMock.mockResolvedValueOnce({
+      adapterType: "hermes_local",
+      status: "warn",
+      checks: [
+        {
+          level: "info",
+          message: "Model: gpt-5.5",
+          code: "hermes_model_configured",
+        },
+        {
+          level: "warn",
+          message: "No LLM API keys found in environment",
+          hint: "Set ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, or ZAI_API_KEY.",
+          code: "hermes_no_api_keys",
+        },
+      ],
+      testedAt: new Date(0).toISOString(),
+    });
+
+    const result = await findActiveServerAdapter("hermes_local")?.testEnvironment?.({
+      companyId: "company-1",
+      adapterType: "hermes_local",
+      config: {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    expect(result?.status).toBe("pass");
+    expect(result?.checks).toContainEqual(expect.objectContaining({
+      level: "info",
+      code: "hermes_codex_oauth_api_key_not_required",
+    }));
   });
 
   it("switches active adapter behavior back to the builtin when an override is paused", async () => {
@@ -383,6 +453,47 @@ describe("server adapter registry", () => {
     expect(patchedCtx.config.hermesCommand).toBe("runtime-hermes");
     expect(patchedCtx.agent.adapterConfig.hermesCommand).toBe("agent-hermes");
     expect(patchedCtx.agent.adapterConfig.env.PAPERCLIP_API_KEY).toBe("agent-run-jwt");
+  });
+
+  it("maps Paperclip issue context into Hermes task prompt fields", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      },
+      runtime: {},
+      config: {},
+      context: {
+        issueId: "issue-123",
+        taskId: "issue-123",
+        wakeReason: "issue_assigned",
+        paperclipIssue: {
+          id: "issue-123",
+          title: "Issue title",
+          description: "Issue description",
+        },
+        paperclipTaskMarkdown: "Paperclip task markdown",
+      },
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "agent-run-jwt",
+    });
+
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.config).toMatchObject({
+      taskId: "issue-123",
+      taskTitle: "Issue title",
+      taskBody: "Issue description",
+      wakeReason: "issue_assigned",
+    });
   });
 
   it("passes the original Hermes context through when authToken is absent", async () => {

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -1,6 +1,7 @@
 import type {
   AdapterModel,
   AdapterModelProfileDefinition,
+  AdapterEnvironmentTestResult,
   AdapterRuntimeCommandSpec,
   ServerAdapterModule,
 } from "./types.js";
@@ -147,6 +148,52 @@ function readConfiguredCommand(config: Record<string, unknown>, fallback: string
   return value.length > 0 ? value : fallback;
 }
 
+function readHermesConfiguredCommand(config: Record<string, unknown>): string {
+  const hermesCommand =
+    typeof config.hermesCommand === "string" ? config.hermesCommand.trim() : "";
+  if (hermesCommand.length > 0) return hermesCommand;
+  return readConfiguredCommand(config, "hermes");
+}
+
+function isHermesCodexOAuthConfig(config: unknown): boolean {
+  if (!config || typeof config !== "object") return false;
+  const provider = (config as Record<string, unknown>).provider;
+  return typeof provider === "string" && provider.trim().toLowerCase() === "openai-codex";
+}
+
+function statusFromEnvironmentChecks(checks: AdapterEnvironmentTestResult["checks"]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function normalizeHermesEnvironmentTestResult<T extends { config?: unknown }>(
+  ctx: T,
+  result: AdapterEnvironmentTestResult,
+): AdapterEnvironmentTestResult {
+  if (!isHermesCodexOAuthConfig(ctx.config)) return result;
+
+  let changed = false;
+  const checks = result.checks.map((check) => {
+    if (check.code !== "hermes_no_api_keys" || check.level !== "warn") return check;
+    changed = true;
+    return {
+      ...check,
+      level: "info" as const,
+      code: "hermes_codex_oauth_api_key_not_required",
+      message: "OpenAI Codex OAuth provider selected; Hermes does not require an LLM API key for this Paperclip run.",
+      hint: "Use `hermes status` or a Paperclip run smoke test to verify the local Codex OAuth session.",
+    };
+  });
+
+  if (!changed) return result;
+  return {
+    ...result,
+    status: statusFromEnvironmentChecks(checks),
+    checks,
+  };
+}
+
 function hasPathSeparator(command: string): boolean {
   return command.includes("/") || command.includes("\\");
 }
@@ -186,6 +233,10 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
     ctx && typeof ctx === "object" && "config" in ctx && ctx.config && typeof ctx.config === "object"
       ? (ctx.config as Record<string, unknown>)
       : null;
+  const context =
+    ctx && typeof ctx === "object" && "context" in ctx && ctx.context && typeof ctx.context === "object"
+      ? (ctx.context as Record<string, unknown>)
+      : null;
   const agent =
     ctx && typeof ctx === "object" && "agent" in ctx && ctx.agent && typeof ctx.agent === "object"
       ? (ctx.agent as Record<string, unknown>)
@@ -207,6 +258,32 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
   }
   if (agentAdapterConfig && !agentAdapterConfig.hermesCommand && agentCommand) {
     agentAdapterConfig.hermesCommand = agentCommand;
+  }
+
+  if (config && context) {
+    const paperclipIssue =
+      context.paperclipIssue && typeof context.paperclipIssue === "object" && !Array.isArray(context.paperclipIssue)
+        ? (context.paperclipIssue as Record<string, unknown>)
+        : null;
+    const contextTaskId = typeof context.taskId === "string" && context.taskId.length > 0 ? context.taskId : undefined;
+    const contextIssueId = typeof context.issueId === "string" && context.issueId.length > 0 ? context.issueId : undefined;
+    const issueId = typeof paperclipIssue?.id === "string" && paperclipIssue.id.length > 0
+      ? paperclipIssue.id
+      : contextTaskId ?? contextIssueId;
+
+    if (!config.taskId && issueId) config.taskId = issueId;
+    if (!config.taskTitle && typeof paperclipIssue?.title === "string") config.taskTitle = paperclipIssue.title;
+    if (!config.taskBody && typeof paperclipIssue?.description === "string") {
+      config.taskBody = paperclipIssue.description;
+    } else if (!config.taskBody && typeof context.paperclipTaskMarkdown === "string") {
+      config.taskBody = context.paperclipTaskMarkdown;
+    }
+    if (!config.commentId && typeof context.commentId === "string" && context.commentId.length > 0) {
+      config.commentId = context.commentId;
+    }
+    if (!config.wakeReason && typeof context.wakeReason === "string" && context.wakeReason.length > 0) {
+      config.wakeReason = context.wakeReason;
+    }
   }
 
   return ctx;
@@ -485,7 +562,11 @@ const hermesLocalAdapter: ServerAdapterModule = {
 
     return executeHermesLocal(patchedCtx);
   },
-  testEnvironment: (ctx) => hermesTestEnvironment(normalizeHermesConfig(ctx) as never),
+  testEnvironment: async (ctx) => {
+    const normalizedCtx = normalizeHermesConfig(ctx);
+    const result = await hermesTestEnvironment(normalizedCtx as never);
+    return normalizeHermesEnvironmentTestResult(normalizedCtx, result);
+  },
   sessionCodec: hermesSessionCodec,
   listSkills: hermesListSkills,
   syncSkills: hermesSyncSkills,
@@ -495,6 +576,14 @@ const hermesLocalAdapter: ServerAdapterModule = {
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: hermesAgentConfigurationDoc,
   detectModel: () => detectModelFromHermes(),
+  getRuntimeCommandSpec: (config) => {
+    const command = readHermesConfiguredCommand(config);
+    return {
+      command,
+      detectCommand: command,
+      installCommand: null,
+    };
+  },
 };
 
 const adaptersByType = new Map<string, ServerAdapterModule>();


### PR DESCRIPTION
## Summary
- Normalize Hermes local adapter configuration for Paperclip issue context, so assigned issues populate Hermes task fields.
- Add Hermes command alias handling via `hermesCommand` and runtime command detection.
- Treat OpenAI Codex OAuth Hermes runs as API-key optional in environment diagnostics.
- Add a YoonCompany Hermes E2E smoke script for local Paperclip/Hermes run verification.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only Hermes integration files and the Hermes smoke script.
- Excludes YoonCompany console cleanup, Codex local Windows fallback, DB backup, redaction/secrets, cost guard, and run/comment safety changes.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond the requested fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-registry.test.ts`
- PowerShell parse check: `[scriptblock]::Create((Get-Content -Raw scripts/yooncompany-hermes-e2e-smoke.ps1))`
- `git diff --cached --check`

## Browser Verification
Not applicable: this is server adapter integration and a local smoke script.