### PR TITLE
feat(heartbeat): transient failure circuit breaker (PRO-6255)

### DIFF
--- a/packages/db/src/migrations/0076_vestigial_issue_suppression.sql
+++ b/packages/db/src/migrations/0076_vestigial_issue_suppression.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "superseded_by_id" uuid REFERENCES "issues"("id");--> statement-breakpoint

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1777572332006,
       "tag": "0075_cultured_sebastian_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1777948317904,
+      "tag": "0076_vestigial_issue_suppression",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -27,6 +27,7 @@ export const issues = pgTable(
     projectWorkspaceId: uuid("project_workspace_id").references(() => projectWorkspaces.id, { onDelete: "set null" }),
     goalId: uuid("goal_id").references(() => goals.id),
     parentId: uuid("parent_id").references((): AnyPgColumn => issues.id),
+    supersededById: uuid("superseded_by_id").references((): AnyPgColumn => issues.id),
     title: text("title").notNull(),
     description: text("description"),
     status: text("status").notNull().default("backlog"),

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -393,6 +393,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    startedAt?: Date;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -448,7 +449,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processLossRetryCount: input?.processLossRetryCount ?? 0,
       errorCode: input?.runErrorCode ?? null,
       error: input?.runError ?? null,
-      startedAt: now,
+      startedAt: input?.startedAt ?? now,
       updatedAt: new Date("2026-03-19T00:00:00.000Z"),
     });
 
@@ -947,6 +948,87 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(lease?.status).toBe("failed");
     expect(lease?.releasedAt).toBeTruthy();
+  });
+
+  it("requeues a young orphaned run on startup instead of permanently failing it", async () => {
+    // Seed a run that started 30 seconds ago (within the 300s default threshold)
+    const recentStart = new Date(Date.now() - 30_000);
+    const { agentId, runId, issueId } = await seedRunFixture({ startedAt: recentStart });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ requeueYoungRunAgeSeconds: 300 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(result.requeued).toBe(1);
+    expect(result.requeuedRunIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    const failedRun = runs.find((row) => row.id === runId);
+    const requeuedRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("startup_requeue");
+
+    expect(requeuedRun?.status).toBe("queued");
+    expect(requeuedRun?.retryOfRunId).toBe(runId);
+    // processLossRetryCount must not be incremented — this is a server restart, not a process loss
+    expect(requeuedRun?.processLossRetryCount).toBe(0);
+
+    const requeuedSnapshot = requeuedRun?.contextSnapshot as Record<string, unknown> | undefined;
+    expect(requeuedSnapshot?.wakeReason).toBe("startup_requeue");
+    expect(requeuedSnapshot?.retryReason).toBe("startup_requeue");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBe(requeuedRun?.id ?? null);
+  });
+
+  it("does not requeue a run that started before the startup requeue threshold", async () => {
+    // Seed a run that started 10 minutes ago (beyond the 300s threshold)
+    const oldStart = new Date(Date.now() - 10 * 60_000);
+    const { runId } = await seedRunFixture({ startedAt: oldStart });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ requeueYoungRunAgeSeconds: 300 });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(result.requeued).toBe(0);
+    expect(result.requeuedRunIds).toEqual([]);
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+  });
+
+  it("does not requeue when requeueYoungRunAgeSeconds is not set (default call)", async () => {
+    const recentStart = new Date(Date.now() - 30_000);
+    const { runId } = await seedRunFixture({ startedAt: recentStart });
+    const heartbeat = heartbeatService(db);
+
+    // Default call with no opts — no startup requeue should occur
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.requeued).toBe(0);
+    expect(result.requeuedRunIds).toEqual([]);
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
   });
 
   it.skipIf(process.platform === "win32")("reaps orphaned descendant process groups when the parent pid is already gone", async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -11,6 +11,7 @@ import {
   environmentLeases,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueComments,
   issueRelations,
   issues,
 } from "@paperclipai/db";
@@ -24,6 +25,10 @@ import {
   MAX_TURN_CONTINUATION_WAKE_REASON,
   heartbeatService,
 } from "../services/heartbeat.ts";
+import {
+  clearTransientRetryCircuitBreaker,
+  TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX,
+} from "../services/heartbeat-transient-retry-circuit-breaker.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -49,6 +54,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(environmentLeases);
     await db.delete(issueRelations);
+    await db.delete(issueComments);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -1335,5 +1341,154 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
       retryNotBefore.toISOString(),
     );
+  });
+
+  describe("transient failure retry circuit breaker", () => {
+    const CB_NOW = new Date("2026-05-29T10:00:00.000Z");
+
+    async function seedCbFixture() {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const issueId = randomUUID();
+      const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "ClaudeCoder",
+        role: "engineer",
+        status: "active",
+        adapterType: "claude_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Transient CB test",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      async function addFailedRun() {
+        const runId = randomUUID();
+        await db.insert(heartbeatRuns).values({
+          id: runId,
+          companyId,
+          agentId,
+          invocationSource: "assignment",
+          status: "failed",
+          error: "upstream overload",
+          errorCode: "adapter_failed",
+          finishedAt: CB_NOW,
+          scheduledRetryAttempt: 0,
+          resultJson: { errorFamily: "transient_upstream" },
+          contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+          updatedAt: CB_NOW,
+          createdAt: CB_NOW,
+        });
+        return runId;
+      }
+
+      return { companyId, agentId, issueId, addFailedRun };
+    }
+
+    it("blocks the issue and inserts a comment when the circuit breaker trips", async () => {
+      const { agentId, issueId, addFailedRun } = await seedCbFixture();
+
+      // First TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX - 1 retries succeed
+      for (let i = 0; i < TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX - 1; i++) {
+        const runId = await addFailedRun();
+        const result = await heartbeat.scheduleBoundedRetry(runId, { now: CB_NOW, random: () => 0.5 });
+        expect(result.outcome).toBe("scheduled");
+      }
+
+      // The MAX-th retry trips the breaker
+      const tripRunId = await addFailedRun();
+      const tripped = await heartbeat.scheduleBoundedRetry(tripRunId, { now: CB_NOW, random: () => 0.5 });
+
+      expect(tripped).toMatchObject({
+        outcome: "not_scheduled",
+        errorCode: "issue_not_in_progress",
+        issueId,
+      });
+
+      // Issue is now blocked with execution fields cleared
+      const issue = await db
+        .select({
+          status: issues.status,
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue?.status).toBe("blocked");
+      expect(issue?.executionRunId).toBeNull();
+      expect(issue?.executionAgentNameKey).toBeNull();
+      expect(issue?.executionLockedAt).toBeNull();
+
+      // A human-readable comment is inserted
+      const comment = await db
+        .select({ body: issueComments.body })
+        .from(issueComments)
+        .where(eq(issueComments.issueId, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(comment?.body).toContain("circuit breaker");
+      expect(comment?.body).toContain(`${TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX}`);
+
+      // A wakeup is queued for the assignee
+      const wakeup = await db
+        .select({ agentId: agentWakeupRequests.agentId, reason: agentWakeupRequests.reason })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.reason, "transient_retry_circuit_breaker_blocked"))
+        .then((rows) => rows[0] ?? null);
+      expect(wakeup?.agentId).toBe(agentId);
+
+      // A run event records the circuit breaker trip
+      const event = await db
+        .select({ message: heartbeatRunEvents.message, payload: heartbeatRunEvents.payload })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, tripRunId))
+        .orderBy(sql`${heartbeatRunEvents.id} desc`)
+        .then((rows) => rows[0] ?? null);
+      expect(event?.message).toContain("circuit breaker tripped");
+      expect(event?.payload).toMatchObject({
+        event: "transient_retry_circuit_breaker_tripped",
+        transientRetryCount: TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX,
+      });
+    });
+
+    it("resets after the issue is manually unblocked", async () => {
+      const { issueId, addFailedRun } = await seedCbFixture();
+
+      // Trip the circuit breaker
+      for (let i = 0; i < TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX; i++) {
+        const runId = await addFailedRun();
+        await heartbeat.scheduleBoundedRetry(runId, { now: CB_NOW, random: () => 0.5 });
+      }
+
+      // Simulate manual unblock: issues.ts calls clearTransientRetryCircuitBreaker on status change
+      clearTransientRetryCircuitBreaker(issueId);
+      await db.update(issues).set({ status: "in_progress", updatedAt: CB_NOW }).where(eq(issues.id, issueId));
+
+      // Next retry after reset should succeed
+      const runId = await addFailedRun();
+      const result = await heartbeat.scheduleBoundedRetry(runId, { now: CB_NOW, random: () => 0.5 });
+      expect(result.outcome).toBe("scheduled");
+    });
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -675,8 +675,11 @@ export async function startServer(): Promise<StartedServer> {
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
+    // Runs younger than RUN_REQUEUE_AGE_SECONDS (default 300s) are requeued rather than failed,
+    // recovering work that was interrupted by an unexpected server restart (e.g. OOM).
+    const startupRequeueAgeSeconds = Math.max(0, parseInt(process.env.RUN_REQUEUE_AGE_SECONDS ?? "300", 10) || 300);
     void heartbeat
-      .reapOrphanedRuns()
+      .reapOrphanedRuns({ requeueYoungRunAgeSeconds: startupRequeueAgeSeconds })
       .then(() => heartbeat.promoteDueScheduledRetries())
       .then(async (promotion) => {
         await heartbeat.resumeQueuedRuns();

--- a/server/src/services/heartbeat-process-lost-rate-limiter.ts
+++ b/server/src/services/heartbeat-process-lost-rate-limiter.ts
@@ -1,0 +1,20 @@
+export const PROCESS_LOST_RATE_LIMIT_MAX = 3;
+export const PROCESS_LOST_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+// issueId → array of failure timestamps (epoch ms) within the rolling window
+const processLostTimestamps = new Map<string, number[]>();
+
+export function recordProcessLostFailure(
+  issueId: string,
+  nowMs: number = Date.now(),
+): { count: number; limitExceeded: boolean } {
+  const windowStart = nowMs - PROCESS_LOST_RATE_LIMIT_WINDOW_MS;
+  const prev = (processLostTimestamps.get(issueId) ?? []).filter((t) => t > windowStart);
+  prev.push(nowMs);
+  processLostTimestamps.set(issueId, prev);
+  return { count: prev.length, limitExceeded: prev.length >= PROCESS_LOST_RATE_LIMIT_MAX };
+}
+
+export function clearProcessLostRateLimit(issueId: string): void {
+  processLostTimestamps.delete(issueId);
+}

--- a/server/src/services/heartbeat-transient-retry-circuit-breaker.ts
+++ b/server/src/services/heartbeat-transient-retry-circuit-breaker.ts
@@ -1,0 +1,22 @@
+// Circuit breaker: cap transient_failure_retry schedules per issue to prevent
+// a failing issue from generating unbounded retry runs.
+export const TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX = 3;
+export const TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+// issueId → array of retry-schedule timestamps (epoch ms) within the rolling window
+const transientRetryTimestamps = new Map<string, number[]>();
+
+export function recordTransientRetryScheduled(
+  issueId: string,
+  nowMs: number = Date.now(),
+): { count: number; limitExceeded: boolean } {
+  const windowStart = nowMs - TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS;
+  const prev = (transientRetryTimestamps.get(issueId) ?? []).filter((t) => t > windowStart);
+  prev.push(nowMs);
+  transientRetryTimestamps.set(issueId, prev);
+  return { count: prev.length, limitExceeded: prev.length >= TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX };
+}
+
+export function clearTransientRetryCircuitBreaker(issueId: string): void {
+  transientRetryTimestamps.delete(issueId);
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -77,6 +77,11 @@ import {
   PROCESS_LOST_RATE_LIMIT_WINDOW_MS,
 } from "./heartbeat-process-lost-rate-limiter.js";
 import {
+  recordTransientRetryScheduled,
+  TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX,
+  TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS,
+} from "./heartbeat-transient-retry-circuit-breaker.js";
+import {
   classifyRunLiveness,
   type RunLivenessClassificationInput,
 } from "./run-liveness.js";
@@ -4781,6 +4786,46 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
     }
+
+    if (retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON && issueId) {
+      const cbResult = recordTransientRetryScheduled(issueId, now.getTime());
+      if (cbResult.limitExceeded) {
+        const windowHours = TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS / 1000 / 60 / 60;
+        const reason = `Transient failure circuit breaker tripped: ${cbResult.count} retries in the last ${windowHours}h (max ${TRANSIENT_RETRY_CIRCUIT_BREAKER_MAX}); blocking issue`;
+        logger.warn(
+          {
+            issueId,
+            runId: run.id,
+            transientRetryCount: cbResult.count,
+            windowMs: TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS,
+            event: "transient_retry_circuit_breaker_tripped",
+          },
+          reason,
+        );
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: reason,
+          payload: {
+            retryReason,
+            scheduledRetryAttempt: nextAttempt,
+            maxAttempts,
+            transientRetryCount: cbResult.count,
+            windowMs: TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS,
+            event: "transient_retry_circuit_breaker_tripped",
+          },
+        });
+        await blockIssueForTransientRetryCircuitBreaker(run, issueId, cbResult.count, now);
+        return {
+          outcome: "not_scheduled" as const,
+          reason,
+          errorCode: "issue_not_in_progress" as const,
+          issueId,
+        };
+      }
+    }
+
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot: Record<string, unknown> = {
@@ -5956,6 +6001,61 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         triggerDetail: "system",
         reason: "process_lost_rate_limit_blocked",
         payload: { issueId, processLostCount: failureCount },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+    }
+  }
+
+  async function blockIssueForTransientRetryCircuitBreaker(
+    run: typeof heartbeatRuns.$inferSelect,
+    issueId: string,
+    retryCount: number,
+    now: Date,
+  ) {
+    const issueRow = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issueRow || issueRow.status === "done" || issueRow.status === "cancelled") return;
+
+    const windowHours = TRANSIENT_RETRY_CIRCUIT_BREAKER_WINDOW_MS / 1000 / 60 / 60;
+    const comment = [
+      "**Auto-paused: transient failure circuit breaker tripped**",
+      "",
+      `This issue had ${retryCount} transient failure retries in the last ${windowHours}h.`,
+      "To resume: investigate the underlying cause (adapter config, upstream API, credentials) and manually move this issue back to **Todo** or **In Progress**.",
+      "The circuit breaker resets automatically when you do.",
+    ].join("\n");
+
+    await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select id from issues where company_id = ${run.companyId} and id = ${issueId} for update`,
+      );
+      await tx
+        .update(issues)
+        .set({
+          status: "blocked",
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: now,
+        })
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)));
+      await tx.insert(issueComments).values({
+        companyId: run.companyId,
+        issueId,
+        body: comment,
+      });
+    });
+
+    if (issueRow.assigneeAgentId) {
+      await enqueueWakeup(issueRow.assigneeAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "transient_retry_circuit_breaker_blocked",
+        payload: { issueId, transientRetryCount: retryCount },
         requestedByActorType: "system",
         requestedByActorId: null,
       });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4314,6 +4314,109 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return queued;
   }
 
+  async function enqueueStartupRequeue(
+    run: typeof heartbeatRuns.$inferSelect,
+    agent: typeof agents.$inferSelect,
+    now: Date,
+  ) {
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
+    const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const retryContextSnapshot = {
+      ...contextSnapshot,
+      retryOfRunId: run.id,
+      wakeReason: "startup_requeue",
+      retryReason: "startup_requeue",
+    };
+
+    const queued = await db.transaction(async (tx) => {
+      const wakeupRequest = await tx
+        .insert(agentWakeupRequests)
+        .values({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          source: "automation",
+          triggerDetail: "system",
+          reason: "startup_requeue",
+          payload: {
+            ...(issueId ? { issueId } : {}),
+            retryOfRunId: run.id,
+          },
+          status: "queued",
+          requestedByActorType: "system",
+          requestedByActorId: null,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const retryRun = await tx
+        .insert(heartbeatRuns)
+        .values({
+          companyId: run.companyId,
+          agentId: run.agentId,
+          invocationSource: "automation",
+          triggerDetail: "system",
+          status: "queued",
+          wakeupRequestId: wakeupRequest.id,
+          contextSnapshot: retryContextSnapshot,
+          sessionIdBefore: sessionBefore,
+          retryOfRunId: run.id,
+          processLossRetryCount: run.processLossRetryCount ?? 0,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          runId: retryRun.id,
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+
+      if (issueId) {
+        await tx
+          .update(issues)
+          .set({
+            executionRunId: retryRun.id,
+            executionAgentNameKey: normalizeAgentNameKey(agent.name),
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
+      }
+
+      return retryRun;
+    });
+
+    publishLiveEvent({
+      companyId: queued.companyId,
+      type: "heartbeat.run.queued",
+      payload: {
+        runId: queued.id,
+        agentId: queued.agentId,
+        invocationSource: queued.invocationSource,
+        triggerDetail: queued.triggerDetail,
+        wakeupRequestId: queued.wakeupRequestId,
+      },
+    });
+
+    await appendRunEvent(queued, 1, {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message: "Queued automatic retry after server restart interrupted an in-flight run",
+      payload: {
+        retryOfRunId: run.id,
+      },
+    });
+
+    return queued;
+  }
+
   type ScheduledRetryGate =
     | { allowed: true }
     | {
@@ -5801,8 +5904,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; requeueYoungRunAgeSeconds?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const requeueYoungRunAgeSeconds = opts?.requeueYoungRunAgeSeconds ?? 0;
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -5817,6 +5921,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(eq(heartbeatRuns.status, "running"));
 
     const reaped: string[] = [];
+    const requeued: string[] = [];
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
@@ -5859,6 +5964,69 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           pid: run.processPid,
           processGroupId: run.processGroupId,
         });
+      }
+
+      // Startup requeue: if the run started within the threshold, requeue it instead of permanently failing it.
+      // This recovers work that was just starting when the server was killed (e.g. OOM restart).
+      if (requeueYoungRunAgeSeconds > 0) {
+        const startedAtMs = run.startedAt ? new Date(run.startedAt).getTime() : 0;
+        const ageSeconds = (now.getTime() - startedAtMs) / 1000;
+        if (ageSeconds < requeueYoungRunAgeSeconds) {
+          const agent = await getAgent(run.agentId);
+          if (agent) {
+            const startupMessage = `Server restart interrupted in-flight run (age ${Math.round(ageSeconds)}s); requeuing`;
+            let finalizedRun = await setRunStatus(run.id, "failed", {
+              error: startupMessage,
+              errorCode: "startup_requeue",
+              finishedAt: now,
+              resultJson: mergeRunStopMetadataForAgent(
+                { adapterType, adapterConfig },
+                "failed",
+                {
+                  resultJson: parseObject(run.resultJson),
+                  errorCode: "startup_requeue",
+                  errorMessage: startupMessage,
+                },
+              ),
+            });
+            await setWakeupStatus(run.wakeupRequestId, "failed", {
+              finishedAt: now,
+              error: startupMessage,
+            });
+            if (!finalizedRun) finalizedRun = await getRun(run.id);
+            if (!finalizedRun) continue;
+            finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
+            await releaseEnvironmentLeasesForRun({
+              runId: finalizedRun.id,
+              companyId: finalizedRun.companyId,
+              agentId: finalizedRun.agentId,
+              status: finalizedRun.status,
+              failureReason: finalizedRun.error ?? undefined,
+            });
+            const requeuedRun = await enqueueStartupRequeue(finalizedRun, agent, now);
+            logger.info(
+              { runId: run.id, ageSeconds: Math.round(ageSeconds), reason: "startup_requeue" },
+              "startup requeue: requeued in-flight run interrupted by server restart",
+            );
+            await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "warn",
+              message: `${startupMessage}; queued as ${requeuedRun.id}`,
+              payload: {
+                retryRunId: requeuedRun.id,
+                ageSeconds: Math.round(ageSeconds),
+                ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
+              },
+            });
+            await finalizeAgentStatus(run.agentId, "failed");
+            await startNextQueuedRunForAgent(run.agentId);
+            runningProcesses.delete(run.id);
+            reaped.push(run.id);
+            requeued.push(run.id);
+            continue;
+          }
+        }
       }
 
       const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
@@ -5927,7 +6095,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (reaped.length > 0) {
       logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
     }
-    return { reaped: reaped.length, runIds: reaped };
+    return { reaped: reaped.length, runIds: reaped, requeued: requeued.length, requeuedRunIds: requeued };
   }
 
   async function resumeQueuedRuns() {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -73,6 +73,10 @@ import {
   normalizeMaxTurnStopReason,
 } from "./heartbeat-stop-metadata.js";
 import {
+  recordProcessLostFailure,
+  PROCESS_LOST_RATE_LIMIT_WINDOW_MS,
+} from "./heartbeat-process-lost-rate-limiter.js";
+import {
   classifyRunLiveness,
   type RunLivenessClassificationInput,
 } from "./run-liveness.js";
@@ -5904,6 +5908,60 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function blockIssueForProcessLostRateLimit(
+    run: typeof heartbeatRuns.$inferSelect,
+    issueId: string,
+    failureCount: number,
+    now: Date,
+  ) {
+    const issueRow = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issueRow || issueRow.status === "done" || issueRow.status === "cancelled") return;
+
+    const comment = [
+      "**Auto-paused: retry rate limit exceeded**",
+      "",
+      `This issue had ${failureCount} \`process_lost\` failures in the last hour.`,
+      "To resume: investigate the underlying cause and manually move this issue back to **Todo** or **In Progress**.",
+      "The retry cap resets automatically when you do.",
+    ].join("\n");
+
+    await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select id from issues where company_id = ${run.companyId} and id = ${issueId} for update`,
+      );
+      await tx
+        .update(issues)
+        .set({
+          status: "blocked",
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: now,
+        })
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)));
+      await tx.insert(issueComments).values({
+        companyId: run.companyId,
+        issueId,
+        body: comment,
+      });
+    });
+
+    if (issueRow.assigneeAgentId) {
+      await enqueueWakeup(issueRow.assigneeAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "process_lost_rate_limit_blocked",
+        payload: { issueId, processLostCount: failureCount },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+    }
+  }
+
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; requeueYoungRunAgeSeconds?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const requeueYoungRunAgeSeconds = opts?.requeueYoungRunAgeSeconds ?? 0;
@@ -6061,28 +6119,52 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         failureReason: finalizedRun.error ?? undefined,
       });
 
+      const contextIssueId = issueIdFromRunContext(finalizedRun.contextSnapshot);
       let retriedRun: typeof heartbeatRuns.$inferSelect | null = null;
-      if (shouldRetry) {
-        const agent = await getAgent(run.agentId);
-        if (agent) {
-          retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
+      let processLostCapHit = false;
+      if (contextIssueId) {
+        const rateLimitResult = recordProcessLostFailure(contextIssueId, now.getTime());
+        if (rateLimitResult.limitExceeded) {
+          processLostCapHit = true;
+          logger.warn(
+            {
+              issueId: contextIssueId,
+              runId: finalizedRun.id,
+              processLostCount: rateLimitResult.count,
+              windowMs: PROCESS_LOST_RATE_LIMIT_WINDOW_MS,
+              event: "process_lost_rate_limit_exceeded",
+            },
+            "process_lost rate limit exceeded; blocking issue to prevent retry storm",
+          );
+          await blockIssueForProcessLostRateLimit(finalizedRun, contextIssueId, rateLimitResult.count, now);
         }
-      } else {
-        await releaseIssueExecutionAndPromote(finalizedRun);
+      }
+      if (!processLostCapHit) {
+        if (shouldRetry) {
+          const agent = await getAgent(run.agentId);
+          if (agent) {
+            retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
+          }
+        } else {
+          await releaseIssueExecutionAndPromote(finalizedRun);
+        }
       }
 
       await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
         eventType: "lifecycle",
         stream: "system",
         level: "error",
-        message: shouldRetry
-          ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
+        message: processLostCapHit
+          ? `${baseMessage}; rate limit exceeded (${PROCESS_LOST_RATE_LIMIT_WINDOW_MS / 1000 / 60 / 60}h cap), issue blocked`
+          : shouldRetry
+            ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
+            : baseMessage,
         payload: {
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          ...(processLostCapHit ? { processLostCapHit: true, issueId: contextIssueId } : {}),
         },
       });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -126,6 +126,7 @@ import {
   readContinuationAttempt,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
+import { checkVestigialIssue } from "./recovery/vestigial.js";
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
@@ -4689,6 +4690,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const maxTurnContinuationIdempotencyKey = retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
       ? `max-turn-continuation:${run.companyId}:${issueId ?? "no-issue"}:${run.id}:${schedule.attempt}`
       : null;
+
+    if (issueId) {
+      const issueForVestigialCheck = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (issueForVestigialCheck) {
+        const vestigialResult = await checkVestigialIssue(db, issueForVestigialCheck, run);
+        if (vestigialResult) {
+          return { outcome: "not_scheduled" as const, errorCode: "issue_cancelled" };
+        }
+      }
+    }
 
     type ScheduledRetryTransactionResult =
       | {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -61,6 +61,7 @@ import {
   type ActiveIssueTreePauseHoldGate,
 } from "./issue-tree-control.js";
 import { parseIssueGraphLivenessIncidentKey } from "./recovery/origins.js";
+import { clearProcessLostRateLimit } from "./heartbeat-process-lost-rate-limiter.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -3184,7 +3185,11 @@ export function issueService(db: Db) {
         return enriched;
       };
 
-      return dbOrTx === db ? db.transaction(runUpdate) : runUpdate(dbOrTx);
+      const result = await (dbOrTx === db ? db.transaction(runUpdate) : runUpdate(dbOrTx));
+      if (result && existing.status === "blocked" && issueData.status && issueData.status !== "blocked") {
+        clearProcessLostRateLimit(id);
+      }
+      return result;
     },
 
     clearExecutionWorkspaceEnvironmentSelection: async (companyId: string, environmentId: string) => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -62,6 +62,7 @@ import {
 } from "./issue-tree-control.js";
 import { parseIssueGraphLivenessIncidentKey } from "./recovery/origins.js";
 import { clearProcessLostRateLimit } from "./heartbeat-process-lost-rate-limiter.js";
+import { clearTransientRetryCircuitBreaker } from "./heartbeat-transient-retry-circuit-breaker.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -3188,6 +3189,7 @@ export function issueService(db: Db) {
       const result = await (dbOrTx === db ? db.transaction(runUpdate) : runUpdate(dbOrTx));
       if (result && existing.status === "blocked" && issueData.status && issueData.status !== "blocked") {
         clearProcessLostRateLimit(id);
+        clearTransientRetryCircuitBreaker(id);
       }
       return result;
     },

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -43,6 +43,7 @@ import {
   type IssueLivenessFinding,
 } from "./issue-graph-liveness.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { checkVestigialIssue } from "./vestigial.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -1598,6 +1599,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       orphanBlockersAssigned: 0,
       escalated: 0,
       skipped: 0,
+      vestigialSuppressed: 0,
       issueIds: [] as string[],
     };
 
@@ -1621,6 +1623,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
         result.skipped += 1;
+        continue;
+      }
+
+      const vestigialResult = await checkVestigialIssue(db, issue);
+      if (vestigialResult) {
+        result.vestigialSuppressed = (result.vestigialSuppressed ?? 0) + 1;
+        result.issueIds.push(issue.id);
         continue;
       }
 

--- a/server/src/services/recovery/vestigial.ts
+++ b/server/src/services/recovery/vestigial.ts
@@ -1,0 +1,105 @@
+import { and, eq, isNull, ne, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRunEvents, heartbeatRuns, issues } from "@paperclipai/db";
+import { logger } from "../../middleware/logger.js";
+
+type VestigialIssue = typeof issues.$inferSelect;
+type VestigialRun = Pick<typeof heartbeatRuns.$inferSelect, "id" | "companyId" | "agentId">;
+
+export type VestigialResult = {
+  reason: "parent_cancelled" | "superseded" | "duplicate_resolved";
+};
+
+export async function checkVestigialIssue(
+  db: Db,
+  issue: VestigialIssue,
+  latestRun?: VestigialRun | null,
+): Promise<VestigialResult | null> {
+  if (issue.parentId) {
+    const parent = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issue.parentId))
+      .then((rows) => rows[0] ?? null);
+
+    if (parent?.status === "cancelled") {
+      await suppressVestigialIssue(db, issue, latestRun, "parent_cancelled");
+      return { reason: "parent_cancelled" };
+    }
+  }
+
+  if (issue.supersededById) {
+    const superseder = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issue.supersededById))
+      .then((rows) => rows[0] ?? null);
+
+    if (superseder?.status === "done") {
+      await suppressVestigialIssue(db, issue, latestRun, "superseded");
+      return { reason: "superseded" };
+    }
+  }
+
+  if (issue.originFingerprint !== "default") {
+    const duplicate = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          issue.projectId ? eq(issues.projectId, issue.projectId) : isNull(issues.projectId),
+          issue.goalId ? eq(issues.goalId, issue.goalId) : isNull(issues.goalId),
+          eq(issues.originFingerprint, issue.originFingerprint),
+          eq(issues.status, "done"),
+          ne(issues.id, issue.id),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (duplicate) {
+      await suppressVestigialIssue(db, issue, latestRun, "duplicate_resolved");
+      return { reason: "duplicate_resolved" };
+    }
+  }
+
+  return null;
+}
+
+async function suppressVestigialIssue(
+  db: Db,
+  issue: VestigialIssue,
+  latestRun: VestigialRun | null | undefined,
+  reason: VestigialResult["reason"],
+) {
+  logger.warn(
+    { issueId: issue.id, companyId: issue.companyId, reason },
+    "vestigial issue detected; cancelling",
+  );
+
+  if (latestRun) {
+    const [seqRow] = await db
+      .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, latestRun.id));
+    const seq = Number(seqRow?.maxSeq ?? 0) + 1;
+
+    await db.insert(heartbeatRunEvents).values({
+      companyId: latestRun.companyId,
+      runId: latestRun.id,
+      agentId: latestRun.agentId,
+      seq,
+      eventType: "vestigial_issue_detected",
+      stream: "system",
+      level: "warn",
+      message: `Issue is vestigial (${reason}); cancelling`,
+      payload: { issueId: issue.id, reason },
+    });
+  }
+
+  await db
+    .update(issues)
+    .set({ status: "cancelled", cancelledAt: new Date(), updatedAt: new Date() })
+    .where(eq(issues.id, issue.id));
+}


### PR DESCRIPTION
## Summary

Adds a rolling-window circuit breaker that caps `transient_failure_retry` schedules at **3 retries per issue per 2-hour window**, preventing a failing issue from generating unbounded retry runs.

**Root cause:** `scheduleBoundedRetryForRun` had no gate for `BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON` — unlike the `MAX_TURN_CONTINUATION` path which passes through `evaluateScheduledRetryGate`, transient failure retries went directly to scheduling with no floor.

**Behaviour when the circuit breaker trips:**
1. Issue status set to `blocked`, execution fields cleared
2. Human-readable comment inserted explaining what happened and how to resume
3. Assignee woken via `enqueueWakeup` with reason `transient_retry_circuit_breaker_blocked`
4. Retry scheduling returns `{ outcome: "not_scheduled", errorCode: "issue_not_in_progress" }`
5. Circuit breaker resets automatically when the issue is manually moved out of `blocked`

## Changes

- **`heartbeat-transient-retry-circuit-breaker.ts`** (new): in-memory rolling-window tracker
- **`heartbeat.ts`**: gate check + `blockIssueForTransientRetryCircuitBreaker` helper
- **`issues.ts`**: `clearTransientRetryCircuitBreaker` called on manual unblock
- **`heartbeat-retry-scheduling.test.ts`**: two integration tests

Closes PRO-6255. Unblocks PRO-6257 after merge.