### PR TITLE
fix: inherit projectId from parent when creating child issues

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4087,6 +4087,16 @@ export function issueService(db: Db) {
         throw unprocessable("in_progress issues require an assignee");
       }
       return db.transaction(async (tx) => {
+        if (issueData.parentId && !issueData.projectId) {
+          const parentRow = await tx
+            .select({ projectId: issues.projectId })
+            .from(issues)
+            .where(and(eq(issues.id, issueData.parentId), eq(issues.companyId, companyId)))
+            .then((rows) => rows[0] ?? null);
+          if (parentRow?.projectId) {
+            issueData.projectId = parentRow.projectId;
+          }
+        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies, so issue/project relationships need to stay structurally consistent across automation flows.
> - The affected subsystem is issue creation in `server/src/services/issues.ts`, which assigns project and goal context for new issues.
> - Child issues are expected to stay aligned with their parent issue's project unless an operator intentionally overrides that linkage.
> - Before this change, creating a child issue without an explicit `projectId` could leave the child outside the parent's project context.
> - That inconsistency can break project-level grouping, reporting, and downstream automation that assumes parent/child issues share the same project.
> - This pull request fixes the gap by inheriting `projectId` from the parent when `parentId` is present and `projectId` is omitted.
> - The benefit is predictable project scoping for child issues without changing the explicit-override path.

## What Changed

- Added a parent issue lookup in `server/src/services/issues.ts` during issue creation.
- When a new issue has `parentId` and no explicit `projectId`, the service now copies the parent's `projectId` into the child issue payload.
- Left existing behavior unchanged for root issues and for child issues that already provide an explicit `projectId`.

## Verification

- Review `server/src/services/issues.ts` and confirm the inheritance branch only runs when `issueData.parentId` is present and `issueData.projectId` is absent.
- Manually create a child issue without `projectId` and confirm the created issue inherits the parent issue's `projectId`.
- Manually create a child issue with an explicit `projectId` and confirm the explicit value is preserved.
- Manual verification steps documented; no additional automated test was added in this PR.

## Risks

- Low risk: the change is scoped to child-issue creation and guarded so explicit `projectId` inputs still win.
- If callers previously relied on child issues being created without project inheritance when `parentId` was set, they will now receive the parent's `projectId` by default.

> Checked `ROADMAP.md`; this is a targeted bug fix and does not duplicate planned roadmap-level feature work. See `CONTRIBUTING.md`.

## Model Used

- Anthropic Claude Opus 4.6 (1M context) via Claude Code, with tool use/code execution. Commit co-author metadata: `Claude Opus 4.6 (1M context)`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
