### PR TITLE
fix: reject non-UUID X-Paperclip-Run-Id at every trust boundary

### DIFF
--- a/cli/src/__tests__/http-runid.test.ts
+++ b/cli/src/__tests__/http-runid.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { PaperclipApiClient } from "../client/http.js";
+
+const VALID_RUN_ID = "0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8a";
+
+describe("PaperclipApiClient runId validation", () => {
+  it("accepts a canonical UUID", () => {
+    const client = new PaperclipApiClient({
+      apiBase: "http://localhost:3100",
+      runId: VALID_RUN_ID,
+    });
+    expect(client.runId).toBe(VALID_RUN_ID);
+  });
+
+  it("normalizes uppercase to lowercase", () => {
+    const client = new PaperclipApiClient({
+      apiBase: "http://localhost:3100",
+      runId: VALID_RUN_ID.toUpperCase(),
+    });
+    expect(client.runId).toBe(VALID_RUN_ID);
+  });
+
+  it("treats missing runId as undefined (no header)", () => {
+    const client = new PaperclipApiClient({ apiBase: "http://localhost:3100" });
+    expect(client.runId).toBeUndefined();
+  });
+
+  it("treats empty/whitespace runId as undefined (no header)", () => {
+    const client = new PaperclipApiClient({
+      apiBase: "http://localhost:3100",
+      runId: "   ",
+    });
+    expect(client.runId).toBeUndefined();
+  });
+
+  it("throws on invalid runId (smoke-script pattern)", () => {
+    expect(
+      () =>
+        new PaperclipApiClient({
+          apiBase: "http://localhost:3100",
+          runId: "smoke-run-1717000000",
+        }),
+    ).toThrow(/Invalid --run-id.*smoke-run-1717000000/);
+  });
+
+  it("throws on invalid runId (manual session pattern)", () => {
+    expect(
+      () =>
+        new PaperclipApiClient({
+          apiBase: "http://localhost:3100",
+          runId: "manual-smilerite-20260527T141106Z",
+        }),
+    ).toThrow(/Invalid --run-id/);
+  });
+});

--- a/cli/src/__tests__/http.test.ts
+++ b/cli/src/__tests__/http.test.ts
@@ -15,7 +15,7 @@ describe("PaperclipApiClient", () => {
     const client = new PaperclipApiClient({
       apiBase: "http://localhost:3100",
       apiKey: "token-123",
-      runId: "run-abc",
+      runId: "0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8a",
     });
 
     await client.post("/api/test", { hello: "world" });
@@ -26,7 +26,7 @@ describe("PaperclipApiClient", () => {
 
     const headers = call[1].headers as Record<string, string>;
     expect(headers.authorization).toBe("Bearer token-123");
-    expect(headers["x-paperclip-run-id"]).toBe("run-abc");
+    expect(headers["x-paperclip-run-id"]).toBe("0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8a");
     expect(headers["content-type"]).toBe("application/json");
   });
 

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -1,4 +1,5 @@
 import { URL } from "node:url";
+import { isRunIdParseError, parseOptionalRunId, type RunId } from "@paperclipai/shared";
 
 export class ApiRequestError extends Error {
   status: number;
@@ -53,13 +54,27 @@ interface ApiClientOptions {
 export class PaperclipApiClient {
   readonly apiBase: string;
   apiKey?: string;
-  readonly runId?: string;
+  readonly runId?: RunId;
   readonly recoverAuth?: (input: RecoverAuthInput) => Promise<string | null>;
 
   constructor(opts: ApiClientOptions) {
     this.apiBase = opts.apiBase.replace(/\/+$/, "");
     this.apiKey = opts.apiKey?.trim() || undefined;
-    this.runId = opts.runId?.trim() || undefined;
+    // Validate runId at construction so every outbound request that sets
+    // X-Paperclip-Run-Id is guaranteed to carry a canonical UUID. The CLI's
+    // long-running entry points get a loud error at startup rather than a
+    // confused 500 at first mutation.
+    const rawRunId = opts.runId?.trim();
+    const runIdResult = parseOptionalRunId(
+      rawRunId && rawRunId.length > 0 ? rawRunId : undefined,
+      "cli",
+    );
+    if (isRunIdParseError(runIdResult)) {
+      throw new Error(
+        `Invalid --run-id / PAPERCLIP_RUN_ID: expected canonical UUID, got ${JSON.stringify(runIdResult.got)}`,
+      );
+    }
+    this.runId = runIdResult ?? undefined;
     this.recoverAuth = opts.recoverAuth;
   }
 

--- a/packages/mcp-server/src/config.test.ts
+++ b/packages/mcp-server/src/config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { readConfigFromEnv } from "./config.js";
+
+const REQUIRED = {
+  PAPERCLIP_API_URL: "http://localhost:3100",
+  PAPERCLIP_API_KEY: "key",
+};
+
+const VALID_RUN_ID = "0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8a";
+
+describe("readConfigFromEnv runId validation", () => {
+  it("accepts a canonical UUID", () => {
+    const cfg = readConfigFromEnv({ ...REQUIRED, PAPERCLIP_RUN_ID: VALID_RUN_ID });
+    expect(cfg.runId).toBe(VALID_RUN_ID);
+  });
+
+  it("normalizes uppercase to lowercase", () => {
+    const cfg = readConfigFromEnv({ ...REQUIRED, PAPERCLIP_RUN_ID: VALID_RUN_ID.toUpperCase() });
+    expect(cfg.runId).toBe(VALID_RUN_ID);
+  });
+
+  it("treats an absent env var as null (no runId)", () => {
+    const cfg = readConfigFromEnv(REQUIRED);
+    expect(cfg.runId).toBeNull();
+  });
+
+  it("treats an empty env var as null (no runId)", () => {
+    const cfg = readConfigFromEnv({ ...REQUIRED, PAPERCLIP_RUN_ID: "" });
+    expect(cfg.runId).toBeNull();
+  });
+
+  it("throws on invalid PAPERCLIP_RUN_ID (smoke-script label pattern)", () => {
+    expect(() =>
+      readConfigFromEnv({ ...REQUIRED, PAPERCLIP_RUN_ID: "smoke-run-1717000000" }),
+    ).toThrow(/Invalid PAPERCLIP_RUN_ID.*smoke-run-1717000000/);
+  });
+
+  it("throws on invalid PAPERCLIP_RUN_ID (manual session label pattern)", () => {
+    expect(() =>
+      readConfigFromEnv({ ...REQUIRED, PAPERCLIP_RUN_ID: "manual-smilerite-20260527T141106Z" }),
+    ).toThrow(/Invalid PAPERCLIP_RUN_ID/);
+  });
+});

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -1,9 +1,18 @@
+import { isRunIdParseError, parseOptionalRunId, type RunId } from "@paperclipai/shared";
+
 export interface PaperclipMcpConfig {
   apiUrl: string;
   apiKey: string;
   companyId: string | null;
   agentId: string | null;
-  runId: string | null;
+  /**
+   * A canonical UUID minted by the Paperclip server. Validated at boot via
+   * `parseOptionalRunId(env.PAPERCLIP_RUN_ID, "env")` so that downstream
+   * code (every outbound request that sets `X-Paperclip-Run-Id`) can trust
+   * the shape. Invalid env throws during `readConfigFromEnv` instead of
+   * producing 500s at first mutation.
+   */
+  runId: RunId | null;
 }
 
 function nonEmpty(value: string | undefined): string | null {
@@ -29,11 +38,18 @@ export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Papercl
     throw new Error("Missing PAPERCLIP_API_KEY");
   }
 
+  const runIdResult = parseOptionalRunId(nonEmpty(env.PAPERCLIP_RUN_ID), "env");
+  if (isRunIdParseError(runIdResult)) {
+    throw new Error(
+      `Invalid PAPERCLIP_RUN_ID: expected canonical UUID, got ${JSON.stringify(runIdResult.got)}`,
+    );
+  }
+
   return {
     apiUrl: normalizeApiUrl(apiUrl),
     apiKey,
     companyId: nonEmpty(env.PAPERCLIP_COMPANY_ID),
     agentId: nonEmpty(env.PAPERCLIP_AGENT_ID),
-    runId: nonEmpty(env.PAPERCLIP_RUN_ID),
+    runId: runIdResult,
   };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1038,6 +1038,17 @@ export {
   type ListPluginState,
 } from "./validators/index.js";
 
+export {
+  isRunId,
+  isRunIdParseError,
+  parseOptionalRunId,
+  parseRunId,
+  unsafeRunId,
+  type RunId,
+  type RunIdParseError,
+  type RunIdSource,
+} from "./validators/index.js";
+
 export { API_PREFIX, API } from "./api.js";
 export { normalizeAgentUrlKey, deriveAgentUrlKey, isUuidLike } from "./agent-url-key.js";
 export { deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "./project-url-key.js";

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -437,3 +437,14 @@ export {
   type SetPluginState,
   type ListPluginState,
 } from "./plugin.js";
+
+export {
+  isRunId,
+  isRunIdParseError,
+  parseOptionalRunId,
+  parseRunId,
+  unsafeRunId,
+  type RunId,
+  type RunIdParseError,
+  type RunIdSource,
+} from "./run-id.js";

--- a/packages/shared/src/validators/run-id.test.ts
+++ b/packages/shared/src/validators/run-id.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRunId,
+  isRunIdParseError,
+  parseOptionalRunId,
+  parseRunId,
+  unsafeRunId,
+  type RunId,
+} from "./run-id.js";
+
+const VALID = "0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8a";
+const VALID_UPPER = "0190F8E2-7B6C-7C1F-9E7F-3D3F4A2B1C8A";
+
+describe("parseRunId", () => {
+  it("accepts a canonical lowercase UUID", () => {
+    const out = parseRunId(VALID, "header");
+    expect(out).toBe(VALID);
+  });
+
+  it("normalizes uppercase UUIDs to lowercase", () => {
+    const out = parseRunId(VALID_UPPER, "header");
+    expect(out).toBe(VALID);
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    const out = parseRunId(`  ${VALID}\n`, "header");
+    expect(out).toBe(VALID);
+  });
+
+  it("rejects the smoke-script label pattern", () => {
+    const out = parseRunId("smoke-run-1717000000", "env");
+    expect(isRunIdParseError(out)).toBe(true);
+    if (isRunIdParseError(out)) {
+      expect(out.source).toBe("env");
+      expect(out.got).toBe("smoke-run-1717000000");
+    }
+  });
+
+  it("rejects the manual session label pattern", () => {
+    const out = parseRunId("manual-smilerite-20260527T141106Z", "header");
+    expect(isRunIdParseError(out)).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    const out = parseRunId("", "header");
+    expect(isRunIdParseError(out)).toBe(true);
+    if (isRunIdParseError(out)) expect(out.got).toBe("");
+  });
+
+  it("rejects whitespace-only input", () => {
+    const out = parseRunId("   ", "header");
+    expect(isRunIdParseError(out)).toBe(true);
+  });
+
+  it("rejects non-string input", () => {
+    const out = parseRunId(12345, "config");
+    expect(isRunIdParseError(out)).toBe(true);
+    if (isRunIdParseError(out)) expect(out.got).toBe("");
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isRunIdParseError(parseRunId(null, "claim"))).toBe(true);
+    expect(isRunIdParseError(parseRunId(undefined, "claim"))).toBe(true);
+  });
+
+  it("rejects almost-UUID shapes", () => {
+    // wrong segment lengths
+    expect(isRunIdParseError(parseRunId("0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8", "header"))).toBe(
+      true,
+    );
+    // non-hex chars
+    expect(isRunIdParseError(parseRunId("0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1cZZ", "header"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("parseOptionalRunId", () => {
+  it("returns null when input is absent", () => {
+    expect(parseOptionalRunId(undefined, "header")).toBeNull();
+    expect(parseOptionalRunId(null, "header")).toBeNull();
+  });
+
+  it("returns RunId when input is a valid UUID", () => {
+    expect(parseOptionalRunId(VALID, "header")).toBe(VALID);
+  });
+
+  it("returns an error for empty string (do not silently accept)", () => {
+    const out = parseOptionalRunId("", "header");
+    expect(isRunIdParseError(out)).toBe(true);
+  });
+
+  it("returns an error for invalid present input", () => {
+    const out = parseOptionalRunId("garbage", "header");
+    expect(isRunIdParseError(out)).toBe(true);
+  });
+});
+
+describe("unsafeRunId", () => {
+  it("brands a string without validation", () => {
+    const out: RunId = unsafeRunId(VALID);
+    expect(out).toBe(VALID);
+  });
+});
+
+describe("isRunId", () => {
+  it("narrows valid UUIDs", () => {
+    expect(isRunId(VALID)).toBe(true);
+  });
+
+  it("rejects non-UUIDs", () => {
+    expect(isRunId("smoke-run-1")).toBe(false);
+    expect(isRunId("")).toBe(false);
+    expect(isRunId(123)).toBe(false);
+    expect(isRunId(null)).toBe(false);
+  });
+
+  it("does NOT lowercase-normalize when narrowing (use parseRunId for that)", () => {
+    // isRunId is a pure type guard; the canonical-form contract is the
+    // caller's responsibility. Uppercase passes only after parseRunId.
+    expect(isRunId(VALID_UPPER)).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/run-id.ts
+++ b/packages/shared/src/validators/run-id.ts
@@ -1,0 +1,88 @@
+/**
+ * RunId — branded canonical-UUID value object.
+ *
+ * `X-Paperclip-Run-Id`, `PAPERCLIP_RUN_ID`, the JWT `run_id` claim, and
+ * `actor.runId` all flow into Postgres `uuid` columns
+ * (`issues.checkout_run_id`, `issue_comments.created_by_run_id`,
+ * `issues.execution_run_id`). Drizzle/Postgres reject anything that is not
+ * a canonical lowercase UUID with a 500 + stack trace — so every untrusted
+ * boundary that produces a runId must validate before handing it to the
+ * service layer.
+ *
+ * Validate once at each trust boundary (HTTP middleware, env reader, CLI
+ * arg parser), brand the result, and let the type system propagate the
+ * guarantee. Service-layer code accepts `RunId` and trusts it.
+ */
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+declare const RunIdBrand: unique symbol;
+
+/** A canonical lowercase UUID known to be safe for `uuid` columns. */
+export type RunId = string & { readonly [RunIdBrand]: "RunId" };
+
+/** Where an attempted RunId came from. Surfaces in errors for caller-side debugging. */
+export type RunIdSource = "header" | "env" | "claim" | "config" | "cli";
+
+export type RunIdParseError = {
+  readonly kind: "invalid_run_id";
+  readonly source: RunIdSource;
+  readonly got: string;
+};
+
+export function isRunIdParseError(value: unknown): value is RunIdParseError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === "invalid_run_id"
+  );
+}
+
+/**
+ * Parse a value that must be a runId.
+ *
+ * Empty string, whitespace, non-string, and non-UUID-shaped input all
+ * return a `RunIdParseError`. Uppercase UUIDs are accepted and normalized
+ * to lowercase (header casing drift from `curl`/scripts is common).
+ *
+ * Use `parseOptional` when the input is allowed to be absent.
+ */
+export function parseRunId(input: unknown, source: RunIdSource): RunId | RunIdParseError {
+  const got = typeof input === "string" ? input : "";
+  const normalized = got.trim().toLowerCase();
+  if (UUID_PATTERN.test(normalized)) return normalized as RunId;
+  return { kind: "invalid_run_id", source, got };
+}
+
+/**
+ * Parse a value that may be absent (`undefined` / `null`).
+ *
+ * - Absent input → `null` (caller falls through to a backup source, e.g. a
+ *   JWT claim).
+ * - Present-but-invalid (including empty string) → `RunIdParseError`. An
+ *   empty header is a caller bug; either send the header with a real UUID
+ *   or omit it entirely.
+ */
+export function parseOptionalRunId(
+  input: unknown,
+  source: RunIdSource,
+): RunId | RunIdParseError | null {
+  if (input === undefined || input === null) return null;
+  return parseRunId(input, source);
+}
+
+/**
+ * Brand a string already known to be a valid UUID (e.g. freshly minted by
+ * `crypto.randomUUID()` or returned from `runs.id`) without re-validating.
+ *
+ * Use only when the caller already controls the value. Untrusted input
+ * (headers, env, CLI args) must go through `parseRunId` / `parseOptionalRunId`.
+ */
+export function unsafeRunId(uuid: string): RunId {
+  return uuid as RunId;
+}
+
+/** Type guard for narrowing arbitrary strings. */
+export function isRunId(value: unknown): value is RunId {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}

--- a/scripts/smoke/openclaw-sse-standalone.sh
+++ b/scripts/smoke/openclaw-sse-standalone.sh
@@ -26,7 +26,11 @@ OPENCLAW_TIMEOUT_SEC="${OPENCLAW_TIMEOUT_SEC:-180}"
 OPENCLAW_MODEL="${OPENCLAW_MODEL:-openclaw}"
 OPENCLAW_USER="${OPENCLAW_USER:-paperclip-smoke}"
 
-PAPERCLIP_RUN_ID="${PAPERCLIP_RUN_ID:-smoke-run-$(date +%s)}"
+# A real UUID, not a free-form label: Paperclip's auth middleware now rejects
+# non-UUID X-Paperclip-Run-Id headers with 400, and the mcp-server / CLI throw
+# at boot on non-UUID env input. Pre-2026-05-27 this defaulted to
+# `smoke-run-$(date +%s)`, which silently corrupted uuid columns.
+PAPERCLIP_RUN_ID="${PAPERCLIP_RUN_ID:-$(uuidgen | tr A-Z a-z)}"
 PAPERCLIP_AGENT_ID="${PAPERCLIP_AGENT_ID:-openclaw-smoke-agent}"
 PAPERCLIP_COMPANY_ID="${PAPERCLIP_COMPANY_ID:-openclaw-smoke-company}"
 PAPERCLIP_API_URL="${PAPERCLIP_API_URL:-http://localhost:3100}"

--- a/server/src/__tests__/auth-runid-validation.test.ts
+++ b/server/src/__tests__/auth-runid-validation.test.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { actorMiddleware } from "../middleware/auth.js";
+
+const VALID_RUN_ID = "0190f8e2-7b6c-7c1f-9e7f-3d3f4a2b1c8a";
+
+function emptyDb() {
+  return {
+    select: vi.fn(),
+  } as unknown as Parameters<typeof actorMiddleware>[0];
+}
+
+function appWithMiddleware() {
+  const app = express();
+  app.use(
+    actorMiddleware(emptyDb(), {
+      deploymentMode: "local_trusted",
+    }),
+  );
+  app.get("/actor", (req, res) => {
+    res.json({ runId: req.actor.runId ?? null });
+  });
+  return app;
+}
+
+describe("actorMiddleware X-Paperclip-Run-Id validation", () => {
+  it("accepts a canonical lowercase UUID header", async () => {
+    const res = await request(appWithMiddleware())
+      .get("/actor")
+      .set("X-Paperclip-Run-Id", VALID_RUN_ID);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: VALID_RUN_ID });
+  });
+
+  it("normalizes uppercase UUID headers to lowercase", async () => {
+    const res = await request(appWithMiddleware())
+      .get("/actor")
+      .set("X-Paperclip-Run-Id", VALID_RUN_ID.toUpperCase());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: VALID_RUN_ID });
+  });
+
+  it("allows the request through when the header is absent", async () => {
+    const res = await request(appWithMiddleware()).get("/actor");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: null });
+  });
+
+  it("rejects the smoke-script label pattern with 400", async () => {
+    const res = await request(appWithMiddleware())
+      .get("/actor")
+      .set("X-Paperclip-Run-Id", "smoke-run-1717000000");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_run_id",
+      source: "header",
+      got: "smoke-run-1717000000",
+    });
+  });
+
+  it("rejects the manual session label pattern with 400", async () => {
+    const res = await request(appWithMiddleware())
+      .get("/actor")
+      .set("X-Paperclip-Run-Id", "manual-smilerite-20260527T141106Z");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_run_id");
+    expect(res.body.got).toBe("manual-smilerite-20260527T141106Z");
+  });
+
+  it("rejects an empty header with 400 (send the header or omit it)", async () => {
+    // supertest collapses empty string headers; force one through with raw set
+    const res = await request(appWithMiddleware())
+      .get("/actor")
+      .set("X-Paperclip-Run-Id", " ");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_run_id");
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import type { Db } from "@paperclipai/db";
 import { agentApiKeys, agents, authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
 import type { DeploymentMode } from "@paperclipai/shared";
+import { isRunIdParseError, parseOptionalRunId } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
@@ -20,7 +21,7 @@ interface ActorMiddlewareOptions {
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
-  return async (req, _res, next) => {
+  return async (req, res, next) => {
     req.actor =
       opts.deploymentMode === "local_trusted"
         ? {
@@ -33,7 +34,26 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    // Single trust boundary for X-Paperclip-Run-Id. The header flows into
+    // Postgres uuid columns (issues.checkout_run_id, etc.) via actor.runId,
+    // so anything that isn't a canonical UUID is rejected here before it can
+    // reach the service layer. Absent header: null (fall through to JWT
+    // claim, which is minted by services/heartbeat.ts). Empty string: 400,
+    // because that's a caller bug (send the header or omit it, don't blank).
+    const runIdHeaderResult = parseOptionalRunId(req.header("x-paperclip-run-id"), "header");
+    if (isRunIdParseError(runIdHeaderResult)) {
+      logger.warn(
+        { source: runIdHeaderResult.source, got: runIdHeaderResult.got, url: req.originalUrl },
+        "auth_middleware reject invalid_run_id",
+      );
+      res.status(400).json({
+        error: "invalid_run_id",
+        source: runIdHeaderResult.source,
+        got: runIdHeaderResult.got,
+      });
+      return;
+    }
+    const runIdHeader = runIdHeaderResult ?? undefined;
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {


### PR DESCRIPTION
## Problem

`X-Paperclip-Run-Id` headers (and the `PAPERCLIP_RUN_ID` env var) flow into Postgres `uuid` columns (`issues.checkout_run_id`, `issue_comments.created_by_run_id`, `issues.execution_run_id`). Callers — including smoke scripts and manual sessions — have been sending free-form labels like `smoke-run-1717000000` and `manual-smilerite-test`, which Drizzle/Postgres rejects with a 500 + stack trace after auth and routing have already run.

## Solution

Validate once at each trust boundary; brand the result so downstream code can't accidentally receive an unvalidated string.

### Commit 1 — `feat(shared)`: `RunId` branded validator
- `packages/shared/src/validators/run-id.ts`: `parseRunId`, `parseOptionalRunId`, `isRunId`, `isRunIdParseError`, `unsafeRunId`, `RunId` brand type.
- Exported from the validators barrel and the main `@paperclipai/shared` barrel.
- 18 unit tests.

### Commit 2 — `fix(server)`: middleware rejects invalid header with 400
- `actorMiddleware` now calls `parseOptionalRunId` on the raw header before touching `req.actor`.
- Absent → pass through (falls back to JWT claim). Present-but-invalid (including empty string) → `400 { error: "invalid_run_id", source, got }`.
- Uppercase UUIDs normalised to lowercase to absorb curl/shell casing drift.
- 6 new tests in `server/src/__tests__/auth-runid-validation.test.ts`.

### Commit 3 — `fix(mcp-server,cli,smoke)`: fail-fast at process boot
- `packages/mcp-server/src/config.ts`: `readConfigFromEnv` throws on non-UUID `PAPERCLIP_RUN_ID`.
- `cli/src/client/http.ts`: `PaperclipApiClient` constructor throws on non-UUID `runId` option.
- `scripts/smoke/openclaw-sse-standalone.sh`: default changed from `smoke-run-$(date +%s)` to `$(uuidgen | tr A-Z a-z)`.
- 6 + 6 new tests; one pre-existing fixture updated (`"run-abc"` → real UUID).

## Test results

| Package | Result |
|---|---|
| `@paperclipai/shared` | 18/18 ✅ |
| `@paperclipai/server` (new) | 6/6 ✅ |
| `@paperclipai/server` (full sweep) | 1815 pass, 3 fail — **all 3 pre-existing on `master`** |
| `@paperclipai/mcp-server` | 6/6 ✅ |
| `paperclipai` CLI | 11/11 ✅ |

## Design note

~100 test fixtures use string literals like `"run-1"` for `actor.runId`. Full brand propagation through every test and service call is a mechanical follow-up with its own cost/value tradeoff — deferred deliberately to keep this PR reviewable.