### PR TITLE
[codex] Ignore run-authored board comments for reopen wakes

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -701,6 +701,57 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
+  it("does not reopen closed issues from board-authenticated run comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+
+    const res = await request(await installActor(createApp(), {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      runId: "77777777-7777-4777-8777-777777777777",
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Done: posted one proposal comment and marked the issue done." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "Done: posted one proposal comment and marked the issue done.",
+      { agentId: undefined, userId: "local-board", runId: "77777777-7777-4777-8777-777777777777" },
+      {
+        authorType: "user",
+        presentation: null,
+        metadata: null,
+      },
+    );
+    await waitForWakeup(() => expect(mockIssueService.findMentionedAgents).toHaveBeenCalled());
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not wake the assignee from board-authenticated run comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("in_progress"));
+
+    const res = await request(await installActor(createApp(), {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      runId: "77777777-7777-4777-8777-777777777777",
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Done: posted one proposal comment and marked the issue done." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.getCurrentScheduledRetry).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    await waitForWakeup(() => expect(mockIssueService.findMentionedAgents).toHaveBeenCalled());
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
   it("passes validated comment presentation fields to trusted board comment writes", async () => {
     const app = await installActor(createApp());
     mockIssueService.getById.mockResolvedValue(makeIssue("todo"));

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -622,10 +622,12 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
   actorId: string;
+  runId?: string | null;
 }) {
   // Only human comments should implicitly reopen finished work.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
+  if (input.runId) return false;
   if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
@@ -636,9 +638,11 @@ function shouldHumanCommentResumeInProgressScheduledRetry(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
+  runId?: string | null;
 }) {
   if (!input.hasComment) return false;
   if (input.actorType !== "user") return false;
+  if (input.runId) return false;
   if (input.issueStatus !== "in_progress") return false;
   return typeof input.assigneeAgentId === "string" && input.assigneeAgentId.length > 0;
 }
@@ -3826,6 +3830,7 @@ export function issueRoutes(
         issueStatus: existing.status,
         assigneeAgentId: requestedAssigneeAgentId,
         actorType: actor.actorType,
+        runId: actor.runId,
       })
         ? await svc.getCurrentScheduledRetry(existing.id)
         : null;
@@ -3840,6 +3845,7 @@ export function issueRoutes(
           assigneeAgentId: requestedAssigneeAgentId,
           actorType: actor.actorType,
           actorId: actor.actorId,
+          runId: actor.runId,
         })) ||
       shouldResumeInProgressScheduledRetry;
     const updateReferenceSummaryBefore = titleOrDescriptionChanged
@@ -4596,7 +4602,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || Boolean(actor.runId) || isClosed;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
@@ -5495,6 +5501,7 @@ export function issueRoutes(
         issueStatus: issue.status,
         assigneeAgentId: issue.assigneeAgentId,
         actorType: actor.actorType,
+        runId: actor.runId,
       })
         ? await svc.getCurrentScheduledRetry(issue.id)
         : null;
@@ -5508,6 +5515,7 @@ export function issueRoutes(
         assigneeAgentId: issue.assigneeAgentId,
         actorType: actor.actorType,
         actorId: actor.actorId,
+        runId: actor.runId,
       }) ||
       shouldResumeInProgressScheduledRetry;
     const hasUnresolvedFirstClassBlockers =
@@ -5683,7 +5691,7 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+      const skipWake = selfComment || Boolean(actor.runId) || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {


### PR DESCRIPTION
## Summary
- Prevent board-authenticated run comments from implicitly reopening closed or blocked issues.
- Prevent board-authenticated run comments from waking the assignee as if a human operator had commented.
- Add focused route tests for both comment paths.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only issue comment reopen/wakeup safety for run-authenticated board comments.
- Excludes Hermes, YoonCompany console, DB backup, redaction/secrets, cost guard, heartbeat cancel reason, and actor run-id normalization changes.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- Initial `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-comment-reopen-routes.test.ts` had one timeout, then a retry passed all 38 tests.
- `git diff --cached --check`

## Browser Verification
Not applicable: server route behavior only.