### PR TITLE
fix: suppress stale_active_run_evaluation when source issue is blocked

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -103,7 +103,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     ageMs: number;
     withOutput?: boolean;
     logChunk?: string;
-    sourceStatus?: "in_progress" | "done" | "cancelled";
+    sourceStatus?: "in_progress" | "done" | "cancelled" | "blocked";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
   }) {
@@ -797,5 +797,29 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       createdByRunId: randomUUID(),
     });
     expect(decision.createdByRunId).toBe(managerRunId);
+  });
+
+  it("suppresses stale_active_run_evaluation creation when source issue is blocked", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      sourceStatus: "blocked",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.status).toBe("blocked");
   });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1395,6 +1395,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
     }
+    if (sourceIssue?.status === "blocked") {
+      await logActivity(db, {
+        companyId: input.run.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: input.run.agentId,
+        runId: input.run.id,
+        action: "heartbeat.output_stale_suppressed_non_actionable_source",
+        entityType: "heartbeat_run",
+        entityId: input.run.id,
+        details: {
+          source: "recovery.scan_silent_active_runs",
+          sourceIssueId: sourceIssue.id,
+          sourceIssueIdentifier: sourceIssue.identifier,
+          sourceIssueStatus: sourceIssue.status,
+          existingEvaluationIssueId: existing?.id ?? null,
+          reason: "Source issue is blocked; stale_active_run_evaluation suppressed.",
+        },
+      });
+      return { kind: "skipped" as const };
+    }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,


### PR DESCRIPTION
## Thinking Path

> - Paperclip monitors active runs and raises  issues when a run has been silent too long
> - A blocked issue means its assigned agent is legitimately waiting on a dependency — silence is expected
> - The stale-run scanner was not checking issue status before raising an evaluation
> - This caused spurious evaluation issues for blocked issues, adding noise and unnecessary wakeups
> - This PR adds a status guard in  to skip evaluation when the source issue is blocked
> - The benefit is blocked issues no longer trigger false stale-run alerts

## What Changed

- :  now accepts  including ; returns early with  when status is blocked
- : added test asserting zero evaluations created when source issue is blocked

## Verification

- Ran  — pass including new test
- New test explicitly asserts  and  for blocked source

## Risks

Low risk — guard is additive; only affects the blocked status path which previously produced noisy evaluations.

## Model Used

- Provider: Nous Research Hermes Agent v0.15.1
- Model: qwen/qwen3.6-27b (Qwen3.6-27B-Instruct Q8_0, 27B dense, 131k context)
- Infrastructure: LM Studio on local GPU via PaperclipForge hermes_local adapter
- Capabilities: terminal, file read/write, search tools

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model Used specified
- [x] Bug fix — Path 1
- [x] Tests pass with new test added
- [x] 2 files changed