### PR TITLE
[codex] Guard cost event company references

### DIFF
--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -10,6 +10,7 @@ import {
   activityLog,
   costEvents,
   financeEvents,
+  goals,
   heartbeatRuns,
   issues,
   projects,
@@ -413,6 +414,7 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(projects);
+    await db.delete(goals);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -494,6 +496,112 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(byAgentRow?.inputTokens).toBe(4_000_000_000);
     expect(byProjectRow?.costCents).toBe(4_000_000_000);
     expect(byAgentModelRow?.costCents).toBe(4_000_000_000);
+  });
+
+  it("rejects cost events that attach issue, project, goal, or run references from another company", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const agentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const otherIssueId = randomUUID();
+    const otherProjectId = randomUUID();
+    const otherGoalId = randomUUID();
+    const otherRunId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Other",
+        issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await db.insert(agents).values([
+      {
+        id: agentId,
+        companyId,
+        name: "Cost Agent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId: otherCompanyId,
+        name: "Other Agent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(projects).values({
+      id: otherProjectId,
+      companyId: otherCompanyId,
+      name: "Other Project",
+      status: "active",
+    });
+    await db.insert(goals).values({
+      id: otherGoalId,
+      companyId: otherCompanyId,
+      title: "Other Goal",
+      status: "planned",
+    });
+    await db.insert(issues).values({
+      id: otherIssueId,
+      companyId: otherCompanyId,
+      projectId: otherProjectId,
+      goalId: otherGoalId,
+      title: "Other Issue",
+      status: "done",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: "OTH-1",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId: otherCompanyId,
+      agentId: otherAgentId,
+      invocationSource: "on_demand",
+      status: "completed",
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: new Date("2026-04-10T00:01:00.000Z"),
+    });
+
+    const baseEvent = {
+      agentId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "metered_api",
+      model: "gpt-5",
+      inputTokens: 10,
+      cachedInputTokens: 0,
+      outputTokens: 5,
+      costCents: 1,
+      occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+    } as const;
+
+    await expect(costs.createEvent(companyId, { ...baseEvent, issueId: otherIssueId }))
+      .rejects.toThrow("Issue does not belong to company");
+    await expect(costs.createEvent(companyId, { ...baseEvent, projectId: otherProjectId }))
+      .rejects.toThrow("Project does not belong to company");
+    await expect(costs.createEvent(companyId, { ...baseEvent, goalId: otherGoalId }))
+      .rejects.toThrow("Goal does not belong to company");
+    await expect(costs.createEvent(companyId, { ...baseEvent, heartbeatRunId: otherRunId }))
+      .rejects.toThrow("Heartbeat run does not belong to company");
+
+    expect(await db.select().from(costEvents)).toHaveLength(0);
   });
 
   it("aggregates issue costs across recursive descendants only", async () => {

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
-import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
+import { activityLog, agents, companies, costEvents, goals, heartbeatRuns, issues, projects } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 
@@ -48,6 +48,68 @@ async function getMonthlySpendTotal(
   return Number(row?.total ?? 0);
 }
 
+async function assertCostReferenceBelongsToCompany(
+  db: Db,
+  input: {
+    companyId: string;
+    agentId: string;
+    issueId?: string | null;
+    projectId?: string | null;
+    goalId?: string | null;
+    heartbeatRunId?: string | null;
+  },
+) {
+  if (input.issueId) {
+    const issue = await db
+      .select({ companyId: issues.companyId })
+      .from(issues)
+      .where(eq(issues.id, input.issueId))
+      .then((rows) => rows[0] ?? null);
+    if (!issue || issue.companyId !== input.companyId) {
+      throw unprocessable("Issue does not belong to company");
+    }
+  }
+
+  if (input.projectId) {
+    const project = await db
+      .select({ companyId: projects.companyId })
+      .from(projects)
+      .where(eq(projects.id, input.projectId))
+      .then((rows) => rows[0] ?? null);
+    if (!project || project.companyId !== input.companyId) {
+      throw unprocessable("Project does not belong to company");
+    }
+  }
+
+  if (input.goalId) {
+    const goal = await db
+      .select({ companyId: goals.companyId })
+      .from(goals)
+      .where(eq(goals.id, input.goalId))
+      .then((rows) => rows[0] ?? null);
+    if (!goal || goal.companyId !== input.companyId) {
+      throw unprocessable("Goal does not belong to company");
+    }
+  }
+
+  if (input.heartbeatRunId) {
+    const run = await db
+      .select({
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, input.heartbeatRunId))
+      .then((rows) => rows[0] ?? null);
+    if (!run || run.companyId !== input.companyId) {
+      throw unprocessable("Heartbeat run does not belong to company");
+    }
+    if (run.agentId !== input.agentId) {
+      throw unprocessable("Heartbeat run does not belong to agent");
+    }
+  }
+}
+
 export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
   const budgets = budgetService(db, budgetHooks);
   return {
@@ -62,6 +124,15 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       if (agent.companyId !== companyId) {
         throw unprocessable("Agent does not belong to company");
       }
+
+      await assertCostReferenceBelongsToCompany(db, {
+        companyId,
+        agentId: data.agentId,
+        issueId: data.issueId,
+        projectId: data.projectId,
+        goalId: data.goalId,
+        heartbeatRunId: data.heartbeatRunId,
+      });
 
       const event = await db
         .insert(costEvents)


### PR DESCRIPTION
## Summary
- Validate that optional cost event issue, project, goal, and heartbeat run references belong to the same company.
- Validate that heartbeat run references also belong to the cost event agent.
- Add embedded Postgres coverage that rejects cross-company reference attachment without writing cost events.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only cost event reference ownership validation and test coverage.
- Excludes Hermes, YoonCompany console, DB backup, redaction/secrets, heartbeat cancel reason, actor run-id normalization, and issue comment reopen safety.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/costs-service.test.ts`
- `git diff --cached --check`

## Browser Verification
Not applicable: server service validation only.