### PR TITLE
Preserve issue assignee on release

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -643,6 +643,8 @@ Server behavior:
 2. if updated row count is 0, return `409` with current owner/status
 3. successful checkout sets `assignee_agent_id`, `status = in_progress`, and `started_at`
 
+`POST /issues/:issueId/release` clears checkout and execution run lock fields without clearing `assignee_agent_id`. If the issue is still `in_progress`, release returns it to `todo`; issues that already moved to review, blocked, done, or another explicit state keep that state.
+
 `POST /issues/:issueId/admin/force-release` is an operator recovery endpoint for stale harness locks. It requires board access to the issue company, clears checkout and execution run lock fields, and may clear the agent assignee when `clearAssignee=true` is passed. The route must write an `issue.admin_force_release` activity log entry containing the previous checkout and execution run IDs.
 
 ## 10.5 Projects

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -206,7 +206,49 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       .then((rows) => rows[0]);
     expect(row).toEqual({
       status: "todo",
-      assigneeAgentId: null,
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+  });
+
+  it("preserves review state and assignee when releasing an already-transitioned issue", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review release",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      status: "in_review",
+      assigneeAgentId: agentId,
       checkoutRunId: null,
       executionRunId: null,
       executionLockedAt: null,

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -255,6 +255,57 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("allows the assignee to release a reviewed issue locked by another live run", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const otherLiveRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: otherLiveRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review release by later run",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: otherLiveRunId,
+      executionRunId: otherLiveRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      status: "in_review",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+  });
+
   it("restricts admin force-release to board users with company access and writes an audit event", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4916,11 +4916,11 @@ export function issueService(db: Db) {
         }
       }
 
+      const releaseStatus = existing.status === "in_progress" ? "todo" : existing.status;
       const updated = await db
         .update(issues)
         .set({
-          status: "todo",
-          assigneeAgentId: null,
+          status: releaseStatus,
           checkoutRunId: null,
           executionRunId: null,
           executionAgentNameKey: null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue checkout and release are the control-plane ownership mechanics that keep agent work attached to the right assignee and run.
> - The normal release endpoint was clearing `assigneeAgentId` every time it cleared execution locks.
> - That made issues become unassigned after an agent released a run, even when the issue had intentionally moved to review or blocked.
> - Admin force-release already has the explicit owner-clearing path through `clearAssignee=true`.
> - This pull request makes normal release a lock-release operation, while keeping assignee clearing explicit through admin force-release.
> - The benefit is that agent-owned work stays owned across release, review, and blocked handoff states.

## Impact

- Prevents the ownership-loss class seen on SUP-2187, including the related SUP-2174 failure mode where completed Michael work was pushed toward review but release/recovery cleared or reassigned ownership and left the issue blocked on recovery instead of preserving Michael as owner for closeout.

## What Changed

- Updated normal issue release semantics to preserve `assigneeAgentId` and clear only checkout/execution lock fields.
- Kept the explicit `in_progress` release transition to `todo`, while preserving already-transitioned states like `in_review`.
- Updated route coverage for normal release behavior versus admin force-release with `clearAssignee=true`.
- Added coverage for releasing an already-reviewed issue whose checkout/execution lock belongs to a different still-running run from the same assignee agent.
- Documented the release endpoint ownership/status semantics in the implementation spec.

## Verification

- `pnpm vitest run server/src/__tests__/issue-stale-execution-lock-routes.test.ts` passed locally with 5 tests.
- `pnpm --filter @paperclipai/server typecheck` passed locally.
- GitHub core verification lanes passed: `verify`, build, typecheck/release-registry, general tests, serialized server suites, canary dry run, policy, and Snyk.

## Risks

- Low risk. This narrows normal release side effects, but callers that relied on normal release unassigning issues must now use the existing board-only admin force-release endpoint with `clearAssignee=true`.
- The separate GitHub e2e job is currently cancelled during Playwright install before tests run; that appears to be CI setup infrastructure rather than a failure in this PR's code path.

## Model Used

- OpenAI GPT-5 Codex coding agent, tool-enabled terminal/code execution, default reasoning mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
