### PR TITLE
fix(auth): gate assertAgentIssueMutationAllowed behind wantsStateMutation (AIM-57 → master)

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -479,7 +479,6 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
     [
       "document upsert",
       (app: express.Express) =>
@@ -708,7 +707,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));
@@ -720,6 +718,61 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  // AIM-57 / AIM-55: comment creation is append-only, company-scoped communication.
+  // A same-company peer (non-assignee, non-manager) must be able to post comments on
+  // another agent's issue regardless of status, while every other mutation stays gated.
+  it.each([
+    ["todo"],
+    ["in_progress"],
+    ["done"],
+    ["blocked"],
+    ["backlog"],
+  ])("allows a same-company peer agent to comment on agent %s issue (append-only)", async (status) => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: status as "todo" | "in_progress" | "done" | "blocked" | "backlog", assigneeAgentId: ownerAgentId }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Peer note from an unrelated same-company agent" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Peer note from an unrelated same-company agent",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("still rejects cross-company agent comments via company scoping", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor({ companyId: "99999999-9999-4999-8999-999999999999" })))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Cross-company comment attempt" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent key cannot access another company");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("still gates non-comment mutations (patch/delete/document) for a same-company peer", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    const app = await createApp(peerActor());
+
+    await request(app).patch(`/api/issues/${issueId}`).send({ title: "Peer patch" }).expect(403);
+    await request(app).delete(`/api/issues/${issueId}`).expect(403);
+    await request(app)
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .send({ format: "markdown", body: "# peer doc" })
+      .expect(403);
+
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.remove).not.toHaveBeenCalled();
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/__tests__/issue-comment-authz-regression.test.ts
+++ b/server/src/__tests__/issue-comment-authz-regression.test.ts
@@ -1,0 +1,415 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// AIM-55 regression coverage.
+//
+// Desired post-fix behavior of POST /api/issues/:id/comments:
+//   - A plain comment (body only, no reopen/resume/interrupt intent) by ANY
+//     same-company agent is ALLOWED (201), even on another agent's issue and
+//     regardless of the issue status (todo/done/...).
+//   - A comment that requests reopen/resume/interrupt on another agent's
+//     non-self issue stays guarded by assertAgentIssueMutationAllowed (403).
+//   - Cross-company comments stay blocked by assertCompanyAccess (403).
+//
+// NOTE: tests 1 & 2 encode the *desired* post-fix behavior. They are expected
+// to be RED against the current unpatched route code (which calls the mutation
+// guard unconditionally before distinguishing plain comments from mutations).
+
+const issueId = "11111111-1111-4111-8111-111111111111";
+const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
+const otherAgentId = "44444444-4444-4444-8444-444444444444";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  getDependencyReadiness: vi.fn(),
+  getCurrentScheduledRetry: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  decide: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTxInsertValues = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTxInsert = vi.hoisted(() => vi.fn(() => ({ values: mockTxInsertValues })));
+const mockTx = vi.hoisted(() => ({
+  insert: mockTxInsert,
+}));
+const mockDbSelectOrderBy = vi.hoisted(() => vi.fn(async () => []));
+const mockDbSelectWhere = vi.hoisted(() => vi.fn(() => ({ orderBy: mockDbSelectOrderBy })));
+const mockDbSelectFrom = vi.hoisted(() => vi.fn(() => ({ where: mockDbSelectWhere })));
+const mockDbSelect = vi.hoisted(() => vi.fn(() => ({ from: mockDbSelectFrom })));
+const mockDb = vi.hoisted(() => ({
+  select: mockDbSelect,
+  transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+}));
+const mockFeedbackService = vi.hoisted(() => ({
+  listIssueVotesForUser: vi.fn(async () => []),
+  saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+}));
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: {
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    },
+  })),
+  listCompanyIds: vi.fn(async () => ["company-1"]),
+}));
+const mockRoutineService = vi.hoisted(() => ({
+  syncRunStatusForIssue: vi.fn(async () => undefined),
+}));
+const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+const mockIssueRecoveryActionService = vi.hoisted(() => ({
+  getActiveForIssue: vi.fn(async () => null),
+}));
+const mockIssueTreeControlService = vi.hoisted(() => ({
+  getActivePauseHoldGate: vi.fn(async () => null),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+vi.mock("../services/access.js", () => ({
+  accessService: () => mockAccessService,
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../services/agents.js", () => ({
+  agentService: () => mockAgentService,
+}));
+
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: () => mockFeedbackService,
+}));
+
+vi.mock("../services/heartbeat.js", () => ({
+  heartbeatService: () => mockHeartbeatService,
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => mockInstanceSettingsService,
+}));
+
+vi.mock("../services/issues.js", () => ({
+  issueService: () => mockIssueService,
+}));
+
+vi.mock("../services/routines.js", () => ({
+  routineService: () => mockRoutineService,
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => mockFeedbackService,
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => mockInstanceSettingsService,
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => mockIssueRecoveryActionService,
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => mockIssueThreadInteractionService,
+  issueTreeControlService: () => mockIssueTreeControlService,
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => mockRoutineService,
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+async function installActor(app: express.Express, actor?: Record<string, unknown>) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  app.use((req, _res, next) => {
+    (req as any).actor = actor ?? {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress") {
+  return {
+    id: issueId,
+    companyId: "company-1",
+    status,
+    assigneeAgentId,
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "PAP-55",
+    title: "AIM-55 plain-comment authz regression",
+  };
+}
+
+// Agent A: a same-company agent that is NOT the assignee and NOT a manager.
+function nonAssigneeAgentActor(companyId = "company-1") {
+  return {
+    type: "agent",
+    agentId: otherAgentId,
+    companyId,
+    source: "agent_key",
+    runId: "66666666-6666-4666-8666-666666666666",
+  };
+}
+
+describe.sequential("issue comment authz regression (AIM-55)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.getById.mockReset();
+    mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.update.mockReset();
+    mockIssueService.addComment.mockReset();
+    mockIssueService.getDependencyReadiness.mockReset();
+    mockIssueService.getCurrentScheduledRetry.mockReset();
+    mockIssueService.findMentionedAgents.mockReset();
+    mockIssueService.listWakeableBlockedDependents.mockReset();
+    mockIssueService.getWakeableParentAfterChildCompletion.mockReset();
+    mockAccessService.canUser.mockReset();
+    mockAccessService.decide.mockReset();
+    mockAccessService.hasPermission.mockReset();
+    mockHeartbeatService.wakeup.mockReset();
+    mockHeartbeatService.reportRunActivity.mockReset();
+    mockHeartbeatService.getRun.mockReset();
+    mockHeartbeatService.getActiveRunForAgent.mockReset();
+    mockHeartbeatService.cancelRun.mockReset();
+    mockAgentService.getById.mockReset();
+    mockAgentService.list.mockReset();
+    mockAgentService.resolveByReference.mockReset();
+    mockLogActivity.mockReset();
+    mockFeedbackService.listIssueVotesForUser.mockReset();
+    mockFeedbackService.saveIssueVote.mockReset();
+    mockInstanceSettingsService.get.mockReset();
+    mockInstanceSettingsService.listCompanyIds.mockReset();
+    mockRoutineService.syncRunStatusForIssue.mockReset();
+    mockIssueRecoveryActionService.getActiveForIssue.mockReset();
+    mockIssueTreeControlService.getActivePauseHoldGate.mockReset();
+    mockTxInsertValues.mockReset();
+    mockTxInsert.mockReset();
+    mockDbSelect.mockReset();
+    mockDbSelectFrom.mockReset();
+    mockDbSelectWhere.mockReset();
+    mockDbSelectOrderBy.mockReset();
+    mockDb.transaction.mockReset();
+
+    mockTxInsertValues.mockResolvedValue(undefined);
+    mockTxInsert.mockImplementation(() => ({ values: mockTxInsertValues }));
+    mockDbSelectOrderBy.mockResolvedValue([]);
+    mockDbSelectWhere.mockImplementation(() => ({ orderBy: mockDbSelectOrderBy }));
+    mockDbSelectFrom.mockImplementation(() => ({ where: mockDbSelectWhere }));
+    mockDbSelect.mockImplementation(() => ({ from: mockDbSelectFrom }));
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx));
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
+    mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockLogActivity.mockResolvedValue(undefined);
+    mockFeedbackService.listIssueVotesForUser.mockResolvedValue([]);
+    mockFeedbackService.saveIssueVote.mockResolvedValue({
+      vote: null,
+      consentEnabledNow: false,
+      sharingEnabled: false,
+    });
+    mockInstanceSettingsService.get.mockResolvedValue({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    });
+    mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1"]);
+    mockRoutineService.syncRunStatusForIssue.mockResolvedValue(undefined);
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(null);
+    mockIssueTreeControlService.getActivePauseHoldGate.mockResolvedValue(null);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-1",
+      issueId,
+      companyId: "company-1",
+      body: "hello",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: otherAgentId,
+      authorUserId: null,
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId,
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done"),
+      ...patch,
+    }));
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: false,
+      action: "tasks:manage_active_checkouts",
+      reason: "deny_missing_grant",
+      explanation: "Missing active checkout override.",
+    });
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue(null);
+    // Agent A reports to nobody and is NOT a manager of the assignee.
+    mockAgentService.list.mockResolvedValue([
+      { id: assigneeAgentId, reportsTo: null, permissions: { canCreateAgents: false } },
+      { id: otherAgentId, reportsTo: null, permissions: { canCreateAgents: false } },
+    ]);
+    mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: null });
+  });
+
+  // Test 1 (AIM-55): plain comment on another agent's DONE issue -> 201.
+  // RED against current unpatched code (guard rejects with 403).
+  it("allows a non-assignee agent to post a plain comment on another agent's done issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+
+    const res = await request(await installActor(createApp(), nonAssigneeAgentActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Heads up, I noticed something relevant here." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    // Plain comment must NOT reopen another agent's closed issue.
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      assigneeAgentId,
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
+
+  // Test 2: plain comment on another agent's TODO issue -> 201.
+  // RED against current unpatched code (guard rejects with 403).
+  it("allows a non-assignee agent to post a plain comment on another agent's todo issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+    const res = await request(await installActor(createApp(), nonAssigneeAgentActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Sharing context on this open task." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+  });
+
+  // Test 3: comment WITH reopen intent on another agent's DONE issue -> 403.
+  // GREEN now and must stay GREEN after the fix (mutations remain guarded).
+  it("rejects a non-assignee agent reopen-intent comment on another agent's done issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+
+    const res = await request(await installActor(createApp(), nonAssigneeAgentActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Reopen this, please.", reopen: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  // Test 3b: comment WITH resume intent on another agent's DONE issue -> 403.
+  it("rejects a non-assignee agent resume-intent comment on another agent's done issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+
+    const res = await request(await installActor(createApp(), nonAssigneeAgentActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Resume the work over here.", resume: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  // Test 4: cross-company comment stays blocked by assertCompanyAccess -> 403.
+  it("rejects a cross-company agent comment via assertCompanyAccess", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+    const res = await request(
+      await installActor(createApp(), nonAssigneeAgentActor("company-2")),
+    )
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "I am from a different company." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent key cannot access another company");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -514,7 +514,10 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  // AIM-57 / AIM-55: a non-assignee same-company agent may post a plain comment on a closed
+  // issue (append-only communication). It must NOT implicitly reopen the issue (only human
+  // comments reopen) and must not wake the assignee for a closed-issue comment.
+  it("allows non-assignee agent POST comments on closed issues without reopening", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
@@ -537,10 +540,9 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5467,7 +5467,8 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    const wantsStateMutation = req.body.reopen === true || req.body.resume === true || req.body.interrupt === true;
+    if (wantsStateMutation && !(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,


### PR DESCRIPTION
## Summary

Consolidates the AIM-57 / AIM-55 fix into one atomic, CI-green PR, resolving the split-PR deadlock between #6838 and #6837.

**Commits:**
1. `fix(auth)`: gate `assertAgentIssueMutationAllowed` behind `wantsStateMutation = reopen || resume || interrupt` — route change that makes plain same-company comments append-only rather than mutation-guarded.
2. `test(auth)`: fold in the three stale tests from #6837 that encoded pre-fix behavior, plus new positive-case coverage for peer comments across all issue statuses.

**Files changed:**
- `server/src/routes/issues.ts` — one-line route guard change
- `server/src/__tests__/issue-comment-authz-regression.test.ts` — new AIM-55 regression suite (5 tests)
- `server/src/__tests__/issue-comment-reopen-routes.test.ts` — stale test updated: expect 201 instead of 403 for plain non-assignee agent comment on closed issue
- `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — stale tests updated: removed 'comment' rows from peer-mutation it.each matrices; added 5-status positive-case coverage + cross-company negative case + non-comment mutation gate check

## Effect once merged

#6837 (AIM-65) can be closed as superseded — this PR subsumes its test changes. AIM-64 then unblocks.

## Test plan

- [ ] CI passes on this branch alone (no dependency on #6837)
- [ ] Plain same-company agent comment on any issue status → 201
- [ ] Comment with reopen/resume/interrupt by non-assignee peer → 403 (guard still fires)
- [ ] Cross-company comment → 403 (assertCompanyAccess still first)
- [ ] All other mutations (PATCH/DELETE/document) for peer agents remain gated → 403