### PR TITLE
fix(issues): guard adoptUnownedCheckoutRun on terminal-state PATCH

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -517,7 +517,7 @@ describe("agent issue mutation checkout ownership", () => {
       .send({ format: "markdown", body: "# updated" })
       .expect(200);
 
-    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId);
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId, { allowUnownedAdoption: true });
     expect(mockIssueService.update).toHaveBeenCalled();
     expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -529,6 +529,17 @@ describe("agent issue mutation checkout ownership", () => {
       }),
     );
   });
+
+  it.each(["done", "cancelled"] as const)(
+    "passes allowUnownedAdoption: false when patching to terminal status %s",
+    async (terminalStatus) => {
+      const app = await createApp(ownerActor());
+
+      await request(app).patch(`/api/issues/${issueId}`).send({ status: terminalStatus }).expect(200);
+
+      expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId, { allowUnownedAdoption: false });
+    },
+  );
 
   it.each([
     [
@@ -566,7 +577,7 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toContain("Cheap status-only recovery runs cannot update issue documents");
-    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId);
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId, { allowUnownedAdoption: true });
     expect(mockWorkProductService.createForIssue).not.toHaveBeenCalled();
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockWorkProductService.remove).not.toHaveBeenCalled();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1425,7 +1425,11 @@ export function issueRoutes(
     }
     const runId = requireAgentRunId(req, res);
     if (!runId) return false;
-    const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId);
+    const targetStatus = typeof req.body?.status === "string" ? req.body.status : undefined;
+    const targetIsTerminal = targetStatus === "done" || targetStatus === "cancelled";
+    const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId, {
+      allowUnownedAdoption: !targetIsTerminal,
+    });
     if (ownership.adoptedFromRunId) {
       const actor = getActorInfo(req);
       await logActivity(db, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4808,7 +4808,12 @@ export function issueService(db: Db) {
       });
     },
 
-    assertCheckoutOwner: async (id: string, actorAgentId: string, actorRunId: string | null) => {
+    assertCheckoutOwner: async (
+      id: string,
+      actorAgentId: string,
+      actorRunId: string | null,
+      options?: { allowUnownedAdoption?: boolean },
+    ) => {
       await clearExecutionRunIfTerminal(id);
       const current = await db
         .select({
@@ -4837,7 +4842,8 @@ export function issueService(db: Db) {
         current.status === "in_progress" &&
         current.assigneeAgentId === actorAgentId &&
         current.checkoutRunId == null &&
-        (current.executionRunId == null || current.executionRunId === actorRunId)
+        (current.executionRunId == null || current.executionRunId === actorRunId) &&
+        options?.allowUnownedAdoption !== false
       ) {
         const adopted = await adoptUnownedCheckoutRun({
           issueId: id,


### PR DESCRIPTION
## Summary

When an agent PATCHes an issue to `done` or `cancelled`, the `adoptUnownedCheckoutRun` path should not be available — adopting ownership of a terminal issue is nonsensical and was causing unexpected ownership transfers on race-condition PATCHes.

## Changes

- `server/src/routes/issues.ts`: check if the target status is terminal before passing `allowUnownedAdoption`; pass `false` when the PATCH is moving to `done` or `cancelled`
- `server/src/services/issues.ts`: honour the new `allowUnownedAdoption` flag in `assertCheckoutOwner`
- `server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`: add regression test

## Test plan

- [ ] PATCH an issue to `done` when a different agent owns checkout — returns 403 (no longer adopts)
- [ ] PATCH an issue to `in_progress` when unowned — still adopts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)