### PR TITLE
feat(heartbeat): ADR-0044 session lifecycle T1/T2/T3/T4 for claude_local

### DIFF
--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -3,6 +3,10 @@ export interface SessionCompactionPolicy {
   maxSessionRuns: number;
   maxRawInputTokens: number;
   maxSessionAgeHours: number;
+  // ADR-0044 additions
+  maxCachedInputTokens: number;        // T1: threshold on cache_read_input_tokens (0 = disabled)
+  rotateOnZeroOpenIssues: boolean;     // T3: rotate when openIssuesCount == 0
+  rotateOnNewIssueWake: boolean;       // T4: rotate when wakeReason == "issue_assigned"
 }
 
 export type NativeContextManagement = "confirmed" | "likely" | "unknown" | "none";
@@ -25,6 +29,9 @@ const DEFAULT_SESSION_COMPACTION_POLICY: SessionCompactionPolicy = {
   maxSessionRuns: 200,
   maxRawInputTokens: 2_000_000,
   maxSessionAgeHours: 72,
+  maxCachedInputTokens: 0,
+  rotateOnZeroOpenIssues: false,
+  rotateOnNewIssueWake: false,
 };
 
 // Adapters with native context management still participate in session resume,
@@ -34,6 +41,21 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   maxSessionRuns: 0,
   maxRawInputTokens: 0,
   maxSessionAgeHours: 0,
+  maxCachedInputTokens: 0,
+  rotateOnZeroOpenIssues: false,
+  rotateOnNewIssueWake: false,
+};
+
+// ADR-0044 «Heartbeat session lifecycle» — fresh-session policy applied to claude_local by default.
+// Per-agent overrides (e.g. CEO/CoS/Analyst T1=1M / T2=12h) are configured via runtimeConfig.heartbeat.sessionCompaction.
+const CLAUDE_LOCAL_ADR_0044_POLICY: SessionCompactionPolicy = {
+  enabled: true,
+  maxSessionRuns: 0,                    // not used (variant D rejected by ADR-0044)
+  maxRawInputTokens: 0,                 // not used (cached_input is the meaningful signal)
+  maxSessionAgeHours: 6,                // T2 default for execution agents
+  maxCachedInputTokens: 500_000,        // T1 default for execution agents
+  rotateOnZeroOpenIssues: true,         // T3
+  rotateOnNewIssueWake: true,           // T4
 };
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
@@ -57,7 +79,7 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
   claude_local: {
     supportsSessionResume: true,
     nativeContextManagement: "confirmed",
-    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+    defaultSessionCompaction: CLAUDE_LOCAL_ADR_0044_POLICY,
   },
   codex_local: {
     supportsSessionResume: true,
@@ -146,11 +168,17 @@ export function readSessionCompactionOverride(runtimeConfig: unknown): Partial<S
   const maxSessionRuns = readNumber(compaction.maxSessionRuns);
   const maxRawInputTokens = readNumber(compaction.maxRawInputTokens);
   const maxSessionAgeHours = readNumber(compaction.maxSessionAgeHours);
+  const maxCachedInputTokens = readNumber(compaction.maxCachedInputTokens);
+  const rotateOnZeroOpenIssues = readBoolean(compaction.rotateOnZeroOpenIssues);
+  const rotateOnNewIssueWake = readBoolean(compaction.rotateOnNewIssueWake);
 
   if (enabled !== undefined) explicit.enabled = enabled;
   if (maxSessionRuns !== undefined) explicit.maxSessionRuns = maxSessionRuns;
   if (maxRawInputTokens !== undefined) explicit.maxRawInputTokens = maxRawInputTokens;
   if (maxSessionAgeHours !== undefined) explicit.maxSessionAgeHours = maxSessionAgeHours;
+  if (maxCachedInputTokens !== undefined) explicit.maxCachedInputTokens = maxCachedInputTokens;
+  if (rotateOnZeroOpenIssues !== undefined) explicit.rotateOnZeroOpenIssues = rotateOnZeroOpenIssues;
+  if (rotateOnNewIssueWake !== undefined) explicit.rotateOnNewIssueWake = rotateOnNewIssueWake;
 
   return explicit;
 }
@@ -174,6 +202,9 @@ export function resolveSessionCompactionPolicy(
       maxSessionRuns: explicitOverride.maxSessionRuns ?? basePolicy.maxSessionRuns,
       maxRawInputTokens: explicitOverride.maxRawInputTokens ?? basePolicy.maxRawInputTokens,
       maxSessionAgeHours: explicitOverride.maxSessionAgeHours ?? basePolicy.maxSessionAgeHours,
+      maxCachedInputTokens: explicitOverride.maxCachedInputTokens ?? basePolicy.maxCachedInputTokens,
+      rotateOnZeroOpenIssues: explicitOverride.rotateOnZeroOpenIssues ?? basePolicy.rotateOnZeroOpenIssues,
+      rotateOnNewIssueWake: explicitOverride.rotateOnNewIssueWake ?? basePolicy.rotateOnNewIssueWake,
     },
     adapterSessionManagement,
     explicitOverride,
@@ -187,7 +218,19 @@ export function resolveSessionCompactionPolicy(
 
 export function hasSessionCompactionThresholds(policy: Pick<
   SessionCompactionPolicy,
-  "maxSessionRuns" | "maxRawInputTokens" | "maxSessionAgeHours"
+  | "maxSessionRuns"
+  | "maxRawInputTokens"
+  | "maxSessionAgeHours"
+  | "maxCachedInputTokens"
+  | "rotateOnZeroOpenIssues"
+  | "rotateOnNewIssueWake"
 >) {
-  return policy.maxSessionRuns > 0 || policy.maxRawInputTokens > 0 || policy.maxSessionAgeHours > 0;
+  return (
+    policy.maxSessionRuns > 0 ||
+    policy.maxRawInputTokens > 0 ||
+    policy.maxSessionAgeHours > 0 ||
+    policy.maxCachedInputTokens > 0 ||
+    policy.rotateOnZeroOpenIssues === true ||
+    policy.rotateOnNewIssueWake === true
+  );
 }

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -3,6 +3,10 @@ export interface SessionCompactionPolicy {
   maxSessionRuns: number;
   maxRawInputTokens: number;
   maxSessionAgeHours: number;
+  // ADR-0044 additions
+  maxCachedInputTokens: number;        // T1: threshold on cache_read_input_tokens (0 = disabled)
+  rotateOnZeroOpenIssues: boolean;     // T3: rotate when openIssuesCount == 0
+  rotateOnNewIssueWake: boolean;       // T4: rotate when wakeReason == "issue_assigned"
 }
 
 export type NativeContextManagement = "confirmed" | "likely" | "unknown" | "none";
@@ -25,6 +29,9 @@ const DEFAULT_SESSION_COMPACTION_POLICY: SessionCompactionPolicy = {
   maxSessionRuns: 200,
   maxRawInputTokens: 2_000_000,
   maxSessionAgeHours: 72,
+  maxCachedInputTokens: 0,
+  rotateOnZeroOpenIssues: false,
+  rotateOnNewIssueWake: false,
 };
 
 // Adapters with native context management still participate in session resume,
@@ -34,6 +41,21 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   maxSessionRuns: 0,
   maxRawInputTokens: 0,
   maxSessionAgeHours: 0,
+  maxCachedInputTokens: 0,
+  rotateOnZeroOpenIssues: false,
+  rotateOnNewIssueWake: false,
+};
+
+// ADR-0044 «Heartbeat session lifecycle» — fresh-session policy applied to claude_local by default.
+// Per-agent overrides (e.g. CEO/CoS/Analyst T1=1M / T2=12h) are configured via runtimeConfig.heartbeat.sessionCompaction.
+const CLAUDE_LOCAL_ADR_0044_POLICY: SessionCompactionPolicy = {
+  enabled: true,
+  maxSessionRuns: 0,                    // not used (variant D rejected by ADR-0044)
+  maxRawInputTokens: 0,                 // not used (cached_input is the meaningful signal)
+  maxSessionAgeHours: 6,                // T2 default for execution agents
+  maxCachedInputTokens: 500_000,        // T1 default for execution agents
+  rotateOnZeroOpenIssues: true,         // T3
+  rotateOnNewIssueWake: true,           // T4
 };
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
@@ -52,7 +74,7 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
   claude_local: {
     supportsSessionResume: true,
     nativeContextManagement: "confirmed",
-    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+    defaultSessionCompaction: CLAUDE_LOCAL_ADR_0044_POLICY,
   },
   codex_local: {
     supportsSessionResume: true,
@@ -146,11 +168,17 @@ export function readSessionCompactionOverride(runtimeConfig: unknown): Partial<S
   const maxSessionRuns = readNumber(compaction.maxSessionRuns);
   const maxRawInputTokens = readNumber(compaction.maxRawInputTokens);
   const maxSessionAgeHours = readNumber(compaction.maxSessionAgeHours);
+  const maxCachedInputTokens = readNumber(compaction.maxCachedInputTokens);
+  const rotateOnZeroOpenIssues = readBoolean(compaction.rotateOnZeroOpenIssues);
+  const rotateOnNewIssueWake = readBoolean(compaction.rotateOnNewIssueWake);
 
   if (enabled !== undefined) explicit.enabled = enabled;
   if (maxSessionRuns !== undefined) explicit.maxSessionRuns = maxSessionRuns;
   if (maxRawInputTokens !== undefined) explicit.maxRawInputTokens = maxRawInputTokens;
   if (maxSessionAgeHours !== undefined) explicit.maxSessionAgeHours = maxSessionAgeHours;
+  if (maxCachedInputTokens !== undefined) explicit.maxCachedInputTokens = maxCachedInputTokens;
+  if (rotateOnZeroOpenIssues !== undefined) explicit.rotateOnZeroOpenIssues = rotateOnZeroOpenIssues;
+  if (rotateOnNewIssueWake !== undefined) explicit.rotateOnNewIssueWake = rotateOnNewIssueWake;
 
   return explicit;
 }
@@ -174,6 +202,9 @@ export function resolveSessionCompactionPolicy(
       maxSessionRuns: explicitOverride.maxSessionRuns ?? basePolicy.maxSessionRuns,
       maxRawInputTokens: explicitOverride.maxRawInputTokens ?? basePolicy.maxRawInputTokens,
       maxSessionAgeHours: explicitOverride.maxSessionAgeHours ?? basePolicy.maxSessionAgeHours,
+      maxCachedInputTokens: explicitOverride.maxCachedInputTokens ?? basePolicy.maxCachedInputTokens,
+      rotateOnZeroOpenIssues: explicitOverride.rotateOnZeroOpenIssues ?? basePolicy.rotateOnZeroOpenIssues,
+      rotateOnNewIssueWake: explicitOverride.rotateOnNewIssueWake ?? basePolicy.rotateOnNewIssueWake,
     },
     adapterSessionManagement,
     explicitOverride,
@@ -187,7 +218,19 @@ export function resolveSessionCompactionPolicy(
 
 export function hasSessionCompactionThresholds(policy: Pick<
   SessionCompactionPolicy,
-  "maxSessionRuns" | "maxRawInputTokens" | "maxSessionAgeHours"
+  | "maxSessionRuns"
+  | "maxRawInputTokens"
+  | "maxSessionAgeHours"
+  | "maxCachedInputTokens"
+  | "rotateOnZeroOpenIssues"
+  | "rotateOnNewIssueWake"
 >) {
-  return policy.maxSessionRuns > 0 || policy.maxRawInputTokens > 0 || policy.maxSessionAgeHours > 0;
+  return (
+    policy.maxSessionRuns > 0 ||
+    policy.maxRawInputTokens > 0 ||
+    policy.maxSessionAgeHours > 0 ||
+    policy.maxCachedInputTokens > 0 ||
+    policy.rotateOnZeroOpenIssues === true ||
+    policy.rotateOnNewIssueWake === true
+  );
 }

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -4,9 +4,10 @@ export interface SessionCompactionPolicy {
   maxRawInputTokens: number;
   maxSessionAgeHours: number;
   // ADR-0044 additions
-  maxCachedInputTokens: number;        // T1: threshold on cache_read_input_tokens (0 = disabled)
+  maxCachedInputTokens: number;        // T1: threshold on session-cumulative cache_read_input_tokens (0 = disabled)
   rotateOnZeroOpenIssues: boolean;     // T3: rotate when openIssuesCount == 0
   rotateOnNewIssueWake: boolean;       // T4: rotate when wakeReason == "issue_assigned"
+  maxSessionTurns: number;             // T5: threshold on session-cumulative turn count (0 = disabled)
 }
 
 export type NativeContextManagement = "confirmed" | "likely" | "unknown" | "none";
@@ -32,6 +33,7 @@ const DEFAULT_SESSION_COMPACTION_POLICY: SessionCompactionPolicy = {
   maxCachedInputTokens: 0,
   rotateOnZeroOpenIssues: false,
   rotateOnNewIssueWake: false,
+  maxSessionTurns: 0,
 };
 
 // Adapters with native context management still participate in session resume,
@@ -44,6 +46,7 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   maxCachedInputTokens: 0,
   rotateOnZeroOpenIssues: false,
   rotateOnNewIssueWake: false,
+  maxSessionTurns: 0,
 };
 
 // ADR-0044 «Heartbeat session lifecycle» — fresh-session policy applied to claude_local by default.
@@ -53,9 +56,10 @@ const CLAUDE_LOCAL_ADR_0044_POLICY: SessionCompactionPolicy = {
   maxSessionRuns: 0,                    // not used (variant D rejected by ADR-0044)
   maxRawInputTokens: 0,                 // not used (cached_input is the meaningful signal)
   maxSessionAgeHours: 6,                // T2 default for execution agents
-  maxCachedInputTokens: 500_000,        // T1 default for execution agents
+  maxCachedInputTokens: 5_000_000,      // T1 default: session-cumulative cache_read across all runs, not per-run
   rotateOnZeroOpenIssues: true,         // T3
   rotateOnNewIssueWake: true,           // T4
+  maxSessionTurns: 150,                 // T5 default: session-cumulative turns, matches maxTurnsPerRun continuation cap
 };
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
@@ -171,6 +175,7 @@ export function readSessionCompactionOverride(runtimeConfig: unknown): Partial<S
   const maxCachedInputTokens = readNumber(compaction.maxCachedInputTokens);
   const rotateOnZeroOpenIssues = readBoolean(compaction.rotateOnZeroOpenIssues);
   const rotateOnNewIssueWake = readBoolean(compaction.rotateOnNewIssueWake);
+  const maxSessionTurns = readNumber(compaction.maxSessionTurns);
 
   if (enabled !== undefined) explicit.enabled = enabled;
   if (maxSessionRuns !== undefined) explicit.maxSessionRuns = maxSessionRuns;
@@ -179,6 +184,7 @@ export function readSessionCompactionOverride(runtimeConfig: unknown): Partial<S
   if (maxCachedInputTokens !== undefined) explicit.maxCachedInputTokens = maxCachedInputTokens;
   if (rotateOnZeroOpenIssues !== undefined) explicit.rotateOnZeroOpenIssues = rotateOnZeroOpenIssues;
   if (rotateOnNewIssueWake !== undefined) explicit.rotateOnNewIssueWake = rotateOnNewIssueWake;
+  if (maxSessionTurns !== undefined) explicit.maxSessionTurns = maxSessionTurns;
 
   return explicit;
 }
@@ -205,6 +211,7 @@ export function resolveSessionCompactionPolicy(
       maxCachedInputTokens: explicitOverride.maxCachedInputTokens ?? basePolicy.maxCachedInputTokens,
       rotateOnZeroOpenIssues: explicitOverride.rotateOnZeroOpenIssues ?? basePolicy.rotateOnZeroOpenIssues,
       rotateOnNewIssueWake: explicitOverride.rotateOnNewIssueWake ?? basePolicy.rotateOnNewIssueWake,
+      maxSessionTurns: explicitOverride.maxSessionTurns ?? basePolicy.maxSessionTurns,
     },
     adapterSessionManagement,
     explicitOverride,
@@ -224,6 +231,7 @@ export function hasSessionCompactionThresholds(policy: Pick<
   | "maxCachedInputTokens"
   | "rotateOnZeroOpenIssues"
   | "rotateOnNewIssueWake"
+  | "maxSessionTurns"
 >) {
   return (
     policy.maxSessionRuns > 0 ||
@@ -231,6 +239,7 @@ export function hasSessionCompactionThresholds(policy: Pick<
     policy.maxSessionAgeHours > 0 ||
     policy.maxCachedInputTokens > 0 ||
     policy.rotateOnZeroOpenIssues === true ||
-    policy.rotateOnNewIssueWake === true
+    policy.rotateOnNewIssueWake === true ||
+    policy.maxSessionTurns > 0
   );
 }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -854,10 +854,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ? ""
     : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const nearRotationNotice = asString(context.paperclipSessionNearRotationNotice, "").trim();
+  const nearRotationAdvisory = nearRotationNotice
+    ? `## Session rotation approaching\n\n${nearRotationNotice}. This session may be rotated to a fresh one soon. Before finishing this run, persist any long-term context worth keeping (open threads, decisions, next steps) now via WORKING-CONTEXT notes or save_to_knowledge — a rotated session will not retain this conversation's in-memory state.`
+    : "";
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
+    nearRotationAdvisory,
     taskContextNote,
     renderedPrompt,
   ]);
@@ -866,6 +871,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
+    nearRotationAdvisoryChars: nearRotationAdvisory.length,
     taskContextChars: taskContextNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };

--- a/packages/adapters/hermes/src/gateway/index.ts
+++ b/packages/adapters/hermes/src/gateway/index.ts
@@ -14,6 +14,9 @@ const sessionManagement: AdapterSessionManagement = {
     maxSessionRuns: 0,
     maxRawInputTokens: 0,
     maxSessionAgeHours: 0,
+    maxCachedInputTokens: 0,
+    rotateOnZeroOpenIssues: false,
+    rotateOnNewIssueWake: false,
   },
 };
 

--- a/packages/adapters/hermes/src/gateway/index.ts
+++ b/packages/adapters/hermes/src/gateway/index.ts
@@ -17,6 +17,7 @@ const sessionManagement: AdapterSessionManagement = {
     maxCachedInputTokens: 0,
     rotateOnZeroOpenIssues: false,
     rotateOnNewIssueWake: false,
+    maxSessionTurns: 0,
   },
 };
 

--- a/packages/adapters/hermes/src/index.ts
+++ b/packages/adapters/hermes/src/index.ts
@@ -54,6 +54,9 @@ const sessionManagement: AdapterSessionManagement = {
     maxSessionRuns: 0,
     maxRawInputTokens: 0,
     maxSessionAgeHours: 0,
+    maxCachedInputTokens: 0,
+    rotateOnZeroOpenIssues: false,
+    rotateOnNewIssueWake: false,
   },
 };
 

--- a/packages/adapters/hermes/src/index.ts
+++ b/packages/adapters/hermes/src/index.ts
@@ -57,6 +57,7 @@ const sessionManagement: AdapterSessionManagement = {
     maxCachedInputTokens: 0,
     rotateOnZeroOpenIssues: false,
     rotateOnNewIssueWake: false,
+    maxSessionTurns: 0,
   },
 };
 

--- a/server/src/__tests__/heartbeat-session-rotation-policy.test.ts
+++ b/server/src/__tests__/heartbeat-session-rotation-policy.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideSessionCompactionTrigger,
+  type SessionCompactionTriggerInput,
+} from "../services/heartbeat.ts";
+import type { SessionCompactionPolicy } from "@paperclipai/adapter-utils";
+
+const DISABLED_POLICY: SessionCompactionPolicy = {
+  enabled: true,
+  maxSessionRuns: 0,
+  maxRawInputTokens: 0,
+  maxSessionAgeHours: 0,
+  maxCachedInputTokens: 0,
+  rotateOnZeroOpenIssues: false,
+  rotateOnNewIssueWake: false,
+};
+
+const ADR_0044_DEFAULT_POLICY: SessionCompactionPolicy = {
+  enabled: true,
+  maxSessionRuns: 0,
+  maxRawInputTokens: 0,
+  maxSessionAgeHours: 6,
+  maxCachedInputTokens: 500_000,
+  rotateOnZeroOpenIssues: true,
+  rotateOnNewIssueWake: true,
+};
+
+function buildInput(overrides: Partial<SessionCompactionTriggerInput> = {}): SessionCompactionTriggerInput {
+  return {
+    policy: DISABLED_POLICY,
+    runsCount: 1,
+    latestRawUsage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    sessionAgeHours: 0,
+    openIssuesCount: 1,
+    wakeReason: null,
+    ...overrides,
+  };
+}
+
+describe("decideSessionCompactionTrigger", () => {
+  it("returns null when no thresholds are crossed", () => {
+    expect(decideSessionCompactionTrigger(buildInput({ policy: ADR_0044_DEFAULT_POLICY }))).toBeNull();
+  });
+
+  it("T1 triggers when cached_input >= maxCachedInputTokens", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        latestRawUsage: { inputTokens: 0, cachedInputTokens: 600_000, outputTokens: 0 },
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t1");
+    expect(result?.reason).toMatch(/cache_read reached 600,000 tokens/);
+  });
+
+  it("T2 triggers when sessionAgeHours >= maxSessionAgeHours", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionAgeHours: 7,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t2");
+    expect(result?.reason).toBe("session age reached 7 hours");
+  });
+
+  it("T3 triggers when openIssuesCount is 0 and rotateOnZeroOpenIssues is true", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        openIssuesCount: 0,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t3");
+    expect(result?.reason).toBe("no open issues for agent");
+  });
+
+  it("T3 does NOT trigger when openIssuesCount is null (caller skipped the count)", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        openIssuesCount: null,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("T4 triggers when wakeReason is issue_assigned and rotateOnNewIssueWake is true", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        wakeReason: "issue_assigned",
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t4");
+    expect(result?.reason).toBe("wake triggered by new issue assignment");
+  });
+
+  it("T4 does NOT trigger for other wake reasons", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        wakeReason: "heartbeat_timer",
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("legacy_runs triggers when runsCount > maxSessionRuns", () => {
+    const policy: SessionCompactionPolicy = { ...DISABLED_POLICY, maxSessionRuns: 5 };
+    const result = decideSessionCompactionTrigger(buildInput({ policy, runsCount: 6 }));
+    expect(result?.triggeredBy).toBe("legacy_runs");
+    expect(result?.reason).toBe("session exceeded 5 runs");
+  });
+
+  it("legacy_raw_input triggers when raw inputTokens >= maxRawInputTokens", () => {
+    const policy: SessionCompactionPolicy = { ...DISABLED_POLICY, maxRawInputTokens: 1_000_000 };
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy,
+        latestRawUsage: { inputTokens: 1_500_000, cachedInputTokens: 0, outputTokens: 0 },
+      }),
+    );
+    expect(result?.triggeredBy).toBe("legacy_raw_input");
+    expect(result?.reason).toMatch(/raw input reached 1,500,000 tokens/);
+  });
+
+  it("priority: legacy_runs wins over T1 when both conditions hold", () => {
+    const policy: SessionCompactionPolicy = {
+      ...ADR_0044_DEFAULT_POLICY,
+      maxSessionRuns: 5,
+    };
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy,
+        runsCount: 6,
+        latestRawUsage: { inputTokens: 0, cachedInputTokens: 800_000, outputTokens: 0 },
+      }),
+    );
+    expect(result?.triggeredBy).toBe("legacy_runs");
+  });
+
+  it("priority: T1 wins over T2 when both conditions hold", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        latestRawUsage: { inputTokens: 0, cachedInputTokens: 800_000, outputTokens: 0 },
+        sessionAgeHours: 10,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t1");
+  });
+
+  it("priority: T2 wins over T3 when both conditions hold", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionAgeHours: 10,
+        openIssuesCount: 0,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t2");
+  });
+
+  it("priority: T3 wins over T4 when both conditions hold", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        openIssuesCount: 0,
+        wakeReason: "issue_assigned",
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t3");
+  });
+
+  it("ignores T3 when rotateOnZeroOpenIssues is false even if count is 0", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, rotateOnZeroOpenIssues: false };
+    const result = decideSessionCompactionTrigger(buildInput({ policy, openIssuesCount: 0 }));
+    expect(result).toBeNull();
+  });
+
+  it("ignores T4 when rotateOnNewIssueWake is false even if wakeReason is issue_assigned", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, rotateOnNewIssueWake: false };
+    const result = decideSessionCompactionTrigger(buildInput({ policy, wakeReason: "issue_assigned" }));
+    expect(result).toBeNull();
+  });
+
+  it("ignores T1 when maxCachedInputTokens is 0 (disabled)", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, maxCachedInputTokens: 0 };
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy,
+        latestRawUsage: { inputTokens: 0, cachedInputTokens: 10_000_000, outputTokens: 0 },
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ignores T2 when maxSessionAgeHours is 0 (disabled)", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, maxSessionAgeHours: 0 };
+    const result = decideSessionCompactionTrigger(buildInput({ policy, sessionAgeHours: 100 }));
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/__tests__/heartbeat-session-rotation-policy.test.ts
+++ b/server/src/__tests__/heartbeat-session-rotation-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   decideSessionCompactionTrigger,
+  decideSessionNearRotationWarning,
   type SessionCompactionTriggerInput,
 } from "../services/heartbeat.ts";
 import type { SessionCompactionPolicy } from "@paperclipai/adapter-utils";
@@ -13,6 +14,7 @@ const DISABLED_POLICY: SessionCompactionPolicy = {
   maxCachedInputTokens: 0,
   rotateOnZeroOpenIssues: false,
   rotateOnNewIssueWake: false,
+  maxSessionTurns: 0,
 };
 
 const ADR_0044_DEFAULT_POLICY: SessionCompactionPolicy = {
@@ -23,6 +25,7 @@ const ADR_0044_DEFAULT_POLICY: SessionCompactionPolicy = {
   maxCachedInputTokens: 500_000,
   rotateOnZeroOpenIssues: true,
   rotateOnNewIssueWake: true,
+  maxSessionTurns: 150,
 };
 
 function buildInput(overrides: Partial<SessionCompactionTriggerInput> = {}): SessionCompactionTriggerInput {
@@ -30,6 +33,8 @@ function buildInput(overrides: Partial<SessionCompactionTriggerInput> = {}): Ses
     policy: DISABLED_POLICY,
     runsCount: 1,
     latestRawUsage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    sessionCachedInputTokens: 0,
+    sessionTurnsCount: 0,
     sessionAgeHours: 0,
     openIssuesCount: 1,
     wakeReason: null,
@@ -42,15 +47,77 @@ describe("decideSessionCompactionTrigger", () => {
     expect(decideSessionCompactionTrigger(buildInput({ policy: ADR_0044_DEFAULT_POLICY }))).toBeNull();
   });
 
-  it("T1 triggers when cached_input >= maxCachedInputTokens", () => {
+  it("T1 triggers when session-cumulative cache_read >= maxCachedInputTokens", () => {
     const result = decideSessionCompactionTrigger(
       buildInput({
         policy: ADR_0044_DEFAULT_POLICY,
-        latestRawUsage: { inputTokens: 0, cachedInputTokens: 600_000, outputTokens: 0 },
+        sessionCachedInputTokens: 600_000,
       }),
     );
     expect(result?.triggeredBy).toBe("t1");
     expect(result?.reason).toMatch(/cache_read reached 600,000 tokens/);
+  });
+
+  it("T1 does NOT trigger from a single run's latestRawUsage alone (must be session-cumulative)", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        latestRawUsage: { inputTokens: 0, cachedInputTokens: 600_000, outputTokens: 0 },
+        sessionCachedInputTokens: 200_000,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("T5 triggers when session-cumulative turns >= maxSessionTurns", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionTurnsCount: 150,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t5");
+    expect(result?.reason).toMatch(/turns reached 150/);
+  });
+
+  it("T5 does NOT trigger below maxSessionTurns", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionTurnsCount: 149,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ignores T5 when maxSessionTurns is 0 (disabled)", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, maxSessionTurns: 0 };
+    const result = decideSessionCompactionTrigger(
+      buildInput({ policy, sessionTurnsCount: 1_000 }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("priority: T1 wins over T5 when both conditions hold", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionCachedInputTokens: 600_000,
+        sessionTurnsCount: 200,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t1");
+  });
+
+  it("priority: T5 wins over T2 when both conditions hold", () => {
+    const result = decideSessionCompactionTrigger(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionTurnsCount: 200,
+        sessionAgeHours: 10,
+      }),
+    );
+    expect(result?.triggeredBy).toBe("t5");
   });
 
   it("T2 triggers when sessionAgeHours >= maxSessionAgeHours", () => {
@@ -134,7 +201,7 @@ describe("decideSessionCompactionTrigger", () => {
       buildInput({
         policy,
         runsCount: 6,
-        latestRawUsage: { inputTokens: 0, cachedInputTokens: 800_000, outputTokens: 0 },
+        sessionCachedInputTokens: 800_000,
       }),
     );
     expect(result?.triggeredBy).toBe("legacy_runs");
@@ -144,7 +211,7 @@ describe("decideSessionCompactionTrigger", () => {
     const result = decideSessionCompactionTrigger(
       buildInput({
         policy: ADR_0044_DEFAULT_POLICY,
-        latestRawUsage: { inputTokens: 0, cachedInputTokens: 800_000, outputTokens: 0 },
+        sessionCachedInputTokens: 800_000,
         sessionAgeHours: 10,
       }),
     );
@@ -190,7 +257,7 @@ describe("decideSessionCompactionTrigger", () => {
     const result = decideSessionCompactionTrigger(
       buildInput({
         policy,
-        latestRawUsage: { inputTokens: 0, cachedInputTokens: 10_000_000, outputTokens: 0 },
+        sessionCachedInputTokens: 10_000_000,
       }),
     );
     expect(result).toBeNull();
@@ -199,6 +266,70 @@ describe("decideSessionCompactionTrigger", () => {
   it("ignores T2 when maxSessionAgeHours is 0 (disabled)", () => {
     const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, maxSessionAgeHours: 0 };
     const result = decideSessionCompactionTrigger(buildInput({ policy, sessionAgeHours: 100 }));
+    expect(result).toBeNull();
+  });
+});
+
+describe("decideSessionNearRotationWarning", () => {
+  it("returns null when nothing is close to threshold", () => {
+    expect(
+      decideSessionNearRotationWarning(buildInput({ policy: ADR_0044_DEFAULT_POLICY })),
+    ).toBeNull();
+  });
+
+  it("warns when cache_read is at 80% of maxCachedInputTokens", () => {
+    const result = decideSessionNearRotationWarning(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionCachedInputTokens: 400_000,
+      }),
+    );
+    expect(result?.reason).toMatch(/cache_read is at 400,000 tokens/);
+  });
+
+  it("does NOT warn just below the 80% cache_read ratio", () => {
+    const result = decideSessionNearRotationWarning(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionCachedInputTokens: 399_999,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("warns when turns are at 80% of maxSessionTurns", () => {
+    const result = decideSessionNearRotationWarning(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionTurnsCount: 120,
+      }),
+    );
+    expect(result?.reason).toMatch(/used 120 turns/);
+  });
+
+  it("does NOT warn just below the 80% turns ratio", () => {
+    const result = decideSessionNearRotationWarning(
+      buildInput({
+        policy: ADR_0044_DEFAULT_POLICY,
+        sessionTurnsCount: 119,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ignores cache_read ratio when maxCachedInputTokens is 0 (disabled)", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, maxCachedInputTokens: 0 };
+    const result = decideSessionNearRotationWarning(
+      buildInput({ policy, sessionCachedInputTokens: 10_000_000 }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("ignores turns ratio when maxSessionTurns is 0 (disabled)", () => {
+    const policy: SessionCompactionPolicy = { ...ADR_0044_DEFAULT_POLICY, maxSessionTurns: 0 };
+    const result = decideSessionNearRotationWarning(
+      buildInput({ policy, sessionTurnsCount: 1_000 }),
+    );
     expect(result).toBeNull();
   });
 });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -2358,18 +2358,27 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
+  it("disables Paperclip-managed rotation by default for codex local (native context management)", () => {
     expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
       maxSessionAgeHours: 0,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
+  });
+
+  it("applies ADR-0044 fresh-session policy by default for claude_local", () => {
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 6,
+      maxCachedInputTokens: 500_000,
+      rotateOnZeroOpenIssues: true,
+      rotateOnNewIssueWake: true,
     });
   });
 
@@ -2379,12 +2388,18 @@ describe("parseSessionCompactionPolicy", () => {
       maxSessionRuns: 200,
       maxRawInputTokens: 2_000_000,
       maxSessionAgeHours: 72,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
     expect(parseSessionCompactionPolicy(buildAgent("opencode_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 200,
       maxRawInputTokens: 2_000_000,
       maxSessionAgeHours: 72,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
   });
 
@@ -2405,6 +2420,34 @@ describe("parseSessionCompactionPolicy", () => {
       maxSessionRuns: 25,
       maxRawInputTokens: 500_000,
       maxSessionAgeHours: 0,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
+    });
+  });
+
+  it("supports ADR-0044 per-agent overrides (T1/T2/T3/T4)", () => {
+    expect(
+      parseSessionCompactionPolicy(
+        buildAgent("claude_local", {
+          heartbeat: {
+            sessionCompaction: {
+              maxCachedInputTokens: 1_000_000,
+              maxSessionAgeHours: 12,
+              rotateOnZeroOpenIssues: false,
+              rotateOnNewIssueWake: false,
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      enabled: true,
+      maxSessionRuns: 0,
+      maxRawInputTokens: 0,
+      maxSessionAgeHours: 12,
+      maxCachedInputTokens: 1_000_000,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
   });
 });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -3041,6 +3041,7 @@ describe("parseSessionCompactionPolicy", () => {
       maxCachedInputTokens: 0,
       rotateOnZeroOpenIssues: false,
       rotateOnNewIssueWake: false,
+      maxSessionTurns: 0,
     });
   });
 
@@ -3050,9 +3051,10 @@ describe("parseSessionCompactionPolicy", () => {
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
       maxSessionAgeHours: 6,
-      maxCachedInputTokens: 500_000,
+      maxCachedInputTokens: 5_000_000,
       rotateOnZeroOpenIssues: true,
       rotateOnNewIssueWake: true,
+      maxSessionTurns: 150,
     });
   });
 
@@ -3065,6 +3067,7 @@ describe("parseSessionCompactionPolicy", () => {
       maxCachedInputTokens: 0,
       rotateOnZeroOpenIssues: false,
       rotateOnNewIssueWake: false,
+      maxSessionTurns: 0,
     });
     expect(parseSessionCompactionPolicy(buildAgent("opencode_local"))).toEqual({
       enabled: true,
@@ -3074,6 +3077,7 @@ describe("parseSessionCompactionPolicy", () => {
       maxCachedInputTokens: 0,
       rotateOnZeroOpenIssues: false,
       rotateOnNewIssueWake: false,
+      maxSessionTurns: 0,
     });
   });
 
@@ -3097,10 +3101,11 @@ describe("parseSessionCompactionPolicy", () => {
       maxCachedInputTokens: 0,
       rotateOnZeroOpenIssues: false,
       rotateOnNewIssueWake: false,
+      maxSessionTurns: 0,
     });
   });
 
-  it("supports ADR-0044 per-agent overrides (T1/T2/T3/T4)", () => {
+  it("supports ADR-0044 per-agent overrides (T1/T2/T3/T4/T5)", () => {
     expect(
       parseSessionCompactionPolicy(
         buildAgent("claude_local", {
@@ -3110,6 +3115,7 @@ describe("parseSessionCompactionPolicy", () => {
               maxSessionAgeHours: 12,
               rotateOnZeroOpenIssues: false,
               rotateOnNewIssueWake: false,
+              maxSessionTurns: 100,
             },
           },
         }),
@@ -3122,6 +3128,7 @@ describe("parseSessionCompactionPolicy", () => {
       maxCachedInputTokens: 1_000_000,
       rotateOnZeroOpenIssues: false,
       rotateOnNewIssueWake: false,
+      maxSessionTurns: 100,
     });
   });
 });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -3032,18 +3032,27 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
+  it("disables Paperclip-managed rotation by default for codex local (native context management)", () => {
     expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
       maxSessionAgeHours: 0,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
+  });
+
+  it("applies ADR-0044 fresh-session policy by default for claude_local", () => {
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 6,
+      maxCachedInputTokens: 500_000,
+      rotateOnZeroOpenIssues: true,
+      rotateOnNewIssueWake: true,
     });
   });
 
@@ -3053,12 +3062,18 @@ describe("parseSessionCompactionPolicy", () => {
       maxSessionRuns: 200,
       maxRawInputTokens: 2_000_000,
       maxSessionAgeHours: 72,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
     expect(parseSessionCompactionPolicy(buildAgent("opencode_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 200,
       maxRawInputTokens: 2_000_000,
       maxSessionAgeHours: 72,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
   });
 
@@ -3079,6 +3094,34 @@ describe("parseSessionCompactionPolicy", () => {
       maxSessionRuns: 25,
       maxRawInputTokens: 500_000,
       maxSessionAgeHours: 0,
+      maxCachedInputTokens: 0,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
+    });
+  });
+
+  it("supports ADR-0044 per-agent overrides (T1/T2/T3/T4)", () => {
+    expect(
+      parseSessionCompactionPolicy(
+        buildAgent("claude_local", {
+          heartbeat: {
+            sessionCompaction: {
+              maxCachedInputTokens: 1_000_000,
+              maxSessionAgeHours: 12,
+              rotateOnZeroOpenIssues: false,
+              rotateOnNewIssueWake: false,
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      enabled: true,
+      maxSessionRuns: 0,
+      maxRawInputTokens: 0,
+      maxSessionAgeHours: 12,
+      maxCachedInputTokens: 1_000_000,
+      rotateOnZeroOpenIssues: false,
+      rotateOnNewIssueWake: false,
     });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1761,18 +1761,87 @@ interface WakeupOptions {
   contextSnapshot?: Record<string, unknown>;
 }
 
-type UsageTotals = {
+export type UsageTotals = {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
 };
 
+export type SessionCompactionTrigger =
+  | "t1"
+  | "t2"
+  | "t3"
+  | "t4"
+  | "legacy_runs"
+  | "legacy_raw_input";
+
 type SessionCompactionDecision = {
   rotate: boolean;
   reason: string | null;
+  triggeredBy: SessionCompactionTrigger | null;
   handoffMarkdown: string | null;
   previousRunId: string | null;
 };
+
+export interface SessionCompactionTriggerInput {
+  policy: SessionCompactionPolicy;
+  runsCount: number;
+  latestRawUsage: UsageTotals | null;
+  sessionAgeHours: number;
+  openIssuesCount: number | null;
+  wakeReason: string | null;
+}
+
+// Pure decision rule for session rotation. Priority order:
+// legacy_runs > legacy_raw_input > T1 (cached input) > T2 (age) > T3 (zero open issues) > T4 (new issue wake).
+// First match wins so triggeredBy is deterministic for retrospective tuning (ADR-0044 §Acceptance criteria).
+export function decideSessionCompactionTrigger(
+  input: SessionCompactionTriggerInput,
+): { reason: string; triggeredBy: SessionCompactionTrigger } | null {
+  const { policy, runsCount, latestRawUsage, sessionAgeHours, openIssuesCount, wakeReason } = input;
+
+  if (policy.maxSessionRuns > 0 && runsCount > policy.maxSessionRuns) {
+    return { reason: `session exceeded ${policy.maxSessionRuns} runs`, triggeredBy: "legacy_runs" };
+  }
+  if (
+    policy.maxRawInputTokens > 0 &&
+    latestRawUsage &&
+    latestRawUsage.inputTokens >= policy.maxRawInputTokens
+  ) {
+    return {
+      reason:
+        `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
+        `(threshold ${formatCount(policy.maxRawInputTokens)})`,
+      triggeredBy: "legacy_raw_input",
+    };
+  }
+  if (
+    policy.maxCachedInputTokens > 0 &&
+    latestRawUsage &&
+    latestRawUsage.cachedInputTokens >= policy.maxCachedInputTokens
+  ) {
+    return {
+      reason:
+        `session cache_read reached ${formatCount(latestRawUsage.cachedInputTokens)} tokens ` +
+        `(threshold ${formatCount(policy.maxCachedInputTokens)})`,
+      triggeredBy: "t1",
+    };
+  }
+  if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
+    return { reason: `session age reached ${Math.floor(sessionAgeHours)} hours`, triggeredBy: "t2" };
+  }
+  if (
+    policy.rotateOnZeroOpenIssues &&
+    typeof openIssuesCount === "number" &&
+    openIssuesCount === 0
+  ) {
+    return { reason: "no open issues for agent", triggeredBy: "t3" };
+  }
+  if (policy.rotateOnNewIssueWake && wakeReason === "issue_assigned") {
+    return { reason: "wake triggered by new issue assignment", triggeredBy: "t4" };
+  }
+  return null;
+}
 
 interface ParsedIssueAssigneeAdapterOverrides {
   modelProfile: ModelProfileKey | null;
@@ -5746,12 +5815,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     sessionId: string | null;
     issueId: string | null;
     continuationSummaryBody?: string | null;
+    wakeReason?: string | null;
+    openIssuesCount?: number | null;
   }): Promise<SessionCompactionDecision> {
     const { agent, sessionId, issueId } = input;
     if (!sessionId) {
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
       };
@@ -5762,6 +5834,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
       };
@@ -5785,6 +5858,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
       };
@@ -5804,25 +5878,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           )
         : 0;
 
-    let reason: string | null = null;
-    if (policy.maxSessionRuns > 0 && runs.length > policy.maxSessionRuns) {
-      reason = `session exceeded ${policy.maxSessionRuns} runs`;
-    } else if (
-      policy.maxRawInputTokens > 0 &&
-      latestRawUsage &&
-      latestRawUsage.inputTokens >= policy.maxRawInputTokens
-    ) {
-      reason =
-        `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
-        `(threshold ${formatCount(policy.maxRawInputTokens)})`;
-    } else if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
-      reason = `session age reached ${Math.floor(sessionAgeHours)} hours`;
-    }
+    const trigger = decideSessionCompactionTrigger({
+      policy,
+      runsCount: runs.length,
+      latestRawUsage,
+      sessionAgeHours,
+      openIssuesCount: typeof input.openIssuesCount === "number" ? input.openIssuesCount : null,
+      wakeReason: input.wakeReason ?? null,
+    });
+    const reason: string | null = trigger?.reason ?? null;
+    const triggeredBy: SessionCompactionTrigger | null = trigger?.triggeredBy ?? null;
 
     if (!reason || !latestRun) {
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: latestRun?.id ?? null,
       };
@@ -5860,6 +5931,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return {
       rotate: true,
       reason,
+      triggeredBy,
       handoffMarkdown,
       previousRunId: latestRun.id,
     };
@@ -8631,6 +8703,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
+  async function countOpenIssuesForAgent(agentId: string) {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.assigneeAgentId, agentId),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      );
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -10766,11 +10851,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       stripPaperclipSessionMetadataFromSessionParams(runtimeSessionParams),
     );
 
+    const wakeReasonForCompaction = readNonEmptyString(context?.wakeReason) ?? null;
+    const policyForCompaction = parseSessionCompactionPolicy(agent);
+    const openIssuesCountForCompaction = policyForCompaction.rotateOnZeroOpenIssues
+      ? await countOpenIssuesForAgent(agent.id)
+      : null;
     const sessionCompaction = await evaluateSessionCompaction({
       agent,
       sessionId: previousSessionDisplayId ?? runtimeSessionIdForAdapter,
       issueId,
       continuationSummaryBody: continuationSummary?.body ?? null,
+      wakeReason: wakeReasonForCompaction,
+      openIssuesCount: openIssuesCountForCompaction,
     });
     if (sessionCompaction.rotate) {
       context.paperclipSessionHandoffMarkdown = sessionCompaction.handoffMarkdown;
@@ -11487,6 +11579,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               freshSession: runtimeForAdapter.sessionId == null && runtimeForAdapter.sessionDisplayId == null,
               sessionRotated: sessionCompaction.rotate,
               sessionRotationReason: sessionCompaction.reason,
+              freshSessionTriggeredBy: sessionCompaction.rotate ? sessionCompaction.triggeredBy : null,
               configFreshness: configFreshnessResultMetadata,
               provider: readNonEmptyString(adapterResult.provider) ?? "unknown",
               biller: resolveLedgerBiller(adapterResult),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -309,6 +309,7 @@ const GIT_SENSITIVE_LOCAL_ADAPTER_TYPES = new Set([
 ]);
 export const MAX_TURN_CONTINUATION_RETRY_REASON = "max_turns_continuation";
 export const MAX_TURN_CONTINUATION_WAKE_REASON = "max_turns_continuation_retry";
+export const ISSUE_ASSIGNED_WAKE_REASON = "issue_assigned";
 const MAX_TURN_CONTINUATION_DEFAULT_MAX_ATTEMPTS = 2;
 const MAX_TURN_CONTINUATION_MAX_ATTEMPTS_CAP = 10;
 const MAX_TURN_CONTINUATION_DEFAULT_DELAY_MS = 1_000;
@@ -1837,7 +1838,7 @@ export function decideSessionCompactionTrigger(
   ) {
     return { reason: "no open issues for agent", triggeredBy: "t3" };
   }
-  if (policy.rotateOnNewIssueWake && wakeReason === "issue_assigned") {
+  if (policy.rotateOnNewIssueWake && wakeReason === ISSUE_ASSIGNED_WAKE_REASON) {
     return { reason: "wake triggered by new issue assignment", triggeredBy: "t4" };
   }
   return null;
@@ -5817,6 +5818,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     continuationSummaryBody?: string | null;
     wakeReason?: string | null;
     openIssuesCount?: number | null;
+    policy?: SessionCompactionPolicy;
   }): Promise<SessionCompactionDecision> {
     const { agent, sessionId, issueId } = input;
     if (!sessionId) {
@@ -5829,7 +5831,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    const policy = parseSessionCompactionPolicy(agent);
+    const policy = input.policy ?? parseSessionCompactionPolicy(agent);
     if (!policy.enabled || !hasSessionCompactionThresholds(policy)) {
       return {
         rotate: false,
@@ -10863,6 +10865,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       continuationSummaryBody: continuationSummary?.body ?? null,
       wakeReason: wakeReasonForCompaction,
       openIssuesCount: openIssuesCountForCompaction,
+      policy: policyForCompaction,
     });
     if (sessionCompaction.rotate) {
       context.paperclipSessionHandoffMarkdown = sessionCompaction.handoffMarkdown;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3514,18 +3514,87 @@ interface WakeupOptions {
   allowRunCoalescing?: boolean;
 }
 
-type UsageTotals = {
+export type UsageTotals = {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
 };
 
+export type SessionCompactionTrigger =
+  | "t1"
+  | "t2"
+  | "t3"
+  | "t4"
+  | "legacy_runs"
+  | "legacy_raw_input";
+
 type SessionCompactionDecision = {
   rotate: boolean;
   reason: string | null;
+  triggeredBy: SessionCompactionTrigger | null;
   handoffMarkdown: string | null;
   previousRunId: string | null;
 };
+
+export interface SessionCompactionTriggerInput {
+  policy: SessionCompactionPolicy;
+  runsCount: number;
+  latestRawUsage: UsageTotals | null;
+  sessionAgeHours: number;
+  openIssuesCount: number | null;
+  wakeReason: string | null;
+}
+
+// Pure decision rule for session rotation. Priority order:
+// legacy_runs > legacy_raw_input > T1 (cached input) > T2 (age) > T3 (zero open issues) > T4 (new issue wake).
+// First match wins so triggeredBy is deterministic for retrospective tuning (ADR-0044 §Acceptance criteria).
+export function decideSessionCompactionTrigger(
+  input: SessionCompactionTriggerInput,
+): { reason: string; triggeredBy: SessionCompactionTrigger } | null {
+  const { policy, runsCount, latestRawUsage, sessionAgeHours, openIssuesCount, wakeReason } = input;
+
+  if (policy.maxSessionRuns > 0 && runsCount > policy.maxSessionRuns) {
+    return { reason: `session exceeded ${policy.maxSessionRuns} runs`, triggeredBy: "legacy_runs" };
+  }
+  if (
+    policy.maxRawInputTokens > 0 &&
+    latestRawUsage &&
+    latestRawUsage.inputTokens >= policy.maxRawInputTokens
+  ) {
+    return {
+      reason:
+        `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
+        `(threshold ${formatCount(policy.maxRawInputTokens)})`,
+      triggeredBy: "legacy_raw_input",
+    };
+  }
+  if (
+    policy.maxCachedInputTokens > 0 &&
+    latestRawUsage &&
+    latestRawUsage.cachedInputTokens >= policy.maxCachedInputTokens
+  ) {
+    return {
+      reason:
+        `session cache_read reached ${formatCount(latestRawUsage.cachedInputTokens)} tokens ` +
+        `(threshold ${formatCount(policy.maxCachedInputTokens)})`,
+      triggeredBy: "t1",
+    };
+  }
+  if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
+    return { reason: `session age reached ${Math.floor(sessionAgeHours)} hours`, triggeredBy: "t2" };
+  }
+  if (
+    policy.rotateOnZeroOpenIssues &&
+    typeof openIssuesCount === "number" &&
+    openIssuesCount === 0
+  ) {
+    return { reason: "no open issues for agent", triggeredBy: "t3" };
+  }
+  if (policy.rotateOnNewIssueWake && wakeReason === "issue_assigned") {
+    return { reason: "wake triggered by new issue assignment", triggeredBy: "t4" };
+  }
+  return null;
+}
 
 interface ParsedIssueAssigneeAdapterOverrides {
   adapterConfig: Record<string, unknown> | null;
@@ -11542,12 +11611,15 @@ export function heartbeatService(
     sessionId: string | null;
     issueId: string | null;
     continuationSummaryBody?: string | null;
+    wakeReason?: string | null;
+    openIssuesCount?: number | null;
   }): Promise<SessionCompactionDecision> {
     const { agent, sessionId, issueId } = input;
     if (!sessionId) {
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
       };
@@ -11558,6 +11630,7 @@ export function heartbeatService(
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
       };
@@ -11589,6 +11662,7 @@ export function heartbeatService(
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
       };
@@ -11610,28 +11684,22 @@ export function heartbeatService(
           )
         : 0;
 
-    let reason: string | null = null;
-    if (policy.maxSessionRuns > 0 && runs.length > policy.maxSessionRuns) {
-      reason = `session exceeded ${policy.maxSessionRuns} runs`;
-    } else if (
-      policy.maxRawInputTokens > 0 &&
-      latestRawUsage &&
-      latestRawUsage.inputTokens >= policy.maxRawInputTokens
-    ) {
-      reason =
-        `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
-        `(threshold ${formatCount(policy.maxRawInputTokens)})`;
-    } else if (
-      policy.maxSessionAgeHours > 0 &&
-      sessionAgeHours >= policy.maxSessionAgeHours
-    ) {
-      reason = `session age reached ${Math.floor(sessionAgeHours)} hours`;
-    }
+    const trigger = decideSessionCompactionTrigger({
+      policy,
+      runsCount: runs.length,
+      latestRawUsage,
+      sessionAgeHours,
+      openIssuesCount: typeof input.openIssuesCount === "number" ? input.openIssuesCount : null,
+      wakeReason: input.wakeReason ?? null,
+    });
+    const reason: string | null = trigger?.reason ?? null;
+    const triggeredBy: SessionCompactionTrigger | null = trigger?.triggeredBy ?? null;
 
     if (!reason || !latestRun) {
       return {
         rotate: false,
         reason: null,
+        triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: latestRun?.id ?? null,
       };
@@ -11669,6 +11737,7 @@ export function heartbeatService(
     return {
       rotate: true,
       reason,
+      triggeredBy,
       handoffMarkdown,
       previousRunId: latestRun.id,
     };
@@ -16355,6 +16424,19 @@ export function heartbeatService(
         and(
           eq(heartbeatRuns.agentId, agentId),
           eq(heartbeatRuns.status, "running"),
+        ),
+      );
+    return Number(count ?? 0);
+  }
+
+  async function countOpenIssuesForAgent(agentId: string) {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.assigneeAgentId, agentId),
+          notInArray(issues.status, ["done", "cancelled"]),
         ),
       );
     return Number(count ?? 0);
@@ -21578,11 +21660,19 @@ export function heartbeatService(
         stripPaperclipSessionMetadataFromSessionParams(runtimeSessionParams),
       );
 
+      const wakeReasonForCompaction = readNonEmptyString(context?.wakeReason) ?? null;
+      const policyForCompaction = parseSessionCompactionPolicy(agent);
+      const openIssuesCountForCompaction = policyForCompaction.rotateOnZeroOpenIssues
+        ? await countOpenIssuesForAgent(agent.id)
+        : null;
       const sessionCompaction = await evaluateSessionCompaction({
         agent,
         sessionId: previousSessionDisplayId ?? runtimeSessionIdForAdapter,
         issueId,
         continuationSummaryBody: continuationSummary?.body ?? null,
+        policy: policyForCompaction,
+        wakeReason: wakeReasonForCompaction,
+        openIssuesCount: openIssuesCountForCompaction,
       });
       if (sessionCompaction.rotate) {
         context.paperclipSessionHandoffMarkdown =
@@ -23749,6 +23839,7 @@ export function heartbeatService(
                   runtimeForAdapter.sessionDisplayId == null,
                 sessionRotated: sessionCompaction.rotate,
                 sessionRotationReason: sessionCompaction.reason,
+                freshSessionTriggeredBy: sessionCompaction.rotate ? sessionCompaction.triggeredBy : null,
                 configFreshness: configFreshnessResultMetadata,
                 provider:
                   readNonEmptyString(adapterResult.provider) ?? "unknown",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3526,6 +3526,7 @@ export type SessionCompactionTrigger =
   | "t2"
   | "t3"
   | "t4"
+  | "t5"
   | "legacy_runs"
   | "legacy_raw_input";
 
@@ -3535,24 +3536,40 @@ type SessionCompactionDecision = {
   triggeredBy: SessionCompactionTrigger | null;
   handoffMarkdown: string | null;
   previousRunId: string | null;
+  nearRotationReason: string | null;
 };
 
 export interface SessionCompactionTriggerInput {
   policy: SessionCompactionPolicy;
   runsCount: number;
   latestRawUsage: UsageTotals | null;
+  // Session-cumulative cache_read across all heartbeatRuns rows for this session (T1).
+  // Distinct from latestRawUsage, which stays single-run for legacy_raw_input.
+  sessionCachedInputTokens: number | null;
+  // Session-cumulative turn count (sum of each run's num_turns result) (T5).
+  sessionTurnsCount: number | null;
   sessionAgeHours: number;
   openIssuesCount: number | null;
   wakeReason: string | null;
 }
 
 // Pure decision rule for session rotation. Priority order:
-// legacy_runs > legacy_raw_input > T1 (cached input) > T2 (age) > T3 (zero open issues) > T4 (new issue wake).
+// legacy_runs > legacy_raw_input > T1 (session-cumulative cached input) > T5 (session-cumulative turns) >
+// T2 (age) > T3 (zero open issues) > T4 (new issue wake).
 // First match wins so triggeredBy is deterministic for retrospective tuning (ADR-0044 §Acceptance criteria).
 export function decideSessionCompactionTrigger(
   input: SessionCompactionTriggerInput,
 ): { reason: string; triggeredBy: SessionCompactionTrigger } | null {
-  const { policy, runsCount, latestRawUsage, sessionAgeHours, openIssuesCount, wakeReason } = input;
+  const {
+    policy,
+    runsCount,
+    latestRawUsage,
+    sessionCachedInputTokens,
+    sessionTurnsCount,
+    sessionAgeHours,
+    openIssuesCount,
+    wakeReason,
+  } = input;
 
   if (policy.maxSessionRuns > 0 && runsCount > policy.maxSessionRuns) {
     return { reason: `session exceeded ${policy.maxSessionRuns} runs`, triggeredBy: "legacy_runs" };
@@ -3571,14 +3588,26 @@ export function decideSessionCompactionTrigger(
   }
   if (
     policy.maxCachedInputTokens > 0 &&
-    latestRawUsage &&
-    latestRawUsage.cachedInputTokens >= policy.maxCachedInputTokens
+    typeof sessionCachedInputTokens === "number" &&
+    sessionCachedInputTokens >= policy.maxCachedInputTokens
   ) {
     return {
       reason:
-        `session cache_read reached ${formatCount(latestRawUsage.cachedInputTokens)} tokens ` +
+        `session cache_read reached ${formatCount(sessionCachedInputTokens)} tokens ` +
         `(threshold ${formatCount(policy.maxCachedInputTokens)})`,
       triggeredBy: "t1",
+    };
+  }
+  if (
+    policy.maxSessionTurns > 0 &&
+    typeof sessionTurnsCount === "number" &&
+    sessionTurnsCount >= policy.maxSessionTurns
+  ) {
+    return {
+      reason:
+        `session turns reached ${formatCount(sessionTurnsCount)} ` +
+        `(threshold ${formatCount(policy.maxSessionTurns)})`,
+      triggeredBy: "t5",
     };
   }
   if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
@@ -3593,6 +3622,43 @@ export function decideSessionCompactionTrigger(
   }
   if (policy.rotateOnNewIssueWake && wakeReason === ISSUE_ASSIGNED_WAKE_REASON) {
     return { reason: "wake triggered by new issue assignment", triggeredBy: "t4" };
+  }
+  return null;
+}
+
+// Pre-rotation advisory: not a trigger, just a heads-up injected into the *current*
+// run when session-cumulative counters are already close to a T1/T5 threshold, so the
+// agent gets a chance to persist WORKING-CONTEXT/save_to_knowledge before a future
+// dispatch's evaluateSessionCompaction call actually rotates the session out from
+// under it (that call only runs between dispatches, never mid-run).
+const NEAR_ROTATION_WARNING_RATIO = 0.8;
+
+export function decideSessionNearRotationWarning(
+  input: SessionCompactionTriggerInput,
+): { reason: string } | null {
+  const { policy, sessionCachedInputTokens, sessionTurnsCount } = input;
+
+  if (
+    policy.maxCachedInputTokens > 0 &&
+    typeof sessionCachedInputTokens === "number" &&
+    sessionCachedInputTokens >= policy.maxCachedInputTokens * NEAR_ROTATION_WARNING_RATIO
+  ) {
+    return {
+      reason:
+        `session cache_read is at ${formatCount(sessionCachedInputTokens)} tokens, ` +
+        `approaching the ${formatCount(policy.maxCachedInputTokens)} rotation threshold`,
+    };
+  }
+  if (
+    policy.maxSessionTurns > 0 &&
+    typeof sessionTurnsCount === "number" &&
+    sessionTurnsCount >= policy.maxSessionTurns * NEAR_ROTATION_WARNING_RATIO
+  ) {
+    return {
+      reason:
+        `session has used ${formatCount(sessionTurnsCount)} turns, ` +
+        `approaching the ${formatCount(policy.maxSessionTurns)} turn rotation threshold`,
+    };
   }
   return null;
 }
@@ -11624,6 +11690,7 @@ export function heartbeatService(
         triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
+        nearRotationReason: null,
       };
     }
 
@@ -11635,6 +11702,7 @@ export function heartbeatService(
         triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
+        nearRotationReason: null,
       };
     }
 
@@ -11667,6 +11735,7 @@ export function heartbeatService(
         triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: null,
+        nearRotationReason: null,
       };
     }
 
@@ -11686,24 +11755,62 @@ export function heartbeatService(
           )
         : 0;
 
-    const trigger = decideSessionCompactionTrigger({
+    let sessionCachedInputTokens: number | null = null;
+    let sessionTurnsCount: number | null = null;
+    if (policy.maxCachedInputTokens > 0 || policy.maxSessionTurns > 0) {
+      const [aggregate] = await db
+        .select({
+          sessionCachedInputTokens: sql<string>`sum(
+            coalesce(
+              (${heartbeatRuns.usageJson} ->> 'rawCachedInputTokens')::numeric,
+              (${heartbeatRuns.usageJson} ->> 'cachedInputTokens')::numeric,
+              0
+            )
+          )`.as("sessionCachedInputTokens"),
+          sessionTurnsCount: sql<string>`sum(
+            coalesce((${heartbeatRuns.resultJson} ->> 'num_turns')::numeric, 0)
+          )`.as("sessionTurnsCount"),
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agent.id),
+            eq(heartbeatRuns.sessionIdAfter, sessionId),
+          ),
+        );
+      sessionCachedInputTokens =
+        policy.maxCachedInputTokens > 0 && aggregate?.sessionCachedInputTokens != null
+          ? Number(aggregate.sessionCachedInputTokens)
+          : null;
+      sessionTurnsCount =
+        policy.maxSessionTurns > 0 && aggregate?.sessionTurnsCount != null
+          ? Number(aggregate.sessionTurnsCount)
+          : null;
+    }
+
+    const triggerInput: SessionCompactionTriggerInput = {
       policy,
       runsCount: runs.length,
       latestRawUsage,
+      sessionCachedInputTokens,
+      sessionTurnsCount,
       sessionAgeHours,
       openIssuesCount: typeof input.openIssuesCount === "number" ? input.openIssuesCount : null,
       wakeReason: input.wakeReason ?? null,
-    });
+    };
+    const trigger = decideSessionCompactionTrigger(triggerInput);
     const reason: string | null = trigger?.reason ?? null;
     const triggeredBy: SessionCompactionTrigger | null = trigger?.triggeredBy ?? null;
 
     if (!reason || !latestRun) {
+      const nearRotationReason = decideSessionNearRotationWarning(triggerInput)?.reason ?? null;
       return {
         rotate: false,
         reason: null,
         triggeredBy: null,
         handoffMarkdown: null,
         previousRunId: latestRun?.id ?? null,
+        nearRotationReason,
       };
     }
 
@@ -11742,6 +11849,7 @@ export function heartbeatService(
       triggeredBy,
       handoffMarkdown,
       previousRunId: latestRun.id,
+      nearRotationReason: null,
     };
   }
 
@@ -21694,6 +21802,11 @@ export function heartbeatService(
         delete context.paperclipSessionHandoffMarkdown;
         delete context.paperclipSessionRotationReason;
         delete context.paperclipPreviousSessionId;
+      }
+      if (!sessionCompaction.rotate && sessionCompaction.nearRotationReason) {
+        context.paperclipSessionNearRotationNotice = sessionCompaction.nearRotationReason;
+      } else {
+        delete context.paperclipSessionNearRotationNotice;
       }
 
       const runtimeForAdapter = {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -821,6 +821,7 @@ const GIT_SENSITIVE_LOCAL_ADAPTER_TYPES = new Set([
 ]);
 export { MAX_TURN_CONTINUATION_RETRY_REASON };
 export const MAX_TURN_CONTINUATION_WAKE_REASON = "max_turns_continuation_retry";
+export const ISSUE_ASSIGNED_WAKE_REASON = "issue_assigned";
 const MAX_TURN_CONTINUATION_DEFAULT_MAX_ATTEMPTS = 2;
 const MAX_TURN_CONTINUATION_MAX_ATTEMPTS_CAP = 10;
 const MAX_TURN_CONTINUATION_DEFAULT_DELAY_MS = 1_000;
@@ -3590,7 +3591,7 @@ export function decideSessionCompactionTrigger(
   ) {
     return { reason: "no open issues for agent", triggeredBy: "t3" };
   }
-  if (policy.rotateOnNewIssueWake && wakeReason === "issue_assigned") {
+  if (policy.rotateOnNewIssueWake && wakeReason === ISSUE_ASSIGNED_WAKE_REASON) {
     return { reason: "wake triggered by new issue assignment", triggeredBy: "t4" };
   }
   return null;
@@ -11613,6 +11614,7 @@ export function heartbeatService(
     continuationSummaryBody?: string | null;
     wakeReason?: string | null;
     openIssuesCount?: number | null;
+    policy?: SessionCompactionPolicy;
   }): Promise<SessionCompactionDecision> {
     const { agent, sessionId, issueId } = input;
     if (!sessionId) {
@@ -11625,7 +11627,7 @@ export function heartbeatService(
       };
     }
 
-    const policy = parseSessionCompactionPolicy(agent);
+    const policy = input.policy ?? parseSessionCompactionPolicy(agent);
     if (!policy.enabled || !hasSessionCompactionThresholds(policy)) {
       return {
         rotate: false,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source platform people use to manage AI agents for work
> - The `claude_local` adapter handles heartbeat-driven session lifecycle for Claude agents running in autonomous loops
> - Sessions can grow unboundedly because `ADAPTER_MANAGED_SESSION_POLICY` sets all compaction thresholds to `0`, causing `hasSessionCompactionThresholds()` to always return `false` — sessions never rotate (see #7238, #5462)
> - ADR-0044 defines a concrete policy for `claude_local`: T1 (token threshold), T2 (session age), T3 (zero open issues), T4 (new issue wake)
> - This PR implements that policy: a pure `decideSessionCompactionTrigger` decision function + `CLAUDE_LOCAL_ADR_0044_POLICY` constant + `countOpenIssuesForAgent` DB helper for T3
> - The benefit is that `claude_local` agents now rotate sessions predictably rather than accumulating context until they hit errors

## Linked Issues or Issue Description

Refs #7238
Refs #5462

## What Changed

- `SessionCompactionPolicy` gains three new fields: `maxCachedInputTokens` (T1), `rotateOnZeroOpenIssues` (T3), `rotateOnNewIssueWake` (T4)
- New `CLAUDE_LOCAL_ADR_0044_POLICY` constant: T1 = 500 000 cached-input tokens, T2 = 6 h, T3 + T4 enabled; replaces `ADAPTER_MANAGED_SESSION_POLICY` for the `claude_local` adapter
- `evaluateSessionCompaction` now checks `cache_read_input_tokens` (the real cost signal under Anthropic prompt caching) instead of raw input tokens
- Pure `decideSessionCompactionTrigger` helper extracted so the decision rule is unit-testable without a database
- `countOpenIssuesForAgent` DB helper added to `heartbeat.ts` (queries `issues` where `assigneeAgentId = $1 AND status NOT IN ('done','cancelled')`); gated behind `rotateOnZeroOpenIssues` flag so the query is skipped when T3 is disabled
- `usageJson` now records `freshSessionTriggeredBy: "t1" | "t2" | "t3" | "t4" | "legacy_runs" | "legacy_raw_input" | null` for retrospective tuning
- Per-agent overrides (e.g. CEO/CoS/Analyst with T1 = 1 M / T2 = 12 h) continue to flow through `runtimeConfig.heartbeat.sessionCompaction`

## Verification

```bash
# Unit tests — 17 new + updated existing
pnpm --filter @paperclipai/server test -- --testPathPattern="heartbeat-session-rotation-policy|heartbeat-workspace-session"

# Type checks
pnpm --filter @paperclipai/adapter-utils typecheck
pnpm --filter @paperclipai/server typecheck

# Full adapter test suite unaffected
pnpm --filter @paperclipai/server test -- --testPathPattern="claude-local"
```

All 17 new unit tests pass covering: T1/T2/T3/T4 triggers, priority ordering (`legacy_runs > legacy_raw_input > T1 > T2 > T3 > T4`), disabled-threshold branches, null-count safety guard for T3.

## Risks

- **Behavioral change for all `claude_local` agents**: sessions will now rotate when T1/T2/T3/T4 fire. Agents that relied on unbounded session accumulation may see more fresh-session starts. Mitigated by: (a) `freshSessionTriggeredBy` field in `usageJson` for observability, (b) per-agent `runtimeConfig` overrides to tune thresholds, (c) policy is reversible by swapping back to `ADAPTER_MANAGED_SESSION_POLICY`.
- **T3 extra DB query**: one `COUNT(*)` per heartbeat when `rotateOnZeroOpenIssues = true`. Low risk — indexed on `assigneeAgentId + status`.
- Low risk for other adapters: no other adapters use `CLAUDE_LOCAL_ADR_0044_POLICY`.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) via Claude Code CLI — tool use + code execution enabled, 200 K context window.

---

- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)