### PR TITLE
[codex] Strip Paperclip fields from OpenClaw gateway params

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -273,9 +273,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright
-        run: npx playwright install --with-deps chromium
-
       - name: Generate Paperclip config
         run: |
           mkdir -p ~/.paperclip/instances/default
@@ -294,6 +291,7 @@ jobs:
       - name: Run e2e tests
         env:
           PAPERCLIP_E2E_SKIP_LLM: "true"
+          PAPERCLIP_E2E_BROWSER_CHANNEL: "chrome"
         run: pnpm run test:e2e
 
       - name: Upload Playwright report

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -42,11 +42,9 @@ Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
-Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+Paperclip context delivery:
+- The wake instructions and environment hints are appended to the gateway message text.
+- Top-level paperclip / paperclipPayload fields are stripped from gateway agent params for OpenClaw protocol compatibility.
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -466,62 +466,6 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
   return sections.join("\n");
 }
 
-function buildStandardPaperclipPayload(
-  ctx: AdapterExecutionContext,
-  wakePayload: WakePayload,
-  paperclipEnv: Record<string, string>,
-  payloadTemplate: Record<string, unknown>,
-): Record<string, unknown> {
-  const templatePaperclip = parseObject(payloadTemplate.paperclip);
-  const workspace = asRecord(ctx.context.paperclipWorkspace);
-  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
-    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
-    : [];
-  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
-  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
-    ? ctx.context.paperclipRuntimeServiceIntents.filter(
-        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
-      )
-    : [];
-
-  const standardPaperclip: Record<string, unknown> = {
-    runId: ctx.runId,
-    companyId: ctx.agent.companyId,
-    agentId: ctx.agent.id,
-    agentName: ctx.agent.name,
-    taskId: wakePayload.taskId,
-    issueId: wakePayload.issueId,
-    issueIds: wakePayload.issueIds,
-    wakeReason: wakePayload.wakeReason,
-    wakeCommentId: wakePayload.wakeCommentId,
-    approvalId: wakePayload.approvalId,
-    approvalStatus: wakePayload.approvalStatus,
-    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
-  };
-  const structuredWake = parseObject(ctx.context.paperclipWake);
-  if (Object.keys(structuredWake).length > 0) {
-    standardPaperclip.wake = structuredWake;
-  }
-
-  if (workspace) {
-    standardPaperclip.workspace = workspace;
-  }
-  if (workspaces.length > 0) {
-    standardPaperclip.workspaces = workspaces;
-  }
-  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
-    standardPaperclip.workspaceRuntime = {
-      ...configuredWorkspaceRuntime,
-      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
-    };
-  }
-
-  return {
-    ...templatePaperclip,
-    ...standardPaperclip,
-  };
-}
-
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1130,7 +1074,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1139,7 +1082,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
+  delete agentParams.paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -25,6 +25,17 @@ async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 
   throw new Error("Timed out waiting for condition");
 }
 
+function structuredWakePayloadFromAgentPayload(payload: Record<string, unknown>) {
+  const message = String(payload.message ?? "");
+  const marker = "Structured wake payload JSON:\n```json\n";
+  const start = message.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const rest = message.slice(start + marker.length);
+  const end = rest.indexOf("\n```");
+  expect(end).toBeGreaterThanOrEqual(0);
+  return JSON.parse(rest.slice(0, end)) as Record<string, unknown>;
+}
+
 async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
@@ -454,11 +465,10 @@ describe("heartbeat comment wake batching", () => {
         return statusesByRunId.get(firstRun!.id) === "succeeded" && statusesByRunId.get(secondRunId) === "succeeded";
       }, 90_000);
 
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [comment2.id, comment3.id],
-          latestCommentId: comment3.id,
-        },
+      expect(secondPayload).not.toHaveProperty("paperclip");
+      expect(structuredWakePayloadFromAgentPayload(secondPayload)).toMatchObject({
+        commentIds: [comment2.id, comment3.id],
+        latestCommentId: comment3.id,
       });
       expect(String(secondPayload.message ?? "")).toContain("Second comment");
       expect(String(secondPayload.message ?? "")).toContain("Third comment");
@@ -593,30 +603,17 @@ describe("heartbeat comment wake batching", () => {
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
       const promotedPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(promotedPayload.paperclip).toMatchObject({
-        wake: {
-          commentIds: [queuedComment.id],
-          latestCommentId: queuedComment.id,
-          comments: [
-            expect.objectContaining({
-              id: queuedComment.id,
-              authorType: "user",
-              body: "Queued follow-up",
-              presentation: expect.objectContaining({
-                kind: "system_notice",
-                tone: "warning",
-              }),
-              metadata: expect.objectContaining({
-                version: 1,
-              }),
-            }),
-          ],
-          commentWindow: {
-            requestedCount: 1,
-            includedCount: 1,
-            missingCount: 0,
-          },
-        },
+      expect(promotedPayload).not.toHaveProperty("paperclip");
+      expect(structuredWakePayloadFromAgentPayload(promotedPayload)).toMatchObject({
+        commentIds: [queuedComment.id],
+        latestCommentId: queuedComment.id,
+        comments: [
+          expect.objectContaining({
+            id: queuedComment.id,
+            authorType: "user",
+            body: "Queued follow-up",
+          }),
+        ],
       });
       expect(String(promotedPayload.message ?? "")).toContain("Queued follow-up");
 
@@ -802,18 +799,17 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
-            status: "in_progress",
-            priority: "medium",
-          },
+      expect(secondPayload).not.toHaveProperty("paperclip");
+      expect(structuredWakePayloadFromAgentPayload(secondPayload)).toMatchObject({
+        reason: "issue_commented",
+        commentIds: [comment2.id],
+        latestCommentId: comment2.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Reopen after deferred comment",
+          status: "in_progress",
+          priority: "medium",
         },
       });
       expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
@@ -1002,18 +998,17 @@ describe("heartbeat comment wake batching", () => {
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_comment_mentioned",
-          commentIds: [comment.id],
-          latestCommentId: comment.id,
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Do not reopen from agent mention",
-            status: "done",
-            priority: "medium",
-          },
+      expect(secondPayload).not.toHaveProperty("paperclip");
+      expect(structuredWakePayloadFromAgentPayload(secondPayload)).toMatchObject({
+        reason: "issue_comment_mentioned",
+        commentIds: [comment.id],
+        latestCommentId: comment.id,
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Do not reopen from agent mention",
+          status: "done",
+          priority: "medium",
         },
       });
       expect(String(secondPayload.message ?? "")).toContain("please review after I finish");
@@ -1088,19 +1083,18 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
-        wake: {
-          reason: "issue_assigned",
-          issue: {
-            id: issueId,
-            identifier: `${issuePrefix}-1`,
-            title: "Require a comment",
-            status: "in_progress",
-            priority: "medium",
-          },
-          checkedOutByHarness: true,
-          commentIds: [],
+      expect(firstPayload).not.toHaveProperty("paperclip");
+      expect(structuredWakePayloadFromAgentPayload(firstPayload)).toMatchObject({
+        reason: "issue_assigned",
+        issue: {
+          id: issueId,
+          identifier: `${issuePrefix}-1`,
+          title: "Require a comment",
+          status: "in_progress",
+          priority: "medium",
         },
+        checkedOutByHarness: true,
+        commentIds: [],
       });
       expect(String(firstPayload.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(firstPayload.message ?? "")).toContain("Do not switch to another issue until you have handled this wake.");

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -410,6 +410,12 @@ describe("openclaw gateway adapter execute", () => {
             },
             payloadTemplate: {
               message: "wake now",
+              paperclip: {
+                legacy: true,
+              },
+              paperclipPayload: {
+                legacy: true,
+              },
             },
             waitTimeoutMs: 2000,
           },
@@ -502,12 +508,8 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      expect(payload).not.toHaveProperty("paperclip");
+      expect(payload).not.toHaveProperty("paperclipPayload");
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -8,6 +8,7 @@ import { defineConfig } from "@playwright/test";
 const PORT = Number(process.env.PAPERCLIP_E2E_PORT ?? 3199);
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const PAPERCLIP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-e2e-home-"));
+const BROWSER_CHANNEL = process.env.PAPERCLIP_E2E_BROWSER_CHANNEL as "chrome" | undefined;
 
 export default defineConfig({
   testDir: ".",
@@ -26,7 +27,7 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { browserName: "chromium" },
+      use: { browserName: "chromium", channel: BROWSER_CHANNEL },
     },
   ],
   // The webServer directive bootstraps a throwaway instance and then starts it.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The OpenClaw gateway adapter is the bridge that invokes OpenClaw agents through the gateway WebSocket protocol.
> - OpenClaw v4 validates gateway `agent` params strictly and rejects unexpected top-level properties.
> - Paperclip was sending standard metadata as top-level `paperclip` / `paperclipPayload` params, matching the live NOX-5148 outage signature: `invalid agent params: unexpected property paperclip`.
> - NOX-5148 was stabilized with a runtime hotpatch that stripped those fields before gateway dispatch.
> - This pull request upstreams that stage-2 hotpatch into the adapter and aligns tests/docs with the message/env-hint context path.
> - The benefit is that OpenClaw gateway agents keep receiving wake context without violating the gateway protocol.

## What Changed

- Removed generated top-level `paperclip` from outbound OpenClaw gateway `agent` params.
- Strip template-provided `paperclip` and `paperclipPayload` after applying `payloadTemplate`, before sending the gateway request.
- Kept wake context delivery through the gateway message text and Paperclip environment hints.
- Updated adapter docs to describe the new context delivery path and protocol-compatible stripping behavior.
- Updated focused gateway adapter and heartbeat wake batching tests to assert wake data is preserved in message text while top-level Paperclip params are absent.
- Updated CI e2e browser configuration to use the GitHub-hosted runner Chrome channel, avoiding the Playwright browser download hang seen on PR #6847.

## Verification

- `pnpm exec vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts` -> 1 file passed, 7 tests passed
- `pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts` -> 1 file passed, 9 tests passed
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck` -> passed
- `pnpm --filter @paperclipai/adapter-openclaw-gateway build` -> passed
- CI on commit `554cfecc2c0c449b9a963dedf152dfcab70862fe`: policy, Typecheck + Release Registry, General tests (server), General tests (workspaces-a/b), Build, Verify serialized server suites 1-4, Canary Dry Run, e2e, verify, and Snyk all pass.

## Risks

- Low runtime risk. This upstreams a live hotpatch already used to recover NOX-5148 and removes fields OpenClaw v4 rejects.
- Behavioral shift: consumers must not rely on top-level `agentParams.paperclip`; wake context is available from message text and env hints instead.
- No migration is required for stored data.

## Model Used

- OpenAI Codex, GPT-5 class coding agent in this Paperclip/Codex runtime.
- Exact exposed model identifier was not provided by the runtime; the session used tool-enabled code execution, git, GitHub CLI, and local test commands.
- Reasoning mode: standard coding-agent reasoning with repository inspection and focused verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge