### PR TITLE
fix(plugins): scope getData calls from nested company params

### DIFF
--- a/server/src/__tests__/fixtures/plugin-worker-invocation-scope.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-invocation-scope.cjs
@@ -12,13 +12,21 @@ function sendNestedHostRequest(originalRequest, invocationId) {
   const params = originalRequest.params?.params ?? {};
   const mode = params.mode;
   const requestedCompanyId = params.requestedCompanyId;
+  const nestedMethod = params.nestedMethod ?? "companies.get";
+  const nestedParams = nestedMethod === "state.get"
+    ? {
+        scopeKind: "company",
+        scopeId: requestedCompanyId,
+        stateKey: "probe",
+      }
+    : {
+        companyId: requestedCompanyId,
+      };
   const nestedRequest = {
     jsonrpc: "2.0",
     id: nestedId,
-    method: "companies.get",
-    params: {
-      companyId: requestedCompanyId,
-    },
+    method: nestedMethod,
+    params: nestedParams,
   };
 
   if (mode === "echo") {

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -275,6 +275,118 @@ describe("plugin-worker-manager stderr failure context", () => {
     }
   });
 
+  it("derives getData invocation scope from nested params companyId", async () => {
+    const companiesGet = vi.fn(async () => ({ id: "company-1" }));
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers: {
+        "companies.get": companiesGet,
+      },
+    });
+
+    try {
+      await handle.start();
+
+      await expect(handle.call("getData", {
+        key: "probe",
+        params: {
+          companyId: "company-1",
+          mode: "echo",
+          requestedCompanyId: "company-1",
+        },
+      } as HostToWorkerMethods["getData"][0])).resolves.toEqual({ id: "company-1" });
+
+      expect(companiesGet).toHaveBeenCalledWith(
+        { companyId: "company-1" },
+        { invocationScope: { companyId: "company-1" } },
+      );
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("infers omitted legacy worker invocation ids from matching company params", async () => {
+    const companiesGet = vi.fn(async () => ({ id: "company-1" }));
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers: {
+        "companies.get": companiesGet,
+      },
+    });
+
+    try {
+      await handle.start();
+
+      await expect(handle.call("getData", {
+        key: "probe",
+        companyId: "company-1",
+        params: {
+          mode: "omit",
+          requestedCompanyId: "company-1",
+        },
+      } as HostToWorkerMethods["getData"][0])).resolves.toEqual({ id: "company-1" });
+
+      expect(companiesGet).toHaveBeenCalledWith(
+        { companyId: "company-1" },
+        { invocationScope: { companyId: "company-1" } },
+      );
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("infers omitted legacy worker invocation ids for scoped state calls", async () => {
+    const stateGet = vi.fn(async () => ({ enabled: true }));
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers: {
+        "state.get": stateGet,
+      },
+    });
+
+    try {
+      await handle.start();
+
+      await expect(handle.call("getData", {
+        key: "probe",
+        companyId: "company-1",
+        params: {
+          mode: "omit",
+          nestedMethod: "state.get",
+          requestedCompanyId: "company-1",
+        },
+      } as HostToWorkerMethods["getData"][0])).resolves.toEqual({ enabled: true });
+
+      expect(stateGet).toHaveBeenCalledWith(
+        { scopeKind: "company", scopeId: "company-1", stateKey: "probe" },
+        { invocationScope: { companyId: "company-1" } },
+      );
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
   it("rejects performAction nested host calls that omit the invocation id", async () => {
     const handlers = createHostClientHandlers({
       pluginId: "test.plugin",

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -513,6 +513,11 @@ export function createPluginWorkerHandle(
     const directCompanyId = readNonEmptyString(params.companyId);
     if (directCompanyId) return { companyId: directCompanyId };
 
+    if (method === "getData" && isRecord(params.params)) {
+      const companyId = readNonEmptyString(params.params.companyId);
+      return companyId ? { companyId } : null;
+    }
+
     if (method === "performAction" && isRecord(params.actorContext)) {
       const companyId = readNonEmptyString(params.actorContext.companyId);
       return companyId ? { companyId } : null;
@@ -554,11 +559,47 @@ export function createPluginWorkerHandle(
     activeInvocations.delete(invocation.id);
   }
 
+  function requestedCompanyIdFromWorkerMessage(
+    message: JsonRpcRequest | JsonRpcNotification,
+  ): string | null {
+    if (!isRecord(message.params)) return null;
+
+    const companyId = readNonEmptyString(message.params.companyId);
+    if (companyId) return companyId;
+
+    if (message.params.scopeKind === "company") {
+      const scopeId = readNonEmptyString(message.params.scopeId);
+      if (scopeId) return scopeId;
+    }
+
+    if (message.method === "events.subscribe" && isRecord(message.params.filter)) {
+      const filterCompanyId = readNonEmptyString(message.params.filter.companyId);
+      if (filterCompanyId) return filterCompanyId;
+    }
+
+    return null;
+  }
+
+  function legacyContextForMissingInvocation(
+    message: JsonRpcRequest | JsonRpcNotification,
+  ): WorkerHostCallContext | null {
+    const companyId = requestedCompanyIdFromWorkerMessage(message);
+    if (!companyId) return null;
+
+    const matchingEntry = Array.from(activeInvocations.values()).find(
+      (entry) => entry.scope.companyId === companyId,
+    );
+    return matchingEntry ? { invocationScope: matchingEntry.scope } : null;
+  }
+
   function contextForWorkerMessage(message: JsonRpcRequest | JsonRpcNotification): WorkerHostCallContext {
     const invocationId = readNonEmptyString(
       (message as { paperclipInvocationId?: unknown }).paperclipInvocationId,
     );
     if (!invocationId) {
+      const legacyContext = legacyContextForMissingInvocation(message);
+      if (legacyContext) return legacyContext;
+
       const hasActiveInvocation = activeInvocations.size > 0 ||
         Array.from(pendingRequests.values()).some((pending) => pending.invocationId);
       return hasActiveInvocation ? { invalidInvocationScope: true } : {};


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies.
> - The plugin runtime lets optional knowledge systems like LLM Wiki run outside core while still using guarded host capabilities.
> - Worker-to-host calls need an invocation scope so company-scoped APIs such as `localFolders.readText` stay bounded to the invoking company.
> - `getData` calls could carry `companyId` only inside `params`, while host-side scope derivation only checked the top-level field.
> - That left LLM Wiki data handlers running without a registered invocation scope and caused `INVOCATION_SCOPE_DENIED` for `localFolders.*` calls.
> - This pull request aligns `getData` scope derivation with the worker handler shape by falling back to nested `params.companyId`.
> - The benefit is that plugin data bridges can safely read company-scoped local folders when the company id is supplied in request params.

## What Changed

- Derive `getData` invocation scope from nested `params.companyId` when top-level `companyId` is absent.
- Add a general legacy fallback for installed plugins built with older SDK bundles that omit `paperclipInvocationId` on nested worker-to-host calls. It matches common company-scoped params such as `companyId`, `scopeKind=company/scopeId`, and event subscription filters.
- Added regression tests for nested `params.companyId` scope derivation, legacy omitted invocation ids, and scoped `state.get` calls.
- Related to LLM Wiki plugin reliability issues: #5818, #5986, #5878, #5987. This does not close those install or migration issues.

## Verification

- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm exec vitest run server/src/__tests__/plugin-worker-manager.test.ts`

## Risks

- Low to medium risk. Change affects plugin worker invocation-scope handling.
- Nested `params.companyId` already reaches plugin data handlers, so this makes host authorization match existing handler input behavior.
- Legacy workers that omit `paperclipInvocationId` are accepted only when the requested company scope matches an active invocation; unknown forged ids still fail.
- No schema, migration, UI, or public API changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI ChatGPT via Pi coding agent API. Exact served model ID and context window were not exposed in this session. Tool use included shell, file editing, GitHub CLI, and focused Vitest verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots, N/A
- [x] I have updated relevant documentation to reflect my changes, N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge