### PR TITLE
fix(wake-on-comment): validate agent:// mention IDs against agents table

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5350,7 +5350,10 @@ export function issueService(db: Db) {
       if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      const resolved = new Set<string>(explicitAgentMentionIds);
+      const validAgentIds = new Set(rows.map((r) => r.id));
+      const resolved = new Set<string>(
+        explicitAgentMentionIds.filter((id) => validAgentIds.has(id)),
+      );
       for (const agent of rows) {
         if (tokens.has(agent.name.toLowerCase())) {
           resolved.add(agent.id);


### PR DESCRIPTION
## Summary

Fixes #6389

Before dispatching wakes for explicit `agent://UUID` mentions in comments, filter the extracted IDs against the agents DB table. Invalid or non-existent agent IDs are silently skipped; valid ones continue to trigger wakes as before.

## Changes

- `server/src/services/issues.ts`: build `validAgentIds` set from DB rows before filtering `explicitAgentMentionIds`

## Test plan

- [ ] Comment mentioning a valid `agent://UUID` — wake fires normally
- [ ] Comment mentioning an invalid/deleted `agent://UUID` — no wake, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)