### PR TITLE
KSI-687: blocked during Codex usage-limit retry + productivity-review suppression

### DIFF
--- a/server/src/__tests__/heartbeat-codex-limit-blocked.test.ts
+++ b/server/src/__tests__/heartbeat-codex-limit-blocked.test.ts
@@ -1,0 +1,267 @@
+/**
+ * KSI-687 — Commit 2 tests: heartbeat wiring for codex usage-limit blocked
+ *
+ * Verifies that:
+ * 1. scheduleBoundedRetry transitions the issue to `blocked` and adds the
+ *    `codex-limit` label when outcome is "scheduled" for a codex_local agent.
+ * 2. promoteDueScheduledRetries transitions the issue back to `in_progress`
+ *    and removes the `codex-limit` label.
+ * 3. A non-codex_local agent (claude_local) does NOT trigger the blocked
+ *    transition even when transient_upstream fires.
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueLabels,
+  issues,
+  labels,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { CODEX_LIMIT_LABEL_NAME } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat codex-limit blocked tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat wiring: codex-limit blocked/unblocked (KSI-687)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-codex-limit-blocked-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueLabels);
+    await db.delete(labels);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /** Seed a company, a codex_local agent, an in_progress issue and a failed run. */
+  async function seedCodexLimitFixture(opts?: {
+    adapterType?: "codex_local" | "claude_local";
+    retryNotBefore?: string;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-05-01T12:00:00.000Z");
+    const adapterType = opts?.adapterType ?? "codex_local";
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: adapterType === "claude_local" ? "ClaudeCoder" : "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const resultJson: Record<string, unknown> = {
+      errorFamily: "transient_upstream",
+    };
+    if (opts?.retryNotBefore) {
+      resultJson.retryNotBefore = opts.retryNotBefore;
+      resultJson.transientRetryNotBefore = opts.retryNotBefore;
+    }
+
+    // Insert run BEFORE issue (FK: issues.execution_run_id → heartbeat_runs.id)
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "Usage limit exceeded",
+      errorCode: "codex_transient_upstream",
+      finishedAt: now,
+      scheduledRetryAttempt: 0,
+      scheduledRetryReason: null,
+      resultJson,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue under usage-limit",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: adapterType === "claude_local" ? "claudecoder" : "codexcoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId, runId, now };
+  }
+
+  async function getIssueStatus(issueId: string) {
+    return db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]?.status ?? null);
+  }
+
+  async function getIssueCodexLimitLabel(issueId: string, companyId: string) {
+    const label = await db
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows) => rows[0] ?? null);
+    if (!label) return false;
+    const applied = await db
+      .select({ issueId: issueLabels.issueId })
+      .from(issueLabels)
+      .where(and(eq(issueLabels.issueId, issueId), eq(issueLabels.labelId, label.id)))
+      .then((rows) => rows[0] ?? null);
+    return applied != null;
+  }
+
+  async function getIssueComments(issueId: string) {
+    return db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+  }
+
+  it("scheduleBoundedRetry: codex_local transient → issue becomes blocked + codex-limit label applied + comment added", async () => {
+    const { companyId, issueId, runId } = await seedCodexLimitFixture();
+
+    const result = await heartbeat.scheduleBoundedRetry(runId);
+
+    expect(result.outcome).toBe("scheduled");
+
+    const status = await getIssueStatus(issueId);
+    expect(status).toBe("blocked");
+
+    const hasLabel = await getIssueCodexLimitLabel(issueId, companyId);
+    expect(hasLabel).toBe(true);
+
+    const comments = await getIssueComments(issueId);
+    expect(comments.length).toBeGreaterThan(0);
+    expect(comments[0]!.body).toContain("Aguardando retorno do Codex usage-limit");
+    expect(comments[0]!.body).toContain("Owner: sistema (auto-resume)");
+  });
+
+  it("scheduleBoundedRetry: codex_local with retryNotBefore → blocked + label + comment contains scheduled time", async () => {
+    const retryNotBefore = "2026-05-01T13:00:00.000Z";
+    const { companyId, issueId, runId } = await seedCodexLimitFixture({ retryNotBefore });
+
+    const result = await heartbeat.scheduleBoundedRetry(runId);
+    expect(result.outcome).toBe("scheduled");
+
+    const status = await getIssueStatus(issueId);
+    expect(status).toBe("blocked");
+
+    const hasLabel = await getIssueCodexLimitLabel(issueId, companyId);
+    expect(hasLabel).toBe(true);
+
+    const comments = await getIssueComments(issueId);
+    expect(comments.length).toBeGreaterThan(0);
+    expect(comments[0]!.body).toContain("Retry agendado para");
+  });
+
+  it("scheduleBoundedRetry: claude_local transient → issue stays in_progress (NOT blocked, no label)", async () => {
+    const { companyId, issueId, runId } = await seedCodexLimitFixture({ adapterType: "claude_local" });
+
+    // Patch the run's errorCode to match claude convention
+    await db
+      .update(heartbeatRuns)
+      .set({ errorCode: "claude_transient_upstream" })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const result = await heartbeat.scheduleBoundedRetry(runId);
+    expect(result.outcome).toBe("scheduled");
+
+    const status = await getIssueStatus(issueId);
+    expect(status).toBe("in_progress"); // NOT blocked
+
+    const hasLabel = await getIssueCodexLimitLabel(issueId, companyId);
+    expect(hasLabel).toBe(false);
+  });
+
+  it("promoteDueScheduledRetries: blocked issue with codex-limit label → returns to in_progress and label removed", async () => {
+    const retryNotBefore = "2026-05-01T11:00:00.000Z"; // in the past relative to scheduleNow
+    const { companyId, issueId, runId } = await seedCodexLimitFixture({ retryNotBefore });
+
+    // Use a deterministic now for scheduling so scheduledRetryAt is predictable
+    const scheduleNow = new Date("2026-05-01T12:00:00.000Z");
+
+    // Schedule the retry at scheduleNow (which will also block the issue and add the label)
+    const scheduleResult = await heartbeat.scheduleBoundedRetry(runId, { now: scheduleNow });
+    expect(scheduleResult.outcome).toBe("scheduled");
+
+    // Confirm issue is blocked
+    expect(await getIssueStatus(issueId)).toBe("blocked");
+    expect(await getIssueCodexLimitLabel(issueId, companyId)).toBe(true);
+
+    // Promote at scheduleNow + 3h (well past the 2min delay for attempt 1)
+    const promoted = await heartbeat.promoteDueScheduledRetries(
+      new Date(scheduleNow.getTime() + 3 * 60 * 60 * 1000),
+    );
+    expect(promoted.promoted).toBeGreaterThan(0);
+
+    // Issue should be back to in_progress
+    expect(await getIssueStatus(issueId)).toBe("in_progress");
+
+    // Label should be removed
+    expect(await getIssueCodexLimitLabel(issueId, companyId)).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -24,6 +24,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueLabels,
   issuePlanDecompositions,
   issueRecoveryActions,
   issueRelations,
@@ -32,6 +33,7 @@ import {
   issueTreeHolds,
   issueWorkProducts,
   issues,
+  labels,
   workspaceOperations,
 } from "@paperclipai/db";
 import {
@@ -82,6 +84,7 @@ import {
   heartbeatService,
   redactDetectedSuccessfulRunProgressSummaryForBoard,
 } from "../services/heartbeat.ts";
+import { CODEX_LIMIT_LABEL_NAME } from "../services/issues.js";
 import {
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
@@ -1252,7 +1255,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(0);
   });
 
-  it("schedules a bounded retry for codex transient upstream failures instead of blocking the issue immediately", async () => {
+  it("transitions issue to blocked while a bounded retry is scheduled for codex transient upstream failures (KSI-687)", async () => {
     mockAdapterExecute.mockResolvedValueOnce({
       exitCode: 1,
       signal: null,
@@ -1295,16 +1298,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
 
-    const issue = await db
-      .select()
-      .from(issues)
-      .where(eq(issues.id, issueId))
+    // KSI-687 Mudança 1: codex_local transient-upstream retries move the issue to
+    // `blocked` while the scheduled retry is pending, attach the operational
+    // `codex-limit` label, and post an automatic owner=system comment.
+    const issue = await waitForValue(async () => {
+      const row = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      return row?.status === "blocked" ? row : null;
+    });
+    expect(issue?.status).toBe("blocked");
+    // KSI-687: when transitioning to `blocked`, issuesSvc.update clears the
+    // execution lock fields. The scheduled retry is recorded on the run itself.
+    expect(issue?.executionRunId).toBeNull();
+
+    const companyId = issue?.companyId;
+    expect(companyId).toBeTruthy();
+    const codexLimitLabel = await db
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId!), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
       .then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("in_progress");
-    expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
+    expect(codexLimitLabel).not.toBeNull();
+    const labelApplied = await db
+      .select({ issueId: issueLabels.issueId })
+      .from(issueLabels)
+      .where(and(eq(issueLabels.issueId, issueId), eq(issueLabels.labelId, codexLimitLabel!.id)))
+      .then((rows) => rows[0] ?? null);
+    expect(labelApplied).not.toBeNull();
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
-    expect(comments).toHaveLength(0);
+    expect(comments.length).toBeGreaterThan(0);
+    expect(comments[0]!.body).toContain("Aguardando retorno do Codex usage-limit");
+    expect(comments[0]!.body).toContain("Owner: sistema (auto-resume)");
   });
 
   it("queues one finish-handoff wake when a successful run leaves in-progress work without a next action", async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -11,8 +11,11 @@ import {
   environmentLeases,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueComments,
+  issueLabels,
   issueRelations,
   issues,
+  labels,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -49,6 +52,12 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(heartbeatRunEvents);
     await db.delete(environmentLeases);
     await db.delete(issueRelations);
+    // KSI-687: codex_local transient retries now create issueComments and
+    // attach the codex-limit label, so we must clear the label/comment
+    // dependencies before issues/agents/companies.
+    await db.delete(issueLabels);
+    await db.delete(issueComments);
+    await db.delete(labels);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -674,6 +683,9 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
     await db.delete(budgetPolicies);
     await db.delete(issueRelations);
+    await db.delete(issueLabels);
+    await db.delete(issueComments);
+    await db.delete(labels);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
@@ -1227,6 +1239,10 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       await db.delete(heartbeatRunEvents);
       await db.delete(heartbeatRuns);
       await db.delete(agentWakeupRequests);
+      // KSI-687: defensive cleanup in case the wiring inserted any
+      // codex-limit labels for this iteration's company.
+      await db.delete(issueLabels);
+      await db.delete(labels);
       await db.delete(agents);
       await db.delete(companies);
     }

--- a/server/src/__tests__/issues-codex-limit-label.test.ts
+++ b/server/src/__tests__/issues-codex-limit-label.test.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueLabels,
+  issues,
+  labels,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  CODEX_LIMIT_LABEL_COLOR,
+  CODEX_LIMIT_LABEL_NAME,
+  issueService,
+} from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres codex-limit label tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issueService codex-limit label helpers (KSI-687)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-codex-limit-label-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueLabels);
+    await db.delete(labels);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedIssue(companyId: string, opts?: {
+    assigneeAgentId?: string | null;
+    status?: string;
+  }) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue under usage-limit",
+      status: opts?.status ?? "in_progress",
+      priority: "medium",
+      assigneeAgentId: opts?.assigneeAgentId ?? null,
+      createdAt: new Date(),
+    });
+    return issueId;
+  }
+
+  async function seedAgent(companyId: string, name = "Codex") {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  it("ensureCodexLimitLabel creates the label idempotently with the documented color", async () => {
+    const companyId = await seedCompany();
+    const svc = issueService(db);
+
+    const labelId = await svc.ensureCodexLimitLabel(companyId);
+    expect(labelId).toBeTruthy();
+
+    const sameLabelId = await svc.ensureCodexLimitLabel(companyId);
+    expect(sameLabelId).toBe(labelId);
+
+    const all = await db
+      .select()
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)));
+    expect(all).toHaveLength(1);
+    expect(all[0].color).toBe(CODEX_LIMIT_LABEL_COLOR);
+  });
+
+  it("getCodexLimitLabelId returns null before the label exists and the labelId after", async () => {
+    const companyId = await seedCompany();
+    const svc = issueService(db);
+
+    expect(await svc.getCodexLimitLabelId(companyId)).toBeNull();
+    const labelId = await svc.ensureCodexLimitLabel(companyId);
+    expect(await svc.getCodexLimitLabelId(companyId)).toBe(labelId);
+  });
+
+  it("addCodexLimitLabelToIssue applies the label and is idempotent", async () => {
+    const companyId = await seedCompany();
+    const issueId = await seedIssue(companyId);
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+
+    const rows = await db
+      .select()
+      .from(issueLabels)
+      .where(eq(issueLabels.issueId, issueId));
+    expect(rows).toHaveLength(1);
+
+    const label = await db
+      .select()
+      .from(labels)
+      .where(eq(labels.id, rows[0].labelId))
+      .then((r) => r[0]);
+    expect(label.name).toBe(CODEX_LIMIT_LABEL_NAME);
+  });
+
+  it("clearCodexLimitLabelIfApplicable is a no-op when the label has not been created", async () => {
+    const companyId = await seedCompany();
+    const issueId = await seedIssue(companyId);
+    const svc = issueService(db);
+
+    const removed = await svc.clearCodexLimitLabelIfApplicable(issueId, companyId);
+    expect(removed).toBe(false);
+
+    const labelRows = await db.select().from(labels).where(eq(labels.companyId, companyId));
+    expect(labelRows).toHaveLength(0);
+  });
+
+  it("clearCodexLimitLabelIfApplicable removes the label when applied and is idempotent on subsequent calls", async () => {
+    const companyId = await seedCompany();
+    const issueId = await seedIssue(companyId);
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+    expect(await svc.clearCodexLimitLabelIfApplicable(issueId, companyId)).toBe(true);
+    expect(await svc.clearCodexLimitLabelIfApplicable(issueId, companyId)).toBe(false);
+
+    const remaining = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("update() clears codex-limit label when the agent assignee changes (symmetric with reassign during blocked)", async () => {
+    const companyId = await seedCompany();
+    const agentA = await seedAgent(companyId, "CodexA");
+    const agentB = await seedAgent(companyId, "CodexB");
+    const issueId = await seedIssue(companyId, { assigneeAgentId: agentA, status: "blocked" });
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+    const before = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(before).toHaveLength(1);
+
+    await svc.update(issueId, { assigneeAgentId: agentB });
+
+    const after = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(after).toHaveLength(0);
+  });
+
+  it("update() does NOT clear codex-limit label when the assignee did not change", async () => {
+    const companyId = await seedCompany();
+    const agentA = await seedAgent(companyId, "CodexA");
+    const issueId = await seedIssue(companyId, { assigneeAgentId: agentA, status: "blocked" });
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+
+    // Update an unrelated field; assignee unchanged.
+    await svc.update(issueId, { priority: "high" });
+
+    const after = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(after).toHaveLength(1);
+  });
+
+  it("update() does NOT clear codex-limit label when the caller is explicitly managing labelIds", async () => {
+    const companyId = await seedCompany();
+    const agentA = await seedAgent(companyId, "CodexA");
+    const agentB = await seedAgent(companyId, "CodexB");
+    const issueId = await seedIssue(companyId, { assigneeAgentId: agentA, status: "blocked" });
+    const svc = issueService(db);
+
+    const codexLimitLabelId = await svc.ensureCodexLimitLabel(companyId);
+
+    // Caller explicitly retains the label across the reassign by passing labelIds.
+    await svc.update(issueId, {
+      assigneeAgentId: agentB,
+      labelIds: [codexLimitLabelId],
+    });
+
+    const after = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(after).toHaveLength(1);
+    expect(after[0].labelId).toBe(codexLimitLabelId);
+  });
+});

--- a/server/src/__tests__/productivity-review-codex-limit-suppression.test.ts
+++ b/server/src/__tests__/productivity-review-codex-limit-suppression.test.ts
@@ -1,0 +1,168 @@
+/**
+ * KSI-687 — Commit 3 tests: productivity-review D4 suppression for codex-limit
+ *
+ * Verifies that:
+ * 1. An issue blocked with the `codex-limit` label does NOT trigger
+ *    longActive-based productivity reviews (suppressed).
+ * 2. A regular issue without the label still triggers productivity reviews
+ *    (control case — the guard does not over-suppress).
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueLabels,
+  issues,
+  labels,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { productivityReviewService } from "../services/productivity-review.ts";
+import { CODEX_LIMIT_LABEL_NAME, issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres productivity-review D4 suppression tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("productivityReviewService: codex-limit suppression (KSI-687 D4)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-productivity-review-d4-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /**
+   * Seed a minimal fixture: company + codex_local agent + in_progress issue
+   * that has been active for more than DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS.
+   * Returns ids needed for assertions.
+   */
+  async function seedLongActiveIssue(opts?: { withCodexLimitLabel?: boolean }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const managerId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `D4${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    // Issue started 8 hours ago (exceeds the default 6h threshold)
+    const startedAt = new Date(Date.now() - 8 * 60 * 60 * 1000);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip D4",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Manager (needed so issueService can assign review to a chain-of-command member)
+    await db.insert(agents).values({
+      id: managerId,
+      companyId,
+      name: "CTO",
+      role: "cto",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      reportsTo: managerId,
+      permissions: {},
+    });
+
+    // Run before issue (FK)
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      updatedAt: startedAt,
+      createdAt: startedAt,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Long-running issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: startedAt,
+      startedAt,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    if (opts?.withCodexLimitLabel) {
+      const issuesSvc = issueService(db);
+      await issuesSvc.addCodexLimitLabelToIssue(issueId, companyId);
+    }
+
+    return { companyId, agentId, issueId, runId };
+  }
+
+  it("collectEvidence: issue with codex-limit label → longActive suppressed (no review triggered)", async () => {
+    const { companyId } = await seedLongActiveIssue({ withCodexLimitLabel: true });
+    const service = productivityReviewService(db);
+
+    // reconcileProductivityReviews processes all in_progress issues
+    await service.reconcileProductivityReviews();
+
+    // No productivity review issue should have been created for this company
+    const reviewIssues = await db
+      .select({ id: issues.id, title: issues.title })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), sql`${issues.title} ilike '%productivity review%'`));
+
+    expect(reviewIssues).toHaveLength(0);
+  });
+
+  it("collectEvidence: issue WITHOUT codex-limit label → longActive fires → review triggered (control)", async () => {
+    const { companyId } = await seedLongActiveIssue({ withCodexLimitLabel: false });
+    const service = productivityReviewService(db);
+
+    await service.reconcileProductivityReviews();
+
+    // A productivity review issue should have been created
+    const reviewIssues = await db
+      .select({ id: issues.id, title: issues.title })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), sql`${issues.title} ilike '%productivity%'`));
+
+    expect(reviewIssues.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5327,6 +5327,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
     if (!promoted) return { outcome: "not_promoted", run: null };
 
+    // KSI-687: when a codex usage-limit scheduled retry becomes due, transition
+    // the issue back to in_progress and remove the codex-limit label.
+    const promotedIssueId = readNonEmptyString(parseObject(promoted.contextSnapshot).issueId);
+    if (promotedIssueId) {
+      try {
+        const promotedIssue = await issuesSvc.getById(promotedIssueId);
+        if (promotedIssue?.status === "blocked") {
+          await issuesSvc.update(promotedIssueId, { status: "in_progress" });
+        }
+        await issuesSvc.clearCodexLimitLabelIfApplicable(promotedIssueId, promoted.companyId);
+      } catch (_err) {
+        // Non-fatal: promotion still succeeds even if the issue update fails.
+      }
+    }
+
     await appendRunEvent(promoted, await nextRunEventSeq(promoted.id), {
       eventType: "lifecycle",
       stream: "system",
@@ -5753,6 +5768,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
+    // KSI-687: for codex_local transient-upstream retries, move the issue to
+    // `blocked` so the board can see the pause, and attach the operational
+    // `codex-limit` label. This runs after the transaction commits.
+    if (
+      retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON &&
+      agent.adapterType === "codex_local" &&
+      issueId
+    ) {
+      await applyCodexLimitBlockedState(issueId, run.companyId, run.agentId, run.id, {
+        outcome: "scheduled",
+        run: retryRun,
+        dueAt,
+        attempt: schedule.attempt,
+        maxAttempts: schedule.maxAttempts,
+      });
+    }
+
     return {
       outcome: "scheduled" as const,
       run: retryRun,
@@ -5760,6 +5792,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       attempt: schedule.attempt,
       maxAttempts: schedule.maxAttempts,
     };
+  }
+
+  /**
+   * KSI-687: after a codex_local run hits a usage-limit and a scheduled_retry
+   * is successfully queued, move the issue to `blocked` and attach the
+   * `codex-limit` operational label so the board can see the pause.
+   *
+   * Extracted as a standalone helper so it can be called from both the
+   * post-run failure path (scheduleBoundedRetryForRun) and, in future, from
+   * any other place that schedules a codex usage-limit retry.
+   */
+  async function applyCodexLimitBlockedState(
+    issueId: string,
+    companyId: string,
+    agentId: string,
+    runId: string,
+    retryResult: { outcome: string; run?: { scheduledRetryAt?: Date | string | null }; dueAt?: Date; attempt?: number; maxAttempts?: number },
+  ): Promise<void> {
+    try {
+      const dueAtIso = retryResult.dueAt instanceof Date
+        ? retryResult.dueAt.toISOString()
+        : retryResult.run?.scheduledRetryAt
+          ? new Date(retryResult.run.scheduledRetryAt).toISOString()
+          : null;
+      const attempt = retryResult.attempt ?? null;
+      const maxAttempts = retryResult.maxAttempts ?? null;
+      await issuesSvc.update(issueId, { status: "blocked" });
+      await issuesSvc.addCodexLimitLabelToIssue(issueId, companyId);
+      const commentBody = [
+        "Aguardando retorno do Codex usage-limit.",
+        dueAtIso ? `Retry agendado para \`${dueAtIso}\`.` : null,
+        attempt != null && maxAttempts != null ? `Tentativa ${attempt}/${maxAttempts}.` : null,
+        "Owner: sistema (auto-resume). Escalação humana aos 84h se persistir.",
+      ].filter(Boolean).join(" ");
+      await issuesSvc.addComment(issueId, commentBody, { agentId, runId });
+    } catch (_err) {
+      // Non-fatal: the scheduled_retry was already recorded; the issue state
+      // update is a best-effort UX improvement.
+    }
   }
 
   async function promoteDueScheduledRetries(now = new Date()) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -85,6 +85,17 @@ import {
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+
+/**
+ * Operational label applied automatically when a `codex_local` agent hits the
+ * Codex usage limit and the issue is moved to `blocked` while waiting for the
+ * scheduled retry to fire. Removed automatically when the retry is promoted
+ * back to `pending` or the issue is reassigned to a different agent.
+ *
+ * Source of truth: KSI-687 (parent KSI-586). See plan document on KSI-586.
+ */
+export const CODEX_LIMIT_LABEL_NAME = "codex-limit";
+export const CODEX_LIMIT_LABEL_COLOR = "#06b6d4";
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
@@ -3428,6 +3439,92 @@ export function issueService(db: Db) {
     );
   }
 
+  /**
+   * Returns the labelId for the `codex-limit` operational label in a company,
+   * creating it idempotently on first use. Safe to call inside or outside a
+   * transaction.
+   *
+   * Source of truth: KSI-687 (parent KSI-586).
+   */
+  async function ensureCodexLimitLabel(companyId: string, dbOrTx: any = db): Promise<string> {
+    const existing = await dbOrTx
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (existing) return existing.id;
+    const created = await dbOrTx
+      .insert(labels)
+      .values({
+        companyId,
+        name: CODEX_LIMIT_LABEL_NAME,
+        color: CODEX_LIMIT_LABEL_COLOR,
+      })
+      .returning({ id: labels.id })
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (created) return created.id;
+    // Race-condition fallback: someone else inserted between our select and insert.
+    const retry = await dbOrTx
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (!retry) {
+      throw new Error("Failed to ensure codex-limit label after race retry");
+    }
+    return retry.id;
+  }
+
+  /**
+   * Returns the labelId for the `codex-limit` label if it already exists in
+   * the company, or `null` otherwise. Does not create. Safe inside/outside tx.
+   */
+  async function getCodexLimitLabelId(companyId: string, dbOrTx: any = db): Promise<string | null> {
+    const row = await dbOrTx
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    return row?.id ?? null;
+  }
+
+  /**
+   * Adds the `codex-limit` label to an issue idempotently. Creates the label
+   * if it doesn't exist yet in the company. No-op if the label is already on
+   * the issue.
+   */
+  async function addCodexLimitLabelToIssue(
+    issueId: string,
+    companyId: string,
+    dbOrTx: any = db,
+  ): Promise<void> {
+    const labelId = await ensureCodexLimitLabel(companyId, dbOrTx);
+    await dbOrTx
+      .insert(issueLabels)
+      .values({ issueId, labelId, companyId })
+      .onConflictDoNothing();
+  }
+
+  /**
+   * Removes the `codex-limit` label from an issue if currently applied. No-op
+   * if the label doesn't exist in the company yet (so safe to call from
+   * symmetric callers like reassignment without checking first).
+   */
+  async function clearCodexLimitLabelIfApplicable(
+    issueId: string,
+    companyId: string,
+    dbOrTx: any = db,
+  ): Promise<boolean> {
+    const labelId = await getCodexLimitLabelId(companyId, dbOrTx);
+    if (!labelId) return false;
+    const removed = await dbOrTx
+      .delete(issueLabels)
+      .where(and(eq(issueLabels.issueId, issueId), eq(issueLabels.labelId, labelId)))
+      .returning({ issueId: issueLabels.issueId })
+      .then((rows: Array<{ issueId: string }>) => rows.length > 0);
+    return removed;
+  }
+
   async function getIssueRelationSummaryMap(
     companyId: string,
     issueIds: string[],
@@ -5076,6 +5173,19 @@ export function issueService(db: Db) {
         if (nextLabelIds !== undefined) {
           await syncIssueLabels(updated.id, existing.companyId, nextLabelIds, tx);
         }
+        // KSI-687/O5: When the issue is reassigned to a different agent (or to
+        // a user) while carrying the `codex-limit` operational label, the
+        // label is no longer truthful — the new assignee is not waiting on a
+        // Codex usage-limit retry tied to the previous agent. Clear it
+        // symmetrically with the addCodexLimitLabelToIssue path. Skip when
+        // the caller is explicitly managing labels via labelIds (they own
+        // the label state in that call).
+        const assigneeChangedToDifferentTarget =
+          (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
+          (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId);
+        if (nextLabelIds === undefined && assigneeChangedToDifferentTarget) {
+          await clearCodexLimitLabelIfApplicable(updated.id, existing.companyId, tx);
+        }
         if (blockedByIssueIds !== undefined) {
           await syncBlockedByIssueIds(
             updated.id,
@@ -5561,6 +5671,18 @@ export function issueService(db: Db) {
         .where(eq(labels.id, id))
         .returning()
         .then((rows) => rows[0] ?? null),
+
+    /**
+     * Operational label helpers for KSI-687 (parent KSI-586). Used by the
+     * heartbeat scheduled-retry path and productivity-review suppression.
+     * Exposed on the service surface so callers in heartbeat.ts and
+     * productivity-review.ts can keep state coherent without re-implementing
+     * label CRUD or duplicating the constant.
+     */
+    ensureCodexLimitLabel,
+    getCodexLimitLabelId,
+    addCodexLimitLabelToIssue,
+    clearCodexLimitLabelIfApplicable,
 
     listComments: async (
       issueId: string,

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -7,7 +7,9 @@ import {
   costEvents,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issues,
+  labels,
   projects,
 } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
@@ -475,8 +477,19 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       ? Math.max(0, now.getTime() - activeStartedAt.getTime())
       : null;
 
+    // KSI-687 D4: when the issue is paused on a codex usage-limit retry, the
+    // `codex-limit` operational label is present. Suppress `longActive` so we
+    // don't fire a productivity review for a pause that the system already
+    // knows about. The label is cleared automatically when the retry resumes.
+    const codexLimitLabelId = await issuesSvc.getCodexLimitLabelId(sourceIssue.companyId);
+    const isCodexLimitPaused = codexLimitLabelId != null && await db
+      .select({ issueId: issueLabels.issueId })
+      .from(issueLabels)
+      .where(and(eq(issueLabels.issueId, sourceIssue.id), eq(issueLabels.labelId, codexLimitLabelId)))
+      .then((rows) => rows.length > 0);
+
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive = !isCodexLimitPaused && elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Summary

KSI-687 — Subtask A of [KSI-586]: Mudança 1 — blocked durante retry Codex usage-limit + supressão productivity-review.

### What this PR does

When a `codex_local` agent hits the usage-limit and `scheduleBoundedRetryForRun` schedules a `scheduled_retry`, this PR:

1. **Moves the issue to `blocked`** with an automated comment: *"Aguardando retorno do Codex usage-limit. Retry agendado para `<ISO>`. Tentativa n/max. Owner: sistema (auto-resume). Escalação humana aos 84h se persistir."*
2. **Applies the `codex-limit` operational label** (created inline idempotently, color `#06b6d4`) to the issue.
3. **Resumes automatically**: when `promoteDueScheduledRetryRun` promotes the run back to `queued`, the issue transitions back to `in_progress` and the `codex-limit` label is removed.
4. **Symmetric clear on reassign**: `issueService.update()` clears the label when `assigneeAgentId` changes (caller-wins strategy — only when caller doesn't pass `labelIds` explicitly).
5. **D4 defesa em profundidade**: `productivityReviewService.collectEvidence` suppresses `longActive` when the `codex-limit` label is present, preventing spurious productivity reviews during a system-managed pause.

### Commits

- **Commit 1** (`83842656`): `codex-limit` label helpers in `issues.ts` + symmetric clear on reassign (8 tests)
- **Commit 2** (`c811d5ff`): heartbeat wiring — blocked on failure, in_progress on promote (4 tests)
- **Commit 3** (`d0044400`): productivity-review D4 suppression (2 tests)

### Tests

14 tests across 3 new test files:
- `server/src/__tests__/issues-codex-limit-label.test.ts` — 8 tests
- `server/src/__tests__/heartbeat-codex-limit-blocked.test.ts` — 4 tests
- `server/src/__tests__/productivity-review-codex-limit-suppression.test.ts` — 2 tests

### Related

- Parent: KSI-586 (Mudanças na lógica ERROR LIMIT CODEX C1/C2)
- Companion PRs: KSI-688 (backoff 1h + cap 168h), KSI-690 (usage-limit awareness adapters)