### PR TITLE
Add env-driven first-boot admin bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,10 @@ PORT=3100
 SERVE_UI=false
 BETTER_AUTH_SECRET=paperclip-dev-secret
 
+# Optional first-boot admin + board API key bootstrap.
+# Consumed only when both are set and no instance_admin exists yet.
+# PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+# PAPERCLIP_BOOTSTRAP_BOARD_API_KEY=pcp_board_replace_me
+
 # Discord webhook for daily merge digest (scripts/discord-daily-digest.sh)
 # DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -20,6 +20,18 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
 
+## First-Boot Admin Bootstrap
+
+These variables are optional. When both are present and the database has no
+`instance_admin` user yet, Paperclip seeds one instance admin and one board API
+key before serving HTTP requests. If either variable is missing, or an admin
+already exists, startup continues without changing admin users or keys.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL` | (unset) | Email for the first instance-admin user seeded on first boot |
+| `PAPERCLIP_BOOTSTRAP_BOARD_API_KEY` | (unset) | Plaintext board API key to hash and store for that first admin; the plaintext is never logged |
+
 ## Secrets
 
 | Variable | Default | Description |

--- a/server/src/__tests__/first-boot-admin-bootstrap.test.ts
+++ b/server/src/__tests__/first-boot-admin-bootstrap.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  authAccounts,
+  authUsers,
+  boardApiKeys,
+  createDb,
+  instanceUserRoles,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  BOOTSTRAP_BOARD_API_KEY_NAME,
+  seedFirstBootAdminAndBoardKeyFromEnv,
+} from "../first-boot-admin-bootstrap.js";
+import { boardAuthService, hashBearerToken } from "../services/board-auth.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function env(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values as NodeJS.ProcessEnv;
+}
+
+function logger() {
+  return { info: vi.fn() };
+}
+
+describe("seedFirstBootAdminAndBoardKeyFromEnv", () => {
+  it("is a no-op when bootstrap env vars are unset", async () => {
+    const db = {
+      transaction: vi.fn(async () => {
+        throw new Error("transaction should not run");
+      }),
+    };
+    const log = logger();
+
+    const result = await seedFirstBootAdminAndBoardKeyFromEnv(db as any, {
+      env: env({}),
+      logger: log,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "env_missing" });
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      {
+        reason: "env_missing",
+        missing: ["PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL", "PAPERCLIP_BOOTSTRAP_BOARD_API_KEY"],
+      },
+      "paperclip.bootstrap.skip",
+    );
+  });
+});
+
+describeEmbeddedPostgres("seedFirstBootAdminAndBoardKeyFromEnv database writes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-first-boot-admin-bootstrap-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(boardApiKeys);
+    await db.delete(authAccounts);
+    await db.delete(instanceUserRoles);
+    await db.delete(authUsers);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("is a no-op when an instance admin already exists", async () => {
+    const now = new Date();
+    await db.insert(authUsers).values({
+      id: "existing-admin",
+      name: "Existing Admin",
+      email: "admin@example.com",
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(instanceUserRoles).values({
+      userId: "existing-admin",
+      role: "instance_admin",
+    });
+    const log = logger();
+
+    const result = await seedFirstBootAdminAndBoardKeyFromEnv(db, {
+      env: env({
+        PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL: "bootstrap@example.com",
+        PAPERCLIP_BOOTSTRAP_BOARD_API_KEY: "pcp_board_bootstrap_test",
+      }),
+      logger: log,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "admin_exists" });
+    expect(await db.select().from(boardApiKeys)).toHaveLength(0);
+    expect(log.info).toHaveBeenCalledWith(
+      { reason: "admin_exists" },
+      "paperclip.bootstrap.skip",
+    );
+  });
+
+  it("seeds the first instance admin and a validating board API key", async () => {
+    const boardApiToken = "pcp_board_agentswarm_platform_bootstrap";
+    const log = logger();
+
+    const result = await seedFirstBootAdminAndBoardKeyFromEnv(db, {
+      env: env({
+        PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL: "ops@example.com",
+        PAPERCLIP_BOOTSTRAP_BOARD_API_KEY: boardApiToken,
+      }),
+      logger: log,
+    });
+
+    expect(result).toMatchObject({
+      status: "seeded",
+      adminEmail: "ops@example.com",
+      keyName: BOOTSTRAP_BOARD_API_KEY_NAME,
+    });
+
+    if (result.status !== "seeded") {
+      throw new Error("expected seeded result");
+    }
+
+    const [user] = await db.select().from(authUsers);
+    expect(user).toMatchObject({
+      id: result.userId,
+      name: "ops@example.com",
+      email: "ops@example.com",
+      emailVerified: true,
+    });
+
+    const [account] = await db.select().from(authAccounts);
+    expect(account).toMatchObject({
+      userId: result.userId,
+      providerId: "credential",
+    });
+    expect(account?.password).toMatch(/^unused:[a-f0-9]{64}$/);
+
+    const [role] = await db.select().from(instanceUserRoles);
+    expect(role).toMatchObject({
+      userId: result.userId,
+      role: "instance_admin",
+    });
+
+    const [key] = await db.select().from(boardApiKeys);
+    expect(key).toMatchObject({
+      id: result.boardApiKeyId,
+      userId: result.userId,
+      name: BOOTSTRAP_BOARD_API_KEY_NAME,
+      keyHash: hashBearerToken(boardApiToken),
+      expiresAt: null,
+    });
+    expect(key?.keyHash).not.toBe(boardApiToken);
+
+    const service = boardAuthService(db);
+    const validatedKey = await service.findBoardApiKeyByToken(boardApiToken);
+    expect(validatedKey?.id).toBe(result.boardApiKeyId);
+
+    const access = await service.resolveBoardAccess(result.userId);
+    expect(access.isInstanceAdmin).toBe(true);
+    expect(access.user).toMatchObject({
+      id: result.userId,
+      email: "ops@example.com",
+    });
+    expect(log.info).toHaveBeenCalledWith(
+      {
+        adminEmail: "ops@example.com",
+        keyName: BOOTSTRAP_BOARD_API_KEY_NAME,
+      },
+      "paperclip.bootstrap.seeded",
+    );
+  });
+});

--- a/server/src/first-boot-admin-bootstrap.ts
+++ b/server/src/first-boot-admin-bootstrap.ts
@@ -1,0 +1,165 @@
+import { createHash, randomBytes } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import {
+  authAccounts,
+  authUsers,
+  boardApiKeys,
+  instanceUserRoles,
+} from "@paperclipai/db";
+import { hashBearerToken } from "./services/board-auth.js";
+
+export const BOOTSTRAP_ADMIN_EMAIL_ENV = "PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL";
+export const BOOTSTRAP_BOARD_API_KEY_ENV = "PAPERCLIP_BOOTSTRAP_BOARD_API_KEY";
+export const BOOTSTRAP_BOARD_API_KEY_NAME = "agentswarm-platform";
+
+type BootstrapLogger = {
+  info(payload: Record<string, unknown>, message: string): void;
+};
+
+const consoleBootstrapLogger: BootstrapLogger = {
+  info(payload, message) {
+    console.info(message, payload);
+  },
+};
+
+export type FirstBootAdminBootstrapResult =
+  | {
+      status: "skipped";
+      reason: "env_missing" | "admin_exists";
+    }
+  | {
+      status: "seeded";
+      adminEmail: string;
+      userId: string;
+      boardApiKeyId: string;
+      keyName: typeof BOOTSTRAP_BOARD_API_KEY_NAME;
+    };
+
+function envValue(env: NodeJS.ProcessEnv, key: string): string | null {
+  const value = env[key]?.trim();
+  return value ? value : null;
+}
+
+function bootstrapUserId(email: string): string {
+  const digest = createHash("sha256").update(email.toLowerCase()).digest("hex").slice(0, 32);
+  return `bootstrap-admin-${digest}`;
+}
+
+function bootstrapAccountId(userId: string): string {
+  return `bootstrap-admin:${userId}`;
+}
+
+export async function seedFirstBootAdminAndBoardKeyFromEnv(
+  db: Db,
+  opts?: {
+    env?: NodeJS.ProcessEnv;
+    logger?: BootstrapLogger;
+  },
+): Promise<FirstBootAdminBootstrapResult> {
+  const env = opts?.env ?? process.env;
+  const log = opts?.logger ?? consoleBootstrapLogger;
+  const adminEmail = envValue(env, BOOTSTRAP_ADMIN_EMAIL_ENV);
+  const boardApiKey = envValue(env, BOOTSTRAP_BOARD_API_KEY_ENV);
+  const missing = [
+    adminEmail ? null : BOOTSTRAP_ADMIN_EMAIL_ENV,
+    boardApiKey ? null : BOOTSTRAP_BOARD_API_KEY_ENV,
+  ].filter((value): value is string => Boolean(value));
+
+  if (!adminEmail || !boardApiKey) {
+    log.info({ reason: "env_missing", missing }, "paperclip.bootstrap.skip");
+    return { status: "skipped", reason: "env_missing" };
+  }
+
+  const result = await db.transaction(async (tx) => {
+    await tx.execute(sql`lock table ${instanceUserRoles} in share row exclusive mode`);
+
+    const existingAdmin = await tx
+      .select({ userId: instanceUserRoles.userId })
+      .from(instanceUserRoles)
+      .where(eq(instanceUserRoles.role, "instance_admin"))
+      .then((rows) => rows[0] ?? null);
+
+    if (existingAdmin) {
+      return { status: "skipped" as const, reason: "admin_exists" as const };
+    }
+
+    const now = new Date();
+    const userId = bootstrapUserId(adminEmail);
+    const randomPassword = `pcp_bootstrap_password_${randomBytes(32).toString("hex")}`;
+
+    await tx
+      .insert(authUsers)
+      .values({
+        id: userId,
+        name: adminEmail,
+        email: adminEmail,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing({
+        target: authUsers.id,
+      });
+
+    await tx
+      .insert(authAccounts)
+      .values({
+        id: bootstrapAccountId(userId),
+        accountId: userId,
+        providerId: "credential",
+        userId,
+        password: `unused:${hashBearerToken(randomPassword)}`,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing({
+        target: authAccounts.id,
+      });
+
+    await tx.insert(instanceUserRoles).values({
+      userId,
+      role: "instance_admin",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const createdKey = await tx
+      .insert(boardApiKeys)
+      .values({
+        userId,
+        name: BOOTSTRAP_BOARD_API_KEY_NAME,
+        keyHash: hashBearerToken(boardApiKey),
+        expiresAt: null,
+        createdAt: now,
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    if (!createdKey) {
+      throw new Error("Failed to create bootstrap board API key");
+    }
+
+    return {
+      status: "seeded" as const,
+      adminEmail,
+      userId,
+      boardApiKeyId: createdKey.id,
+      keyName: BOOTSTRAP_BOARD_API_KEY_NAME as typeof BOOTSTRAP_BOARD_API_KEY_NAME,
+    };
+  });
+
+  if (result.status === "skipped") {
+    log.info({ reason: result.reason }, "paperclip.bootstrap.skip");
+    return result;
+  }
+
+  log.info(
+    {
+      adminEmail: result.adminEmail,
+      keyName: result.keyName,
+    },
+    "paperclip.bootstrap.seeded",
+  );
+  return result;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,6 +47,7 @@ import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
+import { seedFirstBootAdminAndBoardKeyFromEnv } from "./first-boot-admin-bootstrap.js";
 import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
@@ -516,6 +517,7 @@ export async function startServer(): Promise<StartedServer> {
   if (config.deploymentMode === "local_trusted") {
     await ensureLocalTrustedBoardPrincipal(db as any);
   }
+  await seedFirstBootAdminAndBoardKeyFromEnv(db as any, { logger });
   const accessBackfill = await backfillPrincipalAccessCompatibility(db as any);
   if (accessBackfill.agentMembershipsInserted > 0 || accessBackfill.humanGrantsInserted > 0) {
     logger.info(accessBackfill, "Backfilled principal access compatibility records");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI companies through a board, authenticated users, and board API keys.
> - Automated deployments need a headless way for an integrating system to obtain a board API key on first boot.
> - The existing CEO bootstrap flow is intentionally interactive, which blocks fresh or recovered deployments that need to seed Paperclip without a browser.
> - The safest shape is opt-in and first-boot only: env vars are consumed only when no `instance_admin` already exists.
> - This pull request adds a transactional startup hook that creates the first instance admin and one `agentswarm-platform` board API key from env.
> - The benefit is deterministic, idempotent deployment bootstrap without logging or exposing the plaintext API key.

## What Changed

- Added `seedFirstBootAdminAndBoardKeyFromEnv`, which reads `PAPERCLIP_BOOTSTRAP_ADMIN_EMAIL` and `PAPERCLIP_BOOTSTRAP_BOARD_API_KEY`, skips when either is unset, skips when an instance admin already exists, and otherwise seeds an admin plus a hashed board API key in one DB transaction.
- Wired the hook into server startup after DB setup/local trusted principal setup and before the first-admin claim/auth board flow.
- Added tests for unset env no-op, existing-admin no-op, seeded admin/key creation, and validating the seeded key through `boardAuthService`.
- Documented the optional first-boot env vars in `.env.example` and `docs/deploy/environment-variables.md`.

## Verification

- `PATH=/private/tmp/paperclip-bin:$PATH COREPACK_HOME=/private/tmp/corepack corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/first-boot-admin-bootstrap.test.ts` — pass
- `PATH=/private/tmp/paperclip-bin:$PATH COREPACK_HOME=/private/tmp/corepack corepack pnpm --filter @paperclipai/server typecheck` — pass
- `PATH=/private/tmp/paperclip-bin:$PATH COREPACK_HOME=/private/tmp/corepack corepack pnpm -r typecheck` — pass
- `PATH=/private/tmp/paperclip-bin:$PATH COREPACK_HOME=/private/tmp/corepack corepack pnpm build` — pass
- `PATH=/private/tmp/paperclip-bin:$PATH COREPACK_HOME=/private/tmp/corepack corepack pnpm test:run` — 1,288 pass / 1 skipped / 4 fail. The failures are unrelated local-environment assumptions: three Cursor remote-sandbox tests exit `127` for `cursor-agent`, and one `workspace-runtime.test.ts` fixture pushes a nonexistent `master` ref.

## Risks

- Low migration risk: no schema changes, and the hook is opt-in.
- The seeded password is random and stored only to satisfy the account schema; the bootstrap path is intended for board API key auth, not browser password sign-in.
- The board API key is only seeded when no `instance_admin` exists, so env rotation after first boot does not overwrite or create replacement keys.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex with code execution/tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A; no UI changes)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
