### PR TITLE
fix: delete cost_events before heartbeat_runs to respect FK constraint

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -280,13 +280,13 @@ export function companyService(db: Db) {
         }
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
+        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
+        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
-        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
-        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));


### PR DESCRIPTION
## Summary

- Company deletion (`DELETE /api/companies/:id`) fails with a 500 error when `cost_events` rows reference `heartbeat_runs` via the `cost_events_heartbeat_run_id_heartbeat_runs_id_fk` foreign key
- The `remove()` method in `companyService` was deleting `heartbeat_runs` before `cost_events` and `finance_events`, violating the FK constraint (`ON DELETE no action`)
- Moved `cost_events` and `finance_events` deletion before `heartbeat_runs` deletion to satisfy dependency order

## Test plan

- [x] Reproduced: `DELETE /api/companies/:id` returns 500 on a company with cost_events
- [x] Applied fix: same request returns `{"ok": true}` and company is deleted
- [ ] `pnpm test` passes