### PR TITLE
Gate done status on unmerged PR work products

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -80,6 +80,18 @@ An external review service can also be a valid review path when the issue keeps 
 
 The work is complete and terminal.
 
+For code-backed work with associated pull-request work products, `done` also means the merge requirement is satisfied unless a board/user accepted a non-merge terminal outcome and that exception is recorded on the pull-request work product metadata.
+
+### Pull-request merge gate
+
+A pull request is first-class issue evidence when it is stored as an issue work product with `type: "pull_request"`. Comments that merely paste PR URLs are useful context, but they are not enough to create merge-gated lifecycle semantics.
+
+When an issue attempts to move to `done`, Paperclip checks associated pull-request work products unless that work product explicitly disables the merge gate (`metadata.mergeGateRequired: false`, `metadata.requireMergeBeforeDone: false`) or records an accepted non-merge terminal outcome (`metadata.terminalWithoutMergeAccepted: true`, `metadata.doneWithoutMergeAccepted: true`, or `metadata.mergeGateOverrideAccepted: true`).
+
+If all merge-gated pull requests are merged (`status: "merged"`, `metadata.merged: true`, `metadata.state: "merged"`, or a non-empty `metadata.mergedAt`), the issue may become `done`.
+
+If any merge-gated pull request is open, draft, closed-unmerged, failing checks, or changes-requested, Paperclip keeps the issue in `in_review` and arms a bounded one-shot monitor (`serviceName: "github_pull_request_merge"`, `recoveryPolicy: "wake_owner"`) so the assignee is woken to re-check the PR and choose the next owner/action. The monitor is an action path, not an assertion that the PR will merge automatically.
+
 ### `cancelled`
 
 The work will not continue and is terminal.

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -38,6 +38,9 @@ const mockIssueThreadInteractionService = vi.hoisted(() => ({
 const mockIssueApprovalService = vi.hoisted(() => ({
   listApprovalsForIssue: vi.fn(async () => []),
 }));
+const mockWorkProductService = vi.hoisted(() => ({
+  listForIssue: vi.fn(async () => []),
+}));
 
 function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
@@ -95,7 +98,7 @@ function registerModuleMocks() {
     routineService: () => ({
       syncRunStatusForIssue: vi.fn(async () => undefined),
     }),
-    workProductService: () => ({}),
+    workProductService: () => mockWorkProductService,
   }));
 }
 
@@ -152,6 +155,7 @@ describe("issue execution policy routes", () => {
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
     mockIssueService.createChild.mockResolvedValue({
       issue: {
         id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
@@ -353,6 +357,303 @@ describe("issue execution policy routes", () => {
         status: "in_review",
         monitorNextCheckAt: new Date("2026-12-01T12:00:00.000Z"),
       }),
+    );
+  });
+
+  it("keeps an open PR-linked issue in_review with a bounded merge monitor instead of done", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "PR-linked issue",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([
+      {
+        id: "work-product-1",
+        companyId: "company-1",
+        projectId: null,
+        issueId: issue.id,
+        executionWorkspaceId: null,
+        runtimeServiceId: null,
+        type: "pull_request",
+        provider: "github",
+        externalId: "409",
+        title: "PR #409",
+        url: "https://github.com/paperclipai/paperclip/pull/409",
+        status: "ready_for_review",
+        reviewState: "none",
+        isPrimary: true,
+        healthStatus: "healthy",
+        summary: null,
+        metadata: { state: "open" },
+        createdByRunId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        monitorNextCheckAt: expect.any(Date),
+        monitorScheduledBy: "assignee",
+        executionPolicy: expect.objectContaining({
+          monitor: expect.objectContaining({
+            serviceName: "github_pull_request_merge",
+            maxAttempts: 1,
+            recoveryPolicy: "wake_owner",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("allows a PR-linked issue to finish when the associated PR is merged", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1009",
+      title: "Merged PR issue",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([
+      {
+        id: "work-product-1",
+        companyId: "company-1",
+        projectId: null,
+        issueId: issue.id,
+        executionWorkspaceId: null,
+        runtimeServiceId: null,
+        type: "pull_request",
+        provider: "github",
+        externalId: "410",
+        title: "PR #410",
+        url: "https://github.com/paperclipai/paperclip/pull/410",
+        status: "merged",
+        reviewState: "approved",
+        isPrimary: true,
+        healthStatus: "healthy",
+        summary: null,
+        metadata: { merged: true },
+        createdByRunId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({ status: "done" }),
+    );
+  });
+
+  it("routes a closed-unmerged PR-linked issue to owner action instead of done", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1010",
+      title: "Closed PR issue",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([
+      {
+        id: "work-product-closed",
+        companyId: "company-1",
+        projectId: null,
+        issueId: issue.id,
+        executionWorkspaceId: null,
+        runtimeServiceId: null,
+        type: "pull_request",
+        provider: "github",
+        externalId: "411",
+        title: "PR #411",
+        url: "https://github.com/paperclipai/paperclip/pull/411",
+        status: "closed",
+        reviewState: "none",
+        isPrimary: true,
+        healthStatus: "healthy",
+        summary: null,
+        metadata: { state: "closed", merged: false },
+        createdByRunId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    const patch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, any>;
+    expect(patch.status).toBe("in_review");
+    expect(patch.executionPolicy.monitor.notes).toContain("closed-unmerged");
+    expect(patch.executionPolicy.monitor.maxAttempts).toBe(1);
+  });
+
+  it("leaves done completion unchanged for issues without pull request work products", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1011",
+      title: "Docs issue",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({ status: "done" }),
+    );
+  });
+
+  it("allows board-accepted non-merge terminal outcomes through PR work product metadata", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1012",
+      title: "Accepted unmerged PR issue",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([
+      {
+        id: "work-product-accepted",
+        companyId: "company-1",
+        projectId: null,
+        issueId: issue.id,
+        executionWorkspaceId: null,
+        runtimeServiceId: null,
+        type: "pull_request",
+        provider: "github",
+        externalId: "412",
+        title: "PR #412",
+        url: "https://github.com/paperclipai/paperclip/pull/412",
+        status: "closed",
+        reviewState: "approved",
+        isPrimary: true,
+        healthStatus: "healthy",
+        summary: null,
+        metadata: { terminalWithoutMergeAccepted: true },
+        createdByRunId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({ status: "done" }),
     );
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -49,7 +49,9 @@ import {
   type CompanySearchQuery,
   type CompanySearchResponse,
   type ExecutionWorkspace,
+  type IssueExecutionPolicy,
   type IssueRelationIssueSummary,
+  type IssueWorkProduct,
   type SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
 import { trackAgentTaskCompleted } from "@paperclipai/shared/telemetry";
@@ -116,6 +118,9 @@ import { parseIssueExecutionWorkspaceSettings } from "../services/execution-work
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const PR_MERGE_GATE_MONITOR_DELAY_MS = 15 * 60 * 1000;
+const PR_MERGE_GATE_MONITOR_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+const PR_MERGE_GATE_MONITOR_MAX_ATTEMPTS = 1;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
@@ -1185,6 +1190,147 @@ export function issueRoutes(
       environmentId,
       { allowedDrivers: ["local", "ssh", "sandbox"] },
     );
+  }
+
+  function readWorkProductMetadataFlag(product: IssueWorkProduct, keys: string[]) {
+    const metadata = product.metadata;
+    if (!metadata || typeof metadata !== "object") return undefined;
+    for (const key of keys) {
+      const value = metadata[key];
+      if (typeof value === "boolean") return value;
+    }
+    return undefined;
+  }
+
+  function readWorkProductMetadataString(product: IssueWorkProduct, keys: string[]) {
+    const metadata = product.metadata;
+    if (!metadata || typeof metadata !== "object") return null;
+    for (const key of keys) {
+      const value = metadata[key];
+      if (typeof value === "string" && value.trim().length > 0) return value.trim().toLowerCase();
+    }
+    return null;
+  }
+
+  function isPullRequestMergeGateDisabled(product: IssueWorkProduct) {
+    return readWorkProductMetadataFlag(product, [
+      "mergeGate",
+      "mergeGateRequired",
+      "requireMergeBeforeDone",
+    ]) === false || readWorkProductMetadataFlag(product, [
+      "terminalWithoutMergeAccepted",
+      "doneWithoutMergeAccepted",
+      "mergeGateOverrideAccepted",
+    ]) === true;
+  }
+
+  function isPullRequestMerged(product: IssueWorkProduct) {
+    if (product.status === "merged") return true;
+    if (readWorkProductMetadataFlag(product, ["merged"]) === true) return true;
+    if (readWorkProductMetadataString(product, ["state", "mergeState"]) === "merged") return true;
+    const metadata = product.metadata;
+    return Boolean(
+      metadata &&
+      typeof metadata === "object" &&
+      typeof metadata.mergedAt === "string" &&
+      metadata.mergedAt.trim().length > 0
+    );
+  }
+
+  function classifyPullRequestMergeGate(product: IssueWorkProduct) {
+    const state = readWorkProductMetadataString(product, ["state", "reviewDecision", "checksConclusion"]);
+    if (product.status === "closed" || state === "closed") return "closed-unmerged";
+    if (product.status === "draft" || readWorkProductMetadataFlag(product, ["draft", "isDraft"]) === true) return "draft";
+    if (product.status === "failed" || product.healthStatus === "unhealthy" || state === "failure" || state === "failed") {
+      return "failing-checks";
+    }
+    if (product.status === "changes_requested" || product.reviewState === "changes_requested" || state === "changes_requested") {
+      return "changes-requested";
+    }
+    return "open-unmerged";
+  }
+
+  function buildPullRequestMergeGateMonitor(input: {
+    product: IssueWorkProduct;
+    reason: string;
+    scheduledBy: "assignee" | "board";
+    previousPolicy: IssueExecutionPolicy | null;
+  }): IssueExecutionPolicy {
+    const nextCheckAt = new Date(Date.now() + PR_MERGE_GATE_MONITOR_DELAY_MS).toISOString();
+    const timeoutAt = new Date(Date.now() + PR_MERGE_GATE_MONITOR_TIMEOUT_MS).toISOString();
+    const prRef = input.product.url ?? input.product.externalId ?? input.product.id;
+    return normalizeIssueExecutionPolicy({
+      mode: input.previousPolicy?.mode ?? "normal",
+      commentRequired: input.previousPolicy?.commentRequired ?? true,
+      stages: input.previousPolicy?.stages ?? [],
+      monitor: {
+        nextCheckAt,
+        notes: `PR merge gate: ${input.reason}; re-check ${prRef} before completing this issue.`,
+        scheduledBy: input.scheduledBy,
+        kind: "external_service",
+        serviceName: "github_pull_request_merge",
+        externalRef: prRef,
+        timeoutAt,
+        maxAttempts: PR_MERGE_GATE_MONITOR_MAX_ATTEMPTS,
+        recoveryPolicy: "wake_owner",
+      },
+    })!;
+  }
+
+  async function applyPullRequestMergeGateBeforeDone(input: {
+    existing: {
+      id: string;
+      assigneeAgentId?: string | null;
+      assigneeUserId?: string | null;
+      executionPolicy?: unknown;
+    };
+    updateFields: Record<string, unknown>;
+    actor: ReturnType<typeof getActorInfo>;
+  }) {
+    if (input.updateFields.status !== "done") return;
+    const listForIssue = (workProductsSvc as { listForIssue?: (issueId: string) => Promise<IssueWorkProduct[]> }).listForIssue;
+    if (typeof listForIssue !== "function") return;
+
+    const products = await listForIssue(input.existing.id);
+    const gatedPullRequests = products.filter((product) =>
+      product.type === "pull_request" && !isPullRequestMergeGateDisabled(product)
+    );
+    const blockingPullRequest = gatedPullRequests.find((product) => !isPullRequestMerged(product));
+    if (!blockingPullRequest) return;
+
+    const reason = classifyPullRequestMergeGate(blockingPullRequest);
+    input.updateFields.status = "in_review";
+
+    const nextAssigneeUserId = input.updateFields.assigneeUserId === undefined
+      ? input.existing.assigneeUserId ?? null
+      : input.updateFields.assigneeUserId as string | null;
+    const nextAssigneeAgentId = input.updateFields.assigneeAgentId === undefined
+      ? input.existing.assigneeAgentId ?? null
+      : input.updateFields.assigneeAgentId as string | null;
+
+    if (nextAssigneeUserId) return;
+    const monitorOwnerAgentId = nextAssigneeAgentId ?? input.actor.agentId ?? null;
+    if (!monitorOwnerAgentId) {
+      if (input.actor.actorType === "user") {
+        input.updateFields.assigneeUserId = input.actor.actorId;
+      }
+      return;
+    }
+
+    if (!nextAssigneeAgentId) {
+      input.updateFields.assigneeAgentId = monitorOwnerAgentId;
+      input.updateFields.assigneeUserId = null;
+    }
+
+    const previousPolicy = normalizeIssueExecutionPolicy(
+      (input.updateFields.executionPolicy ?? input.existing.executionPolicy ?? null) as Record<string, unknown> | null,
+    );
+    input.updateFields.executionPolicy = buildPullRequestMergeGateMonitor({
+      product: blockingPullRequest,
+      reason,
+      scheduledBy: input.actor.actorType === "user" ? "board" : "assignee",
+      previousPolicy,
+    });
   }
 
   async function assertAgentInReviewReviewPath(input: {
@@ -3926,6 +4072,11 @@ export function issueRoutes(
         actor.actorType,
       );
     }
+    await applyPullRequestMergeGateBeforeDone({
+      existing,
+      updateFields,
+      actor,
+    });
     const previousExecutionPolicy = normalizeIssueExecutionPolicy(existing.executionPolicy ?? null);
     const nextExecutionPolicy =
       updateFields.executionPolicy !== undefined

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -99,8 +99,8 @@ If you are blocked at any point, you MUST update the issue to `blocked` before e
 
 Before ending any heartbeat, apply this final-disposition checklist:
 
-- `done`: the requested work is complete, verification is recorded, and no follow-up remains on this issue.
-- `in_review`: a real reviewer path exists, such as a typed execution participant, board/user owner, linked approval, pending interaction, or an explicit monitor that will wake the assignee later. Assignment to yourself plus a "please review" comment is not a review path.
+- `done`: the requested work is complete, verification is recorded, no follow-up remains on this issue, and any merge-gated pull request work products are merged or have an explicit board/user-accepted non-merge terminal outcome recorded in work-product metadata.
+- `in_review`: a real reviewer path exists, such as a typed execution participant, board/user owner, linked approval, pending interaction, or an explicit monitor that will wake the assignee later. Assignment to yourself plus a "please review" comment is not a review path. For code-backed issues with an open/unmerged PR work product, use `in_review` with a bounded PR merge monitor rather than terminal `done`.
 - `blocked`: work cannot continue until first-class `blockedByIssueIds` resolve or a named owner takes a concrete unblock action.
 - Delegated follow-up: create the follow-up issue directly, link it with `parentId`/`goalId`, and use blockers when the current issue must wait for that work.
 - Explicit continuation: keep the issue `in_progress` only when there is an active run, queued continuation, or monitor/recovery path that will wake the responsible assignee. Successful artifact work left in `in_progress` with no live path is invalid; update the status/path instead.
@@ -133,7 +133,7 @@ Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`,
 - `in_progress` — actively owned, execution-backed work.
 - `in_review` — paused pending reviewer/approver/board/user feedback. Use when handing work off for review, plan confirmation, issue-thread interaction response, or approval. This is a healthy waiting path, not a synonym for done. If a human asks to take the task back, reassign to them and set `in_review`.
 - `blocked` — cannot proceed until something specific changes. Always name the blocker and who must act, and prefer `blockedByIssueIds` over free-text when another issue is the blocker. `parentId` alone does not imply a blocker.
-- `done` — work complete, no follow-up on this issue.
+- `done` — work complete, no follow-up on this issue, and merge-gated PR work products are merged or explicitly accepted as non-merge terminal outcomes.
 - `cancelled` — intentionally abandoned, not to be resumed.
 
 **Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue lifecycle semantics decide when agent work is complete, waiting, blocked, or recoverable.
> - Code-backed issues can already expose pull requests as issue work products, but final issue completion did not enforce the PR merge outcome.
> - That gap let an issue become `done` while its associated GitHub PR was still open or otherwise unmerged.
> - This pull request gates `done` transitions on pull-request work-product merge state and converts unmerged PRs into a bounded `in_review` monitor path.
> - The benefit is that code-backed work keeps a first-class Paperclip waiting path until the PR is merged or an explicit non-merge terminal outcome is recorded.

## What Changed

- Added PR merge-gate logic to issue updates: unmerged pull-request work products turn `done` requests into `in_review` with a bounded `github_pull_request_merge` monitor.
- Allowed merged PRs, no-PR issues, and explicitly accepted non-merge terminal outcomes to keep existing completion behavior.
- Added route tests for open PRs, merged PRs, closed-unmerged PRs, no-PR behavior, and explicit non-merge exceptions.
- Updated execution semantics and Paperclip skill guidance for merge-gated code-backed issues.

## Verification

- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/issue-execution-policy-routes.test.ts --pool=forks --poolOptions.forks.isolate=true`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Behavior change: issues with `type: "pull_request"` work products now remain `in_review` until merged unless metadata records an explicit exception.
- The monitor wakes the assignee to re-check PR state; it does not itself call GitHub or merge PRs automatically.
- Existing PR URL comments without work products remain unchanged by design.

## Model Used

- OpenAI GPT-5.2 via Pi/Codex coding agent, tool-enabled coding workflow with local tests and typecheck.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
