### PR TITLE
[codex] Record heartbeat cancellation reasons

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1440,6 +1440,70 @@ describe.sequential("agent permission routes", () => {
     });
   });
 
+  it("passes a sanitized board cancellation reason to heartbeat runs and activity logs", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId,
+      agentId,
+      status: "running",
+    });
+    mockHeartbeatService.cancelRun.mockResolvedValue({
+      id: "run-1",
+      companyId,
+      agentId,
+      status: "cancelled",
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post("/api/heartbeat-runs/run-1/cancel").send({ reason: "  stale dashboard run  " }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1", "stale dashboard run");
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "heartbeat.cancelled",
+      details: { agentId, reason: "stale dashboard run" },
+    }));
+  });
+
+  it("uses the board operator fallback reason for blank heartbeat run cancellation reasons", async () => {
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId,
+      agentId,
+      status: "running",
+    });
+    mockHeartbeatService.cancelRun.mockResolvedValue({
+      id: "run-1",
+      companyId,
+      agentId,
+      status: "cancelled",
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post("/api/heartbeat-runs/run-1/cancel").send({ reason: "   " }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("run-1", "Cancelled by board operator");
+  });
+
   it("rejects heartbeat cancellation outside the caller company scope", async () => {
     mockHeartbeatService.getRun.mockResolvedValue({
       id: "run-1",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -102,6 +102,8 @@ import { recoveryService } from "../services/recovery/service.js";
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
+const HEARTBEAT_CANCEL_REASON_DEFAULT = "Cancelled by board operator";
+const HEARTBEAT_CANCEL_REASON_MAX_LENGTH = 512;
 
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
@@ -114,6 +116,15 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   if (!Number.isFinite(parsed)) return fallback;
   if (parsed <= 0) return fallback;
   return Math.min(max, Math.trunc(parsed));
+}
+
+function readHeartbeatCancelReason(body: unknown) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return HEARTBEAT_CANCEL_REASON_DEFAULT;
+  const reason = (body as { reason?: unknown }).reason;
+  if (typeof reason !== "string") return HEARTBEAT_CANCEL_REASON_DEFAULT;
+  const trimmed = reason.trim();
+  if (!trimmed) return HEARTBEAT_CANCEL_REASON_DEFAULT;
+  return trimmed.slice(0, HEARTBEAT_CANCEL_REASON_MAX_LENGTH);
 }
 
 export function agentRoutes(
@@ -3201,7 +3212,8 @@ export function agentRoutes(
     if (existing) {
       assertCompanyAccess(req, existing.companyId);
     }
-    const run = await heartbeat.cancelRun(runId);
+    const reason = readHeartbeatCancelReason(req.body);
+    const run = await heartbeat.cancelRun(runId, reason);
 
     if (run) {
       await logActivity(db, {
@@ -3211,7 +3223,7 @@ export function agentRoutes(
         action: "heartbeat.cancelled",
         entityType: "heartbeat_run",
         entityId: run.id,
-        details: { agentId: run.agentId },
+        details: { agentId: run.agentId, reason },
       });
     }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10013,7 +10013,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     },
 
-    cancelRun: (runId: string) => cancelRunInternal(runId),
+    cancelRun: (runId: string, reason?: string) => cancelRunInternal(runId, reason),
 
     cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
 


### PR DESCRIPTION
## Summary
- Accept an optional heartbeat run cancellation reason from board requests.
- Trim and cap the reason, with a board-operator fallback for blank or missing values.
- Pass the reason into heartbeat cancellation and activity log details.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only heartbeat cancellation reason handling and route coverage.
- Excludes Hermes, YoonCompany console, DB backup, redaction/secrets, cost guard, actor run-id normalization, and issue comment reopen safety.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-permissions-routes.test.ts`
- `git diff --cached --check`

## Browser Verification
Not applicable: server route/service behavior only.