### PR TITLE
fix(PRO-6211): handle thinking/redacted_thinking blocks in claude_local session replay

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -52,6 +52,7 @@ import {
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
+  isClaudeThinkingBlocksModifiedError,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
@@ -879,6 +880,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
+    const clearSessionForThinkingBlocks = parsedStream.hasThinkingBlocks;
     const parsedIsError = asBoolean(parsed.is_error, false);
     const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
     const errorMessage = failed
@@ -937,7 +939,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       costUsd: parsedStream.costUsd ?? asNumber(parsed.total_cost_usd, 0),
       resultJson: mergedResultJson,
       summary: parsedStream.summary || asString(parsed.result, ""),
-      clearSession: clearSessionForMaxTurns || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+      clearSession: clearSessionForMaxTurns || clearSessionForThinkingBlocks || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
     };
   };
 
@@ -953,6 +955,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       await onLog(
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+      );
+      const retry = await runAttempt(null);
+      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+    }
+
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      initial.parsed &&
+      isClaudeThinkingBlocksModifiedError(initial.parsed)
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Claude resume session "${sessionId}" failed due to modified thinking/redacted_thinking blocks; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -6,6 +6,7 @@ export {
   parseClaudeStreamJson,
   describeClaudeFailure,
   isClaudeMaxTurnsResult,
+  isClaudeThinkingBlocksModifiedError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 export {

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
+  isClaudeThinkingBlocksModifiedError,
   isClaudeTransientUpstreamError,
+  parseClaudeStreamJson,
 } from "./parse.js";
 
 describe("isClaudeTransientUpstreamError", () => {
@@ -93,6 +95,94 @@ describe("isClaudeTransientUpstreamError", () => {
         errorMessage: "Invalid request_error: Unknown parameter 'foo'.",
       }),
     ).toBe(false);
+  });
+});
+
+describe("isClaudeThinkingBlocksModifiedError", () => {
+  it("detects the canonical Anthropic API 400 thinking-block error", () => {
+    expect(
+      isClaudeThinkingBlocksModifiedError({
+        is_error: true,
+        result:
+          "API Error: 400 messages.3.content.4: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects redacted_thinking variant", () => {
+    expect(
+      isClaudeThinkingBlocksModifiedError({
+        is_error: true,
+        errors: [
+          {
+            message:
+              "redacted_thinking blocks in the latest assistant message cannot be modified.",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(
+      isClaudeThinkingBlocksModifiedError({
+        is_error: true,
+        result: "API Error: 400 Invalid request: unknown parameter 'foo'.",
+      }),
+    ).toBe(false);
+    expect(isClaudeThinkingBlocksModifiedError(null)).toBe(false);
+    expect(isClaudeThinkingBlocksModifiedError(undefined)).toBe(false);
+  });
+});
+
+describe("parseClaudeStreamJson — hasThinkingBlocks", () => {
+  function makeAssistantEvent(contentBlocks: Record<string, unknown>[]) {
+    return JSON.stringify({
+      type: "assistant",
+      session_id: "sess-1",
+      message: { content: contentBlocks },
+    });
+  }
+
+  const resultLine = JSON.stringify({
+    type: "result",
+    session_id: "sess-1",
+    result: "done",
+    usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 0 },
+    total_cost_usd: 0.001,
+  });
+
+  it("sets hasThinkingBlocks when a thinking block is present", () => {
+    const stdout = [
+      makeAssistantEvent([
+        { type: "thinking", thinking: "internal reasoning..." },
+        { type: "text", text: "Hello" },
+      ]),
+      resultLine,
+    ].join("\n");
+    expect(parseClaudeStreamJson(stdout).hasThinkingBlocks).toBe(true);
+  });
+
+  it("sets hasThinkingBlocks when a redacted_thinking block is present", () => {
+    const stdout = [
+      makeAssistantEvent([
+        { type: "redacted_thinking", data: "encrypted..." },
+      ]),
+      resultLine,
+    ].join("\n");
+    expect(parseClaudeStreamJson(stdout).hasThinkingBlocks).toBe(true);
+  });
+
+  it("leaves hasThinkingBlocks false when only text blocks are present", () => {
+    const stdout = [
+      makeAssistantEvent([{ type: "text", text: "Hello" }]),
+      resultLine,
+    ].join("\n");
+    expect(parseClaudeStreamJson(stdout).hasThinkingBlocks).toBe(false);
+  });
+
+  it("leaves hasThinkingBlocks false on empty output", () => {
+    expect(parseClaudeStreamJson("").hasThinkingBlocks).toBe(false);
   });
 });
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -19,6 +19,7 @@ export function parseClaudeStreamJson(stdout: string) {
   let model = "";
   let finalResult: Record<string, unknown> | null = null;
   const assistantTexts: string[] = [];
+  let hasThinkingBlocks = false;
 
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -40,7 +41,11 @@ export function parseClaudeStreamJson(stdout: string) {
       for (const entry of content) {
         if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
         const block = entry as Record<string, unknown>;
-        if (asString(block.type, "") === "text") {
+        const blockType = asString(block.type, "");
+        if (blockType === "thinking" || blockType === "redacted_thinking") {
+          hasThinkingBlocks = true;
+        }
+        if (blockType === "text") {
           const text = asString(block.text, "");
           if (text) assistantTexts.push(text);
         }
@@ -62,6 +67,7 @@ export function parseClaudeStreamJson(stdout: string) {
       usage: null as UsageSummary | null,
       summary: assistantTexts.join("\n\n").trim(),
       resultJson: null as Record<string, unknown> | null,
+      hasThinkingBlocks,
     };
   }
 
@@ -82,7 +88,19 @@ export function parseClaudeStreamJson(stdout: string) {
     usage,
     summary,
     resultJson: finalResult,
+    hasThinkingBlocks,
   };
+}
+
+export function isClaudeThinkingBlocksModifiedError(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+  const resultText = asString(parsed.result, "").trim();
+  const errors = extractClaudeErrorMessages(parsed);
+  const allMessages = [resultText, ...errors].filter(Boolean);
+  return allMessages.some((msg) =>
+    /thinking.*blocks.*cannot be modified|redacted_thinking.*blocks.*cannot be modified/i.test(msg) ||
+    /cannot be modified[\s\S]{0,60}thinking/i.test(msg),
+  );
 }
 
 function extractClaudeErrorMessages(parsed: Record<string, unknown>): string[] {


### PR DESCRIPTION
## Summary

Fixes the `400 messages.X.content.Y: thinking or redacted_thinking blocks in the latest assistant message cannot be modified` error that caused heartbeat failures on agents with extended thinking enabled.

**Root cause:** When the Anthropic API returns `thinking` or `redacted_thinking` blocks in an assistant message, those blocks must be passed back verbatim in subsequent turns. The `claude_local` adapter resumed sessions via `--resume <sessionId>` without awareness of thinking blocks, allowing the CLI to attempt a replay with subtly modified blocks.

**Fix (two-pronged):**

1. **Proactive — clear session after thinking blocks:** `parseClaudeStreamJson` now sets `hasThinkingBlocks: true` when any `thinking` or `redacted_thinking` block is found in the assistant stream. `toAdapterResult` uses this flag to set `clearSession: true`, so the session is never resumed after a turn containing thinking blocks.

2. **Reactive — fresh-session retry on the modified-blocks 400:** `isClaudeThinkingBlocksModifiedError` detects the specific Anthropic API 400 error. If a resumed session hits this error, the adapter retries with a fresh session (same pattern as the existing unknown-session retry), clearing the stale session for future runs.

## Files changed

- `packages/adapters/claude-local/src/server/parse.ts` — `hasThinkingBlocks` in stream parse result; `isClaudeThinkingBlocksModifiedError`
- `packages/adapters/claude-local/src/server/execute.ts` — `clearSessionForThinkingBlocks`; thinking-blocks retry path
- `packages/adapters/claude-local/src/server/index.ts` — export `isClaudeThinkingBlocksModifiedError`
- `packages/adapters/claude-local/src/server/parse.test.ts` — unit tests for new detection and stream parsing

## Test plan

- [ ] Unit tests: `isClaudeThinkingBlocksModifiedError` detects canonical 400 message variants; false-positives return `false`
- [ ] Unit tests: `parseClaudeStreamJson` sets `hasThinkingBlocks: true` for `thinking` / `redacted_thinking` blocks, `false` for text-only or empty output
- [ ] Integration: agents with extended thinking (`--effort`) no longer hit the 400 error on session resume across heartbeats

Tracked in [PRO-6211](/PRO/issues/PRO-6211). Part of [PRO-6190](/PRO/issues/PRO-6190) platform hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)