### PR TITLE
test(issues): regression test for 403 on missing tasks:assign in create-issue route

### DIFF
--- a/server/src/__tests__/issue-create-assign-permission-routes.test.ts
+++ b/server/src/__tests__/issue-create-assign-permission-routes.test.ts
@@ -1,0 +1,207 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const companyId = "22222222-2222-4222-8222-222222222222";
+const agentId = "11111111-1111-4111-8111-111111111111";
+const otherAgentId = "99999999-9999-4999-8999-999999999999";
+
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getByIdentifier: vi.fn(),
+  getById: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+  reportRunActivity: vi.fn(),
+  getRun: vi.fn(),
+  getActiveRunForAgent: vi.fn(),
+  cancelRun: vi.fn(),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(),
+  listCompanyIds: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+function registerRouteMocks() {
+  vi.doMock("@paperclipai/shared/telemetry", () => ({
+    trackAgentTaskCompleted: vi.fn(),
+    trackErrorHandlerCrash: vi.fn(),
+  }));
+
+  vi.doMock("../telemetry.js", () => ({
+    getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+  }));
+
+  vi.doMock("../services/access.js", () => ({
+    accessService: () => mockAccessService,
+  }));
+
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: mockLogActivity,
+  }));
+
+  vi.doMock("../services/agents.js", () => ({
+    agentService: () => mockAgentService,
+  }));
+
+  vi.doMock("../services/issues.js", () => ({
+    issueService: () => mockIssueService,
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: companyId, attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => mockInstanceSettingsService,
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueService: () => mockIssueService,
+    logActivity: mockLogActivity,
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function agentActor(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "agent",
+    agentId,
+    companyId,
+    source: "agent_key",
+    runId: "run-1",
+    ...overrides,
+  };
+}
+
+describe("issue create assign permission", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../services/access.js");
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/agents.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/issues.js");
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerRouteMocks();
+    vi.clearAllMocks();
+
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue({
+      id: agentId,
+      companyId,
+      role: "engineer",
+      permissions: { canCreateAgents: false },
+    });
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
+    mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockInstanceSettingsService.get.mockResolvedValue({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    });
+    mockInstanceSettingsService.listCompanyIds.mockResolvedValue([companyId]);
+    mockLogActivity.mockResolvedValue(undefined);
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+  });
+
+  it("returns 403 not 500 when agent lacks tasks:assign and self-assigns an issue", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Test issue", assigneeAgentId: agentId });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("tasks:assign");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 not 500 when agent lacks tasks:assign and assigns to another agent", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Test issue", assigneeAgentId: otherAgentId });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("tasks:assign");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 not 500 when agent lacks tasks:assign and assigns to a user", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Test issue", assigneeUserId: "user-1" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("tasks:assign");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Observed that `POST /api/companies/:companyId/issues` could return 500 instead of 403 when an agent lacks the `tasks:assign` permission.
- Root cause analysis confirmed the code path is correct: `assertCanAssignTasks()` throws `forbidden()` (an `HttpError`), Express 5 automatically propagates async errors to the error handler, and the error handler maps `HttpError` to its status code.
- No regression test existed for this path — this PR adds three test cases to pin the 403 behavior and prevent future regressions.

**Tests added (`server/src/__tests__/issue-create-assign-permission-routes.test.ts`):**
- Agent self-assigns an issue without `tasks:assign` → 403
- Agent assigns to another agent without `tasks:assign` → 403
- Agent assigns to a user without `tasks:assign` → 403

All three verify `issueService.create` is not called.

## Test plan
- [x] `vitest run src/__tests__/issue-create-assign-permission-routes.test.ts` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)