### PR TITLE
fix(issues): stop local_implicit board comments from re-opening closed issues

### DIFF
--- a/server/src/__tests__/definition-of-done-routes.test.ts
+++ b/server/src/__tests__/definition-of-done-routes.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Integration tests for HUM-183 (Paperclip mechanical DoD guards).
+ *
+ *   1. Pre-flight negative: PATCH /api/issues/:id setting assigneeAgentId on an
+ *      issue whose description lacks `Acceptance:` returns 422.
+ *   2. Post-flight negative: PATCH /api/issues/:id setting status=done when the
+ *      latest assignee comment lacks `Proof:` returns 422.
+ *   3. Happy path: full lifecycle (assign with Acceptance → Proof comment →
+ *      status=done) succeeds with 200 at every step.
+ */
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ISSUE_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ASSIGNEE_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const COMPANY_ID = "company-1";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  findMentionedAgents: vi.fn(async () => []),
+  getRelationSummaries: vi.fn(async () => ({ blockedBy: [], blocks: [] })),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+  getCurrentScheduledRetry: vi.fn(async () => null),
+  getDependencyReadiness: vi.fn(async () => ({ unresolvedBlockerCount: 0 })),
+  listComments: vi.fn(async () => []),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+
+function buildServicesIndexMock() {
+  return {
+    companyService: () => ({
+      getById: vi.fn(async () => ({
+        id: COMPANY_ID,
+        attachmentMaxBytes: 10 * 1024 * 1024,
+      })),
+    }),
+    accessService: () => ({
+      canUser: vi.fn(async () => true),
+      decide: vi.fn(async (input: { action?: string }) => ({
+        allowed: true,
+        action: input.action,
+        reason: "allow_explicit_grant",
+        explanation: "Allowed by test grant.",
+      })),
+      hasPermission: vi.fn(async () => true),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => null),
+      resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+        ambiguous: false,
+        agent: { id: raw },
+      })),
+    }),
+    documentService: () => ({}),
+    documentAnnotationService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({
+        vote: null,
+        consentEnabledNow: false,
+        sharingEnabled: false,
+      })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: {
+          censorUsernameInLogs: false,
+          feedbackDataSharingPreference: "prompt",
+        },
+      })),
+      listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueRecoveryActionService: () => ({
+      getActiveForIssue: vi.fn(async () => null),
+      listActiveForIssues: vi.fn(async () => new Map()),
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => mockIssueThreadInteractionService,
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  };
+}
+
+vi.mock("../services/index.js", () => buildServicesIndexMock());
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => buildServicesIndexMock());
+}
+
+async function createApp() {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>(
+      "../middleware/index.js",
+    ),
+    vi.importActual<typeof import("../routes/issues.js")>(
+      "../routes/issues.js",
+    ),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: COMPANY_ID,
+    status: "todo",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: "local-board",
+    createdByUserId: "local-board",
+    createdByAgentId: null,
+    identifier: "PAP-DOD",
+    title: "DoD test",
+    description: null as string | null,
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    createdAt: new Date("2026-05-26T00:00:00Z"),
+    updatedAt: new Date("2026-05-26T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("HUM-183 — Definition of Done mechanical guards", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("../services/definition-of-done.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    delete process.env.PAPERCLIP_DOD_GUARD_ENFORCEMENT_START_AT;
+    delete process.env.PAPERCLIP_DOD_GUARD_GRANDFATHER_DAYS;
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [],
+      blocks: [],
+    });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(
+      null,
+    );
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      unresolvedBlockerCount: 0,
+    });
+    mockIssueService.listComments.mockResolvedValue([]);
+  });
+
+  it("Test 1 (pre-flight negative): PATCH assigning an agent without Acceptance in description returns 422", async () => {
+    // Non-board-owned issue (assigneeUserId !== "local-board") so the
+    // board-owned exemption does not apply.
+    const existing = makeIssue({
+      description:
+        "We need this fixed by Friday. Some context but no structured acceptance.",
+      assigneeUserId: null,
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ assigneeAgentId: ASSIGNEE_AGENT_ID });
+
+    expect(res.status).toBe(422);
+    expect(String(res.body?.error ?? res.text)).toMatch(/Acceptance/);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("Test 2 (post-flight negative): PATCH status=done without a Proof comment by the assignee returns 422", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+      description: "**Acceptance:** the thing must do X.",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    // Latest comment is from a different agent or lacks Proof:
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-x",
+        body: "Looks fine to me",
+        authorAgentId: ASSIGNEE_AGENT_ID,
+        derivedAuthorAgentId: null,
+      },
+    ]);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(422);
+    expect(String(res.body?.error ?? res.text)).toMatch(/Proof/);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("Test 3 (happy path): assign with Acceptance → Proof comment → status=done returns 200 at every step", async () => {
+    const description =
+      "## Acceptance:\n- The system MUST do the thing\n- The other thing too\n";
+
+    // Step 1: assign with Acceptance present.
+    const beforeAssign = makeIssue({ description });
+    const afterAssign = makeIssue({
+      description,
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    mockIssueService.getById.mockResolvedValue(beforeAssign);
+    mockIssueService.update.mockResolvedValue(afterAssign);
+
+    const assignRes = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ assigneeAgentId: ASSIGNEE_AGENT_ID });
+    expect(assignRes.status).toBe(200);
+
+    // Step 2: assignee posts a Proof comment via PATCH-with-comment.
+    mockIssueService.getById.mockResolvedValue(afterAssign);
+    mockIssueService.update.mockResolvedValue(afterAssign);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-proof",
+      issueId: ISSUE_ID,
+      companyId: COMPANY_ID,
+      body: "Proof: tests pass, smoke pass.",
+      authorAgentId: ASSIGNEE_AGENT_ID,
+    });
+    const commentRes = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ comment: "Proof: tests pass, smoke pass." });
+    expect(commentRes.status).toBe(200);
+
+    // Step 3: status=done with the Proof comment now the latest.
+    const doneIssue = makeIssue({
+      description,
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(doneIssue);
+    mockIssueService.update.mockResolvedValue({
+      ...doneIssue,
+      status: "done",
+    });
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-proof",
+        body: "Proof: tests pass, smoke pass.",
+        authorAgentId: ASSIGNEE_AGENT_ID,
+        derivedAuthorAgentId: null,
+      },
+    ]);
+    const doneRes = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+    expect(doneRes.status).toBe(200);
+  });
+});

--- a/server/src/__tests__/definition-of-done.test.ts
+++ b/server/src/__tests__/definition-of-done.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  commentHasProofBlock,
+  descriptionHasAcceptanceField,
+  evaluatePostflightProofGuard,
+  evaluatePreflightAcceptanceGuard,
+  isWithinGrandfatherWindow,
+  readEnforcementWindowFromEnv,
+} from "../services/definition-of-done.js";
+
+describe("descriptionHasAcceptanceField", () => {
+  it("matches bold markdown header", () => {
+    expect(descriptionHasAcceptanceField("**Acceptance:**\n- X")).toBe(true);
+  });
+  it("matches plain leading", () => {
+    expect(descriptionHasAcceptanceField("Acceptance: X\nY")).toBe(true);
+  });
+  it("matches h2 header", () => {
+    expect(descriptionHasAcceptanceField("## Acceptance:\n- X")).toBe(true);
+  });
+  it("rejects descriptions without an Acceptance line", () => {
+    expect(
+      descriptionHasAcceptanceField("Some context\nnothing structured here"),
+    ).toBe(false);
+  });
+  it("rejects null/empty", () => {
+    expect(descriptionHasAcceptanceField(null)).toBe(false);
+    expect(descriptionHasAcceptanceField("")).toBe(false);
+    expect(descriptionHasAcceptanceField("   ")).toBe(false);
+  });
+});
+
+describe("commentHasProofBlock", () => {
+  it("matches `Proof:` plain", () => {
+    expect(commentHasProofBlock("Proof: test passed")).toBe(true);
+  });
+  it("matches `**Proof:**` bold", () => {
+    expect(commentHasProofBlock("**Proof:**\n- output here")).toBe(true);
+  });
+  it("rejects bodies without Proof", () => {
+    expect(commentHasProofBlock("looks fine")).toBe(false);
+  });
+});
+
+describe("evaluatePreflightAcceptanceGuard", () => {
+  const baseExisting = {
+    description: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    createdByAgentId: null,
+    createdByUserId: "local-board",
+  };
+  const baseActor = {
+    actorType: "user" as const,
+    actorId: "local-board",
+    agentId: null,
+  };
+
+  it("allows when assigneeAgentId is not being changed", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: baseExisting,
+      requestedAssigneeAgentId: undefined,
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows clearing the assignee", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: { ...baseExisting, assigneeAgentId: "agent-x" },
+      requestedAssigneeAgentId: null,
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows no-op reassignment to same agent", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: { ...baseExisting, assigneeAgentId: "agent-x" },
+      requestedAssigneeAgentId: "agent-x",
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows self-assignment by the acting agent", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: baseExisting,
+      requestedAssigneeAgentId: "agent-self",
+      actor: {
+        actorType: "agent",
+        actorId: "agent-self",
+        agentId: "agent-self",
+      },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows reassignment to the original creator agent (author self-assignment)", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: { ...baseExisting, createdByAgentId: "agent-author" },
+      requestedAssigneeAgentId: "agent-author",
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks reassignment to a new agent when description lacks Acceptance", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: { ...baseExisting, description: "no structure" },
+      requestedAssigneeAgentId: "agent-new",
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.status).toBe(422);
+      expect(result.error).toMatch(/Acceptance/);
+    }
+  });
+
+  it("allows reassignment when description has Acceptance", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: { ...baseExisting, description: "**Acceptance:**\n- X" },
+      requestedAssigneeAgentId: "agent-new",
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows reassignment of a board-owned issue without Acceptance (board hand-off)", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: {
+        ...baseExisting,
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        description: null,
+      },
+      requestedAssigneeAgentId: "agent-new",
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("uses requested description when included in the same PATCH", () => {
+    const result = evaluatePreflightAcceptanceGuard({
+      existing: { ...baseExisting, description: "old without acceptance" },
+      requestedDescription: "Acceptance: new structure",
+      requestedAssigneeAgentId: "agent-new",
+      actor: baseActor,
+    });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("evaluatePostflightProofGuard", () => {
+  const baseCtx = {
+    existingAssigneeAgentId: "agent-A",
+    existingCreatedAt: new Date("2026-05-26T00:00:00Z"),
+    transitioningToDone: true,
+  } as const;
+
+  it("allows when not transitioning to done", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      transitioningToDone: false,
+      latestAssigneeComment: null,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows when there is no agent assignee", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      existingAssigneeAgentId: null,
+      latestAssigneeComment: null,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks when no Proof comment exists", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      latestAssigneeComment: null,
+    });
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.status).toBe(422);
+      expect(result.error).toMatch(/Proof/);
+    }
+  });
+
+  it("blocks when latest comment is from a different agent", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      latestAssigneeComment: {
+        body: "Proof: I reviewed",
+        authorAgentId: "agent-B",
+      },
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("blocks when latest assignee comment lacks Proof: prefix", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      latestAssigneeComment: {
+        body: "I'm done",
+        authorAgentId: "agent-A",
+      },
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("allows when latest assignee comment contains Proof:", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      latestAssigneeComment: {
+        body: "Proof: ran the tests, all green",
+        authorAgentId: "agent-A",
+      },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows when derived author matches assignee", () => {
+    const result = evaluatePostflightProofGuard({
+      ...baseCtx,
+      latestAssigneeComment: {
+        body: "**Proof:** see logs",
+        authorAgentId: null,
+        derivedAuthorAgentId: "agent-A",
+      },
+    });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("isWithinGrandfatherWindow", () => {
+  it("returns false when no enforcement window is configured", () => {
+    expect(
+      isWithinGrandfatherWindow(new Date("2026-01-01"), undefined),
+    ).toBe(false);
+  });
+
+  it("returns true for items created before startAt and inside the 7-day window", () => {
+    expect(
+      isWithinGrandfatherWindow(new Date("2026-01-01T00:00:00Z"), {
+        startAt: new Date("2026-05-26T00:00:00Z"),
+        grandfatherDays: 7,
+        now: new Date("2026-05-29T00:00:00Z"),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false past the 7-day grace", () => {
+    expect(
+      isWithinGrandfatherWindow(new Date("2026-01-01T00:00:00Z"), {
+        startAt: new Date("2026-05-26T00:00:00Z"),
+        grandfatherDays: 7,
+        now: new Date("2026-06-10T00:00:00Z"),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for issues created after enforcement startAt", () => {
+    expect(
+      isWithinGrandfatherWindow(new Date("2026-05-27T00:00:00Z"), {
+        startAt: new Date("2026-05-26T00:00:00Z"),
+        grandfatherDays: 7,
+        now: new Date("2026-05-28T00:00:00Z"),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("readEnforcementWindowFromEnv", () => {
+  it("returns nulls when env vars are unset", () => {
+    const w = readEnforcementWindowFromEnv({});
+    expect(w.startAt).toBeNull();
+    expect(w.grandfatherDays).toBe(7);
+  });
+
+  it("parses valid ISO date and grandfather days", () => {
+    const w = readEnforcementWindowFromEnv({
+      PAPERCLIP_DOD_GUARD_ENFORCEMENT_START_AT: "2026-05-26T19:30:00Z",
+      PAPERCLIP_DOD_GUARD_GRANDFATHER_DAYS: "10",
+    });
+    expect(w.startAt?.toISOString()).toBe("2026-05-26T19:30:00.000Z");
+    expect(w.grandfatherDays).toBe(10);
+  });
+
+  it("falls back to defaults when env values are garbage", () => {
+    const w = readEnforcementWindowFromEnv({
+      PAPERCLIP_DOD_GUARD_ENFORCEMENT_START_AT: "not-a-date",
+      PAPERCLIP_DOD_GUARD_GRANDFATHER_DAYS: "abc",
+    });
+    expect(w.startAt).toBeNull();
+    expect(w.grandfatherDays).toBe(7);
+  });
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -170,7 +170,7 @@ async function installActor(app: express.Express, actor?: Record<string, unknown
       type: "board",
       userId: "local-board",
       companyIds: ["company-1"],
-      source: "local_implicit",
+      source: "board_key",
       isInstanceAdmin: false,
     };
     next();
@@ -178,6 +178,20 @@ async function installActor(app: express.Express, actor?: Record<string, unknown
   app.use("/api", issueRoutes(mockDb as any, {} as any));
   app.use(errorHandler);
   return app;
+}
+
+// HUM-196: actor for unauthenticated local-trusted curls (the implicit board
+// attribution applied to any request that does not present a bearer token).
+// CEO-agent curls without auth fall into this bucket and must not silently
+// trigger the human-comment-reopens-closed rule.
+function implicitBoardActor() {
+  return {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  };
 }
 
 async function normalizePolicy(input: {
@@ -512,6 +526,40 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     ));
+  });
+
+  // HUM-196: regression for the silent done -> todo flap. An agent curl posted
+  // without an auth header is attributed to the local-board user with
+  // source "local_implicit". The previous reopen rule treated that as a human
+  // comment and flipped the closed issue back to todo on every acknowledgment.
+  it("HUM-196: does not flip done -> todo via POST comments from a local_implicit board actor", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+
+    const res = await request(await installActor(createApp(), implicitBoardActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "final ack from CEO" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("HUM-196: does not flip done -> todo via the PATCH comment path from a local_implicit board actor", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), implicitBoardActor()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "final ack from CEO" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -71,6 +71,7 @@ export function getActorInfo(req: Request) {
       actorId: req.actor.agentId ?? "unknown-agent",
       agentId: req.actor.agentId ?? null,
       runId: req.actor.runId ?? null,
+      actorSource: req.actor.source ?? null,
     };
   }
 
@@ -79,5 +80,6 @@ export function getActorInfo(req: Request) {
     actorId: req.actor.userId ?? "board",
     agentId: null,
     runId: req.actor.runId ?? null,
+    actorSource: req.actor.source ?? null,
   };
 }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -622,15 +622,28 @@ function isClosedIssueStatus(status: string | null | undefined): status is "done
   return status === "done" || status === "cancelled";
 }
 
+// HUM-196: local_implicit board attribution is the default for any unauthenticated
+// request in local_trusted mode, including agent curls that did not present their
+// API key/JWT. Treating those as human comments silently reopened closed issues
+// every time an agent posted an acknowledgment. We require an authenticated human
+// source (session, board_key, cloud_tenant) for implicit reopen. Local humans and
+// agents can still reopen via explicit `reopen: true` or `status: "todo"` PATCH.
+function isConfirmedHumanActorSource(actorSource: string | null | undefined) {
+  if (typeof actorSource !== "string") return false;
+  return actorSource === "session" || actorSource === "board_key" || actorSource === "cloud_tenant";
+}
+
 function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
   actorId: string;
+  actorSource: string | null | undefined;
 }) {
   // Only human comments should implicitly reopen finished work.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
+  if (!isConfirmedHumanActorSource(input.actorSource)) return false;
   if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
@@ -641,9 +654,11 @@ function shouldHumanCommentResumeInProgressScheduledRetry(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
+  actorSource: string | null | undefined;
 }) {
   if (!input.hasComment) return false;
   if (input.actorType !== "user") return false;
+  if (!isConfirmedHumanActorSource(input.actorSource)) return false;
   if (input.issueStatus !== "in_progress") return false;
   return typeof input.assigneeAgentId === "string" && input.assigneeAgentId.length > 0;
 }
@@ -3864,6 +3879,7 @@ export function issueRoutes(
         issueStatus: existing.status,
         assigneeAgentId: requestedAssigneeAgentId,
         actorType: actor.actorType,
+        actorSource: actor.actorSource,
       })
         ? await svc.getCurrentScheduledRetry(existing.id)
         : null;
@@ -3878,6 +3894,7 @@ export function issueRoutes(
           assigneeAgentId: requestedAssigneeAgentId,
           actorType: actor.actorType,
           actorId: actor.actorId,
+          actorSource: actor.actorSource,
         })) ||
       shouldResumeInProgressScheduledRetry;
     const updateReferenceSummaryBefore = titleOrDescriptionChanged
@@ -5559,6 +5576,7 @@ export function issueRoutes(
         issueStatus: issue.status,
         assigneeAgentId: issue.assigneeAgentId,
         actorType: actor.actorType,
+        actorSource: actor.actorSource,
       })
         ? await svc.getCurrentScheduledRetry(issue.id)
         : null;
@@ -5572,6 +5590,7 @@ export function issueRoutes(
         assigneeAgentId: issue.assigneeAgentId,
         actorType: actor.actorType,
         actorId: actor.actorId,
+        actorSource: actor.actorSource,
       }) ||
       shouldResumeInProgressScheduledRetry;
     const hasUnresolvedFirstClassBlockers =

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -84,6 +84,11 @@ import { logger } from "../middleware/logger.js";
 import { conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import {
+  evaluatePreflightAcceptanceGuard,
+  evaluatePostflightProofGuard,
+  readEnforcementWindowFromEnv,
+} from "../services/definition-of-done.js";
+import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
@@ -3786,6 +3791,39 @@ export function issueRoutes(
     } = req.body;
     const shouldCancelActiveRunForCancelledStatus =
       existing.status !== "cancelled" && updateFields.status === "cancelled";
+
+    {
+      const transitioningToDone =
+        updateFields.status === "done" && existing.status !== "done";
+      if (transitioningToDone && existing.assigneeAgentId) {
+        const enforcement = readEnforcementWindowFromEnv();
+        const recentComments = await svc.listComments(existing.id, {
+          order: "desc",
+          limit: 1,
+        });
+        const latest = recentComments[0] ?? null;
+        const proof = evaluatePostflightProofGuard({
+          existingAssigneeAgentId: existing.assigneeAgentId,
+          existingCreatedAt: existing.createdAt ?? null,
+          transitioningToDone: true,
+          latestAssigneeComment: latest
+            ? {
+                body: latest.body ?? null,
+                authorAgentId: latest.authorAgentId ?? null,
+                derivedAuthorAgentId:
+                  (latest as { derivedAuthorAgentId?: string | null })
+                    .derivedAuthorAgentId ?? null,
+              }
+            : null,
+          enforcement,
+        });
+        if (!proof.allowed) {
+          res.status(proof.status).json({ error: proof.error });
+          return;
+        }
+      }
+    }
+
     if (resumeRequested === true && !commentBody) {
       res.status(400).json({ error: "Follow-up intent requires a comment" });
       return;
@@ -4022,6 +4060,32 @@ export function issueRoutes(
           assigneeAgentId: nextAssigneeAgentId,
           assigneeUserId: nextAssigneeUserId,
         });
+      }
+    }
+
+    {
+      const preflight = evaluatePreflightAcceptanceGuard({
+        existing: {
+          description: existing.description ?? null,
+          assigneeAgentId: existing.assigneeAgentId ?? null,
+          assigneeUserId: existing.assigneeUserId ?? null,
+          createdByAgentId: existing.createdByAgentId ?? null,
+          createdByUserId: existing.createdByUserId ?? null,
+        },
+        requestedAssigneeAgentId: normalizedAssigneeAgentId,
+        requestedDescription:
+          req.body.description === undefined
+            ? undefined
+            : (req.body.description as string | null),
+        actor: {
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+        },
+      });
+      if (!preflight.allowed) {
+        res.status(preflight.status).json({ error: preflight.error });
+        return;
       }
     }
 

--- a/server/src/services/definition-of-done.ts
+++ b/server/src/services/definition-of-done.ts
@@ -1,0 +1,241 @@
+/**
+ * Definition-of-Done mechanical guards.
+ *
+ * Implements two HTTP guards on PATCH /api/issues/:id:
+ *
+ *   1. Pre-flight: an issue cannot be assigned to a non-board agent unless its
+ *      description contains a structured `Acceptance:` field. Board-owned
+ *      issues and self-assignments are exempt.
+ *
+ *   2. Post-flight: an issue cannot be moved to `status=done` unless the most
+ *      recent comment authored by its current `assigneeAgentId` contains a
+ *      `Proof:` block. Comments from other agents or the board do not satisfy.
+ *
+ * Detection here is regex-only (v1). A follow-up may replace this with a
+ * structured column for query-ability. See HUM-183.
+ */
+
+const LOCAL_BOARD_USER_ID = "local-board";
+
+const ACCEPTANCE_FIELD_RE =
+  /(?:^|\n)\s*(?:#{1,6}\s*)?\*{0,2}\s*acceptance\s*\*{0,2}\s*:/i;
+const PROOF_FIELD_RE =
+  /(?:^|\n)\s*(?:#{1,6}\s*)?\*{0,2}\s*proof\s*\*{0,2}\s*[:\s]/i;
+
+/** Test whether an issue description contains a structured Acceptance field. */
+export function descriptionHasAcceptanceField(
+  description: string | null | undefined,
+): boolean {
+  if (typeof description !== "string" || description.trim().length === 0) {
+    return false;
+  }
+  return ACCEPTANCE_FIELD_RE.test(description);
+}
+
+/** Test whether a comment body contains a Proof: block. */
+export function commentHasProofBlock(
+  body: string | null | undefined,
+): boolean {
+  if (typeof body !== "string" || body.trim().length === 0) {
+    return false;
+  }
+  return PROOF_FIELD_RE.test(body);
+}
+
+export type PreflightContext = {
+  /** Issue existing on disk before the PATCH applies. */
+  existing: {
+    description: string | null;
+    assigneeAgentId: string | null;
+    assigneeUserId: string | null;
+    createdByAgentId: string | null;
+    createdByUserId: string | null;
+  };
+  /** Normalized new assigneeAgentId from the PATCH (undefined = unchanged). */
+  requestedAssigneeAgentId: string | null | undefined;
+  /** Actor performing the PATCH. */
+  actor: {
+    actorType: "agent" | "user";
+    actorId: string;
+    agentId: string | null;
+  };
+  /** New description if patched in same call, otherwise undefined. */
+  requestedDescription?: string | null;
+};
+
+export type GuardResult =
+  | { allowed: true }
+  | { allowed: false; status: 422; error: string };
+
+/**
+ * Decide whether a pre-flight Acceptance check should fire and, if so, whether
+ * it passes. Returns `{ allowed: true }` for cases that are exempt or pass.
+ *
+ * Fires only when the PATCH transitions the issue to a *new* non-board,
+ * non-self agent assignee. Other PATCHes (status, comment-only, etc.) are not
+ * affected.
+ */
+export function evaluatePreflightAcceptanceGuard(
+  ctx: PreflightContext,
+): GuardResult {
+  const { existing, requestedAssigneeAgentId, actor } = ctx;
+
+  // Caller did not touch assigneeAgentId → no pre-flight gate.
+  if (requestedAssigneeAgentId === undefined) {
+    return { allowed: true };
+  }
+
+  // Clearing assignment or assigning to no one is not gated.
+  if (requestedAssigneeAgentId === null) {
+    return { allowed: true };
+  }
+
+  // No change in assignee → no pre-flight gate (lets unrelated PATCHes pass).
+  if (requestedAssigneeAgentId === existing.assigneeAgentId) {
+    return { allowed: true };
+  }
+
+  // Self-assignment by the same agent is exempt.
+  if (
+    actor.actorType === "agent" &&
+    actor.agentId &&
+    actor.agentId === requestedAssigneeAgentId
+  ) {
+    return { allowed: true };
+  }
+
+  // Author self-assignment is exempt (new assignee is the original creator).
+  if (
+    existing.createdByAgentId &&
+    existing.createdByAgentId === requestedAssigneeAgentId
+  ) {
+    return { allowed: true };
+  }
+
+  // Board-owned issue → board can re-route freely. Spec exempts "assignee = local-board".
+  const ownerIsBoard =
+    existing.assigneeAgentId === null &&
+    existing.assigneeUserId === LOCAL_BOARD_USER_ID;
+  if (ownerIsBoard) {
+    return { allowed: true };
+  }
+
+  const effectiveDescription =
+    ctx.requestedDescription !== undefined
+      ? ctx.requestedDescription
+      : existing.description;
+
+  if (descriptionHasAcceptanceField(effectiveDescription)) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    status: 422,
+    error:
+      "Definition of Done guard: cannot assign to an agent without a structured `Acceptance:` field in the issue description. Add an Acceptance line before reassigning.",
+  };
+}
+
+export type PostflightContext = {
+  /** Existing assigneeAgentId on the issue right before the PATCH. */
+  existingAssigneeAgentId: string | null;
+  /** Existing issue createdAt (used for grandfathering). */
+  existingCreatedAt: Date | null;
+  /** Whether the PATCH is transitioning status → done. */
+  transitioningToDone: boolean;
+  /**
+   * Latest comment on the issue (any author), or null if none.
+   * Caller is responsible for fetching this only when needed.
+   */
+  latestAssigneeComment:
+    | {
+        body: string | null;
+        authorAgentId: string | null;
+        derivedAuthorAgentId?: string | null;
+      }
+    | null;
+  /** Optional enforcement window override (for tests). */
+  enforcement?: EnforcementWindow;
+};
+
+export type EnforcementWindow = {
+  /** When enforcement deploy happened. Undefined = no grandfather window. */
+  startAt?: Date | null;
+  /** Grace days for in-flight items. Default 7. */
+  grandfatherDays?: number;
+  /** Override clock for tests. */
+  now?: Date;
+};
+
+export function readEnforcementWindowFromEnv(env = process.env): EnforcementWindow {
+  const raw = env.PAPERCLIP_DOD_GUARD_ENFORCEMENT_START_AT?.trim();
+  const startAt = raw ? new Date(raw) : null;
+  const validStart = startAt && !Number.isNaN(startAt.getTime()) ? startAt : null;
+
+  const rawDays = env.PAPERCLIP_DOD_GUARD_GRANDFATHER_DAYS?.trim();
+  const parsedDays = rawDays ? Number(rawDays) : NaN;
+  const grandfatherDays =
+    Number.isFinite(parsedDays) && parsedDays >= 0 ? parsedDays : 7;
+
+  return { startAt: validStart, grandfatherDays };
+}
+
+/**
+ * Decide whether a post-flight Proof check should fire and, if so, whether it
+ * passes. Fires only when the PATCH is transitioning to `status=done` and the
+ * issue's grandfather window has expired or doesn't apply.
+ */
+export function evaluatePostflightProofGuard(
+  ctx: PostflightContext,
+): GuardResult {
+  if (!ctx.transitioningToDone) {
+    return { allowed: true };
+  }
+
+  // Status=done from an unassigned-to-agent issue (e.g. board-owned) is not gated.
+  if (!ctx.existingAssigneeAgentId) {
+    return { allowed: true };
+  }
+
+  if (isWithinGrandfatherWindow(ctx.existingCreatedAt, ctx.enforcement)) {
+    return { allowed: true };
+  }
+
+  const latest = ctx.latestAssigneeComment;
+  const latestAuthor =
+    latest?.authorAgentId ?? latest?.derivedAuthorAgentId ?? null;
+  if (
+    latest &&
+    latestAuthor === ctx.existingAssigneeAgentId &&
+    commentHasProofBlock(latest.body)
+  ) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    status: 422,
+    error:
+      "Definition of Done guard: cannot mark this issue `done` without a `Proof:` block in the latest comment by the assigned agent. Post a Proof comment, then retry.",
+  };
+}
+
+/**
+ * True when the issue was created BEFORE enforcement startAt AND we are still
+ * inside the `grandfatherDays` window from `startAt`. Returns false if no
+ * enforcement window is configured (production default once env var unset).
+ */
+export function isWithinGrandfatherWindow(
+  issueCreatedAt: Date | null,
+  enforcement: EnforcementWindow | undefined,
+): boolean {
+  if (!enforcement || !enforcement.startAt) return false;
+  if (!issueCreatedAt) return false;
+  const grandfatherDays = enforcement.grandfatherDays ?? 7;
+  const now = enforcement.now ?? new Date();
+  const startMs = enforcement.startAt.getTime();
+  const expiryMs = startMs + grandfatherDays * 24 * 60 * 60 * 1000;
+
+  return issueCreatedAt.getTime() < startMs && now.getTime() < expiryMs;
+}


### PR DESCRIPTION
## Summary

- Closed issues silently flipped `done` → `todo` whenever the CEO agent posted a final acknowledgment, because agent curls without an explicit API key/JWT are attributed to `local-board` with `actor.source = "local_implicit"` and the old reopen rule treated those as human comments.
- New `isConfirmedHumanActorSource` helper restricts implicit reopen + scheduled-retry resume to real human actors (`session`, `board_key`, `cloud_tenant`). Local humans, agents, and explicit `reopen: true` / `status: "todo"` PATCHes are unchanged.
- Two new regression tests cover both POST and PATCH comment paths from a `local_implicit` board actor.

Tracks **HUM-196**. Stacked on top of #6752 (HUM-183 / DoD mechanical guards) — the diff vs that PR is the three-file change below; if #6752 lands first, GitHub will show the clean per-commit view.

## Files changed

- `server/src/routes/authz.ts` — `getActorInfo` now exposes `actorSource` for agent and user actors.
- `server/src/routes/issues.ts` — new `isConfirmedHumanActorSource` helper; both `shouldImplicitlyMoveCommentedIssueToTodo` and `shouldHumanCommentResumeInProgressScheduledRetry` now require a confirmed human source. Threaded through the four call sites (PATCH/POST × reopen/scheduled-retry).
- `server/src/__tests__/issue-comment-reopen-routes.test.ts` — `implicitBoardActor()` fixture and two HUM-196 regression tests.

## Test plan

- [x] `npx vitest run src/__tests__/issue-comment-reopen-routes.test.ts` — both new HUM-196 tests pass; 32 tests pass (up from 30 on baseline). 6 pre-existing failures are HUM-183 DoD-guard fallout (same 6 fail on the stash baseline without this PR) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)