### PR TITLE
fix: drop reaped-run attribution instead of 500ing activity and comment writes

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -36,6 +36,7 @@ import {
   ISSUE_LIST_MAX_LIMIT,
   issueService,
 } from "../services/issues.ts";
+import { logActivity } from "../services/activity-log.ts";
 import { buildProjectMentionHref, MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -4113,5 +4114,113 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     );
     expect(record).not.toHaveProperty("requestedChildren");
     expect(record?.childIssues.every((child) => typeof child.title === "string")).toBe(true);
+  });
+});
+
+describeEmbeddedPostgres("run attribution survives a reaped heartbeat run", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-run-attribution-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAgentIssue() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Marketer",
+      role: "marketer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Distribution sprint",
+      status: "todo",
+      priority: "medium",
+      createdByAgentId: agentId,
+    });
+    return { companyId, agentId, issueId };
+  }
+
+  it("nulls the comment attribution when the acting run no longer exists", async () => {
+    const { agentId, issueId } = await seedCompanyAgentIssue();
+    const missingRunId = randomUUID();
+
+    const comment = await svc.addComment(issueId, "Posting after my run was reaped", {
+      agentId,
+      runId: missingRunId,
+    });
+
+    expect(comment.createdByRunId).toBeNull();
+    expect(comment.body).toContain("reaped");
+  });
+
+  it("preserves the comment attribution when the acting run still exists", async () => {
+    const { companyId, agentId, issueId } = await seedCompanyAgentIssue();
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({ id: runId, companyId, agentId });
+
+    const comment = await svc.addComment(issueId, "Posting from a live run", {
+      agentId,
+      runId,
+    });
+
+    expect(comment.createdByRunId).toBe(runId);
+  });
+
+  it("logActivity drops a missing run attribution instead of failing the write", async () => {
+    const { companyId, agentId, issueId } = await seedCompanyAgentIssue();
+    const missingRunId = randomUUID();
+
+    await expect(
+      logActivity(db, {
+        companyId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: issueId,
+        agentId,
+        runId: missingRunId,
+      }),
+    ).resolves.not.toThrow();
+
+    const [row] = await db
+      .select({ runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(row?.runId).toBeNull();
   });
 });

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog } from "@paperclipai/db";
+import { activityLog, heartbeatRuns } from "@paperclipai/db";
 import { PLUGIN_EVENT_TYPES, type PluginEventType } from "@paperclipai/shared";
 import type { PluginEvent } from "@paperclipai/plugin-sdk";
 import { publishLiveEvent } from "./live-events.js";
@@ -62,6 +63,25 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+/**
+ * Returns `runId` only when a matching `heartbeat_runs` row still exists,
+ * otherwise `null`. Use this before persisting a run attribution so a reaped
+ * run (process-lost, retention pruning, company/agent deletion) cannot trip
+ * the `run_id` foreign key and fail an otherwise-valid write.
+ */
+export async function resolveExistingRunId(
+  db: Db,
+  runId: string | null | undefined,
+): Promise<string | null> {
+  if (!runId) return null;
+  const exists = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows.length > 0);
+  return exists ? runId : null;
+}
+
 export async function logActivity(db: Db, input: LogActivityInput) {
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
@@ -70,6 +90,11 @@ export async function logActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = sanitizedDetails
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;
+  // The originating heartbeat run may have been reaped (e.g. process-lost or
+  // retention pruning) while its agent turn was still in flight. Attributing
+  // the activity to a now-missing run violates the run_id foreign key and 500s
+  // the whole write, so drop the attribution when the run no longer exists.
+  const runId = await resolveExistingRunId(db, input.runId);
   await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -78,7 +103,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId,
     details: redactedDetails,
   });
 
@@ -92,7 +117,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
+      runId,
       details: redactedDetails,
     },
   });
@@ -111,7 +136,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       payload: {
         ...redactedDetails,
         agentId: input.agentId ?? null,
-        runId: input.runId ?? null,
+        runId,
       },
     };
     publishPluginDomainEvent(event);

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -78,6 +78,7 @@ export async function resolveExistingRunId(
     .select({ id: heartbeatRuns.id })
     .from(heartbeatRuns)
     .where(eq(heartbeatRuns.id, runId))
+    .limit(1)
     .then((rows) => rows.length > 0);
   return exists ? runId : null;
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -68,6 +68,7 @@ import {
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
+import { resolveExistingRunId } from "./activity-log.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
@@ -5709,6 +5710,10 @@ export function issueService(db: Db) {
       const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
       const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
       const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
+      // The acting run may have been reaped while the agent was still posting;
+      // drop a now-missing run attribution rather than letting the
+      // created_by_run_id foreign key 500 the comment write.
+      const createdByRunId = await resolveExistingRunId(db, actor.runId);
       const [comment] = await db
         .insert(issueComments)
         .values({
@@ -5717,7 +5722,7 @@ export function issueService(db: Db) {
           authorAgentId: actor.agentId ?? null,
           authorUserId: actor.userId ?? null,
           authorType,
-          createdByRunId: actor.runId ?? null,
+          createdByRunId,
           body: redactedBody,
           presentation,
           metadata,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and every agent action is attributed to the `heartbeat_runs` row representing the turn that produced it.
> - Two write paths persist that attribution via a foreign key to `heartbeat_runs.id`: `activity_log.run_id` (written by `logActivity`) and `issue_comments.created_by_run_id` (written by `issueService.addComment`).
> - A heartbeat run can disappear *while its agent turn is still in flight* — process-lost reaping, retention pruning, or company/agent deletion all remove the row.
> - When the agent then writes a comment or status change attributed to that now-missing run, the insert violates the foreign key and Postgres rejects the whole statement with a 500.
> - In practice this fails real, user-visible writes: `PATCH /api/issues/:id` status changes and agent comments 500 out, and the issue's recovery watchdog then reports "no live execution path" because the run it would continue is gone.
> - The codebase already establishes the right pattern elsewhere — `feedback.ts` and `issue-thread-interactions.ts` both check that a run exists before attributing to it.
> - This pull request applies that same guard to the two unguarded write paths: resolve the run id to `null` when the run no longer exists, so the write succeeds unattributed instead of 500-ing.
> - The benefit is that agent comments and activity-log/status writes survive a reaped run, eliminating a recurring class of 500s and the stalled-issue banners they cause.

## What Changed

- Added `resolveExistingRunId(db, runId)` to `server/src/services/activity-log.ts` — returns the id only when a matching `heartbeat_runs` row exists, otherwise `null`.
- `logActivity` now resolves `input.runId` through that helper before insert, and uses the resolved value consistently for the row, the live event, and the plugin event payload.
- `issueService.addComment` resolves `actor.runId` through the same helper before inserting `created_by_run_id`.
- Added regression tests in `server/src/__tests__/issues-service.test.ts` covering: comment attribution nulled when the run is missing, attribution preserved when the run exists, and `logActivity` succeeding (run_id null) instead of throwing on a missing run.

## Verification

- `cd server && pnpm run typecheck` → 0 errors.
- `cd server && npx vitest run src/__tests__/issues-service.test.ts` → **64 passed** (3 new + 61 existing), embedded Postgres.
- `node scripts/check-forbidden-tokens.mjs` → clean.
- Manual root-cause: observed the exact failures in a live workspace — `insert ... activity_log ... violates foreign key constraint "activity_log_run_id_heartbeat_runs_id_fk"` and the matching `issue_comments_created_by_run_id_heartbeat_runs_id_fk` on `PATCH /api/issues/:id` and `addComment`, on `v2026.525.0`. Confirmed the same code paths are unguarded on current `master`.

## Risks

- Low risk. Behavior only changes when the referenced run no longer exists: previously a 500, now a successful write with a `null` run attribution (the same end state `issue_comments` already declares via `onDelete: "set null"`).
- One extra indexed primary-key lookup on `heartbeat_runs` per attributed write. This matches the existing pattern in `feedback.ts` / `issue-thread-interactions.ts`.
- A narrow TOCTOU window remains (a run could be deleted between the existence check and the insert) — identical to the existing run-attribution sites, and far rarer than the steady-state failures this fixes.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, via Claude Code with tool use (filesystem, shell, git). Extended reasoning enabled. Diff authored and verified by the model; reviewed by a human before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
