### PR TITLE
fix(db): backfill company_secret_bindings for legacy webhook routine_triggers

### DIFF
--- a/packages/db/src/backfill-webhook-secret-bindings-migration.test.ts
+++ b/packages/db/src/backfill-webhook-secret-bindings-migration.test.ts
@@ -1,0 +1,172 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { applyPendingMigrations } from "./client.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./test-embedded-postgres.js";
+
+const MIGRATION_FILE = "0227_backfill_webhook_secret_bindings.sql";
+
+const cleanups: Array<() => Promise<void>> = [];
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function migrationHash(): Promise<string> {
+  const content = await fs.promises.readFile(
+    new URL(`./migrations/${MIGRATION_FILE}`, import.meta.url),
+    "utf8",
+  );
+  return createHash("sha256").update(content).digest("hex");
+}
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres backfill webhook secret bindings migration tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("backfill webhook secret bindings migration", () => {
+  afterEach(async () => Promise.all(cleanups.splice(0).map((cleanup) => cleanup())));
+
+  it(
+    "creates missing bindings for legacy webhook triggers (enabled and disabled) and is idempotent",
+    async () => {
+      const database = await startEmbeddedPostgresTestDatabase(
+        "paperclip-backfill-webhook-bindings-",
+      );
+      cleanups.push(database.cleanup);
+      const sql = postgres(database.connectionString, { max: 1, onnotice: () => {} });
+      cleanups.push(async () => sql.end());
+
+      const companyId = randomUUID();
+      // Each webhook trigger lives on its own routine, mirroring how
+      // services/routines.ts writes bindings with target_id=routine_id.
+      const enabledRoutineId = randomUUID();
+      const disabledRoutineId = randomUUID();
+      const alreadyBoundRoutineId = randomUUID();
+      const enabledSecretId = randomUUID();
+      const disabledSecretId = randomUUID();
+      const alreadyBoundSecretId = randomUUID();
+      const enabledTriggerId = randomUUID();
+      const disabledTriggerId = randomUUID();
+      const alreadyBoundTriggerId = randomUUID();
+
+      await sql`
+        INSERT INTO "companies" ("id", "name", "issue_prefix")
+        VALUES (${companyId}, 'Backfill webhook company', 'BWH')
+      `;
+      for (const routineId of [enabledRoutineId, disabledRoutineId, alreadyBoundRoutineId]) {
+        await sql`
+          INSERT INTO "routines" (
+            "id", "company_id", "title"
+          ) VALUES (
+            ${routineId}, ${companyId}, ${`Legacy routine ${routineId}`}
+          )
+        `;
+      }
+      for (const secretId of [enabledSecretId, disabledSecretId, alreadyBoundSecretId]) {
+        await sql`
+          INSERT INTO "company_secrets" (
+            "id", "company_id", "key", "name"
+          ) VALUES (
+            ${secretId}, ${companyId}, ${`webhookSecret:${secretId}`}, ${`webhook-${secretId}`}
+          )
+        `;
+      }
+      await sql`
+        INSERT INTO "routine_triggers" (
+          "id", "company_id", "routine_id", "kind", "enabled", "secret_id"
+        ) VALUES (
+          ${enabledTriggerId}, ${companyId}, ${enabledRoutineId}, 'webhook', true, ${enabledSecretId}
+        )
+      `;
+      await sql`
+        INSERT INTO "routine_triggers" (
+          "id", "company_id", "routine_id", "kind", "enabled", "secret_id"
+        ) VALUES (
+          ${disabledTriggerId}, ${companyId}, ${disabledRoutineId}, 'webhook', false, ${disabledSecretId}
+        )
+      `;
+      await sql`
+        INSERT INTO "routine_triggers" (
+          "id", "company_id", "routine_id", "kind", "enabled", "secret_id"
+        ) VALUES (
+          ${alreadyBoundTriggerId}, ${companyId}, ${alreadyBoundRoutineId}, 'webhook', true, ${alreadyBoundSecretId}
+        )
+      `;
+      // Pre-existing binding for the third trigger, shaped exactly like
+      // services/routines.ts writes for new triggers (target_id=routine_id).
+      // The backfill must skip it rather than create a duplicate or raise a
+      // unique-violation.
+      await sql`
+        INSERT INTO "company_secret_bindings" (
+          "company_id", "secret_id", "target_type", "target_id", "config_path"
+        ) VALUES (
+          ${companyId}, ${alreadyBoundSecretId}, 'routine', ${alreadyBoundRoutineId},
+          ${`webhookSecret:${alreadyBoundSecretId}`}
+        )
+      `;
+      // Remove any bindings the current schema may have auto-created for the
+      // legacy triggers, so we reproduce the pre-enforcement instance state.
+      await sql`
+        DELETE FROM "company_secret_bindings"
+        WHERE "secret_id" IN (${enabledSecretId}, ${disabledSecretId})
+      `;
+
+      const hash = await migrationHash();
+      await sql`
+        DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = ${hash}
+      `;
+
+      await expect(applyPendingMigrations(database.connectionString)).resolves.toBeUndefined();
+
+      const bindings = await sql<
+        { secret_id: string; target_id: string; config_path: string }[]
+      >`
+        SELECT "secret_id", "target_id", "config_path"
+        FROM "company_secret_bindings"
+        WHERE "company_id" = ${companyId}
+        ORDER BY "secret_id"
+      `;
+      // One backfilled row per legacy trigger (enabled + disabled) plus the
+      // pre-existing binding for the already-bound trigger. Total: three.
+      expect(bindings).toHaveLength(3);
+
+      const bySecret = new Map(bindings.map((row) => [row.secret_id, row]));
+      expect(bySecret.get(enabledSecretId)).toEqual({
+        secret_id: enabledSecretId,
+        target_id: enabledRoutineId,
+        config_path: `webhookSecret:${enabledSecretId}`,
+      });
+      // Disabled triggers must be backfilled too, otherwise re-enabling one
+      // would reintroduce the 422 binding_missing regression.
+      expect(bySecret.get(disabledSecretId)).toEqual({
+        secret_id: disabledSecretId,
+        target_id: disabledRoutineId,
+        config_path: `webhookSecret:${disabledSecretId}`,
+      });
+      expect(bySecret.get(alreadyBoundSecretId)).toEqual({
+        secret_id: alreadyBoundSecretId,
+        target_id: alreadyBoundRoutineId,
+        config_path: `webhookSecret:${alreadyBoundSecretId}`,
+      });
+
+      // Idempotency: replay the migration a second time and expect no new
+      // rows (NOT EXISTS guard + ON CONFLICT DO NOTHING).
+      await sql`
+        DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = ${hash}
+      `;
+      await expect(applyPendingMigrations(database.connectionString)).resolves.toBeUndefined();
+      const afterReplay = await sql<{ count: number }[]>`
+        SELECT count(*)::int AS count
+        FROM "company_secret_bindings"
+        WHERE "company_id" = ${companyId}
+      `;
+      expect(afterReplay[0]?.count).toBe(3);
+    },
+    45_000,
+  );
+});

--- a/packages/db/src/migrations/0227_backfill_webhook_secret_bindings.sql
+++ b/packages/db/src/migrations/0227_backfill_webhook_secret_bindings.sql
@@ -1,0 +1,48 @@
+-- Backfill secret bindings for legacy webhook routine_triggers.
+--
+-- Background: server/src/services/secrets.ts:assertBindingContext enforces
+-- that every secret resolved with consumerType="routine" has a matching row
+-- in company_secret_bindings keyed by
+--   (company_id, secret_id, target_type='routine',
+--    target_id=routine_id::text,
+--    config_path='webhookSecret:'||secret_id::text).
+-- server/src/services/routines.ts inserts that binding when minting a new
+-- webhook trigger, but instances that predate the binding-enforcement release
+-- have webhook triggers without bindings — their stored secret value still
+-- exists but the dispatch path returns HTTP 422 binding_missing, breaking
+-- every legacy webhook trigger after upgrade.
+--
+-- This migration inserts the missing binding rows for every webhook trigger
+-- that references a secret, regardless of the trigger's enabled flag. Covering
+-- disabled triggers too avoids a latent regression: an operator re-enabling a
+-- legacy disabled trigger after this migration runs would otherwise still hit
+-- 422 because services/routines.ts writes the binding only at trigger
+-- creation, never on toggle. Idempotent: the NOT EXISTS guard plus the
+-- ON CONFLICT clause on the (company_id, target_type, target_id, config_path)
+-- unique index make re-runs a no-op (0 rows inserted).
+INSERT INTO "company_secret_bindings" (
+  "company_id",
+  "secret_id",
+  "target_type",
+  "target_id",
+  "config_path"
+)
+SELECT
+  t."company_id",
+  t."secret_id",
+  'routine',
+  t."routine_id"::text,
+  'webhookSecret:' || t."secret_id"::text
+FROM "routine_triggers" t
+WHERE t."kind" = 'webhook'
+  AND t."secret_id" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "company_secret_bindings" b
+    WHERE b."company_id" = t."company_id"
+      AND b."secret_id" = t."secret_id"
+      AND b."target_type" = 'routine'
+      AND b."target_id" = t."routine_id"::text
+      AND b."config_path" = 'webhookSecret:' || t."secret_id"::text
+  )
+ON CONFLICT ("company_id", "target_type", "target_id", "config_path") DO NOTHING;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1576,6 +1576,13 @@
       "when": 1787261199301,
       "tag": "0226_tan_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 227,
+      "version": "7",
+      "when": 1787393190574,
+      "tag": "0227_backfill_webhook_secret_bindings",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routines can be triggered by external webhooks, and each webhook trigger stores a shared secret used for HMAC verification when the dispatcher fires
> - At some point before this PR, `services/secrets.ts:assertBindingContext` started enforcing that every secret resolved with `consumerType="routine"` has a matching row in `company_secret_bindings`; new triggers minted by `services/routines.ts` create that row, but no migration backfilled rows for triggers minted by older releases
> - Result: after upgrading, every legacy webhook trigger fails with HTTP `422 binding_missing` on the next fire — the secret still exists but the binding does not, so dispatch is rejected even though the bearer is valid
> - This pull request adds an idempotent Drizzle backfill migration that inserts the missing binding for every webhook trigger that already references a secret, regardless of the trigger's enabled flag
> - The benefit is that any instance upgrading from a pre-enforcement release recovers its webhook triggers automatically at the next `db:migrate` run, with no manual SQL and no runtime fallback in `assertBindingContext`

## Linked Issues or Issue Description

No pre-existing GitHub issue. Inline description follows the bug template.

## What happened

Legacy webhook `routine_triggers` — those created before `assertBindingContext` began enforcing binding presence — return HTTP `422 binding_missing` on every dispatch after the instance upgrades. The trigger row still holds a valid `secret_id`, and the secret row still holds a resolvable value, but the dispatcher rejects the resolution because `company_secret_bindings` has no matching row for the `(company_id, secret_id, target_type='routine', target_id=routine_id::text, config_path='webhookSecret:'||secret_id::text)` key.

## Expected behavior

Legacy webhook triggers should keep firing after upgrade. The upgrade should reconcile the missing binding rows automatically, with no manual SQL and no operator intervention.

## Steps to reproduce

1. Bring up any Paperclip instance on a release that predates the binding-enforcement change (any snapshot where `services/routines.ts` still writes only `company_secrets` and never inserts into `company_secret_bindings` for new webhook triggers).
2. Create a webhook trigger for a routine. Confirm it fires end-to-end (HTTP 200).
3. Upgrade to the release that enforces bindings in `services/secrets.ts:assertBindingContext`.
4. Fire the webhook trigger again → `POST /api/routine-triggers/public/<publicId>/fire` returns `HTTP 422 {"code":"binding_missing"}`.

## Paperclip version

Reproducible on any master snapshot after the `assertBindingContext` enforcement change (`server/src/services/secrets.ts` throws `binding_missing` when `bindingContext` is missing or unmatched) and before this migration is applied. Confirmed against master @ `3ff636bc4`.

## Deployment mode

Self-hosted Docker (Postgres via `paperclip-db`). The bug is deployment-mode independent — it only depends on whether the instance carries webhook triggers minted before the binding-enforcement release.

## What Changed

- Added `packages/db/src/migrations/0227_backfill_webhook_secret_bindings.sql` — backfills `company_secret_bindings` rows for legacy webhook `routine_triggers` (enabled and disabled) that have a `secret_id` but no matching binding.
- Registered the new migration in `packages/db/src/migrations/meta/_journal.json` (idx 227).
- Added `packages/db/src/backfill-webhook-secret-bindings-migration.test.ts` — end-to-end embedded-Postgres test that seeds legacy triggers (enabled + disabled + already-bound), replays the migration, asserts the two missing bindings are created, and asserts idempotency (a second replay inserts zero rows).

The insert mirrors exactly the shape that `server/src/services/routines.ts` writes for new triggers (`target_type='routine'`, `target_id=routine_id::text`, `config_path='webhookSecret:'||secret_id::text`).

## Verification

Manual instance check before the fix (legacy trigger, no binding):

```
POST /api/routine-triggers/public/<publicId>/fire   →  HTTP 422 {"code":"binding_missing"}
```

After running the backfill on the same instance:

```
POST /api/routine-triggers/public/<publicId>/fire   →  HTTP 200 (dispatchRoutineRun)
```

Repeated runs against an already-mitigated instance return `INSERT 0 0` — the migration is safe to apply repeatedly.

Automated: `packages/db/src/backfill-webhook-secret-bindings-migration.test.ts` seeds three legacy triggers (one enabled, one disabled, one already bound) in an embedded Postgres, runs `applyPendingMigrations`, and asserts:

- Both the enabled and disabled legacy triggers get their bindings backfilled (proves the enabled-filter drop covers disabled triggers).
- The already-bound trigger is left untouched (proves `NOT EXISTS` + `ON CONFLICT DO NOTHING` idempotency, no duplicate rows, no unique-violation).
- A second replay of the migration inserts zero additional rows (proves full idempotency across re-runs).

## Risks

- **Low risk**. Pure data backfill; no DDL, no schema change.
- Idempotent via `NOT EXISTS` + `ON CONFLICT ("company_id","target_type","target_id","config_path") DO NOTHING`. Re-runs insert zero rows.
- Covers all webhook triggers with a non-null `secret_id`, including disabled ones. Covering disabled triggers avoids a latent regression: `services/routines.ts` writes the binding only at trigger *creation*, never on toggle, so re-enabling a legacy disabled trigger after the migration would otherwise still hit 422 `binding_missing`.
- Foreign-key safety: every `routine_triggers.secret_id` already references `company_secrets(id)`, so the FK on `company_secret_bindings.secret_id` is guaranteed to resolve for every inserted row.
- Migration runtime is proportional to the number of webhook triggers per instance — a single insert with a `NOT EXISTS` subquery on indexed columns, expected to be well under a second on any reasonable instance size.

## Model Used

- Provider/model: Anthropic Claude — `claude-opus-4-7` (Opus 4.7).
- Context window: 200K tokens.
- Capabilities used: tool use (PostgreSQL via psql over SSH for the original manual verification, GitHub Contents API for cross-file schema reads on master, internal codebase reads of `services/secrets.ts`, `services/routines.ts`, the existing migration set, and reference migration tests).
- No extended thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass — the new embedded-Postgres migration test seeds legacy triggers, replays the migration, and verifies both backfill and idempotency
- [x] I have added or updated tests where applicable — `packages/db/src/backfill-webhook-secret-bindings-migration.test.ts`
- [x] If this change affects the UI, I have included before/after screenshots — N/A
- [x] I have updated relevant documentation to reflect my changes — the migration body includes a long-form comment explaining the root cause for any operator reading the migration history
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
