### PR TITLE
fix(ui): remove clickable links from pending-approval invite panel

### DIFF
--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -506,7 +506,7 @@ describe("InviteLandingPage", () => {
     });
   });
 
-  it("shows the pending approval page with the company icon and linked access instructions", async () => {
+  it("shows the pending approval page with the company icon and plain-text access instructions (no clickable links)", async () => {
     acceptInviteMock.mockResolvedValue({
       id: "join-1",
       companyId: "company-1",
@@ -553,14 +553,12 @@ describe("InviteLandingPage", () => {
     expect(container.querySelector('img[alt="Acme Robotics logo"]')).not.toBeNull();
     expect(container.textContent).not.toContain("http://localhost/company/settings/members");
 
+    // Regression: "Company Settings → Members" must NOT be rendered as clickable <a> links
+    // (they were removed because the approval URL was internal-only and confusing to share)
     const approvalLinks = Array.from(container.querySelectorAll("a")).filter(
       (link) => link.textContent === "Company Settings → Members",
     );
-    expect(approvalLinks).toHaveLength(2);
-    const expectedApprovalUrl = `${window.location.origin}/company/settings/members`;
-    for (const link of approvalLinks) {
-      expect(link.getAttribute("href")).toBe(expectedApprovalUrl);
-    }
+    expect(approvalLinks).toHaveLength(0);
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -181,15 +181,12 @@ function AwaitingJoinApprovalPanel({
           </p>
           <div className="border border-zinc-800 p-3">
             <p className="text-xs text-zinc-500 mb-1">Approval page</p>
-            <a
-              href={approvalUrl}
-              className="text-sm text-zinc-200 underline underline-offset-2 hover:text-zinc-100"
-            >
+            <span className="text-sm text-zinc-200">
               Company Settings → Members
-            </a>
+            </span>
           </div>
           <p className="text-sm text-zinc-400">
-            Ask them to visit <a href={approvalUrl} className="text-zinc-200 underline underline-offset-2 hover:text-zinc-100">Company Settings → Members</a> to approve your request.
+            Ask them to visit <span className="text-zinc-200">Company Settings → Members</span> to approve your request.
           </p>
           <p className="text-xs text-zinc-500">
             Refresh this page after you've been approved — you'll be redirected automatically.


### PR DESCRIPTION
## Thinking Path

> - Paperclip's invite flow allows users to invite collaborators to their company
> - When approval is required, invitees land on a pending-approval screen explaining the invite is waiting for a board review
> - The pending screen previously rendered "Company Settings → Members" as a clickable `<a>` link
> - Invitees who clicked it were routed to `/company/settings/members` — a page they can't access because they're not yet company members — which showed "No company access", making the invite flow appear broken
> - Fix: replace the links with plain text so invitees don't try to navigate to pages they can't access

## Linked Issues or Issue Description

Closes #6784

## What Changed

- `ui/src/pages/InviteLanding.tsx`: replaced `<a>` elements in the pending-approval panel with plain text

## Verification

1. Create an invite requiring board approval
2. Open the `/invite/<token>` URL as the invitee
3. The pending-approval panel shows "Company Settings → Members" as plain text (no clickable link)
4. No "No company access" page shown

## Risks

Low: removes links, no behavior change to the approval flow itself.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge