### PR TITLE
feat(issues): require reviewer on transition to in_review

### DIFF
--- a/packages/db/src/migrations/0086_issue_reviewers.sql
+++ b/packages/db/src/migrations/0086_issue_reviewers.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "issues"
+  ADD COLUMN "reviewer_agent_id" uuid REFERENCES "agents"("id"),
+  ADD COLUMN "reviewer_user_id" text;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1778355326070,
       "tag": "0084_issue_recovery_actions",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1779532800000,
+      "tag": "0086_issue_reviewers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -34,6 +34,8 @@ export const issues = pgTable(
     priority: text("priority").notNull().default("medium"),
     assigneeAgentId: uuid("assignee_agent_id").references(() => agents.id),
     assigneeUserId: text("assignee_user_id"),
+    reviewerAgentId: uuid("reviewer_agent_id").references(() => agents.id),
+    reviewerUserId: text("reviewer_user_id"),
     checkoutRunId: uuid("checkout_run_id").references(() => heartbeatRuns.id, { onDelete: "set null" }),
     executionRunId: uuid("execution_run_id").references(() => heartbeatRuns.id, { onDelete: "set null" }),
     executionAgentNameKey: text("execution_agent_name_key"),

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -315,6 +315,8 @@ const createIssueBaseSchema = z.object({
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
   assigneeAgentId: z.string().uuid().optional().nullable(),
   assigneeUserId: z.string().optional().nullable(),
+  reviewerAgentId: z.string().uuid().optional().nullable(),
+  reviewerUserId: z.string().optional().nullable(),
   requestDepth: issueRequestDepthInputSchema.optional().default(0),
   billingCode: z.string().optional().nullable(),
   assigneeAdapterOverrides: issueAssigneeAdapterOverridesSchema.optional().nullable(),

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -387,6 +387,45 @@ describe("issue execution policy routes", () => {
     expect(mockIssueApprovalService.listApprovalsForIssue).not.toHaveBeenCalled();
   });
 
+  it("allows keeping status=in_review on legacy rows without reviewer", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      reviewerAgentId: null,
+      reviewerUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Legacy review issue",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        title: "Legacy review issue (retitled)",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        title: "Legacy review issue (retitled)",
+      }),
+    );
+  });
+
   it("does not auto-start execution review when reviewers are added to an already in_review issue", async () => {
     const policy = normalizeIssueExecutionPolicy({
       stages: [

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -5,6 +5,7 @@ import { normalizeIssueExecutionPolicy } from "../services/issue-execution-polic
 
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
+  create: vi.fn(),
   assertCheckoutOwner: vi.fn(),
   update: vi.fn(),
   createChild: vi.fn(),
@@ -147,6 +148,13 @@ describe("issue execution policy routes", () => {
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.create.mockResolvedValue({
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      identifier: "PAP-1001",
+      title: "Created issue",
+      status: "todo",
+    });
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
@@ -163,7 +171,7 @@ describe("issue execution policy routes", () => {
     mockAccessService.hasPermission.mockResolvedValue(false);
   });
 
-  it("rejects an agent-authored in_review transition without a review path", async () => {
+  it("rejects in_review transition without reviewer", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       companyId: "company-1",
@@ -187,13 +195,9 @@ describe("issue execution policy routes", () => {
       .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
       .send({ status: "in_review" });
 
-    expect(res.status).toBe(422);
-    expect(res.body.error).toContain("invalid_issue_disposition");
-    expect(res.body.error).toContain("request_confirmation");
-    expect(res.body.details).toMatchObject({
-      code: "invalid_issue_disposition",
-      missing: "review_path",
-    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("reviewer_required");
+    expect(res.body.details).toMatchObject({ code: "reviewer_required" });
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
@@ -227,7 +231,10 @@ describe("issue execution policy routes", () => {
       runId: "run-1",
     }))
       .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
-      .send({ status: "in_review" });
+      .send({
+        status: "in_review",
+        reviewerAgentId: "44444444-4444-4444-8444-444444444444",
+      });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -272,7 +279,11 @@ describe("issue execution policy routes", () => {
       runId: "run-1",
     }))
       .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
-      .send({ status: "in_review", executionPolicy: policy });
+      .send({
+        status: "in_review",
+        reviewerAgentId: "44444444-4444-4444-8444-444444444444",
+        executionPolicy: policy,
+      });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalledWith(
@@ -324,6 +335,7 @@ describe("issue execution policy routes", () => {
       .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
       .send({
         status: "in_review",
+        reviewerAgentId: "44444444-4444-4444-8444-444444444444",
         executionPolicy: {
           monitor: {
             nextCheckAt: "2026-12-01T12:00:00.000Z",
@@ -365,7 +377,10 @@ describe("issue execution policy routes", () => {
 
     const res = await request(await createApp())
       .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
-      .send({ status: "in_review" });
+      .send({
+        status: "in_review",
+        reviewerAgentId: "44444444-4444-4444-8444-444444444444",
+      });
 
     expect(res.status).toBe(200);
     expect(mockIssueThreadInteractionService.listForIssue).not.toHaveBeenCalled();
@@ -420,6 +435,42 @@ describe("issue execution policy routes", () => {
     expect(updatePatch.assigneeUserId).toBeUndefined();
     expect(updatePatch.executionState).toBeUndefined();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("rejects create issue in_review without reviewer", async () => {
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Needs reviewer",
+        status: "in_review",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("reviewer_required");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows create issue in_review with reviewerAgentId", async () => {
+    mockIssueService.create.mockResolvedValue({
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      identifier: "PAP-2001",
+      title: "Needs reviewer",
+      status: "in_review",
+      reviewerAgentId: "44444444-4444-4444-8444-444444444444",
+      reviewerUserId: null,
+    });
+
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Needs reviewer",
+        status: "in_review",
+        reviewerAgentId: "44444444-4444-4444-8444-444444444444",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalled();
   });
 
   it("triggers a scheduled monitor immediately from the dedicated route", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -945,11 +945,12 @@ export function issueRoutes(
   }
 
   function assertReviewerRequiredForInReview(input: {
+    previousStatus: unknown;
     nextStatus: unknown;
     reviewerAgentId: unknown;
     reviewerUserId: unknown;
   }) {
-    if (input.nextStatus !== "in_review") return;
+    if (input.nextStatus !== "in_review" || input.previousStatus === "in_review") return;
     const hasReviewerAgent =
       typeof input.reviewerAgentId === "string" && input.reviewerAgentId.trim().length > 0;
     const hasReviewerUser =
@@ -2544,6 +2545,7 @@ export function issueRoutes(
 
     const actor = getActorInfo(req);
     assertReviewerRequiredForInReview({
+      previousStatus: undefined,
       nextStatus: req.body.status,
       reviewerAgentId: req.body.reviewerAgentId,
       reviewerUserId: req.body.reviewerUserId,
@@ -2957,6 +2959,7 @@ export function issueRoutes(
     }
 
     assertReviewerRequiredForInReview({
+      previousStatus: existing.status,
       nextStatus: updateFields.status,
       reviewerAgentId: updateFields.reviewerAgentId ?? existing.reviewerAgentId,
       reviewerUserId: updateFields.reviewerUserId ?? existing.reviewerUserId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -887,6 +887,8 @@ export function issueRoutes(
       companyId: string;
       status: string;
       assigneeUserId?: string | null;
+      reviewerAgentId?: string | null;
+      reviewerUserId?: string | null;
       executionState?: unknown;
       monitorNextCheckAt?: Date | null;
     };
@@ -902,6 +904,14 @@ export function issueRoutes(
       ? input.existing.assigneeUserId
       : input.updateFields.assigneeUserId;
     if (typeof nextAssigneeUserId === "string" && nextAssigneeUserId.trim().length > 0) return;
+    const nextReviewerAgentId = input.updateFields.reviewerAgentId === undefined
+      ? input.existing.reviewerAgentId
+      : input.updateFields.reviewerAgentId;
+    const nextReviewerUserId = input.updateFields.reviewerUserId === undefined
+      ? input.existing.reviewerUserId
+      : input.updateFields.reviewerUserId;
+    if (typeof nextReviewerAgentId === "string" && nextReviewerAgentId.trim().length > 0) return;
+    if (typeof nextReviewerUserId === "string" && nextReviewerUserId.trim().length > 0) return;
 
     const nextExecutionState = input.updateFields.executionState === undefined
       ? input.existing.executionState
@@ -931,6 +941,22 @@ export function issueRoutes(
         "typed_execution_state_current_participant",
         "scheduled_issue_monitor",
       ],
+    });
+  }
+
+  function assertReviewerRequiredForInReview(input: {
+    nextStatus: unknown;
+    reviewerAgentId: unknown;
+    reviewerUserId: unknown;
+  }) {
+    if (input.nextStatus !== "in_review") return;
+    const hasReviewerAgent =
+      typeof input.reviewerAgentId === "string" && input.reviewerAgentId.trim().length > 0;
+    const hasReviewerUser =
+      typeof input.reviewerUserId === "string" && input.reviewerUserId.trim().length > 0;
+    if (hasReviewerAgent || hasReviewerUser) return;
+    throw new HttpError(400, "reviewer_required", {
+      code: "reviewer_required",
     });
   }
 
@@ -2517,6 +2543,11 @@ export function issueRoutes(
     await assertIssueEnvironmentSelection(companyId, req.body.executionWorkspaceSettings?.environmentId);
 
     const actor = getActorInfo(req);
+    assertReviewerRequiredForInReview({
+      nextStatus: req.body.status,
+      reviewerAgentId: req.body.reviewerAgentId,
+      reviewerUserId: req.body.reviewerUserId,
+    });
     const executionPolicy = applyActorMonitorScheduledBy(
       normalizeIssueExecutionPolicy(req.body.executionPolicy),
       actor.actorType,
@@ -2924,6 +2955,12 @@ export function issueRoutes(
         };
       }
     }
+
+    assertReviewerRequiredForInReview({
+      nextStatus: updateFields.status,
+      reviewerAgentId: updateFields.reviewerAgentId ?? existing.reviewerAgentId,
+      reviewerUserId: updateFields.reviewerUserId ?? existing.reviewerUserId,
+    });
 
     await assertAgentInReviewReviewPath({
       existing,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1551,6 +1551,8 @@ const issueListSelect = {
   priority: issues.priority,
   assigneeAgentId: issues.assigneeAgentId,
   assigneeUserId: issues.assigneeUserId,
+  reviewerAgentId: issues.reviewerAgentId,
+  reviewerUserId: issues.reviewerUserId,
   checkoutRunId: issues.checkoutRunId,
   executionRunId: issues.executionRunId,
   executionAgentNameKey: issues.executionAgentNameKey,


### PR DESCRIPTION
## Summary
- require reviewer only when transitioning into in_review (not when already in in_review)
- enforce reviewer requirement on create when status=in_review
- persist reviewer fields on update and include in issue projections
- add DB migration for reviewer columns and register it in drizzle journal

## Tests
- pnpm exec vitest run server/src/__tests__/issue-execution-policy-routes.test.ts

## Scope
Implements OFM-503 only (no OFM-236 changes).