### PR TITLE
[codex] Add GPT-5.5 Codex local model option

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -33,6 +33,7 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 }
 
 export const models = [
+  { id: "gpt-5.5", label: "gpt-5.5" },
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
   { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -28,7 +28,7 @@ describe("buildCodexExecArgs", () => {
 
   it("enables Codex fast mode overrides for manual models", () => {
     const result = buildCodexExecArgs({
-      model: "gpt-5.5",
+      model: "custom-codex-model",
       fastMode: true,
     });
 
@@ -39,7 +39,7 @@ describe("buildCodexExecArgs", () => {
       "exec",
       "--json",
       "--model",
-      "gpt-5.5",
+      "custom-codex-model",
       "-c",
       'service_tier="fast"',
       "-c",


### PR DESCRIPTION
## Summary
- Add `gpt-5.5` to the known Codex local model option list.

## Scope Control
- Based directly on `paperclipai/paperclip:master`.
- Includes only the Codex local model list entry.
- Excludes Hermes, YoonCompany console, DB backup, redaction/secrets, cost guard, Windows link fallback, and run/comment safety changes.
- Dangerous actions not executed: merge, deploy, DB write, delete, email send, external publish beyond fork push and draft PR.

## Validation
- `corepack pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `corepack pnpm --filter @paperclipai/adapter-codex-local build`
- `git diff --cached --check`

## Review Note
This is intentionally a draft because public OpenAI model docs checked during cleanup did not list `gpt-5.5`; the existing adapter already contains non-public-looking Codex local lanes such as `gpt-5.4`, so maintainers should confirm whether this lane is valid for Codex local.

## Browser Verification
Not applicable: adapter model list only.