### PR TITLE
fix(heartbeat): resolve non-UUID skill identifiers and prevent Promise.all skill-load failure

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -10,6 +10,7 @@ import {
   buildRuntimeMountedSkillSnapshot,
   buildInvocationEnvForLogs,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  listPaperclipSkillEntries,
   materializePaperclipSkillCopy,
   refreshPaperclipWorkspaceEnvForExecution,
   renderPaperclipWakePrompt,
@@ -1159,5 +1160,56 @@ describe("appendWithByteCap", () => {
     expect(output).not.toContain("\uFFFD");
     expect(Buffer.from(output, "utf8").toString("utf8")).toBe(output);
     expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("listPaperclipSkillEntries", () => {
+  it("returns one entry per skill subdirectory, ignoring non-directories", async () => {
+    const skillsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-entries-test-"));
+    try {
+      const skillNames = ["skill-a", "skill-b", "skill-c"];
+      for (const name of skillNames) {
+        await fs.mkdir(path.join(skillsRoot, name), { recursive: true });
+      }
+      await fs.writeFile(path.join(skillsRoot, "not-a-dir.txt"), "ignored");
+
+      // Pass the skillsRoot as an additionalCandidate so resolvePaperclipSkillsDir finds it
+      const entries = await listPaperclipSkillEntries("/dummy", [skillsRoot]);
+      expect(entries).toHaveLength(3);
+      const names = entries.map((e) => e.runtimeName).sort();
+      expect(names).toEqual(["skill-a", "skill-b", "skill-c"]);
+      for (const entry of entries) {
+        expect(entry.key).toBe(`paperclipai/paperclip/${entry.runtimeName}`);
+        expect(entry.source).toBe(path.join(skillsRoot, entry.runtimeName));
+        expect(typeof entry.required).toBe("boolean");
+      }
+    } finally {
+      await fs.rm(skillsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty array when the skills root directory does not exist", async () => {
+    const nonExistentDir = path.join(os.tmpdir(), `no-such-skills-dir-${randomUUID()}`);
+    const entries = await listPaperclipSkillEntries("/dummy", [nonExistentDir]);
+    expect(entries).toEqual([]);
+  });
+
+  it("reads required:false from SKILL.md frontmatter", async () => {
+    const skillsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "skill-entries-required-"));
+    try {
+      const skillDir = path.join(skillsRoot, "optional-skill");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir, "SKILL.md"),
+        "---\nrequired: false\n---\n# Optional Skill\n",
+      );
+
+      const entries = await listPaperclipSkillEntries("/dummy", [skillsRoot]);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.required).toBe(false);
+      expect(entries[0]!.requiredReason).toBeNull();
+    } finally {
+      await fs.rm(skillsRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1410,9 +1410,13 @@ export async function listPaperclipSkillEntries(
           : null,
       };
     }));
-    return results
-      .filter((result): result is PromiseFulfilledResult<PaperclipSkillEntry> => result.status === "fulfilled")
-      .map((result) => result.value);
+    const fulfilled: PaperclipSkillEntry[] = [];
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        fulfilled.push(result.value);
+      }
+    }
+    return fulfilled;
   } catch {
     return [];
   }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1397,7 +1397,7 @@ export async function listPaperclipSkillEntries(
   try {
     const entries = await fs.readdir(root, { withFileTypes: true });
     const dirs = entries.filter((entry) => entry.isDirectory());
-    return Promise.all(dirs.map(async (entry) => {
+    const results = await Promise.allSettled(dirs.map(async (entry) => {
       const skillDir = path.join(root, entry.name);
       const required = await readSkillRequired(skillDir);
       return {
@@ -1410,6 +1410,9 @@ export async function listPaperclipSkillEntries(
           : null,
       };
     }));
+    return results
+      .filter((result): result is PromiseFulfilledResult<PaperclipSkillEntry> => result.status === "fulfilled")
+      .map((result) => result.value);
   } catch {
     return [];
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -615,21 +615,39 @@ async function resolveRunScopedMentionedSkillKeys(input: {
   ]);
   if (mentionedSkillIds.length === 0) return [];
 
-  const skillRows = await input.db
-    .select({
-      id: companySkillsTable.id,
-      key: companySkillsTable.key,
-    })
-    .from(companySkillsTable)
-    .where(
-      and(
-        eq(companySkillsTable.companyId, input.companyId),
-        inArray(companySkillsTable.id, mentionedSkillIds),
-      ),
-    );
-  const skillKeyById = new Map(skillRows.map((row) => [row.id, row.key]));
+  const uuidIds = mentionedSkillIds.filter((id) => isUuidLike(id));
+  const nonUuidIds = mentionedSkillIds.filter((id) => !isUuidLike(id));
+
+  const [byIdRows, byKeyRows] = await Promise.all([
+    uuidIds.length > 0
+      ? input.db
+          .select({ id: companySkillsTable.id, key: companySkillsTable.key })
+          .from(companySkillsTable)
+          .where(
+            and(
+              eq(companySkillsTable.companyId, input.companyId),
+              inArray(companySkillsTable.id, uuidIds),
+            ),
+          )
+      : Promise.resolve([]),
+    nonUuidIds.length > 0
+      ? input.db
+          .select({ id: companySkillsTable.id, key: companySkillsTable.key })
+          .from(companySkillsTable)
+          .where(
+            and(
+              eq(companySkillsTable.companyId, input.companyId),
+              inArray(companySkillsTable.key, nonUuidIds),
+            ),
+          )
+      : Promise.resolve([]),
+  ]);
+
+  const skillKeyById = new Map([...byIdRows, ...byKeyRows].map((row) => [row.id, row.key]));
+  const skillKeyByKey = new Map(byKeyRows.map((row) => [row.key, row.key]));
+
   return mentionedSkillIds
-    .map((skillId) => skillKeyById.get(skillId) ?? null)
+    .map((skillId) => skillKeyById.get(skillId) ?? skillKeyByKey.get(skillId) ?? null)
     .filter((skillKey): skillKey is string => Boolean(skillKey));
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs agents via adapters — the heartbeat process resolves skill mentions (e.g. `skill://paperclipai/paperclip/diagnose-why-work-stopped`) by looking up `companySkills` rows by UUID
> - Skill identifiers can be either UUIDs (row IDs) or human-readable key strings — but the existing lookup only queries by `id`, so non-UUID skill keys return no results and the mention is silently dropped
> - Separately, `listPaperclipSkillEntries` in `adapter-utils` used `Promise.all`, meaning one failed skill directory read would reject the entire batch and block the heartbeat from seeing any skills at all
> - Fix 1: split `mentionedSkillIds` into UUID vs non-UUID groups; run two parallel queries — one by `id`, one by `key` — then merge results
> - Fix 2: replace `Promise.all` with `Promise.allSettled` + for-of loop to filter fulfilled results, so one bad entry doesn't poison the batch
> - Add regression tests for `listPaperclipSkillEntries` covering: normal directory listing (non-directories ignored), missing root, and `required: false` SKILL.md frontmatter

## Linked Issues or Issue Description

Fixes #6226

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: replaced `Promise.all` with `Promise.allSettled` + explicit for-of loop in `listPaperclipSkillEntries` — one failed entry no longer rejects the batch
- `server/src/services/heartbeat.ts`: `resolveRunScopedMentionedSkillKeys` now splits mentioned IDs into UUID vs non-UUID groups and queries `companySkills` by both `id` (UUIDs) and `key` (non-UUIDs), then merges results
- `packages/adapter-utils/src/server-utils.test.ts`: 3 new tests for `listPaperclipSkillEntries`

## Verification

1. `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts` — all 42 tests pass including 3 new ones
2. Heartbeat with a non-UUID skill mention (e.g. `skill://paperclipai/paperclip/diagnose-why-work-stopped`) now resolves the key correctly instead of silently returning null

## Risks

Low: the heartbeat change is additive — the UUID path is unchanged; the non-UUID path is a new parallel query whose results are merged. The `Promise.allSettled` change is defensive: fulfilled entries are returned exactly as before, rejected entries are now silently skipped instead of causing a batch failure.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge