### PR TITLE
Handle Darwin embedded Postgres native runtime

### DIFF
--- a/packages/db/src/embedded-postgres-native.test.ts
+++ b/packages/db/src/embedded-postgres-native.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ensureLinuxSharedLibraryAliases } from "./embedded-postgres-native.js";
+import { ensureLinuxSharedLibraryAliases, upsertAutoConfSetting } from "./embedded-postgres-native.js";
 
 describe("embedded Postgres native runtime", () => {
   const tempDirs: string[] = [];
@@ -39,5 +39,31 @@ describe("embedded Postgres native runtime", () => {
 
     expect(second).toEqual([]);
     expect(fs.readlinkSync(path.join(tempDir, "libicuuc.so.60"))).toBe("libicuuc.so.60.2");
+  });
+
+  it("adds dynamic_library_path to postgresql.auto.conf", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-embedded-pg-auto-conf-"));
+    tempDirs.push(tempDir);
+    const autoConfPath = path.join(tempDir, "postgresql.auto.conf");
+
+    await upsertAutoConfSetting(autoConfPath, "dynamic_library_path", "/tmp/native/lib");
+
+    expect(fs.readFileSync(autoConfPath, "utf8")).toBe("dynamic_library_path = '/tmp/native/lib'\n");
+  });
+
+  it("replaces an existing dynamic_library_path entry without touching other settings", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-embedded-pg-auto-conf-"));
+    tempDirs.push(tempDir);
+    const autoConfPath = path.join(tempDir, "postgresql.auto.conf");
+    fs.writeFileSync(
+      autoConfPath,
+      "shared_buffers = '128MB'\ndynamic_library_path = '/old/lib'\nwork_mem = '4MB'\n",
+    );
+
+    await upsertAutoConfSetting(autoConfPath, "dynamic_library_path", "/new/lib");
+
+    expect(fs.readFileSync(autoConfPath, "utf8")).toBe(
+      "shared_buffers = '128MB'\nwork_mem = '4MB'\ndynamic_library_path = '/new/lib'\n",
+    );
   });
 });

--- a/packages/db/src/embedded-postgres-native.ts
+++ b/packages/db/src/embedded-postgres-native.ts
@@ -4,23 +4,32 @@ import path from "node:path";
 
 const require = createRequire(import.meta.url);
 
-function resolveNativePackageName(): string | null {
-  if (process.platform !== "linux") return null;
+type NativeRuntimeConfig = {
+  envVarName: "LD_LIBRARY_PATH" | "DYLD_LIBRARY_PATH";
+  nativePackageName: string;
+};
 
-  switch (process.arch) {
-    case "arm64":
-      return "linux-arm64";
-    case "arm":
-      return "linux-arm";
-    case "ia32":
-      return "linux-ia32";
-    case "ppc64":
-      return "linux-ppc64";
-    case "x64":
-      return "linux-x64";
-    default:
-      return null;
+function resolveNativePackageName(): string | null {
+  if (process.platform === "linux") {
+    switch (process.arch) {
+      case "arm64":
+        return "linux-arm64";
+      case "arm":
+        return "linux-arm";
+      case "ia32":
+        return "linux-ia32";
+      case "ppc64":
+        return "linux-ppc64";
+      case "x64":
+        return "linux-x64";
+      default:
+        return null;
+    }
   }
+
+  if (process.platform === "darwin" && process.arch === "arm64") return "darwin-arm64";
+
+  return null;
 }
 
 async function pathExists(value: string): Promise<boolean> {
@@ -41,11 +50,54 @@ function resolveEmbeddedPostgresPackageRoot(): string | null {
   }
 }
 
+function resolveNativePackageRoot(nativePackageName: string): string | null {
+  try {
+    const packageRoot = resolveEmbeddedPostgresPackageRoot();
+    if (!packageRoot) return null;
+    const entryPath = require.resolve(`@embedded-postgres/${nativePackageName}`, {
+      paths: [packageRoot],
+    });
+    return path.dirname(path.dirname(entryPath));
+  } catch {
+    return null;
+  }
+}
+
 function prependPathEnv(name: string, value: string): void {
   const current = process.env[name] ?? "";
   const parts = current.split(path.delimiter).filter(Boolean);
   if (parts.includes(value)) return;
   process.env[name] = [value, ...parts].join(path.delimiter);
+}
+
+function resolveNativeRuntimeConfig(): NativeRuntimeConfig | null {
+  const nativePackageName = resolveNativePackageName();
+  if (!nativePackageName) return null;
+  return {
+    envVarName: process.platform === "darwin" ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH",
+    nativePackageName,
+  };
+}
+
+export async function upsertAutoConfSetting(
+  autoConfPath: string,
+  key: string,
+  value: string,
+): Promise<void> {
+  const rendered = `${key} = '${value.replaceAll("'", "''")}'`;
+  let contents = "";
+  try {
+    contents = await fs.readFile(autoConfPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  const lines = contents.length > 0 ? contents.split(/\r?\n/) : [];
+  const filtered = lines.filter((line) => !line.trimStart().startsWith(`${key} =`));
+  filtered.push(rendered);
+  const nextContents = `${filtered.filter((line) => line.length > 0).join("\n")}\n`;
+  if (nextContents === contents) return;
+  await fs.writeFile(autoConfPath, nextContents, "utf8");
 }
 
 export async function ensureLinuxSharedLibraryAliases(libDir: string): Promise<string[]> {
@@ -71,15 +123,26 @@ export async function ensureLinuxSharedLibraryAliases(libDir: string): Promise<s
   return created;
 }
 
-export async function prepareEmbeddedPostgresNativeRuntime(): Promise<void> {
-  const nativePackageName = resolveNativePackageName();
-  const packageRoot = resolveEmbeddedPostgresPackageRoot();
-  if (!nativePackageName || !packageRoot) return;
+export async function prepareEmbeddedPostgresNativeRuntime(dataDir?: string): Promise<void> {
+  const runtimeConfig = resolveNativeRuntimeConfig();
+  if (!runtimeConfig) return;
 
-  const nativeRoot = path.resolve(packageRoot, "..", "@embedded-postgres", nativePackageName);
+  const nativeRoot = resolveNativePackageRoot(runtimeConfig.nativePackageName);
+  if (!nativeRoot) return;
   const libDir = path.join(nativeRoot, "native", "lib");
   if (!(await pathExists(libDir))) return;
 
-  prependPathEnv("LD_LIBRARY_PATH", libDir);
-  await ensureLinuxSharedLibraryAliases(libDir);
+  prependPathEnv(runtimeConfig.envVarName, libDir);
+  if (process.platform === "linux") {
+    await ensureLinuxSharedLibraryAliases(libDir);
+    return;
+  }
+
+  if (process.platform === "darwin" && dataDir) {
+    await upsertAutoConfSetting(
+      path.resolve(dataDir, "postgresql.auto.conf"),
+      "dynamic_library_path",
+      libDir,
+    );
+  }
 }

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -93,7 +93,7 @@ async function ensureEmbeddedPostgresConnection(
   preferredPort: number,
 ): Promise<MigrationConnection> {
   const EmbeddedPostgres = await loadEmbeddedPostgresCtor();
-  await prepareEmbeddedPostgresNativeRuntime();
+  await prepareEmbeddedPostgresNativeRuntime(dataDir);
   const selectedPort = await findAvailablePort(preferredPort);
   const postmasterPidFile = path.resolve(dataDir, "postmaster.pid");
   const pgVersionFile = path.resolve(dataDir, "PG_VERSION");

--- a/packages/db/src/test-embedded-postgres.ts
+++ b/packages/db/src/test-embedded-postgres.ts
@@ -47,9 +47,9 @@ function getReservedTestPorts(): Set<number> {
   return new Set(configuredPorts.filter((port) => Number.isInteger(port) && port > 0 && port <= 65535));
 }
 
-async function getEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {
+async function getEmbeddedPostgresCtor(dataDir: string): Promise<EmbeddedPostgresCtor> {
   const mod = await import("embedded-postgres");
-  await prepareEmbeddedPostgresNativeRuntime();
+  await prepareEmbeddedPostgresNativeRuntime(dataDir);
   return mod.default as EmbeddedPostgresCtor;
 }
 
@@ -87,7 +87,7 @@ async function getAvailablePort(): Promise<number> {
 async function createEmbeddedPostgresTestInstance(tempDirPrefix: string) {
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), tempDirPrefix));
   const port = await getAvailablePort();
-  const EmbeddedPostgres = await getEmbeddedPostgresCtor();
+  const EmbeddedPostgres = await getEmbeddedPostgresCtor(dataDir);
   const instance = new EmbeddedPostgres({
     databaseDir: dataDir,
     user: "paperclip",


### PR DESCRIPTION
## Summary
- add Darwin native runtime handling to `prepareEmbeddedPostgresNativeRuntime`
- resolve `@embedded-postgres/darwin-arm64` via `require.resolve` from the installed `embedded-postgres` package context
- rewrite `postgresql.auto.conf` with the resolved `dynamic_library_path` and cover the config upsert in unit tests

## Verification
- `pnpm vitest run packages/db/src/embedded-postgres-native.test.ts`
- `pnpm --filter @paperclipai/db typecheck`
- Darwin-path simulation:
  - create a temp `postgresql.auto.conf`
  - run `prepareEmbeddedPostgresNativeRuntime(tempDir)` on macOS
  - verify `dynamic_library_path` is rewritten to the resolved `@embedded-postgres/darwin-arm64/native/lib` path

## Issue
- IMP-3408
