### PR TITLE
[codex] Validate actor run ids before persistence

### DIFF
--- a/server/src/__tests__/auth-middleware-run-id.test.ts
+++ b/server/src/__tests__/auth-middleware-run-id.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { normalizeActorRunId } from "../middleware/auth.js";
+
+describe("normalizeActorRunId", () => {
+  it("keeps valid UUID run ids", () => {
+    expect(normalizeActorRunId("9dae664c-7dae-4a1c-860b-c83657e34422")).toBe(
+      "9dae664c-7dae-4a1c-860b-c83657e34422",
+    );
+  });
+
+  it("drops non-UUID run ids before they reach database UUID columns", () => {
+    expect(normalizeActorRunId("manual-auth-smoke-20260526")).toBeUndefined();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,6 +13,14 @@ function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function normalizeActorRunId(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return UUID_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
 interface ActorMiddlewareOptions {
   deploymentMode: DeploymentMode;
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
@@ -33,7 +41,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const runIdHeader = normalizeActorRunId(req.header("x-paperclip-run-id"));
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
@@ -42,7 +50,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         if (cloudTenantActor) {
           req.actor = {
             ...cloudTenantActor,
-            runId: runIdHeader ?? undefined,
+            runId: runIdHeader,
           };
           next();
           return;
@@ -88,7 +96,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
             companyIds: memberships.map((row) => row.companyId),
             memberships,
             isInstanceAdmin: Boolean(roleRow),
-            runId: runIdHeader ?? undefined,
+            runId: runIdHeader,
             source: "session",
           };
           next();
@@ -120,7 +128,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           memberships: access.memberships,
           isInstanceAdmin: access.isInstanceAdmin,
           keyId: boardKey.id,
-          runId: runIdHeader || undefined,
+          runId: runIdHeader,
           source: "board_key",
         };
         next();
@@ -163,7 +171,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         agentId: claims.sub,
         companyId: claims.company_id,
         keyId: undefined,
-        runId: runIdHeader || claims.run_id || undefined,
+        runId: runIdHeader ?? normalizeActorRunId(claims.run_id),
         source: "agent_jwt",
       };
       next();
@@ -191,7 +199,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       agentId: key.agentId,
       companyId: key.companyId,
       keyId: key.id,
-      runId: runIdHeader || undefined,
+      runId: runIdHeader,
       source: "agent_key",
     };
 


### PR DESCRIPTION
## Summary
- Normalize actor run IDs before they are attached to request actors.
- Preserve valid UUID run IDs and drop non-UUID values before they reach database UUID columns.
- Cover the behavior with a focused unit test.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only actor run-id normalization and its test.
- Excludes Hermes, YoonCompany console, DB backup, redaction/secrets, cost guard, and other run/comment changes.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/auth-middleware-run-id.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Browser Verification
Not applicable: server middleware validation only.