### PR TITLE
Add v2026.529.0 release changelog

### DIFF
--- a/releases/v2026.529.0.md
+++ b/releases/v2026.529.0.md
@@ -1,0 +1,20 @@
+# v2026.529.0
+
+> Released: 2026-05-29
+
+## Highlights
+
+- **Inline document annotations and comments** - Issue documents now support inline, revision-aware annotation threads with comments and stable anchor snapshots, so agents and operators can discuss a specific passage instead of leaving detached issue comments or editing the whole document. ([#6733](https://github.com/paperclipai/paperclip/pull/6733), @cryppadotta)
+- **Company skills CLI and catalog management** - Skills are now first-class: install, reset, audit, export, and assign company skills with a new CLI and a board UI, backed by a packaged skills catalog and a clear provenance model across bundled, catalog, runtime, and adapter-provided skills. ([#6782](https://github.com/paperclipai/paperclip/pull/6782), @cryppadotta)
+- **Hide projects and agents from your sidebar** - User-scoped resource membership lets each user leave projects and agents they don't want cluttering their sidebar while keeping every resource accessible, backed by company-scoped membership APIs and a cleaner, easier-to-scan project list. ([#6677](https://github.com/paperclipai/paperclip/pull/6677), @cryppadotta)
+- **First-admin claim flow for fresh self-hosted deployments** - Private, unclaimed deployments (such as Umbrel installs on a LAN) now get a one-time browser claim so operators can create the first admin before any invite exists, while public deployments and installs with active invites keep the existing invite-only model. ([#6755](https://github.com/paperclipai/paperclip/pull/6755), @cryppadotta)
+- **Live Claude model discovery** - The Claude Local adapter can now refresh its Anthropic model catalog from the UI, so newly released Claude models show up without waiting for a code release — with the static fallback list kept current as a safety net. ([#6953](https://github.com/paperclipai/paperclip/pull/6953), @cryppadotta)
+
+## Improvements
+
+- **Bundled plugins now appear in the plugin manager** - Instance Settings → plugin manager lists built-in bundled plugins alongside installed external plugins, so the full set of available plugins is visible in one place. ([#6734](https://github.com/paperclipai/paperclip/pull/6734), @cryppadotta)
+- **Tighter workspace lifecycle guarantees** - Workspace finalize gates and no-remote-git enforcement close holes in the worktree contract — no more silent env reuse across assignees, dependent issue wakes no longer fire before finalize lands, and `issue.interaction.accept` waits for finalize — so dependent issues reliably see a consistent worktree. ([#6969](https://github.com/paperclipai/paperclip/pull/6969), @devinfoley)
+
+## Fixes
+
+- **Accepted plans decompose exactly once** - Accepted plan revisions are now guarded so they can't be decomposed more than once across overlapping runs, fixing the duplicate-subtask fan-out that could occur when agents woke from review decisions and reused isolated workspaces, plus clearer plan-decomposition UI state. ([#6831](https://github.com/paperclipai/paperclip/pull/6831), @devinfoley)


### PR DESCRIPTION
## Release changelog: v2026.529.0

Stable changelog for the **v2026.529.0** release (released 2026-05-29), generated with the `release-changelog` skill.

- Range: `v2026.525.0..origin/master` — 11 squash-merged PRs
- Adds `releases/v2026.529.0.md`
- **No breaking changes** — migrations are additive (`CREATE TABLE IF NOT EXISTS`); the only `DROP CONSTRAINT` lines are FK adjustments, not data loss
- **No external contributors** this cycle — all PR authors are Paperclip founders, who are excluded from the Contributors section per the skill, so that section is omitted

### Highlights
- Inline document annotations and comments (#6733)
- Company skills CLI and catalog management (#6782)
- Hide projects and agents from your sidebar (#6677)
- First-admin claim flow for fresh self-hosted deployments (#6755)
- Live Claude model discovery (#6953)

### Improvements
- Bundled plugins now appear in the plugin manager (#6734)
- Tighter workspace lifecycle guarantees (#6969)

### Fixes
- Accepted plans decompose exactly once (#6831)

Docs-only (README brand/license #6810, #6804) and CI-only (#6967) changes were excluded as not materially user-facing.

Issue: PAP-10155

🤖 Generated with [Claude Code](https://claude.com/claude-code)