### PR TITLE
perf(adapter-utils): reuse one SSH/TCP session per adapter run via ControlMaster (Windows-gated)

### DIFF
--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  _createSshDialPacingQueueForTests,
   buildSshSpawnTarget,
   buildSshEnvLabFixtureConfig,
   getSshEnvLabSupport,
@@ -166,7 +167,7 @@ describe("ssh env-lab fixture", () => {
     ).rejects.toThrow("Invalid SSH environment variable key: BAD KEY");
   });
 
-  it("emits ControlMaster=auto, ControlPath, and ControlPersist on every SSH invocation", async () => {
+  it("emits ControlMaster=auto, ControlPath, and ControlPersist on every SSH invocation (non-Windows only; REI-510 gates it on win32)", async () => {
     const target = await buildSshSpawnTarget({
       spec: {
         host: "ssh.example.test",
@@ -190,6 +191,15 @@ describe("ssh env-lab fixture", () => {
         }
         return -1;
       };
+      if (process.platform === "win32") {
+        // Windows OpenSSH 9.5p2 ControlMaster is broken (REI-510). The fix
+        // gates the multiplexing flags off on win32 and falls back to the
+        // dial-pacing queue to stay under the IONOS rate limit instead.
+        expect(indexOfOption("ControlMaster=auto")).toBe(-1);
+        expect(args.findIndex((entry) => entry.startsWith("ControlPath="))).toBe(-1);
+        expect(indexOfOption("ControlPersist=60s")).toBe(-1);
+        return;
+      }
       expect(indexOfOption("ControlMaster=auto")).toBeGreaterThanOrEqual(0);
       const controlPathIdx = args.findIndex(
         (entry, idx) => idx > 0 && args[idx - 1] === "-o" && entry.startsWith("ControlPath="),
@@ -250,7 +260,7 @@ describe("ssh env-lab fixture", () => {
     SSH_FIXTURE_TEST_TIMEOUT_MS,
   );
 
-  it("emits ControlMaster args even without a privateKey", async () => {
+  it("emits ControlMaster args even without a privateKey (non-Windows only)", async () => {
     const target = await buildSshSpawnTarget({
       spec: {
         host: "ssh.example.test",
@@ -267,12 +277,79 @@ describe("ssh env-lab fixture", () => {
       env: {},
     });
     try {
+      if (process.platform === "win32") {
+        expect(target.args).not.toContain("ControlMaster=auto");
+        expect(target.args).not.toContain("ControlPersist=60s");
+        expect(target.args.some((entry) => entry.startsWith("ControlPath="))).toBe(false);
+        return;
+      }
       expect(target.args).toContain("ControlMaster=auto");
       expect(target.args).toContain("ControlPersist=60s");
       expect(target.args.some((entry) => entry.startsWith("ControlPath="))).toBe(true);
     } finally {
       await target.cleanup();
     }
+  });
+
+  it("serializes Windows SSH dials through a FIFO queue with a post-completion pacing delay (REI-510)", async () => {
+    const pacingMs = 50;
+    const queue = _createSshDialPacingQueueForTests({ isWindows: true, pacingMs });
+    const events: Array<{ kind: "start" | "end"; id: number; at: number }> = [];
+    const start = Date.now();
+    const stamp = () => Date.now() - start;
+    const task = (id: number, durationMs: number) => async () => {
+      events.push({ kind: "start", id, at: stamp() });
+      await new Promise((resolve) => setTimeout(resolve, durationMs));
+      events.push({ kind: "end", id, at: stamp() });
+      return id;
+    };
+
+    const all = await Promise.all([
+      queue(task(1, 30)),
+      queue(task(2, 30)),
+      queue(task(3, 30)),
+    ]);
+    expect(all).toEqual([1, 2, 3]);
+
+    const startEvents = events.filter((e) => e.kind === "start").sort((a, b) => a.at - b.at);
+    const endEvents = events.filter((e) => e.kind === "end").sort((a, b) => a.at - b.at);
+
+    // Task ids must start in submission order — no overlap, FIFO.
+    expect(startEvents.map((e) => e.id)).toEqual([1, 2, 3]);
+    expect(endEvents.map((e) => e.id)).toEqual([1, 2, 3]);
+
+    // Second task starts no earlier than first task's end + pacingMs - jitter.
+    const jitterMs = 15;
+    expect(startEvents[1].at).toBeGreaterThanOrEqual(endEvents[0].at + pacingMs - jitterMs);
+    expect(startEvents[2].at).toBeGreaterThanOrEqual(endEvents[1].at + pacingMs - jitterMs);
+  });
+
+  it("does not serialize SSH dials on non-Windows platforms (queue is a passthrough)", async () => {
+    const queue = _createSshDialPacingQueueForTests({ isWindows: false, pacingMs: 500 });
+    const overlaps: number[] = [];
+    let active = 0;
+    const task = async () => {
+      active += 1;
+      overlaps.push(active);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      active -= 1;
+    };
+    await Promise.all([queue(task), queue(task), queue(task)]);
+    // On non-Windows the queue is a no-op, so we must observe concurrent
+    // execution — at least one tick must report >1 active operations.
+    expect(Math.max(...overlaps)).toBeGreaterThan(1);
+  });
+
+  it("releases the Windows FIFO chain when a queued task rejects so subsequent dials proceed", async () => {
+    const queue = _createSshDialPacingQueueForTests({ isWindows: true, pacingMs: 20 });
+    await expect(queue(async () => { throw new Error("boom"); })).rejects.toThrow("boom");
+    // Without finally-release the next task would hang forever. Race against
+    // a 1s timeout so an unreleased chain shows up as a test failure.
+    const result = await Promise.race([
+      queue(async () => "ok"),
+      new Promise<string>((_, reject) => setTimeout(() => reject(new Error("queue stuck")), 1_000)),
+    ]);
+    expect(result).toBe("ok");
   });
 
   it("syncs a local directory into the remote fixture workspace", async () => {

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -206,6 +206,50 @@ describe("ssh env-lab fixture", () => {
     }
   });
 
+  it(
+    "reuses a single TCP connection across 10 sequential SSH commands via ControlMaster",
+    async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+      cleanupDirs.push(rootDir);
+      const statePath = path.join(rootDir, "state.json");
+
+      const started = await startSshEnvLabFixtureOrSkip(
+        statePath,
+        "ControlMaster connection-reuse test",
+      );
+      if (!started) return;
+      const config = await buildSshEnvLabFixtureConfig(started);
+
+      // Drain any "Connection from" lines emitted by fixture readiness probes
+      // so we measure only the connections opened by the loop below.
+      const baselineLog = await readFile(started.sshdLogPath, "utf8").catch(() => "");
+      const baselineAccepts = (baselineLog.match(/Connection from /g) ?? []).length;
+
+      for (let i = 0; i < 10; i += 1) {
+        // runSshCommand rejects on non-zero exit, so a passing await is enough
+        // to assert each call succeeded.
+        await runSshCommand(config, "true");
+      }
+
+      // sshd flushes accept events to the log file synchronously enough for
+      // the count to be stable by the time runSshCommand returns, but give
+      // the kernel a beat to flush before reading.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const finalLog = await readFile(started.sshdLogPath, "utf8");
+      const finalAccepts = (finalLog.match(/Connection from /g) ?? []).length;
+      const delta = finalAccepts - baselineAccepts;
+
+      // Without ControlMaster, 10 sequential runSshCommand calls would emit 10
+      // "Connection from" lines (one per TCP+SSH handshake). With ControlMaster
+      // the first call establishes the master and the remaining 9 multiplex
+      // over the same TCP connection.
+      expect(delta).toBe(1);
+
+      await stopSshEnvLabFixture(statePath);
+    },
+    SSH_FIXTURE_TEST_TIMEOUT_MS,
+  );
+
   it("emits ControlMaster args even without a privateKey", async () => {
     const target = await buildSshSpawnTarget({
       spec: {

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -166,6 +166,71 @@ describe("ssh env-lab fixture", () => {
     ).rejects.toThrow("Invalid SSH environment variable key: BAD KEY");
   });
 
+  it("emits ControlMaster=auto, ControlPath, and ControlPersist on every SSH invocation", async () => {
+    const target = await buildSshSpawnTarget({
+      spec: {
+        host: "ssh.example.test",
+        port: 22,
+        username: "ssh-user",
+        remoteCwd: "/srv/paperclip/workspace",
+        remoteWorkspacePath: "/srv/paperclip/workspace",
+        privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----",
+        knownHosts: null,
+        strictHostKeyChecking: false,
+      },
+      command: "true",
+      args: [],
+      env: {},
+    });
+    try {
+      const args = target.args;
+      const indexOfOption = (value: string) => {
+        for (let i = 0; i < args.length - 1; i += 1) {
+          if (args[i] === "-o" && args[i + 1] === value) return i;
+        }
+        return -1;
+      };
+      expect(indexOfOption("ControlMaster=auto")).toBeGreaterThanOrEqual(0);
+      const controlPathIdx = args.findIndex(
+        (entry, idx) => idx > 0 && args[idx - 1] === "-o" && entry.startsWith("ControlPath="),
+      );
+      expect(controlPathIdx).toBeGreaterThanOrEqual(0);
+      const controlPathValue = args[controlPathIdx];
+      expect(controlPathValue).toContain("paperclip-ssh-cm-");
+      expect(controlPathValue.endsWith("%C")).toBe(true);
+      expect(controlPathValue.startsWith("ControlPath=")).toBe(true);
+      expect(path.isAbsolute(controlPathValue.slice("ControlPath=".length))).toBe(true);
+      expect(indexOfOption("ControlPersist=60s")).toBeGreaterThanOrEqual(0);
+    } finally {
+      await target.cleanup();
+    }
+  });
+
+  it("emits ControlMaster args even without a privateKey", async () => {
+    const target = await buildSshSpawnTarget({
+      spec: {
+        host: "ssh.example.test",
+        port: 22,
+        username: "ssh-user",
+        remoteCwd: "/srv/paperclip/workspace",
+        remoteWorkspacePath: "/srv/paperclip/workspace",
+        privateKey: null,
+        knownHosts: null,
+        strictHostKeyChecking: false,
+      },
+      command: "true",
+      args: [],
+      env: {},
+    });
+    try {
+      expect(target.args).toContain("ControlMaster=auto");
+      expect(target.args).toContain("ControlPersist=60s");
+      expect(target.args.some((entry) => entry.startsWith("ControlPath="))).toBe(true);
+    } finally {
+      await target.cleanup();
+    }
+  });
+
   it("syncs a local directory into the remote fixture workspace", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -370,6 +370,17 @@ async function createSshAuthArgs(
     "ConnectTimeout=10",
     "-o",
     `StrictHostKeyChecking=${config.strictHostKeyChecking ? "yes" : "no"}`,
+    // Reuse one TCP+SSH session for all calls in a run. Without this every
+    // command opens a new connection, which trips per-IP rate limits on
+    // hardened sshd hosts and surfaces as a ConnectTimeout on the 6th dial.
+    // %C hashes host/port/user so concurrent runs against different targets
+    // don't collide on the control socket path.
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    `ControlPath=${path.join(os.tmpdir(), "paperclip-ssh-cm-%C")}`,
+    "-o",
+    "ControlPersist=60s",
   ];
 
   if (config.strictHostKeyChecking) {

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -359,6 +359,44 @@ async function withTempFile(
   };
 }
 
+// Windows OpenSSH ControlMaster is broken (REI-510), so we cannot collapse
+// repeated dials onto one TCP+SSH session on win32. To stay under the IONOS
+// per-IP rate limit that REI-503 originally fixed, we instead serialize SSH
+// spawns through this FIFO chain and wait a short pacing window after each
+// command completes before releasing the next. The factory shape exists so
+// unit tests can construct an isolated queue with deterministic settings.
+const SSH_DIAL_PACING_MS = 300;
+
+export function _createSshDialPacingQueueForTests(options: {
+  isWindows: boolean;
+  pacingMs: number;
+}): <T>(task: () => Promise<T>) => Promise<T> {
+  let chain: Promise<void> = Promise.resolve();
+  return async function withSshDialPacing<T>(task: () => Promise<T>): Promise<T> {
+    if (!options.isWindows) {
+      return await task();
+    }
+    const previous = chain;
+    let releaseNext!: () => void;
+    const released = new Promise<void>((resolve) => {
+      releaseNext = resolve;
+    });
+    chain = previous.then(() => released).catch(() => undefined);
+    try {
+      await previous.catch(() => undefined);
+      return await task();
+    } finally {
+      const timer = setTimeout(releaseNext, options.pacingMs);
+      timer.unref?.();
+    }
+  };
+}
+
+const withSshDialPacing = _createSshDialPacingQueueForTests({
+  isWindows: process.platform === "win32",
+  pacingMs: SSH_DIAL_PACING_MS,
+});
+
 async function createSshAuthArgs(
   config: Pick<SshConnectionConfig, "privateKey" | "knownHosts" | "strictHostKeyChecking">,
 ): Promise<{ args: string[]; cleanup: () => Promise<void> }> {
@@ -370,18 +408,26 @@ async function createSshAuthArgs(
     "ConnectTimeout=10",
     "-o",
     `StrictHostKeyChecking=${config.strictHostKeyChecking ? "yes" : "no"}`,
-    // Reuse one TCP+SSH session for all calls in a run. Without this every
-    // command opens a new connection, which trips per-IP rate limits on
-    // hardened sshd hosts and surfaces as a ConnectTimeout on the 6th dial.
-    // %C hashes host/port/user so concurrent runs against different targets
-    // don't collide on the control socket path.
-    "-o",
-    "ControlMaster=auto",
-    "-o",
-    `ControlPath=${path.join(os.tmpdir(), "paperclip-ssh-cm-%C")}`,
-    "-o",
-    "ControlPersist=60s",
   ];
+
+  // ControlMaster collapses repeated dials onto one TCP+SSH session, which is
+  // what keeps hardened sshd hosts from rate-limiting the 6th call in a burst.
+  // Windows OpenSSH 9.5p2 ships a broken ControlMaster on AF_UNIX-on-Windows
+  // (every connect returns `getsockname failed: Not a socket`), so on win32 we
+  // skip the multiplexing flags and rely on the dial-pacing queue below to
+  // keep the burst under the rate-limit threshold instead. See REI-510.
+  if (process.platform !== "win32") {
+    sshArgs.push(
+      // %C hashes host/port/user so concurrent runs against different targets
+      // don't collide on the control socket path.
+      "-o",
+      "ControlMaster=auto",
+      "-o",
+      `ControlPath=${path.join(os.tmpdir(), "paperclip-ssh-cm-%C")}`,
+      "-o",
+      "ControlPersist=60s",
+    );
+  }
 
   if (config.strictHostKeyChecking) {
     if (config.knownHosts) {
@@ -514,7 +560,7 @@ async function streamLocalFileToSsh(input: {
     `sh -c ${shellQuote(input.remoteScript)}`,
   ];
 
-  await new Promise<void>((resolve, reject) => {
+  await withSshDialPacing(() => new Promise<void>((resolve, reject) => {
     const source = createReadStream(input.localFile);
     const ssh = spawn("ssh", sshArgs, {
       stdio: ["pipe", "ignore", "pipe"],
@@ -546,7 +592,7 @@ async function streamLocalFileToSsh(input: {
       }
       resolve();
     });
-  }).finally(auth.cleanup);
+  })).finally(auth.cleanup);
 }
 
 async function streamSshToLocalFile(input: {
@@ -563,7 +609,7 @@ async function streamSshToLocalFile(input: {
     `sh -c ${shellQuote(input.remoteScript)}`,
   ];
 
-  await new Promise<void>((resolve, reject) => {
+  await withSshDialPacing(() => new Promise<void>((resolve, reject) => {
     const ssh = spawn("ssh", sshArgs, {
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -597,7 +643,7 @@ async function streamSshToLocalFile(input: {
         resolve();
       });
     });
-  }).finally(auth.cleanup);
+  })).finally(auth.cleanup);
 }
 
 async function importGitWorkspaceToSsh(input: {
@@ -972,16 +1018,18 @@ export async function runSshCommand(
       `sh -c ${shellQuote(remoteScript)}`,
     );
 
-    return options.stdin != null
-      ? await spawnText("ssh", sshArgs, {
-          stdin: options.stdin,
-          timeout: options.timeoutMs ?? 15_000,
-          maxBuffer: options.maxBuffer ?? 1024 * 128,
-        })
-      : await execFileText("ssh", sshArgs, {
-          timeout: options.timeoutMs ?? 15_000,
-          maxBuffer: options.maxBuffer ?? 1024 * 128,
-        });
+    return await withSshDialPacing(() =>
+      options.stdin != null
+        ? spawnText("ssh", sshArgs, {
+            stdin: options.stdin,
+            timeout: options.timeoutMs ?? 15_000,
+            maxBuffer: options.maxBuffer ?? 1024 * 128,
+          })
+        : execFileText("ssh", sshArgs, {
+            timeout: options.timeoutMs ?? 15_000,
+            maxBuffer: options.maxBuffer ?? 1024 * 128,
+          }),
+    );
   } finally {
     await cleanup();
   }
@@ -1050,7 +1098,7 @@ export async function syncDirectoryToSsh(input: {
     `sh -c ${shellQuote(`mkdir -p ${shellQuote(input.remoteDir)} && tar -xf - -C ${shellQuote(input.remoteDir)}`)}`,
   ];
 
-  await new Promise<void>((resolve, reject) => {
+  await withSshDialPacing(() => new Promise<void>((resolve, reject) => {
     const tarArgs = [
       ...(input.followSymlinks ? ["-h"] : []),
       "-C",
@@ -1122,7 +1170,7 @@ export async function syncDirectoryToSsh(input: {
       sshExitCode = code;
       maybeFinish();
     });
-  }).finally(auth.cleanup);
+  })).finally(auth.cleanup);
 }
 
 export async function syncDirectoryFromSsh(input: {
@@ -1147,7 +1195,7 @@ export async function syncDirectoryFromSsh(input: {
   ];
 
   try {
-    await new Promise<void>((resolve, reject) => {
+    await withSshDialPacing(() => new Promise<void>((resolve, reject) => {
       const ssh = spawn("ssh", sshArgs, {
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -1206,7 +1254,7 @@ export async function syncDirectoryFromSsh(input: {
         tarExitCode = code;
         maybeFinish();
       });
-    });
+    }));
 
     await clearLocalDirectory(input.localDir, input.preserveLocalEntries);
     await copyDirectoryContents(stagingDir, input.localDir);


### PR DESCRIPTION
## Summary

`createSshAuthArgs` emits ControlMaster on non-Windows platforms to collapse adapter SSH calls onto one TCP+SSH session. On Windows, ControlMaster is gated off (Windows OpenSSH 9.5p2 ships a broken implementation -- see REI-510 below) and a small FIFO dial-pacing queue holds Windows runs under the per-IP rate limit that originally motivated the patch.

```ts
if (process.platform !== "win32") {
  sshArgs.push(
    "-o", "ControlMaster=auto",
    "-o", `ControlPath=${path.join(os.tmpdir(), "paperclip-ssh-cm-%C")}`,
    "-o", "ControlPersist=60s",
  );
}
```

Single point of change for the multiplexing flags: `createSshAuthArgs` is the lone entry point shared by `runSshCommand`, `buildSshSpawnTarget`, and `syncDirectoryToSsh`, so the gate covers every call site with no downstream edits. The dial-pacing queue is wrapped around the five ssh-dial sites (`runSshCommand`, `streamLocalFileToSsh`, `streamSshToLocalFile`, `syncDirectoryToSsh`, `syncDirectoryFromSsh`); `buildSshSpawnTarget` is intentionally not wrapped -- it returns args for the long-lived runtime spawn whose lifetime is owned by the caller.

## Why (perf framing)

Today every adapter SSH call opens a fresh TCP + SSH session. A typical adapter run fires 8-10 sequential `runSshCommand` / `syncDirectoryToSsh` calls (`mkdir`, workspace bootstrap, command exec, log fetch, snapshot, etc.). That's 8-10 full handshakes -- TCP SYN/SYN-ACK/ACK plus the SSH key exchange, host-key check, and pubkey auth -- for what is logically one session against one host.

With `ControlMaster=auto` + `ControlPersist=60s`, the first call establishes a master connection cached at the `%C`-hashed `ControlPath`, and the next 9 multiplex over it. End result on Linux/macOS: **one TCP+SSH handshake per adapter run instead of 8-10**, with the master torn down 60s after the last call.

`%C` hashes host/port/user, so concurrent runs targeting different environments don't collide on the control-socket path.

## Why (secondary: rate-limit hardening)

On hardened sshd hosts with per-IP connection rate limits (the motivating case for us was an IONOS-style provider), the 6th sequential dial in a tight burst gets TCP-blackholed by the rate limiter. The client `ConnectTimeout=10` then surfaces as a generic connect timeout -- confusing to diagnose because earlier calls in the same run succeeded. Collapsing 8-10 connections to 1 keeps adapter runs comfortably below any reasonable per-IP threshold.

Root-cause reproduction evidence: REI-497 comment `728875d0-f850-4ea2-b345-bb4404eabd43`.

## Windows: REI-510 follow-up

The first revision of this PR enabled ControlMaster unconditionally. That deterministically broke the adapter `test-environment` probe on Windows hosts: every Windows OpenSSH 9.5p2 dial with `ControlMaster=auto` returns

```
getsockname failed: Not a socket
Read from remote host <host>: Unknown error
```

regardless of `ControlPath` slash direction or whether `ControlPersist` is set. Reproduces with bare `ssh.exe`, not Paperclip-specific -- it's a known break in the OpenSSH-for-Windows AF_UNIX-on-Windows implementation. `ControlMaster=no` is the only working configuration on win32.

This revision:

1. **Gates ControlMaster on `process.platform !== "win32"`.** Linux/macOS keep the connection-reuse win; Windows takes the no-multiplexing fallback.
2. **Adds a Windows-only in-process dial-pacing queue.** Module-private FIFO with concurrency=1 and a 300ms post-completion delay, wrapped around every ssh-dial site. Without multiplexing on Windows we would re-trip the rate limit; the queue keeps the burst under threshold (measured ~5 dials per 2s on the IONOS VPS). Exposed as a factory (`_createSshDialPacingQueueForTests`) so tests can build isolated queues with deterministic timing. On non-Windows the queue short-circuits to passthrough so the pacing cost is zero where ControlMaster does the job.

Verified live on Windows 11 Pro (`OpenSSH_for_Windows_9.5p2, LibreSSL 3.8.2`): the adapter `test-environment` probe against the original failing VPS returns **4/4 green** (`claude_environment_target`, `claude_cwd_valid`, `claude_command_resolvable`, `claude_hello_probe_passed`).

## Tests

1. **Unit (`ssh-fixture.test.ts`):** assert `buildSshSpawnTarget` returns args containing `-o ControlMaster=auto`, `-o ControlPath=...paperclip-ssh-cm-%C`, and `-o ControlPersist=60s` on non-Windows -- and assert the same flags are absent on win32. With and without a privateKey.
2. **Unit (`ssh-fixture.test.ts`):** FIFO + pacing on Windows -- three concurrently-submitted tasks start in submission order and each subsequent task starts no earlier than `previous_end + pacingMs - jitter`. Passthrough on non-Windows -- at least one tick observes >1 active operations. Reject-release -- a rejected queued task still releases the chain so subsequent dials proceed (1s race-against-stuck guard).
3. **Integration (`ssh-fixture.test.ts`):** spins up the existing sshd env-lab fixture (already used elsewhere in this file), fires **10 sequential `runSshCommand` calls**, and asserts the delta of `Connection from ` lines in sshd's `LogLevel VERBOSE` log is exactly **1**. Without ControlMaster the delta would be 10. Skips automatically on hosts without `sshd` (Windows, minimal CI images) via the existing `startSshEnvLabFixtureOrSkip` helper.

Local `pnpm --filter @paperclipai/adapter-utils typecheck` is clean. `vitest run packages/adapter-utils/src/ssh-fixture.test.ts` reports **17/17 passing** on the Windows dev host (fixture-backed sshd tests skip there).

## Test plan

- [ ] CI typecheck + tests pass on Linux runner (where sshd is available, the integration tests execute and assert ControlMaster connection reuse)
- [x] Manual: `test-environment` probe on Windows host returns 4/4 green against the original failing VPS (REI-510 verification step 1)
- [ ] Manual: confirm `ssh -O check -o ControlPath=...` against an adapter target reports the master alive after a run on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
