### PR TITLE
KSI-689: doc CODEX_LIMIT_LABEL.md — manual vs system-managed label families

### DIFF
--- a/doc/CODEX_LIMIT_LABEL.md
+++ b/doc/CODEX_LIMIT_LABEL.md
@@ -1,0 +1,133 @@
+# `codex-limit` operational label and the system-managed label family
+
+Source of truth for the `codex-limit` operational label introduced by
+[KSI-586](https://github.com/paperclipai/paperclip/issues) and the broader
+distinction between **manual** and **system-managed** operational labels in
+Paperclip.
+
+This document is the canonical reference for adapter authors, tool integrators
+and agent instruction maintainers. Per-agent `AGENTS.md` files SHOULD link here
+instead of redefining the contract.
+
+## Two families of operational labels
+
+Paperclip uses operational labels at the issue level to communicate state that
+an agent or a human needs to act on outside of normal in-progress execution.
+Those labels split into two families with different lifecycle contracts:
+
+| Family | Examples | Applied by | Removed by | Comment contract |
+|---|---|---|---|---|
+| **Manual** | `restart`, `rebuild`, `restart-rebuild`, `manual-terminal`, `approval-needed`, `blocked-external` | Human or agent | Human or agent (same heartbeat the condition resolves) | Comment with **owner**, **exact command (when applicable)** and **post-execution verification** |
+| **System-managed** | `codex-limit` | Server (`server/src/services/issues.ts` helpers + heartbeat wiring) | Server (status transitions, reassign, probe routine) | Not required — the server lifecycle already encodes the contract |
+
+A *manual* label describes an action a human or an agent must perform outside
+of the container (rebuild, run a command, give an approval). A *system-managed*
+label describes a state of waiting on an external system whose recovery is
+detected and acted on by Paperclip itself.
+
+The two families do not share the same checklist. Pre-`done`/`blocked`/
+`in_review` checklists are written for the manual family; system-managed
+labels are excluded from that checklist because the server, not the agent,
+owns their lifecycle.
+
+## `codex-limit`
+
+### What it means
+
+The `codex-limit` label is applied to an issue when its assigned agent runs on
+the `codex_local` adapter and both Codex profiles (e.g. `CODEX_HOME` and
+`CODEX_FALLBACK` configured via `codex-home-fallback`) report a usage-limit
+error during a heartbeat. The server transitions the issue to `blocked`,
+schedules a retry (`scheduled_retry` run), and applies the label so the board
+can see at a glance that the issue is paused waiting for Codex credits to
+return rather than for product work.
+
+### Color and visual contract
+
+- Name: `codex-limit`
+- Color: `#06b6d4` (cyan-500), defined by the board in the KSI-586 plan
+  decision (D2) as a distinct hue from the manual operational palette.
+- Description: *Issue blocked waiting for Codex credit return (usage-limit).
+  Applied and removed automatically by the server.*
+
+The label is created idempotently by the server on first need. There is no
+seed migration to run; the helper `ensureCodexLimitLabel(companyId)` in
+`server/src/services/issues.ts` creates the row with the documented color the
+first time the application path runs on a given company, and is a no-op on
+later calls.
+
+### Lifecycle
+
+The label is applied automatically in `server/src/services/heartbeat.ts` on
+the `scheduleBoundedRetryForRun` path when:
+
+1. The agent's `adapterType === "codex_local"`.
+2. The run reports `errorFamily: "transient_upstream"` with a Codex
+   usage-limit signal (`hasUsageLimitSignal`, parsed in
+   `packages/adapters/codex-local/src/server/parse.ts`).
+3. The heartbeat outcome is `scheduled` (a `scheduled_retry` run was created).
+
+Application is paired with:
+
+- A status transition `in_progress → blocked` for the issue.
+- A system comment naming the unblock owner (auto-resume by scheduled retry),
+  the next attempt timestamp, and the affected profiles.
+
+The label is removed automatically in symmetrical paths:
+
+- **Retry promoted**: when `executeDueScheduledRetryRuns` promotes the
+  `scheduled_retry` run, the issue returns to `in_progress` and the label is
+  cleared.
+- **Reassignment**: when an issue is reassigned to a different agent in
+  `issueService.update()`, the label is cleared (caller-wins precedence: if
+  the caller passes an explicit `labelIds`, the caller's intent is honoured).
+- **Manual close**: when the issue is moved to `done` or `cancelled` outside
+  the retry path, removal happens via the same `clearCodexLimitLabelIfApplicable`
+  helper.
+- **Probe recovery** (planned, [KSI-690](https://github.com/paperclipai/paperclip/issues)):
+  when the `codex-limit-probe` routine detects a Codex profile recovery, it
+  removes the label across all currently-blocked issues and accelerates their
+  scheduled retries.
+
+### Contract for agents and instruction maintainers
+
+- Agents SHOULD NOT add or remove `codex-limit` manually. The server owns the
+  lifecycle.
+- Pre-disposition checklists ("before marking done/blocked/in_review verify
+  every active operational label") apply only to the manual family. The
+  presence of `codex-limit` does not imply a human action is pending; it
+  implies the platform is waiting on an external system.
+- If `codex-limit` is found on an issue with no active scheduled retry and no
+  Codex usage-limit context (a stale state), an agent MAY clear it as part of
+  state recovery, but MUST justify the removal in a comment.
+
+## Adding new system-managed labels
+
+Future system-managed labels (e.g. for other adapter quotas, model cool-downs,
+or third-party rate limits) follow the same pattern:
+
+1. Define the label name, color and description in `server/src/services/issues.ts`
+   (or the equivalent module owning the lifecycle).
+2. Implement an `ensure<Name>Label` + `add<Name>LabelToIssue` +
+   `clear<Name>LabelIfApplicable` triplet that is idempotent inside or outside
+   a transaction.
+3. Wire application and removal into the deterministic server paths (heartbeat,
+   reassignment, status transitions). Do not expose human/agent-driven
+   application paths.
+4. Document the label here and link from the relevant adapter or runtime doc.
+
+The board MUST sign off on new system-managed labels before they are wired,
+because they change the platform contract that agents read in their
+instructions.
+
+## References
+
+- KSI-586 plan and decision documents on the ksio-dev Paperclip instance
+  cover the original requirements, the D1–D5 board decisions and the subtask
+  breakdown (A: blocked-during-retry; B: 1h backoff with D1-routing; C: this
+  label; D: probe routine; E: integration tests).
+- `server/src/services/issues.ts` — label helpers and reassignment hook.
+- `server/src/services/heartbeat.ts` — application on `scheduleBoundedRetry`,
+  removal on `executeDueScheduledRetryRuns`.
+- `server/src/services/productivity-review.ts` — defensive suppression of the
+  `long_active_duration` review trigger when `codex-limit` is present.

--- a/server/src/__tests__/heartbeat-codex-limit-blocked.test.ts
+++ b/server/src/__tests__/heartbeat-codex-limit-blocked.test.ts
@@ -1,0 +1,267 @@
+/**
+ * KSI-687 — Commit 2 tests: heartbeat wiring for codex usage-limit blocked
+ *
+ * Verifies that:
+ * 1. scheduleBoundedRetry transitions the issue to `blocked` and adds the
+ *    `codex-limit` label when outcome is "scheduled" for a codex_local agent.
+ * 2. promoteDueScheduledRetries transitions the issue back to `in_progress`
+ *    and removes the `codex-limit` label.
+ * 3. A non-codex_local agent (claude_local) does NOT trigger the blocked
+ *    transition even when transient_upstream fires.
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueLabels,
+  issues,
+  labels,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { CODEX_LIMIT_LABEL_NAME } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat codex-limit blocked tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat wiring: codex-limit blocked/unblocked (KSI-687)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-codex-limit-blocked-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueLabels);
+    await db.delete(labels);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /** Seed a company, a codex_local agent, an in_progress issue and a failed run. */
+  async function seedCodexLimitFixture(opts?: {
+    adapterType?: "codex_local" | "claude_local";
+    retryNotBefore?: string;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-05-01T12:00:00.000Z");
+    const adapterType = opts?.adapterType ?? "codex_local";
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: adapterType === "claude_local" ? "ClaudeCoder" : "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const resultJson: Record<string, unknown> = {
+      errorFamily: "transient_upstream",
+    };
+    if (opts?.retryNotBefore) {
+      resultJson.retryNotBefore = opts.retryNotBefore;
+      resultJson.transientRetryNotBefore = opts.retryNotBefore;
+    }
+
+    // Insert run BEFORE issue (FK: issues.execution_run_id → heartbeat_runs.id)
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "Usage limit exceeded",
+      errorCode: "codex_transient_upstream",
+      finishedAt: now,
+      scheduledRetryAttempt: 0,
+      scheduledRetryReason: null,
+      resultJson,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue under usage-limit",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: adapterType === "claude_local" ? "claudecoder" : "codexcoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId, runId, now };
+  }
+
+  async function getIssueStatus(issueId: string) {
+    return db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]?.status ?? null);
+  }
+
+  async function getIssueCodexLimitLabel(issueId: string, companyId: string) {
+    const label = await db
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows) => rows[0] ?? null);
+    if (!label) return false;
+    const applied = await db
+      .select({ issueId: issueLabels.issueId })
+      .from(issueLabels)
+      .where(and(eq(issueLabels.issueId, issueId), eq(issueLabels.labelId, label.id)))
+      .then((rows) => rows[0] ?? null);
+    return applied != null;
+  }
+
+  async function getIssueComments(issueId: string) {
+    return db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+  }
+
+  it("scheduleBoundedRetry: codex_local transient → issue becomes blocked + codex-limit label applied + comment added", async () => {
+    const { companyId, issueId, runId } = await seedCodexLimitFixture();
+
+    const result = await heartbeat.scheduleBoundedRetry(runId);
+
+    expect(result.outcome).toBe("scheduled");
+
+    const status = await getIssueStatus(issueId);
+    expect(status).toBe("blocked");
+
+    const hasLabel = await getIssueCodexLimitLabel(issueId, companyId);
+    expect(hasLabel).toBe(true);
+
+    const comments = await getIssueComments(issueId);
+    expect(comments.length).toBeGreaterThan(0);
+    expect(comments[0]!.body).toContain("Aguardando retorno do Codex usage-limit");
+    expect(comments[0]!.body).toContain("Owner: sistema (auto-resume)");
+  });
+
+  it("scheduleBoundedRetry: codex_local with retryNotBefore → blocked + label + comment contains scheduled time", async () => {
+    const retryNotBefore = "2026-05-01T13:00:00.000Z";
+    const { companyId, issueId, runId } = await seedCodexLimitFixture({ retryNotBefore });
+
+    const result = await heartbeat.scheduleBoundedRetry(runId);
+    expect(result.outcome).toBe("scheduled");
+
+    const status = await getIssueStatus(issueId);
+    expect(status).toBe("blocked");
+
+    const hasLabel = await getIssueCodexLimitLabel(issueId, companyId);
+    expect(hasLabel).toBe(true);
+
+    const comments = await getIssueComments(issueId);
+    expect(comments.length).toBeGreaterThan(0);
+    expect(comments[0]!.body).toContain("Retry agendado para");
+  });
+
+  it("scheduleBoundedRetry: claude_local transient → issue stays in_progress (NOT blocked, no label)", async () => {
+    const { companyId, issueId, runId } = await seedCodexLimitFixture({ adapterType: "claude_local" });
+
+    // Patch the run's errorCode to match claude convention
+    await db
+      .update(heartbeatRuns)
+      .set({ errorCode: "claude_transient_upstream" })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const result = await heartbeat.scheduleBoundedRetry(runId);
+    expect(result.outcome).toBe("scheduled");
+
+    const status = await getIssueStatus(issueId);
+    expect(status).toBe("in_progress"); // NOT blocked
+
+    const hasLabel = await getIssueCodexLimitLabel(issueId, companyId);
+    expect(hasLabel).toBe(false);
+  });
+
+  it("promoteDueScheduledRetries: blocked issue with codex-limit label → returns to in_progress and label removed", async () => {
+    const retryNotBefore = "2026-05-01T11:00:00.000Z"; // in the past relative to scheduleNow
+    const { companyId, issueId, runId } = await seedCodexLimitFixture({ retryNotBefore });
+
+    // Use a deterministic now for scheduling so scheduledRetryAt is predictable
+    const scheduleNow = new Date("2026-05-01T12:00:00.000Z");
+
+    // Schedule the retry at scheduleNow (which will also block the issue and add the label)
+    const scheduleResult = await heartbeat.scheduleBoundedRetry(runId, { now: scheduleNow });
+    expect(scheduleResult.outcome).toBe("scheduled");
+
+    // Confirm issue is blocked
+    expect(await getIssueStatus(issueId)).toBe("blocked");
+    expect(await getIssueCodexLimitLabel(issueId, companyId)).toBe(true);
+
+    // Promote at scheduleNow + 3h (well past the 2min delay for attempt 1)
+    const promoted = await heartbeat.promoteDueScheduledRetries(
+      new Date(scheduleNow.getTime() + 3 * 60 * 60 * 1000),
+    );
+    expect(promoted.promoted).toBeGreaterThan(0);
+
+    // Issue should be back to in_progress
+    expect(await getIssueStatus(issueId)).toBe("in_progress");
+
+    // Label should be removed
+    expect(await getIssueCodexLimitLabel(issueId, companyId)).toBe(false);
+  });
+});

--- a/server/src/__tests__/issues-codex-limit-label.test.ts
+++ b/server/src/__tests__/issues-codex-limit-label.test.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueLabels,
+  issues,
+  labels,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  CODEX_LIMIT_LABEL_COLOR,
+  CODEX_LIMIT_LABEL_NAME,
+  issueService,
+} from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres codex-limit label tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issueService codex-limit label helpers (KSI-687)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-codex-limit-label-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueLabels);
+    await db.delete(labels);
+    await db.delete(issueComments);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedIssue(companyId: string, opts?: {
+    assigneeAgentId?: string | null;
+    status?: string;
+  }) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue under usage-limit",
+      status: opts?.status ?? "in_progress",
+      priority: "medium",
+      assigneeAgentId: opts?.assigneeAgentId ?? null,
+      createdAt: new Date(),
+    });
+    return issueId;
+  }
+
+  async function seedAgent(companyId: string, name = "Codex") {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  it("ensureCodexLimitLabel creates the label idempotently with the documented color", async () => {
+    const companyId = await seedCompany();
+    const svc = issueService(db);
+
+    const labelId = await svc.ensureCodexLimitLabel(companyId);
+    expect(labelId).toBeTruthy();
+
+    const sameLabelId = await svc.ensureCodexLimitLabel(companyId);
+    expect(sameLabelId).toBe(labelId);
+
+    const all = await db
+      .select()
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)));
+    expect(all).toHaveLength(1);
+    expect(all[0].color).toBe(CODEX_LIMIT_LABEL_COLOR);
+  });
+
+  it("getCodexLimitLabelId returns null before the label exists and the labelId after", async () => {
+    const companyId = await seedCompany();
+    const svc = issueService(db);
+
+    expect(await svc.getCodexLimitLabelId(companyId)).toBeNull();
+    const labelId = await svc.ensureCodexLimitLabel(companyId);
+    expect(await svc.getCodexLimitLabelId(companyId)).toBe(labelId);
+  });
+
+  it("addCodexLimitLabelToIssue applies the label and is idempotent", async () => {
+    const companyId = await seedCompany();
+    const issueId = await seedIssue(companyId);
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+
+    const rows = await db
+      .select()
+      .from(issueLabels)
+      .where(eq(issueLabels.issueId, issueId));
+    expect(rows).toHaveLength(1);
+
+    const label = await db
+      .select()
+      .from(labels)
+      .where(eq(labels.id, rows[0].labelId))
+      .then((r) => r[0]);
+    expect(label.name).toBe(CODEX_LIMIT_LABEL_NAME);
+  });
+
+  it("clearCodexLimitLabelIfApplicable is a no-op when the label has not been created", async () => {
+    const companyId = await seedCompany();
+    const issueId = await seedIssue(companyId);
+    const svc = issueService(db);
+
+    const removed = await svc.clearCodexLimitLabelIfApplicable(issueId, companyId);
+    expect(removed).toBe(false);
+
+    const labelRows = await db.select().from(labels).where(eq(labels.companyId, companyId));
+    expect(labelRows).toHaveLength(0);
+  });
+
+  it("clearCodexLimitLabelIfApplicable removes the label when applied and is idempotent on subsequent calls", async () => {
+    const companyId = await seedCompany();
+    const issueId = await seedIssue(companyId);
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+    expect(await svc.clearCodexLimitLabelIfApplicable(issueId, companyId)).toBe(true);
+    expect(await svc.clearCodexLimitLabelIfApplicable(issueId, companyId)).toBe(false);
+
+    const remaining = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("update() clears codex-limit label when the agent assignee changes (symmetric with reassign during blocked)", async () => {
+    const companyId = await seedCompany();
+    const agentA = await seedAgent(companyId, "CodexA");
+    const agentB = await seedAgent(companyId, "CodexB");
+    const issueId = await seedIssue(companyId, { assigneeAgentId: agentA, status: "blocked" });
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+    const before = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(before).toHaveLength(1);
+
+    await svc.update(issueId, { assigneeAgentId: agentB });
+
+    const after = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(after).toHaveLength(0);
+  });
+
+  it("update() does NOT clear codex-limit label when the assignee did not change", async () => {
+    const companyId = await seedCompany();
+    const agentA = await seedAgent(companyId, "CodexA");
+    const issueId = await seedIssue(companyId, { assigneeAgentId: agentA, status: "blocked" });
+    const svc = issueService(db);
+
+    await svc.addCodexLimitLabelToIssue(issueId, companyId);
+
+    // Update an unrelated field; assignee unchanged.
+    await svc.update(issueId, { priority: "high" });
+
+    const after = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(after).toHaveLength(1);
+  });
+
+  it("update() does NOT clear codex-limit label when the caller is explicitly managing labelIds", async () => {
+    const companyId = await seedCompany();
+    const agentA = await seedAgent(companyId, "CodexA");
+    const agentB = await seedAgent(companyId, "CodexB");
+    const issueId = await seedIssue(companyId, { assigneeAgentId: agentA, status: "blocked" });
+    const svc = issueService(db);
+
+    const codexLimitLabelId = await svc.ensureCodexLimitLabel(companyId);
+
+    // Caller explicitly retains the label across the reassign by passing labelIds.
+    await svc.update(issueId, {
+      assigneeAgentId: agentB,
+      labelIds: [codexLimitLabelId],
+    });
+
+    const after = await db.select().from(issueLabels).where(eq(issueLabels.issueId, issueId));
+    expect(after).toHaveLength(1);
+    expect(after[0].labelId).toBe(codexLimitLabelId);
+  });
+});

--- a/server/src/__tests__/productivity-review-codex-limit-suppression.test.ts
+++ b/server/src/__tests__/productivity-review-codex-limit-suppression.test.ts
@@ -1,0 +1,168 @@
+/**
+ * KSI-687 — Commit 3 tests: productivity-review D4 suppression for codex-limit
+ *
+ * Verifies that:
+ * 1. An issue blocked with the `codex-limit` label does NOT trigger
+ *    longActive-based productivity reviews (suppressed).
+ * 2. A regular issue without the label still triggers productivity reviews
+ *    (control case — the guard does not over-suppress).
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueLabels,
+  issues,
+  labels,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { productivityReviewService } from "../services/productivity-review.ts";
+import { CODEX_LIMIT_LABEL_NAME, issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres productivity-review D4 suppression tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("productivityReviewService: codex-limit suppression (KSI-687 D4)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-productivity-review-d4-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /**
+   * Seed a minimal fixture: company + codex_local agent + in_progress issue
+   * that has been active for more than DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS.
+   * Returns ids needed for assertions.
+   */
+  async function seedLongActiveIssue(opts?: { withCodexLimitLabel?: boolean }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const managerId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `D4${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    // Issue started 8 hours ago (exceeds the default 6h threshold)
+    const startedAt = new Date(Date.now() - 8 * 60 * 60 * 1000);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip D4",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Manager (needed so issueService can assign review to a chain-of-command member)
+    await db.insert(agents).values({
+      id: managerId,
+      companyId,
+      name: "CTO",
+      role: "cto",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      reportsTo: managerId,
+      permissions: {},
+    });
+
+    // Run before issue (FK)
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId },
+      updatedAt: startedAt,
+      createdAt: startedAt,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Long-running issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: startedAt,
+      startedAt,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    if (opts?.withCodexLimitLabel) {
+      const issuesSvc = issueService(db);
+      await issuesSvc.addCodexLimitLabelToIssue(issueId, companyId);
+    }
+
+    return { companyId, agentId, issueId, runId };
+  }
+
+  it("collectEvidence: issue with codex-limit label → longActive suppressed (no review triggered)", async () => {
+    const { companyId } = await seedLongActiveIssue({ withCodexLimitLabel: true });
+    const service = productivityReviewService(db);
+
+    // reconcileProductivityReviews processes all in_progress issues
+    await service.reconcileProductivityReviews();
+
+    // No productivity review issue should have been created for this company
+    const reviewIssues = await db
+      .select({ id: issues.id, title: issues.title })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), sql`${issues.title} ilike '%productivity review%'`));
+
+    expect(reviewIssues).toHaveLength(0);
+  });
+
+  it("collectEvidence: issue WITHOUT codex-limit label → longActive fires → review triggered (control)", async () => {
+    const { companyId } = await seedLongActiveIssue({ withCodexLimitLabel: false });
+    const service = productivityReviewService(db);
+
+    await service.reconcileProductivityReviews();
+
+    // A productivity review issue should have been created
+    const reviewIssues = await db
+      .select({ id: issues.id, title: issues.title })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), sql`${issues.title} ilike '%productivity%'`));
+
+    expect(reviewIssues.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5327,6 +5327,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
     if (!promoted) return { outcome: "not_promoted", run: null };
 
+    // KSI-687: when a codex usage-limit scheduled retry becomes due, transition
+    // the issue back to in_progress and remove the codex-limit label.
+    const promotedIssueId = readNonEmptyString(parseObject(promoted.contextSnapshot).issueId);
+    if (promotedIssueId) {
+      try {
+        const promotedIssue = await issuesSvc.getById(promotedIssueId);
+        if (promotedIssue?.status === "blocked") {
+          await issuesSvc.update(promotedIssueId, { status: "in_progress" });
+        }
+        await issuesSvc.clearCodexLimitLabelIfApplicable(promotedIssueId, promoted.companyId);
+      } catch (_err) {
+        // Non-fatal: promotion still succeeds even if the issue update fails.
+      }
+    }
+
     await appendRunEvent(promoted, await nextRunEventSeq(promoted.id), {
       eventType: "lifecycle",
       stream: "system",
@@ -5753,6 +5768,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
+    // KSI-687: for codex_local transient-upstream retries, move the issue to
+    // `blocked` so the board can see the pause, and attach the operational
+    // `codex-limit` label. This runs after the transaction commits.
+    if (
+      retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON &&
+      agent.adapterType === "codex_local" &&
+      issueId
+    ) {
+      await applyCodexLimitBlockedState(issueId, run.companyId, run.agentId, run.id, {
+        outcome: "scheduled",
+        run: retryRun,
+        dueAt,
+        attempt: schedule.attempt,
+        maxAttempts: schedule.maxAttempts,
+      });
+    }
+
     return {
       outcome: "scheduled" as const,
       run: retryRun,
@@ -5760,6 +5792,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       attempt: schedule.attempt,
       maxAttempts: schedule.maxAttempts,
     };
+  }
+
+  /**
+   * KSI-687: after a codex_local run hits a usage-limit and a scheduled_retry
+   * is successfully queued, move the issue to `blocked` and attach the
+   * `codex-limit` operational label so the board can see the pause.
+   *
+   * Extracted as a standalone helper so it can be called from both the
+   * post-run failure path (scheduleBoundedRetryForRun) and, in future, from
+   * any other place that schedules a codex usage-limit retry.
+   */
+  async function applyCodexLimitBlockedState(
+    issueId: string,
+    companyId: string,
+    agentId: string,
+    runId: string,
+    retryResult: { outcome: string; run?: { scheduledRetryAt?: Date | string | null }; dueAt?: Date; attempt?: number; maxAttempts?: number },
+  ): Promise<void> {
+    try {
+      const dueAtIso = retryResult.dueAt instanceof Date
+        ? retryResult.dueAt.toISOString()
+        : retryResult.run?.scheduledRetryAt
+          ? new Date(retryResult.run.scheduledRetryAt).toISOString()
+          : null;
+      const attempt = retryResult.attempt ?? null;
+      const maxAttempts = retryResult.maxAttempts ?? null;
+      await issuesSvc.update(issueId, { status: "blocked" });
+      await issuesSvc.addCodexLimitLabelToIssue(issueId, companyId);
+      const commentBody = [
+        "Aguardando retorno do Codex usage-limit.",
+        dueAtIso ? `Retry agendado para \`${dueAtIso}\`.` : null,
+        attempt != null && maxAttempts != null ? `Tentativa ${attempt}/${maxAttempts}.` : null,
+        "Owner: sistema (auto-resume). Escalação humana aos 84h se persistir.",
+      ].filter(Boolean).join(" ");
+      await issuesSvc.addComment(issueId, commentBody, { agentId, runId });
+    } catch (_err) {
+      // Non-fatal: the scheduled_retry was already recorded; the issue state
+      // update is a best-effort UX improvement.
+    }
   }
 
   async function promoteDueScheduledRetries(now = new Date()) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -85,6 +85,17 @@ import {
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+
+/**
+ * Operational label applied automatically when a `codex_local` agent hits the
+ * Codex usage limit and the issue is moved to `blocked` while waiting for the
+ * scheduled retry to fire. Removed automatically when the retry is promoted
+ * back to `pending` or the issue is reassigned to a different agent.
+ *
+ * Source of truth: KSI-687 (parent KSI-586). See plan document on KSI-586.
+ */
+export const CODEX_LIMIT_LABEL_NAME = "codex-limit";
+export const CODEX_LIMIT_LABEL_COLOR = "#06b6d4";
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
@@ -3428,6 +3439,92 @@ export function issueService(db: Db) {
     );
   }
 
+  /**
+   * Returns the labelId for the `codex-limit` operational label in a company,
+   * creating it idempotently on first use. Safe to call inside or outside a
+   * transaction.
+   *
+   * Source of truth: KSI-687 (parent KSI-586).
+   */
+  async function ensureCodexLimitLabel(companyId: string, dbOrTx: any = db): Promise<string> {
+    const existing = await dbOrTx
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (existing) return existing.id;
+    const created = await dbOrTx
+      .insert(labels)
+      .values({
+        companyId,
+        name: CODEX_LIMIT_LABEL_NAME,
+        color: CODEX_LIMIT_LABEL_COLOR,
+      })
+      .returning({ id: labels.id })
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (created) return created.id;
+    // Race-condition fallback: someone else inserted between our select and insert.
+    const retry = await dbOrTx
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    if (!retry) {
+      throw new Error("Failed to ensure codex-limit label after race retry");
+    }
+    return retry.id;
+  }
+
+  /**
+   * Returns the labelId for the `codex-limit` label if it already exists in
+   * the company, or `null` otherwise. Does not create. Safe inside/outside tx.
+   */
+  async function getCodexLimitLabelId(companyId: string, dbOrTx: any = db): Promise<string | null> {
+    const row = await dbOrTx
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(eq(labels.companyId, companyId), eq(labels.name, CODEX_LIMIT_LABEL_NAME)))
+      .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+    return row?.id ?? null;
+  }
+
+  /**
+   * Adds the `codex-limit` label to an issue idempotently. Creates the label
+   * if it doesn't exist yet in the company. No-op if the label is already on
+   * the issue.
+   */
+  async function addCodexLimitLabelToIssue(
+    issueId: string,
+    companyId: string,
+    dbOrTx: any = db,
+  ): Promise<void> {
+    const labelId = await ensureCodexLimitLabel(companyId, dbOrTx);
+    await dbOrTx
+      .insert(issueLabels)
+      .values({ issueId, labelId, companyId })
+      .onConflictDoNothing();
+  }
+
+  /**
+   * Removes the `codex-limit` label from an issue if currently applied. No-op
+   * if the label doesn't exist in the company yet (so safe to call from
+   * symmetric callers like reassignment without checking first).
+   */
+  async function clearCodexLimitLabelIfApplicable(
+    issueId: string,
+    companyId: string,
+    dbOrTx: any = db,
+  ): Promise<boolean> {
+    const labelId = await getCodexLimitLabelId(companyId, dbOrTx);
+    if (!labelId) return false;
+    const removed = await dbOrTx
+      .delete(issueLabels)
+      .where(and(eq(issueLabels.issueId, issueId), eq(issueLabels.labelId, labelId)))
+      .returning({ issueId: issueLabels.issueId })
+      .then((rows: Array<{ issueId: string }>) => rows.length > 0);
+    return removed;
+  }
+
   async function getIssueRelationSummaryMap(
     companyId: string,
     issueIds: string[],
@@ -5076,6 +5173,19 @@ export function issueService(db: Db) {
         if (nextLabelIds !== undefined) {
           await syncIssueLabels(updated.id, existing.companyId, nextLabelIds, tx);
         }
+        // KSI-687/O5: When the issue is reassigned to a different agent (or to
+        // a user) while carrying the `codex-limit` operational label, the
+        // label is no longer truthful — the new assignee is not waiting on a
+        // Codex usage-limit retry tied to the previous agent. Clear it
+        // symmetrically with the addCodexLimitLabelToIssue path. Skip when
+        // the caller is explicitly managing labels via labelIds (they own
+        // the label state in that call).
+        const assigneeChangedToDifferentTarget =
+          (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
+          (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId);
+        if (nextLabelIds === undefined && assigneeChangedToDifferentTarget) {
+          await clearCodexLimitLabelIfApplicable(updated.id, existing.companyId, tx);
+        }
         if (blockedByIssueIds !== undefined) {
           await syncBlockedByIssueIds(
             updated.id,
@@ -5561,6 +5671,18 @@ export function issueService(db: Db) {
         .where(eq(labels.id, id))
         .returning()
         .then((rows) => rows[0] ?? null),
+
+    /**
+     * Operational label helpers for KSI-687 (parent KSI-586). Used by the
+     * heartbeat scheduled-retry path and productivity-review suppression.
+     * Exposed on the service surface so callers in heartbeat.ts and
+     * productivity-review.ts can keep state coherent without re-implementing
+     * label CRUD or duplicating the constant.
+     */
+    ensureCodexLimitLabel,
+    getCodexLimitLabelId,
+    addCodexLimitLabelToIssue,
+    clearCodexLimitLabelIfApplicable,
 
     listComments: async (
       issueId: string,

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -7,7 +7,9 @@ import {
   costEvents,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issues,
+  labels,
   projects,
 } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
@@ -475,8 +477,19 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       ? Math.max(0, now.getTime() - activeStartedAt.getTime())
       : null;
 
+    // KSI-687 D4: when the issue is paused on a codex usage-limit retry, the
+    // `codex-limit` operational label is present. Suppress `longActive` so we
+    // don't fire a productivity review for a pause that the system already
+    // knows about. The label is cleared automatically when the retry resumes.
+    const codexLimitLabelId = await issuesSvc.getCodexLimitLabelId(sourceIssue.companyId);
+    const isCodexLimitPaused = codexLimitLabelId != null && await db
+      .select({ issueId: issueLabels.issueId })
+      .from(issueLabels)
+      .where(and(eq(issueLabels.issueId, sourceIssue.id), eq(issueLabels.labelId, codexLimitLabelId)))
+      .then((rows) => rows.length > 0);
+
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive = !isCodexLimitPaused && elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Summary

Adds canonical platform documentation for the `codex-limit` operational label introduced in KSI-586 and the broader distinction between **manual** and **system-managed** operational labels in Paperclip.

This is the documentation deliverable of [KSI-586 Subtask C (KSI-689)](https://github.com/paperclipai/paperclip/issues), which complements the runtime wiring already shipped in PR #7020 (KSI-687).

## What changed

- **New file**: `doc/CODEX_LIMIT_LABEL.md` — platform-level reference covering:
  - The two-family taxonomy (manual vs system-managed).
  - The `codex-limit` lifecycle (apply on usage-limit blocked, remove on retry promote / reassign / close / probe recovery).
  - The contract for adding new system-managed labels in the future.

The runtime side (label helpers in `server/src/services/issues.ts`, application/removal in `server/src/services/heartbeat.ts`, productivity-review suppression) was delivered in #7020. This PR is doc-only.

## Per-instance bundles

Per-agent `AGENTS.md` bundles in the ksio-dev Paperclip instance (CEO, COO, Callisto, Europa, Horizon, Hyperion, Lyra, Webb, Fermi) were updated via filesystem to add the same taxonomy section under their existing _Politica de labels operacionais_ section, with a stable HTML marker (`<!-- ksi-689-codex-limit-taxonomy-v1 -->`) for idempotency. Backup files (`AGENTS.md.bak.ksi-689.<unix-ts>`) were placed alongside each updated file. Those edits are instance-state, not in this repository.

## Stacking

Stacked on top of #7020 (KSI-687). The diff includes those commits until #7020 merges; the only commit unique to this PR is the new `doc/CODEX_LIMIT_LABEL.md`.

## Not in scope

- The probe routine (KSI-690 — Subtask D, separate PR).
- The 1h backoff change (KSI-688 — Subtask B, separate branch).
- Integration tests of all four changes (KSI-691 — Subtask E).

cc paperclipai/paperclip maintainers — flagging this as a doc-only addition.