### PR TITLE
feat(adapter): ollama_local adapter for local Ollama HTTP chat-mode

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -44,6 +44,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printCursorCloudEvent } from "@paperclipai/adapter-cursor-cloud/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printGrokStreamEvent } from "@paperclipai/adapter-grok-local/cli";
+import { printOllamaLocalStreamEvent } from "@paperclipai/adapter-ollama-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
@@ -30,6 +31,11 @@ const codexLocalCLIAdapter: CLIAdapterModule = {
 const openCodeLocalCLIAdapter: CLIAdapterModule = {
   type: "opencode_local",
   formatStdoutEvent: printOpenCodeStreamEvent,
+};
+
+const ollamaLocalCLIAdapter: CLIAdapterModule = {
+  type: "ollama_local",
+  formatStdoutEvent: printOllamaLocalStreamEvent,
 };
 
 const piLocalCLIAdapter: CLIAdapterModule = {
@@ -67,6 +73,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     acpxLocalCLIAdapter,
     claudeLocalCLIAdapter,
     codexLocalCLIAdapter,
+    ollamaLocalCLIAdapter,
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -476,6 +476,73 @@ CI runs `pnpm --filter @paperclipai/skills-catalog validate` and the package's
 vitest suite, so always regenerate the manifest in the same commit as the
 catalog change.
 
+## Ollama Local Adapter
+
+Paperclip ships an `ollama_local` adapter that turns a heartbeat into a single
+HTTP roundtrip against a locally-installed [Ollama](https://ollama.com) server.
+It is chat-mode only (no tool calls) and posts the model response back to the
+triggering issue as a comment on the agent's behalf using the heartbeat's run
+JWT. Use it for cheap, fully on-prem pilots, or for agents that only need to
+nudge work along via the Paperclip API + bash/filesystem.
+
+### One-time setup
+
+```sh
+# 1) Install Ollama (Mac: brew install ollama, Linux: curl install script).
+ollama serve &                          # default endpoint: http://127.0.0.1:11434
+ollama pull qwen2.5:14b-instruct        # or another model you want to use
+```
+
+### Example agent adapter config
+
+```json
+{
+  "type": "ollama_local",
+  "endpoint": "http://127.0.0.1:11434",
+  "model": "qwen2.5:14b-instruct",
+  "options": { "temperature": 0.2, "num_ctx": 8192 },
+  "postCommentToIssue": true
+}
+```
+
+Fields:
+
+- `endpoint` (string, optional) — Ollama base URL. Defaults to
+  `http://127.0.0.1:11434`.
+- `model` (string, required) — Ollama model tag. Must already be pulled.
+- `options` (object, optional) — passed verbatim to Ollama as the
+  `options` block of the `/api/chat` request (temperature, num_ctx, top_p,
+  etc.).
+- `promptTemplate` (string, optional) — prepended to the rendered wake prompt.
+- `timeoutSec` (number, optional) — per-run timeout. Defaults to 300.
+- `postCommentToIssue` (boolean, optional) — when true (default) and the wake
+  carries an `issueId`, the adapter posts the model response to that issue as
+  a comment. Set to `false` to keep responses in the heartbeat run summary
+  only.
+
+Telemetry mapping:
+
+- `usage.inputTokens`  ← `prompt_eval_count`
+- `usage.outputTokens` ← `eval_count`
+- `costUsd` is always `0`.
+
+### Smoke test
+
+After a fresh build (`pnpm install && pnpm build`) and with Ollama running:
+
+```sh
+# 1) Start Paperclip:  npx paperclipai run
+# 2) Hire/create an agent with adapterType=ollama_local and the config above.
+# 3) Assign an issue to that agent so it has work to do, then trigger a wake:
+npx paperclipai heartbeat run --agent-id <agent-id>
+# 4) Verify in the issue thread that a comment from the agent appeared, and
+#    that the agent's run history shows tokensIn > 0 and tokensOut > 0.
+```
+
+Rollback is state-free: PATCH the agent's `adapterType` back to whatever it
+was before (for example `opencode_local`). The `ollama_local` adapter does not
+write migrations and does not store adapter-specific state.
+
 ## Quick Health Checks
 
 In another terminal:

--- a/packages/adapters/ollama-local/package.json
+++ b/packages/adapters/ollama-local/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@paperclipai/adapter-ollama-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/ollama-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/ollama-local/src/cli/format-event.ts
+++ b/packages/adapters/ollama-local/src/cli/format-event.ts
@@ -1,0 +1,5 @@
+export function printOllamaLocalStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+  console.log(line);
+}

--- a/packages/adapters/ollama-local/src/cli/index.ts
+++ b/packages/adapters/ollama-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printOllamaLocalStreamEvent } from "./format-event.js";

--- a/packages/adapters/ollama-local/src/index.ts
+++ b/packages/adapters/ollama-local/src/index.ts
@@ -1,0 +1,64 @@
+import type { AdapterModel, AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
+
+export const type = "ollama_local";
+export const label = "Ollama (local)";
+
+export const DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1:11434";
+export const DEFAULT_OLLAMA_MODEL = "qwen2.5:14b-instruct";
+
+export const models: AdapterModel[] = [
+  { id: "qwen2.5:14b-instruct", label: "qwen2.5:14b-instruct" },
+  { id: "llama3.1:8b", label: "llama3.1:8b" },
+  { id: "llama3.2:3b", label: "llama3.2:3b" },
+  { id: "mistral:7b-instruct", label: "mistral:7b-instruct" },
+];
+
+export const modelProfiles: AdapterModelProfileDefinition[] = [
+  {
+    key: "cheap",
+    label: "Cheap",
+    description: "Smaller local Ollama model as the budget lane.",
+    adapterConfig: {
+      model: "llama3.2:3b",
+    },
+    source: "adapter_default",
+  },
+];
+
+export const agentConfigurationDoc = `# ollama_local agent configuration
+
+Adapter: ollama_local
+
+Use when:
+- You want Paperclip heartbeats to run against a locally-hosted Ollama instance.
+- You want a fully on-prem / offline LLM runtime with no API costs.
+- Chat-mode (no tool calls) is sufficient for the agent's job.
+
+Don't use when:
+- The agent needs real tool calls or file-edit capability (use claude_local / opencode_local).
+- You need cloud-grade reasoning quality.
+- Ollama is not installed on the Paperclip host.
+
+Required fields:
+- model (string): Ollama model tag, e.g. "qwen2.5:14b-instruct". Must already be pulled (\`ollama pull <model>\`).
+
+Optional fields:
+- endpoint (string): Ollama server base URL. Defaults to ${DEFAULT_OLLAMA_ENDPOINT}.
+- options (object): Ollama generation options passed verbatim (temperature, num_ctx, top_p, ...).
+- promptTemplate (string): run prompt template prepended to the wake context.
+- timeoutSec (number): per-run timeout in seconds. Defaults to 300.
+- postCommentToIssue (boolean): when true (default) and the wake carries an issueId,
+  the adapter posts the model response to that issue as a comment on the agent's behalf.
+
+Telemetry:
+- tokensIn  ← Ollama \`prompt_eval_count\`
+- tokensOut ← Ollama \`eval_count\`
+- costUsd   = 0
+
+Notes:
+- Communication is a single HTTP POST to /api/chat (Ollama's native chat endpoint).
+  Non-streaming (block) responses for MVP.
+- The wake prompt is forwarded as the user message; \`promptTemplate\` (if set) is prepended.
+- This adapter does not spawn a child process. It runs entirely in-band inside the
+  Paperclip server's heartbeat call.
+`;

--- a/packages/adapters/ollama-local/src/server/execute.ts
+++ b/packages/adapters/ollama-local/src/server/execute.ts
@@ -1,0 +1,225 @@
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  parseObject,
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
+} from "@paperclipai/adapter-utils/server-utils";
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
+import { DEFAULT_OLLAMA_ENDPOINT, DEFAULT_OLLAMA_MODEL } from "../index.js";
+
+interface OllamaChatRequest {
+  model: string;
+  stream: false;
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  options?: Record<string, unknown>;
+}
+
+interface OllamaChatResponse {
+  model?: string;
+  created_at?: string;
+  message?: { role?: string; content?: string };
+  done?: boolean;
+  done_reason?: string;
+  total_duration?: number;
+  load_duration?: number;
+  prompt_eval_count?: number;
+  prompt_eval_duration?: number;
+  eval_count?: number;
+  eval_duration?: number;
+}
+
+function normalizeEndpoint(raw: unknown): string {
+  const value = asString(raw, DEFAULT_OLLAMA_ENDPOINT).trim();
+  const candidate = value.length > 0 ? value : DEFAULT_OLLAMA_ENDPOINT;
+  return candidate.replace(/\/+$/, "");
+}
+
+function buildPrompt(ctx: AdapterExecutionContext, promptTemplate: string): string {
+  const sections: string[] = [];
+  if (promptTemplate.trim().length > 0) {
+    sections.push(promptTemplate.trim());
+  }
+  const wakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
+  if (wakePrompt) sections.push(wakePrompt);
+  const wakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
+  if (wakeJson) {
+    sections.push(`Structured wake payload JSON:\n\`\`\`json\n${wakeJson}\n\`\`\``);
+  }
+  if (sections.length === 0) {
+    sections.push("You are a Paperclip agent. Continue your assigned work.");
+  }
+  return sections.join("\n\n");
+}
+
+async function postCommentToIssue(input: {
+  apiUrl: string;
+  authToken: string;
+  runId: string;
+  issueId: string;
+  body: string;
+}): Promise<{ ok: boolean; errorMessage?: string }> {
+  try {
+    const res = await fetch(`${input.apiUrl.replace(/\/+$/, "")}/api/issues/${input.issueId}/comments`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${input.authToken}`,
+        "x-paperclip-run-id": input.runId,
+      },
+      body: JSON.stringify({ body: input.body }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, errorMessage: `comment POST returned ${res.status}: ${text.slice(0, 200)}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, errorMessage: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const config = parseObject(ctx.config);
+  const endpoint = normalizeEndpoint(config.endpoint);
+  const model = asString(config.model, DEFAULT_OLLAMA_MODEL).trim() || DEFAULT_OLLAMA_MODEL;
+  const options = parseObject(config.options);
+  const timeoutSec = Math.max(1, Math.floor(asNumber(config.timeoutSec, 300)));
+  const promptTemplate = asString(config.promptTemplate, "");
+  const postComment = asBoolean(config.postCommentToIssue, true);
+
+  const prompt = buildPrompt(ctx, promptTemplate);
+  const messages: OllamaChatRequest["messages"] = [{ role: "user", content: prompt }];
+
+  await ctx.onLog(
+    "stdout",
+    `[ollama-local] POST ${endpoint}/api/chat model=${model} promptChars=${prompt.length}\n`,
+  );
+
+  if (ctx.onMeta) {
+    await ctx.onMeta({
+      adapterType: "ollama_local",
+      command: "ollama",
+      commandArgs: ["http", endpoint, "/api/chat"],
+      context: ctx.context,
+      prompt,
+      promptMetrics: { promptChars: prompt.length },
+    });
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutSec * 1000);
+
+  let responseJson: OllamaChatResponse;
+  try {
+    const requestBody: OllamaChatRequest = {
+      model,
+      stream: false,
+      messages,
+      ...(Object.keys(options).length > 0 ? { options } : {}),
+    };
+    const res = await fetch(`${endpoint}/api/chat`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      const trimmed = text.slice(0, 400);
+      await ctx.onLog("stderr", `[ollama-local] HTTP ${res.status}: ${trimmed}\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `Ollama /api/chat returned ${res.status}: ${trimmed}`,
+        errorCode: res.status === 404 ? "ollama_model_not_found" : "ollama_http_error",
+      };
+    }
+    responseJson = (await res.json()) as OllamaChatResponse;
+  } catch (err) {
+    const aborted = (err as Error)?.name === "AbortError";
+    const message = err instanceof Error ? err.message : String(err);
+    await ctx.onLog("stderr", `[ollama-local] request failed: ${message}\n`);
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: aborted,
+      errorMessage: aborted
+        ? `Ollama request timed out after ${timeoutSec}s`
+        : `Ollama request failed: ${message}`,
+      errorCode: aborted ? "ollama_timeout" : "ollama_request_failed",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const content = (responseJson.message?.content ?? "").trim();
+  const tokensIn = Math.max(0, Math.floor(responseJson.prompt_eval_count ?? 0));
+  const tokensOut = Math.max(0, Math.floor(responseJson.eval_count ?? 0));
+
+  await ctx.onLog(
+    "stdout",
+    `[ollama-local] response done=${responseJson.done ?? false} tokensIn=${tokensIn} tokensOut=${tokensOut} responseChars=${content.length}\n`,
+  );
+
+  const issueId =
+    asString(ctx.context.issueId, "").trim() || asString(ctx.context.taskId, "").trim();
+  let commentPostError: string | null = null;
+  if (postComment && issueId && ctx.authToken && content.length > 0) {
+    const apiUrl =
+      asString(ctx.context.paperclipApiUrl, "").trim() ||
+      asString(process.env.PAPERCLIP_API_URL, "").trim();
+    if (apiUrl) {
+      const commentResult = await postCommentToIssue({
+        apiUrl,
+        authToken: ctx.authToken,
+        runId: ctx.runId,
+        issueId,
+        body: content,
+      });
+      if (!commentResult.ok) {
+        commentPostError = commentResult.errorMessage ?? "unknown error";
+        await ctx.onLog(
+          "stderr",
+          `[ollama-local] failed to post issue comment: ${commentPostError}\n`,
+        );
+      } else {
+        await ctx.onLog("stdout", `[ollama-local] posted issue comment to ${issueId}\n`);
+      }
+    } else {
+      await ctx.onLog(
+        "stderr",
+        "[ollama-local] postCommentToIssue requested but no PAPERCLIP_API_URL is set; skipping\n",
+      );
+    }
+  }
+
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    provider: "ollama",
+    biller: "ollama_local",
+    model,
+    billingType: "subscription",
+    usage: tokensIn > 0 || tokensOut > 0
+      ? { inputTokens: tokensIn, outputTokens: tokensOut }
+      : undefined,
+    costUsd: 0,
+    summary: content.length > 0 ? content : null,
+    resultJson: {
+      done: responseJson.done ?? false,
+      done_reason: responseJson.done_reason ?? null,
+      total_duration_ns: responseJson.total_duration ?? null,
+      load_duration_ns: responseJson.load_duration ?? null,
+      prompt_eval_count: tokensIn,
+      eval_count: tokensOut,
+      ...(commentPostError ? { commentPostError } : {}),
+    },
+  };
+}

--- a/packages/adapters/ollama-local/src/server/index.ts
+++ b/packages/adapters/ollama-local/src/server/index.ts
@@ -1,0 +1,32 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+/**
+ * Minimal session codec for ollama_local.
+ *
+ * Chat-mode MVP carries no Ollama-side session state across heartbeats; we
+ * accept an opaque sessionId pass-through so an upstream caller may still
+ * persist a stable conversation id if they wish.
+ */
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = typeof record.sessionId === "string" ? record.sessionId.trim() : "";
+    return sessionId ? { sessionId } : null;
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId.trim() : "";
+    return sessionId ? { sessionId } : null;
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return typeof params.sessionId === "string" && params.sessionId.trim().length > 0
+      ? params.sessionId.trim()
+      : null;
+  },
+};
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { listOllamaModels } from "./models.js";

--- a/packages/adapters/ollama-local/src/server/models.ts
+++ b/packages/adapters/ollama-local/src/server/models.ts
@@ -1,0 +1,46 @@
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import { DEFAULT_OLLAMA_ENDPOINT, models as fallbackModels } from "../index.js";
+
+interface OllamaTag {
+  name?: string;
+  model?: string;
+}
+
+interface OllamaTagsResponse {
+  models?: OllamaTag[];
+}
+
+/**
+ * Best-effort discovery of locally-pulled Ollama models.
+ *
+ * Hits the default endpoint with a tight timeout. On any failure
+ * (no Ollama running, timeout, parse error) we return the static
+ * fallback list from the index module so the UI still has options.
+ */
+export async function listOllamaModels(endpoint = DEFAULT_OLLAMA_ENDPOINT): Promise<AdapterModel[]> {
+  const url = `${endpoint.replace(/\/+$/, "")}/api/tags`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2000);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return fallbackModels;
+    const payload = (await res.json()) as OllamaTagsResponse;
+    const tags = Array.isArray(payload.models) ? payload.models : [];
+    const discovered: AdapterModel[] = [];
+    const seen = new Set<string>();
+    for (const tag of tags) {
+      const id =
+        (typeof tag?.name === "string" && tag.name.trim()) ||
+        (typeof tag?.model === "string" && tag.model.trim()) ||
+        "";
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      discovered.push({ id, label: id });
+    }
+    return discovered.length > 0 ? discovered : fallbackModels;
+  } catch {
+    return fallbackModels;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/adapters/ollama-local/src/server/test.ts
+++ b/packages/adapters/ollama-local/src/server/test.ts
@@ -1,0 +1,117 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_OLLAMA_ENDPOINT, DEFAULT_OLLAMA_MODEL } from "../index.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function normalizeEndpoint(raw: unknown): string {
+  const value = asString(raw, DEFAULT_OLLAMA_ENDPOINT).trim();
+  const candidate = value.length > 0 ? value : DEFAULT_OLLAMA_ENDPOINT;
+  return candidate.replace(/\/+$/, "");
+}
+
+interface OllamaTag {
+  name?: string;
+  model?: string;
+}
+
+interface OllamaTagsResponse {
+  models?: OllamaTag[];
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const endpoint = normalizeEndpoint(config.endpoint);
+  const model = asString(config.model, DEFAULT_OLLAMA_MODEL).trim() || DEFAULT_OLLAMA_MODEL;
+  const timeoutMs = Math.max(1000, Math.floor(asNumber(config.testTimeoutMs, 5000)));
+
+  if (ctx.executionTarget && ctx.executionTarget.kind === "remote") {
+    checks.push({
+      code: "ollama_local_remote_unsupported",
+      level: "warn",
+      message:
+        "ollama_local probes the Paperclip host directly; remote execution targets are not yet supported by testEnvironment.",
+    });
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(`${endpoint}/api/tags`, {
+      method: "GET",
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      checks.push({
+        code: "ollama_tags_http_error",
+        level: "error",
+        message: `Ollama /api/tags returned HTTP ${res.status} at ${endpoint}`,
+        hint: "Confirm `ollama serve` is running and the endpoint is reachable.",
+      });
+      return { adapterType: "ollama_local", status: "fail", checks, testedAt: new Date().toISOString() };
+    }
+    const payload = (await res.json()) as OllamaTagsResponse;
+    const tags = Array.isArray(payload.models) ? payload.models : [];
+    const availableIds = tags
+      .map((t) => (typeof t?.name === "string" && t.name) || (typeof t?.model === "string" && t.model) || "")
+      .filter(Boolean);
+    checks.push({
+      code: "ollama_reachable",
+      level: "info",
+      message: `Ollama reachable at ${endpoint} (${availableIds.length} models pulled).`,
+    });
+    const hasModel = availableIds.some((id) => id === model || id.startsWith(`${model}:`) || id.startsWith(model));
+    if (!hasModel) {
+      checks.push({
+        code: "ollama_model_missing",
+        level: "warn",
+        message: `Configured model "${model}" is not pulled.`,
+        hint: `Run: ollama pull ${model}`,
+        detail: availableIds.length > 0 ? `Available: ${availableIds.slice(0, 10).join(", ")}` : null,
+      });
+    } else {
+      checks.push({
+        code: "ollama_model_present",
+        level: "info",
+        message: `Configured model "${model}" is available locally.`,
+      });
+    }
+  } catch (err) {
+    const aborted = (err as Error)?.name === "AbortError";
+    const message = err instanceof Error ? err.message : String(err);
+    checks.push({
+      code: aborted ? "ollama_tags_timeout" : "ollama_tags_unreachable",
+      level: "error",
+      message: aborted
+        ? `Ollama /api/tags timed out after ${timeoutMs}ms (${endpoint}).`
+        : `Could not reach Ollama at ${endpoint}: ${message}`,
+      hint: "Install Ollama from https://ollama.com and run `ollama serve`.",
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return {
+    adapterType: "ollama_local",
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/ollama-local/src/ui/build-config.ts
+++ b/packages/adapters/ollama-local/src/ui/build-config.ts
@@ -1,0 +1,27 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_OLLAMA_ENDPOINT } from "../index.js";
+
+function getString(values: CreateConfigValues, key: string): string {
+  const schema = values.adapterSchemaValues ?? {};
+  const raw = schema[key];
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function getOptions(values: CreateConfigValues): Record<string, unknown> {
+  const schema = values.adapterSchemaValues ?? {};
+  const raw = schema.options;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  return raw as Record<string, unknown>;
+}
+
+export function buildOllamaLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.model) ac.model = v.model;
+  const endpoint = getString(v, "endpoint");
+  ac.endpoint = endpoint || DEFAULT_OLLAMA_ENDPOINT;
+  if (v.promptTemplate) ac.promptTemplate = v.promptTemplate;
+  const options = getOptions(v);
+  if (Object.keys(options).length > 0) ac.options = options;
+  ac.postCommentToIssue = true;
+  return ac;
+}

--- a/packages/adapters/ollama-local/src/ui/index.ts
+++ b/packages/adapters/ollama-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseOllamaLocalStdoutLine } from "./parse-stdout.js";
+export { buildOllamaLocalConfig } from "./build-config.js";

--- a/packages/adapters/ollama-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/ollama-local/src/ui/parse-stdout.ts
@@ -1,0 +1,15 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+const OLLAMA_LOG_PREFIX = "[ollama-local]";
+
+/**
+ * ollama_local emits human-readable log lines via ctx.onLog, not structured
+ * JSONL. We pass stdout/stderr through as-is so the UI shows them verbatim.
+ */
+export function parseOllamaLocalStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  if (!line.length) return [];
+  if (line.startsWith(OLLAMA_LOG_PREFIX)) {
+    return [{ kind: "system", ts, text: line }];
+  }
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/ollama-local/tsconfig.json
+++ b/packages/adapters/ollama-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@paperclipai/adapter-grok-local':
         specifier: workspace:*
         version: link:../packages/adapters/grok-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -230,6 +233,19 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/ollama-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
@@ -622,6 +638,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':
@@ -648,6 +666,9 @@ importers:
       '@paperclipai/adapter-grok-local':
         specifier: workspace:*
         version: link:../packages/adapters/grok-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -814,6 +835,9 @@ importers:
       '@paperclipai/adapter-grok-local':
         specifier: workspace:*
         version: link:../packages/adapters/grok-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -11,6 +11,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "grok_local",
   "openclaw_gateway",
   "opencode_local",
+  "ollama_local",
   "pi_local",
   "hermes_local",
   "process",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -103,6 +103,17 @@ import {
   modelProfiles as openCodeModelProfiles,
 } from "@paperclipai/adapter-opencode-local";
 import {
+  execute as ollamaExecute,
+  testEnvironment as ollamaTestEnvironment,
+  sessionCodec as ollamaSessionCodec,
+  listOllamaModels,
+} from "@paperclipai/adapter-ollama-local/server";
+import {
+  agentConfigurationDoc as ollamaAgentConfigurationDoc,
+  models as ollamaModels,
+  modelProfiles as ollamaModelProfiles,
+} from "@paperclipai/adapter-ollama-local";
+import {
   execute as openclawGatewayExecute,
   testEnvironment as openclawGatewayTestEnvironment,
 } from "@paperclipai/adapter-openclaw-gateway/server";
@@ -411,6 +422,24 @@ const openCodeLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openCodeAgentConfigurationDoc,
 };
 
+const ollamaLocalAdapter: ServerAdapterModule = {
+  type: "ollama_local",
+  execute: ollamaExecute,
+  testEnvironment: ollamaTestEnvironment,
+  sessionCodec: ollamaSessionCodec,
+  models: ollamaModels,
+  modelProfiles: ollamaModelProfiles,
+  sessionManagement: getAdapterSessionManagement("ollama_local") ?? undefined,
+  listModels: () => listOllamaModels(),
+  // The adapter runs entirely in-band over HTTP and posts comments using the
+  // run JWT itself, so it benefits from a local agent JWT but does not spawn
+  // a child CLI, has no instructions bundle, and does not materialize skills.
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: false,
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: ollamaAgentConfigurationDoc,
+};
+
 const piLocalAdapter: ServerAdapterModule = {
   type: "pi_local",
   execute: piExecute,
@@ -513,6 +542,7 @@ function registerBuiltInAdapters() {
     acpxLocalAdapter,
     claudeLocalAdapter,
     codexLocalAdapter,
+    ollamaLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
     cursorCloudAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -88,6 +88,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Local multi-provider agent",
     icon: OpenCodeLogoIcon,
   },
+  ollama_local: {
+    label: "Ollama",
+    description: "Local Ollama chat-mode agent (no tool calls)",
+    icon: Terminal,
+  },
   hermes_local: {
     label: "Hermes Agent",
     description: "Local Hermes CLI agent",

--- a/ui/src/adapters/ollama-local/config-fields.tsx
+++ b/ui/src/adapters/ollama-local/config-fields.tsx
@@ -1,0 +1,57 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput } from "../../components/agent-config-primitives";
+import { DEFAULT_OLLAMA_ENDPOINT } from "@paperclipai/adapter-ollama-local";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function getSchemaString(
+  values: AdapterConfigFieldsProps["values"],
+  key: string,
+  fallback: string,
+): string {
+  const raw = values?.adapterSchemaValues?.[key];
+  return typeof raw === "string" && raw.length > 0 ? raw : fallback;
+}
+
+export function OllamaLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  const endpointHint =
+    "Base URL of the local Ollama server. Defaults to http://127.0.0.1:11434.";
+  return (
+    <>
+      <Field label="Ollama endpoint" hint={endpointHint}>
+        <DraftInput
+          value={
+            isCreate
+              ? getSchemaString(values, "endpoint", DEFAULT_OLLAMA_ENDPOINT)
+              : eff(
+                  "adapterConfig",
+                  "endpoint",
+                  String(config.endpoint ?? DEFAULT_OLLAMA_ENDPOINT),
+                )
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({
+                  adapterSchemaValues: {
+                    ...(values?.adapterSchemaValues ?? {}),
+                    endpoint: v,
+                  },
+                })
+              : mark("adapterConfig", "endpoint", v || DEFAULT_OLLAMA_ENDPOINT)
+          }
+          immediate
+          className={inputClass}
+          placeholder={DEFAULT_OLLAMA_ENDPOINT}
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/ollama-local/index.ts
+++ b/ui/src/adapters/ollama-local/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { parseOllamaLocalStdoutLine, buildOllamaLocalConfig } from "@paperclipai/adapter-ollama-local/ui";
+import { OllamaLocalConfigFields } from "./config-fields";
+
+export const ollamaLocalUIAdapter: UIAdapterModule = {
+  type: "ollama_local",
+  label: "Ollama (local)",
+  parseStdoutLine: parseOllamaLocalStdoutLine,
+  ConfigFields: OllamaLocalConfigFields,
+  buildAdapterConfig: buildOllamaLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { cursorCloudUIAdapter } from "./cursor-cloud";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
 import { grokLocalUIAdapter } from "./grok-local";
+import { ollamaLocalUIAdapter } from "./ollama-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -59,6 +60,7 @@ function registerBuiltInUIAdapters() {
     geminiLocalUIAdapter,
     grokLocalUIAdapter,
     hermesLocalUIAdapter,
+    ollamaLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -22,6 +22,7 @@ const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   cursor: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   gemini_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   grok_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: false },
+  ollama_local: { supportsInstructionsBundle: false, supportsSkills: false, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: true },
   opencode_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   pi_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: false },
   hermes_local: { supportsInstructionsBundle: false, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, each agent backed by a typed adapter.
> - The adapter registry currently covers spawn-CLI runtimes (claude_local, codex_local, opencode_local, …) and one HTTP/WS gateway (openclaw_gateway). There is no built-in adapter for a locally-hosted Ollama server.
> - Operators who want cheap on-prem pilots, offline experiments, or agents that only need to nudge work via the Paperclip API + bash/filesystem skills have no first-class path today.
> - A chat-mode adapter is sufficient for that use case — tool calls are not required for MVP.
> - This PR adds a built-in `ollama_local` adapter that issues a single non-streaming HTTP POST against `/api/chat`, maps Ollama's eval counters into Paperclip's `usage` shape, and (when the wake carries an issueId) posts the model output as an issue comment using the heartbeat's run JWT.
> - The benefit is a fully on-prem, no-API-cost agent runtime that fits the existing adapter contract and rolls back state-free by simply PATCHing the agent's `adapterType`.

## What Changed

- New workspace package `packages/adapters/ollama-local/` with the standard server / ui / cli entrypoints, mirroring the layout of the existing adapter packages.
- Server side
  - `execute()` POSTs to `${endpoint}/api/chat` with `stream:false`, forwards the rendered Paperclip wake prompt as a single user message, parses Ollama's block response, maps `prompt_eval_count → usage.inputTokens` and `eval_count → usage.outputTokens`, and sets `costUsd = 0`.
  - When `postCommentToIssue` is true (default) and `ctx.context.issueId` is present, the adapter posts the model response back to that issue as a comment using `ctx.authToken` + `X-Paperclip-Run-Id` (the heartbeat's run JWT).
  - `testEnvironment()` GETs `/api/tags`, reports reachability, and warns when the configured model is not yet pulled.
  - `listOllamaModels()` does a best-effort tag enumeration with a 2 s timeout and falls back to the static model list on any failure.
  - Minimal pass-through `sessionCodec`.
- Registration
  - Added to `server/src/adapters/builtin-adapter-types.ts` and the server adapter registry alongside `opencode_local` / `claude_local`.
  - Added to `cli/src/adapters/registry.ts` (uses a passthrough stdout formatter).
  - Added to `ui/src/adapters/registry.ts`, `ui/src/adapters/ollama-local/index.ts` + a slim `config-fields.tsx` for the endpoint field, `adapter-display-registry.ts`, and `use-adapter-capabilities.ts` (chat-mode capabilities: jwt yes, instructions/skills no).
  - Workspace dependencies wired in `server/package.json`, `ui/package.json`, `cli/package.json`.
- `doc/DEVELOPING.md` gains an "Ollama Local Adapter" section with one-time setup, an example agent adapter config, telemetry mapping, and a smoke procedure.

## Verification

```sh
# 1) Workspace install + adapter package build
pnpm install
pnpm --filter @paperclipai/adapter-ollama-local typecheck   # clean
pnpm --filter @paperclipai/adapter-ollama-local build       # clean

# 2) Server / cli / ui typecheck with the new registrations
pnpm --filter @paperclipai/server typecheck                 # clean
pnpm --filter paperclipai          typecheck                # clean
pnpm --filter @paperclipai/ui      typecheck                # clean

# 3) Existing registry tests still green
pnpm --filter @paperclipai/server  exec vitest run src/__tests__/adapter-registry.test.ts   # 18 passed
pnpm --filter @paperclipai/ui      exec vitest run src/adapters/registry.test.ts            # 2 passed

# 4) End-to-end smoke against a local Ollama (llama3.1:8b pulled)
#    Calls execute() with a synthetic wake payload; uses a real
#    PAPERCLIP_API_KEY + PAPERCLIP_API_URL so the comment is actually posted.
#
#    Observed:
#      [ollama-local] POST http://127.0.0.1:11434/api/chat model=llama3.1:8b promptChars=2230
#      [ollama-local] response done=true tokensIn=494 tokensOut=41 responseChars=211
#      [ollama-local] posted issue comment to CON-633
#      usage = { inputTokens: 494, outputTokens: 41 }
#      costUsd = 0
```

The smoke run was executed against the issue thread that tracks this work; both the chat roundtrip and the comment-back path were exercised end-to-end.

## Risks

- **Low–medium.** The adapter is additive; existing adapters are untouched. Rollback is a simple `adapterType` PATCH and requires no migrations.
- The adapter does an outbound HTTP call to the configured endpoint. The default `127.0.0.1:11434` is loopback; operators are responsible for not pointing it at untrusted networks.
- Chat-mode only — no tool calls, no skills materialization, no instructions bundle. Operators wanting real code-editing capability should still use `claude_local` / `opencode_local`.
- The adapter posts comments using the run JWT. If `postCommentToIssue` is true but `PAPERCLIP_API_URL` is missing or the API rejects the call, the failure is logged to `stderr` and recorded in `resultJson.commentPostError`; the run itself still succeeds with the response captured in `summary`.

## Model Used

- Claude (Anthropic) — `claude-opus-4-7` (1M context window), assisting an autonomous Paperclip Coder agent (`8227ae01-2451-42ae-b360-04029b15f4b4`). No extended-thinking mode; standard tool use only (Read / Edit / Write / Bash on the local workspace).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (existing registry tests still green; the smoke procedure is documented in `doc/DEVELOPING.md`)
- [ ] If this change affects the UI, I have included before/after screenshots (the UI change is a minimal config field for `endpoint` only — happy to add a screenshot on request)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge