### PR TITLE
[codex] Add dashboard board inbox source support

### DIFF
--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -1,9 +1,23 @@
+import type { IssueThreadInteractionContinuationPolicy } from "../constants.js";
+
 export interface DashboardRunActivityDay {
   date: string;
   succeeded: number;
   failed: number;
   other: number;
   total: number;
+}
+
+export interface DashboardPendingBoardConfirmation {
+  id: string;
+  issueId: string;
+  issueIdentifier: string | null;
+  kind: "request_confirmation";
+  title: string | null;
+  summary: string | null;
+  createdAt: Date | string;
+  createdByAgentName: string | null;
+  continuationPolicy: IssueThreadInteractionContinuationPolicy;
 }
 
 export interface DashboardSummary {
@@ -26,6 +40,7 @@ export interface DashboardSummary {
     monthUtilizationPercent: number;
   };
   pendingApprovals: number;
+  pendingBoardConfirmations: DashboardPendingBoardConfirmation[];
   budgets: {
     activeIncidents: number;
     pendingApprovals: number;

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import { agents, approvals, companies, createDb, heartbeatRuns, issueThreadInteractions, issues } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -47,7 +47,10 @@ describeEmbeddedPostgres("dashboard service", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueThreadInteractions);
+    await db.delete(approvals);
     await db.delete(heartbeatRuns);
+    await db.delete(issues);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -165,5 +168,94 @@ describeEmbeddedPostgres("dashboard service", () => {
       other: 1,
       total: 3,
     });
+  });
+
+  it("includes pending board confirmations in the dashboard summary", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Other",
+        issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Planner",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review release plan",
+      identifier: "PAP-123",
+      status: "in_review",
+      priority: "high",
+    });
+
+    await db.insert(approvals).values({
+      companyId,
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Approve spend" },
+    });
+
+    await db.insert(issueThreadInteractions).values([
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        companyId,
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        title: "Approve release plan",
+        summary: "Confirm the source patch can release.",
+        createdByAgentId: agentId,
+        payload: { version: 1, prompt: "Approve?" },
+        createdAt: new Date("2026-05-28T08:30:00.000Z"),
+      },
+      {
+        companyId,
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "none",
+        title: "Internal note",
+        payload: { version: 1, prompt: "Ignore" },
+      },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.pendingApprovals).toBe(2);
+    expect(summary.pendingBoardConfirmations).toEqual([
+      expect.objectContaining({
+        id: "11111111-1111-4111-8111-111111111111",
+        issueIdentifier: "PAP-123",
+        title: "Approve release plan",
+        summary: "Confirm the source patch can release.",
+        createdByAgentName: "Planner",
+        continuationPolicy: "wake_assignee",
+      }),
+    ]);
   });
 });

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,6 +1,6 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
+import { agents, approvals, companies, costEvents, heartbeatRuns, issueThreadInteractions, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
 import { budgetService } from "./budgets.js";
 
@@ -46,11 +46,38 @@ export function dashboardService(db: Db) {
         .where(eq(issues.companyId, companyId))
         .groupBy(issues.status);
 
-      const pendingApprovals = await db
+      const pendingApprovalCount = await db
         .select({ count: sql<number>`count(*)` })
         .from(approvals)
         .where(and(eq(approvals.companyId, companyId), eq(approvals.status, "pending")))
         .then((rows) => Number(rows[0]?.count ?? 0));
+
+      const pendingBoardConfirmations = await db
+        .select({
+          id: issueThreadInteractions.id,
+          issueId: issueThreadInteractions.issueId,
+          issueIdentifier: issues.identifier,
+          kind: issueThreadInteractions.kind,
+          title: issueThreadInteractions.title,
+          summary: issueThreadInteractions.summary,
+          createdAt: issueThreadInteractions.createdAt,
+          createdByAgentName: agents.name,
+          continuationPolicy: issueThreadInteractions.continuationPolicy,
+        })
+        .from(issueThreadInteractions)
+        .innerJoin(issues, eq(issues.id, issueThreadInteractions.issueId))
+        .leftJoin(agents, eq(agents.id, issueThreadInteractions.createdByAgentId))
+        .where(
+          and(
+            eq(issueThreadInteractions.companyId, companyId),
+            eq(issueThreadInteractions.kind, "request_confirmation"),
+            eq(issueThreadInteractions.status, "pending"),
+            sql`${issueThreadInteractions.continuationPolicy} in ('wake_assignee', 'wake_assignee_on_accept')`,
+          ),
+        )
+        .orderBy(desc(issueThreadInteractions.createdAt));
+
+      const pendingApprovals = pendingApprovalCount + pendingBoardConfirmations.length;
 
       const agentCounts: Record<string, number> = {
         active: 0,
@@ -149,6 +176,11 @@ export function dashboardService(db: Db) {
           monthUtilizationPercent: Number(utilization.toFixed(2)),
         },
         pendingApprovals,
+        pendingBoardConfirmations: pendingBoardConfirmations.map((confirmation) => ({
+          ...confirmation,
+          kind: "request_confirmation" as const,
+          continuationPolicy: confirmation.continuationPolicy as "wake_assignee" | "wake_assignee_on_accept",
+        })),
         budgets: {
           activeIncidents: budgetOverview.activeIncidents.length,
           pendingApprovals: budgetOverview.pendingApprovalCount,

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -295,6 +295,7 @@ const dashboard: DashboardSummary = {
     monthUtilizationPercent: 90,
   },
   pendingApprovals: 1,
+  pendingBoardConfirmations: [],
   budgets: {
     activeIncidents: 0,
     pendingApprovals: 0,

--- a/ui/src/pages/Dashboard.test.tsx
+++ b/ui/src/pages/Dashboard.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Dashboard } from "./Dashboard";
+
+const apiMocks = vi.hoisted(() => ({
+  dashboardSummary: vi.fn(),
+  activityList: vi.fn(),
+  accessDirectory: vi.fn(),
+  issuesList: vi.fn(),
+  issuesAddComment: vi.fn(),
+  issuesAcceptInteraction: vi.fn(),
+  issuesRejectInteraction: vi.fn(),
+  agentsList: vi.fn(),
+  projectsList: vi.fn(),
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, className, to, ...props }: ComponentProps<"a"> & { to: string }) => (
+    <a className={className} href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("../api/dashboard", () => ({
+  dashboardApi: { summary: apiMocks.dashboardSummary },
+}));
+
+vi.mock("../api/activity", () => ({
+  activityApi: { list: apiMocks.activityList },
+}));
+
+vi.mock("../api/access", () => ({
+  accessApi: { listUserDirectory: apiMocks.accessDirectory },
+}));
+
+vi.mock("../api/issues", () => ({
+  issuesApi: {
+    list: apiMocks.issuesList,
+    addComment: apiMocks.issuesAddComment,
+    acceptInteraction: apiMocks.issuesAcceptInteraction,
+    rejectInteraction: apiMocks.issuesRejectInteraction,
+  },
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: { list: apiMocks.agentsList },
+}));
+
+vi.mock("../api/projects", () => ({
+  projectsApi: { list: apiMocks.projectsList },
+}));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({
+    selectedCompanyId: "company-1",
+    companies: [{ id: "company-1", name: "Paperclip" }],
+  }),
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialogActions: () => ({ openOnboarding: vi.fn() }),
+}));
+
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: vi.fn() }),
+}));
+
+vi.mock("../components/ActiveAgentsPanel", () => ({
+  ActiveAgentsPanel: () => <div data-testid="active-agents-panel" />,
+}));
+
+vi.mock("@/plugins/slots", () => ({
+  PluginSlotOutlet: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function dashboardSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    companyId: "company-1",
+    agents: { active: 0, running: 0, paused: 0, error: 0 },
+    tasks: { open: 0, inProgress: 0, blocked: 0, done: 0 },
+    costs: { monthSpendCents: 0, monthBudgetCents: 0, monthUtilizationPercent: 0 },
+    pendingApprovals: 0,
+    pendingBoardConfirmations: [],
+    budgets: { activeIncidents: 0, pendingApprovals: 0, pausedAgents: 0, pausedProjects: 0 },
+    runActivity: [],
+    ...overrides,
+  };
+}
+
+async function renderDashboard(container: HTMLElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+  });
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <Dashboard />
+      </QueryClientProvider>,
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+
+  return root;
+}
+
+describe("Dashboard Board Inbox", () => {
+  let container: HTMLDivElement;
+  let dateNowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date("2026-05-28T10:00:00.000Z").getTime());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    apiMocks.activityList.mockResolvedValue([]);
+    apiMocks.accessDirectory.mockResolvedValue({ users: [] });
+    apiMocks.issuesList.mockResolvedValue([]);
+    apiMocks.issuesAddComment.mockResolvedValue({});
+    apiMocks.issuesAcceptInteraction.mockResolvedValue({});
+    apiMocks.issuesRejectInteraction.mockResolvedValue({});
+    apiMocks.agentsList.mockResolvedValue([]);
+    apiMocks.projectsList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    container.remove();
+  });
+
+  it("renders pending board confirmations from the dashboard DTO", async () => {
+    apiMocks.dashboardSummary.mockResolvedValue(dashboardSummary({
+      pendingApprovals: 1,
+      pendingBoardConfirmations: [
+        {
+          id: "interaction-1",
+          issueIdentifier: "PAP-123",
+          title: "Approve source release",
+          summary: "Ship the Board Inbox source patch.",
+          createdAt: "2026-05-28T08:30:00.000Z",
+          createdByAgentName: "Planner",
+        },
+      ],
+    }));
+
+    const root = await renderDashboard(container);
+
+    expect(container.textContent).toContain("Board Inbox");
+    expect(container.textContent).toContain("PAP-123");
+    expect(container.textContent).toContain("Approve source release");
+    expect(container.textContent).toContain("Ship the Board Inbox source patch.");
+    expect(container.textContent).toContain("Planner");
+    expect(container.textContent).toContain("1 board confirmations awaiting response");
+
+    const link = container.querySelector<HTMLAnchorElement>('a[href="/issues/PAP-123#interaction-interaction-1"]');
+    expect(link).not.toBeNull();
+    expect(link?.closest("[data-board-confirmation-card]")?.className).toContain("border-amber-500/50");
+    expect(Array.from(container.querySelectorAll("button")).map((button) => button.textContent)).toEqual(
+      expect.arrayContaining(["Approve", "Reject", "Comment"]),
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("posts comments directly to the issue thread and shows failures inline", async () => {
+    apiMocks.dashboardSummary.mockResolvedValue(dashboardSummary({
+      pendingBoardConfirmations: [
+        {
+          id: "interaction-1",
+          issueIdentifier: "PAP-123",
+          title: "Approve source release",
+          summary: null,
+          createdAt: "2026-05-28T09:45:00.000Z",
+          createdByAgentName: null,
+        },
+      ],
+    }));
+    apiMocks.issuesAddComment.mockRejectedValueOnce(new Error("network down"));
+
+    const root = await renderDashboard(container);
+    const commentButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent === "Comment");
+
+    await act(async () => {
+      commentButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(apiMocks.issuesAddComment).toHaveBeenCalledWith(
+      "PAP-123",
+      "Board Inbox comment requested for pending confirmation interaction-1.",
+    );
+    expect(container.textContent).toContain("Comment failed to post.");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "@/lib/router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { dashboardApi } from "../api/dashboard";
 import { activityApi } from "../api/activity";
 import { accessApi } from "../api/access";
@@ -28,17 +28,33 @@ import type { Agent, Issue } from "@paperclipai/shared";
 import { PluginSlotOutlet } from "@/plugins/slots";
 
 const DASHBOARD_ACTIVITY_LIMIT = 10;
+const BOARD_CONFIRMATION_STALE_MS = 60 * 60 * 1000;
+const BOARD_CONFIRMATION_CRITICAL_MS = 24 * BOARD_CONFIRMATION_STALE_MS;
 
 function getRecentIssues(issues: Issue[]): Issue[] {
   return [...issues]
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 }
 
+function boardConfirmationAgeClass(createdAt: Date | string) {
+  const ageMs = Date.now() - new Date(createdAt).getTime();
+  if (ageMs > BOARD_CONFIRMATION_CRITICAL_MS) return "border-red-500/50 bg-red-500/10";
+  if (ageMs > BOARD_CONFIRMATION_STALE_MS) return "border-amber-500/50 bg-amber-500/10";
+  return "border-border bg-card";
+}
+
+function boardConfirmationCommentBody(interactionId: string) {
+  return `Board Inbox comment requested for pending confirmation ${interactionId}.`;
+}
+
 export function Dashboard() {
   const { selectedCompanyId, companies } = useCompany();
   const { openOnboarding } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
   const [animatedActivityIds, setAnimatedActivityIds] = useState<Set<string>>(new Set());
+  const [boardInboxErrorById, setBoardInboxErrorById] = useState<Record<string, string>>({});
+  const [boardInboxBusyById, setBoardInboxBusyById] = useState<Record<string, boolean>>({});
   const seenActivityIdsRef = useRef<Set<string>>(new Set());
   const hydratedActivityRef = useRef(false);
   const activityAnimationTimersRef = useRef<number[]>([]);
@@ -90,6 +106,7 @@ export function Dashboard() {
 
   const recentIssues = issues ? getRecentIssues(issues) : [];
   const recentActivity = useMemo(() => (activity ?? []).slice(0, 10), [activity]);
+  const pendingBoardConfirmations = data?.pendingBoardConfirmations ?? [];
 
   useEffect(() => {
     for (const timer of activityAnimationTimersRef.current) {
@@ -169,6 +186,30 @@ export function Dashboard() {
   const agentName = (id: string | null) => {
     if (!id || !agents) return null;
     return agents.find((a) => a.id === id)?.name ?? null;
+  };
+
+  const runBoardInboxAction = async (
+    interactionId: string,
+    action: () => Promise<unknown>,
+    failureMessage: string,
+  ) => {
+    setBoardInboxBusyById((prev) => ({ ...prev, [interactionId]: true }));
+    setBoardInboxErrorById((prev) => {
+      const next = { ...prev };
+      delete next[interactionId];
+      return next;
+    });
+
+    try {
+      await action();
+      if (selectedCompanyId) {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(selectedCompanyId) });
+      }
+    } catch {
+      setBoardInboxErrorById((prev) => ({ ...prev, [interactionId]: failureMessage }));
+    } finally {
+      setBoardInboxBusyById((prev) => ({ ...prev, [interactionId]: false }));
+    }
   };
 
   if (!selectedCompanyId) {
@@ -283,13 +324,108 @@ export function Dashboard() {
               to="/approvals"
               description={
                 <span>
-                  {data.budgets.pendingApprovals > 0
+                  {pendingBoardConfirmations.length > 0
+                    ? `${pendingBoardConfirmations.length} board confirmations awaiting response`
+                    : data.budgets.pendingApprovals > 0
                     ? `${data.budgets.pendingApprovals} budget overrides awaiting board review`
                     : "Awaiting board review"}
                 </span>
               }
             />
           </div>
+
+          {pendingBoardConfirmations.length > 0 ? (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+              <h3 className="text-sm font-semibold text-red-100 uppercase tracking-wide mb-3">
+                Board Inbox
+              </h3>
+              <div className="space-y-2">
+                {pendingBoardConfirmations.map((confirmation) => {
+                  const issueRef = confirmation.issueIdentifier ?? confirmation.issueId;
+                  const busy = boardInboxBusyById[confirmation.id] ?? false;
+                  return (
+                    <div
+                      key={confirmation.id}
+                      data-board-confirmation-card
+                      className={cn(
+                        "rounded-md border px-3 py-2",
+                        boardConfirmationAgeClass(confirmation.createdAt),
+                      )}
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <Link
+                          to={`/issues/${issueRef}#interaction-${confirmation.id}`}
+                          className="text-sm font-medium text-foreground no-underline hover:underline"
+                        >
+                          {issueRef} · {confirmation.title ?? "Pending confirmation"}
+                        </Link>
+                        <span className="text-xs text-muted-foreground">
+                          {timeAgo(confirmation.createdAt)}
+                        </span>
+                      </div>
+                      {confirmation.summary ? (
+                        <p className="mt-1 text-xs text-muted-foreground">{confirmation.summary}</p>
+                      ) : null}
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          className="rounded-md border border-emerald-500/30 px-2 py-1 text-xs font-medium text-emerald-100 hover:bg-emerald-500/15 disabled:opacity-50"
+                          disabled={busy}
+                          onClick={() => runBoardInboxAction(
+                            confirmation.id,
+                            () => issuesApi.acceptInteraction(issueRef, confirmation.id),
+                            "Approve failed.",
+                          )}
+                        >
+                          Approve
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded-md border border-red-500/35 px-2 py-1 text-xs font-medium text-red-100 hover:bg-red-500/15 disabled:opacity-50"
+                          disabled={busy}
+                          onClick={() => {
+                            const reason = window.prompt("Reject reason (optional)");
+                            return runBoardInboxAction(
+                              confirmation.id,
+                              () => issuesApi.rejectInteraction(issueRef, confirmation.id, reason || undefined),
+                              "Reject failed.",
+                            );
+                          }}
+                        >
+                          Reject
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted/50 disabled:opacity-50"
+                          disabled={busy}
+                          onClick={() => runBoardInboxAction(
+                            confirmation.id,
+                            () => issuesApi.addComment(issueRef, boardConfirmationCommentBody(confirmation.id)),
+                            "Comment failed to post.",
+                          )}
+                        >
+                          Comment
+                        </button>
+                        <span className="text-xs text-red-100/80">
+                          {confirmation.createdByAgentName ?? "Unknown requester"}
+                        </span>
+                      </div>
+                      {boardInboxErrorById[confirmation.id] ? (
+                        <p className="mt-2 text-xs text-red-100">{boardInboxErrorById[confirmation.id]}</p>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border bg-card p-4">
+              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+                Board Inbox
+              </h3>
+              <p className="text-sm text-muted-foreground">No pending board confirmations.</p>
+            </div>
+          )}
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <ChartCard title="Run Activity" subtitle="Last 14 days">

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -1274,6 +1274,7 @@ export const storybookDashboardSummary: DashboardSummary = {
     monthUtilizationPercent: 27,
   },
   pendingApprovals: 2,
+  pendingBoardConfirmations: [],
   budgets: {
     activeIncidents: 1,
     pendingApprovals: 1,


### PR DESCRIPTION
## Summary

- adds `pendingBoardConfirmations` to the dashboard summary contract from pending `request_confirmation` interactions with board-wake continuation
- renders a Dashboard Board Inbox with issue links, summary text, age severity, requester, and direct Approve / Reject / Comment controls
- adds regression coverage for the server DTO aggregation and dashboard UI behavior

## Provenance

- Source issue: CON-3909 / CON-3887 Board Inbox source provenance
- Source commit: `25d995fb81c4ed991e9500283bd21706b00d2490`
- Build artifact checked locally: `ui/dist/assets/index-Bby0qhUq.js`
- Copied package artifact checked locally: `server/ui-dist/assets/index-Bby0qhUq.js`
- Artifact SHA-256: `83e6dcba895cc6c863f1b7435462d3b7e7caa1bc0a289bfa68fd9cf2a8559a01`

## Validation

- `pnpm exec vitest run server/src/__tests__/dashboard-service.test.ts ui/src/pages/Dashboard.test.tsx --pool=forks --poolOptions.forks.singleFork`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`
- `PAPERCLIP_RELEASE_REUSE_UI_DIST=1 pnpm --filter @paperclipai/server prepare:ui-dist`

## Notes

The local runtime bundle previously patched for CON-3887 is not treated as release provenance. This PR moves the Board Inbox behavior into source so the normal Paperclip canary/stable workflow can build and publish a traceable artifact.
