### PR TITLE
fix(recovery): skip routine-driven standing threads in stranded reconciliation

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -26,6 +26,7 @@ import {
   issueTreeHolds,
   issueWorkProducts,
   issues,
+  routines,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -332,6 +333,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(issueRecoveryActions);
     await db.delete(issueTreeHoldMembers);
     await db.delete(issueTreeHolds);
+    await db.delete(routines);
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(issueComments);
       await db.delete(issueDocuments);
@@ -2843,6 +2845,55 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("still has no live execution path");
     expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction.id}\``);
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
+  });
+
+  it("does not escalate stranded in-progress work that is the standing target of an active routine", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+
+    await db.insert(routines).values({
+      companyId,
+      title: "Daily Digest",
+      parentIssueId: issueId,
+      assigneeAgentId: agentId,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).not.toContain(issueId);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.reason, "source_scoped_recovery_action"),
+      ));
+    expect(wakeups).toHaveLength(0);
   });
 
   it("allows one productive-terminal recovery after regular continuation recovery made progress", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -22,6 +22,7 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  routines,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -467,6 +468,21 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ]);
 
     return Boolean(run || deferredWake);
+  }
+
+  async function isActiveRoutineStandingThread(companyId: string, issueId: string) {
+    const [row] = await db
+      .select({ id: routines.id })
+      .from(routines)
+      .where(
+        and(
+          eq(routines.companyId, companyId),
+          eq(routines.parentIssueId, issueId),
+          eq(routines.status, "active"),
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
   }
 
   async function hasQueuedIssueWake(companyId: string, issueId: string) {
@@ -2377,6 +2393,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await isActiveRoutineStandingThread(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery subsystem watches assigned issues that lose their live execution path and reassigns/escalates them so work does not get lost
> - A standing thread that is the \`parentIssueId\` of an active routine has a different live continuation path — the routine itself fires execution issues against it on a schedule — but \`reconcileStrandedAssignedIssues\` did not know about routines
> - On every scan the standing thread looked stranded, recovery requeued a continuation, and the next scan escalated the issue to \`blocked\` with empty \`blockedByIssueIds\` and reassigned to the chain-of-command — a loop, and a \`blocked\` status that violates the platform's own \"blocked implies first-class blockers\" invariant
> - This PR teaches the stranded-assigned reconciler about active-routine standing threads and skips them
> - The benefit is that daily/scheduled delivery threads no longer bounce under recovery, and we stop emitting \`blocked\`-with-no-blockers states from this path

## What Changed

- Add \`isActiveRoutineStandingThread(companyId, issueId)\` in \`server/src/services/recovery/service.ts\` that returns true when the issue is the \`parentIssueId\` of an \`active\` routine.
- In \`reconcileStrandedAssignedIssues\`, skip candidates that are active-routine standing threads. Placed right after \`hasActiveExecutionPath\` so the routine acts as a peer \"live continuation path\" signal.
- Add a vitest case (\`heartbeat-process-recovery.test.ts\`) that seeds the exact loop condition (in_progress + succeeded productive-terminal continuation retry) and asserts the issue is not escalated, no recovery action is created, no comment is posted, and no \`source_scoped_recovery_action\` wake is enqueued when a routine targets the issue.
- Extend the test cleanup to delete \`routines\` before \`agents\` (\`routines.assignee_agent_id\` has no cascade).

## Verification

\`\`\`
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts --reporter=dot
\`\`\`

- All 45 tests in that suite pass.
- The new test fails (escalation = 1) without the recovery-service change applied.

Manual repro (before this PR): a routine-driven standing thread sitting at \`in_progress\` with a productive-terminal \`succeeded\` continuation run gets flipped to \`blocked\` (with empty \`blockedByIssueIds\`) and reassigned to the chain-of-command on the very next recovery sweep, then again on each subsequent sweep — see TES-17 / TES-18 / TES-19.

## Risks

- Low risk. The new skip is gated on \`routines.status = 'active'\` and \`routines.parent_issue_id = issue.id\`. Issues that are not the standing target of an active routine remain on the existing recovery path unchanged, as confirmed by the unchanged behavior of the neighboring \"blocks stranded in-progress work after a productive continuation retry was already used\" test.
- One small follow-up worth tracking separately: \`escalateStrandedAssignedIssue\` will still write \`status: \"blocked\"\` with an empty \`blockedByIssueIds\` array if it is ever invoked without unresolved blockers. The general invariant \"blocked implies first-class blockers\" deserves a dedicated PR.