### PR TITLE
fix: implement heartbeat cancel for sandbox-backed runs

### DIFF
--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -1205,6 +1205,91 @@ export function environmentRuntimeService(
       return released;
     },
 
+    async destroyRunLeases(
+      heartbeatRunId: string,
+    ): Promise<EnvironmentRuntimeLeaseRecord[]> {
+      const leaseRows = await db
+        .select()
+        .from(environmentLeases)
+        .where(
+          and(
+            eq(environmentLeases.heartbeatRunId, heartbeatRunId),
+            inArray(environmentLeases.status, ["active"]),
+          ),
+        );
+      if (leaseRows.length === 0) {
+        return [];
+      }
+
+      const destroyed: EnvironmentRuntimeLeaseRecord[] = [];
+      for (const leaseRow of leaseRows) {
+        const environment = await environmentsSvc.getById(leaseRow.environmentId);
+        if (!environment) continue;
+
+        const leaseSnapshot: EnvironmentLease = {
+          id: leaseRow.id,
+          companyId: leaseRow.companyId,
+          environmentId: leaseRow.environmentId,
+          executionWorkspaceId: leaseRow.executionWorkspaceId ?? null,
+          issueId: leaseRow.issueId ?? null,
+          heartbeatRunId: leaseRow.heartbeatRunId ?? null,
+          status: leaseRow.status as EnvironmentLease["status"],
+          leasePolicy: leaseRow.leasePolicy as EnvironmentLease["leasePolicy"],
+          provider: leaseRow.provider ?? null,
+          providerLeaseId: leaseRow.providerLeaseId ?? null,
+          acquiredAt: leaseRow.acquiredAt,
+          lastUsedAt: leaseRow.lastUsedAt,
+          expiresAt: leaseRow.expiresAt ?? null,
+          releasedAt: leaseRow.releasedAt ?? null,
+          failureReason: leaseRow.failureReason ?? null,
+          cleanupStatus: leaseRow.cleanupStatus as EnvironmentLease["cleanupStatus"],
+          metadata: (leaseRow.metadata as Record<string, unknown> | null) ?? null,
+          createdAt: leaseRow.createdAt,
+          updatedAt: leaseRow.updatedAt,
+        };
+        const driver = getDriver(getLeaseDriverKey(leaseSnapshot, environment));
+        if (!driver) continue;
+
+        try {
+          if (driver.destroyRunLease) {
+            const lease = await driver.destroyRunLease({ environment, lease: leaseSnapshot });
+            if (lease) {
+              destroyed.push({
+                environment,
+                lease,
+                leaseContext: {
+                  executionWorkspaceId: lease.executionWorkspaceId,
+                  executionWorkspaceMode:
+                    (lease.metadata?.executionWorkspaceMode as ExecutionWorkspace["mode"] | null | undefined) ?? null,
+                },
+              });
+            }
+          } else {
+            const lease = await driver.releaseRunLease({
+              environment,
+              lease: leaseSnapshot,
+              status: "released",
+            });
+            if (lease) {
+              destroyed.push({
+                environment,
+                lease,
+                leaseContext: {
+                  executionWorkspaceId: lease.executionWorkspaceId,
+                  executionWorkspaceMode:
+                    (lease.metadata?.executionWorkspaceMode as ExecutionWorkspace["mode"] | null | undefined) ?? null,
+                },
+              });
+            }
+          }
+        } catch {
+          // Individual lease destroy failures should not block others
+        }
+      }
+
+      return destroyed;
+    },
+
     async resumeRunLease(input: EnvironmentDriverLeaseInput): Promise<PluginEnvironmentLease | EnvironmentLease | null> {
       const driver = requireDriverKey(getLeaseDriverKey(input.lease, input.environment));
       if (!driver.resumeRunLease) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9597,6 +9597,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     }
 
+    try {
+      await environmentRuntime.destroyRunLeases(run.id);
+    } catch (err) {
+      logger.warn({ err, runId: run.id }, "Failed to destroy environment leases during cancel");
+    }
+
     const cancelled = await setRunStatus(run.id, "cancelled", {
       finishedAt: new Date(),
       error: reason,
@@ -9670,6 +9676,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           pid: run.processPid,
           processGroupId: run.processGroupId,
         });
+      }
+
+      try {
+        await environmentRuntime.destroyRunLeases(run.id);
+      } catch (err) {
+        logger.warn({ err, runId: run.id }, "Failed to destroy environment leases during cancel");
       }
       await releaseIssueExecutionAndPromote(run);
     }


### PR DESCRIPTION
## Problem

Sandbox-backed heartbeat runs are not registered in the \unningProcesses\ Map, so \cancelRunInternal\ only updates DB state but the actual process keeps running in the remote sandbox until timeout. This means pausing an agent or cancelling a run in the UI effectively does nothing for sandbox-backed agents.

## Fix

- Added \destroyRunLeases(heartbeatRunId)\ to \environmentRuntimeService\ that resolves active environment leases by heartbeat run ID and calls \destroyRunLease\ on the sandbox driver
- Falls back to \eleaseRunLease\ for drivers that don't support destroy (local, SSH)
- Wired into \cancelRunInternal\ and \cancelActiveForAgentInternal\ so cancelling a sandbox-backed run properly terminates the remote process

## Verification

\\\sh
pnpm -r typecheck  # all packages pass
pnpm build         # clean build
\\\

## Risk

Low. The new \destroyRunLeases\ method follows the same pattern as the existing \eleaseRunLeases\ (DB query → resolve driver → call driver method). Failures are caught and logged, never blocking the DB status update or issue promotion.