### PR TITLE
fix(issues): use effective post-patch assignee in monitor authz check

### DIFF
--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -605,4 +605,154 @@ describe("issue execution policy routes", () => {
       }),
     );
   });
+
+  it("allows a non-CEO agent to self-assign and set a monitor in a single PATCH", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Self-assign with monitor",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+        executionPolicy: {
+          monitor: {
+            nextCheckAt: "2026-12-01T12:00:00.000Z",
+            scheduledBy: "assignee",
+            notes: "Self-assigned monitor.",
+          },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+        monitorNextCheckAt: new Date("2026-12-01T12:00:00.000Z"),
+      }),
+    );
+  });
+
+  it("rejects monitor management when patching an unassigned issue without self-assigning", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1009",
+      title: "No self-assign",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        executionPolicy: {
+          monitor: {
+            nextCheckAt: "2026-12-01T12:00:00.000Z",
+            scheduledBy: "assignee",
+          },
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Only the assignee agent or a board user can manage issue monitors");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a current assignee to clear the monitor while self-unassigning in a single PATCH", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1010",
+      title: "Unassign and clear monitor",
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor: {
+          nextCheckAt: "2026-12-01T12:00:00.000Z",
+          scheduledBy: "assignee",
+          notes: null,
+          kind: null,
+          serviceName: null,
+          externalRef: null,
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+        },
+      },
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: new Date("2026-12-01T12:00:00.000Z"),
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: "assignee",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        assigneeAgentId: null,
+        executionPolicy: null,
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3935,7 +3935,15 @@ export function issueRoutes(
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
     const monitorChanged = monitorPoliciesEqual(previousExecutionPolicy, nextExecutionPolicy) === false;
-    assertCanManageIssueMonitor(req, existing.assigneeAgentId, req.body.executionPolicy !== undefined && monitorChanged);
+    // Use the effective post-patch assignee for the monitor authz check. If the
+    // actor is already the assignee their rights are preserved even when they
+    // clear the assignment in the same request; if they are self-assigning in
+    // this PATCH they get monitor rights as the incoming assignee.
+    const monitorCheckAssigneeAgentId =
+      req.actor.type === "agent" && req.actor.agentId === existing.assigneeAgentId
+        ? existing.assigneeAgentId
+        : requestedAssigneeAgentId;
+    assertCanManageIssueMonitor(req, monitorCheckAssigneeAgentId, req.body.executionPolicy !== undefined && monitorChanged);
 
     const transition = applyIssueExecutionPolicyTransition({
       issue: existing,


### PR DESCRIPTION
## Thinking Path

> - Paperclip allows human board users to monitor issues via a monitor policy
> - The PATCH /api/issues/:id route validates that the requesting agent can manage the monitor field
> - The authz check used  — the value before the patch was applied
> - For unassigned issues being self-assigned in the same PATCH, this meant the check ran against null even though the effective post-patch assignee was the requesting agent
> - This PR reads the effective post-patch assignee before the authz check so self-assign + monitor can succeed in one request
> - The benefit is agents can assign themselves and set a monitor in a single operation

## What Changed

- : compute effective assignee from patch body before calling 
- : added test covering self-assign + monitor in a single PATCH

## Verification

- Ran  — pass including new test case

## Risks

Low risk — logic change is localised to the monitor authz check. Existing authorised flows are unaffected.

## Model Used

- Provider: Nous Research Hermes Agent v0.15.1
- Model: qwen/qwen3.6-27b (Qwen3.6-27B-Instruct Q8_0, 27B dense, 131k context)
- Infrastructure: LM Studio on local GPU via PaperclipForge hermes_local adapter
- Capabilities: terminal, file read/write, search tools

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model Used specified
- [x] Bug fix — Path 1
- [x] Tests pass with new test added
- [x] 2 files changed