### PR TITLE
feat(server): graceful heap-drain on 75% heap threshold (PRO-6233)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,6 +47,8 @@ import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
+import { startHeapDrainMonitor } from "./services/heap-drain.js";
+import { runningProcesses } from "./adapters/index.js";
 import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
@@ -916,7 +918,11 @@ export async function startServer(): Promise<StartedServer> {
       resolveListen();
     });
   });
-  
+
+  if (config.heartbeatSchedulerEnabled) {
+    startHeapDrainMonitor({ getActiveRunCount: () => runningProcesses.size });
+  }
+
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
       const telemetryClient = getTelemetryClient();

--- a/server/src/services/heap-drain.ts
+++ b/server/src/services/heap-drain.ts
@@ -1,0 +1,99 @@
+import v8 from "node:v8";
+import { logger } from "../middleware/logger.js";
+
+const HEAP_DRAIN_PERCENT = Math.min(
+  100,
+  Math.max(1, Number(process.env.HEAP_DRAIN_PERCENT) || 75),
+);
+const HEAP_DRAIN_TIMEOUT_MS = Math.max(
+  1000,
+  Number(process.env.HEAP_DRAIN_TIMEOUT_MS) || 120_000,
+);
+const HEAP_DRAIN_POLL_MS = 5_000;
+
+let draining = false;
+
+export function isIntakeSuspended(): boolean {
+  return draining;
+}
+
+export function startHeapDrainMonitor(opts: {
+  getActiveRunCount: () => number;
+}): void {
+  const { heap_size_limit } = v8.getHeapStatistics();
+  const thresholdBytes = Math.floor((HEAP_DRAIN_PERCENT / 100) * heap_size_limit);
+
+  logger.info(
+    {
+      heapSizeLimitMb: Math.round(heap_size_limit / 1024 / 1024),
+      thresholdMb: Math.round(thresholdBytes / 1024 / 1024),
+      thresholdPercent: HEAP_DRAIN_PERCENT,
+      drainTimeoutMs: HEAP_DRAIN_TIMEOUT_MS,
+    },
+    "heap-drain monitor started",
+  );
+
+  async function performDrain(initialActiveRunCount: number): Promise<void> {
+    logger.warn(
+      {
+        activeRunCount: initialActiveRunCount,
+        drainTimeoutMs: HEAP_DRAIN_TIMEOUT_MS,
+      },
+      "heap-drain: drain sequence started — waiting for in-flight runs to complete",
+    );
+
+    const deadline = Date.now() + HEAP_DRAIN_TIMEOUT_MS;
+
+    await new Promise<void>((resolve) => {
+      const poll = setInterval(() => {
+        const remaining = opts.getActiveRunCount();
+        logger.info({ remaining }, "heap-drain: polling in-flight runs");
+        if (remaining === 0) {
+          clearInterval(poll);
+          resolve();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          logger.warn(
+            { remaining, drainTimeoutMs: HEAP_DRAIN_TIMEOUT_MS },
+            "heap-drain: drain timeout reached — proceeding with restart despite in-flight runs",
+          );
+          clearInterval(poll);
+          resolve();
+        }
+      }, 1_000);
+      poll.unref();
+    });
+
+    logger.warn("heap-drain: drain complete — sending SIGTERM for graceful restart");
+    process.kill(process.pid, "SIGTERM");
+  }
+
+  const interval = setInterval(() => {
+    if (draining) return;
+
+    const { used_heap_size } = v8.getHeapStatistics();
+    if (used_heap_size < thresholdBytes) return;
+
+    const usedPercent = Math.round((used_heap_size / heap_size_limit) * 100);
+    const activeRunCount = opts.getActiveRunCount();
+
+    logger.warn(
+      {
+        usedHeapMb: Math.round(used_heap_size / 1024 / 1024),
+        heapSizeLimitMb: Math.round(heap_size_limit / 1024 / 1024),
+        usedPercent,
+        thresholdPercent: HEAP_DRAIN_PERCENT,
+        activeRunCount,
+      },
+      "heap-drain: threshold crossed — suspending intake",
+    );
+
+    draining = true;
+    clearInterval(interval);
+    void performDrain(activeRunCount);
+  }, HEAP_DRAIN_POLL_MS);
+
+  // Do not prevent process exit if no runs are active.
+  interval.unref();
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isIntakeSuspended } from "./heap-drain.js";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
@@ -6878,6 +6879,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function startNextQueuedRunForAgent(agentId: string) {
     return withAgentStartLock(agentId, async () => {
+      if (isIntakeSuspended()) return [];
       const agent = await getAgent(agentId);
       if (!agent) return [];
       if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {


### PR DESCRIPTION
## Summary

Implements D2 from the fleet-collapse guardrail plan (PRO-6233), wiring server-side graceful drain when Node.js heap pressure reaches 75% of `--max-old-space-size`.

- **`server/src/services/heap-drain.ts`** (new): polls V8 heap every 5 s via `setInterval`/`unref`. When `used_heap_size` crosses `HEAP_DRAIN_PERCENT`% (default 75) of `heap_size_limit`, sets a module-level `draining` flag, clears the poll interval, and enters the drain sequence — waits up to `HEAP_DRAIN_TIMEOUT_MS` ms (default 120 000) for `getActiveRunCount()` to reach 0, then sends `SIGTERM` for the existing graceful-shutdown handler to execute.
- **`server/src/services/heartbeat.ts`**: imports `isIntakeSuspended` and adds a one-line guard at the top of `startNextQueuedRunForAgent` (`if (isIntakeSuspended()) return []`) — the single promotion gate where queued runs become running runs.
- **`server/src/index.ts`**: imports `startHeapDrainMonitor` and `runningProcesses`; calls `startHeapDrainMonitor({ getActiveRunCount: () => runningProcesses.size })` after the server starts listening, guarded by `heartbeatSchedulerEnabled`.

Env vars:
| Var | Default | Range |
|---|---|---|
| `HEAP_DRAIN_PERCENT` | `75` | 1–100 |
| `HEAP_DRAIN_TIMEOUT_MS` | `120000` | ≥1000 |

SIGTERM handler in `index.ts` was already graceful; this PR adds the drain wait before that handler is invoked.

## Test plan

- [ ] Server starts and logs `heap-drain monitor started` with correct threshold values
- [ ] Setting `HEAP_DRAIN_PERCENT=1` forces immediate drain on next poll cycle (manual test)
- [ ] `isIntakeSuspended()` returns `true` during drain; `startNextQueuedRunForAgent` returns `[]` rather than starting a new run
- [ ] After drain timeout or active-run count hits 0, SIGTERM is sent and existing shutdown handler runs cleanly
- [ ] CI green

Closes PRO-6233. Parent: PRO-6175.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)