### PR TITLE
ci(e2e): add Playwright browser cache + increase timeout to 60 min

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -253,7 +253,7 @@ jobs:
   e2e:
     needs: [policy]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - name: Checkout repository
@@ -274,6 +274,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -286,6 +287,13 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install chromium
+
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/package.json') }}
 
       - name: Generate Paperclip config
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -281,8 +281,11 @@ jobs:
           restore-keys: |
             playwright-chromium-${{ runner.os }}-
 
-      - name: Install Playwright
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
 
       - name: Generate Paperclip config
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -253,7 +253,12 @@ jobs:
   e2e:
     needs: [policy]
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 20
+    # Use the official Playwright image so Chromium is pre-installed — no runtime
+    # browser download needed. The image is tagged to match the @playwright/test
+    # version locked in pnpm-lock.yaml (1.58.2), guaranteeing binary compatibility.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-jammy
 
     steps:
       - name: Checkout repository
@@ -263,37 +268,20 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.4
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install dependencies
+        # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD prevents the playwright package's
+        # postinstall script from re-downloading browsers that are already in
+        # the container image at /ms-playwright.
         run: pnpm install --frozen-lockfile
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            playwright-chromium-${{ runner.os }}-
-
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps chromium
-
-      - name: Install Playwright browsers
-        run: npx playwright install chromium
-
-      - name: Save Playwright browser cache
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
       - name: Generate Paperclip config
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -253,7 +253,7 @@ jobs:
   e2e:
     needs: [policy]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -272,6 +272,14 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
 
       - name: Install Playwright
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -253,7 +253,7 @@ jobs:
   e2e:
     needs: [policy]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and exposes a CI workflow on the upstream \`paperclipai/paperclip\` repo
> - The \`e2e\` job in \`.github/workflows/pr.yml\` runs Playwright browser tests against the full Paperclip stack
> - On GitHub Actions ubuntu-latest runners, the Chromium binary download is very slow (~90 min due to network bottleneck)
> - The original \`timeout-minutes: 30\` with no browser cache caused every cold-runner e2e to time out before tests start
> - Root cause: \`playwright install --with-deps chromium\` bundles apt install + binary download; download takes ~90 min; every prior timeout was exceeded by exactly ~13 sec
> - Fix: separate apt from binary download, increase timeout to 120 min, add explicit cache save immediately after download so future runs are warm (~4 min)

## What Changed

- Added \`actions/cache@v4\` step (id: \`playwright-cache\`) to restore \`~/.cache/ms-playwright\` (keyed on \`runner.os\` + hash of all \`package.json\` files)
- Split \`playwright install --with-deps chromium\` into two steps:
  - \`playwright install-deps chromium\` — apt system packages (~14 sec on ubuntu-latest; packages pre-installed)
  - \`playwright install chromium\` — browser binary download only (~90 min cold, ~1 sec warm cache hit)
- Added explicit \`actions/cache/save@v4\` step right after browser download (skipped on cache hit), so the browser binary is persisted even if subsequent steps fail or time out
- Increased \`timeout-minutes\` from 30 → 120 to accommodate cold-cache browser download (~90 min + tests ~3 min = ~93 min total)

## Verification

- Run 26587313984 (60-min timeout): \`--with-deps\` timed out at exactly 60 min (exceeded by 13 sec)
- Run 26591479437 (90-min timeout): browser download took 89 min 27 sec; timed out at 89 min 14 sec (again 13 sec short); cache not saved
- Run 26596468805 (120-min timeout + explicit cache save): in progress — cold download expected ~90 min + tests ~3 min = ~93 min → fits in 120 min
- After first successful run: cache primed → subsequent runs complete in ~4 min
- Non-e2e checks: 13/13 PASS on all runs ✅

## Risks

Low risk — CI infrastructure change only; no application code modified. The cache key includes a hash of all \`package.json\` files, so Playwright version bumps automatically bust the cache. Worst case on cache miss: cold download (~90 min) → completes within 120-min timeout. The explicit cache save ensures the browser binary is persisted regardless of subsequent step outcomes.

## Model Used

claude-sonnet-4-6

## Checklist

- [x] CI infrastructure only — no application logic changed
- [x] Timeout sized for observed worst-case download time (90 min) with buffer
- [x] Cache save is idempotent (skipped on hit, explicit save on miss)
- [x] Separate apt/binary steps so apt overhead (~14 sec) doesn't count against download budget