### PR TITLE
fix(PRO-1078): terminate Cursor process group after stream result

### DIFF
--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -45,7 +45,7 @@ import {
   joinPromptSections,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_CURSOR_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
-import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
+import { parseCursorJsonl, isCursorUnknownSessionError, hasCursorTerminalStreamResult } from "./parse.js";
 import { prepareCursorSandboxCommand } from "./remote-command.js";
 import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
@@ -310,6 +310,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     asNumber(config.timeoutSec, 0),
   );
   const graceSec = asNumber(config.graceSec, 20);
+  const terminalResultCleanupGraceMs = Math.max(
+    0,
+    asNumber(config.terminalResultCleanupGraceMs, 5_000),
+  );
   await ensureAdapterExecutionTargetRuntimeCommandInstalled({
     runId,
     target: executionTarget,
@@ -640,6 +644,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           return;
         }
         await flushStdoutChunk(chunk);
+      },
+      terminalResultCleanup: {
+        graceMs: terminalResultCleanupGraceMs,
+        hasTerminalResult: ({ stdout }) => hasCursorTerminalStreamResult(stdout),
       },
     });
     await flushStdoutChunk("", true);

--- a/packages/adapters/cursor-local/src/server/parse.test.ts
+++ b/packages/adapters/cursor-local/src/server/parse.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { hasCursorTerminalStreamResult, parseCursorJsonl } from "./parse.js";
+
+describe("hasCursorTerminalStreamResult", () => {
+  it("returns true when stream-json includes a result event", () => {
+    const stdout = [
+      '{"type":"system","subtype":"init","session_id":"s1"}',
+      '{"type":"assistant","message":{"content":[{"type":"output_text","text":"hi"}]}}',
+      '{"type":"result","subtype":"success","session_id":"s1","result":"ok"}',
+    ].join("\n");
+
+    expect(hasCursorTerminalStreamResult(stdout)).toBe(true);
+    expect(parseCursorJsonl(stdout).summary).toBe("hi");
+  });
+
+  it("returns false for partial output without a result event", () => {
+    const stdout = '{"type":"assistant","message":{"content":[{"type":"output_text","text":"still running"}]}}';
+    expect(hasCursorTerminalStreamResult(stdout)).toBe(false);
+  });
+});

--- a/packages/adapters/cursor-local/src/server/parse.ts
+++ b/packages/adapters/cursor-local/src/server/parse.ts
@@ -149,6 +149,18 @@ export function parseCursorJsonl(stdout: string) {
   };
 }
 
+/** True when stream-json output includes a terminal `result` event. */
+export function hasCursorTerminalStreamResult(stdout: string): boolean {
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = normalizeCursorStreamLine(rawLine).line;
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) continue;
+    if (asString(event.type, "").trim() === "result") return true;
+  }
+  return false;
+}
+
 export function isCursorUnknownSessionError(stdout: string, stderr: string): boolean {
   const haystack = `${stdout}\n${stderr}`
     .split(/\r?\n/)


### PR DESCRIPTION
## Summary

- Add `hasCursorTerminalStreamResult()` to detect terminal `type: result` events in Cursor stream-json output.
- Pass `terminalResultCleanup` from the Cursor local adapter into `runAdapterExecutionTargetProcess`, matching the Claude local adapter pattern.
- After a terminal result is emitted, Paperclip SIGTERMs the spawned process group and escalates to SIGKILL after the configured grace period, preventing orphaned Cursor/agent processes from triggering stale-run evaluation issues.

## Ticket reference

- Paperclip: PRO-1078
- Pre-PR QA: PRO-1093 (PASS)

## Test plan

- [x] `pnpm exec vitest run packages/adapters/cursor-local/src/server/parse.test.ts` (QA PRO-1093)
- [x] `pnpm exec vitest run packages/adapters/cursor-local/src/server/execute.test.ts` (QA PRO-1093)
- [x] `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts -t "cleans up"` (QA PRO-1093 — terminal cleanup regression)
- [ ] Upstream maintainer merge + deploy Paperclip server build
- [ ] Post-deploy: complete one Cursor adapter heartbeat run and confirm no orphaned process group remains after terminal run status

## Checklist

- [x] Feature branch (`fix/PRO-1078-cursor-process-group-cleanup`)
- [x] Unit tests for changed detection path
- [x] Pre-PR QA sign-off (PRO-1093)
- [ ] CTO review
- [ ] Merge to master
- [ ] Deploy + post-deploy QA on running instance


Made with [Cursor](https://cursor.com)