### PR TITLE
fix(server): reap dead `running` run-locks on checkout

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import express from "express";
 import request from "supertest";
 import { eq } from "drizzle-orm";
@@ -130,6 +131,17 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       isInstanceAdmin: false,
       source: "session",
     };
+  }
+
+  // Spawn a trivial child, let it exit, and return its (now reaped) PID. That PID
+  // is guaranteed not to belong to a live process, simulating a run whose host
+  // process died (crash / SIGKILL) without a terminal status transition.
+  async function allocateDeadPid(): Promise<number> {
+    const child = spawn(process.execPath, ["-e", "process.exit(0)"], { stdio: "ignore" });
+    const pid = child.pid;
+    if (typeof pid !== "number") throw new Error("failed to spawn helper process for dead PID");
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    return pid;
   }
 
   it("allows an assigned agent PATCH to recover a terminal stale executionRunId", async () => {
@@ -282,5 +294,148 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
         clearAssignee: true,
       },
     });
+  });
+
+  // Regression: AGEA-45. A run that dies while still marked `running` (crash /
+  // SIGKILL / host reboot, no terminal transition) used to hold its lock forever
+  // because the reaper only recognized terminal/missing runs. A fresh checkout
+  // from the same assignee must now reap a `running` lock whose local PID is dead.
+  it("reaps a wedged `running` lock whose local child process is dead on checkout", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const deadPid = await allocateDeadPid();
+    const wedgedRunId = randomUUID();
+    // Wedged run: still `running` in heartbeat_runs, but its process is gone.
+    // processStartedAt is well past the reap grace window.
+    await db.insert(heartbeatRuns).values({
+      id: wedgedRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(Date.now() - 10 * 60_000),
+      processPid: deadPid,
+      processStartedAt: new Date(Date.now() - 10 * 60_000),
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Wedged running lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: wedgedRunId,
+      executionRunId: wedgedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(Date.now() - 10 * 60_000),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+  });
+
+  // Negative case: a `running` run whose process is still alive is a genuine
+  // live lock and must NOT be reaped. A fresh checkout attempt must 409.
+  it("does not reap a `running` lock whose local process is still alive", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const liveRunId = randomUUID();
+    // Use this test process's own PID as a guaranteed-live local process.
+    await db.insert(heartbeatRuns).values({
+      id: liveRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(Date.now() - 10 * 60_000),
+      processPid: process.pid,
+      processStartedAt: new Date(Date.now() - 10 * 60_000),
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Live running lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: liveRunId,
+      executionRunId: liveRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(Date.now() - 10 * 60_000),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+
+    const row = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    // Lock must remain with the live run.
+    expect(row).toEqual({ checkoutRunId: liveRunId, executionRunId: liveRunId });
+  });
+
+  // Guard: a recently-started `running` run with a dead PID is still inside the
+  // grace window and must NOT be reaped (avoids racing a just-spawned child).
+  it("does not reap a freshly-started `running` lock even if its PID is already dead", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const deadPid = await allocateDeadPid();
+    const freshRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: freshRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+      processPid: deadPid,
+      processStartedAt: new Date(), // within grace window
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Fresh running lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: freshRunId,
+      executionRunId: freshRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
   });
 });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -68,6 +68,7 @@ import { redactSensitiveText } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
+import { isPidAlive, isProcessGroupAlive } from "./local-service-supervisor.js";
 import {
   isVerifiedIssueTreeControlInteractionWake,
   issueTreeControlService,
@@ -333,6 +334,27 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 }
 
 const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
+
+// Local adapters whose runs execute as a child process on the same host as the
+// API server. For these, persisted process metadata (PID / process group) is a
+// reliable cross-process liveness signal, so a run wedged at a non-terminal
+// status with a dead process can be safely treated as stale. Mirrors the set in
+// recovery/service.ts and heartbeat.ts (kept inline to avoid a heavyweight
+// import into this DB-layer service).
+const SESSIONED_LOCAL_ADAPTERS = new Set([
+  "claude_local",
+  "codex_local",
+  "cursor",
+  "gemini_local",
+  "hermes_local",
+  "opencode_local",
+  "pi_local",
+]);
+
+// Grace window before a non-terminal run's dead process is trusted as stale.
+// Guards against a race where the run row is inserted (status `running`) before
+// the child process has spawned and recorded its PID.
+const DEAD_RUNNING_RUN_REAP_GRACE_MS = 60_000;
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
 
@@ -3309,14 +3331,72 @@ export function issueService(db: Db) {
     );
   }
 
-  async function isTerminalOrMissingHeartbeatRun(runId: string) {
+  // A holding run-lock is "stale" — and therefore safe for a fresh run to
+  // reap — when the owning run can no longer be making progress. That is true
+  // when the run is:
+  //   1. missing from heartbeat_runs (deleted), or
+  //   2. in a terminal status (succeeded/failed/cancelled/timed_out), or
+  //   3. non-terminal (e.g. wedged at `running`) but its local child process is
+  //      provably dead — crash / SIGKILL / host reboot with no terminal
+  //      transition. Without (3), such a lock is never reaped and freezes the
+  //      issue for every future heartbeat (see AGEA-45 / AGEA-34).
+  //
+  // The dead-process heuristic is restricted to sessioned local adapters, whose
+  // child process runs on the same host as the API server, so persisted
+  // `process_pid` / `process_group_id` are meaningful here. Runs without process
+  // metadata, runs younger than a short grace window, and runs on remote/cloud
+  // adapters are treated as live and are NOT reaped on this path.
+  async function isStaleHeartbeatRun(runId: string, now: Date = new Date()) {
     const run = await db
-      .select({ status: heartbeatRuns.status })
+      .select({
+        status: heartbeatRuns.status,
+        adapterType: agents.adapterType,
+        processPid: heartbeatRuns.processPid,
+        processGroupId: heartbeatRuns.processGroupId,
+        processStartedAt: heartbeatRuns.processStartedAt,
+        startedAt: heartbeatRuns.startedAt,
+        createdAt: heartbeatRuns.createdAt,
+      })
       .from(heartbeatRuns)
+      .leftJoin(agents, eq(agents.id, heartbeatRuns.agentId))
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
     if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+
+    return isDeadLocalRun(run, now);
+  }
+
+  function isDeadLocalRun(
+    run: {
+      adapterType: string | null;
+      processPid: number | null;
+      processGroupId: number | null;
+      processStartedAt: Date | null;
+      startedAt: Date | null;
+      createdAt: Date | null;
+    },
+    now: Date,
+  ): boolean {
+    // Only same-host local adapters have a meaningful local PID to probe.
+    if (!run.adapterType || !SESSIONED_LOCAL_ADAPTERS.has(run.adapterType)) return false;
+
+    // Need at least one piece of process metadata to make a liveness call.
+    const hasPid = typeof run.processPid === "number" && Number.isInteger(run.processPid) && run.processPid > 0;
+    const hasPgid =
+      typeof run.processGroupId === "number" && Number.isInteger(run.processGroupId) && run.processGroupId > 0;
+    if (!hasPid && !hasPgid) return false;
+
+    // Grace window: avoid reaping a run whose child has only just been spawned.
+    const referenceAt = run.processStartedAt ?? run.startedAt ?? run.createdAt ?? null;
+    if (referenceAt && now.getTime() - referenceAt.getTime() < DEAD_RUNNING_RUN_REAP_GRACE_MS) {
+      return false;
+    }
+
+    const alive =
+      (hasPid && isPidAlive(run.processPid as number)) ||
+      (hasPgid && isProcessGroupAlive(run.processGroupId));
+    return !alive;
   }
 
   async function adoptStaleCheckoutRun(input: {
@@ -3325,10 +3405,10 @@ export function issueService(db: Db) {
     actorRunId: string;
     expectedCheckoutRunId: string;
   }) {
-    const stale = await isTerminalOrMissingHeartbeatRun(input.expectedCheckoutRunId);
+    const now = new Date();
+    const stale = await isStaleHeartbeatRun(input.expectedCheckoutRunId, now);
     if (!stale) return null;
 
-    const now = new Date();
     const adopted = await db
       .update(issues)
       .set({
@@ -3408,11 +3488,25 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select({
+          status: heartbeatRuns.status,
+          adapterType: agents.adapterType,
+          processPid: heartbeatRuns.processPid,
+          processGroupId: heartbeatRuns.processGroupId,
+          processStartedAt: heartbeatRuns.processStartedAt,
+          startedAt: heartbeatRuns.startedAt,
+          createdAt: heartbeatRuns.createdAt,
+        })
         .from(heartbeatRuns)
+        .leftJoin(agents, eq(agents.id, heartbeatRuns.agentId))
         .where(eq(heartbeatRuns.id, issue.executionRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      // Keep the lock only when the run is alive: non-terminal AND not a dead
+      // local child process. A run wedged at `running` whose PID is gone is
+      // reaped here too, matching the checkout-path heuristic (AGEA-45).
+      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status) && !isDeadLocalRun(run, new Date())) {
+        return false;
+      }
 
       const updated = await tx
         .update(issues)
@@ -4905,7 +4999,7 @@ export function issueService(db: Db) {
         existing.checkoutRunId &&
         !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
       ) {
-        const stale = await isTerminalOrMissingHeartbeatRun(existing.checkoutRunId);
+        const stale = await isStaleHeartbeatRun(existing.checkoutRunId);
         if (!stale) {
           throw conflict("Only checkout run can release issue", {
             issueId: existing.id,


### PR DESCRIPTION
## Problem

The checkout reaper (`adoptStaleCheckoutRun` / `clearExecutionRunIfTerminal` in `server/src/services/issues.ts`) only treats a holding run-lock as stale when the owning run is **terminal** (`succeeded`/`failed`/`cancelled`/`timed_out`) or **missing** from `heartbeat_runs`.

A run that dies while still marked `running` — crash, `SIGKILL`, or a host reboot with no terminal-status transition — is treated as live. Its `checkoutRunId` / `executionRunId` lock is therefore **never reaped**, and the issue stays frozen for every future heartbeat: each fresh run hits `409 "Issue run ownership conflict"` bound to the dead run.

Observed in the wild: an issue held an `executionRunId` that was `status: running` in `heartbeat_runs` but absent from the active-run set / dashboard (0 active runs). The existing silent-active-run watchdog (`scanSilentActiveRuns`) only escalates after ≥1h of output silence and never clears the lock, so there is no automatic recovery.

## Fix

Generalize `isTerminalOrMissingHeartbeatRun` → `isStaleHeartbeatRun`, which additionally treats a **non-terminal** run as stale when it is a sessioned **local-adapter** run whose local child process is **provably dead** (PID / process-group not alive, via the existing `isPidAlive` / `isProcessGroupAlive` primitives in `local-service-supervisor.ts`).

The dead-process heuristic is deliberately conservative:

- **Local adapters only** — the child process runs on the same host as the API server, so persisted `process_pid` / `process_group_id` are meaningful. Remote/cloud-adapter runs are never reaped on this path.
- **Requires process metadata** — a run with no PID/PGID is treated as live (never reaped).
- **60s grace window** — guards against a race where the run row is `running` before its child has spawned and recorded a PID.

`clearExecutionRunIfTerminal` applies the same `isDeadLocalRun` check inside its `SELECT … FOR UPDATE` transaction, so the release / PATCH-recovery path also clears a dead `running` execution lock.

No schema change — `process_pid`, `process_group_id`, and `process_started_at` already exist on `heartbeat_runs`.

## Tests

Added to `server/src/__tests__/issue-stale-execution-lock-routes.test.ts` (embedded Postgres):

- ✅ a wedged `running` lock with a dead local PID is reaped on a fresh checkout (the observed failure);
- ✅ a `running` lock with a **live** PID is preserved (checkout still `409`s);
- ✅ a freshly-started `running` run with a dead PID inside the grace window is **not** reaped.

```
✓ src/__tests__/issue-stale-execution-lock-routes.test.ts (6 tests) 5475ms
  Test Files  1 passed (1)
       Tests  6 passed (6)
```

`pnpm --filter @paperclipai/server typecheck` passes.

## Alternative considered

A background watchdog that flips dead `running` runs to `timed_out` (then lets the existing reaper clear the lock) would also work, but it duplicates the `scanSilentActiveRuns` machinery and acts asynchronously. The checkout-path reap above is synchronous, self-healing at the exact moment a fresh run needs the lock, and lower-risk. The two are complementary if a watchdog is later desired.
