### PR TITLE
fix(claude-local): classify 'session limit' as transient upstream error for auto-retry

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -50,6 +50,22 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(true);
   });
 
+  it("classifies Claude Code 'session limit' wording as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          is_error: true,
+          result: "You've hit your session limit · resets 2:40pm (America/New_York)",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeTransientUpstreamError({
+        errorMessage: "You've hit your session limit · resets 2:40pm (America/New_York)",
+      }),
+    ).toBe(true);
+  });
+
   it("classifies the subscription 5-hour / weekly limit wording", () => {
     expect(
       isClaudeTransientUpstreamError({
@@ -113,6 +129,21 @@ describe("extractClaudeRetryNotBefore", () => {
       now,
     );
     expect(extracted?.toISOString()).toBe("2026-04-23T03:15:00.000Z");
+  });
+
+  it("parses the reset time from 'session limit' message", () => {
+    const now = new Date("2026-05-28T17:00:00.000Z");
+    const extracted = extractClaudeRetryNotBefore(
+      {
+        parsed: {
+          is_error: true,
+          result: "You've hit your session limit · resets 2:40pm (America/New_York)",
+        },
+      },
+      now,
+    );
+    // 2:40pm America/New_York = 18:40 UTC on 2026-05-28
+    expect(extracted?.toISOString()).toBe("2026-05-28T18:40:00.000Z");
   });
 
   it("returns null when no reset hint is present", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,9 +10,9 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|session\s+limit)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
-  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached|session\s+limit)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that run Claude Code CLI as their execution adapter
> - The `claude-local` adapter classifies run failures via `isClaudeTransientUpstreamError` to determine if a bounded retry should be scheduled
> - Claude Code emits `"You've hit your session limit · resets 2:40pm (America/New_York)"` when the user's Claude Pro/Max session window is exhausted
> - This message was not matched by `CLAUDE_TRANSIENT_UPSTREAM_RE` (no `session limit` pattern), so the run was recorded as a hard failure with no retry scheduled
> - The reset timestamp (`resets 2:40pm`) was also not extracted by `CLAUDE_EXTRA_USAGE_RESET_RE` for the same reason, so agents could not honor the reset window even if the error family was correct
> - This PR adds `session\s+limit` to both regexes so the session-limit message is treated as transient, and the retry is scheduled at the exact reset time Claude reported
> - The benefit is that agents auto-resume at the reset time without human intervention, matching behavior that already works for extra-usage and 5-hour limit messages

## What Changed

- Added `session\s+limit` to `CLAUDE_TRANSIENT_UPSTREAM_RE` in `parse.ts` so `isClaudeTransientUpstreamError` returns `true` for `"You've hit your session limit"` messages
- Added `session\s+limit` to `CLAUDE_EXTRA_USAGE_RESET_RE` in `parse.ts` so `extractClaudeRetryNotBefore` parses the `resets 2:40pm (America/New_York)` timestamp from the same message
- Added two new test cases in `parse.test.ts` covering both `isClaudeTransientUpstreamError` and `extractClaudeRetryNotBefore` for the session-limit message format

## Verification

```bash
npx vitest run packages/adapters/claude-local/src/server/parse.test.ts
# → 11 tests pass (9 existing + 2 new)
```

The existing `scheduleBoundedRetryForRun` pipeline in `server/src/services/heartbeat.ts` already handles the rest: once `errorFamily` is `transient_upstream` and `retryNotBefore` is set, it schedules a `scheduled_retry` run at the reset time. No server changes needed.

## Risks

Low risk. Two regex additions to an existing pattern set. The patterns are narrow (`session\s+limit`) and do not overlap with existing login/auth/max-turns classifiers. The `isClaudeTransientUpstreamError` guard already excludes login-required and unknown-session messages before reaching the regex.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Mode: tool use / agentic (running as a Paperclip CEO agent heartbeat)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge