### PR TITLE
fix(heartbeat): clear checkoutRunId in releaseIssueExecutionAndPromote (APE-2446)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1730,6 +1730,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       latestRunStatus: "succeeded",
       missingDisposition: "clear_next_step",
     });
+    expect(issue?.executionRunId).toBeNull();
+    // With APE-2446 fix: releaseIssueExecutionAndPromote now also clears checkoutRunId
+    // so a post-crash reap does not leave a stale checkout lock (zombie state).
+    expect(issue?.checkoutRunId).toBeNull();
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8382,6 +8382,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionRunId: null,
             executionAgentNameKey: null,
             executionLockedAt: null,
+            // Also clear checkoutRunId: a post-crash reap must not leave a stale
+            // checkout lock that blocks the next heartbeat from re-checking out
+            // the same issue (zombie/stale-lock -- APE-2446).
+            checkoutRunId: null,
             updatedAt: new Date(),
           })
           .where(eq(issues.id, issue.id));


### PR DESCRIPTION
## Summary

Fix a crash-orphan checkout-lock bug: when `releaseIssueExecutionAndPromote()` clears `executionRunId` during crash recovery, it now also clears `checkoutRunId`. Without this, zombie checkout locks block subsequent heartbeats from re-checking out the same issue.

## Root Cause

`releaseIssueExecutionAndPromote()` in `server/src/services/heartbeat.ts` clears `executionRunId` after crash recovery but does NOT clear `checkoutLock`, leaving zombie locks.

## Changes

- **`server/src/services/heartbeat.ts`**: Add `checkoutRunId: null` to the release set (4-line addition with comment)
- **`server/src/__tests__/heartbeat-process-recovery.test.ts`**: Add assertion verifying `checkoutRunId` is nulled after reap

## Test Plan

- Existing `heartbeat-process-recovery.test.ts` tests pass
- New assertion verifies fix behavior

Closes APE-2446