### PR TITLE
feat(auth): invite-gate email/password sign-up (TWB-60)

### DIFF
--- a/server/src/__tests__/invite-signup-gate.test.ts
+++ b/server/src/__tests__/invite-signup-gate.test.ts
@@ -83,6 +83,17 @@ describe("evaluateInviteSignUpGate", () => {
     ).toEqual({ allowed: false, reason: "invalid_invite" });
   });
 
+  it("rejects an already-accepted invite", () => {
+    expect(
+      evaluateInviteSignUpGate({
+        inviteOnly: true,
+        token: "pcp_invite_abcd1234",
+        invite: makeInvite({ acceptedAt: new Date(NOW - 1000) }),
+        now: NOW,
+      }),
+    ).toEqual({ allowed: false, reason: "invalid_invite" });
+  });
+
   it("rejects an expired invite", () => {
     expect(
       evaluateInviteSignUpGate({

--- a/server/src/__tests__/invite-signup-gate.test.ts
+++ b/server/src/__tests__/invite-signup-gate.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateInviteSignUpGate,
+  hashInviteSignUpToken,
+} from "../auth/invite-signup-gate.js";
+
+const NOW = 1_700_000_000_000;
+
+type InviteOverrides = Partial<{
+  revokedAt: Date | null;
+  acceptedAt: Date | null;
+  expiresAt: Date;
+  allowedJoinTypes: string;
+}>;
+
+function makeInvite(overrides: InviteOverrides = {}) {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    companyId: "00000000-0000-0000-0000-0000000000aa",
+    inviteType: "company_join",
+    tokenHash: hashInviteSignUpToken("pcp_invite_abcd1234"),
+    allowedJoinTypes: overrides.allowedJoinTypes ?? "both",
+    defaultsPayload: null,
+    expiresAt: overrides.expiresAt ?? new Date(NOW + 60_000),
+    invitedByUserId: null,
+    revokedAt: overrides.revokedAt ?? null,
+    acceptedAt: overrides.acceptedAt ?? null,
+    createdAt: new Date(NOW - 60_000),
+    updatedAt: new Date(NOW - 60_000),
+  } as unknown as Parameters<typeof evaluateInviteSignUpGate>[0]["invite"];
+}
+
+describe("evaluateInviteSignUpGate", () => {
+  it("allows open sign-up when invite-only mode is off", () => {
+    expect(
+      evaluateInviteSignUpGate({ inviteOnly: false, token: null, invite: null, now: NOW }),
+    ).toEqual({ allowed: true, reason: "open_signup" });
+  });
+
+  it("rejects an invite-less sign-up when invite-only mode is on", () => {
+    expect(
+      evaluateInviteSignUpGate({ inviteOnly: true, token: null, invite: null, now: NOW }),
+    ).toEqual({ allowed: false, reason: "missing_token" });
+    expect(
+      evaluateInviteSignUpGate({ inviteOnly: true, token: "   ", invite: null, now: NOW }),
+    ).toEqual({ allowed: false, reason: "missing_token" });
+  });
+
+  it("rejects a token that matches no invite", () => {
+    expect(
+      evaluateInviteSignUpGate({ inviteOnly: true, token: "pcp_invite_x", invite: null, now: NOW }),
+    ).toEqual({ allowed: false, reason: "invalid_invite" });
+  });
+
+  it("accepts a valid, unexpired, unrevoked human invite", () => {
+    expect(
+      evaluateInviteSignUpGate({
+        inviteOnly: true,
+        token: "pcp_invite_abcd1234",
+        invite: makeInvite({ allowedJoinTypes: "both" }),
+        now: NOW,
+      }),
+    ).toEqual({ allowed: true, reason: "valid_invite" });
+
+    expect(
+      evaluateInviteSignUpGate({
+        inviteOnly: true,
+        token: "pcp_invite_abcd1234",
+        invite: makeInvite({ allowedJoinTypes: "human" }),
+        now: NOW,
+      }).allowed,
+    ).toBe(true);
+  });
+
+  it("rejects a revoked invite", () => {
+    expect(
+      evaluateInviteSignUpGate({
+        inviteOnly: true,
+        token: "pcp_invite_abcd1234",
+        invite: makeInvite({ revokedAt: new Date(NOW - 1000) }),
+        now: NOW,
+      }),
+    ).toEqual({ allowed: false, reason: "invalid_invite" });
+  });
+
+  it("rejects an expired invite", () => {
+    expect(
+      evaluateInviteSignUpGate({
+        inviteOnly: true,
+        token: "pcp_invite_abcd1234",
+        invite: makeInvite({ expiresAt: new Date(NOW - 1) }),
+        now: NOW,
+      }),
+    ).toEqual({ allowed: false, reason: "invalid_invite" });
+  });
+
+  it("rejects an agent-only invite for human sign-up", () => {
+    expect(
+      evaluateInviteSignUpGate({
+        inviteOnly: true,
+        token: "pcp_invite_abcd1234",
+        invite: makeInvite({ allowedJoinTypes: "agent" }),
+        now: NOW,
+      }),
+    ).toEqual({ allowed: false, reason: "invalid_invite" });
+  });
+
+  it("hashes tokens with the same scheme the invite routes use", () => {
+    // sha256("pcp_invite_abcd1234") — stable, matches routes/access.ts hashToken.
+    expect(hashInviteSignUpToken("pcp_invite_abcd1234")).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashInviteSignUpToken("a")).toBe(
+      "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+    );
+  });
+});

--- a/server/src/__tests__/invite-signup-hook.test.ts
+++ b/server/src/__tests__/invite-signup-hook.test.ts
@@ -1,0 +1,96 @@
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Config } from "../config.js";
+import {
+  createBetterAuthHandler,
+  createBetterAuthInstance,
+} from "../auth/better-auth.js";
+
+/**
+ * Integration test for the invite-only sign-up `before` hook (TWB-60).
+ *
+ * Proves the hook is actually wired into Better Auth and fires for
+ * `/sign-up/email`: an unsolicited sign-up (no invite token) is rejected with
+ * 403 / SIGN_UP_REQUIRES_INVITE *before* any account is created. The reject path
+ * short-circuits before the database adapter is touched, so a stub db is enough.
+ */
+
+const ORIGINAL_SECRET = process.env.BETTER_AUTH_SECRET;
+
+beforeAll(() => {
+  process.env.BETTER_AUTH_SECRET = "test-secret-twb60";
+});
+
+afterAll(() => {
+  if (ORIGINAL_SECRET === undefined) delete process.env.BETTER_AUTH_SECRET;
+  else process.env.BETTER_AUTH_SECRET = ORIGINAL_SECRET;
+});
+
+function inviteOnlyConfig(): Config {
+  return {
+    deploymentMode: "authenticated",
+    deploymentExposure: "private",
+    authBaseUrlMode: "auto",
+    authPublicBaseUrl: undefined,
+    authDisableSignUp: true,
+    allowedHostnames: ["localhost"],
+    port: 3100,
+  } as unknown as Config;
+}
+
+// Stub db whose select() resolves to no invite — exercises the "invalid_invite"
+// branch when a token is presented, and is never reached when none is.
+function emptyDb() {
+  return {
+    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+  } as never;
+}
+
+function createApp(config: Config) {
+  const auth = createBetterAuthInstance(emptyDb(), config, []);
+  const app = express();
+  app.all("/api/auth/{*authPath}", createBetterAuthHandler(auth));
+  return app;
+}
+
+describe("invite-only sign-up hook", () => {
+  it("rejects an unsolicited sign-up (no invite token) with SIGN_UP_REQUIRES_INVITE", async () => {
+    const app = createApp(inviteOnlyConfig());
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .set("Content-Type", "application/json")
+      .send({ name: "Mallory", email: "mallory@example.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(403);
+    const code = res.body?.code ?? res.body?.error?.code;
+    expect(code).toBe("SIGN_UP_REQUIRES_INVITE");
+  });
+
+  it("rejects a sign-up bearing an unknown invite token", async () => {
+    const app = createApp(inviteOnlyConfig());
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .set("Content-Type", "application/json")
+      .set("x-paperclip-invite-token", "pcp_invite_doesnotexist")
+      .send({ name: "Mallory", email: "mallory@example.com", password: "hunter2hunter2" });
+
+    expect(res.status).toBe(403);
+    const code = res.body?.code ?? res.body?.error?.code;
+    expect(code).toBe("SIGN_UP_REQUIRES_INVITE");
+  });
+
+  it("does not gate sign-up when invite-only mode is off (open sign-up reaches the handler)", async () => {
+    const app = createApp({ ...inviteOnlyConfig(), authDisableSignUp: false });
+    const res = await request(app)
+      .post("/api/auth/sign-up/email")
+      .set("Content-Type", "application/json")
+      .send({ name: "Newbie", email: "newbie@example.com", password: "hunter2hunter2" });
+
+    // With open sign-up the hook is a no-op; the request proceeds past the gate
+    // into Better Auth's handler (which then fails on the stub db, not with our
+    // invite-gate 403). The key assertion is that it is NOT our gate rejection.
+    const code = res.body?.code ?? res.body?.error?.code;
+    expect(code).not.toBe("SIGN_UP_REQUIRES_INVITE");
+  });
+});

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -2,6 +2,7 @@ import type { Request, RequestHandler } from "express";
 import type { IncomingHttpHeaders } from "node:http";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { toNodeHandler } from "better-auth/node";
 import type { Db } from "@paperclipai/db";
 import {
@@ -12,6 +13,11 @@ import {
 } from "@paperclipai/db";
 import type { Config } from "../config.js";
 import { resolvePaperclipInstanceId } from "../home-paths.js";
+import {
+  INVITE_SIGNUP_TOKEN_HEADER,
+  SIGN_UP_REQUIRES_INVITE_CODE,
+  evaluateSignUpRequest,
+} from "./invite-signup-gate.js";
 
 export type BetterAuthSessionUser = {
   id: string;
@@ -130,6 +136,13 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
     publicUrl,
   });
 
+  // `config.authDisableSignUp` now means "invite-only sign-up" rather than Better
+  // Auth's hard global off. We keep Better Auth's `disableSignUp` off so the
+  // `/sign-up/email` endpoint stays reachable, and gate unsolicited sign-ups in a
+  // `before` hook that requires a valid invite token. This closes the
+  // open-registration surface while still letting invited operators sign up
+  // (see auth/invite-signup-gate.ts and TWB-60).
+  const inviteOnlySignUp = config.authDisableSignUp;
   const authConfig = {
     baseURL: baseUrl,
     secret,
@@ -146,7 +159,27 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
     emailAndPassword: {
       enabled: true,
       requireEmailVerification: false,
-      disableSignUp: config.authDisableSignUp,
+      disableSignUp: false,
+    },
+    hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== "/sign-up/email") return;
+        if (!inviteOnlySignUp) return;
+        const headerToken = ctx.headers?.get(INVITE_SIGNUP_TOKEN_HEADER) ?? null;
+        const bodyToken =
+          ctx.body && typeof (ctx.body as { inviteToken?: unknown }).inviteToken === "string"
+            ? ((ctx.body as { inviteToken?: string }).inviteToken ?? null)
+            : null;
+        const token = (headerToken ?? bodyToken ?? "").trim() || null;
+        const decision = await evaluateSignUpRequest(db, { inviteOnly: true, token });
+        if (!decision.allowed) {
+          throw new APIError("FORBIDDEN", {
+            code: SIGN_UP_REQUIRES_INVITE_CODE,
+            message:
+              "Sign-up is invite-only on this instance. A valid invite is required to create an account.",
+          });
+        }
+      }),
     },
     advanced: buildBetterAuthAdvancedOptions({ disableSecureCookies }),
   };

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -166,11 +166,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
         if (ctx.path !== "/sign-up/email") return;
         if (!inviteOnlySignUp) return;
         const headerToken = ctx.headers?.get(INVITE_SIGNUP_TOKEN_HEADER) ?? null;
-        const bodyToken =
-          ctx.body && typeof (ctx.body as { inviteToken?: unknown }).inviteToken === "string"
-            ? ((ctx.body as { inviteToken?: string }).inviteToken ?? null)
-            : null;
-        const token = (headerToken ?? bodyToken ?? "").trim() || null;
+        const token = (headerToken ?? "").trim() || null;
         const decision = await evaluateSignUpRequest(db, { inviteOnly: true, token });
         if (!decision.allowed) {
           throw new APIError("FORBIDDEN", {

--- a/server/src/auth/invite-signup-gate.ts
+++ b/server/src/auth/invite-signup-gate.ts
@@ -68,6 +68,7 @@ export function evaluateInviteSignUpGate(input: {
   if (
     !invite ||
     invite.revokedAt ||
+    invite.acceptedAt ||
     invite.expiresAt.getTime() <= now ||
     !inviteAllowsHumanJoin(invite)
   ) {

--- a/server/src/auth/invite-signup-gate.ts
+++ b/server/src/auth/invite-signup-gate.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { type Db, invites } from "@paperclipai/db";
+
+/**
+ * Invite-gated sign-up.
+ *
+ * Better Auth's native `emailAndPassword.disableSignUp` is a hard global on/off:
+ * `true` rejects *every* sign-up, including the invited operators we actually want
+ * to onboard (this is the bug that forced open sign-up in TWB-57). To close the
+ * open-registration surface without breaking invite acceptance, we leave Better
+ * Auth's `disableSignUp` off and instead enforce an invite check in a `before`
+ * hook: when invite-only mode is active, a sign-up must carry a valid (unexpired,
+ * unrevoked, human-eligible) invite token or it is rejected.
+ *
+ * The presented token is matched against `invites.token_hash` using the same
+ * SHA-256 hashing the invite routes use, so a valid invite link unlocks sign-up
+ * and nothing else does.
+ */
+
+/** Header the client uses to attach the invite token to a sign-up request. */
+export const INVITE_SIGNUP_TOKEN_HEADER = "x-paperclip-invite-token";
+
+/** Stable error code returned when an invite-only sign-up is rejected. */
+export const SIGN_UP_REQUIRES_INVITE_CODE = "SIGN_UP_REQUIRES_INVITE";
+
+type InviteRow = typeof invites.$inferSelect;
+
+export type InviteSignUpGateReason =
+  | "open_signup" // invite-only mode disabled — sign-up is open
+  | "valid_invite" // a usable invite token was presented
+  | "missing_token" // invite-only mode on, no token presented
+  | "invalid_invite"; // token presented but invite is unknown/revoked/expired/agent-only
+
+export type InviteSignUpGateDecision = {
+  allowed: boolean;
+  reason: InviteSignUpGateReason;
+};
+
+/** SHA-256 hex hash of an invite token (mirrors `hashToken` in routes/access.ts). */
+export function hashInviteSignUpToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function inviteAllowsHumanJoin(invite: InviteRow): boolean {
+  return invite.allowedJoinTypes === "both" || invite.allowedJoinTypes === "human";
+}
+
+/**
+ * Pure gate decision. Kept side-effect free so it can be unit-tested without a DB:
+ * the caller resolves the invite row, this decides whether sign-up may proceed.
+ */
+export function evaluateInviteSignUpGate(input: {
+  inviteOnly: boolean;
+  token: string | null;
+  invite: InviteRow | null;
+  now?: number;
+}): InviteSignUpGateDecision {
+  if (!input.inviteOnly) {
+    return { allowed: true, reason: "open_signup" };
+  }
+  const token = input.token?.trim();
+  if (!token) {
+    return { allowed: false, reason: "missing_token" };
+  }
+  const invite = input.invite;
+  const now = input.now ?? Date.now();
+  if (
+    !invite ||
+    invite.revokedAt ||
+    invite.expiresAt.getTime() <= now ||
+    !inviteAllowsHumanJoin(invite)
+  ) {
+    return { allowed: false, reason: "invalid_invite" };
+  }
+  return { allowed: true, reason: "valid_invite" };
+}
+
+/** Loads an invite by its raw token, or null if none matches. */
+export async function loadInviteByToken(db: Db, token: string): Promise<InviteRow | null> {
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+  return db
+    .select()
+    .from(invites)
+    .where(eq(invites.tokenHash, hashInviteSignUpToken(trimmed)))
+    .then((rows) => rows[0] ?? null);
+}
+
+/**
+ * Resolves whether a sign-up may proceed. Skips the DB lookup entirely when
+ * invite-only mode is off or no token was presented.
+ */
+export async function evaluateSignUpRequest(
+  db: Db,
+  input: { inviteOnly: boolean; token: string | null; now?: number },
+): Promise<InviteSignUpGateDecision> {
+  if (!input.inviteOnly) {
+    return { allowed: true, reason: "open_signup" };
+  }
+  const token = input.token?.trim() || null;
+  if (!token) {
+    return { allowed: false, reason: "missing_token" };
+  }
+  const invite = await loadInviteByToken(db, token);
+  return evaluateInviteSignUpGate({ inviteOnly: true, token, invite, now: input.now });
+}

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -60,11 +60,15 @@ function extractAuthError(payload: AuthErrorBody, status: number) {
   return new AuthApiError(message, status, payload, code);
 }
 
-async function authPost(path: string, body: Record<string, unknown>) {
+async function authPost(
+  path: string,
+  body: Record<string, unknown>,
+  extraHeaders?: Record<string, string>,
+) {
   const res = await fetch(`/api/auth${path}`, {
     method: "POST",
     credentials: "include",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...extraHeaders },
     body: JSON.stringify(body),
   });
   const payload = await res.json().catch(() => null);
@@ -109,8 +113,17 @@ export const authApi = {
     await authPost("/sign-in/email", input);
   },
 
-  signUpEmail: async (input: { name: string; email: string; password: string }) => {
-    await authPost("/sign-up/email", input);
+  signUpEmail: async (
+    input: { name: string; email: string; password: string },
+    options?: { inviteToken?: string | null },
+  ) => {
+    const inviteToken = options?.inviteToken?.trim();
+    // Invite-only instances gate sign-up behind a valid invite token (TWB-60).
+    // Attach it as a header so it never collides with Better Auth's body schema.
+    const extraHeaders = inviteToken
+      ? { "x-paperclip-invite-token": inviteToken }
+      : undefined;
+    await authPost("/sign-up/email", input, extraHeaders);
   },
 
   getProfile: async (): Promise<CurrentUserProfile> => {

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -363,11 +363,16 @@ export function InviteLandingPage() {
         await authApi.signInEmail({ email: email.trim(), password });
         return;
       }
-      await authApi.signUpEmail({
-        name: name.trim(),
-        email: email.trim(),
-        password,
-      });
+      await authApi.signUpEmail(
+        {
+          name: name.trim(),
+          email: email.trim(),
+          password,
+        },
+        // Unlocks sign-up on invite-only instances (TWB-60); the invite token is
+        // already in scope from the invite-landing URL.
+        { inviteToken: token },
+      );
     },
     onSuccess: async () => {
       setAuthFeedback(null);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and its board/admin surface is protected by Better Auth email/password sessions.
> - Operator onboarding works through invites: an invitee must have an authenticated account *before* `POST /api/invites/:token/accept` (requestType `human`) can grant membership.
> - Better Auth's `emailAndPassword.disableSignUp` is a single global on/off. Turning it on to stop open registration also blocks invited operators from creating the account they need to accept — so a recent fix had to re-enable fully **open** sign-up.
> - Open sign-up is an unnecessary registration surface even when bare accounts grant no access; it should not be permanent.
> - This pull request gates `/sign-up/email` behind a valid invite token via a Better Auth `before` hook, instead of the all-or-nothing global flag.
> - The benefit is that unsolicited sign-ups are rejected while invited operators still onboard end-to-end, closing the open-registration surface with no new account-creation code path to maintain.

## What Changed

- **`server/src/auth/invite-signup-gate.ts`** (new): a pure, unit-tested gate decision (`evaluateInviteSignUpGate`) plus a token lookup (`evaluateSignUpRequest` / `loadInviteByToken`) using the same SHA-256 token-hash scheme as the invite routes. Exposes the `x-paperclip-invite-token` header name and the `SIGN_UP_REQUIRES_INVITE` error code.
- **`server/src/auth/better-auth.ts`**: keep Better Auth's native `disableSignUp` **off** so `/sign-up/email` stays reachable, and add a `hooks.before` middleware that — when invite-only mode is on — requires a valid (unexpired, unrevoked, human-eligible) invite token, else throws `403 / SIGN_UP_REQUIRES_INVITE`. `config.authDisableSignUp` now means "invite-only sign-up" rather than "hard off".
- **`ui/src/api/auth.ts` + `ui/src/pages/InviteLanding.tsx`**: thread the invite token (already in scope on the invite-landing page) through `signUpEmail` as the `x-paperclip-invite-token` header. Sent as a header so it never collides with Better Auth's body schema.
- Tests: `invite-signup-gate.test.ts` (8 pure-logic cases) and `invite-signup-hook.test.ts` (3 integration cases proving the hook is wired and rejects unsolicited sign-ups before any DB write).

## Verification

```bash
pnpm --filter @paperclipai/server typecheck            # passes
pnpm --filter @paperclipai/ui run typecheck            # passes
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/invite-signup-gate.test.ts \
  src/__tests__/invite-signup-hook.test.ts \
  src/__tests__/better-auth.test.ts \
  src/__tests__/auth-routes.test.ts                    # 30 passed
```

- Integration test proves an unsolicited `POST /api/auth/sign-up/email` (no token, or an unknown token) returns `403` with code `SIGN_UP_REQUIRES_INVITE` **before** any account is created; with invite-only mode off the request passes the gate into Better Auth's handler.
- Happy path (valid invite → account created → accept → membership) is covered by composition: the gate-allow decision is unit-tested, and Better Auth's real sign-up + the unchanged accept flow are exercised by existing coverage. A full runtime mint-invite→sign-up→accept E2E against a live instance is the recommended pre-rollout smoke.

## Risks

- **Behavioral shift, opt-in:** default stays `authDisableSignUp=false` (open sign-up), so fresh-instance bootstrap is unaffected. The gate only activates when an operator sets `auth.disableSignUp=true`, which is expected post-bootstrap. The meaning of that flag changes from "disable all sign-up" to "invite-only sign-up" — documented in the commit/PR; no config key rename, so existing config files keep working.
- **Bootstrap:** the first-admin `bootstrap_ceo` invite is `allowedJoinTypes: "human"`, so it passes the gate; and bootstrap normally happens while sign-up is still open. Low risk.
- **Header dependency:** invited sign-up requires the client to send `x-paperclip-invite-token`; the UI change does this on the invite-landing page (the only place a non-authenticated sign-up should occur in the invite flow).
- Checked `ROADMAP.md`; this is a bounded security hardening, not overlapping planned core feature work.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), Anthropic, via Claude Code agent (tool use + code execution), extended reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (UI change is a single header on an existing call — no visual change)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
