### PR TITLE
fix(db): ensure issue_read_states unique constraint exists (HAC-712)

### DIFF
--- a/packages/db/src/migrations/0094_fix_issue_read_states_unique_constraint.sql
+++ b/packages/db/src/migrations/0094_fix_issue_read_states_unique_constraint.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "issue_read_states_company_issue_user_idx" ON "issue_read_states" USING btree ("company_id","issue_id","user_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1780040470886,
       "tag": "0093_giant_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1780116000000,
+      "tag": "0094_fix_issue_read_states_unique_constraint",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds migration `0094` that re-creates the unique index on `issue_read_states(company_id, issue_id, user_id)` with `IF NOT EXISTS`
- Migration 0025 was supposed to create this index but the production DB was missing it, causing every `POST /api/issues/:id/read` to 500 with _"there is no unique or exclusion constraint matching the ON CONFLICT specification"_
- The `IF NOT EXISTS` guard makes the migration idempotent: no-op if the index already exists, creates it if absent

## Root cause

`markRead` in `server/src/services/issues.ts` uses Drizzle's `onConflictDoUpdate` targeting `[companyId, issueId, userId]`. PostgreSQL resolves this by inference against existing unique constraints/indexes. When the index is absent the query fails immediately.

## Test plan

- [ ] Server starts and applies migration 0094 on next deploy
- [ ] `POST /api/issues/:id/read` returns 200 instead of 500
- [ ] Second call to the same endpoint (conflict path) also returns 200 via the upsert

🤖 Generated with [Claude Code](https://claude.com/claude-code)