### PR TITLE
test(auth): update 3 stale comment-403 tests to post-AIM-57 behavior (AIM-65)

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -479,7 +479,6 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
     [
       "document upsert",
       (app: express.Express) =>
@@ -708,7 +707,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));
@@ -720,6 +718,61 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  // AIM-57 / AIM-55: comment creation is append-only, company-scoped communication.
+  // A same-company peer (non-assignee, non-manager) must be able to post comments on
+  // another agent's issue regardless of status, while every other mutation stays gated.
+  it.each([
+    ["todo"],
+    ["in_progress"],
+    ["done"],
+    ["blocked"],
+    ["backlog"],
+  ])("allows a same-company peer agent to comment on agent %s issue (append-only)", async (status) => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: status as "todo" | "in_progress" | "done" | "blocked" | "backlog", assigneeAgentId: ownerAgentId }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Peer note from an unrelated same-company agent" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Peer note from an unrelated same-company agent",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("still rejects cross-company agent comments via company scoping", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor({ companyId: "99999999-9999-4999-8999-999999999999" })))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Cross-company comment attempt" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent key cannot access another company");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("still gates non-comment mutations (patch/delete/document) for a same-company peer", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    const app = await createApp(peerActor());
+
+    await request(app).patch(`/api/issues/${issueId}`).send({ title: "Peer patch" }).expect(403);
+    await request(app).delete(`/api/issues/${issueId}`).expect(403);
+    await request(app)
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .send({ format: "markdown", body: "# peer doc" })
+      .expect(403);
+
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.remove).not.toHaveBeenCalled();
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -514,7 +514,10 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  // AIM-57 / AIM-55: a non-assignee same-company agent may post a plain comment on a closed
+  // issue (append-only communication). It must NOT implicitly reopen the issue (only human
+  // comments reopen) and must not wake the assignee for a closed-issue comment.
+  it("allows non-assignee agent POST comments on closed issues without reopening", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
@@ -537,10 +540,9 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Updates 3 pre-existing tests that encoded the old (pre-AIM-57) behavior where `POST /comments` returned 403 for non-assignee same-company agents. [AIM-57](https://company.aimani.de/AIM/issues/AIM-57) changed the route to only run the issue-mutation guard when the comment requests `reopen`/`resume`/`interrupt` — plain comments are now append-only, company-scoped communication.

## Tests changed

**`server/src/__tests__/issue-comment-reopen-routes.test.ts`**
- `"rejects non-assignee agent POST comments on closed issues"` → renamed to `"allows non-assignee agent POST comments on closed issues without reopening"` and asserts **201** + `addComment` was called (not 403)

**`server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`**
- Removed `"comment"` row from the `"rejects peer agent comment on another agent's active checkout"` parametrized table
- Removed `["todo", "comment"]` row from the `"rejects peer agent mutations outside active checkout ownership"` parametrized table
- Added positive test: `"allows a same-company peer agent to comment on agent %s issue (append-only)"` — 5 status variants, all assert **201**
- Added: `"still rejects cross-company agent comments via company scoping"` — asserts **403**
- Added: `"still gates non-comment mutations (patch/delete/document) for a same-company peer"` — asserts **403** for patch/delete/document

## Invariants preserved
- `reopen`/`resume`/`interrupt` comments → still 403 ✅
- Cross-company → still 403 ✅
- PATCH / DELETE / document mutations → still 403 ✅
- `issue-comment-authz-regression.test.ts` untouched ✅
- No production/route code changed ✅

## Test run
Full vitest suite: **75/75 passing** on the 3 affected files.

Refs: AIM-65 / AIM-57 / AIM-55
