### PR TITLE
fix(issues): prevent comment-path and deferred-wake from promoting done/cancelled issues

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -623,10 +623,10 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   actorType: "agent" | "user";
   actorId: string;
 }) {
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Only human comments on blocked issues should implicitly resume work.
+  // done/cancelled issues must be reopened explicitly via PATCH — not via comments.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -1550,9 +1550,9 @@ export function issueRoutes(
     res: Response,
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
   ) {
-    if (issue.status === "cancelled") {
+    if (issue.status === "done" || issue.status === "cancelled") {
       res.status(409).json({
-        error: "Cancelled issues must be restored through the dedicated restore flow",
+        error: "Terminal issues (done/cancelled) must be restored through the dedicated restore flow, not via comment follow-up",
         details: {
           issueId: issue.id,
           status: issue.status,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8465,58 +8465,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             interaction: true,
           };
         }
-        const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 &&
-          (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
+        // Terminal issues (done/cancelled) must never be auto-promoted by a deferred wake.
+        // Reopening requires an explicit PATCH by an authorized actor.
         let reopenedActivity: LogActivityInput | null = null;
-
-        if (shouldReopenDeferredCommentWake) {
-          const reopenedFromStatus = issue.status;
-          const reopenedIssue = await issuesSvc.update(
-            issue.id,
-            {
-              status: "todo",
-              executionState: null,
-            },
-            tx,
-          );
-          if (reopenedIssue) {
-            issue = {
-              ...issue,
-              identifier: reopenedIssue.identifier,
-              status: reopenedIssue.status,
-              executionRunId: reopenedIssue.executionRunId,
-            };
-            if (!readNonEmptyString(promotedContextSeed.reopenedFrom)) {
-              promotedContextSeed.reopenedFrom = reopenedFromStatus;
-            }
-            reopenedActivity = {
-              companyId: issue.companyId,
-              actorType: "system",
-              actorId: "heartbeat",
-              agentId: deferred.agentId,
-              runId: run.id,
-              action: "issue.updated",
-              entityType: "issue",
-              entityId: issue.id,
-              details: {
-                status: "todo",
-                reopened: true,
-                reopenedFrom: reopenedFromStatus,
-                source: "deferred_comment_wake",
-                identifier: issue.identifier,
-              },
-            };
-          }
-        }
 
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =


### PR DESCRIPTION
## Summary

Fixes #6601

Done and cancelled issues should not be reopened by a comment or a deferred wake. Only `blocked` issues are eligible for the implicit comment-path move-to-todo.

## Changes

- `shouldImplicitlyMoveCommentedIssueToTodo`: narrowed to `blocked` status only; `done`/`cancelled` now require an explicit PATCH to reopen
- `assertExplicitResumeIntentAllowed`: blocks resume/reopen on `done` issues (already blocked `cancelled`; now both treated the same)
- Heartbeat deferred-wake promote path: removed `shouldReopenDeferredCommentWake` block entirely — terminal issues stay terminal regardless of deferred comment wakes

## Test plan

- [ ] Post a comment on a `done` issue — it should NOT be moved to `todo`
- [ ] Post a comment on a `cancelled` issue — same
- [ ] Post a comment on a `blocked` issue — it SHOULD still move to `todo`
- [ ] Deferred wake fires for a `done` issue — status unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)