### PR TITLE
feat(approvals): wake requesting agent on approval comment

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -356,6 +356,58 @@ export function approvalRoutes(
       details: { commentId: comment.id },
     });
 
+    // Wake the requesting agent when a non-agent actor (board user) comments
+    if (approval.requestedByAgentId && actor.actorType !== "agent") {
+      const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
+      const linkedIssueIds = linkedIssues.map((issue) => issue.id);
+      const primaryIssueId = linkedIssueIds[0] ?? null;
+      try {
+        const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
+          source: "automation",
+          triggerDetail: "system",
+          reason: "approval_comment_response",
+          payload: {
+            approvalId: approval.id,
+            approvalStatus: approval.status,
+            commentId: comment.id,
+            issueId: primaryIssueId,
+            issueIds: linkedIssueIds,
+          },
+          requestedByActorType: "user",
+          requestedByActorId: actor.actorId,
+          contextSnapshot: {
+            source: "approval.comment_added",
+            approvalId: approval.id,
+            approvalStatus: approval.status,
+            commentId: comment.id,
+            issueId: primaryIssueId,
+            issueIds: linkedIssueIds,
+            taskId: primaryIssueId,
+            wakeReason: "approval_comment_response",
+          },
+        });
+        await logActivity(db, {
+          companyId: approval.companyId,
+          actorType: "user",
+          actorId: actor.actorId,
+          action: "approval.requester_wakeup_queued",
+          entityType: "approval",
+          entityId: approval.id,
+          details: {
+            requesterAgentId: approval.requestedByAgentId,
+            wakeRunId: wakeRun?.id ?? null,
+            reason: "approval_comment_response",
+            linkedIssueIds,
+          },
+        });
+      } catch (err) {
+        logger.warn(
+          { err, approvalId: approval.id, requestedByAgentId: approval.requestedByAgentId },
+          "failed to queue requester wakeup after approval comment",
+        );
+      }
+    }
+
     res.status(201).json(comment);
   });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -317,7 +317,7 @@ function mergeAdapterRecoveryMetadata(input: {
       : {}),
   };
 }
-const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved"]);
+const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved", "approval_comment_response"]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip has an approval system where agents can request human board-user approval before proceeding
> - When a board user comments on an approval, the requesting agent was not notified
> - The agent had no way to know the human had responded until its next scheduled heartbeat
> - This PR wakes the requesting agent immediately when a non-agent actor comments on an approval
> - It follows the same wakeup pattern used for issue comment responses
> - The benefit is agents get timely approval feedback without waiting for the next heartbeat interval

## What Changed

- : after persisting an approval comment from a board user, calls 

## Verification

- Ran  — pass
- Manually confirmed wake fires when board user comments on approval

## Risks

Low risk — additive. Only fires for non-agent comment authors. Wake failure is caught and logged; it does not block the comment from being persisted.

## Model Used

- Provider: Nous Research Hermes Agent v0.15.1
- Model: qwen/qwen3.6-27b (Qwen3.6-27B-Instruct Q8_0, 27B dense, 131k context)
- Infrastructure: LM Studio on local GPU via PaperclipForge hermes_local adapter
- Capabilities: terminal, file read/write, search tools

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model Used specified
- [x] Feature — discussed pattern matches existing comment-wake flow
- [x] Tests pass
- [x] 3 files changed