### PR TITLE
fix(auth): validate X-Paperclip-Run-Id is a UUID, return 400 not 500

### DIFF
--- a/server/src/__tests__/run-id-header-validation.test.ts
+++ b/server/src/__tests__/run-id-header-validation.test.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import type { Db } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+
+// Minimal Db mock — not called for local_trusted deployments before run-ID validation
+const mockDb = {} as unknown as Db;
+
+function createApp() {
+  const app = express();
+  app.use(actorMiddleware(mockDb, { deploymentMode: "local_trusted" }));
+  app.get("/probe", (_req, res) => res.status(200).json({ ok: true }));
+  return app;
+}
+
+describe("X-Paperclip-Run-Id header validation", () => {
+  const app = createApp();
+
+  it("returns 400 for a non-UUID run-id (the original 500 repro case)", async () => {
+    const res = await request(app)
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", "claude-local-1780081795-78034");
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("UUID") });
+  });
+
+  it("passes through when run-id is a valid UUID v4", async () => {
+    const res = await request(app)
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", randomUUID());
+    expect(res.status).toBe(200);
+  });
+
+  it("passes through when run-id header is absent", async () => {
+    const res = await request(app).get("/probe");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 for an empty run-id string", async () => {
+    const res = await request(app)
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", "");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a UUID missing hyphens", async () => {
+    const res = await request(app)
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", "550e8400e29b41d4a716446655440000");
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,6 +13,8 @@ function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 interface ActorMiddlewareOptions {
   deploymentMode: DeploymentMode;
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
@@ -20,7 +22,7 @@ interface ActorMiddlewareOptions {
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
-  return async (req, _res, next) => {
+  return async (req, res, next) => {
     req.actor =
       opts.deploymentMode === "local_trusted"
         ? {
@@ -34,6 +36,10 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         : { type: "none", source: "none" };
 
     const runIdHeader = req.header("x-paperclip-run-id");
+    if (runIdHeader !== undefined && !UUID_REGEX.test(runIdHeader)) {
+      res.status(400).json({ error: "X-Paperclip-Run-Id must be a valid UUID" });
+      return;
+    }
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {


### PR DESCRIPTION
## Summary

- A non-UUID `X-Paperclip-Run-Id` header value (e.g. `claude-local-1780081795-78034`) was propagated through `actorMiddleware` into `req.actor.runId` and then written to a `uuid` column (`createdByRunId`) — Postgres threw `invalid input syntax for type uuid`, unhandled, surfacing as HTTP 500 on all write routes.
- Adds a UUID regex guard in `actorMiddleware` immediately after header extraction (before any DB interaction), rejecting non-UUID values with 400.
- Adds a regression test suite: exact repro value from issue, valid UUID, absent header, empty string, UUID without hyphens.

Fixes HAC-711.

## Test plan
- [ ] `npx vitest run server/src/__tests__/run-id-header-validation.test.ts` — 5/5 pass
- [ ] `curl -X POST .../companies/:c/issues -H "X-Paperclip-Run-Id: claude-local-123"` → 400
- [ ] Same request with valid UUID → proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)