### PR TITLE
feat(ui): inline audio player for issue attachments

### DIFF
--- a/ui/src/components/AudioAttachmentPlayer.test.tsx
+++ b/ui/src/components/AudioAttachmentPlayer.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IssueAttachment } from "@paperclipai/shared";
+import { AudioAttachmentPlayer } from "./AudioAttachmentPlayer";
+import { resetAudioPlaybackCoordinatorForTests } from "@/lib/audio-playback-coordinator";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createAudioAttachment(overrides: Partial<IssueAttachment> = {}): IssueAttachment {
+  return {
+    id: "attachment-audio-1",
+    companyId: "company-1",
+    issueId: "issue-1",
+    issueCommentId: null,
+    assetId: "audio-1",
+    provider: "local",
+    objectKey: "audio-1",
+    originalFilename: "briefing.mp3",
+    contentPath: "/api/assets/audio-1/content",
+    contentType: "audio/mpeg",
+    byteSize: 2048,
+    sha256: "abc",
+    createdByAgentId: null,
+    createdByUserId: null,
+    createdAt: new Date("2026-05-27T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-27T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("AudioAttachmentPlayer", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    resetAudioPlaybackCoordinatorForTests();
+  });
+
+  afterEach(() => {
+    container.remove();
+    resetAudioPlaybackCoordinatorForTests();
+  });
+
+  it("renders native audio controls with attachment metadata", () => {
+    const root = createRoot(container);
+    const attachment = createAudioAttachment();
+
+    act(() => {
+      root.render(<AudioAttachmentPlayer attachment={attachment} />);
+    });
+
+    const audio = container.querySelector("audio");
+    expect(audio).not.toBeNull();
+    expect(audio?.getAttribute("src")).toBe(attachment.contentPath);
+    expect(audio?.hasAttribute("controls")).toBe(true);
+    expect(container.textContent).toContain("briefing.mp3");
+    expect(container.textContent).toContain("audio/mpeg");
+  });
+
+  it("pauses another player when a second attachment starts playing", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <div>
+          <AudioAttachmentPlayer attachment={createAudioAttachment({ id: "a1", assetId: "a1" })} />
+          <AudioAttachmentPlayer
+            attachment={createAudioAttachment({
+              id: "a2",
+              assetId: "a2",
+              originalFilename: "second.mp3",
+              contentPath: "/api/assets/audio-2/content",
+            })}
+          />
+        </div>,
+      );
+    });
+
+    const [first, second] = Array.from(container.querySelectorAll("audio"));
+    const pauseFirst = vi.spyOn(first, "pause");
+    Object.defineProperty(first, "paused", { configurable: true, get: () => false });
+
+    act(() => {
+      first.dispatchEvent(new Event("play"));
+    });
+    act(() => {
+      second.dispatchEvent(new Event("play"));
+    });
+
+    expect(pauseFirst).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/AudioAttachmentPlayer.tsx
+++ b/ui/src/components/AudioAttachmentPlayer.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useId, useRef } from "react";
+import { Trash2 } from "lucide-react";
+import type { IssueAttachment } from "@paperclipai/shared";
+import { claimAudioPlayback, releaseAudioPlayback } from "@/lib/audio-playback-coordinator";
+import { cn } from "@/lib/utils";
+
+interface AudioAttachmentPlayerProps {
+  attachment: IssueAttachment;
+  onDelete?: () => void;
+  deletePending?: boolean;
+  className?: string;
+}
+
+export function AudioAttachmentPlayer({
+  attachment,
+  onDelete,
+  deletePending = false,
+  className,
+}: AudioAttachmentPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const labelId = useId();
+  const filename = attachment.originalFilename ?? attachment.id;
+  const sizeKb = (attachment.byteSize / 1024).toFixed(1);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const handlePlay = () => claimAudioPlayback(audio);
+    const handlePause = () => releaseAudioPlayback(audio);
+    const handleEnded = () => releaseAudioPlayback(audio);
+
+    audio.addEventListener("play", handlePlay);
+    audio.addEventListener("pause", handlePause);
+    audio.addEventListener("ended", handleEnded);
+
+    return () => {
+      audio.removeEventListener("play", handlePlay);
+      audio.removeEventListener("pause", handlePause);
+      audio.removeEventListener("ended", handleEnded);
+      releaseAudioPlayback(audio);
+    };
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border bg-accent/5 p-2 space-y-1.5",
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-2 min-w-0">
+        <div className="min-w-0">
+          <p id={labelId} className="text-xs font-medium truncate" title={filename}>
+            {filename}
+          </p>
+          <p className="text-[11px] text-muted-foreground">
+            {attachment.contentType} · {sizeKb} KB
+          </p>
+        </div>
+        {onDelete ? (
+          <button
+            type="button"
+            className="shrink-0 text-muted-foreground hover:text-destructive"
+            onClick={onDelete}
+            disabled={deletePending}
+            title="Delete attachment"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+      </div>
+      <audio
+        ref={audioRef}
+        controls
+        preload="metadata"
+        src={attachment.contentPath}
+        aria-labelledby={labelId}
+        className="h-9 w-full"
+      />
+    </div>
+  );
+}

--- a/ui/src/lib/audio-playback-coordinator.test.ts
+++ b/ui/src/lib/audio-playback-coordinator.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  claimAudioPlayback,
+  releaseAudioPlayback,
+  resetAudioPlaybackCoordinatorForTests,
+} from "./audio-playback-coordinator";
+
+describe("audio-playback-coordinator", () => {
+  afterEach(() => {
+    resetAudioPlaybackCoordinatorForTests();
+  });
+
+  it("pauses the previously playing audio when another claims playback", () => {
+    const first = document.createElement("audio");
+    const second = document.createElement("audio");
+    const pauseFirst = vi.spyOn(first, "pause");
+
+    Object.defineProperty(first, "paused", { configurable: true, get: () => false });
+    Object.defineProperty(second, "paused", { configurable: true, get: () => true });
+
+    claimAudioPlayback(first);
+    claimAudioPlayback(second);
+
+    expect(pauseFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pause audio that is already paused", () => {
+    const first = document.createElement("audio");
+    const second = document.createElement("audio");
+    const pauseFirst = vi.spyOn(first, "pause");
+
+    Object.defineProperty(first, "paused", { configurable: true, get: () => true });
+
+    claimAudioPlayback(first);
+    claimAudioPlayback(second);
+
+    expect(pauseFirst).not.toHaveBeenCalled();
+  });
+
+  it("clears the active element on release", () => {
+    const audio = document.createElement("audio");
+    claimAudioPlayback(audio);
+    releaseAudioPlayback(audio);
+
+    const next = document.createElement("audio");
+    const pauseNext = vi.spyOn(next, "pause");
+    Object.defineProperty(audio, "paused", { configurable: true, get: () => false });
+
+    claimAudioPlayback(audio);
+
+    expect(pauseNext).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/audio-playback-coordinator.ts
+++ b/ui/src/lib/audio-playback-coordinator.ts
@@ -1,0 +1,20 @@
+/** Ensures only one issue audio attachment plays at a time. */
+let activeAudio: HTMLAudioElement | null = null;
+
+export function claimAudioPlayback(element: HTMLAudioElement): void {
+  if (activeAudio && activeAudio !== element && !activeAudio.paused) {
+    activeAudio.pause();
+  }
+  activeAudio = element;
+}
+
+export function releaseAudioPlayback(element: HTMLAudioElement): void {
+  if (activeAudio === element) {
+    activeAudio = null;
+  }
+}
+
+/** @internal Test helper */
+export function resetAudioPlaybackCoordinatorForTests(): void {
+  activeAudio = null;
+}

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -1278,6 +1278,36 @@ describe("IssueDetail", () => {
     expect(container.textContent).toContain("Planning");
   });
 
+  it("renders inline audio controls for audio attachments", async () => {
+    const issue = createIssue();
+    mockIssuesApi.get.mockResolvedValue(issue);
+    mockIssuesApi.listAttachments.mockResolvedValue([
+      {
+        id: "attachment-audio",
+        issueId: issue.id,
+        issueCommentId: null,
+        originalFilename: "ceo-briefing.mp3",
+        contentPath: "/api/assets/briefing/content",
+        contentType: "audio/mpeg",
+        byteSize: 8192,
+        uploadedByUserId: null,
+        uploadedAt: new Date("2026-05-27T00:00:00.000Z"),
+      },
+    ]);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.querySelector("audio[controls]")).not.toBeNull();
+    expect(container.textContent).toContain("ceo-briefing.mp3");
+  });
+
   it("forwards composer work mode changes to the issues API", async () => {
     const issue = createIssue();
     mockIssuesApi.get.mockResolvedValue(issue);

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -77,6 +77,7 @@ import { IssueProperties } from "../components/IssueProperties";
 import { IssueRunLedger } from "../components/IssueRunLedger";
 import { IssueWorkspaceCard } from "../components/IssueWorkspaceCard";
 import type { MentionOption } from "../components/MarkdownEditor";
+import { AudioAttachmentPlayer } from "../components/AudioAttachmentPlayer";
 import { ImageGalleryModal } from "../components/ImageGalleryModal";
 import { ScrollToBottom } from "../components/ScrollToBottom";
 import { StatusIcon } from "../components/StatusIcon";
@@ -2810,9 +2811,11 @@ export function IssueDetail() {
   }, [detailTab, pendingCommentComposerFocusKey]);
 
   const isImageAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("image/");
+  const isAudioAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("audio/");
   const attachmentList = attachments ?? [];
   const imageAttachments = attachmentList.filter(isImageAttachment);
-  const nonImageAttachments = attachmentList.filter((a) => !isImageAttachment(a));
+  const audioAttachments = attachmentList.filter(isAudioAttachment);
+  const fileAttachments = attachmentList.filter((a) => !isImageAttachment(a) && !isAudioAttachment(a));
 
   const handleChatImageClick = useCallback(
     (src: string) => {
@@ -3838,9 +3841,22 @@ export function IssueDetail() {
           </div>
         )}
 
-        {nonImageAttachments.length > 0 && (
+        {audioAttachments.length > 0 && (
           <div className="space-y-2">
-            {nonImageAttachments.map((attachment) => (
+            {audioAttachments.map((attachment) => (
+              <AudioAttachmentPlayer
+                key={attachment.id}
+                attachment={attachment}
+                onDelete={() => deleteAttachment.mutate(attachment.id)}
+                deletePending={deleteAttachment.isPending}
+              />
+            ))}
+          </div>
+        )}
+
+        {fileAttachments.length > 0 && (
+          <div className="space-y-2">
+            {fileAttachments.map((attachment) => (
               <div key={attachment.id} className="border border-border rounded-md p-2">
                 <div className="flex items-center justify-between gap-2">
                   <a


### PR DESCRIPTION
## Summary
- Render `audio/*` issue attachments with native `<audio controls>` on the issue detail page
- Pause any other playing attachment when a new one starts (`audio-playback-coordinator`)

## Test plan
- [x] `pnpm -w exec vitest run ui/src/components/AudioAttachmentPlayer.test.tsx ui/src/lib/audio-playback-coordinator.test.ts`
- [x] `pnpm -w exec vitest run ui/src/pages/IssueDetail.test.tsx -t "inline audio"`
- [ ] Manual: open an issue with an MP3 attachment and verify single-playback behavior


Made with [Cursor](https://cursor.com)