### PR TITLE
fix(adapter-claude-local): classify ConnectionRefused as transient upstream error

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -109,6 +109,27 @@ describe("isClaudeTransientUpstreamError", () => {
       }),
     ).toBe(false);
   });
+
+  it("classifies local CLI connection failures as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({ stderr: "Error: connect ECONNREFUSED 127.0.0.1:35345" }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({ errorMessage: "ConnectionRefused: unable to connect to api" }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({ stderr: "Error: getaddrinfo ENOTFOUND api.anthropic.com" }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({ stderr: "Error: connect EHOSTUNREACH 192.168.1.1" }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({ stderr: "Error: connect ETIMEDOUT 1.2.3.4:443" }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({ errorMessage: "socket hang up" }),
+    ).toBe(true);
+  });
 });
 
 describe("isClaudePoisonedPreviousMessageIdError", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,7 +10,7 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|unable\s+to\s+connect\s+to\s+api|connectionrefused|econnrefused|enotfound|ehostunreach|etimedout|socket\s+hang\s+up)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs agents via `claude_local` which spawns a local Claude CLI process for each heartbeat
> - When the local Claude binary is unreachable (connection refused, DNS failure, network timeout), the adapter receives error strings like `ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`, or `socket hang up`
> - The existing `CLAUDE_TRANSIENT_UPSTREAM_RE` regex did not match any of these local-connection error patterns
> - Without a transient match, the heartbeat run is finalized as `adapter_failed` with no retry classification — the agent stays unreachable until manually reassigned
> - Fix: extend `CLAUDE_TRANSIENT_UPSTREAM_RE` to also match `ConnectionRefused`, `ECONNREFUSED`, `ENOTFOUND`, `EHOSTUNREACH`, `ETIMEDOUT`, and `socket hang up` — these are all network-layer transient errors that warrant an automatic retry

## Linked Issues or Issue Description

Fixes #6731

## What Changed

- `packages/adapters/claude-local/src/server/parse.ts`: extended `CLAUDE_TRANSIENT_UPSTREAM_RE` to include local-CLI connection failure patterns (`unable to connect to api`, `connectionrefused`, `econnrefused`, `enotfound`, `ehostunreach`, `etimedout`, `socket hang up`)

## Verification

1. Network unreachable error string `ECONNREFUSED 127.0.0.1:35345` → `isClaudeTransientUpstreamError` returns `true` → heartbeat retries instead of finalizing as `adapter_failed`
2. Existing test suite passes: `pnpm exec vitest run packages/adapters/claude-local/src/server/parse.test.ts`

## Risks

Low: the regex extension only adds new positive-match patterns. Existing matches are unchanged. Network transient errors will now trigger retries instead of permanent failure — this is the intended behavior for unreachable-binary scenarios.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge