### PR TITLE
[codex] Preserve JavaScript backup fallback inserts

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createGunzip } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import postgres from "postgres";
 import { createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
@@ -403,6 +404,79 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
           `),
         ).rejects.toThrow();
       } finally {
+        await sourceSql.end();
+        await restoreSql.end();
+      }
+    },
+    60_000,
+  );
+
+  it(
+    "falls back to restorable javascript inserts when pg_dump is unavailable",
+    async () => {
+      const previousPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      const previousPsqlPath = process.env.PAPERCLIP_PSQL_PATH;
+      process.env.PAPERCLIP_PG_DUMP_PATH = "paperclip-missing-pg-dump";
+      process.env.PAPERCLIP_PSQL_PATH = "paperclip-missing-psql";
+
+      const sourceConnectionString = await createTempDatabase();
+      const restoreConnectionString = await createSiblingDatabase(
+        sourceConnectionString,
+        "paperclip_auto_fallback_restore_target",
+      );
+      const backupDir = createTempDir("paperclip-db-auto-fallback-backup-");
+      const sourceSql = postgres(sourceConnectionString, { max: 1, onnotice: () => {} });
+      const restoreSql = postgres(restoreConnectionString, { max: 1, onnotice: () => {} });
+
+      try {
+        await sourceSql.unsafe(`
+          CREATE TABLE "public"."auto_fallback_records" (
+            "id" serial PRIMARY KEY,
+            "payload" text NOT NULL
+          );
+          INSERT INTO "public"."auto_fallback_records" ("payload")
+          VALUES ('restorable without psql');
+        `);
+
+        const result = await runDatabaseBackup({
+          connectionString: sourceConnectionString,
+          backupDir,
+          retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+          filenamePrefix: "paperclip-auto-fallback-test",
+        });
+
+        const backupText = await new Promise<string>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          fs.createReadStream(result.backupFile)
+            .pipe(createGunzip())
+            .on("data", (chunk) => chunks.push(Buffer.from(chunk)))
+            .on("error", reject)
+            .on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        });
+        expect(backupText).toContain("INSERT INTO \"public\".\"auto_fallback_records\"");
+        expect(backupText).not.toContain("COPY \"public\".\"auto_fallback_records\"");
+
+        await runDatabaseRestore({
+          connectionString: restoreConnectionString,
+          backupFile: result.backupFile,
+        });
+
+        const rows = await restoreSql.unsafe<{ payload: string }[]>(`
+          SELECT "payload"
+          FROM "public"."auto_fallback_records"
+        `);
+        expect(rows).toEqual([{ payload: "restorable without psql" }]);
+      } finally {
+        if (previousPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = previousPgDumpPath;
+        }
+        if (previousPsqlPath === undefined) {
+          delete process.env.PAPERCLIP_PSQL_PATH;
+        } else {
+          process.env.PAPERCLIP_PSQL_PATH = previousPsqlPath;
+        }
         await sourceSql.end();
         await restoreSql.end();
       }

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -523,6 +523,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const retention = opts.retention;
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
   const backupEngine = opts.backupEngine ?? "auto";
+  let effectiveBackupEngine = backupEngine;
   const canUsePgDump = !hasBackupTransforms(opts);
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
   const nullifiedColumnsByTable = normalizeNullifyColumnMap(opts.nullifyColumns);
@@ -563,6 +564,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         if (backupEngine === "pg_dump") {
           throw error;
         }
+        effectiveBackupEngine = "javascript";
         sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
         sqlClosed = false;
       }
@@ -896,7 +898,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       emit(`-- Data for: ${schema_name}.${tablename} (${count[0]!.n} rows)`);
 
       const nullifiedColumns = nullifiedColumnsByTable.get(currentTableKey) ?? new Set<string>();
-      if (backupEngine !== "javascript" && nullifiedColumns.size === 0) {
+      if (effectiveBackupEngine !== "javascript" && nullifiedColumns.size === 0) {
         emit(`COPY ${qualifiedTableName} (${colNames}) FROM stdin;`);
         await writer.writeRaw("\n");
         const copySql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });


### PR DESCRIPTION
## Summary
- Track the effective backup engine when `pg_dump` is unavailable in auto mode.
- Keep the JavaScript fallback on INSERT output so backups remain restorable without relying on `psql` COPY handling.
- Add embedded Postgres coverage for backup and restore when `pg_dump` and `psql` are unavailable.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only DB backup fallback behavior and test coverage.
- Excludes Hermes, YoonCompany console, redaction/secrets, cost guard, heartbeat cancel reason, actor run-id normalization, and issue comment reopen safety.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/db exec vitest run src/backup-lib.test.ts`
- `corepack pnpm --filter @paperclipai/db run check:migrations`
- `corepack pnpm --filter @paperclipai/db exec tsc --noEmit`
- `git diff --cached --check`

Note: `corepack pnpm --filter @paperclipai/db typecheck` was attempted first, but the package script itself shells out to bare `pnpm`, which is unavailable in this Windows environment. The equivalent migration check and `tsc --noEmit` were run with `corepack pnpm` directly.

## Browser Verification
Not applicable: DB backup library behavior only.