### PR TITLE
Inject PAPERCLIP_COMPANY_ID into plugin worker environment in PluginWorkerManager

### DIFF
--- a/server/src/__tests__/fixtures/plugin-worker-env-report.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-env-report.cjs
@@ -1,0 +1,65 @@
+const readline = require("node:readline");
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  const message = JSON.parse(line);
+  const method = message && typeof message.method === "string" ? message.method : null;
+
+  if (method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        ok: true,
+        supportedMethods: ["reportEnv"],
+      },
+    });
+    return;
+  }
+
+  if (method === "reportEnv") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        companyId:
+          typeof process.env.PAPERCLIP_COMPANY_ID === "string"
+            ? process.env.PAPERCLIP_COMPANY_ID
+            : null,
+        pluginId:
+          typeof process.env.PAPERCLIP_PLUGIN_ID === "string"
+            ? process.env.PAPERCLIP_PLUGIN_ID
+            : null,
+      },
+    });
+    return;
+  }
+
+  if (method === "shutdown") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {},
+    });
+    setImmediate(() => process.exit(0));
+    return;
+  }
+
+  send({
+    jsonrpc: "2.0",
+    id: message.id,
+    error: {
+      code: -32601,
+      message: `Unhandled method: ${method}`,
+    },
+  });
+});

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -22,6 +22,7 @@ const INVOCATION_SCOPE_WORKER_ENTRYPOINT = path.join(
   "plugin-worker-invocation-scope.cjs",
 );
 const TERMINATED_WORKER_ENTRYPOINT = path.join(FIXTURES_DIR, "plugin-worker-terminated.cjs");
+const ENV_REPORT_WORKER_ENTRYPOINT = path.join(FIXTURES_DIR, "plugin-worker-env-report.cjs");
 
 const TEST_MANIFEST: PaperclipPluginManifestV1 = {
   id: "test.plugin",
@@ -415,6 +416,99 @@ describe("plugin-worker-manager stderr failure context", () => {
       expect(companiesGet).not.toHaveBeenCalled();
     } finally {
       await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("forwards the host PAPERCLIP_COMPANY_ID into the worker environment", async () => {
+    vi.stubEnv("PAPERCLIP_COMPANY_ID", "6bcff946-2075-4bce-8b86-c20c0cfe7129");
+
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: ENV_REPORT_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers: {},
+    });
+
+    try {
+      await handle.start();
+
+      await expect(
+        handle.call(
+          "reportEnv" as keyof HostToWorkerMethods,
+          {} as HostToWorkerMethods[keyof HostToWorkerMethods][0],
+        ),
+      ).resolves.toMatchObject({
+        companyId: "6bcff946-2075-4bce-8b86-c20c0cfe7129",
+        pluginId: "test.plugin",
+      });
+    } finally {
+      await handle.stop().catch(() => undefined);
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("omits PAPERCLIP_COMPANY_ID from the worker when the host value is blank", async () => {
+    vi.stubEnv("PAPERCLIP_COMPANY_ID", "   ");
+
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: ENV_REPORT_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers: {},
+    });
+
+    try {
+      await handle.start();
+
+      await expect(
+        handle.call(
+          "reportEnv" as keyof HostToWorkerMethods,
+          {} as HostToWorkerMethods[keyof HostToWorkerMethods][0],
+        ),
+      ).resolves.toMatchObject({ companyId: null });
+    } finally {
+      await handle.stop().catch(() => undefined);
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("omits PAPERCLIP_COMPANY_ID from the worker when the host value is unset", async () => {
+    vi.stubEnv("PAPERCLIP_COMPANY_ID", undefined as unknown as string);
+
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: ENV_REPORT_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers: {},
+    });
+
+    try {
+      await handle.start();
+
+      await expect(
+        handle.call(
+          "reportEnv" as keyof HostToWorkerMethods,
+          {} as HostToWorkerMethods[keyof HostToWorkerMethods][0],
+        ),
+      ).resolves.toMatchObject({ companyId: null });
+    } finally {
+      await handle.stop().catch(() => undefined);
+      vi.unstubAllEnvs();
     }
   });
 });

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -727,6 +727,16 @@ export function createPluginWorkerHandle(
       TZ: process.env.TZ ?? "UTC",
     };
 
+    // Forward the host's company scope so workers that receive no per-invocation
+    // scope (e.g. the messaging plugin handling inbound Postmark webhooks) can
+    // still resolve which company to invoke agents under. Sourced from the host
+    // process env like PATH/NODE_PATH above; omitted when unset so single-value
+    // deployments stay explicit and multi-tenant hosts don't pin a stale scope.
+    const companyId = process.env.PAPERCLIP_COMPANY_ID;
+    if (companyId && companyId.trim().length > 0) {
+      workerEnv.PAPERCLIP_COMPANY_ID = companyId;
+    }
+
     const child = fork(options.entrypointPath, [], {
       stdio: ["pipe", "pipe", "pipe", "ipc"],
       execArgv: options.execArgv ?? [],


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The server's `PluginWorkerManager` forks one long-lived worker child process per installed plugin and talks to it over JSON-RPC; for safety it does **not** let the worker inherit the host `process.env`, instead overlaying a fixed allow-list (`PATH`, `NODE_PATH`, `PAPERCLIP_PLUGIN_ID`, `NODE_ENV`, `TZ`)
> - Some worker code paths receive **no** per-invocation scope — e.g. `aperim.paperclip-messaging` handling an inbound Postmark webhook — so they have no way to learn which company to invoke an agent under
> - Without a company scope the worker logs `PAPERCLIP_COMPANY_ID not set — cannot invoke agent` and the subsequent `agents.invoke` fails with `JsonRpcCallError: Agent not found`
> - The host process already carries `PAPERCLIP_COMPANY_ID`, but `spawnProcess()` never forwarded it the way it forwards the other allow-listed keys
> - This pull request forwards the host's `PAPERCLIP_COMPANY_ID` into the forked worker environment, guarded so it is omitted when unset or blank
> - The benefit is that scope-less worker paths (inbound messaging webhooks) can resolve the company and successfully invoke agents, unblocking the paperclip-messaging delivery path

## What Changed

- `server/src/services/plugin-worker-manager.ts`: in `spawnProcess()`, after the `workerEnv` allow-list is built and before `fork(...)`, forward `process.env.PAPERCLIP_COMPANY_ID` into the worker env when it is a non-blank string (omitted otherwise). Mirrors the existing `PATH`/`NODE_PATH`/`PAPERCLIP_PLUGIN_ID` sourcing and preserves the deliberate env-minimization control — only this one explicit key is added.
- `server/src/__tests__/fixtures/plugin-worker-env-report.cjs`: new JSON-RPC fixture worker that reports its own `PAPERCLIP_COMPANY_ID` / `PAPERCLIP_PLUGIN_ID` back to the host via a `reportEnv` method.
- `server/src/__tests__/plugin-worker-manager.test.ts`: three tests — forwards the host value into the worker, omits it when the host value is blank, omits it when the host value is unset.

## Verification

- `cd server && pnpm typecheck` → `tsc --noEmit` exits **0**.
- Targeted suite: `cd server && pnpm exec vitest run src/__tests__/plugin-worker-manager.test.ts --testTimeout=20000 --no-file-parallelism` → **14 passed (14)**.
- The three new tests assert the forward/omit-blank/omit-unset behaviour directly by reading the env reported back from a real forked worker child.

## Risks

Low risk. The change is purely additive and guarded: when `PAPERCLIP_COMPANY_ID` is unset or blank the worker environment is byte-for-byte unchanged from today. No host env inheritance is introduced — exactly one explicit, already-trusted key is forwarded, so the worker's env-minimization security posture is preserved. No schema, migration, or API surface is touched.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. This is a targeted bug fix (env forwarding), not core feature work, and does not duplicate planned roadmap items.

## Model Used

Claude (Anthropic) — model `claude-opus-4-7`, extended thinking enabled, with tool use via the Claude Code agent harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (no UI change)
- [ ] I have updated relevant documentation to reflect my changes — N/A (internal worker env behaviour; no user-facing docs affected)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
