### PR TITLE
feat(heartbeat): rate-limit process_lost retry loops per issue (PRO-6244)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -227,6 +227,8 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+const PROCESS_LOST_RETRY_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const PROCESS_LOST_RETRY_HOURLY_CAP = 3;
 export const MAX_TURN_CONTINUATION_RETRY_REASON = "max_turns_continuation";
 export const MAX_TURN_CONTINUATION_WAKE_REASON = "max_turns_continuation_retry";
 const MAX_TURN_CONTINUATION_DEFAULT_MAX_ATTEMPTS = 2;
@@ -4820,6 +4822,48 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+
+    // Guard: if this issue has hit PROCESS_LOST_RETRY_HOURLY_CAP failures in the
+    // rolling window, block it instead of queueing another retry.
+    if (issueId) {
+      const windowStart = new Date(now.getTime() - PROCESS_LOST_RETRY_RATE_LIMIT_WINDOW_MS);
+      const [{ recentCount }] = await db
+        .select({ recentCount: sql<number>`count(*)::int` })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, run.companyId),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            eq(heartbeatRuns.status, "failed"),
+            eq(heartbeatRuns.errorCode, "process_lost"),
+            gt(heartbeatRuns.finishedAt, windowStart),
+          ),
+        );
+      if (recentCount >= PROCESS_LOST_RETRY_HOURLY_CAP) {
+        logger.warn(
+          {
+            issueId,
+            companyId: run.companyId,
+            errorClass: "process_lost",
+            retryCount: recentCount,
+            windowMs: PROCESS_LOST_RETRY_RATE_LIMIT_WINDOW_MS,
+            runId: run.id,
+          },
+          "process_lost retry rate limit exceeded: auto-blocking issue",
+        );
+        await db
+          .update(issues)
+          .set({ executionRunId: null, executionAgentNameKey: null, executionLockedAt: null, status: "blocked", updatedAt: now })
+          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)));
+        await issuesSvc.addComment(
+          issueId,
+          `Auto-paused: retry rate limit exceeded.\n\nThis issue has had ${recentCount} \`process_lost\` failures in the last hour and has been automatically moved to \`blocked\`.\n\nTo resume: investigate the root cause of the agent run failure, then manually unblock this issue.`,
+          { agentId: run.agentId, runId: run.id },
+        );
+        return null;
+      }
+    }
+
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot = withRecoveryModelProfileHint({


### PR DESCRIPTION
## Summary

- Adds a rolling-window guard inside `enqueueProcessLossRetry` that counts `process_lost` failures for the affected issue over the past hour
- At **≥ 3 failures/hour** per (issue), auto-blocks the issue, clears execution lock, emits structured telemetry, and posts a system comment
- Returns `null` so the caller naturally skips `releaseIssueExecutionAndPromote` without additional changes
- Cap resets only on manual unblock — not time-based

**Constants added:**
- `PROCESS_LOST_RETRY_RATE_LIMIT_WINDOW_MS = 3600000` (1 hour)
- `PROCESS_LOST_RETRY_HOURLY_CAP = 3`

**Telemetry event fields:** `issueId`, `companyId`, `errorClass`, `retryCount`, `windowMs`, `runId`

## What this fixes

The retry storm root cause: `shouldRetry` allowed 1 auto-retry per run, but after that retry also failed, `releaseIssueExecutionAndPromote` would queue a new recovery run with `processLossRetryCount = 0` — giving it another auto-retry slot. This created an indefinite `run → fail → auto-retry → fail → recovery run → ...` loop.

This guardrail breaks the loop at the platform layer without touching the per-run `processLossRetryCount` logic.

## Test plan

- [ ] Unit: verify count query returns correct value for a mocked set of recent failed runs
- [ ] Unit: verify that when `recentCount >= 3`, function returns `null` and does not insert a wakeup request or retry run
- [ ] Integration: verify issue status becomes `blocked` with a system comment after cap is hit
- [ ] Verify unaffected: `shouldRetry = false` path still calls `releaseIssueExecutionAndPromote` normally
- [ ] Verify unaffected: runs without an `issueId` in contextSnapshot skip the guard entirely

Closes PRO-6244

🤖 Generated with [Claude Code](https://claude.com/claude-code)