### PR TITLE
[codex] Harden secret redaction boundaries

### DIFF
--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactEventPayload,
+  redactSensitiveLogValue,
+  redactSensitiveText,
+  sanitizeRecord,
+} from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -134,5 +140,28 @@ describe("redaction", () => {
 
     expect(result?.args).toEqual(["--api-key", "not-a-command-secret"]);
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
+  });
+
+  it("redacts sensitive values from logger error objects and unstructured params", () => {
+    const err = new Error(
+      "Failed query: update heartbeat_runs set result_json=$1 -- params: stdout=OPENAI_API_KEY=sk-live-example",
+    ) as Error & { params?: string; cause?: Error };
+    err.params = "github token ghp_1234567890abcdefghijklmnopqrstuvwxyz";
+    err.cause = new Error("nested bearer token: Bearer nested-secret-value");
+
+    const result = redactSensitiveLogValue({
+      err,
+      msg: "failed with sk-message-example and ghp_message_secret_value_123456",
+    }) as {
+      err: { message: string; params: string; cause: { message: string } };
+      msg: string;
+    };
+
+    expect(JSON.stringify(result)).toContain(REDACTED_EVENT_VALUE);
+    expect(JSON.stringify(result)).not.toContain("sk-live-example");
+    expect(JSON.stringify(result)).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwxyz");
+    expect(JSON.stringify(result)).not.toContain("nested-secret-value");
+    expect(JSON.stringify(result)).not.toContain("sk-message-example");
+    expect(JSON.stringify(result)).not.toContain("ghp_message_secret_value_123456");
   });
 });

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -18,6 +18,7 @@ const mockSecretService = vi.hoisted(() => ({
   setDefaultProviderConfig: vi.fn(),
   checkProviderConfigHealth: vi.fn(),
   getById: vi.fn(),
+  list: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
   remove: vi.fn(),
@@ -93,6 +94,51 @@ describe("secret routes", () => {
     expect(res.status).toBe(400);
     expect(JSON.stringify(res.body)).toMatch(/Managed secrets cannot set externalRef/);
     expect(mockSecretService.create).not.toHaveBeenCalled();
+  });
+
+  it("redacts persistence-only secret material fields returned by the service", async () => {
+    const createdAt = new Date("2026-05-06T00:00:00.000Z");
+    mockSecretService.list.mockResolvedValue([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        companyId: "company-1",
+        key: "openai-api-key",
+        name: "OpenAI API Key",
+        provider: "local_encrypted",
+        status: "active",
+        managedMode: "paperclip_managed",
+        externalRef: null,
+        providerConfigId: null,
+        providerMetadata: null,
+        latestVersion: 1,
+        description: null,
+        lastResolvedAt: null,
+        lastRotatedAt: createdAt,
+        deletedAt: null,
+        createdByAgentId: null,
+        createdByUserId: "user-1",
+        createdAt,
+        updatedAt: createdAt,
+        referenceCount: 0,
+        value: "raw-secret-should-not-leak",
+        material: { ciphertext: "ciphertext-should-not-leak" },
+        valueSha256: "hash-should-not-leak",
+        fingerprintSha256: "fingerprint-should-not-leak",
+      },
+    ]);
+
+    const res = await request(createApp()).get("/api/companies/company-1/secrets");
+
+    expect(res.status).toBe(200);
+    expect(res.body[0]).not.toHaveProperty("value");
+    expect(res.body[0]).not.toHaveProperty("material");
+    expect(res.body[0]).not.toHaveProperty("valueSha256");
+    expect(res.body[0]).not.toHaveProperty("fingerprintSha256");
+    expect(res.body[0].key).toBe("openai-api-key");
+    expect(JSON.stringify(res.body)).not.toContain("raw-secret-should-not-leak");
+    expect(JSON.stringify(res.body)).not.toContain("ciphertext-should-not-leak");
+    expect(JSON.stringify(res.body)).not.toContain("hash-should-not-leak");
+    expect(JSON.stringify(res.body)).not.toContain("fingerprint-should-not-leak");
   });
 
   it("rejects provider vault routes for non-board actors", async () => {
@@ -343,6 +389,50 @@ describe("secret routes", () => {
       },
     }));
     expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("accessKey");
+  });
+
+  it("redacts credential-like provider vault config fields returned by the service", async () => {
+    const createdAt = new Date("2026-05-06T00:00:00.000Z");
+    mockSecretService.listProviderConfigs.mockResolvedValue([
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        companyId: "company-1",
+        provider: "aws_secrets_manager",
+        displayName: "AWS prod",
+        status: "ready",
+        isDefault: true,
+        config: {
+          region: "us-east-1",
+          secretNamePrefix: "paperclip",
+          accessKeyId: "AKIA-SHOULD-NOT-LEAK",
+          nested: { clientSecret: "client-secret-should-not-leak" },
+        },
+        healthStatus: "ok",
+        healthCheckedAt: createdAt,
+        healthMessage: "ok",
+        healthDetails: {
+          code: "ok",
+          authorization: "Bearer should-not-leak",
+        },
+        disabledAt: null,
+        createdByAgentId: null,
+        createdByUserId: "user-1",
+        createdAt,
+        updatedAt: createdAt,
+      },
+    ]);
+
+    const res = await request(createApp()).get("/api/companies/company-1/secret-provider-configs");
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].config.region).toBe("us-east-1");
+    expect(res.body[0].config.secretNamePrefix).toBe("paperclip");
+    expect(res.body[0].config.accessKeyId).toBe("***REDACTED***");
+    expect(res.body[0].config.nested.clientSecret).toBe("***REDACTED***");
+    expect(res.body[0].healthDetails.authorization).toBe("***REDACTED***");
+    expect(JSON.stringify(res.body)).not.toContain("AKIA-SHOULD-NOT-LEAK");
+    expect(JSON.stringify(res.body)).not.toContain("client-secret-should-not-leak");
+    expect(JSON.stringify(res.body)).not.toContain("Bearer should-not-leak");
   });
 
   it("removes provider vault config locally without deleting remote provider data", async () => {

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -5,6 +5,7 @@ import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+import { redactSensitiveLogValue } from "../redaction.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -30,6 +31,12 @@ const sharedOpts = {
 export const logger = pino({
   level: "debug",
   redact: ["req.headers.authorization"],
+  hooks: {
+    logMethod(inputArgs, method) {
+      const redactedArgs = inputArgs.map((arg) => redactSensitiveLogValue(arg));
+      return method.apply(this, redactedArgs as Parameters<typeof method>);
+    },
+  },
 }, pino.transport({
   targets: [
     {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -50,6 +50,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
+function isError(value: unknown): value is Error {
+  return value instanceof Error;
+}
+
 function sanitizeValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (Array.isArray(value)) return value.map(sanitizeValue);
@@ -131,4 +135,53 @@ export function redactSensitiveText(input: string): string {
       .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`),
     REDACTED_EVENT_VALUE,
   );
+}
+
+function redactSensitiveLogValueInternal(value: unknown, seen: WeakSet<object>, depth: number): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return redactSensitiveText(value);
+  if (typeof value !== "object") return value;
+  if (depth > 12) return "[Truncated]";
+
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveLogValueInternal(entry, seen, depth + 1));
+  }
+
+  if (value instanceof Date) return value;
+
+  if (isError(value)) {
+    const serialized: Record<string, unknown> = {
+      type: value.constructor?.name ?? "Error",
+      message: redactSensitiveText(value.message),
+      stack: value.stack ? redactSensitiveText(value.stack) : undefined,
+    };
+    for (const [key, entry] of Object.entries(value as Error & Record<string, unknown>)) {
+      if (key in serialized) continue;
+      serialized[key] = SECRET_PAYLOAD_KEY_RE.test(key)
+        ? REDACTED_EVENT_VALUE
+        : redactSensitiveLogValueInternal(entry, seen, depth + 1);
+    }
+    const cause = (value as Error & { cause?: unknown }).cause;
+    if (cause !== undefined) {
+      serialized.cause = redactSensitiveLogValueInternal(cause, seen, depth + 1);
+    }
+    return serialized;
+  }
+
+  if (!isPlainObject(value)) return value;
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    redacted[key] = SECRET_PAYLOAD_KEY_RE.test(key)
+      ? REDACTED_EVENT_VALUE
+      : redactSensitiveLogValueInternal(entry, seen, depth + 1);
+  }
+  return redacted;
+}
+
+export function redactSensitiveLogValue<T>(value: T): T {
+  return redactSensitiveLogValueInternal(value, new WeakSet<object>(), 0) as T;
 }

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -14,6 +14,67 @@ import { validate } from "../middleware/validate.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
 import { logActivity, secretService } from "../services/index.js";
 import { getConfiguredSecretProvider } from "../secrets/configured-provider.js";
+import { REDACTED_EVENT_VALUE } from "../redaction.js";
+
+const SECRET_RESPONSE_OMIT_KEYS = new Set([
+  "fingerprintSha256",
+  "fingerprint_sha256",
+  "material",
+  "plainText",
+  "plaintext",
+  "rawValue",
+  "secretValue",
+  "value",
+  "valueSha256",
+  "value_sha256",
+]);
+const PROVIDER_CONFIG_SECRET_KEY_RE =
+  /(?:access[-_]?key(?:[-_]?id)?|api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|client[-_]?secret|credential|connectionstring|cookie|jwt|passwd|password|private[-_]?key|secret[-_]?access[-_]?key|token)$/i;
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redactSecretApiRecord<T>(record: T): T {
+  if (Array.isArray(record)) {
+    return record.map((item) => redactSecretApiRecord(item)) as T;
+  }
+  if (!isPlainRecord(record)) return record;
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (SECRET_RESPONSE_OMIT_KEYS.has(key)) continue;
+    redacted[key] = value;
+  }
+  return redacted as T;
+}
+
+function redactProviderConfigApiRecord<T>(record: T): T {
+  if (Array.isArray(record)) {
+    return record.map((item) => redactProviderConfigApiRecord(item)) as T;
+  }
+  if (!isPlainRecord(record)) return record;
+
+  return {
+    ...record,
+    config: redactProviderConfigPayload(record.config),
+    healthDetails: redactProviderConfigPayload(record.healthDetails),
+  } as T;
+}
+
+function redactProviderConfigPayload(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactProviderConfigPayload);
+  if (!isPlainRecord(value)) return value;
+  const redacted: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    redacted[key] = PROVIDER_CONFIG_SECRET_KEY_RE.test(key)
+      ? REDACTED_EVENT_VALUE
+      : redactProviderConfigPayload(child);
+  }
+  return redacted;
+}
 
 export function secretRoutes(db: Db) {
   const router = Router();
@@ -39,7 +100,7 @@ export function secretRoutes(db: Db) {
     assertBoard(req);
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    res.json(await svc.listProviderConfigs(companyId));
+    res.json(redactProviderConfigApiRecord(await svc.listProviderConfigs(companyId)));
   });
 
   router.post(
@@ -109,7 +170,7 @@ export function secretRoutes(db: Db) {
       },
     });
 
-    res.status(201).json(created);
+    res.status(201).json(redactProviderConfigApiRecord(created));
   });
 
   router.get("/secret-provider-configs/:id", async (req, res) => {
@@ -120,7 +181,7 @@ export function secretRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    res.json(existing);
+    res.json(redactProviderConfigApiRecord(existing));
   });
 
   router.patch("/secret-provider-configs/:id", validate(updateSecretProviderConfigSchema), async (req, res) => {
@@ -159,7 +220,7 @@ export function secretRoutes(db: Db) {
       },
     });
 
-    res.json(updated);
+    res.json(redactProviderConfigApiRecord(updated));
   });
 
   router.delete("/secret-provider-configs/:id", async (req, res) => {
@@ -192,7 +253,7 @@ export function secretRoutes(db: Db) {
       },
     });
 
-    res.json(removed);
+    res.json(redactProviderConfigApiRecord(removed));
   });
 
   router.post("/secret-provider-configs/:id/default", async (req, res) => {
@@ -225,7 +286,7 @@ export function secretRoutes(db: Db) {
       },
     });
 
-    res.json(updated);
+    res.json(redactProviderConfigApiRecord(updated));
   });
 
   router.post("/secret-provider-configs/:id/health", async (req, res) => {
@@ -266,7 +327,7 @@ export function secretRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const secrets = await svc.list(companyId);
-    res.json(secrets);
+    res.json(redactSecretApiRecord(secrets));
   });
 
   router.post("/companies/:companyId/secrets", validate(createSecretSchema), async (req, res) => {
@@ -301,7 +362,7 @@ export function secretRoutes(db: Db) {
       details: { name: created.name, provider: created.provider },
     });
 
-    res.status(201).json(created);
+    res.status(201).json(redactSecretApiRecord(created));
   });
 
   router.post(
@@ -410,7 +471,7 @@ export function secretRoutes(db: Db) {
       details: { version: rotated.latestVersion },
     });
 
-    res.json(rotated);
+    res.json(redactSecretApiRecord(rotated));
   });
 
   router.patch("/secrets/:id", validate(updateSecretSchema), async (req, res) => {
@@ -452,7 +513,7 @@ export function secretRoutes(db: Db) {
       details: { name: updated.name },
     });
 
-    res.json(updated);
+    res.json(redactSecretApiRecord(updated));
   });
 
   router.get("/secrets/:id/usage", async (req, res) => {


### PR DESCRIPTION
## Summary
- Redact sensitive values from logger arguments, including nested `Error` fields and unstructured strings.
- Omit persistence-only secret material fields from secret API responses.
- Redact credential-like provider config and health detail fields before returning provider vault config data.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only secret/redaction boundary hardening and related tests.
- Excludes Hermes, YoonCompany console, DB backup, cost guard, heartbeat cancel reason, actor run-id normalization, and issue comment reopen safety.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/redaction.test.ts src/__tests__/secrets-routes.test.ts`
- `git diff --cached --check`

## Browser Verification
Not applicable: server API/log redaction behavior only.