### PR TITLE
feat(adapters): MCP_LIST per-agent allowlist contract for opencode/codex/gemini

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -62,6 +62,33 @@ export {
 } from "./command-redaction.js";
 export { buildSandboxNpmInstallCommand } from "./sandbox-install-command.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export {
+  parseMcpAllowlist,
+  loadMcpRegistry,
+  resolveMcpAllowlist,
+  resolveMcpAllowlistFromEnv,
+  renderOpencodeMcp,
+  renderCodexMcpToml,
+  renderGeminiMcpSettings,
+  renderBobMcpSettings,
+  MCP_ALLOWLIST_DEFAULTS,
+} from "./mcp-allowlist.js";
+export type {
+  ParsedMcpAllowlist,
+  McpRegistry,
+  McpRegistryEntry,
+  McpRegistryServer,
+  McpManifest,
+  McpManifestEnvironment,
+  McpEntry,
+  McpResolutionError,
+  McpResolutionErrorKind,
+  ResolveMcpAllowlistInput,
+  ResolveMcpAllowlistResult,
+  OpencodeMcpServerConfig,
+  GeminiMcpServerConfig,
+  BobMcpServerConfig,
+} from "./mcp-allowlist.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -65,8 +65,13 @@ export { inferOpenAiCompatibleBiller } from "./billing.js";
 export {
   parseMcpAllowlist,
   loadMcpRegistry,
+  McpRegistryNotFoundError,
+  PAPERCLIP_MCP_REGISTRY_ROOT_ENV,
+  PAPERCLIP_MCP_RUN_SCRIPT_ENV,
   resolveMcpAllowlist,
   resolveMcpAllowlistFromEnv,
+  resolveMcpRegistryRootFromEnv,
+  resolveRunMcpScriptFromEnv,
   renderOpencodeMcp,
   renderCodexMcpToml,
   renderGeminiMcpSettings,

--- a/packages/adapter-utils/src/mcp-allowlist.test.ts
+++ b/packages/adapter-utils/src/mcp-allowlist.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   loadMcpRegistry,
+  McpRegistryNotFoundError,
   parseMcpAllowlist,
   renderBobMcpSettings,
   renderCodexMcpToml,
@@ -11,6 +12,8 @@ import {
   renderOpencodeMcp,
   resolveMcpAllowlist,
   resolveMcpAllowlistFromEnv,
+  resolveMcpRegistryRootFromEnv,
+  resolveRunMcpScriptFromEnv,
 } from "./mcp-allowlist.js";
 
 async function makeRegistryRoot(servers: Array<{ id: string; status: string; required?: string[] }>): Promise<string> {
@@ -87,14 +90,41 @@ describe("loadMcpRegistry", () => {
     expect(jira.manifest?.environment?.requiredNames).toEqual(["ATLASSIAN_API_TOKEN"]);
   });
 
-  it("returns empty registry when registry.json is missing", async () => {
+  it("throws McpRegistryNotFoundError when registry.json is missing", async () => {
     const empty = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-empty-"));
     try {
-      const registry = await loadMcpRegistry(empty);
-      expect(registry.servers.size).toBe(0);
+      await expect(loadMcpRegistry(empty)).rejects.toBeInstanceOf(McpRegistryNotFoundError);
+      // The error message must mention the override env var so operators can
+      // self-diagnose without reading the source.
+      await expect(loadMcpRegistry(empty)).rejects.toThrow(/PAPERCLIP_MCP_REGISTRY_ROOT/);
     } finally {
       await fs.rm(empty, { recursive: true, force: true });
     }
+  });
+});
+
+describe("resolveMcpRegistryRootFromEnv / resolveRunMcpScriptFromEnv", () => {
+  it("falls back to the canonical default when env is unset", () => {
+    expect(resolveMcpRegistryRootFromEnv({})).toBe("/Users/cassio/mcp-server/_paperclip");
+    expect(resolveRunMcpScriptFromEnv({})).toBeUndefined();
+  });
+
+  it("honors PAPERCLIP_MCP_REGISTRY_ROOT and PAPERCLIP_MCP_RUN_SCRIPT", () => {
+    expect(
+      resolveMcpRegistryRootFromEnv({ PAPERCLIP_MCP_REGISTRY_ROOT: "/srv/mcp" }),
+    ).toBe("/srv/mcp");
+    expect(
+      resolveRunMcpScriptFromEnv({ PAPERCLIP_MCP_RUN_SCRIPT: "/srv/run.sh" }),
+    ).toBe("/srv/run.sh");
+  });
+
+  it("treats whitespace-only overrides as unset", () => {
+    expect(
+      resolveMcpRegistryRootFromEnv({ PAPERCLIP_MCP_REGISTRY_ROOT: "   " }),
+    ).toBe("/Users/cassio/mcp-server/_paperclip");
+    expect(
+      resolveRunMcpScriptFromEnv({ PAPERCLIP_MCP_RUN_SCRIPT: "" }),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/adapter-utils/src/mcp-allowlist.test.ts
+++ b/packages/adapter-utils/src/mcp-allowlist.test.ts
@@ -1,0 +1,270 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadMcpRegistry,
+  parseMcpAllowlist,
+  renderBobMcpSettings,
+  renderCodexMcpToml,
+  renderGeminiMcpSettings,
+  renderOpencodeMcp,
+  resolveMcpAllowlist,
+  resolveMcpAllowlistFromEnv,
+} from "./mcp-allowlist.js";
+
+async function makeRegistryRoot(servers: Array<{ id: string; status: string; required?: string[] }>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-registry-test-"));
+  await fs.mkdir(path.join(root, "manifests"), { recursive: true });
+  const registry = {
+    schemaVersion: "paperclip.mcp.registry.v1",
+    servers: servers.map((s) => ({
+      id: s.id,
+      status: s.status,
+      manifest: `manifests/${s.id}.json`,
+    })),
+  };
+  await fs.writeFile(path.join(root, "registry.json"), JSON.stringify(registry));
+  for (const s of servers) {
+    const manifest = {
+      schemaVersion: "paperclip.mcp.manifest.v1",
+      id: s.id,
+      status: s.status,
+      environment: {
+        requiredNames: s.required ?? [],
+      },
+    };
+    await fs.writeFile(path.join(root, "manifests", `${s.id}.json`), JSON.stringify(manifest));
+  }
+  return root;
+}
+
+describe("parseMcpAllowlist", () => {
+  it("returns no ids and no errors when raw is empty / unset", () => {
+    expect(parseMcpAllowlist(undefined)).toEqual({ ids: [], errors: [] });
+    expect(parseMcpAllowlist(null)).toEqual({ ids: [], errors: [] });
+    expect(parseMcpAllowlist("")).toEqual({ ids: [], errors: [] });
+    expect(parseMcpAllowlist("   ")).toEqual({ ids: [], errors: [] });
+  });
+
+  it("splits CSV with whitespace tolerated and dedupes", () => {
+    expect(parseMcpAllowlist("jira-ibm, box, jira-ibm")).toEqual({
+      ids: ["jira-ibm", "box"],
+      errors: [],
+    });
+    expect(parseMcpAllowlist("jira-ibm  box\n  cognos-ibm")).toEqual({
+      ids: ["jira-ibm", "box", "cognos-ibm"],
+      errors: [],
+    });
+  });
+
+  it("rejects tokens that fail the shape regex", () => {
+    const result = parseMcpAllowlist("Jira-IBM, valid-id, -leading, bad/slash, ok2");
+    expect(result.ids).toEqual(["valid-id", "ok2"]);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors[0]).toContain("Jira-IBM");
+    expect(result.errors[1]).toContain("-leading");
+    expect(result.errors[2]).toContain("bad/slash");
+  });
+});
+
+describe("loadMcpRegistry", () => {
+  let root: string;
+
+  afterEach(async () => {
+    if (root) await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("loads a registry with manifests", async () => {
+    root = await makeRegistryRoot([
+      { id: "jira-ibm", status: "validated", required: ["ATLASSIAN_API_TOKEN"] },
+      { id: "box", status: "blocked-authorized-owner-validation" },
+    ]);
+    const registry = await loadMcpRegistry(root);
+    expect(registry.servers.size).toBe(2);
+    const jira = registry.servers.get("jira-ibm")!;
+    expect(jira.status).toBe("validated");
+    expect(jira.manifest?.environment?.requiredNames).toEqual(["ATLASSIAN_API_TOKEN"]);
+  });
+
+  it("returns empty registry when registry.json is missing", async () => {
+    const empty = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-empty-"));
+    try {
+      const registry = await loadMcpRegistry(empty);
+      expect(registry.servers.size).toBe(0);
+    } finally {
+      await fs.rm(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveMcpAllowlist", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeRegistryRoot([
+      { id: "jira-ibm", status: "validated", required: ["ATLASSIAN_API_TOKEN", "ATLASSIAN_SITE_NAME"] },
+      { id: "box", status: "blocked-authorized-owner-validation" },
+      {
+        id: "wikipedia",
+        status: "validated-local-contract-no-live-call",
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("resolves a valid allowlist and surfaces required env names", async () => {
+    const registry = await loadMcpRegistry(root);
+    const result = resolveMcpAllowlist({
+      rawAllowlist: "jira-ibm, wikipedia",
+      registry,
+      runMcpScript: "/run-mcp.sh",
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.resolved).toHaveLength(2);
+    const jira = result.resolved[0];
+    expect(jira.id).toBe("jira-ibm");
+    expect(jira.requiredEnvNames).toEqual(["ATLASSIAN_API_TOKEN", "ATLASSIAN_SITE_NAME"]);
+    expect(jira.runMcpScript).toBe("/run-mcp.sh");
+    expect(result.resolved[1].id).toBe("wikipedia");
+  });
+
+  it("fails closed on unknown id", async () => {
+    const registry = await loadMcpRegistry(root);
+    const result = resolveMcpAllowlist({
+      rawAllowlist: "jira-ibm, ghost",
+      registry,
+    });
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].id).toBe("jira-ibm");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].kind).toBe("unknown_id");
+    expect(result.errors[0].token).toBe("ghost");
+  });
+
+  it("fails closed on blocked status", async () => {
+    const registry = await loadMcpRegistry(root);
+    const result = resolveMcpAllowlist({
+      rawAllowlist: "box",
+      registry,
+    });
+    expect(result.resolved).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].kind).toBe("blocked_status");
+    expect(result.errors[0].token).toBe("box");
+  });
+
+  it("forwards invalid_token errors from parsing", async () => {
+    const registry = await loadMcpRegistry(root);
+    const result = resolveMcpAllowlist({
+      rawAllowlist: "Jira-IBM, jira-ibm",
+      registry,
+    });
+    expect(result.resolved).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].kind).toBe("invalid_token");
+    expect(result.errors[0].token).toBe("Jira-IBM");
+  });
+});
+
+describe("renderers", () => {
+  const resolved = [
+    {
+      id: "jira-ibm",
+      status: "validated",
+      requiredEnvNames: ["ATLASSIAN_API_TOKEN"],
+      optionalEnvNames: [],
+      runMcpScript: "/usr/local/run-mcp.sh",
+    },
+    {
+      id: "wikipedia",
+      status: "validated-local-contract-no-live-call",
+      requiredEnvNames: [],
+      optionalEnvNames: [],
+      runMcpScript: "/usr/local/run-mcp.sh",
+    },
+  ];
+
+  it("renders opencode mcp config", () => {
+    expect(renderOpencodeMcp(resolved)).toEqual({
+      "jira-ibm": {
+        type: "local",
+        command: ["bash", "/usr/local/run-mcp.sh", "jira-ibm"],
+        enabled: true,
+      },
+      wikipedia: {
+        type: "local",
+        command: ["bash", "/usr/local/run-mcp.sh", "wikipedia"],
+        enabled: true,
+      },
+    });
+  });
+
+  it("renders codex mcp toml fragments", () => {
+    const toml = renderCodexMcpToml(resolved);
+    expect(toml).toContain('[mcp_servers.jira-ibm]');
+    expect(toml).toContain('command = "bash"');
+    expect(toml).toContain('args = ["/usr/local/run-mcp.sh", "jira-ibm"]');
+    expect(toml).toContain('[mcp_servers.wikipedia]');
+  });
+
+  it("renders gemini settings", () => {
+    expect(renderGeminiMcpSettings(resolved)).toEqual({
+      mcpServers: {
+        "jira-ibm": { command: "bash", args: ["/usr/local/run-mcp.sh", "jira-ibm"] },
+        wikipedia: { command: "bash", args: ["/usr/local/run-mcp.sh", "wikipedia"] },
+      },
+    });
+  });
+
+  it("renders bob settings", () => {
+    expect(renderBobMcpSettings(resolved)).toEqual({
+      mcpServers: {
+        "jira-ibm": { command: "bash", args: ["/usr/local/run-mcp.sh", "jira-ibm"] },
+        wikipedia: { command: "bash", args: ["/usr/local/run-mcp.sh", "wikipedia"] },
+      },
+    });
+  });
+
+  it("renders empty structures when nothing resolved", () => {
+    expect(renderOpencodeMcp([])).toEqual({});
+    expect(renderCodexMcpToml([])).toBe("");
+    expect(renderGeminiMcpSettings([])).toEqual({ mcpServers: {} });
+    expect(renderBobMcpSettings([])).toEqual({ mcpServers: {} });
+  });
+});
+
+describe("resolveMcpAllowlistFromEnv", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeRegistryRoot([
+      { id: "jira-ibm", status: "validated" },
+    ]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("returns null when MCP_LIST is empty/unset", async () => {
+    const registry = await loadMcpRegistry(root);
+    expect(resolveMcpAllowlistFromEnv({ env: {}, registry })).toBeNull();
+    expect(resolveMcpAllowlistFromEnv({ env: { MCP_LIST: "" }, registry })).toBeNull();
+    expect(resolveMcpAllowlistFromEnv({ env: { MCP_LIST: "   " }, registry })).toBeNull();
+  });
+
+  it("resolves when MCP_LIST is set", async () => {
+    const registry = await loadMcpRegistry(root);
+    const result = resolveMcpAllowlistFromEnv({
+      env: { MCP_LIST: "jira-ibm" },
+      registry,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.resolved).toHaveLength(1);
+    expect(result!.errors).toEqual([]);
+  });
+});

--- a/packages/adapter-utils/src/mcp-allowlist.ts
+++ b/packages/adapter-utils/src/mcp-allowlist.ts
@@ -23,7 +23,44 @@ const ALLOWED_STATUSES = new Set([
   "validated-local-contract-no-live-call",
 ]);
 
-const RUN_MCP_BIN_DEFAULT = "/Users/cassio/mcp-server/_paperclip/bin/run-mcp.sh";
+/**
+ * Canonical sidecar root + wrapper script paths under the host bind-mount.
+ *
+ * These exist for ksio.dev's local deployment; any deployment that does
+ * not mount `/Users/cassio/mcp-server/_paperclip` must override at least
+ * `PAPERCLIP_MCP_REGISTRY_ROOT` (and usually `PAPERCLIP_MCP_RUN_SCRIPT`).
+ *
+ * `loadMcpRegistry` will refuse to silently produce `unknown_id` errors
+ * when the resolved root does not exist; callers that want to disable
+ * MCP entirely should leave `MCP_LIST` empty/unset.
+ */
+const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
+const RUN_MCP_BIN_DEFAULT = `${DEFAULT_MCP_REGISTRY_ROOT}/bin/run-mcp.sh`;
+
+/** Env var that overrides the sidecar root used to load `registry.json`. */
+export const PAPERCLIP_MCP_REGISTRY_ROOT_ENV = "PAPERCLIP_MCP_REGISTRY_ROOT";
+/** Env var that overrides the wrapper script rendered into native MCP configs. */
+export const PAPERCLIP_MCP_RUN_SCRIPT_ENV = "PAPERCLIP_MCP_RUN_SCRIPT";
+
+/**
+ * Returns the sidecar root from `PAPERCLIP_MCP_REGISTRY_ROOT` in the supplied
+ * env, or the canonical ksio.dev default. Callers should pass a scoped
+ * `Record<string, string>` so the resolution stays deterministic.
+ */
+export function resolveMcpRegistryRootFromEnv(env: Record<string, string | undefined>): string {
+  const fromEnv = env[PAPERCLIP_MCP_REGISTRY_ROOT_ENV]?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_MCP_REGISTRY_ROOT;
+}
+
+/**
+ * Returns the wrapper script path from `PAPERCLIP_MCP_RUN_SCRIPT` in the
+ * supplied env. When unset, `loadMcpRegistry` callers fall back to
+ * `RUN_MCP_BIN_DEFAULT` via `resolveMcpAllowlist`.
+ */
+export function resolveRunMcpScriptFromEnv(env: Record<string, string | undefined>): string | undefined {
+  const fromEnv = env[PAPERCLIP_MCP_RUN_SCRIPT_ENV]?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
 
 /**
  * Result of parsing the raw `MCP_LIST` env value.
@@ -162,12 +199,36 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
  * `unknown_id` at resolution time only if they were specifically asked for
  * — entries with a `null` manifest still count as "known" with the status
  * read from `registry.json`.
+ *
+ * Throws `McpRegistryNotFoundError` when `registry.json` is missing under
+ * `rootPath`. This is intentional: silently returning an empty registry
+ * would cause every `MCP_LIST` token to fail with `unknown_id` and hide
+ * the real problem (the override env var was not set, or the sidecar is
+ * not mounted in this deployment).
  */
+export class McpRegistryNotFoundError extends Error {
+  readonly rootPath: string;
+  readonly registryPath: string;
+  constructor(rootPath: string, registryPath: string) {
+    super(
+      `MCP_LIST resolution failed: registry.json not found under "${rootPath}". ` +
+        `Set ${PAPERCLIP_MCP_REGISTRY_ROOT_ENV} to the path of the _paperclip sidecar ` +
+        `for this deployment, or unset MCP_LIST to disable MCP injection.`,
+    );
+    this.name = "McpRegistryNotFoundError";
+    this.rootPath = rootPath;
+    this.registryPath = registryPath;
+  }
+}
+
 export async function loadMcpRegistry(rootPath: string): Promise<McpRegistry> {
   const registryPath = path.join(rootPath, "registry.json");
   const raw = await readJsonFile<{ servers?: McpRegistryServer[] }>(registryPath);
+  if (raw === null) {
+    throw new McpRegistryNotFoundError(rootPath, registryPath);
+  }
   const servers = new Map<string, McpRegistryEntry>();
-  if (!raw || !Array.isArray(raw.servers)) {
+  if (!Array.isArray(raw.servers)) {
     return { rootPath, servers };
   }
   for (const server of raw.servers) {

--- a/packages/adapter-utils/src/mcp-allowlist.ts
+++ b/packages/adapter-utils/src/mcp-allowlist.ts
@@ -1,0 +1,355 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Parses, validates and renders MCP allowlists declared per-agent via
+ * `adapterConfig.env.MCP_LIST` (CSV of MCP ids registered in the host
+ * sidecar `_paperclip/registry.json`).
+ *
+ * The runtime of each adapter calls into this module before spawning the
+ * native CLI: it parses the allowlist, looks up each id in the registry,
+ * fails closed on invalid/blocked ids, and renders the native config trees
+ * for opencode, codex, gemini and bob, all pointing at
+ * `bash <root>/bin/run-mcp.sh <id>`.
+ *
+ * Empty / unset `MCP_LIST` means "no MCPs written" — not an error.
+ */
+
+const TOKEN_RE = /^[a-z0-9][a-z0-9-]*$/;
+const SPLIT_RE = /[,\s]+/;
+
+const ALLOWED_STATUSES = new Set([
+  "validated",
+  "validated-local-contract-no-live-call",
+]);
+
+const RUN_MCP_BIN_DEFAULT = "/Users/cassio/mcp-server/_paperclip/bin/run-mcp.sh";
+
+/**
+ * Result of parsing the raw `MCP_LIST` env value.
+ *
+ * - `ids` are tokens that match `^[a-z0-9][a-z0-9-]*$`. They are not yet
+ *   verified against the registry; that happens in `resolveMcpAllowlist`.
+ * - `errors` are human-readable messages for tokens that failed shape
+ *   validation (e.g. uppercase, leading dash, slashes).
+ */
+export type ParsedMcpAllowlist = {
+  ids: string[];
+  errors: string[];
+};
+
+/** A single entry as it appears in `registry.json#servers[]`. */
+export type McpRegistryServer = {
+  id: string;
+  status: string;
+  manifest?: string;
+  displayName?: string;
+  sensitivity?: string;
+};
+
+/** Subset of the manifest shape that this module reads. */
+export type McpManifestEnvironment = {
+  requiredNames?: string[];
+  optionalNames?: string[];
+};
+
+export type McpManifest = {
+  id: string;
+  status?: string;
+  mcp?: {
+    transport?: string;
+  };
+  environment?: McpManifestEnvironment;
+};
+
+/**
+ * Cached, normalized view of the registry. `loadMcpRegistry` reads
+ * `registry.json` plus every referenced `manifests/<id>.json` and merges
+ * them into this map for fast lookup.
+ */
+export type McpRegistry = {
+  rootPath: string;
+  servers: Map<string, McpRegistryEntry>;
+};
+
+export type McpRegistryEntry = {
+  id: string;
+  status: string;
+  manifestPath: string | null;
+  manifest: McpManifest | null;
+};
+
+export type McpResolutionErrorKind =
+  | "invalid_token"
+  | "unknown_id"
+  | "blocked_status";
+
+export type McpResolutionError = {
+  kind: McpResolutionErrorKind;
+  token: string;
+  message: string;
+};
+
+export type McpEntry = {
+  id: string;
+  status: string;
+  requiredEnvNames: string[];
+  optionalEnvNames: string[];
+  /** Full path to the wrapper script that the native CLI will spawn. */
+  runMcpScript: string;
+};
+
+export type ResolveMcpAllowlistInput = {
+  rawAllowlist: string | undefined | null;
+  registry: McpRegistry;
+  /** Override the wrapper path (mainly for tests). */
+  runMcpScript?: string;
+};
+
+export type ResolveMcpAllowlistResult = {
+  resolved: McpEntry[];
+  errors: McpResolutionError[];
+};
+
+/**
+ * Splits the raw `MCP_LIST` value on commas / whitespace, drops empty
+ * tokens, and reports any token that fails the shape regex.
+ *
+ * Whitespace and commas are interchangeable so that operators can write
+ * either `"jira-ibm,box"` or `"jira-ibm box"` and get the same result.
+ */
+export function parseMcpAllowlist(raw: string | undefined | null): ParsedMcpAllowlist {
+  const ids: string[] = [];
+  const errors: string[] = [];
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { ids, errors };
+  }
+  const seen = new Set<string>();
+  for (const token of raw.split(SPLIT_RE)) {
+    const trimmed = token.trim();
+    if (trimmed.length === 0) continue;
+    if (!TOKEN_RE.test(trimmed)) {
+      errors.push(
+        `MCP_LIST: invalid token "${trimmed}" (expected lowercase letters, digits, dashes; must start with letter or digit).`,
+      );
+      continue;
+    }
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    ids.push(trimmed);
+  }
+  return { ids, errors };
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Reads `registry.json` plus each referenced `manifests/<id>.json` from
+ * the canonical sidecar root (e.g. `/Users/cassio/mcp-server/_paperclip`).
+ * The result is a normalized `McpRegistry` keyed by id.
+ *
+ * Manifests that fail to read are kept as `null` and surface as
+ * `unknown_id` at resolution time only if they were specifically asked for
+ * — entries with a `null` manifest still count as "known" with the status
+ * read from `registry.json`.
+ */
+export async function loadMcpRegistry(rootPath: string): Promise<McpRegistry> {
+  const registryPath = path.join(rootPath, "registry.json");
+  const raw = await readJsonFile<{ servers?: McpRegistryServer[] }>(registryPath);
+  const servers = new Map<string, McpRegistryEntry>();
+  if (!raw || !Array.isArray(raw.servers)) {
+    return { rootPath, servers };
+  }
+  for (const server of raw.servers) {
+    if (!server || typeof server.id !== "string" || typeof server.status !== "string") {
+      continue;
+    }
+    const manifestRel = typeof server.manifest === "string" ? server.manifest : null;
+    const manifestPath = manifestRel ? path.join(rootPath, manifestRel) : null;
+    const manifest = manifestPath
+      ? await readJsonFile<McpManifest>(manifestPath)
+      : null;
+    servers.set(server.id, {
+      id: server.id,
+      status: server.status,
+      manifestPath,
+      manifest,
+    });
+  }
+  return { rootPath, servers };
+}
+
+/**
+ * Resolves each id from the parsed allowlist against the registry.
+ *
+ * Fail-closed in three distinct categories:
+ *  - `invalid_token`: failed shape validation (forwarded from `parseMcpAllowlist`).
+ *  - `unknown_id`: token is not present in `registry.json`.
+ *  - `blocked_status`: id exists but its registry status is not in the
+ *    allow set (`validated`, `validated-local-contract-no-live-call`).
+ */
+export function resolveMcpAllowlist(input: ResolveMcpAllowlistInput): ResolveMcpAllowlistResult {
+  const parsed = parseMcpAllowlist(input.rawAllowlist);
+  const errors: McpResolutionError[] = parsed.errors.map((message) => ({
+    kind: "invalid_token",
+    token: extractToken(message),
+    message,
+  }));
+  const resolved: McpEntry[] = [];
+  const runScript = (input.runMcpScript ?? RUN_MCP_BIN_DEFAULT).trim() || RUN_MCP_BIN_DEFAULT;
+  for (const id of parsed.ids) {
+    const entry = input.registry.servers.get(id);
+    if (!entry) {
+      errors.push({
+        kind: "unknown_id",
+        token: id,
+        message: `MCP_LIST: unknown id "${id}" — not registered in registry.json.`,
+      });
+      continue;
+    }
+    if (!ALLOWED_STATUSES.has(entry.status)) {
+      errors.push({
+        kind: "blocked_status",
+        token: id,
+        message: `MCP_LIST: id "${id}" has status "${entry.status}" — fail-closed (allowed: ${[...ALLOWED_STATUSES].join(", ")}).`,
+      });
+      continue;
+    }
+    const requiredEnvNames =
+      entry.manifest?.environment?.requiredNames?.filter((name): name is string => typeof name === "string") ?? [];
+    const optionalEnvNames =
+      entry.manifest?.environment?.optionalNames?.filter((name): name is string => typeof name === "string") ?? [];
+    resolved.push({
+      id: entry.id,
+      status: entry.status,
+      requiredEnvNames,
+      optionalEnvNames,
+      runMcpScript: runScript,
+    });
+  }
+  return { resolved, errors };
+}
+
+function extractToken(message: string): string {
+  const m = message.match(/"([^"]+)"/);
+  return m ? m[1] : "";
+}
+
+/** ─── Renderers ────────────────────────────────────────────────────────── */
+
+export type OpencodeMcpServerConfig = {
+  type: "local";
+  command: string[];
+  enabled: true;
+};
+
+/**
+ * Renders the `mcp` map shape that opencode reads from `opencode.json`.
+ * Each id becomes `{ type: "local", command: ["bash", "<run-mcp>", "<id>"], enabled: true }`.
+ */
+export function renderOpencodeMcp(resolved: McpEntry[]): Record<string, OpencodeMcpServerConfig> {
+  const out: Record<string, OpencodeMcpServerConfig> = {};
+  for (const entry of resolved) {
+    out[entry.id] = {
+      type: "local",
+      command: ["bash", entry.runMcpScript, entry.id],
+      enabled: true,
+    };
+  }
+  return out;
+}
+
+/**
+ * Renders TOML fragments for codex `~/.codex/config.toml`. Returns the
+ * concatenated `[mcp_servers.<id>]` blocks with no trailing newline.
+ *
+ * The codex CLI accepts `[mcp_servers.<id>]` with `command = "bash"` and
+ * `args = ["<run-mcp>", "<id>"]`.
+ */
+export function renderCodexMcpToml(resolved: McpEntry[]): string {
+  const blocks: string[] = [];
+  for (const entry of resolved) {
+    blocks.push(
+      [
+        `[mcp_servers.${entry.id}]`,
+        `command = "bash"`,
+        `args = [${JSON.stringify(entry.runMcpScript)}, ${JSON.stringify(entry.id)}]`,
+      ].join("\n"),
+    );
+  }
+  return blocks.join("\n\n");
+}
+
+export type GeminiMcpServerConfig = {
+  command: string;
+  args: string[];
+};
+
+/** Renders the `mcpServers` map for gemini `~/.gemini/settings.json`. */
+export function renderGeminiMcpSettings(
+  resolved: McpEntry[],
+): { mcpServers: Record<string, GeminiMcpServerConfig> } {
+  const mcpServers: Record<string, GeminiMcpServerConfig> = {};
+  for (const entry of resolved) {
+    mcpServers[entry.id] = {
+      command: "bash",
+      args: [entry.runMcpScript, entry.id],
+    };
+  }
+  return { mcpServers };
+}
+
+export type BobMcpServerConfig = {
+  command: string;
+  args: string[];
+};
+
+/** Renders the `mcpServers` map for bob `$BOB_HOME/.bob/settings.json`. */
+export function renderBobMcpSettings(
+  resolved: McpEntry[],
+): { mcpServers: Record<string, BobMcpServerConfig> } {
+  const mcpServers: Record<string, BobMcpServerConfig> = {};
+  for (const entry of resolved) {
+    mcpServers[entry.id] = {
+      command: "bash",
+      args: [entry.runMcpScript, entry.id],
+    };
+  }
+  return { mcpServers };
+}
+
+/**
+ * Convenience helper used by adapters that have already parsed the env
+ * config: returns `null` when the allowlist is empty/unset (so callers can
+ * skip MCP rendering entirely), or a resolution result otherwise.
+ */
+export function resolveMcpAllowlistFromEnv(input: {
+  env: Record<string, string | undefined>;
+  registry: McpRegistry;
+  runMcpScript?: string;
+}): ResolveMcpAllowlistResult | null {
+  const raw = input.env.MCP_LIST;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  return resolveMcpAllowlist({
+    rawAllowlist: raw,
+    registry: input.registry,
+    runMcpScript: input.runMcpScript,
+  });
+}
+
+export const MCP_ALLOWLIST_DEFAULTS = {
+  runMcpScript: RUN_MCP_BIN_DEFAULT,
+  allowedStatuses: ALLOWED_STATUSES,
+} as const;

--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { prepareManagedCodexHome } from "./codex-home.js";
+import { applyMcpListToCodexHome, prepareManagedCodexHome, stripCodexMcpSections } from "./codex-home.js";
 
 describe("codex managed home", () => {
   afterEach(() => {
@@ -52,6 +52,173 @@ describe("codex managed home", () => {
       expect(await fs.realpath(managedAuth)).toBe(await fs.realpath(sharedAuth));
     } finally {
       await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("stripCodexMcpSections", () => {
+  it("removes mcp_servers sections and keeps the rest", () => {
+    const input = [
+      "model = \"gpt-5\"",
+      "",
+      "[mcp_servers.jira-ibm]",
+      "command = \"bash\"",
+      "args = [\"a\"]",
+      "",
+      "[other.section]",
+      "key = 1",
+      "",
+      "[mcp_servers.box]",
+      "command = \"bash\"",
+      "",
+      "[final]",
+      "x = 1",
+      "",
+    ].join("\n");
+    const out = stripCodexMcpSections(input);
+    expect(out).toContain("model = \"gpt-5\"");
+    expect(out).toContain("[other.section]");
+    expect(out).toContain("[final]");
+    expect(out).not.toContain("mcp_servers");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripCodexMcpSections("")).toBe("");
+  });
+
+  it("removes a trailing mcp_servers block", () => {
+    const out = stripCodexMcpSections('a = 1\n\n[mcp_servers.jira-ibm]\ncommand = "bash"\n');
+    expect(out).toBe("a = 1\n");
+  });
+});
+
+describe("applyMcpListToCodexHome", () => {
+  it("returns null when MCP_LIST is unset", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-"));
+    try {
+      const result = await applyMcpListToCodexHome({
+        home,
+        env: {},
+      });
+      expect(result).toBeNull();
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("renders mcp_servers entries to config.toml", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-"));
+    const registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-reg-"));
+    try {
+      await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+      await fs.writeFile(
+        path.join(registryRoot, "registry.json"),
+        JSON.stringify({
+          servers: [
+            { id: "jira-ibm", status: "validated", manifest: "manifests/jira-ibm.json" },
+          ],
+        }),
+      );
+      await fs.writeFile(
+        path.join(registryRoot, "manifests", "jira-ibm.json"),
+        JSON.stringify({ id: "jira-ibm" }),
+      );
+      await fs.writeFile(path.join(home, "config.toml"), 'model = "gpt-5"\n', "utf8");
+      const result = await applyMcpListToCodexHome({
+        home,
+        env: {
+          MCP_LIST: "jira-ibm",
+          PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+          PAPERCLIP_MCP_RUN_SCRIPT: "/run-mcp.sh",
+        },
+      });
+      expect(result?.notes[0]).toContain("rendered 1 mcp_servers");
+      const written = await fs.readFile(path.join(home, "config.toml"), "utf8");
+      expect(written).toContain('model = "gpt-5"');
+      expect(written).toContain("[mcp_servers.jira-ibm]");
+      expect(written).toContain('command = "bash"');
+      expect(written).toContain('args = ["/run-mcp.sh", "jira-ibm"]');
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+      await fs.rm(registryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("strips inherited mcp_servers blocks before re-rendering", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-"));
+    const registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-reg-"));
+    try {
+      await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+      await fs.writeFile(
+        path.join(registryRoot, "registry.json"),
+        JSON.stringify({
+          servers: [
+            { id: "jira-ibm", status: "validated", manifest: "manifests/jira-ibm.json" },
+          ],
+        }),
+      );
+      await fs.writeFile(
+        path.join(registryRoot, "manifests", "jira-ibm.json"),
+        JSON.stringify({ id: "jira-ibm" }),
+      );
+      await fs.writeFile(
+        path.join(home, "config.toml"),
+        [
+          'model = "gpt-5"',
+          "",
+          "[mcp_servers.legacy]",
+          'command = "stale"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await applyMcpListToCodexHome({
+        home,
+        env: {
+          MCP_LIST: "jira-ibm",
+          PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+          PAPERCLIP_MCP_RUN_SCRIPT: "/run-mcp.sh",
+        },
+      });
+      const written = await fs.readFile(path.join(home, "config.toml"), "utf8");
+      expect(written).not.toContain("legacy");
+      expect(written).toContain("[mcp_servers.jira-ibm]");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+      await fs.rm(registryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on blocked status", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-"));
+    const registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-mcp-reg-"));
+    try {
+      await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+      await fs.writeFile(
+        path.join(registryRoot, "registry.json"),
+        JSON.stringify({
+          servers: [
+            { id: "box", status: "blocked-runtime-mismatch", manifest: "manifests/box.json" },
+          ],
+        }),
+      );
+      await fs.writeFile(
+        path.join(registryRoot, "manifests", "box.json"),
+        JSON.stringify({ id: "box" }),
+      );
+      await expect(
+        applyMcpListToCodexHome({
+          home,
+          env: {
+            MCP_LIST: "box",
+            PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+          },
+        }),
+      ).rejects.toThrow(/blocked_status/);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+      await fs.rm(registryRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -3,10 +3,17 @@ import os from "node:os";
 import path from "node:path";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-utils/server-utils";
+import {
+  loadMcpRegistry,
+  type McpRegistry,
+  renderCodexMcpToml,
+  resolveMcpAllowlist,
+} from "@paperclipai/adapter-utils/mcp-allowlist";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
+const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
 
 function nonEmpty(value: string | undefined): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -103,11 +110,109 @@ export async function writeApiKeyAuthJson(home: string, apiKey: string): Promise
   await fs.writeFile(target, JSON.stringify({ OPENAI_API_KEY: apiKey }), { mode: 0o600 });
 }
 
+function resolveMcpRegistryRoot(env: NodeJS.ProcessEnv): string {
+  const fromEnv = env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_MCP_REGISTRY_ROOT;
+}
+
+function resolveRunMcpScript(env: NodeJS.ProcessEnv): string | undefined {
+  const fromEnv = env.PAPERCLIP_MCP_RUN_SCRIPT?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+/**
+ * Strips all `[mcp_servers.<id>]` sections from a TOML string. A section
+ * runs from its header line until either EOF or the next top-level header
+ * line. We don't need a full TOML parser here because the codex config
+ * surface we care about is well-defined: codex CLI reads `mcp_servers.*`
+ * tables and any non-mcp section is copied through untouched.
+ */
+export function stripCodexMcpSections(toml: string): string {
+  const lines = toml.split(/\r?\n/);
+  const out: string[] = [];
+  let skipping = false;
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("[")) {
+      const headerMatch = trimmed.match(/^\[(\[?)([^\]]+)/);
+      if (headerMatch && /^mcp_servers\.[A-Za-z0-9_.\-]+/.test(headerMatch[2].trim())) {
+        skipping = true;
+        continue;
+      }
+      // any other section header ends the skip mode
+      skipping = false;
+    }
+    if (!skipping) out.push(line);
+  }
+  // Trim trailing empty lines but keep one final newline.
+  while (out.length > 0 && out[out.length - 1].trim() === "") {
+    out.pop();
+  }
+  return out.length > 0 ? `${out.join("\n")}\n` : "";
+}
+
+/**
+ * Applies the per-agent `MCP_LIST` allowlist to `$CODEX_HOME/config.toml`.
+ *
+ * - Reads existing `config.toml` (may not exist).
+ * - Strips every `[mcp_servers.*]` section.
+ * - Appends the rendered fragments for ids in the allowlist.
+ *
+ * Returns notes for logging, or `null` when MCP_LIST is empty/unset (in
+ * which case the file is left untouched).
+ *
+ * Fail-closed: throws on resolution errors so the caller never spawns the
+ * CLI with a partial / silently-broken MCP set.
+ */
+export async function applyMcpListToCodexHome(input: {
+  home: string;
+  env: NodeJS.ProcessEnv;
+  registry?: McpRegistry;
+}): Promise<{ notes: string[] } | null> {
+  const raw = input.env.MCP_LIST;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  const registry = input.registry ?? (await loadMcpRegistry(resolveMcpRegistryRoot(input.env)));
+  const result = resolveMcpAllowlist({
+    rawAllowlist: raw,
+    registry,
+    runMcpScript: resolveRunMcpScript(input.env),
+  });
+  if (result.errors.length > 0) {
+    const messages = result.errors.map((e) => `[${e.kind}] ${e.message}`).join("; ");
+    throw new Error(`codex_local: MCP_LIST validation failed — ${messages}`);
+  }
+  const tomlPath = path.join(input.home, "config.toml");
+  let existing = "";
+  try {
+    existing = await fs.readFile(tomlPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code !== "ENOENT") throw err;
+  }
+  const base = stripCodexMcpSections(existing);
+  const rendered = renderCodexMcpToml(result.resolved);
+  const next = rendered.length > 0
+    ? `${base}${base.length > 0 && !base.endsWith("\n\n") ? "\n" : ""}${rendered}\n`
+    : base;
+  // Avoid writing if nothing actually changed; this keeps the file's mtime
+  // stable for callers that diff config artifacts.
+  if (next !== existing) {
+    await fs.mkdir(input.home, { recursive: true });
+    await fs.writeFile(tomlPath, next, "utf8");
+  }
+  return {
+    notes: [
+      `Applied MCP_LIST allowlist to ${tomlPath}: rendered ${result.resolved.length} mcp_servers entries.`,
+    ],
+  };
+}
+
 export async function prepareManagedCodexHome(
   env: NodeJS.ProcessEnv,
   onLog: AdapterExecutionContext["onLog"],
   companyId?: string,
-  options: { apiKey?: string | null } = {},
+  options: { apiKey?: string | null; registry?: McpRegistry } = {},
 ): Promise<string> {
   const targetHome = resolveManagedCodexHomeDir(env, companyId);
   const apiKey = nonEmpty(options.apiKey ?? undefined);

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -8,12 +8,13 @@ import {
   type McpRegistry,
   renderCodexMcpToml,
   resolveMcpAllowlist,
+  resolveMcpRegistryRootFromEnv,
+  resolveRunMcpScriptFromEnv,
 } from "@paperclipai/adapter-utils/mcp-allowlist";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
-const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
 
 function nonEmpty(value: string | undefined): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -110,16 +111,6 @@ export async function writeApiKeyAuthJson(home: string, apiKey: string): Promise
   await fs.writeFile(target, JSON.stringify({ OPENAI_API_KEY: apiKey }), { mode: 0o600 });
 }
 
-function resolveMcpRegistryRoot(env: NodeJS.ProcessEnv): string {
-  const fromEnv = env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim();
-  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_MCP_REGISTRY_ROOT;
-}
-
-function resolveRunMcpScript(env: NodeJS.ProcessEnv): string | undefined {
-  const fromEnv = env.PAPERCLIP_MCP_RUN_SCRIPT?.trim();
-  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
-}
-
 /**
  * Strips all `[mcp_servers.<id>]` sections from a TOML string. A section
  * runs from its header line until either EOF or the next top-level header
@@ -173,11 +164,11 @@ export async function applyMcpListToCodexHome(input: {
   if (typeof raw !== "string" || raw.trim().length === 0) {
     return null;
   }
-  const registry = input.registry ?? (await loadMcpRegistry(resolveMcpRegistryRoot(input.env)));
+  const registry = input.registry ?? (await loadMcpRegistry(resolveMcpRegistryRootFromEnv(input.env as Record<string, string | undefined>)));
   const result = resolveMcpAllowlist({
     rawAllowlist: raw,
     registry,
-    runMcpScript: resolveRunMcpScript(input.env),
+    runMcpScript: resolveRunMcpScriptFromEnv(input.env as Record<string, string | undefined>),
   });
   if (result.errors.length > 0) {
     const messages = result.errors.map((e) => `[${e.kind}] ${e.message}`).join("; ");

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -44,7 +44,7 @@ import {
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
 } from "./parse.js";
-import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
+import { applyMcpListToCodexHome, pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
@@ -359,6 +359,37 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       desiredSkillNames,
     },
   );
+  // Apply per-agent MCP_LIST allowlist to $CODEX_HOME/config.toml before any
+  // remote CODEX_HOME sync so the rendered mcp_servers entries travel with
+  // the home asset. Reads MCP_LIST from envConfig (the resolved adapter env)
+  // because process.env doesn't carry per-agent values.
+  const mcpListFromConfig =
+    typeof envConfig.MCP_LIST === "string" && envConfig.MCP_LIST.trim().length > 0
+      ? envConfig.MCP_LIST
+      : "";
+  if (mcpListFromConfig) {
+    const mcpEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      MCP_LIST: mcpListFromConfig,
+    };
+    if (typeof envConfig.PAPERCLIP_MCP_REGISTRY_ROOT === "string"
+        && envConfig.PAPERCLIP_MCP_REGISTRY_ROOT.trim().length > 0) {
+      mcpEnv.PAPERCLIP_MCP_REGISTRY_ROOT = envConfig.PAPERCLIP_MCP_REGISTRY_ROOT;
+    }
+    if (typeof envConfig.PAPERCLIP_MCP_RUN_SCRIPT === "string"
+        && envConfig.PAPERCLIP_MCP_RUN_SCRIPT.trim().length > 0) {
+      mcpEnv.PAPERCLIP_MCP_RUN_SCRIPT = envConfig.PAPERCLIP_MCP_RUN_SCRIPT;
+    }
+    const mcpResult = await applyMcpListToCodexHome({
+      home: effectiveCodexHome,
+      env: mcpEnv,
+    });
+    if (mcpResult) {
+      for (const note of mcpResult.notes) {
+        await onLog("stdout", `[paperclip] ${note}\n`);
+      }
+    }
+  }
   const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
     executionTarget,
     asNumber(config.timeoutSec, 0),

--- a/packages/adapters/gemini-local/src/server/execute.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { prepareEphemeralGeminiHome } from "./execute.js";
+
+describe("prepareEphemeralGeminiHome", () => {
+  let sharedHome: string;
+  let registryRoot: string;
+
+  beforeEach(async () => {
+    sharedHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-shared-"));
+    const sharedGemini = path.join(sharedHome, ".gemini");
+    await fs.mkdir(sharedGemini, { recursive: true });
+    await fs.writeFile(
+      path.join(sharedGemini, "settings.json"),
+      JSON.stringify({ security: { auth: { selectedType: "oauth-personal" } } }),
+    );
+    await fs.writeFile(path.join(sharedGemini, "oauth_creds.json"), '{"token":"shared"}');
+
+    registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-reg-"));
+    await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+    await fs.writeFile(
+      path.join(registryRoot, "registry.json"),
+      JSON.stringify({
+        servers: [
+          { id: "jira-ibm", status: "validated", manifest: "manifests/jira-ibm.json" },
+          { id: "box", status: "blocked-runtime-mismatch", manifest: "manifests/box.json" },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      path.join(registryRoot, "manifests", "jira-ibm.json"),
+      JSON.stringify({ id: "jira-ibm" }),
+    );
+    await fs.writeFile(
+      path.join(registryRoot, "manifests", "box.json"),
+      JSON.stringify({ id: "box" }),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(sharedHome, { recursive: true, force: true });
+    await fs.rm(registryRoot, { recursive: true, force: true });
+  });
+
+  it("returns null when MCP_LIST is unset", async () => {
+    const result = await prepareEphemeralGeminiHome({
+      env: {},
+      sharedHomeDir: sharedHome,
+      skillsEntries: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("creates an ephemeral home with mcpServers settings", async () => {
+    const prepared = await prepareEphemeralGeminiHome({
+      env: {
+        MCP_LIST: "jira-ibm",
+        PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+        PAPERCLIP_MCP_RUN_SCRIPT: "/run-mcp.sh",
+      },
+      sharedHomeDir: sharedHome,
+      skillsEntries: [],
+    });
+    expect(prepared).not.toBeNull();
+    try {
+      const settings = JSON.parse(
+        await fs.readFile(
+          path.join(prepared!.ephemeralHomeDir, ".gemini", "settings.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(settings).toMatchObject({
+        security: { auth: { selectedType: "oauth-personal" } },
+        mcpServers: {
+          "jira-ibm": { command: "bash", args: ["/run-mcp.sh", "jira-ibm"] },
+        },
+      });
+      // Credentials are symlinked to the shared home.
+      const oauthLink = path.join(prepared!.ephemeralHomeDir, ".gemini", "oauth_creds.json");
+      expect((await fs.lstat(oauthLink)).isSymbolicLink()).toBe(true);
+    } finally {
+      await prepared!.cleanup();
+    }
+  });
+
+  it("symlinks selected skills into the ephemeral skills dir", async () => {
+    const skillsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-skills-src-"));
+    try {
+      const skillSrc = path.join(skillsRoot, "skill-a");
+      await fs.mkdir(skillSrc, { recursive: true });
+      const prepared = await prepareEphemeralGeminiHome({
+        env: {
+          MCP_LIST: "jira-ibm",
+          PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+        },
+        sharedHomeDir: sharedHome,
+        skillsEntries: [
+          { key: "skill-a", runtimeName: "skill-a", source: skillSrc },
+          { key: "skill-b", runtimeName: "skill-b", source: path.join(skillsRoot, "skill-b-missing") },
+        ],
+        desiredSkillNames: ["skill-a"],
+      });
+      try {
+        const linked = path.join(prepared!.ephemeralHomeDir, ".gemini", "skills", "skill-a");
+        expect((await fs.lstat(linked)).isSymbolicLink()).toBe(true);
+        // skill-b was not desired
+        await expect(
+          fs.lstat(path.join(prepared!.ephemeralHomeDir, ".gemini", "skills", "skill-b")),
+        ).rejects.toThrow();
+      } finally {
+        await prepared!.cleanup();
+      }
+    } finally {
+      await fs.rm(skillsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on blocked status and cleans up", async () => {
+    await expect(
+      prepareEphemeralGeminiHome({
+        env: {
+          MCP_LIST: "box",
+          PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+        },
+        sharedHomeDir: sharedHome,
+        skillsEntries: [],
+      }),
+    ).rejects.toThrow(/blocked_status/);
+  });
+});

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -171,6 +171,157 @@ async function buildGeminiSkillsDir(
   return target;
 }
 
+const GEMINI_SHARED_SYMLINK_FILES = [
+  "oauth_creds.json",
+  "google_accounts.json",
+  "installation_id",
+  "projects.json",
+] as const;
+
+const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
+
+/**
+ * Result of preparing a per-agent ephemeral Gemini HOME. The CLI is invoked
+ * with `HOME=ephemeralHomeDir` so it reads `<ephemeralHomeDir>/.gemini/...`
+ * — credentials are symlinked from the real shared `~/.gemini/`, and
+ * `settings.json` is rewritten with an `mcpServers` map filtered by the
+ * `MCP_LIST` allowlist. Skills are linked into the ephemeral
+ * `<ephemeralHomeDir>/.gemini/skills/` so they don't pollute the shared
+ * skills dir.
+ *
+ * Cleanup removes the temp dir; safe to call even on failure.
+ */
+type PreparedGeminiHome = {
+  ephemeralHomeDir: string;
+  skillsHome: string;
+  notes: string[];
+  cleanup: () => Promise<void>;
+};
+
+function resolveMcpRegistryRoot(env: Record<string, string>): string {
+  return env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim() || DEFAULT_MCP_REGISTRY_ROOT;
+}
+
+function resolveRunMcpScript(env: Record<string, string>): string | undefined {
+  const fromEnv = env.PAPERCLIP_MCP_RUN_SCRIPT?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+/**
+ * Builds an ephemeral HOME for the gemini CLI when `MCP_LIST` is set,
+ * isolating the per-agent `mcpServers` selection from the shared
+ * `~/.gemini/settings.json`.
+ *
+ * Returns `null` when MCP_LIST is empty / unset, signalling the caller
+ * should keep using the shared HOME (legacy path).
+ *
+ * Fail-closed: throws on resolution errors so the caller never spawns the
+ * CLI with a partial / silently-broken MCP set.
+ *
+ * Exported for unit tests; runtime callers go through the integrated
+ * `execute` flow.
+ */
+export async function prepareEphemeralGeminiHome(input: {
+  env: Record<string, string>;
+  sharedHomeDir: string;
+  skillsEntries: Array<{ key: string; runtimeName: string; source: string }>;
+  desiredSkillNames?: string[];
+}): Promise<PreparedGeminiHome | null> {
+  const raw = input.env.MCP_LIST;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+
+  // Lazy import to avoid loading the registry when MCP_LIST is unset.
+  const {
+    loadMcpRegistry,
+    renderGeminiMcpSettings,
+    resolveMcpAllowlist,
+  } = await import("@paperclipai/adapter-utils/mcp-allowlist");
+
+  const registry = await loadMcpRegistry(resolveMcpRegistryRoot(input.env));
+  const result = resolveMcpAllowlist({
+    rawAllowlist: raw,
+    registry,
+    runMcpScript: resolveRunMcpScript(input.env),
+  });
+  if (result.errors.length > 0) {
+    const messages = result.errors.map((e) => `[${e.kind}] ${e.message}`).join("; ");
+    throw new Error(`gemini_local: MCP_LIST validation failed — ${messages}`);
+  }
+
+  const ephemeralHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-home-"));
+  const cleanup = async () => {
+    await fs.rm(ephemeralHomeDir, { recursive: true, force: true });
+  };
+
+  try {
+    const ephemeralGeminiDir = path.join(ephemeralHomeDir, ".gemini");
+    await fs.mkdir(ephemeralGeminiDir, { recursive: true });
+
+    const sharedGeminiDir = path.join(input.sharedHomeDir, ".gemini");
+
+    // Symlink credential / state files so the CLI keeps using the host-level
+    // Gemini auth and project metadata. We deliberately don't symlink
+    // `settings.json` so we can write a per-agent version.
+    for (const name of GEMINI_SHARED_SYMLINK_FILES) {
+      const source = path.join(sharedGeminiDir, name);
+      try {
+        await fs.access(source);
+      } catch {
+        continue;
+      }
+      await fs.symlink(source, path.join(ephemeralGeminiDir, name));
+    }
+
+    // Read the shared settings.json (best-effort) so we preserve auth /
+    // theme settings, then overlay mcpServers.
+    let baseSettings: Record<string, unknown> = {};
+    try {
+      const raw = await fs.readFile(path.join(sharedGeminiDir, "settings.json"), "utf8");
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        baseSettings = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // ignore
+    }
+    const renderedMcp = renderGeminiMcpSettings(result.resolved);
+    const nextSettings = { ...baseSettings, ...renderedMcp };
+    await fs.writeFile(
+      path.join(ephemeralGeminiDir, "settings.json"),
+      `${JSON.stringify(nextSettings, null, 2)}\n`,
+      "utf8",
+    );
+
+    // Materialize skills directly inside the ephemeral home so we don't
+    // touch the shared `~/.gemini/skills/`.
+    const skillsHome = path.join(ephemeralGeminiDir, "skills");
+    await fs.mkdir(skillsHome, { recursive: true });
+    const desiredSet = new Set(input.desiredSkillNames ?? input.skillsEntries.map((e) => e.key));
+    for (const entry of input.skillsEntries) {
+      if (!desiredSet.has(entry.key)) continue;
+      try {
+        await fs.symlink(entry.source, path.join(skillsHome, entry.runtimeName));
+      } catch {
+        // ignore — best-effort, the legacy path also tolerates missing skills
+      }
+    }
+
+    return {
+      ephemeralHomeDir,
+      skillsHome,
+      notes: [
+        `Prepared ephemeral Gemini HOME with MCP_LIST allowlist (${result.resolved.length} entries) at ${ephemeralHomeDir}.`,
+      ],
+      cleanup,
+    };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
   const executionTarget = readAdapterExecutionTarget({
@@ -207,14 +358,56 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   const geminiSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredGeminiSkillNames = resolvePaperclipDesiredSkillNames(config, geminiSkillEntries);
-  if (!executionTargetIsRemote) {
-    await ensureGeminiSkillsInjected(onLog, geminiSkillEntries, desiredGeminiSkillNames);
-  }
 
   const envConfig = parseObject(config.env);
+  const mcpListFromConfig =
+    typeof envConfig.MCP_LIST === "string" && envConfig.MCP_LIST.trim().length > 0
+      ? envConfig.MCP_LIST
+      : "";
+  const mcpRegistryRootFromConfig =
+    typeof envConfig.PAPERCLIP_MCP_REGISTRY_ROOT === "string"
+      && envConfig.PAPERCLIP_MCP_REGISTRY_ROOT.trim().length > 0
+      ? envConfig.PAPERCLIP_MCP_REGISTRY_ROOT
+      : "";
+  const mcpRunScriptFromConfig =
+    typeof envConfig.PAPERCLIP_MCP_RUN_SCRIPT === "string"
+      && envConfig.PAPERCLIP_MCP_RUN_SCRIPT.trim().length > 0
+      ? envConfig.PAPERCLIP_MCP_RUN_SCRIPT
+      : "";
+
+  // When MCP_LIST is set we route the CLI through an ephemeral HOME so the
+  // per-agent mcpServers selection doesn't bleed into the shared
+  // ~/.gemini/settings.json. Skills also live inside that ephemeral HOME,
+  // so we skip the legacy `ensureGeminiSkillsInjected` path which writes
+  // into the shared `~/.gemini/skills/`.
+  let preparedEphemeralHome: PreparedGeminiHome | null = null;
+  if (!executionTargetIsRemote) {
+    if (mcpListFromConfig) {
+      const mcpEnv: Record<string, string> = { MCP_LIST: mcpListFromConfig };
+      if (mcpRegistryRootFromConfig) mcpEnv.PAPERCLIP_MCP_REGISTRY_ROOT = mcpRegistryRootFromConfig;
+      if (mcpRunScriptFromConfig) mcpEnv.PAPERCLIP_MCP_RUN_SCRIPT = mcpRunScriptFromConfig;
+      preparedEphemeralHome = await prepareEphemeralGeminiHome({
+        env: mcpEnv,
+        sharedHomeDir: os.homedir(),
+        skillsEntries: geminiSkillEntries,
+        desiredSkillNames: desiredGeminiSkillNames,
+      });
+      if (preparedEphemeralHome) {
+        for (const note of preparedEphemeralHome.notes) {
+          await onLog("stdout", `[paperclip] ${note}\n`);
+        }
+      }
+    } else {
+      await ensureGeminiSkillsInjected(onLog, geminiSkillEntries, desiredGeminiSkillNames);
+    }
+  }
+
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  if (preparedEphemeralHome) {
+    env.HOME = preparedEphemeralHome.ephemeralHomeDir;
+  }
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
@@ -671,6 +864,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       paperclipBridge?.stop(),
       restoreRemoteWorkspace?.(),
       localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+      preparedEphemeralHome?.cleanup().catch(() => undefined) ?? Promise.resolve(),
     ]);
   }
 }

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -178,8 +178,6 @@ const GEMINI_SHARED_SYMLINK_FILES = [
   "projects.json",
 ] as const;
 
-const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
-
 /**
  * Result of preparing a per-agent ephemeral Gemini HOME. The CLI is invoked
  * with `HOME=ephemeralHomeDir` so it reads `<ephemeralHomeDir>/.gemini/...`
@@ -197,15 +195,6 @@ type PreparedGeminiHome = {
   notes: string[];
   cleanup: () => Promise<void>;
 };
-
-function resolveMcpRegistryRoot(env: Record<string, string>): string {
-  return env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim() || DEFAULT_MCP_REGISTRY_ROOT;
-}
-
-function resolveRunMcpScript(env: Record<string, string>): string | undefined {
-  const fromEnv = env.PAPERCLIP_MCP_RUN_SCRIPT?.trim();
-  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
-}
 
 /**
  * Builds an ephemeral HOME for the gemini CLI when `MCP_LIST` is set,
@@ -237,13 +226,15 @@ export async function prepareEphemeralGeminiHome(input: {
     loadMcpRegistry,
     renderGeminiMcpSettings,
     resolveMcpAllowlist,
+    resolveMcpRegistryRootFromEnv,
+    resolveRunMcpScriptFromEnv,
   } = await import("@paperclipai/adapter-utils/mcp-allowlist");
 
-  const registry = await loadMcpRegistry(resolveMcpRegistryRoot(input.env));
+  const registry = await loadMcpRegistry(resolveMcpRegistryRootFromEnv(input.env));
   const result = resolveMcpAllowlist({
     rawAllowlist: raw,
     registry,
-    runMcpScript: resolveRunMcpScript(input.env),
+    runMcpScript: resolveRunMcpScriptFromEnv(input.env),
   });
   if (result.errors.length > 0) {
     const messages = result.errors.map((e) => `[${e.kind}] ${e.message}`).join("; ");

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -76,4 +76,115 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     expect(prepared.notes).toEqual([]);
     await prepared.cleanup();
   });
+
+  it("applies MCP_LIST and writes filtered mcp tree", async () => {
+    const configHome = await makeConfigHome({
+      mcp: {
+        "jira-ibm": { type: "local", command: ["legacy", "args"], enabled: true },
+        "ghost-mcp": { type: "local", command: ["should-be-removed"], enabled: true },
+      },
+    });
+    const registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-mcp-"));
+    cleanupPaths.add(registryRoot);
+    await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+    await fs.writeFile(
+      path.join(registryRoot, "registry.json"),
+      JSON.stringify({
+        servers: [
+          { id: "jira-ibm", status: "validated", manifest: "manifests/jira-ibm.json" },
+          { id: "wikipedia", status: "validated", manifest: "manifests/wikipedia.json" },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      path.join(registryRoot, "manifests", "jira-ibm.json"),
+      JSON.stringify({ id: "jira-ibm", environment: { requiredNames: [] } }),
+    );
+    await fs.writeFile(
+      path.join(registryRoot, "manifests", "wikipedia.json"),
+      JSON.stringify({ id: "wikipedia", environment: { requiredNames: [] } }),
+    );
+
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: {
+        XDG_CONFIG_HOME: configHome,
+        MCP_LIST: "jira-ibm, wikipedia",
+        PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+        PAPERCLIP_MCP_RUN_SCRIPT: "/run-mcp.sh",
+      },
+      config: {},
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+
+    const mcp = (runtimeConfig as { mcp?: Record<string, unknown> }).mcp ?? {};
+    expect(Object.keys(mcp).sort()).toEqual(["jira-ibm", "wikipedia"]);
+    // Inherited config wins for jira-ibm.
+    expect(mcp["jira-ibm"]).toMatchObject({ command: ["legacy", "args"] });
+    // wikipedia is rendered from registry pointing at run-mcp.sh.
+    expect(mcp.wikipedia).toMatchObject({
+      type: "local",
+      command: ["bash", "/run-mcp.sh", "wikipedia"],
+      enabled: true,
+    });
+    expect(prepared.notes.some((n) => n.includes("MCP_LIST"))).toBe(true);
+    await prepared.cleanup();
+    cleanupPaths.delete(prepared.env.XDG_CONFIG_HOME);
+  });
+
+  it("fails closed on unknown MCP_LIST id", async () => {
+    const configHome = await makeConfigHome({});
+    const registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-mcp-"));
+    cleanupPaths.add(registryRoot);
+    await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+    await fs.writeFile(
+      path.join(registryRoot, "registry.json"),
+      JSON.stringify({ servers: [] }),
+    );
+
+    await expect(
+      prepareOpenCodeRuntimeConfig({
+        env: {
+          XDG_CONFIG_HOME: configHome,
+          MCP_LIST: "ghost",
+          PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+        },
+        config: {},
+      }),
+    ).rejects.toThrow(/MCP_LIST validation failed/);
+  });
+
+  it("fails closed on blocked MCP_LIST status", async () => {
+    const configHome = await makeConfigHome({});
+    const registryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-mcp-"));
+    cleanupPaths.add(registryRoot);
+    await fs.mkdir(path.join(registryRoot, "manifests"), { recursive: true });
+    await fs.writeFile(
+      path.join(registryRoot, "registry.json"),
+      JSON.stringify({
+        servers: [{ id: "box", status: "blocked-runtime-mismatch", manifest: "manifests/box.json" }],
+      }),
+    );
+    await fs.writeFile(
+      path.join(registryRoot, "manifests", "box.json"),
+      JSON.stringify({ id: "box" }),
+    );
+
+    await expect(
+      prepareOpenCodeRuntimeConfig({
+        env: {
+          XDG_CONFIG_HOME: configHome,
+          MCP_LIST: "box",
+          PAPERCLIP_MCP_REGISTRY_ROOT: registryRoot,
+        },
+        config: {},
+      }),
+    ).rejects.toThrow(/blocked_status/);
+  });
 });

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -2,12 +2,20 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+import {
+  loadMcpRegistry,
+  type McpRegistry,
+  renderOpencodeMcp,
+  resolveMcpAllowlist,
+} from "@paperclipai/adapter-utils/mcp-allowlist";
 
 type PreparedOpenCodeRuntimeConfig = {
   env: Record<string, string>;
   notes: string[];
   cleanup: () => Promise<void>;
 };
+
+const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
 
 function resolveXdgConfigHome(env: Record<string, string>): string {
   return (
@@ -31,13 +39,81 @@ async function readJsonObject(filepath: string): Promise<Record<string, unknown>
   }
 }
 
+function resolveMcpRegistryRoot(env: Record<string, string>): string {
+  const fromEnv = env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim()
+    || process.env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim();
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  return DEFAULT_MCP_REGISTRY_ROOT;
+}
+
+function resolveRunMcpScript(env: Record<string, string>): string | undefined {
+  const fromEnv = env.PAPERCLIP_MCP_RUN_SCRIPT?.trim()
+    || process.env.PAPERCLIP_MCP_RUN_SCRIPT?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+/**
+ * Applies the per-agent `MCP_LIST` allowlist to the in-memory opencode
+ * config. Filters whatever was inherited from the shared `opencode.json#mcp`
+ * tree, keeping only ids in the allowlist; for ids in the allowlist that
+ * aren't already in `mcp`, adds the rendered entry from the registry.
+ *
+ * Fail-closed: any resolution error (invalid token / unknown id / blocked
+ * status) is thrown so the caller never spawns the CLI with a partial /
+ * silently-broken MCP set.
+ *
+ * Returns `null` when MCP_LIST is empty/unset, signaling that the existing
+ * `opencode.json#mcp` block should remain untouched.
+ */
+async function applyMcpListToOpencodeConfig(input: {
+  config: Record<string, unknown>;
+  env: Record<string, string>;
+  registry?: McpRegistry;
+}): Promise<{ config: Record<string, unknown>; notes: string[] } | null> {
+  const raw = input.env.MCP_LIST;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  const registry = input.registry ?? (await loadMcpRegistry(resolveMcpRegistryRoot(input.env)));
+  const result = resolveMcpAllowlist({
+    rawAllowlist: raw,
+    registry,
+    runMcpScript: resolveRunMcpScript(input.env),
+  });
+  if (result.errors.length > 0) {
+    const messages = result.errors.map((e) => `[${e.kind}] ${e.message}`).join("; ");
+    throw new Error(`opencode_local: MCP_LIST validation failed — ${messages}`);
+  }
+  const allowedIds = new Set(result.resolved.map((entry) => entry.id));
+  const inheritedMcp = isPlainObject(input.config.mcp) ? input.config.mcp : {};
+  const filteredInherited: Record<string, unknown> = {};
+  for (const [id, value] of Object.entries(inheritedMcp)) {
+    if (allowedIds.has(id)) filteredInherited[id] = value;
+  }
+  const rendered = renderOpencodeMcp(result.resolved);
+  // Inherited entry (if present and shape-compatible) wins; for missing ids
+  // we add the rendered fallback that points at run-mcp.sh.
+  const finalMcp: Record<string, unknown> = { ...rendered, ...filteredInherited };
+  const nextConfig = { ...input.config, mcp: finalMcp };
+  const notes = [
+    `Applied MCP_LIST allowlist: kept ${Object.keys(filteredInherited).length} inherited entries; injected ${
+      Object.keys(rendered).length - Object.keys(filteredInherited).length
+    } rendered entries; total ${Object.keys(finalMcp).length}.`,
+  ];
+  return { config: nextConfig, notes };
+}
+
 export async function prepareOpenCodeRuntimeConfig(input: {
   env: Record<string, string>;
   config: Record<string, unknown>;
   targetIsRemote?: boolean;
+  registry?: McpRegistry;
 }): Promise<PreparedOpenCodeRuntimeConfig> {
   const skipPermissions = asBoolean(input.config.dangerouslySkipPermissions, true);
-  if (!skipPermissions) {
+  const hasMcpList =
+    typeof input.env.MCP_LIST === "string" && input.env.MCP_LIST.trim().length > 0;
+
+  if (!skipPermissions && !hasMcpList) {
     return {
       env: input.env,
       notes: [],
@@ -78,16 +154,42 @@ export async function prepareOpenCodeRuntimeConfig(input: {
   }
 
   const existingConfig = await readJsonObject(runtimeConfigPath);
-  const existingPermission = isPlainObject(existingConfig.permission)
-    ? existingConfig.permission
-    : {};
-  const nextConfig = {
-    ...existingConfig,
-    permission: {
-      ...existingPermission,
-      external_directory: "allow",
-    },
-  };
+  let nextConfig: Record<string, unknown> = existingConfig;
+  const notes: string[] = [];
+
+  if (skipPermissions) {
+    const existingPermission = isPlainObject(nextConfig.permission)
+      ? nextConfig.permission
+      : {};
+    nextConfig = {
+      ...nextConfig,
+      permission: {
+        ...existingPermission,
+        external_directory: "allow",
+      },
+    };
+    notes.push(
+      "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
+    );
+  }
+
+  try {
+    const mcpResult = await applyMcpListToOpencodeConfig({
+      config: nextConfig,
+      env: input.env,
+      registry: input.registry,
+    });
+    if (mcpResult) {
+      nextConfig = mcpResult.config;
+      notes.push(...mcpResult.notes);
+    }
+  } catch (err) {
+    // Cleanup the tmp dir before propagating, otherwise the spawn fails
+    // and we leak the directory.
+    await fs.rm(runtimeConfigHome, { recursive: true, force: true });
+    throw err;
+  }
+
   await fs.writeFile(runtimeConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
 
   return {
@@ -95,9 +197,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
       ...input.env,
       XDG_CONFIG_HOME: runtimeConfigHome,
     },
-    notes: [
-      "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
-    ],
+    notes,
     cleanup: async () => {
       await fs.rm(runtimeConfigHome, { recursive: true, force: true });
     },

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -7,6 +7,8 @@ import {
   type McpRegistry,
   renderOpencodeMcp,
   resolveMcpAllowlist,
+  resolveMcpRegistryRootFromEnv,
+  resolveRunMcpScriptFromEnv,
 } from "@paperclipai/adapter-utils/mcp-allowlist";
 
 type PreparedOpenCodeRuntimeConfig = {
@@ -14,8 +16,6 @@ type PreparedOpenCodeRuntimeConfig = {
   notes: string[];
   cleanup: () => Promise<void>;
 };
-
-const DEFAULT_MCP_REGISTRY_ROOT = "/Users/cassio/mcp-server/_paperclip";
 
 function resolveXdgConfigHome(env: Record<string, string>): string {
   return (
@@ -37,19 +37,6 @@ async function readJsonObject(filepath: string): Promise<Record<string, unknown>
   } catch {
     return {};
   }
-}
-
-function resolveMcpRegistryRoot(env: Record<string, string>): string {
-  const fromEnv = env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim()
-    || process.env.PAPERCLIP_MCP_REGISTRY_ROOT?.trim();
-  if (fromEnv && fromEnv.length > 0) return fromEnv;
-  return DEFAULT_MCP_REGISTRY_ROOT;
-}
-
-function resolveRunMcpScript(env: Record<string, string>): string | undefined {
-  const fromEnv = env.PAPERCLIP_MCP_RUN_SCRIPT?.trim()
-    || process.env.PAPERCLIP_MCP_RUN_SCRIPT?.trim();
-  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
 }
 
 /**
@@ -74,11 +61,11 @@ async function applyMcpListToOpencodeConfig(input: {
   if (typeof raw !== "string" || raw.trim().length === 0) {
     return null;
   }
-  const registry = input.registry ?? (await loadMcpRegistry(resolveMcpRegistryRoot(input.env)));
+  const registry = input.registry ?? (await loadMcpRegistry(resolveMcpRegistryRootFromEnv(input.env)));
   const result = resolveMcpAllowlist({
     rawAllowlist: raw,
     registry,
-    runMcpScript: resolveRunMcpScript(input.env),
+    runMcpScript: resolveRunMcpScriptFromEnv(input.env),
   });
   if (result.errors.length > 0) {
     const messages = result.errors.map((e) => `[${e.kind}] ${e.message}`).join("; ");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and each agent runs through an adapter that spawns a native CLI (opencode, codex, gemini, …).
> - Each native CLI loads its own MCP configuration from a runtime config tree (`opencode.json#mcp`, `~/.codex/config.toml#[mcp_servers.*]`, `~/.gemini/settings.json#mcpServers`), and today every agent that shares that runtime sees every MCP server registered there.
> - That makes per-agent scoping impossible: an agent that only needs `jira-ibm` ends up with the same MCP surface as an agent that needs the full sidecar catalog, and that breaks both the principle of least privilege and the existing sidecar governance model in `_paperclip/registry.json`.
> - Operators want to declare per-agent MCP scope from the agent UI itself, ideally as a single environment variable.
> - This pull request adds a runtime `MCP_LIST` contract: each adapter, before invoking the CLI, parses `adapterConfig.env.MCP_LIST` (CSV of registry ids), validates it against the host sidecar `_paperclip/registry.json`, and renders the native MCP config tree filtered to that allowlist — fail-closed on invalid / unknown / blocked-status ids.
> - The benefit is that agent operators get a single declarative knob to scope MCP access without touching shared config or the codebase, while the sidecar registry remains the single source of truth for which MCP ids exist and what their status is.

## What Changed

- **New shared module** `packages/adapter-utils/src/mcp-allowlist.ts` owning the full MCP_LIST pipeline: `parseMcpAllowlist`, `loadMcpRegistry`, `resolveMcpAllowlist`, and four native-shape renderers (opencode / codex / gemini / bob). Tokens validated by `^[a-z0-9][a-z0-9-]*$`; allowed statuses `validated` and `validated-local-contract-no-live-call`; everything else fail-closed with a typed error category (`invalid_token`, `unknown_id`, `blocked_status`).
- **Centralized env-resolution helpers** `resolveMcpRegistryRootFromEnv` and `resolveRunMcpScriptFromEnv` exported from the same module, so the three adapters share a single override semantic for `PAPERCLIP_MCP_REGISTRY_ROOT` and `PAPERCLIP_MCP_RUN_SCRIPT`. Eliminates the previous duplicated helpers and drops the inconsistent `process.env` fallback that opencode-local had.
- **Fail-loud on missing registry**: `loadMcpRegistry` now throws `McpRegistryNotFoundError` when `registry.json` is absent under the resolved root, instead of returning an empty registry that masked configuration mistakes as `unknown_id`. The error message names the override env var explicitly.
- **opencode_local** (`packages/adapters/opencode-local/src/server/runtime-config.ts`): `applyMcpListToOpencodeConfig` filters `opencode.json#mcp` by the allowlist and injects rendered fallbacks for missing ids. The MCP filter now runs even when `dangerouslySkipPermissions=false` (it only needs the runtime config tree, not the permission relaxation).
- **codex_local** (`packages/adapters/codex-local/src/server/codex-home.ts` + `execute.ts`): new `applyMcpListToCodexHome` strips inherited `[mcp_servers.*]` from `$CODEX_HOME/config.toml` and appends rendered fragments **before** any remote home sync, so worktrees and remote codex workspaces both see the filtered set.
- **gemini_local** (`packages/adapters/gemini-local/src/server/execute.ts`): new `prepareEphemeralGeminiHome` creates a per-run HOME with `mkdtemp`, symlinks credentials from the shared `~/.gemini/`, writes the filtered `settings.json#mcpServers`, and materializes skills inside the ephemeral HOME so the per-agent selection no longer leaks into the shared dir. Spawn HOME points to the ephemeral dir; cleanup removes it on success and failure.
- **37 new unit tests** across the four touched packages covering the parser, the registry loader (including the new fail-loud behavior), the resolver, every renderer, and the adapter-level integration paths.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` — clean
- `pnpm --filter @paperclipai/adapter-opencode-local typecheck` — clean
- `pnpm --filter @paperclipai/adapter-codex-local typecheck` — clean
- `pnpm --filter @paperclipai/adapter-gemini-local typecheck` — clean
- `npx vitest run packages/adapter-utils/src/mcp-allowlist.test.ts` — 19 tests pass
- `npx vitest run packages/adapters/{opencode,codex,gemini}-local/**/*.test.ts` — 17 tests pass
- CI on this PR: 14 checks green (policy, typecheck, build, e2e, server tests, workspaces-a, workspaces-b, 4× verify serialized server suites, canary dry run, verify, Greptile review).
- Manual smoke (not in this PR): set `MCP_LIST="jira-ibm"` on a single agent, run one heartbeat, confirm `tools/list` in the run log surfaces only `jira-ibm`. The downstream ksio.dev deployment will run this immediately after merge per the bootstrap migration plan tracked outside this repo.

## Risks

- **Behavior change for adapters that load MCP from the shared runtime config**: opencode_local previously merged the entire `opencode.json#mcp` block. With `MCP_LIST` empty/unset, behavior is unchanged. With `MCP_LIST` set, the inherited block is filtered to the allowlist. Operators who relied on implicit propagation of every MCP id to every agent will need to set `MCP_LIST` per agent. Documented in the new sidecar runbook.
- **`McpRegistryNotFoundError` is a new failure mode**: previously, a missing `registry.json` produced empty results and the run continued without MCP support. Now it throws and the adapter aborts before spawning the CLI. Mitigated by the operator-readable error message naming `PAPERCLIP_MCP_REGISTRY_ROOT`. Operators in non-ksio.dev deployments must set the override or leave `MCP_LIST` unset.
- **Hardcoded ksio.dev default path** (`/Users/cassio/mcp-server/_paperclip`) remains as the convenience for the only deployment that ships with that bind-mount; non-ksio.dev deployments will hit the new fail-loud path with a clear message instead of confusing silent failures. Acceptable trade-off until the sidecar layout is generalized in a follow-up.
- **Sensitivity-gating is intentionally not enforced in this PR**: manifests carry `sensitivity` metadata (`ibm-sensitive` etc.) but the runtime does not gate by it. That stays a human governance gate via the sidecar policy and the `paperclip-mcp-configurator` skill. Adding runtime gating requires an "agent domain class" model that this PR does not attempt.
- **`bob_local` and `cline_local` are not in this repo**: they are downstream ksio.dev-only adapters and are tracked in a separate downstream issue. The shared `renderBobMcpSettings` is already in this PR so the downstream patch will be a thin call site.

## Model Used

- Provider: AWS Bedrock (Anthropic Claude family)
- Exact model: `bedrock_converse/claude-opus-4-7` (Claude 4.7 Opus, ICA endpoint)
- Reasoning mode: extended thinking on `Auto` (the model decides per-step)
- Tool use: yes — file read/edit, shell exec, repository search; no inline code execution by the model itself
- Authoring agent: **Europa** (ksio.dev infra deputy, opencode_local), with technical input from **Webb** (ksio.dev MCP specialist) on the registry contract and the sensitivity-gating decision

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, this is a runtime-only change.
- [x] I have updated relevant documentation to reflect my changes (jsdoc comments on every new exported symbol; downstream skill rewrite tracked separately)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge