### PR TITLE
Recover stalled issue interactions without forbidden fallback loops

### DIFF
--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -577,6 +577,68 @@ describe("agent live run routes", () => {
     });
   });
 
+  it("rejects malformed stalled checkout wake issue ids before queueing", async () => {
+    const res = await requestApp(
+      await createApp(),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          source: "on_demand",
+          reason: "stalled_checkout_sweep",
+          forceFreshSession: true,
+          payload: {
+            issueId: "ae?",
+            mutation: "manual_unstall",
+          },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "Invalid stalled checkout wake payload issueId",
+      details: {
+        field: "payload.issueId",
+        code: "invalid_issue_id",
+      },
+    });
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("normalizes stalled checkout wake issue identifiers before queueing", async () => {
+    const issueId = "22222222-2222-4222-8222-222222222222";
+    const query = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn(async () => [{ id: issueId }]),
+    };
+    const db = {
+      select: vi.fn(() => query),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          source: "on_demand",
+          reason: "stalled_checkout_sweep",
+          forceFreshSession: true,
+          payload: {
+            issueId: "NOX-4140",
+            mutation: "manual_unstall",
+          },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(routeAgentId, expect.objectContaining({
+      reason: "stalled_checkout_sweep",
+      payload: {
+        issueId,
+        mutation: "manual_unstall",
+      },
+    }));
+  });
+
   it("calls heartbeat.wakeup with the legacy minimal shape when the body is empty", async () => {
     const res = await requestApp(
       await createApp(),

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -11,6 +11,7 @@ vi.mock("acpx/runtime", () => ({
 }));
 
 const agentId = "11111111-1111-4111-8111-111111111111";
+const targetAgentId = "11111111-1111-4111-8111-222222222222";
 const companyId = "22222222-2222-4222-8222-222222222222";
 
 const baseAgent = {
@@ -68,6 +69,7 @@ const mockBudgetService = vi.hoisted(() => ({
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
   listTaskSessions: vi.fn(),
   resetRuntimeSession: vi.fn(),
   getRun: vi.fn(),
@@ -310,6 +312,7 @@ describe.sequential("agent permission routes", () => {
     mockApprovalService.create.mockReset();
     mockApprovalService.getById.mockReset();
     mockBudgetService.upsertPolicy.mockReset();
+    mockHeartbeatService.wakeup.mockReset();
     mockHeartbeatService.listTaskSessions.mockReset();
     mockHeartbeatService.resetRuntimeSession.mockReset();
     mockHeartbeatService.getRun.mockReset();
@@ -356,6 +359,11 @@ describe.sequential("agent permission routes", () => {
     mockAccessService.listPrincipalGrants.mockResolvedValue([]);
     mockAccessService.ensureMembership.mockResolvedValue(undefined);
     mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+    mockHeartbeatService.wakeup.mockResolvedValue({
+      id: "run-1",
+      agentId,
+      status: "queued",
+    });
     mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
     mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(async (_companyId, requested) => requested);
     mockBudgetService.upsertPolicy.mockResolvedValue(undefined);
@@ -477,6 +485,88 @@ describe.sequential("agent permission routes", () => {
       .send({}));
 
     expect(res.status).toBe(403);
+  });
+
+  it("blocks agent-authenticated cross-agent wakeups without task assignment permission", async () => {
+    const targetAgent = {
+      ...baseAgent,
+      id: targetAgentId,
+      name: "Target",
+      urlKey: "target",
+    };
+    mockAgentService.getById.mockImplementation(async (id: string) => (id === targetAgentId ? targetAgent : baseAgent));
+    mockAccessService.hasPermission.mockResolvedValue(false);
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${targetAgentId}/wakeup`)
+      .send({
+        source: "automation",
+        reason: "human_merge_gate_escalation",
+      }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("tasks:assign");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("allows agents with task assignment permission to wake same-company agents", async () => {
+    const targetAgent = {
+      ...baseAgent,
+      id: targetAgentId,
+      name: "Target",
+      urlKey: "target",
+    };
+    const wakeRun = {
+      id: "run-cross-agent",
+      agentId: targetAgentId,
+      status: "queued",
+    };
+    mockAgentService.getById.mockImplementation(async (id: string) => (id === targetAgentId ? targetAgent : baseAgent));
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockHeartbeatService.wakeup.mockResolvedValue(wakeRun);
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${targetAgentId}/wakeup`)
+      .send({
+        source: "automation",
+        reason: "human_merge_gate_escalation",
+        triggerDetail: "system",
+      }));
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual(wakeRun);
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "tasks:assign",
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      targetAgentId,
+      expect.objectContaining({
+        source: "automation",
+        triggerDetail: "system",
+        reason: "human_merge_gate_escalation",
+        requestedByActorType: "agent",
+        requestedByActorId: agentId,
+      }),
+    );
   });
 
   it("blocks agent-authenticated self-updates that set host-executed workspace commands", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -20,6 +20,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueThreadInteractions,
   issueRecoveryActions,
   issueRelations,
   issueTreeHoldMembers,
@@ -324,6 +325,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(environmentLeases);
     await db.delete(environments);
     await db.delete(issueWorkProducts);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueDocuments);
     await db.delete(documentRevisions);
@@ -808,6 +810,206 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       )
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
+
+  it("skips operator-only pending confirmations on already blocked issues without logging every sweep", async () => {
+    const { companyId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db
+      .update(issues)
+      .set({ status: "blocked" })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Confirm plan",
+      summary: "Operator approval required.",
+      payload: { title: "Confirm plan", summary: "Operator approval required." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+    const second = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+      outcomes: [{
+        interactionId,
+        issueId,
+        outcome: "skip_operator_interaction_already_waiting",
+      }],
+    });
+    expect(second).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      outcomes: [{
+        interactionId,
+        issueId,
+        outcome: "skip_operator_interaction_already_waiting",
+      }],
+    });
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity.filter((event) => event.action === "issue.thread_interaction_operator_waiting")).toHaveLength(0);
+  });
+
+  it("routes operator-only pending confirmations once", async () => {
+    const { companyId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Confirm plan",
+      summary: "Operator approval required.",
+      payload: { title: "Confirm plan", summary: "Operator approval required." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+    const second = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 1,
+      agentWoken: 0,
+      skipped: 0,
+      outcomes: [{
+        interactionId,
+        issueId,
+        outcome: "route_operator_board",
+      }],
+    });
+    expect(second).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      outcomes: [{
+        interactionId,
+        issueId,
+        outcome: "skip_operator_interaction_already_routed",
+      }],
+    });
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity.filter((event) => event.action === "issue.thread_interaction_operator_waiting")).toHaveLength(1);
+  });
+
+  it("routes pending suggested-task interactions to the operator", async () => {
+    const { companyId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Pick follow-up tasks",
+      summary: "Operator selection required.",
+      payload: { version: 1, tasks: [] },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 1,
+      agentWoken: 0,
+      skipped: 0,
+      outcomes: [{
+        interactionId,
+        issueId,
+        outcome: "route_operator_board",
+      }],
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakeups.filter((wakeup) => wakeup.reason === "issue_interaction_stalled")).toHaveLength(0);
+  });
+
+  it("wakes an agent-wakeable stalled pending interaction cleanly", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "implementation_followup",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Resume implementation",
+      summary: "Agent needs to continue the interaction.",
+      createdByAgentId: agentId,
+      payload: { title: "Resume implementation", summary: "Agent needs to continue the interaction." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 1,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+      outcomes: [{
+        interactionId,
+        issueId,
+        outcome: "agent_wake_queued",
+      }],
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const stalledWakeups = wakeups.filter((wakeup) => wakeup.reason === "issue_interaction_stalled");
+    expect(stalledWakeups).toHaveLength(1);
+    expect(stalledWakeups[0]?.payload).toMatchObject({
+      issueId,
+      interactionId,
+      interactionKind: "implementation_followup",
+      mutation: "stalled_interaction_recovery",
+    });
+  });
 
   async function seedQueuedIssueRunFixture() {
     const companyId = randomUUID();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -696,6 +696,12 @@ export async function startServer(): Promise<StartedServer> {
         }
       })
       .then(async () => {
+        const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+        if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+          logger.warn({ ...reconciled }, "startup stalled interaction reconciliation routed pending interactions");
+        }
+      })
+      .then(async () => {
         const reconciled = await heartbeat.reconcileIssueGraphLiveness();
         if (reconciled.escalationsCreated > 0) {
           logger.warn({ ...reconciled }, "startup issue-graph liveness reconciliation created escalations");
@@ -759,6 +765,12 @@ export async function startServer(): Promise<StartedServer> {
               { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
               "periodic heartbeat recovery changed assigned issue state",
             );
+          }
+        })
+        .then(async () => {
+          const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+          if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+            logger.warn({ ...reconciled }, "periodic stalled interaction reconciliation routed pending interactions");
           }
         })
         .then(async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -48,7 +48,7 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
-import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
+import { badRequest, conflict, forbidden, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -571,6 +571,24 @@ export function agentRoutes(
     if (!allowed) {
       throw forbidden("Missing permission: agents:create");
     }
+  }
+
+  async function canAgentWakeTarget(companyId: string, actorAgentId: string | undefined, targetAgentId: string) {
+    if (actorAgentId === targetAgentId) return true;
+    if (typeof actorAgentId !== "string") return false;
+    return access.hasPermission(companyId, "agent", actorAgentId, "tasks:assign");
+  }
+
+  async function assertCanWakeAgent(req: Request, companyId: string, targetAgentId: string) {
+    if (req.actor.type === "agent") {
+      const allowed = await canAgentWakeTarget(companyId, req.actor.agentId, targetAgentId);
+      if (!allowed) {
+        throw forbidden("Agent can only invoke itself or use tasks:assign delegated wakeups");
+      }
+      return;
+    }
+
+    await assertBoardCanManageAgentsForCompany(req, companyId);
   }
 
   async function assertCanReadConfigurations(req: Request, companyId: string) {
@@ -2917,6 +2935,32 @@ export function agentRoutes(
     source: HeartbeatSource | undefined;
     skippedResponse: (agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>) => unknown | Promise<unknown>;
   };
+
+  async function normalizeStalledCheckoutWakePayload(payload: unknown, companyId: string) {
+    if (!payload || typeof payload !== "object") return payload;
+    const issueId = (payload as { issueId?: unknown }).issueId;
+    if (typeof issueId !== "string" || issueId.trim().length === 0) return payload;
+    const rawIssueId = issueId.trim();
+    if (isUuidLike(rawIssueId)) {
+      return { ...payload, issueId: rawIssueId };
+    }
+    const identifier = normalizeIssueIdentifier(rawIssueId);
+    if (identifier) {
+      const issue = await db
+        .select({ id: issuesTable.id })
+        .from(issuesTable)
+        .where(and(eq(issuesTable.companyId, companyId), eq(issuesTable.identifier, identifier)))
+        .then((rows) => rows[0] ?? null);
+      if (issue) {
+        return { ...payload, issueId: issue.id };
+      }
+    }
+    throw badRequest("Invalid stalled checkout wake payload issueId", {
+      field: "payload.issueId",
+      code: "invalid_issue_id",
+    });
+  }
+
   const handleWakeupRoute = async (
     req: Request,
     res: Response,
@@ -2930,13 +2974,10 @@ export function agentRoutes(
     }
     assertCompanyAccess(req, agent.companyId);
 
-    if (req.actor.type === "agent") {
-      if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
-        return;
-      }
-    } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
+    await assertCanWakeAgent(req, agent.companyId, id);
+
+    if (req.body.reason === "stalled_checkout_sweep") {
+      req.body.payload = await normalizeStalledCheckoutWakePayload(req.body.payload ?? null, agent.companyId);
     }
 
     const run = await heartbeat.wakeup(id, {
@@ -2998,14 +3039,7 @@ export function agentRoutes(
     }
     assertCompanyAccess(req, agent.companyId);
 
-    if (req.actor.type === "agent") {
-      if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
-        return;
-      }
-    } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
-    }
+    await assertCanWakeAgent(req, agent.companyId, id);
 
     const body = (req.body ?? {}) as Partial<{
       reason: unknown;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6593,6 +6593,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileStrandedAssignedIssues();
   }
 
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    return recovery.reconcileStalledIssueThreadInteractions(opts);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -9744,6 +9752,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    reconcileStalledIssueThreadInteractions,
 
     buildIssueGraphLivenessAutoRecoveryPreview,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -11,6 +11,7 @@ import {
   agents,
   agentWakeupRequests,
   approvals,
+  activityLog,
   companies,
   issueComments,
   heartbeatRunEvents,
@@ -269,6 +270,21 @@ function isAgentInvokable(agent: typeof agents.$inferSelect | null | undefined) 
   return Boolean(agent && !["paused", "terminated", "pending_approval"].includes(agent.status));
 }
 
+function isOperatorResolvedInteractionKind(kind: string) {
+  return kind === "suggest_tasks" || kind === "ask_user_questions" || kind === "request_confirmation";
+}
+
+type StalledInteractionOutcome =
+  | "route_operator_board"
+  | "agent_wake_queued"
+  | "skip_operator_interaction_already_waiting"
+  | "skip_operator_interaction_already_routed"
+  | "skip_missing_agent"
+  | "skip_agent_unavailable"
+  | "skip_wake_already_queued"
+  | "skip_budget_blocked"
+  | "skip_wakeup_not_queued";
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -473,6 +489,238 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasQueuedInteractionWake(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          sql`${agentWakeupRequests.payload} ->> 'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function hasOperatorRoutingActivity(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issueId),
+          eq(activityLog.action, "issue.thread_interaction_operator_waiting"),
+          sql`${activityLog.details} ->> 'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = Math.max(60_000, Math.floor(opts?.thresholdMs ?? 10 * 60 * 1000));
+    const cutoff = new Date(now.getTime() - thresholdMs);
+    const candidates = await db
+      .select({
+        id: issueThreadInteractions.id,
+        companyId: issueThreadInteractions.companyId,
+        issueId: issueThreadInteractions.issueId,
+        kind: issueThreadInteractions.kind,
+        status: issueThreadInteractions.status,
+        sourceCommentId: issueThreadInteractions.sourceCommentId,
+        sourceRunId: issueThreadInteractions.sourceRunId,
+        createdByAgentId: issueThreadInteractions.createdByAgentId,
+        updatedAt: issueThreadInteractions.updatedAt,
+        issueIdentifier: issues.identifier,
+        issueStatus: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        projectId: issues.projectId,
+      })
+      .from(issueThreadInteractions)
+      .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+      .where(
+        and(
+          eq(issueThreadInteractions.status, "pending"),
+          lt(issueThreadInteractions.updatedAt, cutoff),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(asc(issueThreadInteractions.updatedAt))
+      .limit(100);
+
+    const result = {
+      scanned: candidates.length,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [] as string[],
+      issueIds: [] as string[],
+      outcomes: [] as Array<{
+        interactionId: string;
+        issueId: string;
+        outcome: StalledInteractionOutcome;
+      }>,
+    };
+    const seenIssues = new Set<string>();
+
+    for (const interaction of candidates) {
+      result.interactionIds.push(interaction.id);
+      if (!seenIssues.has(interaction.issueId)) {
+        seenIssues.add(interaction.issueId);
+        result.issueIds.push(interaction.issueId);
+      }
+
+      if (isOperatorResolvedInteractionKind(interaction.kind)) {
+        if (interaction.issueStatus === "blocked" || interaction.issueStatus === "in_review") {
+          result.skipped += 1;
+          result.outcomes.push({
+            interactionId: interaction.id,
+            issueId: interaction.issueId,
+            outcome: "skip_operator_interaction_already_waiting",
+          });
+          continue;
+        }
+
+        if (await hasOperatorRoutingActivity(interaction.companyId, interaction.issueId, interaction.id)) {
+          result.skipped += 1;
+          result.outcomes.push({
+            interactionId: interaction.id,
+            issueId: interaction.issueId,
+            outcome: "skip_operator_interaction_already_routed",
+          });
+          continue;
+        }
+
+        result.operatorRouted += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "route_operator_board",
+        });
+        await logActivity(db, {
+          companyId: interaction.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: opts?.runId ?? null,
+          action: "issue.thread_interaction_operator_waiting",
+          entityType: "issue",
+          entityId: interaction.issueId,
+          details: {
+            source: "recovery.reconcile_stalled_issue_thread_interactions",
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            issueIdentifier: interaction.issueIdentifier,
+            ageMs: Math.max(0, now.getTime() - interaction.updatedAt.getTime()),
+            resolver: "operator_board",
+          },
+        });
+        continue;
+      }
+
+      const agentId = interaction.assigneeAgentId ?? interaction.createdByAgentId;
+      if (!agentId) {
+        result.skipped += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "skip_missing_agent",
+        });
+        continue;
+      }
+
+      const agent = await getAgent(agentId);
+      if (!agent || agent.companyId !== interaction.companyId || !isAgentInvokable(agent)) {
+        result.skipped += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "skip_agent_unavailable",
+        });
+        continue;
+      }
+
+      if (await hasQueuedInteractionWake(interaction.companyId, interaction.issueId, interaction.id)) {
+        result.skipped += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "skip_wake_already_queued",
+        });
+        continue;
+      }
+
+      if (await isInvocationBudgetBlocked({
+        id: interaction.issueId,
+        companyId: interaction.companyId,
+        projectId: interaction.projectId,
+      }, agentId)) {
+        result.skipped += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "skip_budget_blocked",
+        });
+        continue;
+      }
+
+      const queued = await deps.enqueueWakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_interaction_stalled",
+        payload: withRecoveryModelProfileHint({
+          issueId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          mutation: "stalled_interaction_recovery",
+        }),
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: withRecoveryModelProfileHint({
+          issueId: interaction.issueId,
+          taskId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          interactionStatus: interaction.status,
+          sourceCommentId: interaction.sourceCommentId ?? null,
+          sourceRunId: interaction.sourceRunId ?? null,
+          wakeReason: "issue_interaction_stalled",
+          source: "recovery.reconcile_stalled_issue_thread_interactions",
+        }),
+      });
+
+      if (queued) {
+        result.agentWoken += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "agent_wake_queued",
+        });
+      } else {
+        result.skipped += 1;
+        result.outcomes.push({
+          interactionId: interaction.id,
+          issueId: interaction.issueId,
+          outcome: "skip_wakeup_not_queued",
+        });
+      }
+    }
+
+    return result;
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -536,7 +784,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
   }
 
-  async function isInvocationBudgetBlocked(issue: typeof issues.$inferSelect, agentId: string) {
+  async function isInvocationBudgetBlocked(
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "projectId">,
+    agentId: string,
+  ) {
     const budgetBlock = await budgets.getInvocationBlock(issue.companyId, agentId, {
       issueId: issue.id,
       projectId: issue.projectId,
@@ -3047,6 +3298,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
     buildIssueGraphLivenessAutoRecoveryPreview,
+    reconcileStalledIssueThreadInteractions,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
   };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through a company-scoped task and heartbeat control plane.
> - The affected subsystem is heartbeat recovery for stalled issue interactions and agent wakeup authorization.
> - NOX-5053 showed that the stalled sweep was repeatedly attempting paths that current auth forbids: NOX-CLONE-style delegated agent wakeups and board-gated interaction responses.
> - The supported policy is to preserve board-gated operator decisions while making non-operator stalled interaction recovery explicit and wakeable through typed outcomes.
> - This pull request separates the NOX-5053 server recovery fix from the unrelated `nox-3699-routine-coalescing` branch drift.
> - The benefit is a clean recovery path that either wakes an authorized agent, routes operator decisions to the board, or records a typed skip outcome without noisy forbidden fallback loops.

## What Changed

- Added stalled issue-thread interaction reconciliation with typed outcomes for operator routing, agent wakeups, duplicate queued wakes, missing agents, unavailable agents, budget blocks, and already-waiting operator interactions.
- Wired the reconciliation into heartbeat service startup and periodic recovery sweeps.
- Allowed agent-authenticated delegated wakeups only when the acting agent has `tasks:assign`, while preserving self-wakeup and board-management checks.
- Normalized stalled checkout wake payload issue identifiers to UUIDs before enqueueing and rejected malformed identifiers before queueing.
- Added focused server coverage for stalled interaction recovery, cross-agent wake permissions, and stalled checkout payload validation/normalization.

## Verification

- `pnpm run preflight:workspace-links && pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/agent-permissions-routes.test.ts src/__tests__/agent-live-run-routes.test.ts` — 3 files / 102 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/server build` — passed.
- `git rev-list @{upstream}..HEAD` — empty after push.
- `git status --short --branch` — clean tracked worktree on `nox-5053-stalled-interaction-recovery...cablackmon/nox-5053-stalled-interaction-recovery`.

## Risks

- Medium operational behavior risk: stalled pending interactions now trigger a recovery sweep path instead of staying inert/noisy. Tests cover operator-only waits, agent-wakeable interactions, duplicate prevention, permission boundaries, and malformed payload rejection.
- No database schema or migration changes.
- ROADMAP.md checked; this is a tightly scoped recovery/bug fix, not a new roadmap-level core feature.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent, tool-use enabled, repository-local verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
