### PR TITLE
Restore tasks:assign bypass on per-assignee guard for reassign-only P…

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -495,6 +495,14 @@ describe("agent issue mutation checkout ownership", () => {
     ],
     ["attachment delete", (app: express.Express) => request(app).delete("/api/attachments/attachment-1")],
   ])("rejects peer agent %s on another agent's active checkout", async (_name, sendRequest) => {
+    // Default decide mock allows tasks:assign — explicitly deny here so the bypass
+    // restored for reassign-only PATCH and non-lifecycle comments doesn't apply.
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_missing_grant",
+      explanation: "Missing permission.",
+    }));
     const res = await sendRequest(await createApp(peerActor()));
 
     expect(res.status, JSON.stringify(res.body)).toBe(409);
@@ -712,6 +720,15 @@ describe("agent issue mutation checkout ownership", () => {
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));
+    // PATCH bodies carry a non-`assigneeAgentId` field (title) and the comment
+    // body is plain text, so neither qualifies for the `tasks:assign` bypass;
+    // explicitly deny the grant to guarantee the assertion isolates the guard.
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_missing_grant",
+      explanation: "Missing permission.",
+    }));
 
     const res = await sendRequest(await createApp(peerActor()));
 
@@ -870,5 +887,101 @@ describe("agent issue mutation checkout ownership", () => {
       }),
     }));
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  describe("tasks:assign per-assignee guard bypass", () => {
+    function grantTasksAssign(allowed: boolean) {
+      mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+        allowed: allowed && input.action === "tasks:assign",
+        action: input.action,
+        reason: allowed && input.action === "tasks:assign" ? "allow_explicit_grant" : "deny_missing_grant",
+        explanation:
+          allowed && input.action === "tasks:assign"
+            ? "Allowed by tasks:assign grant."
+            : "Missing permission.",
+      }));
+    }
+
+    it("allows a peer with tasks:assign to PATCH reassign-only on an in_progress issue assigned to another agent", async () => {
+      grantTasksAssign(true);
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
+      mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: makeAgent(peerAgentId) });
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ assigneeAgentId: peerAgentId });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({ assigneeAgentId: peerAgentId }),
+      );
+    });
+
+    it("rejects a peer with tasks:assign when the PATCH body adds any field beyond assigneeAgentId", async () => {
+      grantTasksAssign(true);
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+      mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: makeAgent(peerAgentId) });
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ assigneeAgentId: peerAgentId, status: "done" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects PATCH reassign-only when the peer lacks tasks:assign (no privilege escalation)", async () => {
+      grantTasksAssign(false);
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+      mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: makeAgent(peerAgentId) });
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ assigneeAgentId: peerAgentId });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+
+    it("allows a peer with tasks:assign to POST a non-lifecycle comment cross-assignee", async () => {
+      grantTasksAssign(true);
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "Ack: received your question, escalating to the board." });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+      expect(mockIssueService.addComment).toHaveBeenCalled();
+    });
+
+    it("rejects a peer cross-assignee comment carrying a lifecycle flag even with tasks:assign", async () => {
+      grantTasksAssign(true);
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "done", assigneeAgentId: ownerAgentId }));
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "Reopening someone else's work", resume: true });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("rejects a peer cross-assignee comment without tasks:assign", async () => {
+      grantTasksAssign(false);
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "Plain ack" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -514,7 +514,7 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  it("rejects non-assignee agent POST comments on closed issues without tasks:assign", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
@@ -526,6 +526,14 @@ describe.sequential("issue comment reopen routes", () => {
       authorAgentId: "33333333-3333-4333-8333-333333333333",
       authorUserId: null,
     });
+    // Default decide() in this file allows everything except tasks:manage_active_checkouts.
+    // Deny tasks:assign so the non-lifecycle-comment bypass cannot apply.
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_missing_grant",
+      explanation: "Missing permission.",
+    }));
 
     const res = await request(await installActor(createApp(), {
       type: "agent",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1379,10 +1379,53 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  // Narrow per-assignee guard bypass for principals that hold the
+  // explicit `tasks:assign` grant. Restores the historical bot bypass
+  // (necessary for the 2-PATCH close pattern used by webhook automations
+  // and for hierarchical comment acks across CEO/CTO/board chains) while
+  // keeping all other cross-assignee mutations (status, title, description,
+  // priority, lifecycle flags) gated by the assignee check.
+  async function hasTasksAssignOverride(actorAgentId: string, companyId: string) {
+    const decision = await access.decide({
+      actor: { type: "agent", agentId: actorAgentId, companyId },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId },
+    });
+    return decision.allowed;
+  }
+
+  type IssueMutationBypassHint =
+    // PATCH /issues/:id payload restricted to a single field: `assigneeAgentId`.
+    | { kind: "reassign_only" }
+    // POST /issues/:id/comments payload without lifecycle flags
+    // (`reopen`/`resume`/`interrupt`).
+    | { kind: "non_lifecycle_comment" };
+
+  function isReassignOnlyPatchBody(body: unknown): boolean {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const entries = Object.entries(body as Record<string, unknown>).filter(
+      ([, value]) => value !== undefined,
+    );
+    if (entries.length !== 1) return false;
+    const [key] = entries[0];
+    return key === "assigneeAgentId";
+  }
+
+  function isNonLifecycleCommentBody(body: unknown): boolean {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const { reopen, resume, interrupt } = body as {
+      reopen?: unknown;
+      resume?: unknown;
+      interrupt?: unknown;
+    };
+    return reopen !== true && resume !== true && interrupt !== true;
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    bypass?: IssueMutationBypassHint,
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1395,6 +1438,9 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+        return true;
+      }
+      if (bypass && (await hasTasksAssignOverride(actorAgentId, issue.companyId))) {
         return true;
       }
       if (issue.status === "in_progress") {
@@ -3760,7 +3806,10 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    const reassignOnlyBypass: IssueMutationBypassHint | undefined = isReassignOnlyPatchBody(req.body)
+      ? { kind: "reassign_only" }
+      : undefined;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, reassignOnlyBypass))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -5467,7 +5516,10 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    const nonLifecycleCommentBypass: IssueMutationBypassHint | undefined = isNonLifecycleCommentBody(req.body)
+      ? { kind: "non_lifecycle_comment" }
+      : undefined;
+    if (!(await assertAgentIssueMutationAllowed(req, res, issue, nonLifecycleCommentBypass))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,


### PR DESCRIPTION
…ATCH and non-lifecycle comments

The per-assignee mutation guard on `PATCH /api/issues/:id` and `POST /api/issues/:id/comments` rejects every cross-assignee mutation by an agent actor, even when that actor holds an explicit `tasks:assign` grant. This was the historical bypass introduced for the bot 2-PATCH close pattern in SWY-139 / commit e80d5ca (2026-05-15) and then unintentionally removed by the SWY-258/SWY-252 hardening (2026-05-16). It re-broke the GitHub webhook autoclose path and the hierarchical comment ack flow used to coordinate across CEO/CTO/board chains.

This change reintroduces the bypass with two narrow scopes, gated on the caller actually holding `tasks:assign`:

1. `PATCH /issues/:id` where the request body is reassign-only — i.e. a single field `assigneeAgentId` and nothing else. This is exactly what the WebhookSwy bot needs to PATCH the assignee to itself before closing the issue.
2. `POST /issues/:id/comments` where the body has no lifecycle flag (`reopen`/`resume`/`interrupt` are not true). This permits the hierarchical ack/Q&R chain (e.g. CTO posting an ack on an issue currently assigned to the CEO) without re-enabling cross-assignee reopen/resume.

Any other cross-assignee mutation (status, title, description, priority, multi-field PATCH, lifecycle-flagged comment) continues to return 403, even with `tasks:assign`. The active-checkout protection (409 on `in_progress`) is also unaffected when the bypass does not apply.

Refs: SWY-139, SWY-258, SWY-252, SWY-305, SWY-307, SWY-309

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
