### PR TITLE
[codex] Fix plugin dev loader paths on Windows

### DIFF
--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -30,6 +30,8 @@ try {
 }
 
 const relativeSdkDir = relative(scopeDir, sdkDir);
-symlinkSync(relativeSdkDir, linkTarget, "dir");
+const linkType = process.platform === "win32" ? "junction" : "dir";
+const sdkLinkSource = process.platform === "win32" ? sdkDir : relativeSdkDir;
+symlinkSync(sdkLinkSource, linkTarget, linkType);
 
 console.log(`  ✓ Linked local @paperclipai/plugin-sdk for ${packageDir}`);

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1858,7 +1858,7 @@ export function pluginLoader(
       // (for example @paperclipai/shared exports). Run those workers through
       // the tsx loader so first-party example plugins work in development.
       if (activePlugin.packagePath && existsSync(DEV_TSX_LOADER_PATH)) {
-        workerOptions.execArgv = ["--import", DEV_TSX_LOADER_PATH];
+        workerOptions.execArgv = ["--import", pathToFileURL(DEV_TSX_LOADER_PATH).href];
       }
 
       await workerManager.startWorker(pluginId, workerOptions);


### PR DESCRIPTION
## Summary
- Use Windows junctions for local plugin SDK links created by the dev helper script.
- Pass the development tsx loader to worker `execArgv` as a file URL, which avoids Windows path parsing issues.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only plugin development/link-loader Windows path handling.
- Excludes Hermes, YoonCompany console, DB backup, redaction/secrets, cost guard, heartbeat cancel reason, actor run-id normalization, and issue comment reopen safety.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- `node --check scripts/link-plugin-dev-sdk.mjs`
- `git diff --cached --check`

## Browser Verification
Not applicable: development script and server worker launch path behavior only.