### PR TITLE
fix(productivity-review): stop refreshing evidence on decided/parked reviews

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -255,6 +255,92 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
   });
 
+  it("stops refreshing once the review issue is blocked", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+    await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, review!.id));
+
+    const result = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
+      companyId: seeded.companyId,
+    });
+
+    expect(result.updated).toBe(0);
+    expect(result.existing).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(0);
+  });
+
+  it("stops refreshing once the review issue is handed off for review", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+    await db.update(issues).set({ status: "in_review" }).where(eq(issues.id, review!.id));
+
+    const result = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
+      companyId: seeded.companyId,
+    });
+
+    expect(result.updated).toBe(0);
+    expect(result.existing).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(0);
+  });
+
+  it("stops refreshing once a manager decision comment is recorded", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+    // Review is still `todo` but the manager owner has recorded a decision via comment.
+    await db.insert(issueComments).values({
+      companyId: seeded.companyId,
+      issueId: review!.id,
+      authorAgentId: seeded.managerId,
+      body: "Decision: continue, this churn is expected for the import backfill.",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
+      companyId: seeded.companyId,
+    });
+
+    expect(result.updated).toBe(0);
+    expect(result.existing).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(0);
+  });
+
   it("caps productivity review creation per source issue in the rolling creation window", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -37,6 +37,10 @@ const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
 export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
+// Evidence is only refreshed while the review is still awaiting a decision. Once the owner
+// engages or parks it (in_review/blocked) or resolves it (done/cancelled, already excluded by
+// findOpenProductivityReview), refreshing stops so we don't keep appending evidence comments.
+export const REFRESHABLE_REVIEW_STATUSES = ["todo", "in_progress"] as const;
 
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
@@ -327,6 +331,24 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           latestCreatedAt: coerceDate(row?.latestCreatedAt),
         };
       });
+  }
+
+  // A review owner records a decision by commenting (status changes are covered separately by
+  // REFRESHABLE_REVIEW_STATUSES). Refresh comments are system-authored with no agent/user, so any
+  // comment with a real author that is not a refresh comment means a manager has weighed in.
+  async function hasRecordedManagerDecision(companyId: string, reviewIssueId: string) {
+    return db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.issueId, reviewIssueId),
+          sql`(${issueComments.authorUserId} is not null or ${issueComments.authorAgentId} is not null)`,
+          sql`${issueComments.body} not like ${`${PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX}%`}`,
+        ),
+      )
+      .then((rows) => Number(rows[0]?.count ?? 0) > 0);
   }
 
   async function addRefreshComment(
@@ -639,6 +661,15 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   ) {
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
+      const reviewAwaitingDecision = REFRESHABLE_REVIEW_STATUSES.includes(
+        existing.status as (typeof REFRESHABLE_REVIEW_STATUSES)[number],
+      );
+      if (
+        !reviewAwaitingDecision ||
+        (await hasRecordedManagerDecision(evidence.sourceIssue.companyId, existing.id))
+      ) {
+        return { kind: "existing" as const, reviewIssueId: existing.id };
+      }
       const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
       const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
       if (


### PR DESCRIPTION
## Problem

The productivity-review **evidence refresher** appends a `Productivity review evidence refreshed.` comment to an open review every reconcile tick as long as the review's status is not `done`/`cancelled`. A review that an owner has parked (`blocked`) or handed off (`in_review`), or one where a decision was already recorded via a non-system comment, keeps accumulating evidence comments indefinitely.

On a downstream instance running this codebase, a single review (the source issue was stuck `in_progress` due to an unrelated bug) accumulated **~15,800 `evidence refreshed` comments at exact 30s intervals over ~5.5 days** before the owner cancelled the affected reviews. The existing cadence cap in `master` (`MAX_REFRESH_COMMENTS=3`, `REFRESH_INTERVAL_MS=1h`) limits the rate going forward but does not address the *gating* question — a parked or decided review still pulls refreshes.

## Fix

Surgical gate at the top of `createOrUpdateReview` for the "already-have-a-review" branch:

- Refresh only while the review is **awaiting a decision**, i.e. status in `{todo, in_progress}`. A new `REFRESHABLE_REVIEW_STATUSES` constant is exported for clarity and reuse.
- Additionally, skip refresh once a **manager decision comment** has been recorded. Refresh comments are system-authored (no agent/user); any comment with a real `authorAgentId`/`authorUserId` that is not a `Productivity review evidence refreshed.` comment counts as a recorded decision.

`findOpenProductivityReview` is left unchanged so continuation-hold semantics (which deliberately consider parked reviews "open") are not affected — only the *refresh* path is gated.

## Tests

Three new cases in `productivity-review-service.test.ts` that all exercise the existing fixture set:

1. Review transitions to `blocked` → next reconcile produces 0 refresh comments.
2. Review transitions to `in_review` → same.
3. A non-refresh comment authored by the manager agent is inserted on a `todo` review → next reconcile produces 0 refresh comments.

Full file (`productivity-review-service.test.ts`) passes locally — 14/14 — and `tsc --noEmit` is clean for `@paperclipai/server`.

## Files

- `server/src/services/productivity-review.ts` (+31 lines)
- `server/src/__tests__/productivity-review-service.test.ts` (+86 lines)

## Notes for reviewers

- Builds on the bounded-cadence cap already in `master`; complementary, not a replacement.
- The decision-comment heuristic is intentionally simple (any non-system, non-refresh comment); if you'd prefer an explicit decision marker on the issue/comment row, happy to switch.
