### PR TITLE
fix(heartbeat): process_lost retry rate-limit guardrail (PRO-6244)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, gte, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -4820,6 +4820,70 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+
+    if (issueId) {
+      const windowStart = new Date(now.getTime() - 60 * 60 * 1000);
+      const [countRow] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, run.companyId),
+            eq(heartbeatRuns.errorCode, "process_lost"),
+            gte(heartbeatRuns.finishedAt, windowStart),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          ),
+        );
+      const recentCount = countRow?.count ?? 0;
+      if (recentCount >= 3) {
+        await issuesSvc.update(issueId, { status: "blocked" });
+        await issuesSvc.addComment(
+          issueId,
+          [
+            `**Auto-paused: \`process_lost\` retry rate limit exceeded.**`,
+            ``,
+            `- Recent \`process_lost\` failures (last 1 hour): ${recentCount}`,
+            `- Cap: 3 per hour`,
+            ``,
+            `Paperclip has blocked this issue to contain token burn. This cap resets when the issue is manually unblocked.`,
+            `A board operator or manager should investigate the \`process_lost\` root cause before resuming.`,
+          ].join("\n"),
+          {},
+          { authorType: "system" },
+        );
+        logger.warn(
+          {
+            issueId,
+            companyId: run.companyId,
+            errorClass: "process_lost",
+            recentCount,
+            cap: 3,
+            windowMs: 60 * 60 * 1000,
+            timestamp: now.toISOString(),
+          },
+          "process_loss_retry_rate_limit_exceeded",
+        );
+        await logActivity(db, {
+          companyId: run.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: null,
+          action: "issue.process_loss_retry_rate_limit",
+          entityType: "issue",
+          entityId: issueId,
+          details: {
+            errorClass: "process_lost",
+            recentCount,
+            cap: 3,
+            windowMs: 60 * 60 * 1000,
+            timestamp: now.toISOString(),
+          },
+        });
+        return null;
+      }
+    }
+
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot = withRecoveryModelProfileHint({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -399,6 +399,9 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
+const PROCESS_LOSS_RETRY_RATE_LIMIT_CAP = 3;
+const PROCESS_LOSS_RETRY_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
 export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
@@ -436,6 +439,83 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
       .limit(1)
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function countRecentProcessLossRunsForIssue(
+    companyId: string,
+    issueId: string,
+    windowMs: number,
+    now: Date,
+  ): Promise<number> {
+    const windowStart = new Date(now.getTime() - windowMs);
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.errorCode, "process_lost"),
+          gte(heartbeatRuns.finishedAt, windowStart),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      );
+    return row?.count ?? 0;
+  }
+
+  async function enforceProcessLossRetryRateLimit(
+    issue: typeof issues.$inferSelect,
+    recentCount: number,
+    now: Date,
+  ): Promise<typeof issues.$inferSelect | null> {
+    const updated = await issuesSvc.update(issue.id, { status: "blocked" });
+    await issuesSvc.addComment(
+      issue.id,
+      [
+        `**Auto-paused: \`process_lost\` retry rate limit exceeded.**`,
+        ``,
+        `- Issue: \`${issue.identifier ?? issue.id}\``,
+        `- Recent \`process_lost\` failures (last 1 hour): ${recentCount}`,
+        `- Cap: ${PROCESS_LOSS_RETRY_RATE_LIMIT_CAP} per hour`,
+        ``,
+        `Paperclip has blocked this issue to contain token burn. This cap resets when the issue is manually unblocked.`,
+        `A board operator or manager should investigate the \`process_lost\` root cause before resuming.`,
+      ].join("\n"),
+      {},
+      { authorType: "system" },
+    );
+    logger.warn(
+      {
+        issueId: issue.id,
+        companyId: issue.companyId,
+        identifier: issue.identifier,
+        errorClass: "process_lost",
+        recentCount,
+        cap: PROCESS_LOSS_RETRY_RATE_LIMIT_CAP,
+        windowMs: PROCESS_LOSS_RETRY_RATE_LIMIT_WINDOW_MS,
+        timestamp: now.toISOString(),
+      },
+      "process_loss_retry_rate_limit_exceeded",
+    );
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.process_loss_retry_rate_limit",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        errorClass: "process_lost",
+        recentCount,
+        cap: PROCESS_LOSS_RETRY_RATE_LIMIT_CAP,
+        windowMs: PROCESS_LOSS_RETRY_RATE_LIMIT_WINDOW_MS,
+        timestamp: now.toISOString(),
+        previousStatus: issue.status,
+      },
+    });
+    return updated;
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
@@ -2384,6 +2464,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
         result.skipped += 1;
         continue;
+      }
+
+      if (issue.status === "in_progress") {
+        const rlNow = new Date();
+        const recentProcessLossCount = await countRecentProcessLossRunsForIssue(
+          issue.companyId,
+          issue.id,
+          PROCESS_LOSS_RETRY_RATE_LIMIT_WINDOW_MS,
+          rlNow,
+        );
+        if (recentProcessLossCount >= PROCESS_LOSS_RETRY_RATE_LIMIT_CAP) {
+          const updated = await enforceProcessLossRetryRateLimit(issue, recentProcessLossCount, rlNow);
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
       }
 
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);


### PR DESCRIPTION
## Summary

Implements the `process_lost` retry rate-limit guardrail requested in PRO-6244 (CTO escalation 2026-05-29).

- **Cap**: max 3 `process_lost` retries per issue per rolling 1-hour window
- **On cap hit**: auto-move issue to `blocked`, post a system comment, emit `process_loss_retry_rate_limit_exceeded` structured log event, and write an `issue.process_loss_retry_rate_limit` activity-log entry
- **Reset path**: manual unblock only — `blocked` status prevents recovery loop from reprocessing
- **Scope**: `process_lost` only (not `adapter_failed`; `adapter_failed` has a separate recovery path and this change does not touch it)

### Why two callsites?

The storm occurs via two independent code paths, both guarded:

1. **`reconcileStrandedAssignedIssues` (`recovery/service.ts`)** — primary. The recovery scan loop re-wakes `in_progress` issues whose execution run has gone silent. This is the main storm vector: it fires on every recovery tick and can retry indefinitely without the new cap.

2. **`enqueueProcessLossRetry` (`heartbeat.ts`)** — secondary. The direct per-run retry triggered immediately when a run finalises with `errorCode = "process_lost"`. Already capped at 1 retry by the existing `processLossRetryCount < 1` check, but the new rolling-window guard makes the cap explicit and consistent with the recovery path.

### Implementation details

Both callsites query `heartbeatRuns` by:
- `companyId`
- `errorCode = 'process_lost'`
- `finishedAt >= now - 3600000ms`
- `contextSnapshot ->> 'issueId' = $issueId` (existing Drizzle JSON extraction pattern)

Constants: `PROCESS_LOSS_RETRY_RATE_LIMIT_CAP = 3`, `PROCESS_LOSS_RETRY_RATE_LIMIT_WINDOW_MS = 3600000` (defined in `recovery/service.ts`; inlined in `heartbeat.ts` for locality).

## Test plan

- [ ] Deploy to staging; trigger 3 consecutive `process_lost` runs on a single issue → confirm issue moves to `blocked` on the 3rd attempt with the expected system comment
- [ ] Verify `process_loss_retry_rate_limit_exceeded` appears in structured logs with correct fields
- [ ] Verify `issue.process_loss_retry_rate_limit` appears in the activity log
- [ ] Manually unblock the issue → confirm recovery loop resumes it after the 1-hour window expires
- [ ] Confirm `adapter_failed` issues are unaffected (no status change, normal retry flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)