### PR TITLE
[codex] Dedup silent-active-run reviews on same alive run

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -270,6 +270,102 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(source?.status).toBe("blocked");
   });
 
+  it("dedups repeat suspicious reviews after a closed review on the same alive run", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const firstEvaluationId = first.evaluationIssueIds[0];
+    expect(firstEvaluationId).toBeTruthy();
+
+    const closedAt = new Date(now.getTime() + 4 * 60_000);
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: closedAt, updatedAt: closedAt })
+      .where(eq(issues.id, firstEvaluationId!));
+
+    // The run is still genuinely silent. Without dedup this would create review #2.
+    const stillSilentRun = await db
+      .update(heartbeatRuns)
+      .set({ startedAt: new Date(closedAt.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000) })
+      .where(eq(heartbeatRuns.id, runId))
+      .returning();
+    expect(stillSilentRun).toHaveLength(1);
+
+    const within = await heartbeat.scanSilentActiveRuns({ now: closedAt, companyId });
+    expect(within.created).toBe(0);
+    expect(within.deduped).toBe(1);
+    expect(within.evaluationIssueIds).toContain(firstEvaluationId);
+
+    const stillOne = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(stillOne).toHaveLength(1);
+
+    // After the rearm window expires a fresh review may fire again.
+    const afterRearm = new Date(closedAt.getTime() + ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS + 60_000);
+    await db
+      .update(heartbeatRuns)
+      .set({
+        startedAt: new Date(afterRearm.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000),
+        processStartedAt: new Date(afterRearm.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000),
+        lastOutputAt: null,
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const after = await heartbeat.scanSilentActiveRuns({ now: afterRearm, companyId });
+    expect(after.created).toBe(1);
+    expect(after.deduped).toBe(0);
+    expect(after.evaluationIssueIds[0]).not.toBe(firstEvaluationId);
+  });
+
+  it("still fires critical reviews even when a suspicious review was just closed", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const firstEvaluationId = first.evaluationIssueIds[0];
+
+    const closedAt = new Date(now.getTime() + 5 * 60_000);
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: closedAt, updatedAt: closedAt })
+      .where(eq(issues.id, firstEvaluationId!));
+
+    // Critical-threshold scan happens within the suspicious dedup window.
+    const criticalNow = new Date(closedAt.getTime() + 10 * 60_000);
+    await db
+      .update(heartbeatRuns)
+      .set({
+        startedAt: new Date(criticalNow.getTime() - ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS - 60_000),
+        processStartedAt: new Date(criticalNow.getTime() - ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS - 60_000),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const critical = await heartbeat.scanSilentActiveRuns({ now: criticalNow, companyId });
+    expect(critical.created).toBe(1);
+    expect(critical.deduped).toBe(0);
+    const newId = critical.evaluationIssueIds[0];
+    expect(newId).not.toBe(firstEvaluationId);
+
+    const [escalated] = await db
+      .select({ priority: issues.priority })
+      .from(issues)
+      .where(eq(issues.id, newId!));
+    expect(escalated?.priority).toBe("high");
+  });
+
   it("skips snoozed runs and healthy noisy runs", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const stale = await seedRunningRun({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -629,6 +629,37 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function findRecentlyClosedStaleRunEvaluation(
+    companyId: string,
+    runId: string,
+    since: Date,
+  ) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        completedAt: issues.completedAt,
+        cancelledAt: issues.cancelledAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+          sql`coalesce(${issues.completedAt}, ${issues.cancelledAt}) >= ${since.toISOString()}::timestamptz`,
+        ),
+      )
+      .orderBy(
+        desc(sql`coalesce(${issues.completedAt}, ${issues.cancelledAt})`),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -943,6 +974,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       now: input.now,
     });
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+    if (level === "suspicious") {
+      const recentClose = await findRecentlyClosedStaleRunEvaluation(
+        input.run.companyId,
+        input.run.id,
+        new Date(input.now.getTime() - ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS),
+      );
+      if (recentClose) {
+        return { kind: "deduped" as const, evaluationIssueId: recentClose.id };
+      }
+    }
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (existing) {
       if (level === "critical" && existing.priority !== "high") {
@@ -1077,6 +1118,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       created: 0,
       existing: 0,
       escalated: 0,
+      deduped: 0,
       snoozed: 0,
       skipped: 0,
       evaluationIssueIds: [] as string[],
@@ -1091,6 +1133,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (outcome.kind === "created") result.created += 1;
       else if (outcome.kind === "existing") result.existing += 1;
       else if (outcome.kind === "escalated") result.escalated += 1;
+      else if (outcome.kind === "deduped") result.deduped += 1;
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {
         result.evaluationIssueIds.push(outcome.evaluationIssueId);


### PR DESCRIPTION
## Problem

A single alive heartbeat run (Inside Sales agent, Sonnet 4.6 with `--max-turns 80`, ~1h 5m elapsed, run `75684f0c-bd91-48c9-bdc8-09036400e2b6`) spawned three identical suspicious-threshold silent-active-run review issues in four minutes because the Sonnet model produces no stdout until it finishes a turn. The run was genuinely silent while doing legitimate Apollo + Jina enrichment.

Existing snooze signal (`recordWatchdogDecision({decision: "continue"})`) wasn't firing because the reviewer agent closed each review via plain `PATCH /api/issues/{id}` — that path doesn't record a watchdog decision, so `latestActiveOutputQuietUntilDecision` returned null and the next scan created another review.

## Change

`server/src/services/recovery/service.ts`:

- New helper `findRecentlyClosedStaleRunEvaluation(companyId, runId, since)` selects the most recent closed (`done`/`cancelled`) stale-run evaluation for a given run, using `coalesce(completedAt, cancelledAt)` so the close timestamp comes from the canonical fields the issues service sets on status transitions.
- In `createOrUpdateStaleRunEvaluation`: after computing `level`, if the level is `suspicious` and a recently-closed evaluation exists within the existing `ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS` (30 min) window, return `{ kind: "deduped" }` and skip creating a new review. Critical (4h) still always fires — the dedup gate is bypassed at that level so the genuinely different decision point survives.
- `scanSilentActiveRuns` result now reports `deduped: number` alongside `created/existing/escalated/snoozed/skipped`.

## Tests

`server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`:

- New: `dedups repeat suspicious reviews after a closed review on the same alive run` — scan after close within the rearm window reports `created: 0, deduped: 1`; after the rearm window expires a new evaluation fires.
- New: `still fires critical reviews even when a suspicious review was just closed` — critical (4h) bypasses the dedup gate and creates a fresh high-priority eval.

All 10 watchdog tests pass; server typecheck clean.