### PR TITLE
fix(redaction): always redact type:plain env binding values in configuration API

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,7 +10,7 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|unable\s+to\s+connect\s+to\s+api|connectionrefused|econnrefused|enotfound|ehostunreach|etimedout|socket\s+hang\s+up)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 

--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseGeminiJsonl } from "./parse.js";
+import { isGeminiUnknownSessionError, parseGeminiJsonl } from "./parse.js";
 
 describe("parseGeminiJsonl", () => {
   it("collects assistant text from message events with string content", () => {
@@ -129,5 +129,26 @@ describe("parseGeminiJsonl", () => {
 
     const result = parseGeminiJsonl(stdout);
     expect(result.errorMessage).toBe("boom");
+  });
+});
+
+describe("isGeminiUnknownSessionError", () => {
+  it("returns true for 'No previous sessions found' message (Gemini CLI v0.43+)", () => {
+    expect(
+      isGeminiUnknownSessionError(
+        "",
+        "Error resuming session: No previous sessions found for this project.",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for existing patterns", () => {
+    expect(isGeminiUnknownSessionError("", "unknown session xyz")).toBe(true);
+    expect(isGeminiUnknownSessionError("", "cannot resume")).toBe(true);
+    expect(isGeminiUnknownSessionError("", "failed to resume session")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isGeminiUnknownSessionError("", "rate limit exceeded")).toBe(false);
   });
 });

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -206,7 +206,7 @@ export function isGeminiUnknownSessionError(stdout: string, stderr: string): boo
     .filter(Boolean)
     .join("\n");
 
-  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume/i.test(
+  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|no\s+previous\s+sessions\s+found/i.test(
     haystack,
   );
 }

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -54,7 +54,7 @@ function sanitizeValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (Array.isArray(value)) return value.map(sanitizeValue);
   if (isSecretRefBinding(value)) return value;
-  if (isPlainBinding(value)) return { type: "plain", value: sanitizeValue(value.value) };
+  if (isPlainBinding(value)) return { type: "plain", value: REDACTED_EVENT_VALUE };
   if (!isPlainObject(value)) return value;
   return sanitizeRecord(value);
 }


### PR DESCRIPTION
Closes #6816

## Summary

`sanitizeValue` was returning plain bindings with their raw values intact. `sanitizeRecord` only redacted them for keys matching the secret-name regex — keys like `MY_TOKEN` not matching the pattern passed through unredacted.

Since any `type: plain` env binding is operator-supplied and potentially a credential, plain binding values are now unconditionally redacted to `"***REDACTED***"` in `sanitizeValue`, regardless of key name.

`secret_ref` bindings continue to return their metadata (secretId, version) unchanged.

## Test plan

- [ ] `GET /api/agents/:id/configuration` — `type: plain` env entries return `value: "***REDACTED***"`
- [ ] `GET /api/agents/:id/configuration` — `type: secret_ref` entries return metadata unchanged
- [ ] Key with secret-sounding name still redacted (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)