### PR TITLE
fix: wrap cost event creation and budget enforcement in DB transaction

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -777,3 +777,7 @@ export async function ensurePostgresDatabase(
 }
 
 export type Db = ReturnType<typeof createDb>;
+
+export type TxDb = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+export type QueryableDb = Db | TxDb;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,6 +10,8 @@ export {
   migratePostgresIfEmpty,
   type MigrationBootstrapResult,
   type Db,
+  type TxDb,
+  type QueryableDb,
 } from "./client.js";
 export {
   getEmbeddedPostgresTestSupport,

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Db } from "@paperclipai/db";
+import type { QueryableDb } from "@paperclipai/db";
 import { activityLog } from "@paperclipai/db";
 import { PLUGIN_EVENT_TYPES, type PluginEventType } from "@paperclipai/shared";
 import type { PluginEvent } from "@paperclipai/plugin-sdk";
@@ -62,7 +62,7 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
-export async function logActivity(db: Db, input: LogActivityInput) {
+export async function logActivity(db: QueryableDb, input: LogActivityInput) {
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
   };

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, gte, inArray, lt, ne, sql } from "drizzle-orm";
-import type { Db } from "@paperclipai/db";
+import type { QueryableDb } from "@paperclipai/db";
 import {
   agents,
   approvals,
@@ -78,7 +78,7 @@ function normalizeScopeName(scopeType: BudgetScopeType, name: string) {
   return name.trim().length > 0 ? name : scopeType;
 }
 
-async function resolveScopeRecord(db: Db, scopeType: BudgetScopeType, scopeId: string): Promise<ScopeRecord> {
+async function resolveScopeRecord(db: QueryableDb, scopeType: BudgetScopeType, scopeId: string): Promise<ScopeRecord> {
   if (scopeType === "company") {
     const row = await db
       .select({
@@ -140,7 +140,7 @@ async function resolveScopeRecord(db: Db, scopeType: BudgetScopeType, scopeId: s
 }
 
 async function computeObservedAmount(
-  db: Db,
+  db: QueryableDb,
   policy: Pick<PolicyRow, "companyId" | "scopeType" | "scopeId" | "windowKind" | "metric">,
 ) {
   if (policy.metric !== "billed_cents") return 0;
@@ -190,7 +190,7 @@ function buildApprovalPayload(input: {
 }
 
 async function markApprovalStatus(
-  db: Db,
+  db: QueryableDb,
   approvalId: string | null,
   status: "approved" | "rejected",
   decisionNote: string | null | undefined,
@@ -209,11 +209,11 @@ async function markApprovalStatus(
     .where(eq(approvals.id, approvalId));
 }
 
-export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
+export function budgetService(db: QueryableDb, hooks: BudgetServiceHooks = {}) {
   async function pauseScopeForBudget(policy: PolicyRow) {
     const now = new Date();
     if (policy.scopeType === "agent") {
-      await db
+      const [result] = await db
         .update(agents)
         .set({
           status: "paused",
@@ -221,23 +221,45 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
           pausedAt: now,
           updatedAt: now,
         })
-        .where(and(eq(agents.id, policy.scopeId), inArray(agents.status, ["active", "idle", "running", "error"])));
+        .where(and(eq(agents.id, policy.scopeId), inArray(agents.status, ["active", "idle", "running", "error"])))
+        .returning({ id: agents.id });
+      if (!result) return;
+      await logActivity(db, {
+        companyId: policy.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "budget.pause_agent",
+        entityType: "agent",
+        entityId: policy.scopeId,
+        details: { reason: "budget", budgetPolicyId: policy.id },
+      });
       return;
     }
 
     if (policy.scopeType === "project") {
-      await db
+      const [result] = await db
         .update(projects)
         .set({
           pauseReason: "budget",
           pausedAt: now,
           updatedAt: now,
         })
-        .where(eq(projects.id, policy.scopeId));
+        .where(eq(projects.id, policy.scopeId))
+        .returning({ id: projects.id });
+      if (!result) return;
+      await logActivity(db, {
+        companyId: policy.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "budget.pause_project",
+        entityType: "project",
+        entityId: policy.scopeId,
+        details: { reason: "budget", budgetPolicyId: policy.id },
+      });
       return;
     }
 
-    await db
+    const [result] = await db
       .update(companies)
       .set({
         status: "paused",
@@ -245,7 +267,18 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         pausedAt: now,
         updatedAt: now,
       })
-      .where(eq(companies.id, policy.scopeId));
+      .where(eq(companies.id, policy.scopeId))
+      .returning({ id: companies.id });
+    if (!result) return;
+    await logActivity(db, {
+      companyId: policy.companyId,
+      actorType: "system",
+      actorId: "system",
+      action: "budget.pause_company",
+      entityType: "company",
+      entityId: policy.scopeId,
+      details: { reason: "budget", budgetPolicyId: policy.id },
+    });
   }
 
   async function pauseAndCancelScopeForBudget(policy: PolicyRow) {
@@ -260,7 +293,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
   async function resumeScopeFromBudget(policy: PolicyRow) {
     const now = new Date();
     if (policy.scopeType === "agent") {
-      await db
+      const [result] = await db
         .update(agents)
         .set({
           status: "idle",
@@ -268,23 +301,45 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
           pausedAt: null,
           updatedAt: now,
         })
-        .where(and(eq(agents.id, policy.scopeId), eq(agents.pauseReason, "budget")));
+        .where(and(eq(agents.id, policy.scopeId), eq(agents.pauseReason, "budget")))
+        .returning({ id: agents.id });
+      if (!result) return;
+      await logActivity(db, {
+        companyId: policy.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "budget.resume_agent",
+        entityType: "agent",
+        entityId: policy.scopeId,
+        details: { budgetPolicyId: policy.id },
+      });
       return;
     }
 
     if (policy.scopeType === "project") {
-      await db
+      const [result] = await db
         .update(projects)
         .set({
           pauseReason: null,
           pausedAt: null,
           updatedAt: now,
         })
-        .where(and(eq(projects.id, policy.scopeId), eq(projects.pauseReason, "budget")));
+        .where(and(eq(projects.id, policy.scopeId), eq(projects.pauseReason, "budget")))
+        .returning({ id: projects.id });
+      if (!result) return;
+      await logActivity(db, {
+        companyId: policy.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "budget.resume_project",
+        entityType: "project",
+        entityId: policy.scopeId,
+        details: { budgetPolicyId: policy.id },
+      });
       return;
     }
 
-    await db
+    const [result] = await db
       .update(companies)
       .set({
         status: "active",
@@ -292,7 +347,18 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         pausedAt: null,
         updatedAt: now,
       })
-      .where(and(eq(companies.id, policy.scopeId), eq(companies.pauseReason, "budget")));
+      .where(and(eq(companies.id, policy.scopeId), eq(companies.pauseReason, "budget")))
+      .returning({ id: companies.id });
+    if (!result) return;
+    await logActivity(db, {
+      companyId: policy.companyId,
+      actorType: "system",
+      actorId: "system",
+      action: "budget.resume_company",
+      entityType: "company",
+      entityId: policy.scopeId,
+      details: { budgetPolicyId: policy.id },
+    });
   }
 
   async function getPolicyRow(policyId: string) {
@@ -407,6 +473,13 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         amountObserved,
         status: "open",
         approvalId: approval?.id ?? null,
+      })
+      .onConflictDoNothing({
+        target: [
+          budgetIncidents.policyId,
+          budgetIncidents.windowStart,
+          budgetIncidents.thresholdType,
+        ],
       })
       .returning()
       .then((rows) => rows[0] ?? null);

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
-import type { Db } from "@paperclipai/db";
+import type { QueryableDb } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
@@ -27,7 +27,7 @@ function currentUtcMonthWindow(now = new Date()) {
 }
 
 async function getMonthlySpendTotal(
-  db: Db,
+  db: QueryableDb,
   scope: { companyId: string; agentId?: string | null },
 ) {
   const { start, end } = currentUtcMonthWindow();
@@ -48,57 +48,60 @@ async function getMonthlySpendTotal(
   return Number(row?.total ?? 0);
 }
 
-export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
+export function costService(db: QueryableDb, budgetHooks: BudgetServiceHooks = {}) {
   const budgets = budgetService(db, budgetHooks);
   return {
     createEvent: async (companyId: string, data: Omit<typeof costEvents.$inferInsert, "companyId">) => {
-      const agent = await db
-        .select()
-        .from(agents)
-        .where(eq(agents.id, data.agentId))
-        .then((rows) => rows[0] ?? null);
+      return db.transaction(async (tx) => {
+        const agent = await tx
+          .select()
+          .from(agents)
+          .where(eq(agents.id, data.agentId))
+          .then((rows) => rows[0] ?? null);
 
-      if (!agent) throw notFound("Agent not found");
-      if (agent.companyId !== companyId) {
-        throw unprocessable("Agent does not belong to company");
-      }
+        if (!agent) throw notFound("Agent not found");
+        if (agent.companyId !== companyId) {
+          throw unprocessable("Agent does not belong to company");
+        }
 
-      const event = await db
-        .insert(costEvents)
-        .values({
-          ...data,
-          companyId,
-          biller: data.biller ?? data.provider,
-          billingType: data.billingType ?? "unknown",
-          cachedInputTokens: data.cachedInputTokens ?? 0,
-        })
-        .returning()
-        .then((rows) => rows[0]);
+        const event = await tx
+          .insert(costEvents)
+          .values({
+            ...data,
+            companyId,
+            biller: data.biller ?? data.provider,
+            billingType: data.billingType ?? "unknown",
+            cachedInputTokens: data.cachedInputTokens ?? 0,
+          })
+          .returning()
+          .then((rows) => rows[0]);
 
-      const [agentMonthSpend, companyMonthSpend] = await Promise.all([
-        getMonthlySpendTotal(db, { companyId, agentId: event.agentId }),
-        getMonthlySpendTotal(db, { companyId }),
-      ]);
+        const [agentMonthSpend, companyMonthSpend] = await Promise.all([
+          getMonthlySpendTotal(tx, { companyId, agentId: event.agentId }),
+          getMonthlySpendTotal(tx, { companyId }),
+        ]);
 
-      await db
-        .update(agents)
-        .set({
-          spentMonthlyCents: agentMonthSpend,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, event.agentId));
+        await tx
+          .update(agents)
+          .set({
+            spentMonthlyCents: agentMonthSpend,
+            updatedAt: new Date(),
+          })
+          .where(eq(agents.id, event.agentId));
 
-      await db
-        .update(companies)
-        .set({
-          spentMonthlyCents: companyMonthSpend,
-          updatedAt: new Date(),
-        })
-        .where(eq(companies.id, companyId));
+        await tx
+          .update(companies)
+          .set({
+            spentMonthlyCents: companyMonthSpend,
+            updatedAt: new Date(),
+          })
+          .where(eq(companies.id, companyId));
 
-      await budgets.evaluateCostEvent(event);
+        const txBudgets = budgetService(tx, budgetHooks);
+        await txBudgets.evaluateCostEvent(event);
 
-      return event;
+        return event;
+      });
     },
 
     summary: async (companyId: string, range?: CostDateRange) => {

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -1,4 +1,4 @@
-import type { Db } from "@paperclipai/db";
+import type { QueryableDb } from "@paperclipai/db";
 import { companies, instanceSettings } from "@paperclipai/db";
 import {
   DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
@@ -72,7 +72,7 @@ function toInstanceSettings(row: typeof instanceSettings.$inferSelect): Instance
   };
 }
 
-export function instanceSettingsService(db: Db) {
+export function instanceSettingsService(db: QueryableDb) {
   async function getOrCreateRow() {
     const existing = await db
       .select()


### PR DESCRIPTION
## Problem

Concurrent cost events can produce inconsistent state between \costEvents\, \gents.spentMonthlyCents\, \companies.spentMonthlyCents\, and \udgetIncidents\ because \createEvent\ does insert + update + evaluate without a transaction. Two cost events arriving simultaneously can interleave their DB writes.

## Fix

- Added \QueryableDb\ type (\Db | TxDb\) to \@paperclipai/db\ to allow transaction objects to be threaded through service layer
- Updated \logActivity\, \instanceSettingsService\, \costService\, and \udgetService\ to accept \QueryableDb\
- Wrapped \createEvent\ body in \db.transaction()\ so cost insertion, monthly spend updates, and budget evaluation are atomic

## Verification

\\\sh
pnpm -r typecheck  # all packages pass
pnpm test:run      # existing tests pass (2 pre-existing Windows-only failures unrelated)
pnpm build         # clean build
\\\

## Risk

Low. The \QueryableDb\ type is a superset of the existing \Db\ type — existing callers passing \Db\ still work. The only behavioral change is that \createEvent\ runs inside a transaction where it previously did not.