### PR TITLE
feat(claude-local): load per-agent .env on spawn (JDD-133)

### DIFF
--- a/docs/deploy/local-development.md
+++ b/docs/deploy/local-development.md
@@ -93,6 +93,7 @@ pnpm dev
 | Data | Path |
 |------|------|
 | Config | `~/.paperclip/instances/default/config.json` |
+| Instance `.env` | `~/.paperclip/instances/default/.env` |
 | Database | `~/.paperclip/instances/default/db` |
 | Storage | `~/.paperclip/instances/default/data/storage` |
 | Secrets key | `~/.paperclip/instances/default/secrets/master.key` |
@@ -103,3 +104,44 @@ Override with environment variables:
 ```sh
 PAPERCLIP_HOME=/custom/path PAPERCLIP_INSTANCE_ID=dev pnpm paperclipai run
 ```
+
+### Instance-Wide `.env`
+
+The server loads `~/.paperclip/instances/<id>/.env` into `process.env` at startup
+(via the standard `dotenv` parser). Every agent run inherits these values, so
+treat the instance `.env` as the place for secrets that genuinely apply to every
+agent on this instance.
+
+### Per-Agent `.env` Overrides (`claude_local` only)
+
+The `claude_local` adapter additionally loads a per-agent dotenv file when
+spawning a run process:
+
+```
+~/.paperclip/instances/<id>/companies/<companyId>/agents/<agentId>/.env
+```
+
+Drop the file on disk out-of-band — there is no UI or JSON API for it yet. Use
+standard dotenv syntax (`KEY=value`, one per line, `#` for comments).
+
+**Precedence (lowest → highest):**
+
+1. Instance `.env` (`process.env`).
+2. Per-agent `agents/<agentId>/.env`.
+3. `adapterConfig.env` and the Paperclip-managed runtime variables
+   (`PAPERCLIP_API_KEY`, `PAPERCLIP_RUN_ID`, etc.).
+
+So per-agent values override instance values on key collision but never
+override `adapterConfig.env` or the `PAPERCLIP_*` runtime variables.
+
+**Recommended permissions:** `chmod 600 <file>` so only the user running the
+server can read it. The Paperclip CLI does not enforce this; it is your
+responsibility as the operator.
+
+**Lifecycle:** Deleting an agent through the board UI removes this file and the
+parent `agents/<agentId>/` directory if no other artifacts remain. Recreating
+the file after an agent run starts has no effect until the next spawn.
+
+**When to use this:** secrets you want bound to a single agent (for example,
+a Supabase service-role key for one agent only) without exposing them to
+every other `claude_local` agent on the instance.

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "dotenv": "^17.0.1",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/claude-local/src/server/agent-env.ts
+++ b/packages/adapters/claude-local/src/server/agent-env.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parse as parseDotenv } from "dotenv";
+import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-utils/server-utils";
+
+const PATH_SEGMENT_RE = /^[a-zA-Z0-9_-]+$/;
+
+export interface AgentEnvFileLocator {
+  id: string;
+  companyId: string;
+}
+
+export function resolveAgentDir(agent: AgentEnvFileLocator): string {
+  if (!PATH_SEGMENT_RE.test(agent.companyId)) {
+    throw new Error(`Refusing to resolve agent dir for unsafe companyId '${agent.companyId}'`);
+  }
+  if (!PATH_SEGMENT_RE.test(agent.id)) {
+    throw new Error(`Refusing to resolve agent dir for unsafe agentId '${agent.id}'`);
+  }
+  return path.resolve(
+    resolvePaperclipInstanceRootForAdapter(),
+    "companies",
+    agent.companyId,
+    "agents",
+    agent.id,
+  );
+}
+
+export function resolveAgentEnvFilePath(agent: AgentEnvFileLocator): string {
+  return path.resolve(resolveAgentDir(agent), ".env");
+}
+
+export async function readAgentEnvFile(agent: AgentEnvFileLocator): Promise<Record<string, string>> {
+  const filePath = resolveAgentEnvFilePath(agent);
+  let contents: string;
+  try {
+    contents = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+  return parseDotenv(contents);
+}

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -56,6 +56,7 @@ import {
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { prepareClaudeConfigSeed } from "./claude-config.js";
+import { readAgentEnvFile } from "./agent-env.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
@@ -179,7 +180,11 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  // Per-agent .env values override instance .env (process.env), but
+  // Paperclip-managed env vars and adapterConfig.env still take precedence
+  // (assigned below). See `agent-env.ts`.
+  const agentEnv = await readAgentEnvFile(agent);
+  const env: Record<string, string> = { ...agentEnv, ...buildPaperclipEnv(agent) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -1,4 +1,9 @@
 export { claudeSessionCwdMatchesExecutionTarget, execute, runClaudeLogin } from "./execute.js";
+export {
+  readAgentEnvFile,
+  resolveAgentDir,
+  resolveAgentEnvFilePath,
+} from "./agent-env.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
 export { listClaudeModels } from "./models.js";
 export { testEnvironment } from "./test.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
+      dotenv:
+        specifier: ^17.0.1
+        version: 17.3.1
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -11190,14 +11193,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -14884,7 +14879,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/server/src/__tests__/agent-artifacts-cleanup.test.ts
+++ b/server/src/__tests__/agent-artifacts-cleanup.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  removeAgentArtifacts,
+  resolveAgentArtifactRoot,
+  resolveAgentEnvFilePath,
+} from "../services/agent-instructions.js";
+
+const COMPANY_ID = "company1";
+const AGENT_ID = "agentA";
+
+interface Fixture {
+  root: string;
+  artifactRoot: string;
+  envFile: string;
+  instructionsDir: string;
+  restore: () => void;
+}
+
+async function setupFixture(): Promise<Fixture> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-artifacts-"));
+  const previousHome = process.env.PAPERCLIP_HOME;
+  process.env.PAPERCLIP_HOME = path.join(root, "home");
+  const artifactRoot = resolveAgentArtifactRoot({ id: AGENT_ID, companyId: COMPANY_ID });
+  await fs.mkdir(artifactRoot, { recursive: true });
+  return {
+    root,
+    artifactRoot,
+    envFile: resolveAgentEnvFilePath({ id: AGENT_ID, companyId: COMPANY_ID }),
+    instructionsDir: path.join(artifactRoot, "instructions"),
+    restore: () => {
+      if (previousHome === undefined) delete process.env.PAPERCLIP_HOME;
+      else process.env.PAPERCLIP_HOME = previousHome;
+    },
+  };
+}
+
+describe("removeAgentArtifacts", () => {
+  let fixture: Fixture;
+
+  beforeEach(async () => {
+    fixture = await setupFixture();
+  });
+
+  afterEach(async () => {
+    fixture.restore();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  });
+
+  it("removes a per-agent .env file when present", async () => {
+    await fs.writeFile(fixture.envFile, "FOO=bar\n", "utf8");
+    await expect(fs.access(fixture.envFile)).resolves.toBeUndefined();
+
+    await removeAgentArtifacts({ id: AGENT_ID, companyId: COMPANY_ID });
+
+    await expect(fs.access(fixture.envFile)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the instructions tree when present", async () => {
+    await fs.mkdir(fixture.instructionsDir, { recursive: true });
+    await fs.writeFile(path.join(fixture.instructionsDir, "AGENTS.md"), "hi", "utf8");
+
+    await removeAgentArtifacts({ id: AGENT_ID, companyId: COMPANY_ID });
+
+    await expect(fs.access(fixture.instructionsDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the agent directory when it is empty after cleanup", async () => {
+    await fs.writeFile(fixture.envFile, "FOO=bar\n", "utf8");
+
+    await removeAgentArtifacts({ id: AGENT_ID, companyId: COMPANY_ID });
+
+    await expect(fs.access(fixture.artifactRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("leaves the agent directory intact if unrelated files remain", async () => {
+    await fs.writeFile(fixture.envFile, "FOO=bar\n", "utf8");
+    const stray = path.join(fixture.artifactRoot, "something-else.txt");
+    await fs.writeFile(stray, "keep me", "utf8");
+
+    await removeAgentArtifacts({ id: AGENT_ID, companyId: COMPANY_ID });
+
+    await expect(fs.access(fixture.envFile)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(stray)).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when the agent directory does not exist", async () => {
+    await fs.rm(fixture.artifactRoot, { recursive: true, force: true });
+    await expect(removeAgentArtifacts({ id: AGENT_ID, companyId: COMPANY_ID })).resolves.toBeUndefined();
+  });
+});

--- a/server/src/__tests__/claude-local-per-agent-env.test.ts
+++ b/server/src/__tests__/claude-local-per-agent-env.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-claude-local/server";
+
+async function writeEnvCaptureClaudeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const probeKey = process.env.PAPERCLIP_TEST_PROBE_KEY;
+const payload = {
+  probeKey,
+  probeValue: probeKey ? (process.env[probeKey] ?? null) : null,
+  hasInstanceLeak: process.env.PER_AGENT_LEAK_PROBE ?? null,
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-x", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "assistant", session_id: "claude-session-x", message: { content: [{ type: "text", text: "ok" }] } }));
+console.log(JSON.stringify({ type: "result", session_id: "claude-session-x", result: "ok", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+const COMPANY_ID = "company1";
+const AGENT_WITH_ENV = "agentA";
+const AGENT_WITHOUT_ENV = "agentB";
+
+interface TestEnv {
+  root: string;
+  paperclipHome: string;
+  workspace: string;
+  commandPath: string;
+  capturePath: string;
+  agentEnvFilePath: string;
+  restore: () => void;
+}
+
+async function setupPerAgentEnvFixture(): Promise<TestEnv> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-per-agent-env-"));
+  const paperclipHome = path.join(root, "home");
+  const instanceRoot = path.join(paperclipHome, "instances", "default");
+  const agentDirA = path.join(instanceRoot, "companies", COMPANY_ID, "agents", AGENT_WITH_ENV);
+  const workspace = path.join(root, "workspace");
+  const binDir = path.join(root, "bin");
+  const commandPath = path.join(binDir, "claude");
+  const capturePath = path.join(root, "capture.json");
+  await fs.mkdir(agentDirA, { recursive: true });
+  await fs.mkdir(workspace, { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
+  await writeEnvCaptureClaudeCommand(commandPath);
+
+  const previous = {
+    PAPERCLIP_HOME: process.env.PAPERCLIP_HOME,
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+    PER_AGENT_LEAK_PROBE: process.env.PER_AGENT_LEAK_PROBE,
+  };
+  process.env.PAPERCLIP_HOME = paperclipHome;
+  process.env.HOME = root;
+  process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  delete process.env.PER_AGENT_LEAK_PROBE;
+
+  return {
+    root,
+    paperclipHome,
+    workspace,
+    commandPath,
+    capturePath,
+    agentEnvFilePath: path.join(agentDirA, ".env"),
+    restore: () => {
+      for (const key of Object.keys(previous) as (keyof typeof previous)[]) {
+        const value = previous[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    },
+  };
+}
+
+describe("claude_local per-agent .env loading", () => {
+  let env: TestEnv;
+
+  beforeEach(async () => {
+    env = await setupPerAgentEnvFixture();
+  });
+
+  afterEach(async () => {
+    env.restore();
+    await fs.rm(env.root, { recursive: true, force: true });
+  });
+
+  it("injects per-agent .env values into the spawned run process", async () => {
+    await fs.writeFile(
+      env.agentEnvFilePath,
+      "SUPABASE_SERVICE_ROLE_KEY=agent-secret-value\n",
+      "utf8",
+    );
+
+    await execute({
+      runId: "run-with-env",
+      agent: {
+        id: AGENT_WITH_ENV,
+        companyId: COMPANY_ID,
+        name: "Test",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: env.commandPath,
+        cwd: env.workspace,
+        env: {
+          PAPERCLIP_TEST_CAPTURE_PATH: env.capturePath,
+          PAPERCLIP_TEST_PROBE_KEY: "SUPABASE_SERVICE_ROLE_KEY",
+        },
+        promptTemplate: "Do work.",
+      },
+      context: {},
+      authToken: "tok",
+      onLog: async () => {},
+    });
+
+    const captured = JSON.parse(await fs.readFile(env.capturePath, "utf8"));
+    expect(captured.probeValue).toBe("agent-secret-value");
+  });
+
+  it("does not leak per-agent .env values to other agents on the same instance", async () => {
+    await fs.writeFile(
+      env.agentEnvFilePath,
+      "SUPABASE_SERVICE_ROLE_KEY=agent-secret-value\n",
+      "utf8",
+    );
+
+    await execute({
+      runId: "run-without-env",
+      agent: {
+        id: AGENT_WITHOUT_ENV,
+        companyId: COMPANY_ID,
+        name: "Other",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: env.commandPath,
+        cwd: env.workspace,
+        env: {
+          PAPERCLIP_TEST_CAPTURE_PATH: env.capturePath,
+          PAPERCLIP_TEST_PROBE_KEY: "SUPABASE_SERVICE_ROLE_KEY",
+        },
+        promptTemplate: "Do work.",
+      },
+      context: {},
+      authToken: "tok",
+      onLog: async () => {},
+    });
+
+    const captured = JSON.parse(await fs.readFile(env.capturePath, "utf8"));
+    expect(captured.probeValue).toBeNull();
+  });
+
+  it("per-agent values override instance env vars (process.env) for the agent that owns them", async () => {
+    await fs.writeFile(
+      env.agentEnvFilePath,
+      "PER_AGENT_LEAK_PROBE=agent-value\n",
+      "utf8",
+    );
+    process.env.PER_AGENT_LEAK_PROBE = "instance-value";
+
+    await execute({
+      runId: "run-override",
+      agent: {
+        id: AGENT_WITH_ENV,
+        companyId: COMPANY_ID,
+        name: "Test",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: env.commandPath,
+        cwd: env.workspace,
+        env: { PAPERCLIP_TEST_CAPTURE_PATH: env.capturePath },
+        promptTemplate: "Do work.",
+      },
+      context: {},
+      authToken: "tok",
+      onLog: async () => {},
+    });
+
+    const captured = JSON.parse(await fs.readFile(env.capturePath, "utf8"));
+    expect(captured.hasInstanceLeak).toBe("agent-value");
+  });
+
+  it("adapterConfig.env still wins over per-agent .env on key collision", async () => {
+    await fs.writeFile(
+      env.agentEnvFilePath,
+      "OVERRIDDEN_BY_CONFIG=from-agent-env\n",
+      "utf8",
+    );
+
+    await execute({
+      runId: "run-config-wins",
+      agent: {
+        id: AGENT_WITH_ENV,
+        companyId: COMPANY_ID,
+        name: "Test",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: env.commandPath,
+        cwd: env.workspace,
+        env: {
+          PAPERCLIP_TEST_CAPTURE_PATH: env.capturePath,
+          PAPERCLIP_TEST_PROBE_KEY: "OVERRIDDEN_BY_CONFIG",
+          OVERRIDDEN_BY_CONFIG: "from-config",
+        },
+        promptTemplate: "Do work.",
+      },
+      context: {},
+      authToken: "tok",
+      onLog: async () => {},
+    });
+
+    const captured = JSON.parse(await fs.readFile(env.capturePath, "utf8"));
+    expect(captured.probeValue).toBe("from-config");
+  });
+
+  it("treats a missing per-agent .env file as no-op", async () => {
+    await execute({
+      runId: "run-no-file",
+      agent: {
+        id: AGENT_WITH_ENV,
+        companyId: COMPANY_ID,
+        name: "Test",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: env.commandPath,
+        cwd: env.workspace,
+        env: {
+          PAPERCLIP_TEST_CAPTURE_PATH: env.capturePath,
+          PAPERCLIP_TEST_PROBE_KEY: "SUPABASE_SERVICE_ROLE_KEY",
+        },
+        promptTemplate: "Do work.",
+      },
+      context: {},
+      authToken: "tok",
+      onLog: async () => {},
+    });
+
+    const captured = JSON.parse(await fs.readFile(env.capturePath, "utf8"));
+    expect(captured.probeValue).toBeNull();
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -35,6 +35,7 @@ import { validate } from "../middleware/validate.js";
 import {
   agentService,
   agentInstructionsService,
+  removeAgentArtifacts,
   accessService,
   approvalService,
   companySkillService,
@@ -2812,6 +2813,15 @@ export function agentRoutes(
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
       return;
+    }
+
+    try {
+      await removeAgentArtifacts({ id: agent.id, companyId: agent.companyId });
+    } catch (err) {
+      console.warn(
+        { err, agentId: agent.id, companyId: agent.companyId },
+        "agent.deleted: failed to clean up filesystem artifacts",
+      );
     }
 
     await logActivity(db, {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -131,14 +131,41 @@ function resolvePathWithinRoot(rootPath: string, relativePath: string): string {
 }
 
 function resolveManagedInstructionsRoot(agent: AgentLike): string {
+  return path.resolve(resolveAgentArtifactRoot(agent), "instructions");
+}
+
+export function resolveAgentArtifactRoot(agent: Pick<AgentLike, "id" | "companyId">): string {
   return path.resolve(
     resolvePaperclipInstanceRoot(),
     "companies",
     agent.companyId,
     "agents",
     agent.id,
-    "instructions",
   );
+}
+
+export function resolveAgentEnvFilePath(agent: Pick<AgentLike, "id" | "companyId">): string {
+  return path.resolve(resolveAgentArtifactRoot(agent), ".env");
+}
+
+/**
+ * Best-effort filesystem cleanup for an agent that has been deleted from the
+ * database. Removes the per-agent `.env` file, the managed `instructions/`
+ * tree, and the parent `agents/<id>/` directory if it is empty afterwards.
+ * Errors are swallowed so callers can log and proceed.
+ */
+export async function removeAgentArtifacts(
+  agent: Pick<AgentLike, "id" | "companyId">,
+): Promise<void> {
+  const artifactRoot = resolveAgentArtifactRoot(agent);
+  await fs.rm(path.resolve(artifactRoot, ".env"), { force: true });
+  await fs.rm(path.resolve(artifactRoot, "instructions"), { recursive: true, force: true });
+  try {
+    await fs.rmdir(artifactRoot);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOTEMPTY" && code !== "ENOENT") throw err;
+  }
 }
 
 function resolveLegacyInstructionsPath(candidatePath: string, config: Record<string, unknown>): string {

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -3,7 +3,13 @@ export { companySearchService } from "./company-search.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
-export { agentInstructionsService, syncInstructionsBundleConfigFromFilePath } from "./agent-instructions.js";
+export {
+  agentInstructionsService,
+  removeAgentArtifacts,
+  resolveAgentArtifactRoot,
+  resolveAgentEnvFilePath,
+  syncInstructionsBundleConfigFromFilePath,
+} from "./agent-instructions.js";
 export { assetService } from "./assets.js";
 export { documentService, extractLegacyPlanBody } from "./documents.js";
 export { documentAnnotationService } from "./document-annotations.js";


### PR DESCRIPTION
The claude_local adapter now additionally loads
~/.paperclip/instances/<id>/companies/<companyId>/agents/<agentId>/.env when spawning a run process. Per-agent values override the instance .env on key collision; adapterConfig.env and PAPERCLIP_* runtime vars still win.

Parsed with dotenv (same loader as the instance .env) but via parse() so values flow only into the spawn's env, never into the server's process.env. This prevents per-agent secrets from leaking to other claude_local agents on the same instance.

Agent deletion now also cleans up the per-agent .env file, the instructions/ tree, and the parent agents/<id>/ directory when empty.

Follow-up after merge: rotate any per-agent secrets that currently live in the instance .env (e.g. SUPABASE_SERVICE_ROLE_KEY for Codd) into their per-agent files and remove them from the instance .env.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
