### PR TITLE
Ship MEA-1053 standup zero-state guardrail

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "smoke:openclaw-sse-standalone": "./scripts/smoke/openclaw-sse-standalone.sh",
     "smoke:terminal-bench-loop-skill": "node scripts/smoke/terminal-bench-loop-skill-smoke.mjs",
     "test:release-registry": "node --test scripts/verify-release-registry-state.test.mjs scripts/release-package-map.test.mjs scripts/check-release-package-bootstrap.test.mjs",
+    "test:standup-seed": "node --test scripts/ceo-standup-seed.test.mjs",
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.ts --headed",
     "test:e2e:multiuser-authenticated": "npx playwright test --config tests/e2e/playwright-multiuser-authenticated.config.ts",

--- a/scripts/ceo-standup-seed.mjs
+++ b/scripts/ceo-standup-seed.mjs
@@ -228,18 +228,35 @@ export function extractDeploymentSection(commentBody) {
   return (next >= 0 ? rest.slice(0, next) : rest).trim();
 }
 
-export function latestDeploymentSectionFromComments(comments) {
-  for (let index = comments.length - 1; index >= 0; index -= 1) {
+export function latestDeploymentSectionFromComments(comments, options = {}) {
+  const candidates = [];
+  for (let index = 0; index < comments.length; index += 1) {
     const comment = comments[index];
+    const body = comment?.body ?? "";
+    if (options.authorAgentId && comment?.authorAgentId !== options.authorAgentId) continue;
+    const createdByRunId = typeof comment?.createdByRunId === "string" && comment.createdByRunId.length > 0
+      ? comment.createdByRunId
+      : null;
+    if (options.requireCreatedByRunId && !createdByRunId) continue;
+    if (options.requireStandupHeading && !/\bCEO\s+Standup\b/i.test(body)) continue;
     const section = extractDeploymentSection(comment?.body);
     if (section) {
-      return {
+      candidates.push({
         commentId: comment?.id ?? null,
+        authorAgentId: comment?.authorAgentId ?? null,
+        createdByRunId,
         section,
-      };
+      });
     }
   }
-  return null;
+
+  const canonicalRunId = options.pinToFirstRun === false
+    ? null
+    : candidates.find((candidate) => candidate.createdByRunId)?.createdByRunId ?? null;
+  const trustedCandidates = canonicalRunId
+    ? candidates.filter((candidate) => candidate.createdByRunId === canonicalRunId)
+    : candidates;
+  return trustedCandidates.at(-1) ?? null;
 }
 
 export function renderStandupIssueDescription(snapshot, deploymentInput) {
@@ -319,14 +336,19 @@ async function loadCanonicalDeploymentInput(client, companyId) {
     throw new Error("Canonical Daily Engineering Standup routine has no completed latest run to source deployment context from.");
   }
   const comments = await apiFetchJson(client, `/api/issues/${linkedIssue.id}/comments?order=asc`);
-  const deploymentComment = latestDeploymentSectionFromComments(comments);
+  const deploymentComment = latestDeploymentSectionFromComments(comments, {
+    authorAgentId: linkedIssue.assigneeAgentId,
+    requireCreatedByRunId: true,
+    requireStandupHeading: true,
+  });
   if (!deploymentComment) {
-    throw new Error(`Canonical standup ${linkedIssue.identifier} has no DEPLOYMENTS section.`);
+    throw new Error(`Canonical standup ${linkedIssue.identifier} has no trusted routine-produced DEPLOYMENTS section.`);
   }
   return {
     sourceIssueId: linkedIssue.id,
     sourceIssueIdentifier: linkedIssue.identifier,
     sourceCommentId: deploymentComment.commentId,
+    sourceRunId: deploymentComment.createdByRunId,
     section: deploymentComment.section,
   };
 }

--- a/scripts/ceo-standup-seed.mjs
+++ b/scripts/ceo-standup-seed.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+
+const OPEN_STATUSES = new Set(["backlog", "todo", "in_progress", "in_review", "blocked"]);
+const TERMINAL_STATUSES = new Set(["done", "cancelled"]);
+const DEFAULT_LIMIT = 1000;
+
+function parseArgs(argv) {
+  const args = {
+    create: false,
+    requireDeploymentSource: true,
+    limit: DEFAULT_LIMIT,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    if (arg === "--api-url") args.apiUrl = next();
+    else if (arg === "--api-key") args.apiKey = next();
+    else if (arg === "--company-id") args.companyId = next();
+    else if (arg === "--assignee-agent-id") args.assigneeAgentId = next();
+    else if (arg === "--goal-id") args.goalId = next();
+    else if (arg === "--parent-id") args.parentId = next();
+    else if (arg === "--date") args.date = next();
+    else if (arg === "--limit") args.limit = Number.parseInt(next(), 10);
+    else if (arg === "--create") args.create = true;
+    else if (arg === "--allow-missing-deployment-source") args.requireDeploymentSource = false;
+    else if (arg === "--help" || arg === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/ceo-standup-seed.mjs [options]",
+    "",
+    "Builds a manual CEO standup seed from live Paperclip issue state.",
+    "",
+    "Options:",
+    "  --api-url <url>                       Paperclip API URL (default: PAPERCLIP_API_URL)",
+    "  --api-key <token>                     Paperclip API bearer token (default: PAPERCLIP_API_KEY)",
+    "  --company-id <id>                     Company id (default: PAPERCLIP_COMPANY_ID)",
+    "  --date <iso-date>                     Snapshot time (default: now)",
+    "  --limit <n>                           Issue fetch limit (default: 1000)",
+    "  --create                              Create the manual CEO standup issue",
+    "  --assignee-agent-id <id>              Assignee for --create",
+    "  --goal-id <id>                        Goal for --create",
+    "  --parent-id <id>                      Parent issue for --create",
+    "  --allow-missing-deployment-source     Print seed even if canonical deployment section is unavailable",
+  ].join("\n");
+}
+
+function toDate(value, fallback = null) {
+  if (!value) return fallback;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? fallback : date;
+}
+
+function issueTimestamp(issue) {
+  return toDate(issue.completedAt) ?? toDate(issue.updatedAt) ?? toDate(issue.createdAt) ?? new Date(0);
+}
+
+function issueLabel(issue) {
+  return issue.identifier ?? issue.id ?? "(unidentified)";
+}
+
+function issueAssignee(issue, agentsById) {
+  if (issue.assigneeAgentId && agentsById.has(issue.assigneeAgentId)) {
+    return agentsById.get(issue.assigneeAgentId);
+  }
+  if (issue.assigneeAgentId) return issue.assigneeAgentId.slice(0, 8);
+  if (issue.assigneeUserId) return "board";
+  return "unassigned";
+}
+
+function issueRef(issue, agentsById = new Map()) {
+  return {
+    id: issue.id,
+    identifier: issue.identifier ?? null,
+    title: issue.title,
+    status: issue.status,
+    priority: issue.priority ?? "medium",
+    assignee: issueAssignee(issue, agentsById),
+    updatedAt: toDate(issue.updatedAt)?.toISOString() ?? null,
+    completedAt: toDate(issue.completedAt)?.toISOString() ?? null,
+  };
+}
+
+function sortByPriorityThenActivity(left, right) {
+  const priorityRank = { critical: 0, high: 1, medium: 2, low: 3 };
+  const priority = (priorityRank[left.priority] ?? 4) - (priorityRank[right.priority] ?? 4);
+  if (priority !== 0) return priority;
+  return String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? ""));
+}
+
+export function buildStandupSnapshot(input) {
+  const now = toDate(input.now) ?? new Date();
+  const since = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const staleBefore = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const agentsById = new Map((input.agents ?? []).map((agent) => [agent.id, agent.name ?? agent.title ?? agent.id]));
+  const issues = (input.issues ?? []).filter((issue) => !issue.hiddenAt);
+  const categories = {
+    shipped: [],
+    inStaging: [],
+    inProgress: [],
+    blockedOrStale: [],
+    backlog: [],
+    unknownOpen: [],
+  };
+
+  for (const issue of issues) {
+    if (issue.status === "done" && issueTimestamp(issue) >= since) {
+      categories.shipped.push(issueRef(issue, agentsById));
+      continue;
+    }
+
+    if (issue.status === "in_review") categories.inStaging.push(issueRef(issue, agentsById));
+    else if (issue.status === "in_progress") categories.inProgress.push(issueRef(issue, agentsById));
+    else if (issue.status === "blocked") categories.blockedOrStale.push(issueRef(issue, agentsById));
+    else if (issue.status === "todo" || issue.status === "backlog") categories.backlog.push(issueRef(issue, agentsById));
+    else if (!TERMINAL_STATUSES.has(issue.status)) categories.unknownOpen.push(issueRef(issue, agentsById));
+  }
+
+  for (const values of Object.values(categories)) {
+    values.sort(sortByPriorityThenActivity);
+  }
+
+  const openIssues = issues.filter((issue) => OPEN_STATUSES.has(issue.status));
+  const staleOpenIssues = openIssues
+    .filter((issue) => issueTimestamp(issue) <= staleBefore)
+    .map((issue) => issueRef(issue, agentsById))
+    .sort(sortByPriorityThenActivity);
+
+  const statusCounts = {};
+  for (const issue of issues) {
+    statusCounts[issue.status] = (statusCounts[issue.status] ?? 0) + 1;
+  }
+
+  return {
+    generatedAt: now.toISOString(),
+    window: {
+      since: since.toISOString(),
+      staleBefore: staleBefore.toISOString(),
+    },
+    counts: {
+      totalIssues: issues.length,
+      open: openIssues.length,
+      staleOpen: staleOpenIssues.length,
+      byStatus: statusCounts,
+      categories: Object.fromEntries(Object.entries(categories).map(([key, values]) => [key, values.length])),
+    },
+    categories,
+    staleOpenIssues,
+  };
+}
+
+export function seedCountsFromSnapshot(snapshot) {
+  return {
+    shipped: snapshot.categories.shipped.length,
+    inStaging: snapshot.categories.inStaging.length,
+    inProgress: snapshot.categories.inProgress.length,
+    blockedOrStale: snapshot.categories.blockedOrStale.length,
+    backlog: snapshot.categories.backlog.length,
+  };
+}
+
+export function validateSeedCountsAgainstLiveSnapshot(seedCounts, snapshot) {
+  const expected = seedCountsFromSnapshot(snapshot);
+  const mismatches = Object.entries(expected).filter(([key, value]) => seedCounts[key] !== value);
+  if (mismatches.length > 0) {
+    throw new Error(
+      [
+        "Standup seed counts do not match the live issue snapshot.",
+        `Live open issues: ${snapshot.counts.open}.`,
+        `Mismatches: ${mismatches.map(([key, value]) => `${key} expected ${value}, got ${seedCounts[key] ?? "missing"}`).join("; ")}.`,
+      ].join(" "),
+    );
+  }
+
+  const allSeedCategoriesZero = Object.values(seedCounts).every((value) => value === 0);
+  if (snapshot.counts.open > 0 && allSeedCategoriesZero) {
+    throw new Error(
+      `Refusing to emit an all-zero standup seed while ${snapshot.counts.open} live issues are open.`,
+    );
+  }
+
+  if (snapshot.categories.unknownOpen.length > 0) {
+    throw new Error(
+      `Refusing to emit standup seed with ${snapshot.categories.unknownOpen.length} open issues in unknown statuses.`,
+    );
+  }
+}
+
+function truncate(value, maxLength) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}...`;
+}
+
+function renderIssueList(items, limit = 12) {
+  if (items.length === 0) return "";
+  const visible = items.slice(0, limit).map((issue) => {
+    const label = issue.identifier ?? issue.id;
+    return `  - ${label}: ${truncate(issue.title, 72)} (${issue.assignee}, ${issue.priority})`;
+  });
+  if (items.length > limit) {
+    visible.push(`  - ... ${items.length - limit} more`);
+  }
+  return `${visible.join("\n")}\n`;
+}
+
+export function extractDeploymentSection(commentBody) {
+  if (!commentBody) return null;
+  const normalized = commentBody.replace(/\r\n/g, "\n");
+  const heading = /(?:^|\n)[^\n]*(?:\*\*|\*)\s*DEPLOYMENTS\s*(?:\*\*|\*)[^\n]*/i.exec(normalized);
+  if (!heading) return null;
+  const start = heading.index + (heading[0].startsWith("\n") ? 1 : 0);
+  const rest = normalized.slice(start);
+  const next = rest.search(/\n[^\n]*(?:\*\*|\*)\s*(SHIPPED|IN STAGING|IN PROGRESS|BLOCKED|BACKLOG)\b/i);
+  return (next >= 0 ? rest.slice(0, next) : rest).trim();
+}
+
+export function latestDeploymentSectionFromComments(comments) {
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const comment = comments[index];
+    const section = extractDeploymentSection(comment?.body);
+    if (section) {
+      return {
+        commentId: comment?.id ?? null,
+        section,
+      };
+    }
+  }
+  return null;
+}
+
+export function renderStandupIssueDescription(snapshot, deploymentInput) {
+  const counts = seedCountsFromSnapshot(snapshot);
+  validateSeedCountsAgainstLiveSnapshot(counts, snapshot);
+
+  const lines = [
+    "As CEO of Measure Coffee, write today's engineering standup summary.",
+    "",
+    "The issue categories below were generated from the live Paperclip issue API at snapshot time. If any category looks impossible, stop and report a seed integrity error instead of writing a narrative summary.",
+    "",
+    "Format for Slack #paperclip-eng. Use clear sections, mention specific issue IDs, and identify who is assigned. Write in first person as CEO. Keep under 50 lines.",
+    "",
+    "---",
+    "",
+    `SNAPSHOT: ${snapshot.generatedAt}`,
+    `OPEN ISSUE STATUS COUNTS: in_review=${snapshot.counts.byStatus.in_review ?? 0}, blocked=${snapshot.counts.byStatus.blocked ?? 0}, todo/backlog=${(snapshot.counts.byStatus.todo ?? 0) + (snapshot.counts.byStatus.backlog ?? 0)}, in_progress=${snapshot.counts.byStatus.in_progress ?? 0}, open_total=${snapshot.counts.open}`,
+    `STALE OPEN SIGNAL: ${snapshot.counts.staleOpen} open issues have not updated since ${snapshot.window.staleBefore}.`,
+    "",
+    `SHIPPED (last 24h) - ${snapshot.categories.shipped.length} items:`,
+    renderIssueList(snapshot.categories.shipped).trimEnd(),
+    "",
+    `DEPLOYMENTS - canonical source: ${deploymentInput.sourceIssueIdentifier ?? "missing"}`,
+    deploymentInput.section,
+    "",
+    `IN STAGING - ${snapshot.categories.inStaging.length} items:`,
+    renderIssueList(snapshot.categories.inStaging).trimEnd(),
+    "",
+    `IN PROGRESS - ${snapshot.categories.inProgress.length} items:`,
+    renderIssueList(snapshot.categories.inProgress).trimEnd(),
+    "",
+    `BLOCKED/STALE - ${snapshot.categories.blockedOrStale.length} items:`,
+    renderIssueList(snapshot.categories.blockedOrStale).trimEnd(),
+    "",
+    `BACKLOG - ${snapshot.categories.backlog.length} items:`,
+    renderIssueList(snapshot.categories.backlog).trimEnd(),
+    "",
+    "---",
+    "VERIFICATION NOTE: This seed path rejects the May 25, 2026 failure mode where MEA-1044 emitted all-zero categories while MEA-1043 and the live API showed 148 open issues: 25 in review, 98 blocked, 24 todo/backlog, and 1 in progress.",
+    "",
+    "INSTRUCTIONS: Write the standup summary as a comment on this issue. Use Slack markdown format. Post ONLY the summary - no extra commentary.",
+  ];
+
+  return lines.filter((line) => line !== undefined).join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+async function apiFetchJson({ apiUrl, apiKey }, path, init = {}) {
+  const res = await fetch(`${apiUrl.replace(/\/$/, "")}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await res.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  if (!res.ok) {
+    const message = typeof body === "object" && body && "error" in body ? body.error : text;
+    throw new Error(`Paperclip API ${res.status}: ${message}`);
+  }
+  return body;
+}
+
+async function loadCanonicalDeploymentInput(client, companyId) {
+  const routines = await apiFetchJson(client, `/api/companies/${companyId}/routines`);
+  const routine = routines.find((candidate) => candidate.title === "Daily Engineering Standup" && candidate.status === "active");
+  const linkedIssue = routine?.lastRun?.linkedIssue;
+  if (!linkedIssue || linkedIssue.status !== "done") {
+    throw new Error("Canonical Daily Engineering Standup routine has no completed latest run to source deployment context from.");
+  }
+  const comments = await apiFetchJson(client, `/api/issues/${linkedIssue.id}/comments?order=asc`);
+  const deploymentComment = latestDeploymentSectionFromComments(comments);
+  if (!deploymentComment) {
+    throw new Error(`Canonical standup ${linkedIssue.identifier} has no DEPLOYMENTS section.`);
+  }
+  return {
+    sourceIssueId: linkedIssue.id,
+    sourceIssueIdentifier: linkedIssue.identifier,
+    sourceCommentId: deploymentComment.commentId,
+    section: deploymentComment.section,
+  };
+}
+
+async function loadIssuesForStandup(client, companyId, limit) {
+  const statusQueries = [
+    "backlog,todo,in_progress,in_review,blocked",
+    "done",
+  ];
+  const issueById = new Map();
+  for (const statuses of statusQueries) {
+    const rows = await apiFetchJson(
+      client,
+      `/api/companies/${companyId}/issues?status=${encodeURIComponent(statuses)}&limit=${limit}&includeRoutineExecutions=true`,
+    );
+    if (rows.length >= limit) {
+      throw new Error(`Issue fetch for status=${statuses} returned ${rows.length} rows, which reached --limit. Increase --limit before generating a standup seed.`);
+    }
+    for (const row of rows) {
+      issueById.set(row.id, row);
+    }
+  }
+  return [...issueById.values()];
+}
+
+async function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const apiUrl = args.apiUrl ?? process.env.PAPERCLIP_API_URL;
+  const apiKey = args.apiKey ?? process.env.PAPERCLIP_API_KEY;
+  const companyId = args.companyId ?? process.env.PAPERCLIP_COMPANY_ID;
+  if (!apiUrl || !apiKey || !companyId) {
+    throw new Error("Missing API configuration. Set PAPERCLIP_API_URL, PAPERCLIP_API_KEY, and PAPERCLIP_COMPANY_ID or pass flags.");
+  }
+  if (!Number.isInteger(args.limit) || args.limit < 1) {
+    throw new Error("--limit must be a positive integer");
+  }
+
+  const client = { apiUrl, apiKey };
+  const [issues, agents] = await Promise.all([
+    loadIssuesForStandup(client, companyId, args.limit),
+    apiFetchJson(client, `/api/companies/${companyId}/agents`),
+  ]);
+  const snapshot = buildStandupSnapshot({
+    issues,
+    agents,
+    now: args.date ? new Date(args.date) : new Date(),
+  });
+
+  let deploymentInput;
+  try {
+    deploymentInput = await loadCanonicalDeploymentInput(client, companyId);
+  } catch (error) {
+    if (args.requireDeploymentSource) throw error;
+    deploymentInput = {
+      sourceIssueIdentifier: null,
+      section: `Deployment source unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const description = renderStandupIssueDescription(snapshot, deploymentInput);
+
+  if (!args.create) {
+    console.log(description);
+    return;
+  }
+
+  if (!args.assigneeAgentId) {
+    throw new Error("--create requires --assignee-agent-id");
+  }
+
+  const title = `CEO Standup - ${new Date(snapshot.generatedAt).toLocaleDateString("en-US", {
+    month: "long",
+    day: "2-digit",
+    year: "numeric",
+    timeZone: "America/Chicago",
+  })}`;
+  const issue = await apiFetchJson(client, `/api/companies/${companyId}/issues`, {
+    method: "POST",
+    headers: process.env.PAPERCLIP_RUN_ID ? { "X-Paperclip-Run-Id": process.env.PAPERCLIP_RUN_ID } : {},
+    body: JSON.stringify({
+      title,
+      description,
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: args.assigneeAgentId,
+      goalId: args.goalId,
+      parentId: args.parentId,
+    }),
+  });
+  console.log(JSON.stringify({
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    status: issue.status,
+  }, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ceo-standup-seed.test.mjs
+++ b/scripts/ceo-standup-seed.test.mjs
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildStandupSnapshot,
+  extractDeploymentSection,
+  latestDeploymentSectionFromComments,
+  renderStandupIssueDescription,
+  seedCountsFromSnapshot,
+  validateSeedCountsAgainstLiveSnapshot,
+} from "./ceo-standup-seed.mjs";
+
+function issue(overrides) {
+  return {
+    id: `issue-${overrides.identifier}`,
+    identifier: overrides.identifier,
+    title: overrides.title ?? `Issue ${overrides.identifier}`,
+    status: overrides.status,
+    priority: overrides.priority ?? "medium",
+    assigneeAgentId: overrides.assigneeAgentId ?? "cto",
+    createdAt: overrides.createdAt ?? "2026-05-01T12:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-05-17T12:00:00.000Z",
+    completedAt: overrides.completedAt ?? null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+function range(count, factory) {
+  return Array.from({ length: count }, (_, index) => factory(index));
+}
+
+const agents = [
+  { id: "cto", name: "CTO" },
+  { id: "ceo", name: "CEO" },
+  { id: "qa", name: "QA Engineer" },
+];
+
+test("builds the May 25 standup snapshot from live open status membership", () => {
+  const issues = [
+    ...range(25, (index) => issue({ identifier: `MEA-R${index}`, status: "in_review" })),
+    ...range(98, (index) => issue({ identifier: `MEA-B${index}`, status: "blocked", assigneeAgentId: "qa" })),
+    ...range(23, (index) => issue({ identifier: `MEA-T${index}`, status: "todo" })),
+    issue({ identifier: "MEA-BACKLOG", status: "backlog" }),
+    issue({ identifier: "MEA-1043", status: "in_progress", assigneeAgentId: "ceo" }),
+    issue({
+      identifier: "MEA-OLD-DONE",
+      status: "done",
+      completedAt: "2026-05-20T12:00:00.000Z",
+      updatedAt: "2026-05-20T12:00:00.000Z",
+    }),
+  ];
+
+  const snapshot = buildStandupSnapshot({
+    issues,
+    agents,
+    now: "2026-05-25T19:07:00.000Z",
+  });
+
+  assert.equal(snapshot.counts.open, 148);
+  assert.deepEqual(seedCountsFromSnapshot(snapshot), {
+    shipped: 0,
+    inStaging: 25,
+    inProgress: 1,
+    blockedOrStale: 98,
+    backlog: 24,
+  });
+
+  validateSeedCountsAgainstLiveSnapshot(seedCountsFromSnapshot(snapshot), snapshot);
+});
+
+test("rejects the former all-zero manual seed when live issues are open", () => {
+  const snapshot = buildStandupSnapshot({
+    issues: [
+      issue({ identifier: "MEA-REVIEW", status: "in_review" }),
+      issue({ identifier: "MEA-BLOCKED", status: "blocked" }),
+      issue({ identifier: "MEA-TODO", status: "todo" }),
+    ],
+    agents,
+    now: "2026-05-25T19:07:00.000Z",
+  });
+
+  assert.throws(
+    () => validateSeedCountsAgainstLiveSnapshot({
+      shipped: 0,
+      inStaging: 0,
+      inProgress: 0,
+      blockedOrStale: 0,
+      backlog: 0,
+    }, snapshot),
+    /Standup seed counts do not match the live issue snapshot/,
+  );
+});
+
+test("renders a seed with the canonical deployment section and regression note", () => {
+  const snapshot = buildStandupSnapshot({
+    issues: [
+      issue({ identifier: "MEA-1007", title: "Founder route restore", status: "in_review" }),
+      issue({ identifier: "MEA-993", title: "Preview token fix", status: "blocked" }),
+      issue({ identifier: "MEA-935", title: "Claim resume continuity", status: "todo" }),
+    ],
+    agents,
+    now: "2026-05-25T19:07:00.000Z",
+  });
+
+  const rendered = renderStandupIssueDescription(snapshot, {
+    sourceIssueIdentifier: "MEA-1043",
+    section: "**DEPLOYMENTS**\n\n**PRODUCTION**\n- No production deployment record landed.",
+  });
+
+  assert.match(rendered, /OPEN ISSUE STATUS COUNTS: in_review=1, blocked=1, todo\/backlog=1, in_progress=0, open_total=3/);
+  assert.match(rendered, /DEPLOYMENTS - canonical source: MEA-1043/);
+  assert.match(rendered, /VERIFICATION NOTE: This seed path rejects the May 25, 2026 failure mode/);
+});
+
+test("extracts the deployment section from the canonical routine report", () => {
+  const section = extractDeploymentSection([
+    "Engineering standup for May 25, 2026",
+    "",
+    "**DEPLOYMENTS**",
+    "",
+    "**PRODUCTION**",
+    "- No production deployment record landed.",
+    "",
+    "**LIVE PREVIEWS**",
+    "- Preview still live.",
+    "",
+    "**SHIPPED**",
+    "- Nothing shipped.",
+  ].join("\n"));
+
+  assert.equal(section, [
+    "**DEPLOYMENTS**",
+    "",
+    "**PRODUCTION**",
+    "- No production deployment record landed.",
+    "",
+    "**LIVE PREVIEWS**",
+    "- Preview still live.",
+  ].join("\n"));
+});
+
+test("extracts Slack-style deployment heading before issue categories", () => {
+  const section = extractDeploymentSection([
+    "*CEO Standup — May 28, 2026*",
+    "",
+    "📦 *Deployments*",
+    "*Production*",
+    "No production deployment records landed.",
+    "",
+    "*Live Previews*",
+    "- Preview is live.",
+    "",
+    "👀 *In Staging — 25 Issues*",
+    "- MEA-1007 is ready for review.",
+  ].join("\n"));
+
+  assert.equal(section, [
+    "📦 *Deployments*",
+    "*Production*",
+    "No production deployment records landed.",
+    "",
+    "*Live Previews*",
+    "- Preview is live.",
+  ].join("\n"));
+});
+
+test("selects the latest deployment-bearing comment before housekeeping comments", () => {
+  const selected = latestDeploymentSectionFromComments([
+    { id: "old", body: "**DEPLOYMENTS**\n\n**PRODUCTION**\n- Older deployment note." },
+    { id: "latest", body: "**DEPLOYMENTS**\n\n**PRODUCTION**\n- Current deployment note." },
+    { id: "closeout", body: "Closing this heartbeat; the report above is final." },
+  ]);
+
+  assert.equal(selected.commentId, "latest");
+  assert.equal(selected.section, "**DEPLOYMENTS**\n\n**PRODUCTION**\n- Current deployment note.");
+});

--- a/scripts/ceo-standup-seed.test.mjs
+++ b/scripts/ceo-standup-seed.test.mjs
@@ -174,3 +174,75 @@ test("selects the latest deployment-bearing comment before housekeeping comments
   assert.equal(selected.commentId, "latest");
   assert.equal(selected.section, "**DEPLOYMENTS**\n\n**PRODUCTION**\n- Current deployment note.");
 });
+
+test("ignores later deployment-looking comments outside the canonical report run", () => {
+  const selected = latestDeploymentSectionFromComments([
+    {
+      id: "report-1",
+      authorAgentId: "ceo",
+      createdByRunId: "routine-report-run",
+      body: [
+        "*CEO Standup — May 28, 2026*",
+        "",
+        "📦 *Deployments*",
+        "*Production*",
+        "- Canonical production note.",
+      ].join("\n"),
+    },
+    {
+      id: "report-2",
+      authorAgentId: "ceo",
+      createdByRunId: "routine-report-run",
+      body: [
+        "*CEO Standup — May 28, 2026*",
+        "",
+        "📦 *Deployments*",
+        "*Production*",
+        "- Canonical corrected note.",
+      ].join("\n"),
+    },
+    {
+      id: "thread-contamination",
+      authorAgentId: "ceo",
+      createdByRunId: "later-thread-run",
+      body: [
+        "*CEO Standup — May 28, 2026*",
+        "",
+        "📦 *Deployments*",
+        "*Production*",
+        "- Non-canonical later thread content.",
+      ].join("\n"),
+    },
+  ], {
+    authorAgentId: "ceo",
+    requireCreatedByRunId: true,
+    requireStandupHeading: true,
+  });
+
+  assert.equal(selected.commentId, "report-2");
+  assert.equal(selected.createdByRunId, "routine-report-run");
+  assert.match(selected.section, /Canonical corrected note/);
+  assert.doesNotMatch(selected.section, /Non-canonical/);
+});
+
+test("rejects deployment-looking comments without run provenance in strict mode", () => {
+  const selected = latestDeploymentSectionFromComments([
+    {
+      id: "manual-thread-comment",
+      authorAgentId: "ceo",
+      body: [
+        "*CEO Standup — May 28, 2026*",
+        "",
+        "📦 *Deployments*",
+        "*Production*",
+        "- Manual thread content.",
+      ].join("\n"),
+    },
+  ], {
+    authorAgentId: "ceo",
+    requireCreatedByRunId: true,
+    requireStandupHeading: true,
+  });
+
+  assert.equal(selected, null);
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -28,6 +28,7 @@ import {
   clampIssueListLimit,
   deriveIssueCommentRunLogAttribution,
   ISSUE_LIST_MAX_LIMIT,
+  isAllZeroCeoStandupSeed,
   issueService,
 } from "../services/issues.ts";
 import { buildProjectMentionHref, MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
@@ -103,6 +104,36 @@ describe("deriveIssueCommentRunLogAttribution", () => {
     );
 
     expect(derived.has(commentId)).toBe(false);
+  });
+});
+
+describe("isAllZeroCeoStandupSeed", () => {
+  it("detects the false zero-state CEO standup seed shape", () => {
+    expect(isAllZeroCeoStandupSeed({
+      title: "CEO Standup - May 28, 2026",
+      description: [
+        "As CEO of Measure Coffee, write today's engineering standup summary.",
+        "",
+        "SHIPPED (last 24h) — 0 items:",
+        "IN STAGING — 0 items:",
+        "IN PROGRESS — 0 items:",
+        "BLOCKED/STALE (7+ days) — 0 items:",
+        "BACKLOG — 0 items:",
+      ].join("\n"),
+    })).toBe(true);
+  });
+
+  it("does not flag a live-count seed with nonzero operating data", () => {
+    expect(isAllZeroCeoStandupSeed({
+      title: "CEO Standup - May 28, 2026",
+      description: [
+        "OPEN ISSUE STATUS COUNTS: in_review=25, blocked=98, todo/backlog=25, in_progress=1, open_total=149",
+        "IN STAGING - 25 items:",
+        "IN PROGRESS - 1 items:",
+        "BLOCKED/STALE - 98 items:",
+        "BACKLOG - 25 items:",
+      ].join("\n"),
+    })).toBe(false);
   });
 });
 
@@ -1518,6 +1549,75 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
 
   afterAll(async () => {
     await tempDb?.cleanup();
+  });
+
+  function falseZeroStandupDescription() {
+    return [
+      "As CEO of Measure Coffee, write today's engineering standup summary.",
+      "",
+      "The data below is complete and accurate.",
+      "",
+      "SHIPPED (last 24h) — 0 items:",
+      "IN STAGING — 0 items:",
+      "IN PROGRESS — 0 items:",
+      "BLOCKED/STALE (7+ days) — 0 items:",
+      "BACKLOG — 0 items:",
+    ].join("\n");
+  }
+
+  it("rejects all-zero CEO standup seed creation when live open issues exist", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Measure Coffee",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Ready for review",
+      status: "in_review",
+      priority: "medium",
+    });
+
+    await expect(svc.create(companyId, {
+      title: "CEO Standup - May 28, 2026",
+      description: falseZeroStandupDescription(),
+      status: "todo",
+      priority: "medium",
+    })).rejects.toThrow(/Refusing to emit an all-zero CEO standup seed while 1 live open issues exist/);
+  });
+
+  it("rejects updating an issue into an all-zero CEO standup seed when live open issues exist", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Measure Coffee",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Blocked launch validation",
+      status: "blocked",
+      priority: "high",
+    });
+
+    const draft = await svc.create(companyId, {
+      title: "Draft standup",
+      description: "Placeholder.",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(svc.update(draft.id, {
+      title: "CEO Standup - May 28, 2026",
+      description: falseZeroStandupDescription(),
+    })).rejects.toThrow(/Refusing to emit an all-zero CEO standup seed while 1 live open issues exist/);
   });
 
   it("inherits the parent issue workspace linkage when child workspace fields are omitted", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -80,6 +80,7 @@ import {
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+const STANDUP_OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
@@ -120,6 +121,64 @@ function readStringFromRecord(record: unknown, key: string) {
   if (!record || typeof record !== "object") return null;
   const value = (record as Record<string, unknown>)[key];
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function isAllZeroCeoStandupSeed(input: { title?: string | null; description?: string | null }) {
+  const title = input.title ?? "";
+  const description = input.description ?? "";
+  if (!/\bCEO\s+Standup\b/i.test(`${title}\n${description}`)) return false;
+
+  return [
+    /\bIN\s+STAGING\b[^\n]*[-—]\s*0\s+(?:items?|issues?)\b/i,
+    /\bIN\s+PROGRESS\b[^\n]*[-—]\s*0\s+(?:items?|issues?)\b/i,
+    /\bBLOCKED(?:\/STALE)?\b[^\n]*[-—]\s*0\s+(?:items?|issues?)\b/i,
+    /\bBACKLOG\b[^\n]*[-—]\s*0\s+(?:items?|issues?)\b/i,
+  ].every((pattern) => pattern.test(description));
+}
+
+async function countLiveOpenIssuesForStandupGuard(
+  dbOrTx: Pick<Db, "select">,
+  companyId: string,
+  excludeIssueId?: string | null,
+) {
+  const conditions = [
+    eq(issues.companyId, companyId),
+    isNull(issues.hiddenAt),
+    inArray(issues.status, STANDUP_OPEN_ISSUE_STATUSES),
+  ];
+  if (excludeIssueId) {
+    conditions.push(ne(issues.id, excludeIssueId));
+  }
+
+  const [row] = await dbOrTx
+    .select({ count: sql<number>`count(*)::int` })
+    .from(issues)
+    .where(and(...conditions));
+  return Number(row?.count ?? 0);
+}
+
+async function assertCeoStandupSeedIsNotFalseZero(input: {
+  dbOrTx: Pick<Db, "select">;
+  companyId: string;
+  title?: string | null;
+  description?: string | null;
+  excludeIssueId?: string | null;
+}) {
+  if (!isAllZeroCeoStandupSeed(input)) return;
+
+  const liveOpenIssues = await countLiveOpenIssuesForStandupGuard(
+    input.dbOrTx,
+    input.companyId,
+    input.excludeIssueId,
+  );
+  if (liveOpenIssues === 0) return;
+
+  throw unprocessable(
+    [
+      `Refusing to emit an all-zero CEO standup seed while ${liveOpenIssues} live open issues exist.`,
+      "Generate the seed from canonical live issue/deployment data or leave the artifact uncreated.",
+    ].join(" "),
+  );
 }
 
 function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
@@ -4086,6 +4145,12 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      await assertCeoStandupSeedIsNotFalseZero({
+        dbOrTx: db,
+        companyId,
+        title: issueData.title,
+        description: issueData.description,
+      });
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
@@ -4379,6 +4444,15 @@ export function issueService(db: Db) {
       }
       if (nextExecutionWorkspaceId) {
         await assertValidExecutionWorkspace(existing.companyId, nextProjectId, nextExecutionWorkspaceId);
+      }
+      if (issueData.title !== undefined || issueData.description !== undefined) {
+        await assertCeoStandupSeedIsNotFalseZero({
+          dbOrTx,
+          companyId: existing.companyId,
+          title: issueData.title !== undefined ? issueData.title : existing.title,
+          description: issueData.description !== undefined ? issueData.description : existing.description,
+          excludeIssueId: existing.id,
+        });
       }
 
       applyStatusSideEffects(issueData.status, patch);


### PR DESCRIPTION
## Summary
- ship the Staff-approved MEA-1053 standup zero-state guardrail onto current `master`
- add service-level guard to reject all-zero `CEO Standup` seeds when open issues exist
- add strict report-run provenance binding for deployment extraction in `scripts/ceo-standup-seed.mjs`
- add regression coverage for zero-state detection and deployment provenance edge cases

## Provenance
- source approved branch: `fork/fix/mea-1053-standup-guardrail`
- source approved commit: `4fd767afeaba0812115461f4a676a1903656471c`
- rebased release branch: `rhon3n:release/mea-1058-ship-mea-1053`
- issue links: MEA-1053, MEA-1056 (Staff approval), MEA-1058 (release)

## Verification
- `pnpm test:standup-seed`
- `pnpm --filter @paperclipai/server typecheck`
