### PR TITLE
feat(claude-local): failover, classifier, secret-fetch, tier1

### DIFF
--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/01-rate-limit-429.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/01-rate-limit-429.json
@@ -1,0 +1,15 @@
+{
+  "name": "01-rate-limit-429",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Error: HTTP 429 Too Many Requests: rate-limit exceeded\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "rate_limit",
+    "matchContains": "429"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/02-quota-exhausted.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/02-quota-exhausted.json
@@ -1,0 +1,15 @@
+{
+  "name": "02-quota-exhausted",
+  "input": {
+    "exitCode": 1,
+    "stderr": "{\"type\":\"billing_error\",\"message\":\"credit balance too low\"}\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "quota_exhausted",
+    "matchContains": "billing_error"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/03-token-refresh-transient.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/03-token-refresh-transient.json
@@ -1,0 +1,15 @@
+{
+  "name": "03-token-refresh-transient",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Warning: access token expired, attempting refresh...\nrefresh failed retry in 5s\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "token_refresh_transient",
+    "matchContains": "access token expired"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/04-token-refresh-revoked.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/04-token-refresh-revoked.json
@@ -1,0 +1,15 @@
+{
+  "name": "04-token-refresh-revoked",
+  "input": {
+    "exitCode": 1,
+    "stderr": "OAuth error: invalid_grant: refresh token revoked\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "token_refresh_revoked",
+    "matchContains": "invalid_grant"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/05-econnreset-midstream.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/05-econnreset-midstream.json
@@ -1,0 +1,15 @@
+{
+  "name": "05-econnreset-midstream",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Error: socket hang up: read ECONNRESET\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "network_econnreset",
+    "matchContains": "socket hang up"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/06-etimedout-prestream.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/06-etimedout-prestream.json
@@ -1,0 +1,15 @@
+{
+  "name": "06-etimedout-prestream",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Error: connect ETIMEDOUT 1.2.3.4:443\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "network_etimedout",
+    "matchContains": "ETIMEDOUT"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/07-fetch-failed-dns.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/07-fetch-failed-dns.json
@@ -1,0 +1,15 @@
+{
+  "name": "07-fetch-failed-dns",
+  "input": {
+    "exitCode": 1,
+    "stderr": "TypeError: fetch failed\n  caused by: getaddrinfo ENOTFOUND api.anthropic.com\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "network_fetch_failed",
+    "matchContains": "fetch failed"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/08-anthropic-529-overloaded.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/08-anthropic-529-overloaded.json
@@ -1,0 +1,15 @@
+{
+  "name": "08-anthropic-529-overloaded",
+  "input": {
+    "exitCode": 1,
+    "stderr": "HTTP 529 {\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "anthropic_5xx",
+    "matchContains": "HTTP 529"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/09-anthropic-503.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/09-anthropic-503.json
@@ -1,0 +1,15 @@
+{
+  "name": "09-anthropic-503",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Error: HTTP 503 service unavailable\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "anthropic_5xx",
+    "matchContains": "503"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/10-malformed-json-exit0.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/10-malformed-json-exit0.json
@@ -1,0 +1,15 @@
+{
+  "name": "10-malformed-json-exit0",
+  "input": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"partial\"}",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "malformed_stream_json",
+    "matchContains": "exit_0_no_parsed_result"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/11-claude-cli-panic.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/11-claude-cli-panic.json
@@ -1,0 +1,15 @@
+{
+  "name": "11-claude-cli-panic",
+  "input": {
+    "exitCode": 134,
+    "stderr": "panic: runtime error: invalid memory address or nil pointer dereference\ngoroutine 1 [running]:\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "claude_cli_panic",
+    "matchContains": "panic:"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/12-node-uncaught.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/12-node-uncaught.json
@@ -1,0 +1,15 @@
+{
+  "name": "12-node-uncaught",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Uncaught Exception: TypeError: Cannot read properties of undefined\n    at node:internal/process/task_queues:96:5\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": true,
+    "reason": "claude_cli_panic",
+    "matchContains": "Uncaught"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/13-auth-required.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/13-auth-required.json
@@ -1,0 +1,15 @@
+{
+  "name": "13-auth-required",
+  "input": {
+    "exitCode": 1,
+    "stderr": "You are not logged in. Please run `claude login` to continue.\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "auth_required",
+    "matchContains": "claude_auth_required"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/14-unknown-session.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/14-unknown-session.json
@@ -1,0 +1,19 @@
+{
+  "name": "14-unknown-session",
+  "input": {
+    "exitCode": 1,
+    "stderr": "",
+    "stdout": "",
+    "parsed": {
+      "type": "result",
+      "subtype": "error",
+      "result": "no conversation found with session id: abc-123"
+    },
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "unknown_session",
+    "matchContains": "no conversation found"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/15-max-turns.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/15-max-turns.json
@@ -1,0 +1,19 @@
+{
+  "name": "15-max-turns",
+  "input": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+    "parsed": {
+      "type": "result",
+      "subtype": "error_max_turns",
+      "result": "Reached maximum turns"
+    },
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "max_turns",
+    "matchContains": "error_max_turns"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/16-timeout.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/16-timeout.json
@@ -1,0 +1,15 @@
+{
+  "name": "16-timeout",
+  "input": {
+    "exitCode": null,
+    "stderr": "",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": true
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "timeout",
+    "matchContains": null
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/17-user-sigint.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/17-user-sigint.json
@@ -1,0 +1,15 @@
+{
+  "name": "17-user-sigint",
+  "input": {
+    "exitCode": 130,
+    "stderr": "Aborted by user\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "user_abort",
+    "matchContains": "exitCode=130"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/18-http-400.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/18-http-400.json
@@ -1,0 +1,15 @@
+{
+  "name": "18-http-400",
+  "input": {
+    "exitCode": 1,
+    "stderr": "Error: HTTP 400 Bad Request: prompt too long\n",
+    "stdout": "",
+    "parsed": null,
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "non_recoverable_other",
+    "matchContains": "exitCode=1"
+  }
+}

--- a/packages/adapters/claude-local/src/server/__fixtures__/classifier/19-success.json
+++ b/packages/adapters/claude-local/src/server/__fixtures__/classifier/19-success.json
@@ -1,0 +1,19 @@
+{
+  "name": "19-success",
+  "input": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+    "parsed": {
+      "type": "result",
+      "subtype": "success",
+      "result": "ok"
+    },
+    "timedOut": false
+  },
+  "expected": {
+    "recoverable": false,
+    "reason": "ok",
+    "matchContains": null
+  }
+}

--- a/packages/adapters/claude-local/src/server/classifier.test.ts
+++ b/packages/adapters/claude-local/src/server/classifier.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CLASSIFIER_VERSION,
+  isRecoverable,
+  type ClassifierInput,
+  type RecoverabilityReason,
+} from "./classifier.js";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__", "classifier");
+
+interface Fixture {
+  name: string;
+  input: ClassifierInput;
+  expected: {
+    recoverable: boolean;
+    reason: RecoverabilityReason;
+    matchContains: string | null;
+  };
+}
+
+function loadFixtures(): Fixture[] {
+  return readdirSync(FIXTURE_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .sort()
+    .map((f) => JSON.parse(readFileSync(join(FIXTURE_DIR, f), "utf8")) as Fixture);
+}
+
+describe("classifier", () => {
+  it("CLASSIFIER_VERSION is stable", () => {
+    expect(CLASSIFIER_VERSION).toBe("1.0.0");
+  });
+
+  const fixtures = loadFixtures();
+
+  it("loaded the expected number of fixtures", () => {
+    // Catches accidental fixture deletion / misnaming.
+    expect(fixtures.length).toBeGreaterThanOrEqual(19);
+  });
+
+  for (const fx of fixtures) {
+    it(`fixture ${fx.name}: classifies as ${fx.expected.reason} (recoverable=${fx.expected.recoverable})`, () => {
+      const verdict = isRecoverable(fx.input);
+      expect(verdict.reason).toBe(fx.expected.reason);
+      expect(verdict.recoverable).toBe(fx.expected.recoverable);
+      if (fx.expected.matchContains == null) {
+        // null match permitted for timeout/ok cases
+      } else {
+        expect(verdict.match).not.toBeNull();
+        expect(verdict.match ?? "").toContain(fx.expected.matchContains);
+      }
+    });
+  }
+});

--- a/packages/adapters/claude-local/src/server/classifier.ts
+++ b/packages/adapters/claude-local/src/server/classifier.ts
@@ -1,0 +1,232 @@
+// Failover classifier for the claude_local adapter.
+//
+// Spec source: ROCAA-27 (Failover classifier spec, log schema, and test fixtures).
+// Wiring: ROCAA-28. Tier 1 runner: ROCAA-29.
+//
+// The classifier is pure: it inspects fields off the Tier 0 process result and
+// returns a verdict. It does not re-spawn, re-parse, or know which tier called
+// it; loop-prevention is the wiring layer's job (Tier 1 outcomes never feed
+// back into the classifier).
+//
+// Starting regex from the parent ticket — kept here so future readers can grep
+// from the ticket to the code: /rate.?limit|429|ECONN|ETIMEDOUT|fetch failed|token.refresh/i
+// That regex is insufficient on its own (misses revoked-token vs. transient,
+// quota vs. rate-limit, Anthropic 5xx, CLI panics, malformed JSON). The
+// decision order below subsumes it.
+
+import {
+  detectClaudeLoginRequired,
+  isClaudeMaxTurnsResult,
+  isClaudeUnknownSessionError,
+} from "./parse.js";
+
+/** Bump when decision order or reason taxonomy changes. */
+export const CLASSIFIER_VERSION = "1.0.0";
+
+export type Tier = "tier_0_claude_cli" | "tier_1_anthropic_sdk";
+
+export type RecoverabilityReason =
+  | "rate_limit"
+  | "quota_exhausted"
+  | "token_refresh_transient"
+  | "token_refresh_revoked"
+  | "network_econnreset"
+  | "network_etimedout"
+  | "network_fetch_failed"
+  | "anthropic_5xx"
+  | "claude_cli_panic"
+  | "malformed_stream_json"
+  | "auth_required"
+  | "max_turns"
+  | "timeout"
+  | "unknown_session"
+  | "user_abort"
+  | "non_recoverable_other"
+  | "ok";
+
+export interface RecoverabilityVerdict {
+  recoverable: boolean;
+  /** Stable id used in tier_transitions[].reason and metrics. */
+  reason: RecoverabilityReason;
+  /** Which regex / parsed-field matched. Logged verbatim in tier_transitions[]. */
+  match: string | null;
+  /** Optional human-readable hint that the wiring layer can echo to onLog. */
+  detail?: string;
+}
+
+export interface ClassifierInput {
+  exitCode: number | null;
+  stderr: string;
+  stdout: string;
+  parsed: Record<string, unknown> | null;
+  timedOut: boolean;
+}
+
+interface RegexRule {
+  reason: RecoverabilityReason;
+  recoverable: boolean;
+  pattern: RegExp;
+}
+
+// Order matters. Evaluated against `${stderr}\n${stdout}` so signals split
+// between channels both match. Each rule's `pattern` is matched against the
+// raw text; the first capturing of the match string is stored verbatim.
+
+// Token-refresh: revoked path FIRST, before any generic refresh signal.
+const RULE_TOKEN_REVOKED: RegexRule = {
+  reason: "token_refresh_revoked",
+  recoverable: false,
+  pattern: /(invalid_grant|refresh.token.*revoked|account.*disabled|unauthorized_client)/i,
+};
+
+// Quota exhausted BEFORE plain rate limit. Quota is a policy signal, not a
+// load-shed signal — auto-retry on quota would burn operators.
+const RULE_QUOTA_EXHAUSTED: RegexRule = {
+  reason: "quota_exhausted",
+  recoverable: false,
+  pattern: /(quota.exhausted|monthly.limit|usage.limit.reached|insufficient_quota|credit.balance.too.low|"type"\s*:\s*"billing_error")/i,
+};
+
+const RULE_RATE_LIMIT: RegexRule = {
+  reason: "rate_limit",
+  recoverable: true,
+  pattern: /rate.?limit|HTTP\s*429|"status"\s*:\s*429|Too Many Requests/i,
+};
+
+const RULE_TOKEN_REFRESH_TRANSIENT: RegexRule = {
+  reason: "token_refresh_transient",
+  recoverable: true,
+  pattern: /token.refresh|access.token.expired|reauth(?:enticate)?|refresh.failed.*retry/i,
+};
+
+const RULE_ECONNRESET: RegexRule = {
+  reason: "network_econnreset",
+  recoverable: true,
+  pattern: /ECONNRESET|socket hang up|read ECONNRESET|stream.*aborted/i,
+};
+
+const RULE_ETIMEDOUT: RegexRule = {
+  reason: "network_etimedout",
+  recoverable: true,
+  pattern: /ETIMEDOUT|connect ETIMEDOUT|request timeout/i,
+};
+
+const RULE_FETCH_FAILED: RegexRule = {
+  reason: "network_fetch_failed",
+  recoverable: true,
+  pattern: /fetch failed|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EPIPE|getaddrinfo/i,
+};
+
+const RULE_ANTHROPIC_5XX: RegexRule = {
+  reason: "anthropic_5xx",
+  recoverable: true,
+  pattern: /HTTP\s*5\d\d|"status"\s*:\s*5\d\d|overloaded_error|api_error.*server|service.unavailable|bad.gateway/i,
+};
+
+// Claude CLI panic — the binary itself crashed. Tier 1 bypasses the binary, so
+// this is exactly the failure shape Tier 1 earns its keep on.
+const RULE_CLAUDE_CLI_PANIC: RegexRule = {
+  reason: "claude_cli_panic",
+  recoverable: true,
+  // We also gate on non-zero exit at the call site (see runRegexRules).
+  pattern: /panic:|Uncaught (Exception|Error)|Segmentation fault|node:internal\/.*Error/,
+};
+
+const SIGINT_PATTERN = /SIGINT|Aborted by user/i;
+
+/**
+ * Inspect a Tier 0 outcome and decide whether failover should fire.
+ * See ROCAA-27 "Decision order" — order is meaningful and tested by fixture.
+ */
+export function isRecoverable(input: ClassifierInput): RecoverabilityVerdict {
+  const { exitCode, stderr, stdout, parsed, timedOut } = input;
+
+  // 1. Hard timeout: Tier 1 is not magically faster than Tier 0; let timeout
+  // policy handle it.
+  if (timedOut) {
+    return { recoverable: false, reason: "timeout", match: null };
+  }
+
+  // 2. Login required — silently swapping to a different billing path would
+  // hide a human-in-the-loop event. Surface, do not failover.
+  const loginMeta = detectClaudeLoginRequired({ parsed, stdout, stderr }); console.log("LOGIN META", loginMeta);
+  if (loginMeta.requiresLogin) {
+    return {
+      recoverable: false,
+      reason: "auth_required",
+      match: loginMeta.loginUrl ? `loginUrl=${loginMeta.loginUrl}` : "claude_auth_required",
+    };
+  }
+
+  // 3. Max turns — graceful termination, exit 0; retrying just blows turns.
+  if (parsed && isClaudeMaxTurnsResult(parsed)) {
+    return { recoverable: false, reason: "max_turns", match: "subtype=error_max_turns" };
+  }
+
+  // 4. Unknown session — existing resume-retry branch in execute.ts handles
+  // this. The classifier explicitly tags it non-recoverable so Tier 1 cannot
+  // double-fire on top of that branch.
+  if (parsed && isClaudeUnknownSessionError(parsed)) {
+    return { recoverable: false, reason: "unknown_session", match: "no conversation found with session id" };
+  }
+
+  // 5. User-initiated abort.
+  if (exitCode === 130 || SIGINT_PATTERN.test(stderr) || SIGINT_PATTERN.test(stdout)) {
+    return { recoverable: false, reason: "user_abort", match: exitCode === 130 ? "exitCode=130" : "SIGINT" };
+  }
+
+  // 6+. Regex rules in priority order. We match against `${stderr}\n${stdout}`
+  // so a signal in either stream wins.
+  const haystack = `${stderr}\n${stdout}`;
+
+  const orderedRules: RegexRule[] = [
+    RULE_TOKEN_REVOKED,
+    RULE_QUOTA_EXHAUSTED,
+    RULE_RATE_LIMIT,
+    RULE_TOKEN_REFRESH_TRANSIENT,
+    RULE_ECONNRESET,
+    RULE_ETIMEDOUT,
+    RULE_FETCH_FAILED,
+    RULE_ANTHROPIC_5XX,
+  ];
+  for (const rule of orderedRules) {
+    const m = haystack.match(rule.pattern);
+    if (m) {
+      return { recoverable: rule.recoverable, reason: rule.reason, match: truncateMatch(m[0]) };
+    }
+  }
+
+  // 12. Claude CLI panic — gated on non-zero exit. A zero-exit panic regex
+  // hit on stdout would be a false positive (panics-as-text in successful
+  // tool output, etc.).
+  if ((exitCode ?? 0) !== 0) {
+    const panicHit = haystack.match(RULE_CLAUDE_CLI_PANIC.pattern);
+    if (panicHit) {
+      return {
+        recoverable: true,
+        reason: "claude_cli_panic",
+        match: truncateMatch(panicHit[0]),
+      };
+    }
+  }
+
+  // 13. Malformed stream JSON: exit 0 but parsed is null. Stream cut before
+  // final result event. Tier 1 retries the prompt and gets a clean result.
+  if (parsed == null && (exitCode ?? 0) === 0) {
+    return { recoverable: true, reason: "malformed_stream_json", match: "exit_0_no_parsed_result" };
+  }
+
+  // 14. Non-zero exit with no specific signal: do not retry.
+  if ((exitCode ?? 0) !== 0) {
+    return { recoverable: false, reason: "non_recoverable_other", match: `exitCode=${exitCode ?? -1}` };
+  }
+
+  // 15. Exit 0 with parsed result. Caller typically short-circuits before
+  // calling the classifier on success; this exists for safety.
+  return { recoverable: false, reason: "ok", match: null };
+}
+
+function truncateMatch(value: string | null | undefined): string | null {
+  if (value == null) return null;
+  return value.length > 240 ? value.slice(0, 240) : value;
+}

--- a/packages/adapters/claude-local/src/server/failover-events.test.ts
+++ b/packages/adapters/claude-local/src/server/failover-events.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AdapterInvocationMeta } from "@paperclipai/adapter-utils";
+
+import {
+  buildFailoverEvent,
+  buildFailoverLogLine,
+  buildTierTransition,
+  emitFailoverVisibility,
+  FAILOVER_CLASSIFIER_VERSION,
+} from "./failover-events.js";
+import { BLUEPRINT_WORKER_SECRET_NAME } from "./secret-fetch.js";
+
+type LogFn = (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+type MetaFn = (meta: AdapterInvocationMeta) => Promise<void>;
+
+const FIXED_AT = "2026-05-22T19:00:00.000Z";
+const now = () => FIXED_AT;
+
+describe("failover-events", () => {
+  it("FAILOVER_CLASSIFIER_VERSION is stable", () => {
+    expect(FAILOVER_CLASSIFIER_VERSION).toBe("1.0.0");
+  });
+
+  it("builds a tier_transitions[] entry that satisfies the log-schema fields", () => {
+    const t = buildTierTransition({
+      verdict: { reason: "rate_limit", match: "HTTP 429", detail: "Tier 0 stderr matched rate_limit" },
+      fromExitCode: 1,
+      fromParsed: true,
+      now,
+    });
+    expect(t).toEqual({
+      at: FIXED_AT,
+      from: "tier_0_claude_cli",
+      to: "tier_1_anthropic_sdk",
+      reason: "rate_limit",
+      classifierMatch: "HTTP 429",
+      detail: "Tier 0 stderr matched rate_limit",
+      fromExitCode: 1,
+      fromParsed: true,
+    });
+  });
+
+  it("truncates classifierMatch and detail to bounded lengths", () => {
+    const huge = "x".repeat(1000);
+    const t = buildTierTransition({
+      verdict: { reason: "anthropic_5xx", match: huge, detail: huge },
+      fromExitCode: 1,
+      fromParsed: false,
+      now,
+    });
+    expect(t.classifierMatch?.length).toBe(240);
+    expect(t.detail?.length).toBe(240);
+  });
+
+  it("builds a failoverEvent with the biller key name surfaced", () => {
+    const evt = buildFailoverEvent({
+      verdict: { reason: "anthropic_5xx", match: "HTTP 529 overloaded_error" },
+      fromExitCode: 1,
+      fromParsed: true,
+      now,
+    });
+    expect(evt.billerKeyName).toBe(BLUEPRINT_WORKER_SECRET_NAME);
+    expect(evt.reason).toBe("anthropic_5xx");
+    expect(evt.classifierMatch).toBe("HTTP 529 overloaded_error");
+  });
+
+  it("builds a stdout line with both Tier 0 and Tier 1 substrings and the biller key name", () => {
+    const line = buildFailoverLogLine({
+      verdict: { reason: "rate_limit", match: "HTTP 429" },
+      fromExitCode: 1,
+      fromParsed: true,
+      now,
+    });
+    expect(line).toContain("Tier 0");
+    expect(line).toContain("Tier 1");
+    expect(line).toContain("reason=rate_limit");
+    expect(line).toContain('match="HTTP 429"');
+    expect(line).toContain(BLUEPRINT_WORKER_SECRET_NAME);
+    expect(line).toMatch(/\[paperclip\] Tier 0 .* Failing over to Tier 1/);
+  });
+
+  it("emits onLog + onMeta together with a shared timestamp", async () => {
+    const logCalls: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    const metaCalls: AdapterInvocationMeta[] = [];
+    const onLog: LogFn = async (stream, chunk) => {
+      logCalls.push({ stream, chunk });
+    };
+    const onMeta: MetaFn = async (meta) => {
+      metaCalls.push(meta);
+    };
+
+    const { transition, event } = await emitFailoverVisibility({
+      verdict: { reason: "network_econnreset", match: "read ECONNRESET" },
+      fromExitCode: 1,
+      fromParsed: false,
+      onLog,
+      onMeta,
+      baseMeta: { adapterType: "claude_local", command: "claude" },
+      now,
+    });
+
+    expect(transition.at).toBe(FIXED_AT);
+    expect(event.at).toBe(FIXED_AT);
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0]!.stream).toBe("stdout");
+    expect(logCalls[0]!.chunk).toContain("Tier 0");
+    expect(logCalls[0]!.chunk).toContain("Tier 1");
+    expect(logCalls[0]!.chunk).toContain("reason=network_econnreset");
+
+    expect(metaCalls).toHaveLength(1);
+    const metaArg = metaCalls[0]!;
+    expect(metaArg.adapterType).toBe("claude_local");
+    expect(metaArg.failoverEvent).toBeDefined();
+    expect(metaArg.failoverEvent!.reason).toBe("network_econnreset");
+    expect(metaArg.failoverEvent!.billerKeyName).toBe(BLUEPRINT_WORKER_SECRET_NAME);
+  });
+
+  it("emits onLog even when onMeta is not provided (cost-visibility test #3 per ROCAA-29 scope)", async () => {
+    const logCalls: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    const onLog: LogFn = async (stream, chunk) => {
+      logCalls.push({ stream, chunk });
+    };
+    await emitFailoverVisibility({
+      verdict: { reason: "claude_cli_panic", match: "panic: runtime error" },
+      fromExitCode: 1,
+      fromParsed: false,
+      onLog,
+      now,
+    });
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0]!.chunk).toContain("Tier 0");
+    expect(logCalls[0]!.chunk).toContain("Tier 1");
+    expect(logCalls[0]!.chunk).toContain("reason=claude_cli_panic");
+  });
+
+  it("escapes double-quotes inside match so the stdout line stays parseable", async () => {
+    const logCalls: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    const onLog: LogFn = async (stream, chunk) => {
+      logCalls.push({ stream, chunk });
+    };
+    await emitFailoverVisibility({
+      verdict: { reason: "anthropic_5xx", match: 'inner "quoted" segment' },
+      fromExitCode: 1,
+      fromParsed: false,
+      onLog,
+      now,
+    });
+    expect(logCalls[0]!.chunk).toContain('match="inner \\"quoted\\" segment"');
+  });
+});

--- a/packages/adapters/claude-local/src/server/failover-events.ts
+++ b/packages/adapters/claude-local/src/server/failover-events.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared cost-visibility helpers for the claude_local Tier 0 → Tier 1 failover.
+ *
+ * The schema (ROCAA-27 log-schema doc) requires three surfaces every time a
+ * transition fires:
+ *
+ *   1. An `onMeta({ failoverEvent })` event so the run UI can render the
+ *      "Tier 1 (API key)" pill on the run card.
+ *   2. A single grep-friendly `[paperclip] Tier 0 ... Tier 1 ...` stdout line so
+ *      terminal users see the swap inline.
+ *   3. A `tier_transitions[]` entry on `AdapterExecutionResult` so post-run
+ *      consumers can query the structured shape.
+ *
+ * ROCAA-28 owns the wiring (calling these helpers from `execute.ts`). This module
+ * owns the *contents*: identical formatting in every consumer, no copy-paste.
+ */
+import type {
+  AdapterFailoverEvent,
+  AdapterInvocationMeta,
+  AdapterTierTransition,
+  AdapterTierTransitionReason,
+} from "@paperclipai/adapter-utils";
+
+import { BLUEPRINT_WORKER_SECRET_NAME } from "./secret-fetch.js";
+import { CLASSIFIER_VERSION } from "./classifier.js";
+
+/**
+ * Bumped when the classifier decision order or schema fields change. Re-exported
+ * from `./classifier.js` so the version string has a single source of truth
+ * (the classifier itself), and external callers that depend on either module
+ * see the same value.
+ */
+export const FAILOVER_CLASSIFIER_VERSION = CLASSIFIER_VERSION;
+
+const MAX_CLASSIFIER_MATCH_LEN = 240;
+const MAX_DETAIL_LEN = 240;
+const MAX_LOG_MATCH_LEN = 120;
+
+export interface ClassifierVerdictLike {
+  reason: AdapterTierTransitionReason;
+  match: string | null;
+  detail?: string;
+}
+
+export interface FailoverTransitionInput {
+  verdict: ClassifierVerdictLike;
+  fromExitCode: number | null;
+  fromParsed: boolean;
+  /**
+   * Operator-facing name of the credential Tier 1 is using. Defaults to
+   * `ANTHROPIC_API_KEY_BLUEPRINT_WORKER` because every Tier 1 spawn billed by
+   * this adapter charges that key. Override only when the env-var fallback path
+   * is in use.
+   */
+  billerKeyName?: string;
+  /** Injection seam for tests. Defaults to `() => new Date().toISOString()`. */
+  now?: () => string;
+}
+
+function truncate(value: string | null, max: number): string | null {
+  if (value == null) return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function quoteShort(value: string | null): string {
+  if (value == null || value.length === 0) return '""';
+  return `"${truncate(value, MAX_LOG_MATCH_LEN)?.replace(/"/g, '\\"') ?? ""}"`;
+}
+
+/**
+ * Builds the structured `tierTransitions[]` entry that the wiring layer attaches
+ * to the AdapterExecutionResult. The verdict's `match`/`detail` are truncated to
+ * keep the run-row payload bounded.
+ */
+export function buildTierTransition(input: FailoverTransitionInput): AdapterTierTransition {
+  const at = (input.now ?? (() => new Date().toISOString()))();
+  return {
+    at,
+    from: "tier_0_claude_cli",
+    to: "tier_1_anthropic_sdk",
+    reason: input.verdict.reason,
+    classifierMatch: truncate(input.verdict.match, MAX_CLASSIFIER_MATCH_LEN),
+    ...(input.verdict.detail
+      ? { detail: truncate(input.verdict.detail, MAX_DETAIL_LEN) ?? undefined }
+      : {}),
+    fromExitCode: input.fromExitCode,
+    fromParsed: input.fromParsed,
+  };
+}
+
+/**
+ * Builds the `failoverEvent` payload that goes on the next `onMeta` call. The
+ * UI reads this to render the run-card chip. Always includes the biller key
+ * name so operators can see *which budget* this invocation will spend.
+ */
+export function buildFailoverEvent(input: FailoverTransitionInput): AdapterFailoverEvent {
+  const transition = buildTierTransition(input);
+  return {
+    at: transition.at,
+    from: transition.from,
+    to: transition.to,
+    reason: transition.reason,
+    classifierMatch: transition.classifierMatch,
+    billerKeyName: input.billerKeyName ?? BLUEPRINT_WORKER_SECRET_NAME,
+  };
+}
+
+/**
+ * Builds the single mandatory stdout line per the log-schema contract. Format
+ * is fixed:
+ *
+ *   [paperclip] Tier 0 (claude CLI) failed: reason=<id> match="<≤120 chars>". Failing over to Tier 1 (Anthropic SDK, billed to <KEY_NAME>).
+ *
+ * The literal substrings `Tier 0` and `Tier 1` are case-sensitive and grep-friendly.
+ */
+export function buildFailoverLogLine(input: FailoverTransitionInput): string {
+  const billerKeyName = input.billerKeyName ?? BLUEPRINT_WORKER_SECRET_NAME;
+  return (
+    `[paperclip] Tier 0 (claude CLI) failed: reason=${input.verdict.reason} ` +
+    `match=${quoteShort(input.verdict.match)}. ` +
+    `Failing over to Tier 1 (Anthropic SDK, billed to ${billerKeyName}).\n`
+  );
+}
+
+/** Helper for the wiring layer to emit all three surfaces in one call. */
+export interface EmitFailoverVisibilityInput extends FailoverTransitionInput {
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  onMeta?: (meta: AdapterInvocationMeta) => Promise<void>;
+  /** The base meta payload (adapterType, command, etc.) that the meta event extends. */
+  baseMeta?: Omit<AdapterInvocationMeta, "failoverEvent">;
+}
+
+export async function emitFailoverVisibility(
+  input: EmitFailoverVisibilityInput,
+): Promise<{ transition: AdapterTierTransition; event: AdapterFailoverEvent }> {
+  // Build transition + event together so they share an `at` timestamp via `now`.
+  const at = (input.now ?? (() => new Date().toISOString()))();
+  const fixedNow = () => at;
+  const transition = buildTierTransition({ ...input, now: fixedNow });
+  const event = buildFailoverEvent({ ...input, now: fixedNow });
+
+  const line = buildFailoverLogLine({ ...input, now: fixedNow });
+  await input.onLog("stdout", line);
+
+  if (input.onMeta) {
+    await input.onMeta({
+      adapterType: "claude_local",
+      command: "",
+      ...(input.baseMeta ?? {}),
+      failoverEvent: event,
+    });
+  }
+
+  return { transition, event };
+}

--- a/packages/adapters/claude-local/src/server/failover.acceptance.test.ts
+++ b/packages/adapters/claude-local/src/server/failover.acceptance.test.ts
@@ -1,0 +1,413 @@
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  AdapterInvocationMeta,
+  AdapterTierTransitionReason,
+} from "@paperclipai/adapter-utils";
+
+import {
+  executeClaudeLocalWithFailover,
+  type Tier0RawOutcome,
+  type Tier0Runner,
+  type Tier1Runner,
+} from "./failover.js";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__", "classifier");
+
+interface Fixture {
+  name: string;
+  input: {
+    exitCode: number | null;
+    stderr: string;
+    stdout: string;
+    parsed: Record<string, unknown> | null;
+    timedOut: boolean;
+  };
+  expected: {
+    recoverable: boolean;
+    reason: AdapterTierTransitionReason | string;
+    matchContains: string | null;
+  };
+}
+
+function loadFixture(name: string): Fixture {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, `${name}.json`), "utf8")) as Fixture;
+}
+
+function makeStubTier0(fixtureName: string): Tier0Runner {
+  const fx = loadFixture(fixtureName);
+  return {
+    async runTier0(): Promise<Tier0RawOutcome> {
+      return {
+        proc: {
+          exitCode: fx.input.exitCode,
+          stderr: fx.input.stderr,
+          stdout: fx.input.stdout,
+          timedOut: fx.input.timedOut,
+          signal: null,
+          pid: null,
+          startedAt: null,
+        },
+        parsedStream: {
+          sessionId: null,
+          usage: null,
+          model: null,
+          summary: null,
+          costUsd: null,
+          resultJson: fx.input.parsed,
+        },
+        parsed: fx.input.parsed,
+      };
+    },
+  };
+}
+
+function makeStubTier1(opts: { ok: boolean } = { ok: true }): {
+  runner: Tier1Runner;
+  calls: number;
+} {
+  const state = { calls: 0 };
+  const runner: Tier1Runner = {
+    async runTier1() {
+      state.calls += 1;
+      if (opts.ok) {
+        return {
+          exitCode: 0,
+          biller: "anthropic",
+          billingType: "api_key",
+          model: "claude-sonnet-4-6",
+          summary: "tier 1 result",
+          parsed: { type: "result", subtype: "success", result: "tier 1 result" },
+          usage: { inputTokens: 100, cachedInputTokens: 0, outputTokens: 50 },
+          costUsd: 0,
+        };
+      }
+      return {
+        exitCode: 1,
+        biller: "anthropic",
+        billingType: "api_key",
+        model: "claude-sonnet-4-6",
+        summary: "",
+        parsed: { type: "error", subtype: "tier1_sdk_error", message: "tier 1 itself rate-limited" },
+        usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+        costUsd: 0,
+      };
+    },
+  };
+  return {
+    runner,
+    get calls() {
+      return state.calls;
+    },
+  } as { runner: Tier1Runner; calls: number };
+}
+
+const noopLog = async (_stream: "stdout" | "stderr", _chunk: string) => {};
+const noopMeta = async (_meta: AdapterInvocationMeta) => {};
+
+describe("executeClaudeLocalWithFailover — acceptance", () => {
+  describe("fires Tier 1 on recoverable Tier 0 failure", () => {
+    const recoverableFixtures = [
+      "01-rate-limit-429",
+      "03-token-refresh-transient",
+      "05-econnreset-midstream",
+      "06-etimedout-prestream",
+      "07-fetch-failed-dns",
+      "08-anthropic-529-overloaded",
+      "09-anthropic-503",
+      "10-malformed-json-exit0",
+      "11-claude-cli-panic",
+      "12-node-uncaught",
+    ];
+
+    for (const fixtureName of recoverableFixtures) {
+      it(`fixture ${fixtureName} routes to Tier 1`, async () => {
+        const tier1 = makeStubTier1({ ok: true });
+        const onLog = vi.fn(async (_stream: "stdout" | "stderr", _chunk: string) => {});
+        const onMeta = vi.fn(async (_meta: AdapterInvocationMeta) => {});
+        const result = await executeClaudeLocalWithFailover({
+          tier0: makeStubTier0(fixtureName),
+          tier1: tier1.runner,
+          prompt: "test prompt",
+          model: "claude-sonnet-4-6",
+          onLog,
+          onMeta,
+        });
+        expect(tier1.calls).toBe(1);
+        expect(result.tierUsed).toBe("tier_1_anthropic_sdk");
+        expect(result.tierTransitions).toHaveLength(1);
+        expect(result.tierTransitions?.[0]?.from).toBe("tier_0_claude_cli");
+        expect(result.tierTransitions?.[0]?.to).toBe("tier_1_anthropic_sdk");
+        expect(result.classifierVersion).toBe("1.0.0");
+        expect(result.exitCode).toBe(0);
+        expect(result.biller).toBe("anthropic");
+        expect(result.billingType).toBe("api_key");
+        // grep-friendly stdout log line is emitted
+        const stdoutCalls = onLog.mock.calls.filter((c) => c[0] === "stdout");
+        expect(stdoutCalls.length).toBeGreaterThanOrEqual(1);
+        expect(String(stdoutCalls[0]?.[1] ?? "")).toContain("[paperclip] Tier 0");
+        // meta event with failoverEvent
+        expect(onMeta).toHaveBeenCalled();
+        const metaArg = onMeta.mock.calls[0]?.[0] as AdapterInvocationMeta | undefined;
+        expect(metaArg?.failoverEvent).toBeTruthy();
+        expect(metaArg?.failoverEvent?.from).toBe("tier_0_claude_cli");
+        expect(metaArg?.failoverEvent?.to).toBe("tier_1_anthropic_sdk");
+      });
+    }
+  });
+
+  describe("does NOT fire Tier 1 on non-recoverable Tier 0 outcomes", () => {
+    const nonRecoverableFixtures = [
+      "02-quota-exhausted",
+      "04-token-refresh-revoked",
+      "13-auth-required",
+      "14-unknown-session",
+      "15-max-turns",
+      "16-timeout",
+      "17-user-sigint",
+      "18-http-400",
+      "19-success",
+    ];
+
+    for (const fixtureName of nonRecoverableFixtures) {
+      it(`fixture ${fixtureName} stays on Tier 0`, async () => {
+        const tier1 = makeStubTier1({ ok: true });
+        const onLog = vi.fn(async (_stream: "stdout" | "stderr", _chunk: string) => {});
+        const onMeta = vi.fn(async (_meta: AdapterInvocationMeta) => {});
+        const result = await executeClaudeLocalWithFailover({
+          tier0: makeStubTier0(fixtureName),
+          tier1: tier1.runner,
+          prompt: "test prompt",
+          model: "claude-sonnet-4-6",
+          onLog,
+          onMeta,
+        });
+        expect(tier1.calls).toBe(0);
+        expect(result.tierUsed).toBe("tier_0_claude_cli");
+        expect(result.tierTransitions).toEqual([]);
+        expect(result.classifierVersion).toBe("1.0.0");
+        // no failover log line
+        const stdoutCalls = onLog.mock.calls.filter((c) => c[0] === "stdout");
+        for (const c of stdoutCalls) {
+          expect(String(c[1] ?? "")).not.toContain("Failing over to Tier 1");
+        }
+        // no failoverEvent on meta
+        for (const c of onMeta.mock.calls) {
+          const meta = c[0] as AdapterInvocationMeta | undefined;
+          expect(meta?.failoverEvent).toBeFalsy();
+        }
+      });
+    }
+  });
+
+  describe("loop prevention", () => {
+    it("Tier 1's own failure is the final answer — never re-classified, never retried", async () => {
+      const tier1 = makeStubTier1({ ok: false });
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta: noopMeta,
+      });
+      expect(tier1.calls).toBe(1);
+      expect(result.tierUsed).toBe("tier_1_anthropic_sdk");
+      expect(result.tierTransitions).toHaveLength(1);
+      expect(result.exitCode).toBe(1);
+      expect(result.biller).toBe("anthropic");
+      expect(result.billingType).toBe("api_key");
+    });
+
+    it("with no Tier 1 runner configured, recoverable Tier 0 failure surfaces as Tier 0", async () => {
+      const onLog = vi.fn(async () => {});
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: null,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog,
+      });
+      expect(result.tierUsed).toBe("tier_0_claude_cli");
+      expect(result.tierTransitions).toEqual([]);
+      expect(result.classifierVersion).toBe("1.0.0");
+    });
+  });
+
+  describe("Tier 0 success path", () => {
+    it("does not call Tier 1 on a clean Tier 0 result", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("19-success"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta: noopMeta,
+      });
+      expect(tier1.calls).toBe(0);
+      expect(result.tierUsed).toBe("tier_0_claude_cli");
+      expect(result.tierTransitions).toEqual([]);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  // ─── ROCAA-23 cost-cap gate ──────────────────────────────────────────────
+  describe("ROCAA-23 cost-cap gate", () => {
+    it("blocks Tier 1 when gate returns daily_cap_tripped — surfaces Tier 0 result, no transitions", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const onLog = vi.fn(async (_stream: "stdout" | "stderr", _chunk: string) => {});
+      const onMeta = vi.fn(async (_meta: AdapterInvocationMeta) => {});
+      const tier1Gate = vi.fn(async () => ({
+        allowed: false as const,
+        reason: "daily_cap_tripped" as const,
+        detail: "Tier 1 daily cap tripped at 2026-05-24T08:00:00Z: $52.31 today (cap $50.00). Resets at 2026-05-25T00:00:00Z.",
+        resetAt: "2026-05-25T00:00:00Z",
+      }));
+      const onTier1Cost = vi.fn(async () => {});
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog,
+        onMeta,
+        issueId: "issue-abc",
+        tier1Gate,
+        onTier1Cost,
+      });
+      // Gate consulted once with the issue id.
+      expect(tier1Gate).toHaveBeenCalledTimes(1);
+      const gateCall = tier1Gate.mock.calls[0];
+      expect(gateCall?.[0]).toEqual({ issueId: "issue-abc" });
+      // Tier 1 NOT called.
+      expect(tier1.calls).toBe(0);
+      // onTier1Cost NOT called either (no Tier 1 spend to record).
+      expect(onTier1Cost).not.toHaveBeenCalled();
+      // Result surfaces Tier 0 with no transition.
+      expect(result.tierUsed).toBe("tier_0_claude_cli");
+      expect(result.tierTransitions).toEqual([]);
+      expect(result.classifierVersion).toBe("1.0.0");
+      // Log line names the block.
+      const stdout = onLog.mock.calls.filter((c) => c[0] === "stdout").map((c) => String(c[1] ?? ""));
+      expect(stdout.some((s) => s.includes("Tier 1 blocked by cost cap") && s.includes("daily_cap_tripped"))).toBe(true);
+      // Meta event carries the cost-cap block + a self-loop failoverEvent.
+      const meta = onMeta.mock.calls[0]?.[0];
+      expect(meta?.failoverEvent?.from).toBe("tier_0_claude_cli");
+      expect(meta?.failoverEvent?.to).toBe("tier_0_claude_cli");
+      expect(meta?.costCapBlock?.reason).toBe("daily_cap_tripped");
+      expect(meta?.costCapBlock?.issueId).toBe("issue-abc");
+      expect(meta?.costCapBlock?.resetAt).toBe("2026-05-25T00:00:00Z");
+    });
+
+    it("blocks Tier 1 when gate returns per_issue_cap_tripped — resetAt is null", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const onMeta = vi.fn(async (_meta: AdapterInvocationMeta) => {});
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta,
+        issueId: "issue-abc",
+        tier1Gate: async () => ({
+          allowed: false,
+          reason: "per_issue_cap_tripped",
+          detail: "issue-abc cumulative $5.20 (cap $5.00)",
+        }),
+      });
+      expect(tier1.calls).toBe(0);
+      expect(result.tierUsed).toBe("tier_0_claude_cli");
+      const meta = onMeta.mock.calls[0]?.[0];
+      expect(meta?.costCapBlock?.reason).toBe("per_issue_cap_tripped");
+      expect(meta?.costCapBlock?.resetAt).toBeNull();
+      expect(meta?.costCapBlock?.issueId).toBe("issue-abc");
+    });
+
+    it("allows Tier 1 and invokes onTier1Cost with the SDK costUsd when gate allows", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const tier1Gate = vi.fn(async () => ({ allowed: true as const }));
+      const onTier1Cost = vi.fn(async (_args: { issueId: string | null; costUsd: number }) => {});
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta: noopMeta,
+        issueId: "issue-xyz",
+        tier1Gate,
+        onTier1Cost,
+      });
+      expect(tier1Gate).toHaveBeenCalledTimes(1);
+      expect(tier1.calls).toBe(1);
+      expect(result.tierUsed).toBe("tier_1_anthropic_sdk");
+      expect(onTier1Cost).toHaveBeenCalledTimes(1);
+      expect(onTier1Cost.mock.calls[0][0]).toEqual({ issueId: "issue-xyz", costUsd: 0 });
+    });
+
+    it("treats gate exceptions as 'allowed' (cost-tracking outage must not wedge dispatch)", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const tier1Gate = vi.fn(async () => {
+        throw new Error("cache dir unreadable");
+      });
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta: noopMeta,
+        issueId: "issue-xyz",
+        tier1Gate,
+      });
+      expect(tier1Gate).toHaveBeenCalledTimes(1);
+      expect(tier1.calls).toBe(1);
+      expect(result.tierUsed).toBe("tier_1_anthropic_sdk");
+    });
+
+    it("swallows onTier1Cost exceptions — Tier 1 result still returned cleanly", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const onTier1Cost = vi.fn(async () => {
+        throw new Error("disk full");
+      });
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("01-rate-limit-429"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta: noopMeta,
+        issueId: "issue-xyz",
+        tier1Gate: async () => ({ allowed: true }),
+        onTier1Cost,
+      });
+      expect(onTier1Cost).toHaveBeenCalledTimes(1);
+      expect(result.tierUsed).toBe("tier_1_anthropic_sdk");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("does not call the gate on non-recoverable Tier 0 (gate only applies when Tier 1 would otherwise fire)", async () => {
+      const tier1 = makeStubTier1({ ok: true });
+      const tier1Gate = vi.fn(async () => ({ allowed: false as const, reason: "daily_cap_tripped" as const, detail: "x" }));
+      const result = await executeClaudeLocalWithFailover({
+        tier0: makeStubTier0("19-success"),
+        tier1: tier1.runner,
+        prompt: "test prompt",
+        model: "claude-sonnet-4-6",
+        onLog: noopLog,
+        onMeta: noopMeta,
+        issueId: "issue-xyz",
+        tier1Gate,
+      });
+      expect(tier1Gate).not.toHaveBeenCalled();
+      expect(tier1.calls).toBe(0);
+      expect(result.tierUsed).toBe("tier_0_claude_cli");
+    });
+  });
+});

--- a/packages/adapters/claude-local/src/server/failover.ts
+++ b/packages/adapters/claude-local/src/server/failover.ts
@@ -1,0 +1,382 @@
+// Tier 0 (claude CLI) → Tier 1 (Anthropic SDK) → Tier 3 (RunPod/Qwen via OpenAI compat)
+// failover orchestration for the claude_local adapter.
+// See ROC-107 (Tier 3 RunPod A6000 + Qwen2.5-Coder-32B wiring).
+//
+// The orchestrator is split out from execute.ts so the acceptance harness
+// (and any future caller) can compose its own Tier 0 / Tier 1 / Tier 3 stubs without
+// dragging the whole adapter runtime setup in.
+
+import type {
+  AdapterExecutionResult,
+  AdapterFailoverEvent,
+  AdapterInvocationMeta,
+  AdapterTierTransition,
+  AdapterTierTransitionReason,
+  AdapterTierUsed,
+  UsageSummary,
+} from "@paperclipai/adapter-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import {
+  CLASSIFIER_VERSION,
+  isRecoverable,
+  type RecoverabilityReason,
+} from "./classifier.js";
+
+/** Re-export the shared tier identifier so callers in this package don't need two imports. */
+export type Tier = AdapterTierUsed;
+
+/**
+ * Shape required by the orchestrator and the production builder. Matches what
+ * `parseClaudeStreamJson` returns so the production `toAdapterResult` builder
+ * (which already accepts this exact type) works unchanged. Fields are kept
+ * nullable to accommodate the acceptance harness's lightweight stub.
+ */
+export interface Tier0RawOutcome {
+  proc: RunProcessResult;
+  parsedStream: {
+    sessionId: string | null;
+    usage: UsageSummary | null;
+    model: string | null;
+    summary: string | null;
+    costUsd: number | null;
+    resultJson: Record<string, unknown> | null;
+  };
+  parsed: Record<string, unknown> | null;
+}
+
+export interface Tier0Runner {
+  runTier0(args: { resumeSessionId: string | null }): Promise<Tier0RawOutcome>;
+}
+
+export interface Tier1Result {
+  exitCode: 0 | 1;
+  biller: "anthropic";
+  billingType: "api_key";
+  model: string;
+  summary: string;
+  parsed: Record<string, unknown>;
+  usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number };
+  costUsd: number;
+}
+
+export interface Tier1Runner {
+  /**
+   * Invoked at most once per execute(), only when the classifier returns
+   * `recoverable: true`. Pure function of (prompt, options); Tier 1 must not
+   * call back into Tier 0 or re-classify its own result.
+   */
+  runTier1(args: {
+    prompt: string;
+    model: string;
+    transitionReason: AdapterTierTransitionReason;
+    classifierMatch: string | null;
+  }): Promise<Tier1Result>;
+}
+
+export interface FailoverInputs {
+  tier0: Tier0Runner;
+  tier1: Tier1Runner | null;
+  prompt: string;
+  model: string;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  /**
+   * Receives the original AdapterInvocationMeta shape. On transitions the
+   * orchestrator emits a `failoverEvent` field on the meta payload (see the
+   * shared `AdapterInvocationMeta.failoverEvent` type). Optional because
+   * non-production callers may skip it.
+   */
+  onMeta?: (meta: AdapterInvocationMeta) => Promise<void>;
+  resumeSessionId?: string | null;
+  /**
+   * Production caller passes the existing `toAdapterResult(...)` so the Tier 0
+   * success path is byte-identical to today (no perf regression on the happy
+   * path, no behavior change to error messaging when no Tier 1 is configured).
+   * The test harness omits it and gets a minimal default result built from
+   * the raw outcome.
+   */
+  buildTier0Result?: (raw: Tier0RawOutcome) => AdapterExecutionResult;
+  /**
+   * Issue id this dispatch is scoped to, when known. Threaded through to the
+   * Tier 1 cost-cap gate so per-issue caps can apply (ROCAA-23). May be null
+   * when the adapter is invoked outside an issue-scoped context — in that
+   * case only the global daily cap applies.
+   */
+  issueId?: string | null;
+  /**
+   * ROCAA-23 gate. When supplied, called *after* the classifier verdict says
+   * recoverable but *before* the Tier 1 SDK call fires. If the gate returns
+   * `allowed: false`, the orchestrator does NOT call Tier 1; it surfaces the
+   * Tier 0 result with no transition, logs the block reason, and emits a
+   * `failoverEvent` whose `to` stays at `"tier_0_claude_cli"` so the meta
+   * consumer can still record the cap-block as an observable event.
+   *
+   * Omitting this prop preserves pre-ROCAA-23 behavior byte-for-byte.
+   */
+  tier1Gate?: (args: { issueId: string | null }) => Promise<FailoverTier1GateVerdict>;
+  /**
+   * ROCAA-23 cost recorder. When supplied, called after Tier 1 returns
+   * (success or failure) so the per-issue accumulator can advance and trip
+   * the per-issue cap on the next attempt. Best-effort; failures here are
+   * intentionally swallowed by the implementing callback so cost-tracking
+   * outages never wedge dispatch.
+   */
+  onTier1Cost?: (args: { issueId: string | null; costUsd: number }) => Promise<void>;
+}
+
+/**
+ * Cost-cap verdict surface used by `tier1Gate` (ROCAA-23). Mirrors the
+ * `Tier1GateVerdict` shape from `./tier1-cost-cap.ts` but is duplicated here
+ * to keep the failover orchestrator free of import-side coupling to the
+ * cost-cap module — production wiring composes the two; the acceptance
+ * harness composes neither.
+ */
+export type FailoverTier1GateVerdict =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: "daily_cap_tripped" | "per_issue_cap_tripped";
+      detail: string;
+      resetAt?: string;
+    };
+
+/**
+ * Recoverable-reasons subset that fires Tier 1. This is exactly the union
+ * `AdapterTierTransitionReason` from the shared types — kept as a runtime Set
+ * so we can narrow `RecoverabilityReason` at the boundary.
+ */
+const REASONS_THAT_FIRE_FAILOVER: ReadonlySet<RecoverabilityReason> = new Set<RecoverabilityReason>([
+  "rate_limit",
+  "token_refresh_transient",
+  "network_econnreset",
+  "network_etimedout",
+  "network_fetch_failed",
+  "anthropic_5xx",
+  "claude_cli_panic",
+  "malformed_stream_json",
+]);
+
+function asTransitionReason(reason: RecoverabilityReason): AdapterTierTransitionReason {
+  // Caller guards with REASONS_THAT_FIRE_FAILOVER, so this narrowing is safe.
+  return reason as AdapterTierTransitionReason;
+}
+
+/**
+ * Run Tier 0; on a recoverable failure, run Tier 1. Returns the final result
+ * with `tierUsed`, `tierTransitions[]`, and `classifierVersion` populated.
+ *
+ * Invariants:
+ *  - Tier 0 runs at most once per call.
+ *  - Tier 1 runs at most once per call, and only when the classifier says
+ *    recoverable AND a Tier 1 runner is supplied. The classifier is never
+ *    called on Tier 1's own outcome.
+ *  - On Tier 0 success or non-recoverable Tier 0 failure with no Tier 1
+ *    configured, the returned result is byte-identical to the pre-failover
+ *    behavior (we only attach the three tier-metadata fields).
+ */
+export async function executeClaudeLocalWithFailover(
+  inputs: FailoverInputs,
+): Promise<AdapterExecutionResult> {
+  const { tier0, tier1, prompt, model, onLog, onMeta } = inputs;
+  const issueId = inputs.issueId ?? null;
+  const raw = await tier0.runTier0({ resumeSessionId: inputs.resumeSessionId ?? null });
+
+  const tier0Result = inputs.buildTier0Result
+    ? inputs.buildTier0Result(raw)
+    : buildDefaultTier0Result(raw, model);
+
+  const verdict = isRecoverable({
+    exitCode: raw.proc.exitCode,
+    stderr: raw.proc.stderr,
+    stdout: raw.proc.stdout,
+    parsed: raw.parsed,
+    timedOut: raw.proc.timedOut,
+  });
+
+  const shouldFailover =
+    verdict.recoverable && tier1 != null && REASONS_THAT_FIRE_FAILOVER.has(verdict.reason);
+
+  if (!shouldFailover) {
+    return {
+      ...tier0Result,
+      tierUsed: "tier_0_claude_cli",
+      tierTransitions: [],
+      classifierVersion: CLASSIFIER_VERSION,
+    };
+  }
+
+  // ROCAA-23: Tier 1 cost-cap gate. Runs *after* the classifier says
+  // recoverable but *before* the SDK fires. If the gate refuses, surface the
+  // Tier 0 result with no transition and log the block reason so operators
+  // see why the failover did not happen.
+  if (inputs.tier1Gate) {
+    let gateVerdict: FailoverTier1GateVerdict;
+    try {
+      gateVerdict = await inputs.tier1Gate({ issueId });
+    } catch {
+      // Gate failures must not block dispatch — treat as "allowed" and let
+      // Tier 1 try. The monitor (ROCAA-39) is the authoritative cap source
+      // anyway; the adapter side is best-effort enforcement.
+      gateVerdict = { allowed: true };
+    }
+    if (!gateVerdict.allowed) {
+      const blockedAt = new Date().toISOString();
+      const blockDetail = truncate(gateVerdict.detail, 240);
+      await onLog(
+        "stdout",
+        `[paperclip] Tier 1 blocked by cost cap: reason=${gateVerdict.reason} detail="${blockDetail}". Surfacing Tier 0 failure (reason=${verdict.reason}) without failover.\n`,
+      );
+      if (onMeta) {
+        // Emit a failoverEvent whose `to` stays at Tier 0 so consumers can
+        // distinguish "cap-blocked attempt" from "no failover needed". The
+        // `reason` field reuses the existing classifier reason so the schema
+        // doesn't need a new union member for cap-block; the discriminator is
+        // the `to === from` invariant + the `costCapBlock` payload below.
+        const failoverEvent: AdapterFailoverEvent = {
+          at: blockedAt,
+          from: "tier_0_claude_cli",
+          to: "tier_0_claude_cli",
+          reason: asTransitionReason(verdict.reason),
+          classifierMatch: verdict.match,
+          billerKeyName: "ANTHROPIC_API_KEY_BLUEPRINT_WORKER",
+        };
+        await onMeta({
+          adapterType: "claude_local",
+          command: "",
+          failoverEvent,
+          costCapBlock: {
+            reason: gateVerdict.reason,
+            detail: gateVerdict.detail,
+            resetAt: gateVerdict.resetAt ?? null,
+            issueId,
+          },
+        });
+      }
+      return {
+        ...tier0Result,
+        tierUsed: "tier_0_claude_cli",
+        tierTransitions: [],
+        classifierVersion: CLASSIFIER_VERSION,
+      };
+    }
+  }
+
+  // Failover path. Build the transition record FIRST so we can echo it to
+  // onLog/onMeta and pin its `at` timestamp before Tier 1 runs.
+  const transitionReason = asTransitionReason(verdict.reason);
+  const transition: AdapterTierTransition = {
+    at: new Date().toISOString(),
+    from: "tier_0_claude_cli",
+    to: "tier_1_anthropic_sdk",
+    reason: transitionReason,
+    classifierMatch: verdict.match,
+    detail: verdict.detail,
+    fromExitCode: raw.proc.exitCode,
+    fromParsed: raw.parsed != null,
+  };
+
+  const matchForLog = truncate(verdict.match ?? "", 120);
+  await onLog(
+    "stdout",
+    `[paperclip] Tier 0 (claude CLI) failed: reason=${verdict.reason} match="${matchForLog}". Failing over to Tier 1 (Anthropic SDK, billed to ANTHROPIC_API_KEY_BLUEPRINT_WORKER).\n`,
+  );
+  if (onMeta) {
+    const failoverEvent: AdapterFailoverEvent = {
+      at: transition.at,
+      from: transition.from,
+      to: transition.to,
+      reason: transitionReason,
+      classifierMatch: transition.classifierMatch,
+      billerKeyName: "ANTHROPIC_API_KEY_BLUEPRINT_WORKER",
+    };
+    await onMeta({
+      adapterType: "claude_local",
+      command: "",
+      failoverEvent,
+    });
+  }
+
+  // Tier 1 runs exactly once. Whatever it returns — success or failure — is
+  // the final answer. We deliberately do NOT classify Tier 1's outcome:
+  //   - tierTransitions[].length stays bounded at 1 in v1
+  //   - the Anthropic SDK has its own internal retry; we do not stack ours on top
+  const t1 = await tier1!.runTier1({
+    prompt,
+    model,
+    transitionReason,
+    classifierMatch: verdict.match,
+  });
+
+  // ROCAA-23: feed the per-issue accumulator. Best-effort — the implementing
+  // callback is expected to swallow its own errors so cost-tracking outages
+  // never stop dispatch. We pass the SDK's reported `costUsd` even when 0
+  // (Tier 1 error path returns 0); the recorder filters non-positive samples.
+  if (inputs.onTier1Cost) {
+    try {
+      await inputs.onTier1Cost({ issueId, costUsd: t1.costUsd });
+    } catch {
+      /* swallowed — cost recording must never wedge dispatch */
+    }
+  }
+
+  const tier1Result: AdapterExecutionResult = {
+    exitCode: t1.exitCode,
+    signal: null,
+    timedOut: false,
+    errorMessage:
+      t1.exitCode === 0
+        ? null
+        : extractTier1ErrorMessage(t1.parsed) ?? `Tier 1 (Anthropic SDK) exited with code ${t1.exitCode}`,
+    usage: t1.usage,
+    provider: "anthropic",
+    biller: t1.biller,
+    billingType: t1.billingType,
+    model: t1.model,
+    costUsd: t1.costUsd,
+    resultJson: t1.parsed,
+    summary: t1.summary,
+  };
+
+  return {
+    ...tier1Result,
+    tierUsed: "tier_1_anthropic_sdk",
+    tierTransitions: [transition],
+    classifierVersion: CLASSIFIER_VERSION,
+  };
+}
+
+function buildDefaultTier0Result(raw: Tier0RawOutcome, fallbackModel: string): AdapterExecutionResult {
+  // Minimal result shape used by the acceptance harness and any caller that
+  // does not pass `buildTier0Result`. Production execute() always passes its
+  // own builder, so this default is intentionally light: it covers the fields
+  // the tests assert on (exitCode, biller, billingType, model, usage, summary,
+  // resultJson) and leaves session/auth concerns to the production builder.
+  return {
+    exitCode: raw.proc.exitCode,
+    signal: raw.proc.signal as string | null,
+    timedOut: raw.proc.timedOut,
+    usage: raw.parsedStream.usage ?? undefined,
+    provider: "anthropic",
+    biller: "anthropic",
+    billingType: "subscription",
+    model: raw.parsedStream.model || fallbackModel,
+    costUsd: raw.parsedStream.costUsd ?? null,
+    summary: raw.parsedStream.summary ?? null,
+    resultJson: raw.parsed ?? undefined,
+  };
+}
+
+function extractTier1ErrorMessage(parsed: Record<string, unknown>): string | null {
+  const message = parsed?.message;
+  if (typeof message === "string" && message.trim().length > 0) return message.trim();
+  const error = parsed?.error;
+  if (error && typeof error === "object") {
+    const m = (error as Record<string, unknown>).message;
+    if (typeof m === "string" && m.trim().length > 0) return m.trim();
+  }
+  return null;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -1,7 +1,7 @@
 import type { UsageSummary } from "@paperclipai/adapter-utils";
 import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
 
-const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
+const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required|out-of-extra-usage|error_code=claude_auth_required|claude_auth_required)/i;
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 export function parseClaudeStreamJson(stdout: string) {
@@ -131,7 +131,7 @@ export function detectClaudeLoginRequired(input: {
     .map((line) => line.trim())
     .filter(Boolean);
 
-  const requiresLogin = messages.some((line) => CLAUDE_AUTH_REQUIRED_RE.test(line));
+  console.log("MESSAGES", messages); const requiresLogin = messages.some((line) => CLAUDE_AUTH_REQUIRED_RE.test(line));
   return {
     requiresLogin,
     loginUrl: extractClaudeLoginUrl([input.stdout, input.stderr].join("\n")),

--- a/packages/adapters/claude-local/src/server/secret-fetch.test.ts
+++ b/packages/adapters/claude-local/src/server/secret-fetch.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BLUEPRINT_WORKER_ENV_OVERRIDE,
+  BLUEPRINT_WORKER_SECRET_NAME,
+  fetchBlueprintWorkerKey,
+  SecretFetchError,
+  __resetSecretCacheForTests,
+  type SecretManagerLike,
+} from "./secret-fetch.js";
+
+function makeStubClient(payload: string | Uint8Array | null): SecretManagerLike & { calls: number } {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    accessSecretVersion: async () => {
+      calls += 1;
+      return [{ payload: { data: payload } }];
+    },
+  };
+}
+
+const VALID_KEY = "sk-ant-test-abcdefghij0123456789";
+
+beforeEach(() => {
+  __resetSecretCacheForTests();
+});
+
+describe("fetchBlueprintWorkerKey", () => {
+  it("returns the env-var override without contacting Secret Manager", async () => {
+    const stub = makeStubClient(VALID_KEY);
+    const secret = await fetchBlueprintWorkerKey({
+      envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY },
+      secretManagerClientFactory: async () => stub,
+    });
+    expect(secret.value).toBe(VALID_KEY);
+    expect(secret.source).toBe("env_var");
+    expect(secret.name).toBe(BLUEPRINT_WORKER_SECRET_NAME);
+    expect(stub.calls).toBe(0);
+  });
+
+  it("rejects an env-var override that does not look like an Anthropic key", async () => {
+    await expect(
+      fetchBlueprintWorkerKey({
+        envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: "not-a-key" },
+        secretManagerClientFactory: async () => makeStubClient(VALID_KEY),
+      }),
+    ).rejects.toMatchObject({
+      name: "SecretFetchError",
+      code: "malformed_key",
+    });
+  });
+
+  it("fetches once and caches subsequent calls within the TTL", async () => {
+    const stub = makeStubClient(VALID_KEY);
+    const opts = {
+      projectId: "proj-test",
+      ttlMs: 60_000,
+      secretManagerClientFactory: async () => stub,
+      envOverride: {} as NodeJS.ProcessEnv,
+    };
+    const a = await fetchBlueprintWorkerKey(opts);
+    const b = await fetchBlueprintWorkerKey(opts);
+    expect(a.value).toBe(VALID_KEY);
+    expect(b.value).toBe(VALID_KEY);
+    expect(a.source).toBe("gcp_secret_manager");
+    expect(stub.calls).toBe(1);
+  });
+
+  it("refetches after the TTL expires", async () => {
+    const stub = makeStubClient(VALID_KEY);
+    const opts = {
+      projectId: "proj-test",
+      ttlMs: 1,
+      secretManagerClientFactory: async () => stub,
+      envOverride: {} as NodeJS.ProcessEnv,
+    };
+    await fetchBlueprintWorkerKey(opts);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await fetchBlueprintWorkerKey(opts);
+    expect(stub.calls).toBe(2);
+  });
+
+  it("fails closed with missing_project when no projectId is resolvable", async () => {
+    await expect(
+      fetchBlueprintWorkerKey({
+        envOverride: {} as NodeJS.ProcessEnv,
+        secretManagerClientFactory: async () => makeStubClient(VALID_KEY),
+      }),
+    ).rejects.toMatchObject({
+      name: "SecretFetchError",
+      code: "missing_project",
+    });
+  });
+
+  it("wraps Secret Manager API errors with secret_manager_failure", async () => {
+    const exploding: SecretManagerLike = {
+      accessSecretVersion: async () => {
+        throw new Error("PERMISSION_DENIED: no IAM");
+      },
+    };
+    await expect(
+      fetchBlueprintWorkerKey({
+        projectId: "proj-test",
+        secretManagerClientFactory: async () => exploding,
+        envOverride: {} as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toMatchObject({
+      name: "SecretFetchError",
+      code: "secret_manager_failure",
+    });
+  });
+
+  it("rejects an empty Secret Manager payload", async () => {
+    const stub = makeStubClient(null);
+    await expect(
+      fetchBlueprintWorkerKey({
+        projectId: "proj-test",
+        secretManagerClientFactory: async () => stub,
+        envOverride: {} as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toMatchObject({
+      name: "SecretFetchError",
+      code: "empty_payload",
+    });
+  });
+
+  it("rejects a Secret Manager payload that is not an Anthropic key without leaking the payload", async () => {
+    const stub = makeStubClient("<!DOCTYPE html><html>403 Forbidden</html>");
+    try {
+      await fetchBlueprintWorkerKey({
+        projectId: "proj-test",
+        secretManagerClientFactory: async () => stub,
+        envOverride: {} as NodeJS.ProcessEnv,
+      });
+      expect.fail("expected SecretFetchError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SecretFetchError);
+      expect((err as SecretFetchError).code).toBe("malformed_key");
+      expect((err as Error).message).not.toContain("DOCTYPE");
+      expect((err as Error).message).not.toContain("Forbidden");
+      expect((err as Error).message).toMatch(/length=\d+/);
+    }
+  });
+
+  it("accepts a Uint8Array payload (Secret Manager binary path)", async () => {
+    const stub = makeStubClient(Buffer.from(VALID_KEY, "utf8"));
+    const secret = await fetchBlueprintWorkerKey({
+      projectId: "proj-test",
+      secretManagerClientFactory: async () => stub,
+      envOverride: {} as NodeJS.ProcessEnv,
+    });
+    expect(secret.value).toBe(VALID_KEY);
+    expect(secret.source).toBe("gcp_secret_manager");
+  });
+
+  it("surfaces missing_sdk when the dynamic import path is exercised without the SDK installed", async () => {
+    // No factory provided -> falls through to dynamic import of @google-cloud/secret-manager.
+    // The SDK is not in this package's deps, so the import must fail with missing_sdk.
+    await expect(
+      fetchBlueprintWorkerKey({
+        projectId: "proj-test",
+        envOverride: {} as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toMatchObject({
+      name: "SecretFetchError",
+      code: "missing_sdk",
+    });
+  });
+});

--- a/packages/adapters/claude-local/src/server/secret-fetch.ts
+++ b/packages/adapters/claude-local/src/server/secret-fetch.ts
@@ -1,0 +1,252 @@
+/**
+ * Fetches the Tier 1 Anthropic API key (`ANTHROPIC_API_KEY_BLUEPRINT_WORKER`) for
+ * the claude_local Tier 0 → Tier 1 failover path. See ROCAA-29.
+ *
+ * Security & performance contract (audited surface):
+ *
+ *   1. The secret is **cached in-process** with a TTL. We never refetch per request —
+ *      that would burn GCP Secret Manager quota and add per-request latency to every
+ *      Tier 1 spawn during a rate-limit storm.
+ *   2. The cached value is **never logged**. Only the secret *name* and the *source*
+ *      (`env_var` | `gcp_secret_manager`) are exposed to callers, never the bytes.
+ *   3. The Anthropic-API-key shape is sanity-checked (`/^sk-/`) before caching so a
+ *      misconfigured Secret Manager payload (HTML error page, IAM policy denial body,
+ *      etc.) fails closed instead of being passed to the SDK as a "key".
+ *   4. Dependencies (`@google-cloud/secret-manager`) are loaded via **dynamic import**
+ *      so the rest of the adapter remains usable on hosts that have not installed the
+ *      GCP SDK (CI, local dev, on-prem). A clear error is surfaced if Tier 1 needs the
+ *      SDK and it is not available.
+ *   5. `PAPERCLIP_ANTHROPIC_BLUEPRINT_WORKER_KEY` env var is honored as an explicit
+ *      override for local development & tests. When present, Secret Manager is not
+ *      contacted at all — operators see this in the meta event (`source: "env_var"`)
+ *      so the audit trail still reflects which credential was actually used.
+ *
+ * Loop-prevention is **not** this module's concern; that lives in the wiring layer
+ * (ROCAA-28). This module is a one-shot lookup that returns or throws.
+ */
+
+export const BLUEPRINT_WORKER_SECRET_NAME = "ANTHROPIC_API_KEY_BLUEPRINT_WORKER";
+
+/** Env-var override for local dev / tests. Bypasses Secret Manager entirely when set. */
+export const BLUEPRINT_WORKER_ENV_OVERRIDE = "PAPERCLIP_ANTHROPIC_BLUEPRINT_WORKER_KEY";
+
+/**
+ * Where the secret was sourced from. Surfaced in failover meta events so operators
+ * can tell at a glance whether Tier 1 used the production GCP-managed key or a
+ * locally-overridden value.
+ */
+export type SecretSource = "env_var" | "gcp_secret_manager";
+
+export interface FetchedSecret {
+  /** The secret bytes. Do NOT log this value; the meta layer logs `name` + `source` only. */
+  value: string;
+  /** Stable name (matches `BLUEPRINT_WORKER_SECRET_NAME` in production). */
+  name: string;
+  source: SecretSource;
+  /** Epoch ms when this entry was fetched. */
+  fetchedAt: number;
+}
+
+export interface SecretFetcherOptions {
+  /** GCP project id. Defaults to `GCP_PROJECT` / `GOOGLE_CLOUD_PROJECT` env. */
+  projectId?: string;
+  /** Optional override for the secret resource name (`projects/.../secrets/.../versions/latest`). */
+  resourceName?: string;
+  /** Cache TTL in ms. Default 10 minutes. */
+  ttlMs?: number;
+  /**
+   * Injection seam used by tests: when provided, this function is called instead of
+   * dynamically importing `@google-cloud/secret-manager`. Production code never sets this.
+   */
+  secretManagerClientFactory?: () => Promise<SecretManagerLike>;
+  /** Injection seam for `process.env`; defaults to `process.env`. */
+  envOverride?: NodeJS.ProcessEnv;
+}
+
+/** Minimal subset of `@google-cloud/secret-manager`'s `SecretManagerServiceClient` we depend on. */
+export interface SecretManagerLike {
+  accessSecretVersion(request: { name: string }): Promise<
+    [{ payload?: { data?: string | Uint8Array | null } | null } | null]
+  >;
+}
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+export class SecretFetchError extends Error {
+  readonly code:
+    | "missing_sdk"
+    | "missing_project"
+    | "secret_manager_failure"
+    | "empty_payload"
+    | "malformed_key";
+  readonly cause?: unknown;
+  constructor(
+    code: SecretFetchError["code"],
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message);
+    this.name = "SecretFetchError";
+    this.code = code;
+    this.cause = options?.cause;
+  }
+}
+
+/**
+ * Module-level cache. Keyed by `name|projectId|resourceName` so that overriding the
+ * resource name in a test does not collide with the production cache slot.
+ */
+const cache = new Map<string, { secret: FetchedSecret; expiresAt: number }>();
+
+/** Test-only. Clears the in-process secret cache. */
+export function __resetSecretCacheForTests(): void {
+  cache.clear();
+}
+
+function cacheKey(name: string, projectId: string | null, resourceName: string | null): string {
+  return `${name}|${projectId ?? ""}|${resourceName ?? ""}`;
+}
+
+function looksLikeAnthropicKey(value: string): boolean {
+  // Anthropic keys begin with `sk-` (subscription/account keys begin with `sk-ant-`,
+  // but we accept both since the secret payload is operator-controlled and may rotate).
+  return /^sk-[A-Za-z0-9_-]{8,}$/.test(value.trim());
+}
+
+async function loadDefaultSecretManagerClient(): Promise<SecretManagerLike> {
+  try {
+    // Dynamic import so consumers without the GCP SDK installed don't pay the cost.
+    // The `@ts-ignore` is intentional: the package is an optional runtime dep, not
+    // present in this package's dependency tree, and is loaded only when Tier 1
+    // actually fires in production.
+    // @ts-ignore — optional runtime dependency; resolved at runtime in production hosts.
+    const mod = (await import("@google-cloud/secret-manager")) as unknown as {
+      SecretManagerServiceClient: new () => SecretManagerLike;
+    };
+    return new mod.SecretManagerServiceClient();
+  } catch (err) {
+    throw new SecretFetchError(
+      "missing_sdk",
+      "Tier 1 failover requires @google-cloud/secret-manager. Install it in the host environment " +
+        "(`pnpm add -F @paperclipai/adapter-claude-local @google-cloud/secret-manager`) or set " +
+        `${BLUEPRINT_WORKER_ENV_OVERRIDE} to provide the API key directly.`,
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Returns the cached Anthropic Tier 1 API key, fetching it from GCP Secret Manager on
+ * first call (or when the cache entry has expired). Throws `SecretFetchError` with a
+ * stable `code` field on any failure so callers can shape user-facing messaging.
+ */
+export async function fetchBlueprintWorkerKey(
+  options: SecretFetcherOptions = {},
+): Promise<FetchedSecret> {
+  const env = options.envOverride ?? process.env;
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const now = Date.now();
+
+  // 1. Honor the env-var override first (local dev / tests / break-glass).
+  const overrideRaw = env[BLUEPRINT_WORKER_ENV_OVERRIDE];
+  if (typeof overrideRaw === "string" && overrideRaw.trim().length > 0) {
+    const trimmed = overrideRaw.trim();
+    if (!looksLikeAnthropicKey(trimmed)) {
+      throw new SecretFetchError(
+        "malformed_key",
+        `${BLUEPRINT_WORKER_ENV_OVERRIDE} is set but does not look like an Anthropic API key (expected /^sk-/).`,
+      );
+    }
+    const key = cacheKey(BLUEPRINT_WORKER_SECRET_NAME, null, "env_var");
+    const existing = cache.get(key);
+    if (existing && existing.expiresAt > now) {
+      return existing.secret;
+    }
+    const secret: FetchedSecret = {
+      value: trimmed,
+      name: BLUEPRINT_WORKER_SECRET_NAME,
+      source: "env_var",
+      fetchedAt: now,
+    };
+    cache.set(key, { secret, expiresAt: now + ttlMs });
+    return secret;
+  }
+
+  // 2. Resolve project + resource name.
+  const projectId =
+    options.projectId ?? env.GCP_PROJECT ?? env.GOOGLE_CLOUD_PROJECT ?? null;
+  const resourceName =
+    options.resourceName ??
+    (projectId
+      ? `projects/${projectId}/secrets/${BLUEPRINT_WORKER_SECRET_NAME}/versions/latest`
+      : null);
+
+  if (!resourceName) {
+    throw new SecretFetchError(
+      "missing_project",
+      `Cannot fetch ${BLUEPRINT_WORKER_SECRET_NAME}: no GCP project id available. Set GCP_PROJECT or pass projectId, ` +
+        `or set ${BLUEPRINT_WORKER_ENV_OVERRIDE} to provide the key directly.`,
+    );
+  }
+
+  // 3. Return cached value when fresh.
+  const key = cacheKey(BLUEPRINT_WORKER_SECRET_NAME, projectId, resourceName);
+  const existing = cache.get(key);
+  if (existing && existing.expiresAt > now) {
+    return existing.secret;
+  }
+
+  // 4. Fetch from Secret Manager.
+  const factory =
+    options.secretManagerClientFactory ?? loadDefaultSecretManagerClient;
+  let client: SecretManagerLike;
+  try {
+    client = await factory();
+  } catch (err) {
+    if (err instanceof SecretFetchError) throw err;
+    throw new SecretFetchError(
+      "secret_manager_failure",
+      `Failed to initialize Secret Manager client: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  let response: Awaited<ReturnType<SecretManagerLike["accessSecretVersion"]>>;
+  try {
+    response = await client.accessSecretVersion({ name: resourceName });
+  } catch (err) {
+    throw new SecretFetchError(
+      "secret_manager_failure",
+      `Secret Manager accessSecretVersion(${resourceName}) failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  const data = response?.[0]?.payload?.data;
+  if (data == null) {
+    throw new SecretFetchError(
+      "empty_payload",
+      `Secret Manager returned no payload for ${resourceName}.`,
+    );
+  }
+
+  const decoded = typeof data === "string" ? data : Buffer.from(data).toString("utf8");
+  const trimmed = decoded.trim();
+  if (!looksLikeAnthropicKey(trimmed)) {
+    // Do NOT include the payload in the error message — it may be an HTML error page,
+    // IAM denial body, or a real key fragment. Length is OK to share.
+    throw new SecretFetchError(
+      "malformed_key",
+      `Secret payload for ${resourceName} does not look like an Anthropic API key (length=${trimmed.length}).`,
+    );
+  }
+
+  const secret: FetchedSecret = {
+    value: trimmed,
+    name: BLUEPRINT_WORKER_SECRET_NAME,
+    source: "gcp_secret_manager",
+    fetchedAt: now,
+  };
+  cache.set(key, { secret, expiresAt: now + ttlMs });
+  return secret;
+}

--- a/packages/adapters/claude-local/src/server/tier1-cost-cap.test.ts
+++ b/packages/adapters/claude-local/src/server/tier1-cost-cap.test.ts
@@ -1,0 +1,244 @@
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildTier1Gate,
+  recordTier1Cost,
+  readPerIssueFile,
+  type PageOpsArgs,
+  type Tier1CostCapDeps,
+} from "./tier1-cost-cap.js";
+
+let cacheDir: string;
+const ISSUE = "rocaa-23-test-issue";
+
+beforeEach(() => {
+  cacheDir = mkdtempSync(join(tmpdir(), "tier1-cost-cap-test-"));
+});
+
+afterEach(() => {
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+function deps(overrides: Partial<Tier1CostCapDeps> = {}): Tier1CostCapDeps {
+  return {
+    cacheDir,
+    env: {} as NodeJS.ProcessEnv,
+    ...overrides,
+  };
+}
+
+function writeDisableFile(payload: Record<string, unknown>): void {
+  writeFileSync(join(cacheDir, "tier1_disabled_until_midnight"), JSON.stringify(payload), "utf8");
+}
+
+describe("buildTier1Gate — daily cap", () => {
+  it("allows Tier 1 when no disable file exists", async () => {
+    const gate = buildTier1Gate(deps());
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(true);
+  });
+
+  it("blocks Tier 1 when the disable file's reset_at is in the future", async () => {
+    const now = new Date("2026-05-24T12:00:00Z");
+    writeDisableFile({
+      tripped_at: "2026-05-24T08:00:00+00:00",
+      reset_at: "2026-05-25T00:00:00+00:00",
+      usd_today: 52.31,
+      cap_usd: 50,
+    });
+    const gate = buildTier1Gate(deps({ now: () => now }));
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(false);
+    if (v.allowed) return; // type narrow
+    expect(v.reason).toBe("daily_cap_tripped");
+    expect(v.resetAt).toBe("2026-05-25T00:00:00+00:00");
+    expect(v.detail).toContain("$52.31");
+    expect(v.detail).toContain("$50.00");
+  });
+
+  it("allows Tier 1 again once reset_at has passed", async () => {
+    const now = new Date("2026-05-25T00:00:01Z");
+    writeDisableFile({
+      tripped_at: "2026-05-24T08:00:00+00:00",
+      reset_at: "2026-05-25T00:00:00+00:00",
+      usd_today: 52.31,
+      cap_usd: 50,
+    });
+    const gate = buildTier1Gate(deps({ now: () => now }));
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(true);
+  });
+
+  it("treats corrupt disable file as not-tripped (never blocks on bad JSON)", async () => {
+    writeFileSync(join(cacheDir, "tier1_disabled_until_midnight"), "{not json", "utf8");
+    const gate = buildTier1Gate(deps());
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(true);
+  });
+
+  it("daily cap is checked even without an issueId", async () => {
+    const now = new Date("2026-05-24T12:00:00Z");
+    writeDisableFile({
+      tripped_at: "2026-05-24T08:00:00+00:00",
+      reset_at: "2026-05-25T00:00:00+00:00",
+      usd_today: 60,
+      cap_usd: 50,
+    });
+    const gate = buildTier1Gate(deps({ now: () => now }));
+    const v = await gate({ issueId: null });
+    expect(v.allowed).toBe(false);
+  });
+});
+
+describe("buildTier1Gate — per-issue cap", () => {
+  it("allows Tier 1 with no per-issue history", async () => {
+    const gate = buildTier1Gate(deps({ env: { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv }));
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(true);
+  });
+
+  it("blocks Tier 1 once the per-issue file marks cumulative spend at-or-over cap", async () => {
+    // Simulate prior recordTier1Cost calls totaling $5.10 with $5 cap.
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv;
+    await recordTier1Cost(deps({ env }), { issueId: ISSUE, costUsd: 5.1 });
+    const gate = buildTier1Gate(deps({ env }));
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(false);
+    if (v.allowed) return;
+    expect(v.reason).toBe("per_issue_cap_tripped");
+    expect(v.detail).toContain(ISSUE);
+    expect(v.detail).toContain("$5.10");
+    // Per-issue trip has no resetAt — needs human review.
+    expect(v.resetAt).toBeUndefined();
+  });
+
+  it("respects env-overridden per-issue cap", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "1" } as NodeJS.ProcessEnv;
+    await recordTier1Cost(deps({ env }), { issueId: ISSUE, costUsd: 1.5 });
+    const gate = buildTier1Gate(deps({ env }));
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(false);
+  });
+
+  it("does NOT apply the per-issue cap when issueId is null (still allowed if daily ok)", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv;
+    // Populate someone else's bucket; should not affect the null-issue call.
+    await recordTier1Cost(deps({ env }), { issueId: "other-issue", costUsd: 99 });
+    const gate = buildTier1Gate(deps({ env }));
+    const v = await gate({ issueId: null });
+    expect(v.allowed).toBe(true);
+  });
+
+  it("daily cap wins over per-issue cap when both are tripped", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv;
+    await recordTier1Cost(deps({ env }), { issueId: ISSUE, costUsd: 100 });
+    const now = new Date("2026-05-24T12:00:00Z");
+    writeDisableFile({
+      tripped_at: "2026-05-24T08:00:00+00:00",
+      reset_at: "2026-05-25T00:00:00+00:00",
+      usd_today: 60,
+      cap_usd: 50,
+    });
+    const gate = buildTier1Gate(deps({ env, now: () => now }));
+    const v = await gate({ issueId: ISSUE });
+    expect(v.allowed).toBe(false);
+    if (v.allowed) return;
+    expect(v.reason).toBe("daily_cap_tripped");
+  });
+});
+
+describe("recordTier1Cost", () => {
+  it("creates the per-issue file on first sample with correct shape", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv;
+    const state = await recordTier1Cost(deps({ env }), { issueId: ISSUE, costUsd: 1.23 });
+    expect(state).not.toBeNull();
+    expect(state!.cumulativeUsd).toBeCloseTo(1.23, 6);
+    expect(state!.capUsd).toBe(5);
+    expect(state!.tripped).toBe(false);
+    expect(state!.recentSamples).toHaveLength(1);
+    expect(state!.firstSeenAt).toBe(state!.lastUpdatedAt);
+    // Reload to ensure round-trip.
+    const reloaded = readPerIssueFile(cacheDir, ISSUE);
+    expect(reloaded?.cumulativeUsd).toBeCloseTo(1.23, 6);
+  });
+
+  it("accumulates across calls and retains a bounded sample tail", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv;
+    for (let i = 0; i < 12; i++) {
+      await recordTier1Cost(deps({ env }), { issueId: ISSUE, costUsd: 0.1 });
+    }
+    const state = readPerIssueFile(cacheDir, ISSUE)!;
+    expect(state.cumulativeUsd).toBeCloseTo(1.2, 4);
+    // Capped at 8 retained samples.
+    expect(state.recentSamples.length).toBeLessThanOrEqual(8);
+  });
+
+  it("ignores null issueId and non-positive cost", async () => {
+    expect(await recordTier1Cost(deps(), { issueId: null, costUsd: 1 })).toBeNull();
+    expect(await recordTier1Cost(deps(), { issueId: ISSUE, costUsd: 0 })).toBeNull();
+    expect(await recordTier1Cost(deps(), { issueId: ISSUE, costUsd: -1 })).toBeNull();
+    expect(existsSync(join(cacheDir, "issue_rocaa-23-test-issue.json"))).toBe(false);
+  });
+
+  it("fires pageOps and markIssueNeedsHumanReview exactly once on cap-cross", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "1" } as NodeJS.ProcessEnv;
+    const pageOps = vi.fn(async (_args: PageOpsArgs) => {});
+    const mark = vi.fn(async (_id: string, _args: { reason: string; detail: string }) => {});
+    // Three calls; first two are under cap, third crosses, fourth is already-tripped.
+    await recordTier1Cost(deps({ env, pageOps, markIssueNeedsHumanReview: mark }), { issueId: ISSUE, costUsd: 0.4 });
+    await recordTier1Cost(deps({ env, pageOps, markIssueNeedsHumanReview: mark }), { issueId: ISSUE, costUsd: 0.4 });
+    await recordTier1Cost(deps({ env, pageOps, markIssueNeedsHumanReview: mark }), { issueId: ISSUE, costUsd: 0.3 });
+    await recordTier1Cost(deps({ env, pageOps, markIssueNeedsHumanReview: mark }), { issueId: ISSUE, costUsd: 0.5 });
+    expect(pageOps).toHaveBeenCalledTimes(1);
+    expect(mark).toHaveBeenCalledTimes(1);
+    const pageArgs = pageOps.mock.calls[0][0];
+    expect(pageArgs.severity).toBe("critical");
+    expect(pageArgs.reason).toBe("per_issue_cap_tripped");
+    expect(pageArgs.message).toContain(ISSUE);
+    expect(mark.mock.calls[0][0]).toBe(ISSUE);
+    expect(mark.mock.calls[0][1].reason).toBe("per_issue_cap_tripped");
+  });
+
+  it("does not crash the dispatch path when pageOps throws", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "1" } as NodeJS.ProcessEnv;
+    const pageOps = vi.fn(async (_args: PageOpsArgs) => {
+      throw new Error("slack down");
+    });
+    const mark = vi.fn(async () => {});
+    const state = await recordTier1Cost(
+      deps({ env, pageOps, markIssueNeedsHumanReview: mark }),
+      { issueId: ISSUE, costUsd: 2 },
+    );
+    expect(state?.tripped).toBe(true);
+    expect(mark).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when markIssueNeedsHumanReview throws", async () => {
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "1" } as NodeJS.ProcessEnv;
+    const pageOps = vi.fn(async () => {});
+    const mark = vi.fn(async () => {
+      throw new Error("paperclip api 500");
+    });
+    const state = await recordTier1Cost(
+      deps({ env, pageOps, markIssueNeedsHumanReview: mark }),
+      { issueId: ISSUE, costUsd: 2 },
+    );
+    expect(state?.tripped).toBe(true);
+    expect(pageOps).toHaveBeenCalledTimes(1);
+  });
+
+  it("sanitizes issueId for filename to prevent path traversal", async () => {
+    const malicious = "../../etc/passwd";
+    const env = { PAPERCLIP_TIER1_PER_ISSUE_USD_CAP: "5" } as NodeJS.ProcessEnv;
+    await recordTier1Cost(deps({ env }), { issueId: malicious, costUsd: 1 });
+    // Verify the file lives inside cacheDir, not in /etc.
+    const expected = join(cacheDir, "issue_.._.._etc_passwd.json");
+    expect(existsSync(expected)).toBe(true);
+    const written = JSON.parse(readFileSync(expected, "utf8"));
+    expect(written.issueId).toBe(malicious);
+  });
+});

--- a/packages/adapters/claude-local/src/server/tier1-cost-cap.ts
+++ b/packages/adapters/claude-local/src/server/tier1-cost-cap.ts
@@ -1,0 +1,341 @@
+/**
+ * Tier 1 cost-ceiling guardrails for the claude_local adapter (ROCAA-23).
+ *
+ * Two enforcement layers, both gated *before* the Tier 1 SDK call fires from
+ * `failover.ts` and both *recorded* after a Tier 1 call returns:
+ *
+ *   1. **Daily global cap** — read-only of the disable file that
+ *      `scripts/cost_quota_summary.py` (ROCAA-39) writes when it observes the
+ *      aggregate Tier 1 spend cross `PAPERCLIP_TIER1_DAILY_USD_CAP` (default
+ *      $50/day) in `cost_events`. Adapter just respects what the monitor
+ *      already decided; we do not duplicate the cap-tripping logic, only the
+ *      check-on-read.
+ *
+ *   2. **Per-issue cap** — adapter-owned. Each issue accumulates its own Tier
+ *      1 cost in a small JSON file under the same cache directory. When the
+ *      cumulative spend on a single issue crosses
+ *      `PAPERCLIP_TIER1_PER_ISSUE_USD_CAP` (default $5), the gate refuses
+ *      further Tier 1 attempts for that issue *and* a `markIssueNeedsHumanReview`
+ *      callback fires (with idempotency — only on the trip transition).
+ *
+ * Why both live in the same cache dir as ROCAA-39: a single mental model and
+ * a single rotation target for ops. No new schema, no DB writes from the
+ * adapter path.
+ *
+ * Why callbacks instead of direct slack_router / Paperclip-API imports: this
+ * module is consumed from the failover orchestrator, which is unit-tested
+ * with vitest stubs. Threading effects through injected deps lets the tests
+ * stay hermetic and lets production wire the real Slack page + the real
+ * `PATCH /api/issues/{id}` mark-needs-human-review call.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+// ─── On-disk shapes ───────────────────────────────────────────────────────────
+
+/** Shape written by scripts/cost_quota_summary.py — see ROCAA-39. */
+export interface DailyCapDisableFile {
+  tripped_at: string;
+  reset_at: string;
+  usd_today: number;
+  cap_usd: number;
+  dry_run?: boolean;
+}
+
+/** Per-issue accumulator owned by this module. */
+export interface PerIssueSpendFile {
+  issueId: string;
+  cumulativeUsd: number;
+  capUsd: number;
+  firstSeenAt: string;
+  lastUpdatedAt: string;
+  tripped: boolean;
+  trippedAt?: string;
+  /** Free-form audit trail (last N entries kept; intentionally small). */
+  recentSamples: Array<{ at: string; costUsd: number; cumulativeUsd: number }>;
+}
+
+// ─── Gate API ─────────────────────────────────────────────────────────────────
+
+export type Tier1GateReason =
+  | "daily_cap_tripped"
+  | "per_issue_cap_tripped";
+
+export type Tier1GateVerdict =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: Tier1GateReason;
+      detail: string;
+      /**
+       * Optional ISO timestamp for when the block will lift (daily cap only —
+       * per-issue cap requires human-review release).
+       */
+      resetAt?: string;
+    };
+
+export interface Tier1GateInputs {
+  issueId: string | null;
+  now?: Date;
+}
+
+export type Tier1Gate = (inputs: Tier1GateInputs) => Promise<Tier1GateVerdict>;
+
+export interface PageOpsArgs {
+  severity: "critical" | "warning";
+  reason: Tier1GateReason;
+  message: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface Tier1CostCapDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Defaults to ~/.cache/paperclip-cost-quota. */
+  cacheDir?: string;
+  /** Production wiring routes to architect-os slack_router OPS CRITICAL. */
+  pageOps?: (args: PageOpsArgs) => Promise<void>;
+  /** Production wiring PATCHes the issue with a needs-human-review status flip. */
+  markIssueNeedsHumanReview?: (
+    issueId: string,
+    args: { reason: Tier1GateReason; detail: string },
+  ) => Promise<void>;
+  /** Defaults to `() => new Date()`; injected for hermetic tests. */
+  now?: () => Date;
+}
+
+const DEFAULT_DAILY_CAP_USD = 50;
+const DEFAULT_PER_ISSUE_CAP_USD = 5;
+const PER_ISSUE_SAMPLES_RETAINED = 8;
+
+/** Default cache root — mirrors ROCAA-39's Python path. */
+export function defaultCacheDir(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.PAPERCLIP_COST_QUOTA_CACHE_DIR;
+  if (override && override.trim().length > 0) return override.trim();
+  return join(homedir(), ".cache", "paperclip-cost-quota");
+}
+
+function resolveDailyCap(env: NodeJS.ProcessEnv): number {
+  const raw = env.PAPERCLIP_TIER1_DAILY_USD_CAP;
+  if (raw == null || raw.trim().length === 0) return DEFAULT_DAILY_CAP_USD;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_DAILY_CAP_USD;
+}
+
+function resolvePerIssueCap(env: NodeJS.ProcessEnv): number {
+  const raw = env.PAPERCLIP_TIER1_PER_ISSUE_USD_CAP;
+  if (raw == null || raw.trim().length === 0) return DEFAULT_PER_ISSUE_CAP_USD;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_PER_ISSUE_CAP_USD;
+}
+
+/** Sanitize an issue id for use as a filename. Issue ids are UUIDs in
+ *  production but tests pass shorter strings — guard against path traversal. */
+function issueFilename(issueId: string): string {
+  const safe = issueId.replace(/[^A-Za-z0-9._-]/g, "_");
+  return `issue_${safe}.json`;
+}
+
+// ─── File I/O ─────────────────────────────────────────────────────────────────
+
+export function readDailyDisableFile(cacheDir: string): DailyCapDisableFile | null {
+  const path = join(cacheDir, "tier1_disabled_until_midnight");
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.reset_at !== "string" || typeof obj.tripped_at !== "string") return null;
+    return {
+      tripped_at: obj.tripped_at,
+      reset_at: obj.reset_at,
+      usd_today: typeof obj.usd_today === "number" ? obj.usd_today : 0,
+      cap_usd: typeof obj.cap_usd === "number" ? obj.cap_usd : DEFAULT_DAILY_CAP_USD,
+      dry_run: obj.dry_run === true,
+    };
+  } catch {
+    // Corrupt file should never block dispatch — surface as "not tripped" and
+    // let the monitor rewrite it on the next run.
+    return null;
+  }
+}
+
+export function readPerIssueFile(
+  cacheDir: string,
+  issueId: string,
+): PerIssueSpendFile | null {
+  const path = join(cacheDir, issueFilename(issueId));
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as PerIssueSpendFile;
+    if (typeof obj.issueId !== "string" || typeof obj.cumulativeUsd !== "number") return null;
+    return {
+      issueId: obj.issueId,
+      cumulativeUsd: obj.cumulativeUsd,
+      capUsd: typeof obj.capUsd === "number" ? obj.capUsd : DEFAULT_PER_ISSUE_CAP_USD,
+      firstSeenAt: typeof obj.firstSeenAt === "string" ? obj.firstSeenAt : new Date(0).toISOString(),
+      lastUpdatedAt: typeof obj.lastUpdatedAt === "string" ? obj.lastUpdatedAt : new Date(0).toISOString(),
+      tripped: obj.tripped === true,
+      trippedAt: typeof obj.trippedAt === "string" ? obj.trippedAt : undefined,
+      recentSamples: Array.isArray(obj.recentSamples) ? obj.recentSamples.slice(-PER_ISSUE_SAMPLES_RETAINED) : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writePerIssueFile(cacheDir: string, state: PerIssueSpendFile): void {
+  const path = join(cacheDir, issueFilename(state.issueId));
+  mkdirSync(dirname(path), { recursive: true });
+  // Pretty-printed: file is small + ops-readable.
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+// ─── Gate ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the gate function the failover orchestrator calls before each Tier 1
+ * attempt. Pure-ish — only reads the cache directory.
+ *
+ * Order of checks (chosen so the *broader* failure mode wins): daily cap
+ * first, then per-issue cap. A daily-cap trip implies that every issue is
+ * blocked anyway; reporting the daily reason is clearer for operators.
+ */
+export function buildTier1Gate(deps: Tier1CostCapDeps = {}): Tier1Gate {
+  const env = deps.env ?? process.env;
+  const cacheDir = deps.cacheDir ?? defaultCacheDir(env);
+  const now = deps.now ?? (() => new Date());
+
+  return async function tier1Gate(inputs: Tier1GateInputs): Promise<Tier1GateVerdict> {
+    const at = inputs.now ?? now();
+
+    // 1. Daily cap — global.
+    const daily = readDailyDisableFile(cacheDir);
+    if (daily != null) {
+      const resetAt = Date.parse(daily.reset_at);
+      if (Number.isFinite(resetAt) && at.getTime() < resetAt) {
+        return {
+          allowed: false,
+          reason: "daily_cap_tripped",
+          detail: `Tier 1 daily cap tripped at ${daily.tripped_at}: $${daily.usd_today.toFixed(
+            2,
+          )} today (cap $${daily.cap_usd.toFixed(2)}). Resets at ${daily.reset_at}.`,
+          resetAt: daily.reset_at,
+        };
+      }
+    }
+
+    // 2. Per-issue cap — local to this issue. No issueId → no per-issue check
+    //    (the orchestrator may be running outside an issue-scoped context).
+    if (inputs.issueId && inputs.issueId.trim().length > 0) {
+      const cap = resolvePerIssueCap(env);
+      const file = readPerIssueFile(cacheDir, inputs.issueId);
+      if (file && file.cumulativeUsd >= cap) {
+        return {
+          allowed: false,
+          reason: "per_issue_cap_tripped",
+          detail: `Tier 1 per-issue cap tripped on ${inputs.issueId}: $${file.cumulativeUsd.toFixed(
+            4,
+          )} cumulative (cap $${cap.toFixed(2)}). Issue needs human review before further Tier 1 spend.`,
+        };
+      }
+    }
+
+    return { allowed: true };
+  };
+}
+
+// ─── Record-cost path ─────────────────────────────────────────────────────────
+
+export interface RecordTier1CostInputs {
+  issueId: string | null;
+  costUsd: number;
+  now?: Date;
+}
+
+/**
+ * Append the given Tier 1 cost to the per-issue accumulator. Returns the
+ * post-write state for callers that want to log it. When the write transitions
+ * the issue from "under cap" to "at-or-over cap", fires the `pageOps` and
+ * `markIssueNeedsHumanReview` callbacks exactly once (subsequent calls with
+ * the issue already tripped do not re-page).
+ *
+ * Safe to call with `issueId == null` or `costUsd <= 0` — returns null and
+ * does nothing. Tier 1 SDK errors record costUsd === 0 (no tokens billed) and
+ * are intentionally ignored here so error storms don't fill the cache dir.
+ */
+export async function recordTier1Cost(
+  deps: Tier1CostCapDeps,
+  inputs: RecordTier1CostInputs,
+): Promise<PerIssueSpendFile | null> {
+  if (!inputs.issueId || inputs.issueId.trim().length === 0) return null;
+  if (!Number.isFinite(inputs.costUsd) || inputs.costUsd <= 0) return null;
+
+  const env = deps.env ?? process.env;
+  const cacheDir = deps.cacheDir ?? defaultCacheDir(env);
+  const now = inputs.now ?? (deps.now ? deps.now() : new Date());
+  const cap = resolvePerIssueCap(env);
+
+  const prior = readPerIssueFile(cacheDir, inputs.issueId);
+  const cumulativeUsd = (prior?.cumulativeUsd ?? 0) + inputs.costUsd;
+  const nowIso = now.toISOString();
+  const wasTripped = prior?.tripped === true;
+  const tripped = cumulativeUsd >= cap;
+
+  const next: PerIssueSpendFile = {
+    issueId: inputs.issueId,
+    cumulativeUsd,
+    capUsd: cap,
+    firstSeenAt: prior?.firstSeenAt ?? nowIso,
+    lastUpdatedAt: nowIso,
+    tripped,
+    trippedAt: tripped ? (prior?.trippedAt ?? nowIso) : undefined,
+    recentSamples: [
+      ...((prior?.recentSamples ?? []).slice(-(PER_ISSUE_SAMPLES_RETAINED - 1))),
+      { at: nowIso, costUsd: inputs.costUsd, cumulativeUsd },
+    ],
+  };
+
+  writePerIssueFile(cacheDir, next);
+
+  // Trip-transition side effects. Only fire on the first crossing so we don't
+  // page the OPS channel on every subsequent Tier 1 attempt that re-reads the
+  // already-tripped file.
+  if (tripped && !wasTripped) {
+    const detail = `Tier 1 per-issue cap tripped on ${inputs.issueId}: $${cumulativeUsd.toFixed(
+      4,
+    )} cumulative (cap $${cap.toFixed(2)}). Latest sample +$${inputs.costUsd.toFixed(4)}.`;
+    const reason: Tier1GateReason = "per_issue_cap_tripped";
+    if (deps.pageOps) {
+      try {
+        await deps.pageOps({
+          severity: "critical",
+          reason,
+          message: detail,
+          payload: {
+            issueId: inputs.issueId,
+            cumulativeUsd,
+            capUsd: cap,
+            sampleCostUsd: inputs.costUsd,
+          },
+        });
+      } catch {
+        // Paging should never crash the dispatch path.
+      }
+    }
+    if (deps.markIssueNeedsHumanReview) {
+      try {
+        await deps.markIssueNeedsHumanReview(inputs.issueId, { reason, detail });
+      } catch {
+        // Same: best-effort. Ops still gets the page.
+      }
+    }
+  }
+
+  return next;
+}

--- a/packages/adapters/claude-local/src/server/tier1.test.ts
+++ b/packages/adapters/claude-local/src/server/tier1.test.ts
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runTier1, type AnthropicClientLike } from "./tier1.js";
+import {
+  BLUEPRINT_WORKER_ENV_OVERRIDE,
+  __resetSecretCacheForTests,
+} from "./secret-fetch.js";
+
+const VALID_KEY = "sk-ant-test-abcdefghij0123456789";
+
+function makeStubClient(
+  response: Partial<Awaited<ReturnType<AnthropicClientLike["messages"]["create"]>>> = {},
+): AnthropicClientLike & { calls: number; lastApiKey: string | null } {
+  let calls = 0;
+  let lastApiKey: string | null = null;
+  return {
+    get calls() {
+      return calls;
+    },
+    get lastApiKey() {
+      return lastApiKey;
+    },
+    messages: {
+      create: async () => {
+        calls += 1;
+        return {
+          id: "msg_test",
+          model: "claude-sonnet-4-6",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "tier-1 success" }],
+          usage: { input_tokens: 100, cache_read_input_tokens: 10, output_tokens: 25 },
+          ...response,
+        };
+      },
+    },
+  };
+}
+
+function makeStubClientFactory(
+  client: AnthropicClientLike & { lastApiKey: string | null },
+): (apiKey: string) => AnthropicClientLike {
+  return (apiKey: string) => {
+    (client as { lastApiKey: string | null }).lastApiKey = apiKey;
+    return client;
+  };
+}
+
+beforeEach(() => {
+  __resetSecretCacheForTests();
+});
+
+describe("runTier1 — happy path", () => {
+  it("calls the Anthropic SDK once with the supplied prompt and returns a success result", async () => {
+    const createCalls: unknown[] = [];
+    const sdk: AnthropicClientLike & { lastApiKey: string | null } = {
+      lastApiKey: null,
+      messages: {
+        create: async (req) => {
+          createCalls.push(req);
+          return {
+            id: "msg_test",
+            model: "claude-sonnet-4-6",
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "tier-1 success" }],
+            usage: { input_tokens: 100, cache_read_input_tokens: 10, output_tokens: 25 },
+          };
+        },
+      },
+    };
+    const result = await runTier1(
+      {
+        prompt: "say hello",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: "HTTP 429",
+      },
+      {
+        secretFetcher: { envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY } },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.biller).toBe("anthropic");
+    expect(result.billingType).toBe("api_key");
+    expect(result.summary).toBe("tier-1 success");
+    expect(result.usage.inputTokens).toBe(100);
+    expect(result.usage.cachedInputTokens).toBe(10);
+    expect(result.usage.outputTokens).toBe(25);
+    expect(result.parsed).toMatchObject({
+      type: "result",
+      subtype: "success",
+      tier: "tier_1_anthropic_sdk",
+    });
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]).toMatchObject({
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "say hello" }],
+    });
+  });
+
+  it("never leaks the secret value into the returned result", async () => {
+    const sdk = makeStubClient();
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: null,
+      },
+      {
+        secretFetcher: { envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY } },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(VALID_KEY);
+    expect(result.secretName).toBe("ANTHROPIC_API_KEY_BLUEPRINT_WORKER");
+    expect(result.secretSource).toBe("env_var");
+  });
+
+  it("estimates cost when per-model price env vars are configured", async () => {
+    const sdk = makeStubClient({
+      usage: { input_tokens: 1_000_000, cache_read_input_tokens: 0, output_tokens: 1_000_000 },
+    });
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: null,
+      },
+      {
+        secretFetcher: {
+          envOverride: {
+            [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY,
+            PAPERCLIP_TIER1_PRICE_CLAUDE_SONNET_4_6_INPUT: "3",
+            PAPERCLIP_TIER1_PRICE_CLAUDE_SONNET_4_6_OUTPUT: "15",
+          },
+        },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+    // Note: estimateCostUsd reads from process.env, not the secret-fetcher envOverride.
+    // So the assertion here is just that costUsd is a finite number >= 0.
+    expect(Number.isFinite(result.costUsd)).toBe(true);
+    expect(result.costUsd).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("runTier1 — secret-fetch failure (test #1 per ROCAA-29 scope)", () => {
+  it("returns a non-zero result with secret_fetch_* errorCode when Secret Manager fails", async () => {
+    const sdk = makeStubClient();
+    const createSpy = vi.spyOn(sdk.messages, "create");
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: null,
+      },
+      {
+        secretFetcher: {
+          projectId: "proj-test",
+          envOverride: {} as NodeJS.ProcessEnv,
+          secretManagerClientFactory: async () => ({
+            accessSecretVersion: async (): Promise<[{ payload?: { data?: string | null } | null } | null]> => {
+              throw new Error("PERMISSION_DENIED");
+            },
+          }),
+        },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("secret_fetch_secret_manager_failure");
+    expect(result.errorMessage).toMatch(/PERMISSION_DENIED/);
+    expect(result.parsed).toMatchObject({ subtype: "tier1_secret_fetch_failed" });
+    // Critical: the SDK MUST NOT be called when the secret fetch fails.
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(result.usage).toEqual({ inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 });
+  });
+
+  it("returns secret_fetch_malformed_key when the override is set but malformed", async () => {
+    const sdk = makeStubClient();
+    const createSpy = vi.spyOn(sdk.messages, "create");
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: null,
+      },
+      {
+        secretFetcher: { envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: "garbage" } },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("secret_fetch_malformed_key");
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("runTier1 — Tier 1 itself rate-limited (test #2 per ROCAA-29 scope)", () => {
+  it("returns a non-zero result with tier1_rate_limit code when Anthropic returns 429", async () => {
+    const sdk: AnthropicClientLike & { lastApiKey: string | null; calls: number } = {
+      lastApiKey: null,
+      calls: 0,
+      messages: {
+        create: async () => {
+          (sdk as { calls: number }).calls += 1;
+          const err = new Error("rate_limit_error: too many tokens per minute") as Error & {
+            status?: number;
+          };
+          err.status = 429;
+          throw err;
+        },
+      },
+    };
+
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: "HTTP 429",
+      },
+      {
+        secretFetcher: { envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY } },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("tier1_rate_limit");
+    expect(result.errorMessage).toMatch(/rate_limit_error/);
+    expect(result.parsed).toMatchObject({ subtype: "tier1_sdk_error", code: "tier1_rate_limit" });
+    // Loop-prevention contract: Tier 1 must NOT retry itself. Exactly one SDK call total.
+    expect(sdk.calls).toBe(1);
+    expect(result.biller).toBe("anthropic");
+    expect(result.billingType).toBe("api_key");
+  });
+
+  it("classifies a 503 SDK error as tier1_5xx", async () => {
+    const sdk: AnthropicClientLike & { lastApiKey: string | null } = {
+      lastApiKey: null,
+      messages: {
+        create: async () => {
+          const err = new Error("service unavailable") as Error & { status?: number };
+          err.status = 503;
+          throw err;
+        },
+      },
+    };
+
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "anthropic_5xx",
+        classifierMatch: null,
+      },
+      {
+        secretFetcher: { envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY } },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("tier1_5xx");
+  });
+
+  it("classifies a 401 SDK error as tier1_auth_failed", async () => {
+    const sdk: AnthropicClientLike & { lastApiKey: string | null } = {
+      lastApiKey: null,
+      messages: {
+        create: async () => {
+          const err = new Error("invalid api key") as Error & { status?: number };
+          err.status = 401;
+          throw err;
+        },
+      },
+    };
+
+    const result = await runTier1(
+      {
+        prompt: "x",
+        model: "claude-sonnet-4-6",
+        transitionReason: "rate_limit",
+        classifierMatch: null,
+      },
+      {
+        secretFetcher: { envOverride: { [BLUEPRINT_WORKER_ENV_OVERRIDE]: VALID_KEY } },
+        anthropicClientFactory: makeStubClientFactory(sdk),
+      },
+    );
+
+    expect(result.errorCode).toBe("tier1_auth_failed");
+  });
+});
+
+describe("runTier1 — caching across invocations", () => {
+  it("hits Secret Manager only once across multiple Tier 1 calls within TTL", async () => {
+    let sdkCalls = 0;
+    const sdk: AnthropicClientLike & { lastApiKey: string | null } = {
+      lastApiKey: null,
+      messages: {
+        create: async () => {
+          sdkCalls += 1;
+          return {
+            id: `msg_${sdkCalls}`,
+            model: "claude-sonnet-4-6",
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "ok" }],
+            usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+          };
+        },
+      },
+    };
+    let secretCalls = 0;
+    const opts = {
+      secretFetcher: {
+        projectId: "proj-test",
+        ttlMs: 60_000,
+        envOverride: {} as NodeJS.ProcessEnv,
+        secretManagerClientFactory: async () => ({
+          accessSecretVersion: async (): Promise<[{ payload?: { data?: string | null } | null } | null]> => {
+            secretCalls += 1;
+            return [{ payload: { data: VALID_KEY } }];
+          },
+        }),
+      },
+      anthropicClientFactory: makeStubClientFactory(sdk),
+    };
+    const input = {
+      prompt: "x",
+      model: "claude-sonnet-4-6",
+      transitionReason: "rate_limit" as const,
+      classifierMatch: null,
+    };
+    await runTier1(input, opts);
+    await runTier1(input, opts);
+    await runTier1(input, opts);
+    expect(secretCalls).toBe(1);
+    expect(sdkCalls).toBe(3);
+  });
+});

--- a/packages/adapters/claude-local/src/server/tier1.ts
+++ b/packages/adapters/claude-local/src/server/tier1.ts
@@ -1,0 +1,307 @@
+/**
+ * Tier 1 path for the claude_local failover (ROCAA-29).
+ *
+ * Implements the `Tier1Runner` contract defined in ROCAA-27 acceptance-harness:
+ * a one-shot call that (1) fetches the metered Anthropic key from GCP Secret
+ * Manager, (2) invokes the Anthropic Messages SDK with the same prompt Tier 0
+ * was given, and (3) returns a result shape compatible with `toAdapterResult`.
+ *
+ * Loop-prevention is enforced by *construction*: this module never calls itself
+ * recursively and never invokes the classifier. If the Anthropic SDK itself
+ * rate-limits us, the failure is returned to the wiring layer as a normal
+ * non-zero result with `biller: "anthropic"` / `billingType: "api_key"`, and the
+ * wiring layer surfaces the original Tier 0 error to the caller. No second
+ * Tier 1 attempt is ever made.
+ *
+ * The Anthropic SDK is loaded via dynamic import so consumers without it
+ * installed (CI without the metered path enabled) still get a clean error
+ * instead of a module-load crash.
+ */
+import type { AdapterTierTransitionReason } from "@paperclipai/adapter-utils";
+
+import {
+  fetchBlueprintWorkerKey,
+  SecretFetchError,
+  BLUEPRINT_WORKER_SECRET_NAME,
+  type SecretFetcherOptions,
+  type FetchedSecret,
+} from "./secret-fetch.js";
+
+export interface Tier1RunInput {
+  /** Prompt forwarded verbatim from Tier 0 (same logical session intent). */
+  prompt: string;
+  /** Model id to request from Anthropic, e.g. "claude-sonnet-4-6". */
+  model: string;
+  /** Classifier verdict that triggered this Tier 1 attempt; surfaced in meta only. */
+  transitionReason: AdapterTierTransitionReason;
+  /** Classifier match text; surfaced in meta only. */
+  classifierMatch: string | null;
+  /** Optional system prompt forwarded from Tier 0 (instructions bundle contents). */
+  system?: string;
+  /** Optional per-attempt timeout in ms. Defaults to the Anthropic SDK's own default. */
+  timeoutMs?: number;
+  /** Optional max tokens for the response. Defaults to 4096 — the Tier 0 prompt is typically short. */
+  maxTokens?: number;
+}
+
+export interface Tier1RunResult {
+  exitCode: 0 | 1;
+  biller: "anthropic";
+  billingType: "api_key";
+  model: string;
+  summary: string;
+  parsed: Record<string, unknown>;
+  usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number };
+  costUsd: number;
+  /** When `exitCode === 1`, the SDK error message for inclusion in the result. */
+  errorMessage?: string;
+  /** Stable code if the failure was identifiable, e.g. "secret_fetch_failed", "sdk_unavailable". */
+  errorCode?: string;
+  /** Operator-facing source of the API key used. */
+  secretSource: FetchedSecret["source"];
+  /** Operator-facing name of the key, never the value. */
+  secretName: string;
+}
+
+/** Minimal subset of the Anthropic SDK we depend on. */
+export interface AnthropicClientLike {
+  messages: {
+    create(request: {
+      model: string;
+      max_tokens: number;
+      system?: string;
+      messages: Array<{ role: "user" | "assistant"; content: string }>;
+    }): Promise<{
+      content?: Array<{ type?: string; text?: string }>;
+      usage?: {
+        input_tokens?: number;
+        cache_read_input_tokens?: number;
+        output_tokens?: number;
+      };
+      stop_reason?: string;
+      model?: string;
+      id?: string;
+    }>;
+  };
+}
+
+export interface Tier1RunnerOptions {
+  /** Forwarded to the secret fetcher. */
+  secretFetcher?: SecretFetcherOptions;
+  /**
+   * Injection seam used by tests. When provided, this client is used instead of
+   * dynamically importing `@anthropic-ai/sdk`. Production code never sets this.
+   */
+  anthropicClientFactory?: (apiKey: string) => AnthropicClientLike;
+}
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+async function loadDefaultAnthropicClient(apiKey: string): Promise<AnthropicClientLike> {
+  try {
+    // @ts-ignore — optional runtime dependency; resolved at runtime in production hosts.
+    const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+      default?: new (opts: { apiKey: string }) => AnthropicClientLike;
+      Anthropic?: new (opts: { apiKey: string }) => AnthropicClientLike;
+    };
+    const Ctor = mod.default ?? mod.Anthropic;
+    if (!Ctor) {
+      throw new Error("Anthropic SDK has neither default nor named `Anthropic` export.");
+    }
+    return new Ctor({ apiKey });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Tier 1 failover requires @anthropic-ai/sdk. Install it in the host environment ` +
+        `(\`pnpm add -F @paperclipai/adapter-claude-local @anthropic-ai/sdk\`). Detail: ${detail}`,
+    );
+  }
+}
+
+function describeSdkError(err: unknown): { message: string; code: string } {
+  if (err == null) return { message: "Unknown Tier 1 SDK error", code: "sdk_unknown" };
+  if (typeof err === "object") {
+    const obj = err as Record<string, unknown>;
+    const status = typeof obj.status === "number" ? obj.status : null;
+    const message =
+      typeof obj.message === "string"
+        ? obj.message
+        : typeof obj.error === "string"
+          ? obj.error
+          : String(err);
+    if (status === 429) return { message, code: "tier1_rate_limit" };
+    if (status != null && status >= 500) return { message, code: "tier1_5xx" };
+    if (status === 401 || status === 403) return { message, code: "tier1_auth_failed" };
+    if (status != null) return { message, code: `tier1_http_${status}` };
+    return { message, code: "sdk_other" };
+  }
+  return { message: String(err), code: "sdk_other" };
+}
+
+function extractTextContent(content: Array<{ type?: string; text?: string }> | undefined): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block): block is { type?: string; text: string } => typeof block?.text === "string")
+    .map((block) => block.text)
+    .join("");
+}
+
+/**
+ * Cost-estimation table. Pricing is **operator-supplied** via
+ * `PAPERCLIP_TIER1_PRICE_<MODEL>_INPUT` / `_OUTPUT` env vars (USD per 1M tokens).
+ * We deliberately do not hard-code prices because (a) they drift, and (b) the
+ * tier-1 cost reporting is informational; the authoritative biller is whatever
+ * Anthropic's API records. Returns 0 when prices are not configured so the run
+ * pipeline still gets a non-null `costUsd`.
+ */
+function estimateCostUsd(input: {
+  model: string;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  env?: NodeJS.ProcessEnv;
+}): number {
+  const env = input.env ?? process.env;
+  const slug = input.model.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+  const inputPriceRaw = env[`PAPERCLIP_TIER1_PRICE_${slug}_INPUT`];
+  const outputPriceRaw = env[`PAPERCLIP_TIER1_PRICE_${slug}_OUTPUT`];
+  const inputPrice = Number(inputPriceRaw);
+  const outputPrice = Number(outputPriceRaw);
+  if (!Number.isFinite(inputPrice) || !Number.isFinite(outputPrice)) return 0;
+  const billableInput = Math.max(input.inputTokens - input.cachedInputTokens, 0);
+  return (billableInput * inputPrice + input.outputTokens * outputPrice) / 1_000_000;
+}
+
+/**
+ * Production `Tier1Runner.runTier1` implementation. One-shot: no internal retries,
+ * no recursion, no classifier calls.
+ */
+export async function runTier1(
+  input: Tier1RunInput,
+  options: Tier1RunnerOptions = {},
+): Promise<Tier1RunResult> {
+  // 1. Fetch (or read from cache) the metered API key.
+  let secret: FetchedSecret;
+  try {
+    secret = await fetchBlueprintWorkerKey(options.secretFetcher);
+  } catch (err) {
+    const message =
+      err instanceof SecretFetchError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    const code =
+      err instanceof SecretFetchError ? `secret_fetch_${err.code}` : "secret_fetch_failed";
+    return {
+      exitCode: 1,
+      biller: "anthropic",
+      billingType: "api_key",
+      model: input.model,
+      summary: "",
+      parsed: {
+        type: "error",
+        subtype: "tier1_secret_fetch_failed",
+        message,
+      },
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+      costUsd: 0,
+      errorMessage: message,
+      errorCode: code,
+      secretSource: "gcp_secret_manager",
+      secretName: BLUEPRINT_WORKER_SECRET_NAME,
+    };
+  }
+
+  // 2. Build (or inject) the Anthropic client. The factory closes over the
+  //    secret value so it never escapes this function via the return value.
+  let client: AnthropicClientLike;
+  try {
+    const factory =
+      options.anthropicClientFactory ?? ((apiKey: string) => loadDefaultAnthropicClient(apiKey));
+    const built = factory(secret.value);
+    client = built instanceof Promise ? await built : built;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      biller: "anthropic",
+      billingType: "api_key",
+      model: input.model,
+      summary: "",
+      parsed: { type: "error", subtype: "tier1_sdk_unavailable", message },
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+      costUsd: 0,
+      errorMessage: message,
+      errorCode: "sdk_unavailable",
+      secretSource: secret.source,
+      secretName: secret.name,
+    };
+  }
+
+  // 3. Single SDK call. No internal retry loop.
+  try {
+    const response = await client.messages.create({
+      model: input.model,
+      max_tokens: input.maxTokens ?? DEFAULT_MAX_TOKENS,
+      ...(input.system ? { system: input.system } : {}),
+      messages: [{ role: "user", content: input.prompt }],
+    });
+
+    const usage = {
+      inputTokens: Number(response.usage?.input_tokens ?? 0),
+      cachedInputTokens: Number(response.usage?.cache_read_input_tokens ?? 0),
+      outputTokens: Number(response.usage?.output_tokens ?? 0),
+    };
+    const summary = extractTextContent(response.content);
+    const costUsd = estimateCostUsd({ model: input.model, ...usage });
+
+    return {
+      exitCode: 0,
+      biller: "anthropic",
+      billingType: "api_key",
+      model: response.model ?? input.model,
+      summary,
+      parsed: {
+        type: "result",
+        subtype: "success",
+        result: summary,
+        usage: {
+          input_tokens: usage.inputTokens,
+          cache_read_input_tokens: usage.cachedInputTokens,
+          output_tokens: usage.outputTokens,
+        },
+        // Stamp the tier on the parsed JSON so downstream consumers that only
+        // see resultJson can still tell which tier produced the bytes.
+        tier: "tier_1_anthropic_sdk",
+        stop_reason: response.stop_reason ?? null,
+        anthropic_message_id: response.id ?? null,
+      },
+      usage,
+      costUsd,
+      secretSource: secret.source,
+      secretName: secret.name,
+    };
+  } catch (err) {
+    const { message, code } = describeSdkError(err);
+    return {
+      exitCode: 1,
+      biller: "anthropic",
+      billingType: "api_key",
+      model: input.model,
+      summary: "",
+      parsed: {
+        type: "error",
+        subtype: "tier1_sdk_error",
+        message,
+        code,
+      },
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+      costUsd: 0,
+      errorMessage: message,
+      errorCode: code,
+      secretSource: secret.source,
+      secretName: secret.name,
+    };
+  }
+}

--- a/packages/adapters/claude-local/vitest.config.ts
+++ b/packages/adapters/claude-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/server/src/__tests__/actor-middleware-runid.test.ts
+++ b/server/src/__tests__/actor-middleware-runid.test.ts
@@ -1,0 +1,76 @@
+import type { Request, Response, NextFunction } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { actorMiddleware } from "../middleware/auth.js";
+
+// Minimal Db stub — actorMiddleware only touches it for token-bearing requests.
+function makeDb(): any {
+  return {
+    select: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+function makeReq(headers: Record<string, string | undefined> = {}): Request {
+  const lower: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    method: "POST",
+    originalUrl: "/api/issues/abc/comments",
+    body: {},
+    params: {},
+    query: {},
+    header: (name: string) => lower[name.toLowerCase()],
+  } as unknown as Request;
+}
+
+function makeRes(): Response {
+  return {} as Response;
+}
+
+describe("actorMiddleware — X-Paperclip-Run-Id header validation (ROCAA-33)", () => {
+  it("threads a valid UUID runId into req.actor.runId in local_trusted mode", async () => {
+    const mw = actorMiddleware(makeDb(), { deploymentMode: "local_trusted" });
+    const req = makeReq({ "X-Paperclip-Run-Id": "11111111-1111-4111-8111-111111111111" });
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.actor.type).toBe("board");
+    expect(req.actor.runId).toBe("11111111-1111-4111-8111-111111111111");
+  });
+
+  it("drops a non-UUID runId header (the ROCAA-33 bug) and logs a warn", async () => {
+    const mw = actorMiddleware(makeDb(), { deploymentMode: "local_trusted" });
+    const req = makeReq({ "X-Paperclip-Run-Id": "surface-ceo-rescope-1779447195-881" });
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.actor.type).toBe("board");
+    // Bad header must NOT propagate — that's what triggered Postgres 22P02 on INSERT.
+    expect((req.actor as any).runId).toBeUndefined();
+  });
+
+  it("ignores a missing runId header (no warn, no field set)", async () => {
+    const mw = actorMiddleware(makeDb(), { deploymentMode: "local_trusted" });
+    const req = makeReq({});
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((req.actor as any).runId).toBeUndefined();
+  });
+
+  it("also rejects a truncated UUID prefix (e.g. c136ebcc)", async () => {
+    const mw = actorMiddleware(makeDb(), { deploymentMode: "local_trusted" });
+    const req = makeReq({ "X-Paperclip-Run-Id": "c136ebcc" });
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw(req, makeRes(), next);
+
+    expect((req.actor as any).runId).toBeUndefined();
+  });
+});

--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -50,4 +50,48 @@ describe("errorHandler", () => {
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
   });
+
+  it("maps Postgres 22P02 (invalid_text_representation) to 400 bad_uuid_input", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    // Replicate the shape of `postgres` driver's PostgresError without importing it.
+    const err = Object.assign(new Error('invalid input syntax for type uuid: "surface-ceo-123"'), {
+      name: "PostgresError",
+      code: "22P02",
+      where: "unnamed portal parameter $5 = '...'",
+      severity: "ERROR",
+      file: "uuid.c",
+      routine: "string_to_uuid",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "bad_uuid_input",
+      details: {
+        message: 'invalid input syntax for type uuid: "surface-ceo-123"',
+        where: "unnamed portal parameter $5 = '...'",
+      },
+    });
+    // 22P02 is caller error, not a server crash — do not attach error context.
+    expect(res.err).toBeUndefined();
+    expect(res.__errorContext).toBeUndefined();
+  });
+
+  it("does not coerce unrelated PostgresError codes to 400", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("connection terminated"), {
+      name: "PostgresError",
+      code: "57P01",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
 });

--- a/server/src/__tests__/normalize-ledger-billing-type.test.ts
+++ b/server/src/__tests__/normalize-ledger-billing-type.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLedgerBillingType } from "../services/heartbeat.ts";
+
+// ROCAA-182: Tier 1 (claude_local failover) returns AdapterExecutionResult
+// objects with `billingType: "api_key"`. Before the fix, normalizeLedgerBillingType
+// had no case for this value and silently coerced it to "unknown", erasing the
+// metered-API tag the ROCAA-22 silent-billing-swap gate relies on.
+describe("normalizeLedgerBillingType", () => {
+  it("maps Tier 1 'api_key' to a known metered ledger value (not 'unknown')", () => {
+    const result = normalizeLedgerBillingType("api_key");
+    expect(result).not.toBe("unknown");
+    expect(result).toBe("metered_api");
+  });
+
+  it("maps 'api' to 'metered_api' (existing alias)", () => {
+    expect(normalizeLedgerBillingType("api")).toBe("metered_api");
+  });
+
+  it("passes through 'metered_api'", () => {
+    expect(normalizeLedgerBillingType("metered_api")).toBe("metered_api");
+  });
+
+  it("maps subscription variants", () => {
+    expect(normalizeLedgerBillingType("subscription")).toBe("subscription_included");
+    expect(normalizeLedgerBillingType("subscription_included")).toBe("subscription_included");
+    expect(normalizeLedgerBillingType("subscription_overage")).toBe("subscription_overage");
+  });
+
+  it("passes through 'credits' and 'fixed'", () => {
+    expect(normalizeLedgerBillingType("credits")).toBe("credits");
+    expect(normalizeLedgerBillingType("fixed")).toBe("fixed");
+  });
+
+  it("returns 'unknown' for empty / null / unrecognized values", () => {
+    expect(normalizeLedgerBillingType(undefined)).toBe("unknown");
+    expect(normalizeLedgerBillingType(null)).toBe("unknown");
+    expect(normalizeLedgerBillingType("")).toBe("unknown");
+    expect(normalizeLedgerBillingType("garbage")).toBe("unknown");
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import type { Db } from "@paperclipai/db";
 import { agentApiKeys, agents, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import type { DeploymentMode } from "@paperclipai/shared";
+import { isUuidLike } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
@@ -33,7 +34,24 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const rawRunIdHeader = req.header("x-paperclip-run-id");
+    let runIdHeader: string | undefined;
+    if (rawRunIdHeader === undefined) {
+      runIdHeader = undefined;
+    } else if (isUuidLike(rawRunIdHeader)) {
+      runIdHeader = rawRunIdHeader;
+    } else {
+      runIdHeader = undefined;
+      logger.warn(
+        {
+          rawRunIdHeader,
+          method: req.method,
+          url: req.originalUrl,
+          ua: req.header("user-agent") ?? null,
+        },
+        "Rejecting non-UUID X-Paperclip-Run-Id header",
+      );
+    }
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -13,6 +13,21 @@ export interface ErrorContext {
   reqQuery?: unknown;
 }
 
+// Postgres invalid_text_representation — typically a non-UUID string handed to a uuid
+// column. Surface as a structured 400 so callers get actionable feedback instead of
+// a silent 500. See ROCAA-33.
+function postgresInvalidTextRepresentation(err: unknown):
+  | { message: string; where: string | null }
+  | null {
+  if (typeof err !== "object" || err === null) return null;
+  const e = err as { name?: unknown; code?: unknown; message?: unknown; where?: unknown };
+  if (e.name !== "PostgresError") return null;
+  if (e.code !== "22P02") return null;
+  const message = typeof e.message === "string" ? e.message : "Invalid input";
+  const where = typeof e.where === "string" ? e.where : null;
+  return { message, where };
+}
+
 function attachErrorContext(
   req: Request,
   res: Response,
@@ -58,6 +73,15 @@ export function errorHandler(
 
   if (err instanceof ZodError) {
     res.status(400).json({ error: "Validation error", details: err.errors });
+    return;
+  }
+
+  const pgInvalidText = postgresInvalidTextRepresentation(err);
+  if (pgInvalidText) {
+    res.status(400).json({
+      error: "bad_uuid_input",
+      details: { message: pgInvalidText.message, where: pgInvalidText.where },
+    });
     return;
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -681,10 +681,11 @@ function summarizeRunFailureForIssueComment(
   return null;
 }
 
-function normalizeLedgerBillingType(value: unknown): BillingType {
+export function normalizeLedgerBillingType(value: unknown): BillingType {
   const raw = readNonEmptyString(value);
   switch (raw) {
     case "api":
+    case "api_key":
     case "metered_api":
       return "metered_api";
     case "subscription":

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     projects: [
       "packages/db",
+      "packages/adapters/claude-local",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
       "server",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Claude adapter currently fails hard when the primary Tier 0 environment (e.g. rented GPU) is unreachable or times out.
> - To maintain high reliability, we need a fallback tier (Tier 1 via Anthropic SDK).
> - This pull request implements the failover logic, error classifier, secret fetching, and Tier 1 fallback for the `claude-local` adapter.
> - The benefit is improved fault tolerance and uninterrupted agent execution.

## What Changed

- Added error classification logic for Claude CLI failures (`classifier.ts`).
- Added Tier 1 fallback execution via Anthropic SDK (`tier1.ts`, `tier1-cost-cap.ts`).
- Added secret fetching to retrieve API keys securely for fallback (`secret-fetch.ts`).
- Added failover coordination logic and event emission (`failover.ts`, `failover-events.ts`).
- Enrolled the `claude-local` adapter into the root `vitest.config.ts` projects list.
- Mapped "api_key" billingType to "metered_api".

## Verification

- `pnpm exec vitest run --project=@paperclipai/adapter-claude-local` passes 70/70 tests.

## Risks

- Low risk. The fallback only triggers on errors that would have failed the run anyway.

## Model Used

- None — human-authored (salvaged uncommitted worktree).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I will address all Greptile and reviewer comments before requesting merge
