### PR TITLE
fix: auto-propagate issue.billing_code to cost_events at heartbeat record time

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1393,6 +1393,7 @@ async function resolveLedgerScopeForRun(
     return {
       issueId: null,
       projectId: contextProjectId,
+      billingCode: null,
     };
   }
 
@@ -1400,6 +1401,7 @@ async function resolveLedgerScopeForRun(
     .select({
       id: issues.id,
       projectId: issues.projectId,
+      billingCode: issues.billingCode,
     })
     .from(issues)
     .where(and(eq(issues.id, contextIssueId), eq(issues.companyId, companyId)))
@@ -1408,6 +1410,7 @@ async function resolveLedgerScopeForRun(
   return {
     issueId: issue?.id ?? null,
     projectId: issue?.projectId ?? contextProjectId,
+    billingCode: issue?.billingCode ?? null,
   };
 }
 
@@ -6863,6 +6866,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         agentId: agent.id,
         issueId: ledgerScope.issueId,
         projectId: ledgerScope.projectId,
+        billingCode: ledgerScope.billingCode,
         provider,
         biller,
         billingType,


### PR DESCRIPTION
## Summary

Fixes billing code attribution in cost tracking. When a heartbeat records a `cost_event`, the `billing_code` from the parent issue is now automatically propagated, ensuring token costs are correctly attributed to the originating issue.

## Change

4-line fix in the heartbeat recording path: reads `issue.billing_code` and sets it on the `cost_event` record at write time.

## Review

Reviewed and approved by Lead Backend Engineer and CTO. Commit `7f30a20c` (rebased from `9901e80e`).

Closes: LEG-21852, LEG-21877