### PR TITLE
fix(adapter-claude-local): fresh-session retry on thinking-block mutation 400

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -328,4 +328,107 @@ describe("claude remote execution", () => {
     expect(call?.[2]).toContain("session-123");
   });
 
+  it("retries with a fresh session when resume hits the thinking-block mutation 400", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-thinking-block-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const managedRemoteWorkspace = "/remote/workspace/.paperclip-runtime/runs/run-thinking-block/workspace";
+    await mkdir(workspaceDir, { recursive: true });
+
+    const resumeFailureStdout = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "session-123", model: "claude-sonnet" }),
+      JSON.stringify({
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "session-123",
+        is_error: true,
+        result:
+          "API Error: 400 messages.12: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain in their original sequence and content.",
+      }),
+    ].join("\n");
+    const freshSessionStdout = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "session-456", model: "claude-sonnet" }),
+      JSON.stringify({ type: "assistant", session_id: "session-456", message: { content: [{ type: "text", text: "recovered" }] } }),
+      JSON.stringify({ type: "result", session_id: "session-456", result: "recovered", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }),
+    ].join("\n");
+
+    runChildProcess
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: resumeFailureStdout,
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: freshSessionStdout,
+        stderr: "",
+        pid: 124,
+        startedAt: new Date().toISOString(),
+      });
+
+    const result = await execute({
+      runId: "run-thinking-block",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "session-123",
+        sessionParams: {
+          sessionId: "session-123",
+          cwd: managedRemoteWorkspace,
+          remoteExecution: {
+            transport: "ssh",
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteCwd: managedRemoteWorkspace,
+          },
+        },
+        sessionDisplayId: "session-123",
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(2);
+    const firstCall = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    const secondCall = runChildProcess.mock.calls[1] as unknown as [string, string, string[]] | undefined;
+    expect(firstCall?.[2]).toContain("--resume");
+    expect(secondCall?.[2]).not.toContain("--resume");
+    expect(result.exitCode).toBe(0);
+    expect(result.errorMessage ?? null).toBeNull();
+    expect(result.sessionId).toBe("session-456");
+  });
+
 });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -52,6 +52,7 @@ import {
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
+  isClaudeThinkingBlockMutationError,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
@@ -953,6 +954,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       await onLog(
         "stdout",
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+      );
+      const retry = await runAttempt(null);
+      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+    }
+
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      initial.parsed &&
+      isClaudeThinkingBlockMutationError(initial.parsed)
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Claude resume session "${sessionId}" cannot be resumed because its latest assistant turn carries thinking blocks; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,8 +1,61 @@
 import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
+  isClaudeThinkingBlockMutationError,
   isClaudeTransientUpstreamError,
 } from "./parse.js";
+
+describe("isClaudeThinkingBlockMutationError", () => {
+  it("classifies the latest-assistant thinking-block mutation 400", () => {
+    expect(
+      isClaudeThinkingBlockMutationError({
+        is_error: true,
+        result:
+          "API Error: 400 messages.12: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain in their original sequence and content.",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeThinkingBlockMutationError({
+        is_error: true,
+        errors: [
+          {
+            type: "invalid_request_error",
+            message:
+              "messages.4: thinking or redacted_thinking blocks in the latest assistant message cannot be modified.",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("classifies the interleaved-thinking ordering 400 on resume", () => {
+    expect(
+      isClaudeThinkingBlockMutationError({
+        is_error: true,
+        result:
+          "API Error: 400 Expected `thinking` or `redacted_thinking`, but found `text`. When `thinking` is enabled, a final `assistant` message must start with a thinking block.",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated failures", () => {
+    expect(
+      isClaudeThinkingBlockMutationError({
+        result: "No conversation found with session id abc-123",
+      }),
+    ).toBe(false);
+    expect(
+      isClaudeThinkingBlockMutationError({
+        result: "Maximum turns reached.",
+      }),
+    ).toBe(false);
+    expect(
+      isClaudeThinkingBlockMutationError({
+        errors: [{ message: "Invalid request_error: Unknown parameter 'foo'." }],
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("isClaudeTransientUpstreamError", () => {
   it("classifies the 'out of extra usage' subscription window failure as transient", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -196,6 +196,27 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
   );
 }
 
+/**
+ * Detects the deterministic 400 the Anthropic API returns when a resumed
+ * (`--resume`) transcript's latest assistant message carries `thinking` /
+ * `redacted_thinking` blocks that the resume request would have to alter.
+ * With interleaved thinking enabled this makes the session impossible to
+ * resume; restarting with a fresh session is the only recovery. Sibling of
+ * {@link isClaudeUnknownSessionError} — both classify resume-incompatible
+ * failures that a fresh-session retry resolves.
+ */
+export function isClaudeThinkingBlockMutationError(parsed: Record<string, unknown>): boolean {
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) =>
+    /(?:thinking|redacted_thinking)[\s\S]{0,200}?cannot be modified/i.test(msg) ||
+    /when[\s`]*thinking[\s`]*is enabled[\s\S]{0,200}?must start with[\s\S]{0,40}?thinking/i.test(msg),
+  );
+}
+
 function buildClaudeTransientHaystack(input: {
   parsed?: Record<string, unknown> | null;
   stdout?: string | null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents running Claude Code CLI via `@paperclipai/adapter-claude-local`
> - When `extended_thinking` / interleaved thinking is enabled, Claude Code sessions embed `thinking` and `redacted_thinking` blocks in assistant turns
> - On `--resume`, the Anthropic API returns a deterministic HTTP 400 if the latest assistant message's thinking blocks would need to be altered: *"messages.N: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified"*
> - The existing fallback in `execute.ts` retries with a fresh session only for `isClaudeUnknownSessionError`; the thinking-block mutation 400 falls through, surfaces as a hard failure, and stalls the agent permanently
> - This PR adds `isClaudeThinkingBlockMutationError` (parse.ts) — a sibling to the existing unknown-session helper — and wires a matching retry branch so the adapter transparently starts a fresh session instead
> - The benefit is that thinking-enabled agents resume normally after a thinking-block 400 instead of failing, with no loss of data (the new session proceeds from the current prompt)

## What Changed

- **`packages/adapters/claude-local/src/server/parse.ts`**: Added exported `isClaudeThinkingBlockMutationError` helper. Matches both the canonical mutation message (`thinking … cannot be modified`) and the interleaved-thinking ordering 400 (`when thinking is enabled … must start with a thinking block`). Follows the same pattern as `isClaudeUnknownSessionError`.
- **`packages/adapters/claude-local/src/server/execute.ts`**: Imported the new helper. Added a second fresh-retry branch in the `try` block (after the existing unknown-session branch) that fires when `isClaudeThinkingBlockMutationError` matches, logs a descriptive message, and calls `runAttempt(null)` with `clearSessionOnMissingSession: true` — identical semantics to the unknown-session path.
- **`packages/adapters/claude-local/src/server/parse.test.ts`**: New `describe("isClaudeThinkingBlockMutationError")` block — positive cases for the canonical mutation text via `result`, the same via `errors[]`, the interleaved-thinking ordering 400, plus negative cases (unrelated errors must not match).
- **`packages/adapters/claude-local/src/server/execute.remote.test.ts`**: New execute-level regression test that drives `execute()` through a resumed session whose first attempt returns the thinking-block 400. Asserts the adapter (1) retries **without** `--resume` (fresh session), and (2) surfaces a **success** result (`exitCode 0`, no `errorMessage`) instead of `adapter_failed`. This is the direct end-to-end proof of the fallback firing.

## Verification

```bash
cd /Users/kobayashirika/work/paperclip-dai8
# package typecheck + emit build
(cd packages/adapters/claude-local && npx tsc --noEmit && npx tsc)   # zero errors
# detector + execute-level firing tests
npx vitest run packages/adapters/claude-local/src/server/parse.test.ts \
              packages/adapters/claude-local/src/server/execute.remote.test.ts
# => 16/16 pass (12 parse.test incl. detector cases, 4 execute.remote incl. new firing test)
node ./scripts/release-package-map.mjs check   # manifest OK, adapter enabled for CI publish
```

Manual path: trigger a Claude Code `--resume` against a session whose last assistant turn contained a `thinking` block with `extended_thinking` enabled. Before this fix the run fails with a 400. After this fix the adapter logs `[paperclip] Claude resume session "…" cannot be resumed because its latest assistant turn carries thinking blocks; retrying with a fresh session.` and continues.

## Risks

Low. The new branch fires only on a deterministic 400 matching the specific thinking-block mutation message pattern, and only when `sessionId` is set (i.e. a resume attempt was made). The fallback is identical to the already-established unknown-session path: start fresh, clear session on missing. False-positive risk (matching the regex on a non-thinking-related message) is negligible given the specificity of the pattern.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 1M (`claude-opus-4-7`) for the execute-level test + verification; Claude Sonnet 4.6 (`claude-sonnet-4-6`) for the original fix commit
- Context window: 1M / 200K
- Tool use: yes (code editing, shell, file read, vitest)
- Reasoning mode: standard

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge