### PR TITLE
codex-limit-probe: hourly Codex profile probe and auto-recovery (KSI-690)

### DIFF
--- a/server/src/__tests__/codex-limit-probe.test.ts
+++ b/server/src/__tests__/codex-limit-probe.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CODEX_LIMIT_PROBE_CRON,
+  CODEX_LIMIT_PROBE_TIMEZONE,
+  codexLimitProbeService,
+  profileLabelForHome,
+  resolveProbeProfiles,
+  matchesCronTickInTimeZone,
+  looksLikeCodexUsageLimit,
+} from "../services/codex-limit-probe.js";
+
+describe("codex-limit-probe helpers", () => {
+  describe("profileLabelForHome", () => {
+    it("maps known c1/c2 paths to their canonical labels", () => {
+      expect(profileLabelForHome("/paperclip/.codex-c1")).toBe("codex-c1");
+      expect(profileLabelForHome("/paperclip/.codex-c2")).toBe("codex-c2");
+    });
+
+    it("falls back to 'custom-<base>' for sanitisable basenames", () => {
+      expect(profileLabelForHome("/paperclip/.codex-staging")).toBe("custom-codex-staging");
+      expect(profileLabelForHome("/tmp/myhome")).toBe("custom-myhome");
+    });
+  });
+
+  describe("resolveProbeProfiles", () => {
+    it("returns CODEX_HOME first, then CODEX_FALLBACK entries, deduplicated", () => {
+      const profiles = resolveProbeProfiles({
+        CODEX_HOME: "/paperclip/.codex-c1",
+        CODEX_FALLBACK: "/paperclip/.codex-c1,/paperclip/.codex-c2",
+      } as NodeJS.ProcessEnv);
+      expect(profiles).toEqual([
+        { label: "codex-c1", home: "/paperclip/.codex-c1" },
+        { label: "codex-c2", home: "/paperclip/.codex-c2" },
+      ]);
+    });
+
+    it("supports colon-separated CODEX_FALLBACK", () => {
+      const profiles = resolveProbeProfiles({
+        CODEX_HOME: "",
+        CODEX_FALLBACK: "/paperclip/.codex-c1:/paperclip/.codex-c2",
+      } as NodeJS.ProcessEnv);
+      expect(profiles.map((p) => p.label)).toEqual(["codex-c1", "codex-c2"]);
+    });
+
+    it("ignores relative paths", () => {
+      const profiles = resolveProbeProfiles({
+        CODEX_HOME: "../bogus",
+        CODEX_FALLBACK: "/paperclip/.codex-c1",
+      } as NodeJS.ProcessEnv);
+      expect(profiles).toEqual([{ label: "codex-c1", home: "/paperclip/.codex-c1" }]);
+    });
+
+    it("returns empty when nothing is configured", () => {
+      expect(resolveProbeProfiles({} as NodeJS.ProcessEnv)).toEqual([]);
+    });
+  });
+
+  describe("looksLikeCodexUsageLimit", () => {
+    it("matches English usage-limit phrases", () => {
+      expect(looksLikeCodexUsageLimit("you've hit your usage limit; try again at 5pm")).toBe(true);
+      expect(looksLikeCodexUsageLimit("You have hit your usage limit")).toBe(true);
+    });
+
+    it("matches Portuguese usage-limit phrases", () => {
+      expect(looksLikeCodexUsageLimit("Você atingiu o limite de mensagens por hoje.")).toBe(true);
+      expect(looksLikeCodexUsageLimit("seu limite de uso será redefinido às 14:00")).toBe(true);
+    });
+
+    it("does not match unrelated stderr", () => {
+      expect(looksLikeCodexUsageLimit("codex 0.123.4")).toBe(false);
+      expect(looksLikeCodexUsageLimit("error: connection refused")).toBe(false);
+    });
+  });
+
+  describe("matchesCronTickInTimeZone", () => {
+    it("matches the documented `0 * * * *` cron at the top of the UTC hour", () => {
+      const onHour = new Date("2026-01-15T17:00:00Z");
+      expect(matchesCronTickInTimeZone(CODEX_LIMIT_PROBE_CRON, CODEX_LIMIT_PROBE_TIMEZONE, onHour)).toBe(true);
+    });
+
+    it("rejects ticks that are not on the 0th minute", () => {
+      const offHour = new Date("2026-01-15T17:01:00Z");
+      expect(matchesCronTickInTimeZone(CODEX_LIMIT_PROBE_CRON, CODEX_LIMIT_PROBE_TIMEZONE, offHour)).toBe(false);
+      const offHour2 = new Date("2026-01-15T17:30:00Z");
+      expect(matchesCronTickInTimeZone(CODEX_LIMIT_PROBE_CRON, CODEX_LIMIT_PROBE_TIMEZONE, offHour2)).toBe(false);
+    });
+  });
+});
+
+describe("codexLimitProbeService", () => {
+  // We intentionally bypass the real DB by passing a tiny stub that
+  // satisfies just the calls the probe makes via Drizzle's fluent builder.
+  // This keeps the unit test fast and free of postgres.
+  function makeDbStub(blockedRows: Array<{
+    runId: string;
+    companyId: string;
+    agentId: string;
+    issueId: string | null;
+    adapterType: string;
+    errorFamily: string | null;
+  }>) {
+    return {
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({
+            where: () => Promise.resolve(blockedRows),
+          }),
+        }),
+      }),
+    } as unknown as Parameters<typeof codexLimitProbeService>[0]["db"];
+  }
+
+  function makeHeartbeatStub() {
+    return {
+      retryScheduledRetryNow: vi.fn(async (input: { issueId: string }) => ({
+        outcome: "promoted" as const,
+        message: "ok",
+        scheduledRetry: { runId: `run-for-${input.issueId}` },
+      })),
+    };
+  }
+
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("skips silently when the cron is not due", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const probe = codexLimitProbeService({
+      db: makeDbStub([]),
+      heartbeat,
+      isDueAt: () => false,
+      execFile: vi.fn() as never,
+      resolveProfiles: () => [{ label: "codex-c1", home: "/paperclip/.codex-c1" }],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:30:00Z"));
+    expect(result.ran).toBe(false);
+    expect(result.skippedReason).toBe("cron_not_due");
+    expect(heartbeat.retryScheduledRetryNow).not.toHaveBeenCalled();
+  });
+
+  it("skips silently when no codex_local scheduled_retry runs are blocked", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const probe = codexLimitProbeService({
+      db: makeDbStub([]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: vi.fn() as never,
+      resolveProfiles: () => [{ label: "codex-c1", home: "/paperclip/.codex-c1" }],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(false);
+    expect(result.skippedReason).toBe("no_blocked_runs");
+    expect(heartbeat.retryScheduledRetryNow).not.toHaveBeenCalled();
+  });
+
+  it("skips when no profiles are configured even if blocked runs exist", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const probe = codexLimitProbeService({
+      db: makeDbStub([
+        {
+          runId: "run-1",
+          companyId: "c-1",
+          agentId: "a-1",
+          issueId: "issue-1",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+      ]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: vi.fn() as never,
+      resolveProfiles: () => [],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(false);
+    expect(result.skippedReason).toBe("no_profiles_configured");
+    expect(heartbeat.retryScheduledRetryNow).not.toHaveBeenCalled();
+  });
+
+  it("filters out runs whose contextSnapshot.errorFamily is not transient_upstream", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const execFile = vi.fn(async () => ({ stdout: "codex 0.123.4\n", stderr: "" }));
+    const probe = codexLimitProbeService({
+      db: makeDbStub([
+        {
+          runId: "run-not-transient",
+          companyId: "c-1",
+          agentId: "a-1",
+          issueId: "issue-1",
+          adapterType: "codex_local",
+          errorFamily: "max_turn",
+        },
+      ]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: execFile as never,
+      resolveProfiles: () => [{ label: "codex-c1", home: "/paperclip/.codex-c1" }],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(false);
+    expect(result.skippedReason).toBe("no_blocked_runs");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("does not accelerate any retry when both profiles still report usage_limit", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const execFile = vi.fn(async () => {
+      const error = new Error("Command exited 1") as Error & { stdout: string; stderr: string };
+      error.stdout = "";
+      error.stderr = "you've hit your usage limit; try again at 5pm";
+      throw error;
+    });
+    const probe = codexLimitProbeService({
+      db: makeDbStub([
+        {
+          runId: "run-1",
+          companyId: "c-1",
+          agentId: "a-1",
+          issueId: "issue-1",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+      ]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: execFile as never,
+      resolveProfiles: () => [
+        { label: "codex-c1", home: "/paperclip/.codex-c1" },
+        { label: "codex-c2", home: "/paperclip/.codex-c2" },
+      ],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(true);
+    expect(result.acceleratedRunCount).toBe(0);
+    expect(result.profiles.map((p) => p.status)).toEqual(["usage_limit", "usage_limit"]);
+    expect(execFile).toHaveBeenCalledTimes(2);
+    expect(heartbeat.retryScheduledRetryNow).not.toHaveBeenCalled();
+  });
+
+  it("accelerates each unique blocked issue when at least one profile recovers", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const execFile = vi.fn(async (_bin: string, _args: readonly string[], opts: { env: NodeJS.ProcessEnv }) => {
+      // c1 still exhausted; c2 recovered
+      if (opts.env.CODEX_HOME === "/paperclip/.codex-c1") {
+        const err = new Error("Command exited 1") as Error & { stdout: string; stderr: string };
+        err.stdout = "";
+        err.stderr = "you've hit your usage limit";
+        throw err;
+      }
+      return { stdout: "codex 0.123.4\n", stderr: "" };
+    });
+    const probe = codexLimitProbeService({
+      db: makeDbStub([
+        {
+          runId: "run-1",
+          companyId: "c-1",
+          agentId: "a-1",
+          issueId: "issue-1",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+        {
+          runId: "run-2",
+          companyId: "c-1",
+          agentId: "a-2",
+          issueId: "issue-2",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+        {
+          // duplicate issueId — should be deduped
+          runId: "run-3",
+          companyId: "c-1",
+          agentId: "a-3",
+          issueId: "issue-1",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+      ]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: execFile as never,
+      resolveProfiles: () => [
+        { label: "codex-c1", home: "/paperclip/.codex-c1" },
+        { label: "codex-c2", home: "/paperclip/.codex-c2" },
+      ],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(true);
+    expect(result.profiles).toEqual([
+      { label: "codex-c1", home: "/paperclip/.codex-c1", status: "usage_limit" },
+      { label: "codex-c2", home: "/paperclip/.codex-c2", status: "alive" },
+    ]);
+    expect(result.acceleratedRunCount).toBe(2);
+    expect(heartbeat.retryScheduledRetryNow).toHaveBeenCalledTimes(2);
+    const issueIds = heartbeat.retryScheduledRetryNow.mock.calls.map((call) => call[0].issueId).sort();
+    expect(issueIds).toEqual(["issue-1", "issue-2"]);
+    for (const call of heartbeat.retryScheduledRetryNow.mock.calls) {
+      expect(call[0].actor).toEqual({ actorType: "system", actorId: "codex-limit-probe" });
+    }
+  });
+
+  it("treats a runtime spawn error (no stderr) as a transient probe failure, not as recovery", async () => {
+    const heartbeat = makeHeartbeatStub();
+    const execFile = vi.fn(async () => {
+      throw new Error("ENOENT: no such file or directory, open 'codex'");
+    });
+    const probe = codexLimitProbeService({
+      db: makeDbStub([
+        {
+          runId: "run-1",
+          companyId: "c-1",
+          agentId: "a-1",
+          issueId: "issue-1",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+      ]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: execFile as never,
+      resolveProfiles: () => [{ label: "codex-c1", home: "/paperclip/.codex-c1" }],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(true);
+    expect(result.profiles[0].status).toBe("error");
+    // Still no acceleration since "error" is not "alive".
+    expect(heartbeat.retryScheduledRetryNow).not.toHaveBeenCalled();
+  });
+
+  it("survives a heartbeat retry promotion failure for one issue without aborting the rest", async () => {
+    const heartbeat = {
+      retryScheduledRetryNow: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          throw new Error("transaction conflict");
+        })
+        .mockImplementationOnce(async (input: { issueId: string }) => ({
+          outcome: "promoted" as const,
+          message: "ok",
+          scheduledRetry: { runId: `run-for-${input.issueId}` },
+        })),
+    };
+    const execFile = vi.fn(async () => ({ stdout: "codex 0.123.4\n", stderr: "" }));
+    const probe = codexLimitProbeService({
+      db: makeDbStub([
+        {
+          runId: "run-a",
+          companyId: "c-1",
+          agentId: "a-1",
+          issueId: "issue-a",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+        {
+          runId: "run-b",
+          companyId: "c-1",
+          agentId: "a-2",
+          issueId: "issue-b",
+          adapterType: "codex_local",
+          errorFamily: "transient_upstream",
+        },
+      ]),
+      heartbeat,
+      isDueAt: () => true,
+      execFile: execFile as never,
+      resolveProfiles: () => [{ label: "codex-c1", home: "/paperclip/.codex-c1" }],
+    });
+
+    const result = await probe.tickProbe(new Date("2026-01-15T17:00:00Z"));
+    expect(result.ran).toBe(true);
+    expect(result.acceleratedRunCount).toBe(1);
+    expect(heartbeat.retryScheduledRetryNow).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { setupLiveEventsWebSocketServer } from "./realtime/live-events-ws.js";
 import {
   feedbackService,
   backfillPrincipalAccessCompatibility,
+  codexLimitProbeService,
   heartbeatService,
   instanceSettingsService,
   reconcileCloudUpstreamRunsOnStartup,
@@ -719,6 +720,7 @@ export async function startServer(): Promise<StartedServer> {
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });
+    const codexLimitProbe = codexLimitProbeService({ db: db as any, heartbeat });
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
@@ -784,6 +786,26 @@ export async function startServer(): Promise<StartedServer> {
         })
         .catch((err) => {
           logger.error({ err }, "routine scheduler tick failed");
+        });
+
+      // KSI-690: Codex usage-limit probe. Cheap no-op invocation against
+      // each configured CODEX_HOME on the cron `0 * * * *`. Skips silently
+      // when no codex_local scheduled_retry runs exist (auto-deactivation).
+      void codexLimitProbe
+        .tickProbe(new Date())
+        .then((result) => {
+          if (result.ran) {
+            logger.info(
+              {
+                profiles: result.profiles.map((p) => ({ label: p.label, status: p.status })),
+                acceleratedRunCount: result.acceleratedRunCount,
+              },
+              "codex limit probe tick completed",
+            );
+          }
+        })
+        .catch((err) => {
+          logger.error({ err }, "codex limit probe tick failed");
         });
   
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure

--- a/server/src/services/codex-limit-probe.ts
+++ b/server/src/services/codex-limit-probe.ts
@@ -1,0 +1,459 @@
+/**
+ * Codex usage-limit probe — KSI-690.
+ *
+ * Background: Paperclip codex_local agents can be configured with two profiles
+ * (CODEX_HOME + CODEX_FALLBACK, e.g. `/paperclip/.codex-c1` and
+ * `/paperclip/.codex-c2`). When both profiles report a Codex usage-limit, the
+ * adapter marks the run as `errorCode = codex_transient_upstream` and the
+ * heartbeat scheduler records a scheduled retry. Until at least one profile
+ * recovers, no Codex agent can make progress on Codex-blocked issues.
+ *
+ * This module periodically probes the configured Codex profiles via a no-op
+ * `codex --version`-style invocation (which does not consume model turns) and,
+ * when at least one profile is responsive again, accelerates every scheduled
+ * retry that is parked on `codex_transient_upstream` so the retry runs on the
+ * next scheduler tick.
+ *
+ * Design notes:
+ *
+ * - The probe is *self-gating*. It is "active" iff there is at least one
+ *   Codex `scheduled_retry` heartbeat run waiting on
+ *   `errorFamily = transient_upstream`. When the queue drains, the probe
+ *   simply does nothing on subsequent ticks (auto-deactivation).
+ * - Trigger cadence is honored via the cron expression `0 * * * *` (top of
+ *   every UTC hour). The cron is evaluated against the same wall-clock as the
+ *   server-internal heartbeat scheduler tick (no separate timer needed).
+ * - The probe never spawns more than one `codex` process per profile per tick
+ *   and uses a short timeout to keep the operation cheap.
+ * - On recovery, the probe calls `heartbeatService.retryScheduledRetryNow`
+ *   for each affected issue. That helper already handles promotion +
+ *   wakeup-request payload bookkeeping.
+ *
+ * Decisions explicitly made for KSI-690:
+ *
+ * - `D3` (issue plan): implement as a server-internal periodic task instead
+ *   of a `routines`-table row. The `routines` table only knows how to
+ *   dispatch issues to agents; running an out-of-band `codex --version` per
+ *   profile does not fit that model and would either require a Codex agent
+ *   (chicken-and-egg: the agent itself is exhausted) or a dispatch-intercept
+ *   hook just for this routine. A server-internal probe is simpler, has no
+ *   external state, and is auditable through structured logger output. UI
+ *   visibility under `/routines` can be added in a follow-up if leadership
+ *   wants it.
+ * - The probe is intentionally lenient toward partial integration with the
+ *   sibling subtasks KSI-687 (Mudança 1, blocked status) and KSI-689
+ *   (Mudança 3, label `codex-limit`). It identifies affected runs by
+ *   `errorFamily = transient_upstream` on a codex_local agent and does not
+ *   require the label to exist; once those subtasks land the probe will pick
+ *   up the additional state (label removal, blocked → in_progress) for free
+ *   because the existing transitions in heartbeat.ts already react to
+ *   scheduled-retry promotion.
+ */
+
+import { execFile as execFileCallback } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { and, eq, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, heartbeatRuns } from "@paperclipai/db";
+
+import { logger } from "../middleware/logger.js";
+import { parseCron, type ParsedCron } from "./cron.js";
+import type { heartbeatService } from "./heartbeat.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Cron tick for the probe. Top of every UTC hour. Mirrors the value
+ * documented in KSI-690.
+ */
+export const CODEX_LIMIT_PROBE_CRON = "0 * * * *";
+
+/**
+ * Wall-clock timezone used to evaluate `CODEX_LIMIT_PROBE_CRON`. The server
+ * already runs internal jobs against UTC; using UTC keeps probe behavior
+ * stable regardless of host timezone.
+ */
+export const CODEX_LIMIT_PROBE_TIMEZONE = "UTC";
+
+/**
+ * Default per-profile probe timeout. Probes are no-op `--version` calls so
+ * they normally return in milliseconds; the cap exists to protect against
+ * stuck child processes.
+ */
+export const CODEX_LIMIT_PROBE_PER_PROFILE_TIMEOUT_MS = 10_000;
+
+/**
+ * Default codex binary used for the probe. Overridable for tests via
+ * `PAPERCLIP_CODEX_COMMAND`. The probe never invokes the
+ * `codex-home-fallback` wrapper because we want to test exactly *one*
+ * profile per spawn.
+ */
+const DEFAULT_CODEX_BINARY = "/usr/local/bin/codex";
+
+const DEFAULT_CODEX_PROBE_ARGS = ["--version"] as const;
+
+const RECOGNIZED_USAGE_LIMIT_RE =
+  /usage limit|limite de mensagens|limite de uso|you'?ve hit your usage limit|you have hit your usage limit|voce atingiu o limite|voc[eê] atingiu o limite|seu limite de uso/i;
+
+// ---------------------------------------------------------------------------
+// Helpers (public for testing)
+// ---------------------------------------------------------------------------
+
+const execFileAsync = promisify(execFileCallback);
+
+/**
+ * Resolve which CODEX_HOME directories the probe should test for the local
+ * Paperclip instance. Reads `CODEX_HOME` and `CODEX_FALLBACK` from the
+ * provided env (default: `process.env`).
+ *
+ * The returned array is the de-duplicated, ordered list of homes that match
+ * the host filesystem: paths that do not look absolute are dropped (we will
+ * never silently probe a relative path).
+ */
+export function resolveProbeProfiles(env: NodeJS.ProcessEnv = process.env): Array<{
+  label: string;
+  home: string;
+}> {
+  const seen = new Set<string>();
+  const result: Array<{ label: string; home: string }> = [];
+
+  const candidates: string[] = [];
+  const primary = (env.CODEX_HOME ?? "").trim();
+  if (primary) candidates.push(primary);
+  const fallbackRaw = (env.CODEX_FALLBACK ?? "").trim();
+  if (fallbackRaw) {
+    for (const piece of fallbackRaw.split(/[,:]/)) {
+      const trimmed = piece.trim();
+      if (trimmed) candidates.push(trimmed);
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (!path.isAbsolute(candidate)) continue;
+    const normalized = path.resolve(candidate);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push({ label: profileLabelForHome(normalized), home: normalized });
+  }
+
+  return result;
+}
+
+/**
+ * Pick a stable, log-safe label for a CODEX_HOME path. Mirrors the labelling
+ * scheme used by `paperclip/bin/codex-home-fallback` so the probe's logs read
+ * the same as the wrapper's.
+ */
+export function profileLabelForHome(home: string): string {
+  const base = path.basename(home).replace(/^\./, "");
+  if (base === "codex-c1") return "codex-c1";
+  if (base === "codex-c2") return "codex-c2";
+  if (/^[A-Za-z0-9._-]+$/.test(base) && base.length > 0) return `custom-${base}`;
+  return "custom";
+}
+
+/**
+ * True when the captured stdout/stderr from a probe spawn looks like a
+ * Codex-side usage-limit message. Matches the same regex as the wrapper.
+ */
+export function looksLikeCodexUsageLimit(text: string): boolean {
+  return RECOGNIZED_USAGE_LIMIT_RE.test(text);
+}
+
+// ---------------------------------------------------------------------------
+// cron.ts re-export (to avoid coupling consumers to the routines module)
+// ---------------------------------------------------------------------------
+
+export type { ParsedCron };
+
+/**
+ * Returns true when `now` falls on a tick of the given cron expression in
+ * the configured timezone (rounded to the minute).
+ *
+ * Implemented in terms of the existing `parseCron` helper from
+ * `./cron.js`, with timezone parts derived from `Intl.DateTimeFormat`.
+ */
+export function matchesCronTickInTimeZone(
+  expression: string,
+  timeZone: string,
+  date: Date,
+): boolean {
+  const cron = parseCron(expression);
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    weekday: "short",
+  });
+  const parts = formatter.formatToParts(date);
+  const map = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  const weekdayIndex: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  const weekday = weekdayIndex[map.weekday ?? ""];
+  if (weekday == null) return false;
+  return (
+    cron.minutes.includes(Number(map.minute)) &&
+    cron.hours.includes(Number(map.hour)) &&
+    cron.daysOfMonth.includes(Number(map.day)) &&
+    cron.months.includes(Number(map.month)) &&
+    cron.daysOfWeek.includes(weekday)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Probe service
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe outcome for a single CODEX_HOME.
+ */
+export type ProbeProfileOutcome =
+  | { label: string; home: string; status: "alive" }
+  | { label: string; home: string; status: "usage_limit" }
+  | { label: string; home: string; status: "error"; reason: string };
+
+/**
+ * Aggregate outcome for a probe tick.
+ */
+export interface ProbeTickOutcome {
+  ranAt: Date;
+  /** Profiles tested. Empty array means probe was skipped (not active). */
+  profiles: ProbeProfileOutcome[];
+  /**
+   * Number of `scheduled_retry` heartbeat runs that the probe accelerated to
+   * `scheduledRetryAt = now()` because at least one profile recovered.
+   */
+  acceleratedRunCount: number;
+  /**
+   * True when the cron was due AND there was at least one Codex
+   * `scheduled_retry` run blocked on usage-limit.
+   */
+  ran: boolean;
+  /** Skip reason when `ran === false`, e.g. `"cron_not_due"`, `"no_blocked_runs"`. */
+  skippedReason?: "cron_not_due" | "no_blocked_runs" | "no_profiles_configured";
+}
+
+interface CodexLimitProbeDeps {
+  db: Db;
+  heartbeat: Pick<ReturnType<typeof heartbeatService>, "retryScheduledRetryNow">;
+  /** Override for the codex binary command. Defaults to PAPERCLIP_CODEX_COMMAND or /usr/local/bin/codex. */
+  codexBinary?: string;
+  /** Override probe args. Defaults to ["--version"]. */
+  codexProbeArgs?: readonly string[];
+  /** Override profile resolver. Defaults to reading process.env. */
+  resolveProfiles?: () => Array<{ label: string; home: string }>;
+  /** Override spawn function for tests. */
+  execFile?: typeof execFileAsync;
+  /** Override cron evaluator for tests. */
+  isDueAt?: (now: Date) => boolean;
+  /** Per-profile probe timeout. */
+  perProfileTimeoutMs?: number;
+}
+
+/**
+ * Public service factory for the Codex limit probe.
+ */
+export function codexLimitProbeService(deps: CodexLimitProbeDeps) {
+  const codexBinary = deps.codexBinary
+    ?? process.env.PAPERCLIP_CODEX_COMMAND
+    ?? DEFAULT_CODEX_BINARY;
+  const codexProbeArgs = deps.codexProbeArgs ?? DEFAULT_CODEX_PROBE_ARGS;
+  const resolveProfiles = deps.resolveProfiles ?? (() => resolveProbeProfiles());
+  const execFile = deps.execFile ?? execFileAsync;
+  const isDueAt = deps.isDueAt
+    ?? ((now: Date) => matchesCronTickInTimeZone(CODEX_LIMIT_PROBE_CRON, CODEX_LIMIT_PROBE_TIMEZONE, now));
+  const perProfileTimeoutMs = deps.perProfileTimeoutMs ?? CODEX_LIMIT_PROBE_PER_PROFILE_TIMEOUT_MS;
+
+  /**
+   * List `scheduled_retry` heartbeat runs that are parked on
+   * `errorFamily = transient_upstream` for `codex_local` agents. Each entry
+   * has the issue id (when available) so the probe can target
+   * `retryScheduledRetryNow` per issue.
+   */
+  async function listBlockedCodexRuns(): Promise<
+    Array<{ runId: string; companyId: string; agentId: string; issueId: string | null }>
+  > {
+    const rows = await deps.db
+      .select({
+        runId: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
+        issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`,
+        adapterType: agents.adapterType,
+        errorFamily: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'errorFamily'`,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(
+        and(
+          eq(heartbeatRuns.status, "scheduled_retry"),
+          eq(agents.adapterType, "codex_local"),
+        ),
+      );
+    return rows
+      .filter((row) => row.errorFamily === "transient_upstream")
+      .map((row) => ({
+        runId: row.runId,
+        companyId: row.companyId,
+        agentId: row.agentId,
+        issueId: row.issueId,
+      }));
+  }
+
+  /**
+   * Spawn the probe binary once with `CODEX_HOME=<home>`. Returns the
+   * profile outcome.
+   */
+  async function probeProfile(profile: {
+    label: string;
+    home: string;
+  }): Promise<ProbeProfileOutcome> {
+    try {
+      const { stdout, stderr } = await execFile(
+        codexBinary,
+        [...codexProbeArgs],
+        {
+          env: { ...process.env, CODEX_HOME: profile.home },
+          timeout: perProfileTimeoutMs,
+          windowsHide: true,
+        },
+      );
+      const combined = `${stdout ?? ""}\n${stderr ?? ""}`;
+      if (looksLikeCodexUsageLimit(combined)) {
+        return { label: profile.label, home: profile.home, status: "usage_limit" };
+      }
+      return { label: profile.label, home: profile.home, status: "alive" };
+    } catch (err) {
+      // Even when the binary exits non-zero, the captured stderr may signal
+      // usage-limit (the wrapper does the same thing). Prefer the
+      // usage-limit classification over a generic error so the probe does
+      // not falsely mark the profile as recovered.
+      const stderr = (err as { stderr?: unknown }).stderr;
+      const stdout = (err as { stdout?: unknown }).stdout;
+      const combined = `${typeof stdout === "string" ? stdout : ""}\n${typeof stderr === "string" ? stderr : ""}`;
+      if (combined.length > 0 && looksLikeCodexUsageLimit(combined)) {
+        return { label: profile.label, home: profile.home, status: "usage_limit" };
+      }
+      const reason = err instanceof Error ? err.message : String(err);
+      return { label: profile.label, home: profile.home, status: "error", reason };
+    }
+  }
+
+  /**
+   * Run the probe once. Skips silently when the cron is not due or when
+   * there are no Codex runs parked on `transient_upstream`.
+   *
+   * Safe to call from any periodic tick that fires more often than once
+   * per minute.
+   */
+  async function tickProbe(now: Date = new Date()): Promise<ProbeTickOutcome> {
+    if (!isDueAt(now)) {
+      return { ranAt: now, profiles: [], acceleratedRunCount: 0, ran: false, skippedReason: "cron_not_due" };
+    }
+
+    const blockedRuns = await listBlockedCodexRuns();
+    if (blockedRuns.length === 0) {
+      return { ranAt: now, profiles: [], acceleratedRunCount: 0, ran: false, skippedReason: "no_blocked_runs" };
+    }
+
+    const profiles = resolveProfiles();
+    if (profiles.length === 0) {
+      logger.warn(
+        { configuredCodexHome: process.env.CODEX_HOME ?? null, configuredCodexFallback: process.env.CODEX_FALLBACK ?? null },
+        "Codex limit probe: no profiles configured but blocked runs exist; cannot probe",
+      );
+      return {
+        ranAt: now,
+        profiles: [],
+        acceleratedRunCount: 0,
+        ran: false,
+        skippedReason: "no_profiles_configured",
+      };
+    }
+
+    const outcomes: ProbeProfileOutcome[] = [];
+    for (const profile of profiles) {
+      // Sequential: total fan-out is at most ~2 profiles in the documented
+      // configuration, and serial execution avoids competing for the codex
+      // binary on the host.
+      // eslint-disable-next-line no-await-in-loop
+      const outcome = await probeProfile(profile);
+      outcomes.push(outcome);
+    }
+
+    const anyAlive = outcomes.some((o) => o.status === "alive");
+    let acceleratedRunCount = 0;
+
+    if (anyAlive) {
+      // Snapshot the issues we are accelerating once; a new run may show up
+      // mid-loop but it will be picked up by the next tick.
+      const seenIssues = new Set<string>();
+      for (const blocked of blockedRuns) {
+        if (!blocked.issueId || seenIssues.has(blocked.issueId)) continue;
+        seenIssues.add(blocked.issueId);
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const result = await deps.heartbeat.retryScheduledRetryNow({
+            issueId: blocked.issueId,
+            actor: { actorType: "system", actorId: "codex-limit-probe" },
+            now,
+          });
+          if (result.outcome === "promoted" || result.outcome === "already_promoted") {
+            acceleratedRunCount += 1;
+          }
+        } catch (err) {
+          logger.warn(
+            { err, issueId: blocked.issueId, runId: blocked.runId },
+            "Codex limit probe: failed to accelerate scheduled retry for blocked issue",
+          );
+        }
+      }
+      logger.info(
+        {
+          profiles: outcomes.map((o) => ({ label: o.label, status: o.status })),
+          acceleratedRunCount,
+          blockedRunCount: blockedRuns.length,
+        },
+        "Codex limit probe: at least one profile recovered; accelerated scheduled retries",
+      );
+    } else {
+      logger.info(
+        {
+          profiles: outcomes.map((o) => ({ label: o.label, status: o.status })),
+          blockedRunCount: blockedRuns.length,
+        },
+        "Codex limit probe: no profile recovered; will retry on the next cron tick",
+      );
+    }
+
+    return {
+      ranAt: now,
+      profiles: outcomes,
+      acceleratedRunCount,
+      ran: true,
+    };
+  }
+
+  return {
+    tickProbe,
+    listBlockedCodexRuns,
+    probeProfile,
+  };
+}
+
+export type CodexLimitProbeService = ReturnType<typeof codexLimitProbeService>;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -36,6 +36,15 @@ export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
 export { heartbeatService } from "./heartbeat.js";
 export {
+  codexLimitProbeService,
+  CODEX_LIMIT_PROBE_CRON,
+  CODEX_LIMIT_PROBE_TIMEZONE,
+  resolveProbeProfiles,
+  type CodexLimitProbeService,
+  type ProbeProfileOutcome,
+  type ProbeTickOutcome,
+} from "./codex-limit-probe.js";
+export {
   productivityReviewService,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
 } from "./productivity-review.js";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat scheduler parks Codex (`codex_local`) runs on `errorCode = codex_transient_upstream` whenever both `CODEX_HOME` and `CODEX_FALLBACK` profiles report a usage-limit
> - Today the parked retries only resume on the per-run `retryNotBefore` window or on a manual `retry now`, so an agent waiting on usage-limit recovery can sit idle long after a profile has credits again
> - KSI-586's plan calls out a probe loop ("Mudança 4") that periodically tests each profile and accelerates the parked retries when at least one profile recovers
> - This PR is the implementation of that probe (subtask KSI-690)
> - The benefit is that Codex agents resume within at most ~1 hour of a profile getting credits back, with no human action required and zero extra cost when no agent is parked

## What Changed

- New service `server/src/services/codex-limit-probe.ts` exposing `codexLimitProbeService(deps)` with `tickProbe`, `listBlockedCodexRuns`, and `probeProfile`. The probe is gated by:
  - cron `0 * * * *` evaluated in UTC against the existing `parseCron` helper from `./cron.js`,
  - presence of at least one `scheduled_retry` `heartbeat_run` joined to a `codex_local` agent with `contextSnapshot.errorFamily = "transient_upstream"`.
- The probe spawns `codex --version` (configurable via `PAPERCLIP_CODEX_COMMAND`) once per resolved `CODEX_HOME` from `process.env.CODEX_HOME` + `process.env.CODEX_FALLBACK` (de-duplicated, absolute-path-only) with a 10s per-profile timeout. A version invocation does not consume model turns, so the probe is essentially free.
- When at least one profile reports `alive`, the probe calls `heartbeatService.retryScheduledRetryNow` for each unique blocked `issueId` (`actor: { actorType: "system", actorId: "codex-limit-probe" }`). Failures on individual issues are logged but do not abort the loop.
- `server/src/index.ts` constructs the probe service alongside `heartbeat`/`routines` and ticks it on the existing heartbeat scheduler interval.
- `server/src/services/index.ts` re-exports the new service and its types.
- `server/src/__tests__/codex-limit-probe.test.ts` adds 19 unit tests covering the helpers (`profileLabelForHome`, `resolveProbeProfiles`, `looksLikeCodexUsageLimit`, `matchesCronTickInTimeZone`) and the service contract (cron gating, no-blocked-runs early-return, no-profiles guard, all-profiles-exhausted, single-profile recovery + dedup of duplicate issue ids, runtime spawn error handling, and survival on per-issue heartbeat retry failures).

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/codex-limit-probe.test.ts` → 19/19 passing.
- `pnpm --filter @paperclipai/server vitest run src/__tests__/codex-local-execute.test.ts` → 13/13 passing (sanity check on adjacent codex coverage).
- `pnpm --filter @paperclipai/server typecheck` (i.e. `tsc --noEmit`) reports the same set of pre-existing errors in `registry.ts`, `plugin-host-services.ts`, `plugins.ts`, and `plugin-worker-manager.ts` and nothing new from this change.
- Manual smoke (described in the issue plan) is intentionally deferred to KSI-691 (E — Testes integrados das 4 mudanças). Until then the probe is exercised in unit-tests via `execFile` injection.

## Risks

- **D3 architecture choice (deferred from KSI-586 plan section 3.4).** The plan listed two options for "Mudança 4": (a) routines-table cron with UI visibility, (b) server-internal periodic timer. This PR implements (b). Rationale: routines today only know how to dispatch issues to agents, and dispatching a Codex agent to probe Codex is chicken-and-egg (the agent itself is exhausted). Wrapping it as a routine with a custom dispatch hook would be substantially larger and would diverge from the existing routine semantics. A future PR can add a status row under `/routines` if leadership wants UI visibility; that is independent of the probe behavior shipped here.
- **Sibling subtasks not yet landed.** KSI-687 (Mudança 1: blocked status) and KSI-689 (Mudança 3: label `codex-limit`) are both in flight. The probe is intentionally lenient about missing label/blocked-status state: it identifies parked runs by `(adapterType = codex_local) AND (errorFamily = transient_upstream) AND (status = scheduled_retry)`, all of which exist in `master` today. Once A and C land, label removal and `blocked → in_progress` transitions happen automatically through the existing transitions wired into `heartbeat.ts` when `retryScheduledRetryNow` promotes a run.
- **`codex --version` exit codes.** A future `codex` CLI version could change the exit code or add a usage-limit warning to `--version`. The probe checks both stdout and stderr against the same regex used by `paperclip/bin/codex-home-fallback`, so a regression there would degrade gracefully (treat profile as still exhausted) rather than falsely reporting recovery.
- **Cron once per hour, not per minute.** If a profile recovers at 14:01 UTC, the next probe is at 15:00 UTC. This matches the issue spec ("a cada 1 hora") and is acceptable because the parked retry would have waited at least that long anyway.

## Model Used

- Provider: Anthropic
- Model: Claude (`claude-opus-4-7`, configured via OpenCode adapter)
- Mode: Tool-use (file edit/read/grep + bash)
- No extended-thinking mode used for this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-side only
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
