### PR TITLE
feat(authorization): scope-profile narrow grants for tasks:manage_active_checkouts

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1381,6 +1381,44 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  // Profile-keyed narrow-grant enforcement. When a `tasks:manage_active_checkouts`
+  // grant was issued with `scope.profile`, the mutation chokepoint records the
+  // decision on the request so downstream route handlers can apply additional
+  // per-op constraints (field allow-list on PATCH, hard deny on DELETE) without
+  // re-running authorization. Today `risk_compliance_v1` is the only profile.
+  const NARROW_PATCH_FIELDS = new Set(["status", "assigneeAgentId", "blockedByIssueIds", "comment"]);
+
+  function enforceNarrowGrantOp(
+    req: Request,
+    res: Response,
+    op: "patch" | "delete_issue" | "delete_comment",
+    body?: Record<string, unknown>,
+  ): boolean {
+    const profile = req.access?.checkoutOverride?.grant?.scope?.profile;
+    if (typeof profile !== "string") return true;
+    if (profile !== "risk_compliance_v1") return true;
+    if (op === "patch") {
+      const offenders = Object.keys(body ?? {}).filter((k) => !NARROW_PATCH_FIELDS.has(k));
+      if (offenders.length > 0) {
+        res.status(403).json({
+          error: `Profile ${profile} cannot patch field: ${offenders[0]}`,
+          details: {
+            profile,
+            disallowedFields: offenders,
+            allowedFields: Array.from(NARROW_PATCH_FIELDS),
+          },
+        });
+        return false;
+      }
+      return true;
+    }
+    res.status(403).json({
+      error: `Profile ${profile} cannot ${op.replace("_", " ")}`,
+      details: { profile },
+    });
+    return false;
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -1396,8 +1434,29 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
-      if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+      // Capture the full decision so route handlers can introspect grant scope (e.g.
+      // narrow-grant scope profiles applying per-op constraints).
+      const overrideDecision = await access.decide({
+        actor: { type: "agent", agentId: actorAgentId, companyId: issue.companyId },
+        action: "tasks:manage_active_checkouts",
+        resource: { type: "issue", companyId: issue.companyId, assigneeAgentId: issue.assigneeAgentId },
+      });
+      if (overrideDecision.allowed) {
+        if (!req.access) req.access = {};
+        req.access.checkoutOverride = overrideDecision;
         return true;
+      }
+      if (overrideDecision.reason === "deny_ceo_immunity") {
+        res.status(403).json({
+          error: "Profile risk_compliance_v1 cannot mutate CEO-assigned issues",
+          details: {
+            reason: "deny_ceo_immunity",
+            issueId: issue.id,
+            assigneeAgentId: issue.assigneeAgentId,
+            actorAgentId,
+          },
+        });
+        return false;
       }
       if (issue.status === "in_progress") {
         res.status(409).json({
@@ -3908,6 +3967,7 @@ export function issueRoutes(
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!enforceNarrowGrantOp(req, res, "patch", req.body)) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -4880,6 +4940,7 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!enforceNarrowGrantOp(req, res, "delete_issue")) return;
     const attachments = await svc.listAttachments(id);
 
     const issue = await svc.remove(id);
@@ -5472,6 +5533,7 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, issue.companyId);
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!enforceNarrowGrantOp(req, res, "delete_comment")) return;
 
     const comment = await svc.getComment(commentId);
     if (!comment || comment.issueId !== id) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -68,7 +68,8 @@ export type AuthorizationDecision = {
     | "deny_missing_grant"
     | "deny_policy_restricted"
     | "deny_scope"
-    | "deny_unsupported_action";
+    | "deny_unsupported_action"
+    | "deny_ceo_immunity";
   grant?: {
     principalType: PrincipalType;
     principalId: string;
@@ -777,7 +778,30 @@ export function authorizationService(db: Db) {
         permissionKey,
         scope: input.scope,
       });
-      if (grantDecision.allowed) return grantDecision;
+      if (grantDecision.allowed) {
+        // Scope-profile carve-out: narrow grants can declare a `scope.profile` that
+        // applies structural deny rules at this chokepoint. Profile `risk_compliance_v1`
+        // (per the ITM-40 board ratification of GR-002 stop-early authority) cannot
+        // mutate CEO-assigned issues — role-based so a future CEO inherits immunity
+        // automatically. Future profiles (`auditor_v1`, `risk_compliance_v2`) can
+        // compose alongside without changing this gate.
+        if (
+          input.action === "tasks:manage_active_checkouts" &&
+          grantDecision.grant?.scope?.profile === "risk_compliance_v1" &&
+          input.resource.type === "issue" &&
+          input.resource.assigneeAgentId
+        ) {
+          const target = await loadAgent(input.resource.assigneeAgentId);
+          if (target?.role === "ceo") {
+            return deny({
+              action: input.action,
+              reason: "deny_ceo_immunity",
+              explanation: "Profile risk_compliance_v1 cannot mutate CEO-assigned issues.",
+            });
+          }
+        }
+        return grantDecision;
+      }
     }
 
     if (

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -1,3 +1,5 @@
+import type { AuthorizationDecision } from "../services/authorization";
+
 export {};
 
 declare global {
@@ -20,6 +22,9 @@ declare global {
         keyId?: string;
         runId?: string;
         source?: "local_implicit" | "session" | "board_key" | "agent_key" | "agent_jwt" | "cloud_tenant" | "none";
+      };
+      access?: {
+        checkoutOverride?: AuthorizationDecision;
       };
     }
   }


### PR DESCRIPTION
## Summary

Introduce a `scope.profile` keying for `tasks:manage_active_checkouts` grants so narrowing rules can be expressed structurally instead of binary allow/deny at the chokepoint.

The first profile, `risk_compliance_v1`, applies:

- a field allow-list on `PATCH /api/issues/:id` (`status`, `assigneeAgentId`, `blockedByIssueIds`, plus the synthetic `comment` field)
- a hard deny on `DELETE /api/issues/:id` and `DELETE /api/issues/:id/comments/:commentId`
- a structural CEO-immunity carve-out (role-based, so a future CEO inherits immunity automatically)

## Motivation

A downstream operator (the ITM instance — see internal issue ITM-40 board-ratified scope, parent ITM-33, governance register GR-002) needs a narrow permission grant for a Risk & Compliance agent so it can operationalize stop-early authority on non-CEO issues without having editorial control or any mutation power on CEO-assigned issues.

The chokepoint at `assertAgentIssueMutationAllowed` is binary today — once a `tasks:manage_active_checkouts` grant exists, the actor can mutate any field and DELETE. We considered adding a binary `scope.narrow: true` flag, but the CTO directive on the original spec called for a *profile* key (`risk_compliance_v1`) so:

- audit clarity: deny errors name the profile, not just "narrow"
- composability: future profiles (`auditor_v1`, `risk_compliance_v2`) coexist without re-touching the chokepoint
- versioning headroom: the schema for profile rules can evolve in-place without breaking older grants
- second-implementation test (the design's named heuristic): the profile mechanism is built with the second user in mind, even though only one consumer exists today

## What changed

| File | Change |
|---|---|
| `server/src/services/authorization.ts` | New `deny_ceo_immunity` decision reason. CEO carve-out applied inside `decide()` after `decidePrincipalGrant` returns allow, gated on `grant.scope.profile === "risk_compliance_v1"` and `resource.assigneeAgentId` resolving to an agent with `role === "ceo"`. |
| `server/src/routes/issues.ts` | `assertAgentIssueMutationAllowed` now captures the full decision object (instead of a bool) and stashes it on `req.access.checkoutOverride` when allowed. New `enforceNarrowGrantOp(req, res, op, body?)` helper applies per-profile per-op constraints. Wired into PATCH `/issues/:id`, DELETE `/issues/:id`, DELETE `/issues/:id/comments/:commentId`. |
| `server/src/types/express.d.ts` | `Request.access?.checkoutOverride?: AuthorizationDecision`. |

Footprint: ~95 added lines across 3 files. No DB schema change, no new permission key in `PERMISSION_KEYS`, no scope-evaluator change.

## Backward compatibility

Inert for any grant without `scope.profile`. Existing broad `tasks:manage_active_checkouts` grants continue to behave exactly as before — the `if (profile !== "risk_compliance_v1") return true;` short-circuit covers both the missing-profile case and unknown-profile case.

`AuthorizationDecision.reason` adds one new variant (`deny_ceo_immunity`). Downstream consumers that exhaustively switch over the union will need to handle the new case; consumers that treat it as opaque diagnostic data are unaffected.

## Operationalizing the grant

```http
POST /api/companies/{companyId}/agents/{agentId}/permissions
{
  "principalType": "agent",
  "principalId": "<risk-compliance-agent-id>",
  "permissionKey": "tasks:manage_active_checkouts",
  "scope": { "profile": "risk_compliance_v1" }
}
```

## Verification matrix (13 probes)

Run from a `tasks:manage_active_checkouts` actor with the `risk_compliance_v1` scope profile, against four target issues (a non-CEO issue, a CEO-assigned issue, a non-CEO issue for the negative narrow-field cases, and a self-owned finding):

| # | Probe | Expected |
|---|---|---|
| 1 | POST comment on non-CEO issue | 201 |
| 2 | PATCH `{status, blockedByIssueIds}` on non-CEO issue | 200 |
| 3 | PATCH `{assigneeAgentId: <ceo>}` on non-CEO issue | 200 |
| 4 | PATCH `{title}` on non-CEO issue | 403, `disallowedFields: ["title"]`, names profile |
| 5 | PATCH `{description}` | 403, names field |
| 6 | PATCH `{priority}` | 403, names field |
| 7 | PATCH `{parentId}` | 403, names field |
| 8 | PATCH `{projectId}` | 403, names field |
| 9 | DELETE comment on non-CEO issue | 403, profile-named |
| 10 | DELETE non-CEO issue | 403, profile-named |
| 11 | POST comment on CEO-assigned issue | 403, `reason: "deny_ceo_immunity"` |
| 12 | PATCH `{status}` on CEO-assigned issue | 403, `reason: "deny_ceo_immunity"` |
| 13 | DELETE on a self-owned finding (allow_self path) | 200 |

This patch has been running locally in production against the ITM instance for ~30 minutes against `@paperclipai/server@2026.525.0` with the same 95-line JavaScript translation in `dist/`; the local-runtime behavior matches the table above. CI typecheck/tests on this PR will validate the TS translation.

## Test plan

- [ ] CI typecheck passes (the TS edits are a faithful translation of the verified JS patch, but I did not run `pnpm typecheck` locally due to time constraints — see below)
- [ ] CI test suite passes
- [ ] Reviewer sanity-checks the CEO-immunity carve-out covers the `agents.role` enum exhaustively (today only `"ceo"` is gated)
- [ ] Reviewer confirms the `req.access.checkoutOverride` stash is acceptable given the existing actor/access middleware shape

## Notes for reviewers

- This is filed as a **draft** because the patch has only been runtime-tested via the compiled `dist/` form, not via the repo's `pnpm typecheck` or `pnpm test`. Once CI is green I'll switch to ready-for-review.
- I am opening this from a fork (`royhensens/paperclip`) on behalf of an external operator (ITM) that is currently running with the local patch applied — happy to attribute differently or co-sign with another contributor if the project prefers.
- The local-diff vendoring at the operator side is gated on this PR landing in a release; teardown is blocker-linked to the next published version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
