### PR TITLE
fix(onboarding): explicitly await first-task wake so phantom-run failures surface

### DIFF
--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -10,8 +10,12 @@ import { test, expect } from "@playwright/test";
  *   Step 4 — Ready to launch (summary + open issue)
  *
  * By default this runs in skip_llm mode: we do NOT assert that an LLM
- * heartbeat fires. Set PAPERCLIP_E2E_SKIP_LLM=false to enable LLM-dependent
- * assertions (requires a valid ANTHROPIC_API_KEY).
+ * heartbeat completes. We DO assert that at least one heartbeat run is
+ * queued/running for the new assignee within 30s of "Create & Open Issue".
+ * That run will fail-fast in CI without ANTHROPIC_API_KEY, which is fine —
+ * the assertion is regression coverage for the onboarding-wake handoff
+ * (companion fix to the orphan-runId bug). Set PAPERCLIP_E2E_SKIP_LLM=false
+ * to enable LLM-dependent assertions (requires a valid ANTHROPIC_API_KEY).
  */
 
 const SKIP_LLM = process.env.PAPERCLIP_E2E_SKIP_LLM !== "false";
@@ -73,24 +77,6 @@ test.describe("Onboarding wizard", () => {
         (a: { name: string }) => a.name === AGENT_NAME
       );
       expect(ceoAgentAfterCreate).toBeTruthy();
-
-      const disableWakeRes = await page.request.patch(
-        `${baseUrl}/api/agents/${ceoAgentAfterCreate.id}?companyId=${encodeURIComponent(companyAfterAgent.id)}`,
-        {
-          data: {
-            runtimeConfig: {
-              heartbeat: {
-                enabled: false,
-                intervalSec: 300,
-                wakeOnDemand: false,
-                cooldownSec: 10,
-                maxConcurrentRuns: 5,
-              },
-            },
-          },
-        }
-      );
-      expect(disableWakeRes.ok()).toBe(true);
     }
 
     const taskTitleInput = page.locator(
@@ -174,8 +160,8 @@ test.describe("Onboarding wizard", () => {
           expect(runsRes.ok()).toBe(true);
           const runs = await runsRes.json();
           return Array.isArray(runs) ? runs.length : -1;
-        }, { timeout: 10_000, intervals: [500, 1_000, 2_000] })
-        .toBe(0);
+        }, { timeout: 30_000, intervals: [500, 1_000, 2_000] })
+        .toBeGreaterThanOrEqual(1);
     }
   });
 });

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -566,6 +566,33 @@ export function OnboardingWizard() {
         queryClient.invalidateQueries({
           queryKey: queryKeys.issues.list(createdCompanyId)
         });
+
+        // The server's `queueIssueAssignmentWakeup` runs fire-and-forget on
+        // issue create. On a rare wake-transaction failure, the issue can be
+        // stamped with an `executionRunId` for a run that never starts,
+        // leaving the freshly-onboarded agent locked to a phantom run with
+        // no live continuation path. Issue an explicit on-demand wake here
+        // so the user is told if the first run cannot be queued, instead of
+        // landing on an issue page whose assignee never ticks.
+        try {
+          await agentsApi.wakeup(
+            createdAgentId,
+            {
+              source: "on_demand",
+              triggerDetail: "manual",
+              reason: "onboarding_first_task",
+              payload: { issueId: issue.id }
+            },
+            createdCompanyId
+          );
+        } catch (wakeErr) {
+          setError(
+            wakeErr instanceof Error
+              ? `Task created but failed to start the agent: ${wakeErr.message}. Open the agent's run history to retry.`
+              : "Task created but failed to start the agent. Open the agent's run history to retry."
+          );
+          return;
+        }
       }
 
       setSelectedCompanyId(createdCompanyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Onboarding is the first interaction a new user has with the platform: pick an adapter, create one agent, give it one task, click "Create & Open Issue"
> - That click implicitly promises "your agent is now working on this" — landing the user on the issue page
> - But the server queues the assignee-wake fire-and-forget (`void queueIssueAssignmentWakeup(...)`), so any wake-transaction failure is swallowed and the freshly-onboarded agent silently never ticks
> - This pull request makes the wizard issue an explicit, awaited `agentsApi.wakeup` after the issue is created, surfacing failures to the user instead of stranding them on a dead issue
> - The benefit is that the onboarding promise actually holds: if the agent cannot be woken, the user sees the error and can retry, instead of staring at an inert issue and assuming the platform is broken

## What Changed

- `ui/src/components/OnboardingWizard.tsx` — after `issuesApi.create` succeeds, explicitly `await agentsApi.wakeup(...)` with `source: "on_demand"` and `reason: "onboarding_first_task"`. On failure, set the wizard error and return without navigating. The comment block in the source explains the rationale inline.
- `tests/e2e/onboarding.spec.ts` — drop the SKIP_LLM PATCH that disabled the new agent's heartbeat + `wakeOnDemand` (which blocked all regression coverage of this exact handoff). Update the post-create poll from `runs.length === 0` (intentionally proving nothing was queued) to `runs.length >= 1` within 30s, which is the regression assertion the bug actually needs. The header comment is updated to reflect the new invariant.

## Verification

- `pnpm test:e2e tests/e2e/onboarding.spec.ts` — the SKIP_LLM path now exercises the real wake handoff and asserts a queued run exists. In CI without `ANTHROPIC_API_KEY` the queued run will fail-fast at the LLM call; that is fine — the assertion is run-existence, not run-success.
- Manual reproducer: in a clean instance, throttle the database or otherwise force the server's `queueIssueAssignmentWakeup` to throw. Before this change: wizard navigates to the issue and the agent never ticks. After this change: wizard shows "Task created but failed to start the agent: …" and the user can recover.

## Risks

- Low risk for the wizard change: the new code is one awaited call to an existing endpoint (`agentsApi.wakeup`) using already-used arguments and types. It only runs in the onboarding flow.
- Test risk: dropping the disable-wake PATCH means the SKIP_LLM run will now queue (and quickly fail) one heartbeat run per test invocation. This adds at most one no-op run to the DB per CI run, which matches the assertion intent.
- Out of scope and explicitly NOT done in this PR (companion server-side scope from the original EVE-120 / EVE-168 diagnosis):
  1. `server/src/routes/issues.ts:3588` — `await queueIssueAssignmentWakeup(...)` with `rethrowOnError: true` for the onboarding-create path. Risky because the same call site serves many non-onboarding creates; needs a new `onboarding=true` flag or a separate route to avoid changing blocking semantics elsewhere.
  2. `server/src/services/heartbeat.ts` — clear `executionRunId` in the rollback path when wake TX fails after stamping, and add a watchdog that nullifies orphaned `executionRunId` references. Many call sites, deserves a dedicated PR.
  These are intentionally deferred so this PR stays small, focused, and reviewable. The wizard-side fix alone closes the user-visible failure for onboarding without introducing those broader changes.

## Model Used

- Provider: Anthropic
- Model: `claude-opus-4-7` (Opus 4.7)
- Context window: 200K
- Capabilities used: extended reasoning, tool use, file editing