### PR TITLE
fix: sprint batch 1 — openclaw v4, deep merge, secrets CLI, Windows paths, company prefix, markdown render

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -106,6 +106,20 @@ import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
 
+function deepMerge(base: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    const existing = base[key];
+    if (value !== null && typeof value === "object" && !Array.isArray(value) &&
+        existing !== null && typeof existing === "object" && !Array.isArray(existing)) {
+      result[key] = deepMerge(existing as Record<string, unknown>, value as Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
   if (!Number.isFinite(parsed)) return RUN_LOG_DEFAULT_LIMIT_BYTES;


### PR DESCRIPTION
## Summary

Batch of 10 bug fixes from the overnight sprint.

### Fixes
- GH#6747: openclaw-gateway PROTOCOL_VERSION 3→4
- GH#6625: remove paperclip root field from openclaw-gateway payloads
- GH#6628: PATCH /api/agents/:id deep-merges adapterConfig (not shallow)
- GH#6817: CLI secrets rotate and delete commands added
- GH#6805: process adapter quotes paths on Windows for spaces in usernames
- GH#6634 / GH#6484: isIssuePrefixConflict unwraps DrizzleQueryError.cause chain
- GH#6800: interaction reject preserves reason field
- GH#6653: request_confirmation prompt renders as markdown in UI
- GH#6845: billingCode shown in issue Properties panel
- Fix malformed finalizeAgentStatus from prior partial edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)