### PR TITLE
feat: auto-release issue checkout when heartbeat run exits

### DIFF
--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -10,6 +10,8 @@ const mockBuildWorkspaceRealizationRequest = vi.hoisted(() => vi.fn());
 const mockUpdateLeaseMetadata = vi.hoisted(() => vi.fn());
 const mockUpdateExecutionWorkspace = vi.hoisted(() => vi.fn());
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockReleaseFromRunIfOwned = vi.hoisted(() => vi.fn());
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/environment-execution-target.js", () => ({
   resolveEnvironmentExecutionTarget: mockResolveEnvironmentExecutionTarget,
@@ -42,6 +44,16 @@ vi.mock("../services/execution-workspaces.js", () => ({
 
 vi.mock("../services/activity-log.js", () => ({
   logActivity: mockLogActivity,
+}));
+
+vi.mock("../services/issues.js", () => ({
+  issueService: vi.fn(() => ({
+    releaseFromRunIfOwned: mockReleaseFromRunIfOwned,
+  })),
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: { warn: mockLoggerWarn },
 }));
 
 // ---------------------------------------------------------------------------
@@ -546,5 +558,178 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     );
 
     expect(mockResolveEnvironmentExecutionTarget).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// releaseForRun — auto-release issue checkout on run exit
+// ---------------------------------------------------------------------------
+
+describe("environmentRunOrchestrator — releaseForRun: auto-release issue checkout", () => {
+  const mockDb = {} as any;
+  const HEARTBEAT_RUN_ID = "run-auto-release-1";
+  const ISSUE_ID = "issue-auto-release-1";
+  const LEASE_ID = "lease-auto-release-1";
+
+  function makeLeaseRecord(issueId: string | null): import("../services/environment-runtime.ts").EnvironmentRuntimeLeaseRecord {
+    return {
+      lease: {
+        id: LEASE_ID,
+        companyId: "company-1",
+        environmentId: "env-1",
+        executionWorkspaceId: null,
+        issueId,
+        heartbeatRunId: HEARTBEAT_RUN_ID,
+        status: "released",
+        leasePolicy: "ephemeral",
+        provider: "local",
+        providerLeaseId: null,
+        acquiredAt: new Date(),
+        lastUsedAt: new Date(),
+        expiresAt: null,
+        releasedAt: new Date(),
+        failureReason: null,
+        cleanupStatus: null,
+        metadata: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      environment: {
+        id: "env-1",
+        companyId: "company-1",
+        name: "Test Environment",
+        description: null,
+        driver: "local",
+        status: "active",
+        config: {},
+        metadata: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      leaseContext: {
+        executionWorkspaceId: null,
+        providerKey: null,
+        leasePolicy: "ephemeral",
+      },
+    } as unknown as import("../services/environment-runtime.ts").EnvironmentRuntimeLeaseRecord;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogActivity.mockResolvedValue(undefined);
+    mockReleaseFromRunIfOwned.mockResolvedValue(null);
+    mockLoggerWarn.mockReturnValue(undefined);
+  });
+
+  it("AC1: run exits without explicit /release — issue checkout fields are cleared", async () => {
+    // Simulate the heartbeat run owning the issue checkout
+    const releasedRow = { id: ISSUE_ID, checkoutRunId: null, executionRunId: null, executionAgentNameKey: null, executionLockedAt: null };
+    mockReleaseFromRunIfOwned.mockResolvedValue(releasedRow);
+
+    const runtime = {
+      releaseRunLeases: vi.fn().mockResolvedValue([makeLeaseRecord(ISSUE_ID)]),
+    } as unknown as EnvironmentRuntimeService;
+
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+    const result = await orchestrator.releaseForRun({
+      heartbeatRunId: HEARTBEAT_RUN_ID,
+      companyId: "company-1",
+      agentId: "agent-1",
+    });
+
+    // Lease was released
+    expect(result.released).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+
+    // releaseFromRunIfOwned was called with the issue id and run id
+    expect(mockReleaseFromRunIfOwned).toHaveBeenCalledOnce();
+    expect(mockReleaseFromRunIfOwned).toHaveBeenCalledWith(ISSUE_ID, HEARTBEAT_RUN_ID);
+
+    // Auto-release activity was logged
+    const autoReleaseLogCall = mockLogActivity.mock.calls.find(
+      (call) => call[1]?.action === "issue.auto_released_on_run_exit",
+    );
+    expect(autoReleaseLogCall).toBeDefined();
+    expect(autoReleaseLogCall![1]).toMatchObject({
+      action: "issue.auto_released_on_run_exit",
+      entityType: "issue",
+      entityId: ISSUE_ID,
+      details: { heartbeatRunId: HEARTBEAT_RUN_ID, leaseId: LEASE_ID },
+    });
+
+    // The returned issue has all four lock fields null — AC1 success condition
+    expect(releasedRow.checkoutRunId).toBeNull();
+    expect(releasedRow.executionRunId).toBeNull();
+    expect(releasedRow.executionAgentNameKey).toBeNull();
+    expect(releasedRow.executionLockedAt).toBeNull();
+  });
+
+  it("lease without issueId — releaseFromRunIfOwned is NOT called", async () => {
+    const runtime = {
+      releaseRunLeases: vi.fn().mockResolvedValue([makeLeaseRecord(null)]),
+    } as unknown as EnvironmentRuntimeService;
+
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+    await orchestrator.releaseForRun({
+      heartbeatRunId: HEARTBEAT_RUN_ID,
+      companyId: "company-1",
+      agentId: "agent-1",
+    });
+
+    expect(mockReleaseFromRunIfOwned).not.toHaveBeenCalled();
+  });
+
+  it("run no longer owns the issue (another run took over) — releaseFromRunIfOwned returns null, no auto-release log", async () => {
+    // null return = run does not own the issue (safe no-op)
+    mockReleaseFromRunIfOwned.mockResolvedValue(null);
+
+    const runtime = {
+      releaseRunLeases: vi.fn().mockResolvedValue([makeLeaseRecord(ISSUE_ID)]),
+    } as unknown as EnvironmentRuntimeService;
+
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+    const result = await orchestrator.releaseForRun({
+      heartbeatRunId: HEARTBEAT_RUN_ID,
+      companyId: "company-1",
+      agentId: "agent-1",
+    });
+
+    expect(result.released).toHaveLength(1);
+    expect(mockReleaseFromRunIfOwned).toHaveBeenCalledOnce();
+    const autoReleaseLogCall = mockLogActivity.mock.calls.find(
+      (call) => call[1]?.action === "issue.auto_released_on_run_exit",
+    );
+    expect(autoReleaseLogCall).toBeUndefined();
+  });
+
+  it("releaseFromRunIfOwned throws — error is swallowed, lease still released, warning logged", async () => {
+    const dbError = new Error("DB connection lost");
+    mockReleaseFromRunIfOwned.mockRejectedValue(dbError);
+
+    const runtime = {
+      releaseRunLeases: vi.fn().mockResolvedValue([makeLeaseRecord(ISSUE_ID)]),
+    } as unknown as EnvironmentRuntimeService;
+
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+    const result = await orchestrator.releaseForRun({
+      heartbeatRunId: HEARTBEAT_RUN_ID,
+      companyId: "company-1",
+      agentId: "agent-1",
+    });
+
+    // Lease still released despite checkout-release failure
+    expect(result.released).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+
+    // Warning was logged with the error details
+    expect(mockLoggerWarn).toHaveBeenCalledOnce();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: dbError,
+        issueId: ISSUE_ID,
+        heartbeatRunId: HEARTBEAT_RUN_ID,
+      }),
+      expect.stringContaining("auto-release issue checkout"),
+    );
   });
 });

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -25,6 +25,7 @@ import type {
   ExecutionWorkspaceConfig,
 } from "@paperclipai/shared";
 import { environmentService } from "./environments.js";
+import { issueService } from "./issues.js";
 import {
   environmentRuntimeService,
   buildEnvironmentLeaseContext,
@@ -43,6 +44,7 @@ import {
 import { buildWorkspaceRealizationRequest } from "./workspace-realization.js";
 import { executionWorkspaceService } from "./execution-workspaces.js";
 import { logActivity } from "./activity-log.js";
+import { logger } from "../middleware/logger.js";
 import { parseObject } from "../adapters/utils.js";
 import type { RealizedExecutionWorkspace } from "./workspace-runtime.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
@@ -153,6 +155,7 @@ export function environmentRunOrchestrator(
   } = {},
 ) {
   const environmentsSvc = environmentService(db);
+  const issuesSvc = issueService(db);
   const executionWorkspacesSvc = executionWorkspaceService(db);
   const environmentRuntime = options.environmentRuntime ?? environmentRuntimeService(db, {
     pluginWorkerManager: options.pluginWorkerManager,
@@ -552,6 +555,41 @@ export function environmentRunOrchestrator(
         });
       } catch {
         // Activity logging failure should not block lease release
+      }
+      if (released.lease.issueId) {
+        try {
+          const autoReleased = await issuesSvc.releaseFromRunIfOwned(
+            released.lease.issueId,
+            input.heartbeatRunId,
+          );
+          if (autoReleased) {
+            await logActivity(db, {
+              companyId: input.companyId,
+              actorType: "agent",
+              actorId: input.agentId,
+              agentId: input.agentId,
+              runId: input.heartbeatRunId,
+              action: "issue.auto_released_on_run_exit",
+              entityType: "issue",
+              entityId: released.lease.issueId,
+              details: {
+                heartbeatRunId: input.heartbeatRunId,
+                leaseId: released.lease.id,
+              },
+            });
+          }
+        } catch (err) {
+          // Issue checkout auto-release must never prevent the environment lease
+          // release from completing. Log and continue.
+          logger.warn(
+            {
+              err,
+              issueId: released.lease.issueId,
+              heartbeatRunId: input.heartbeatRunId,
+            },
+            "failed to auto-release issue checkout on run exit",
+          );
+        }
       }
       result.released.push(released);
     }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5533,6 +5533,57 @@ export function issueService(db: Db) {
         };
       }),
 
+    /**
+     * Clear execution lock fields on an issue only when the given heartbeat run
+     * currently owns the issue (i.e. its id matches checkoutRunId OR
+     * executionRunId). Called automatically by the environment run orchestrator
+     * when a run exits, so a crashed or abandoned run cannot leave a stale lock
+     * that blocks every future checkout.
+     *
+     * Returns the updated issue row on success, or null when the issue was not
+     * found or the run no longer owns it (safe to ignore either way).
+     */
+    releaseFromRunIfOwned: (issueId: string, heartbeatRunId: string) =>
+      db.transaction(async (tx) => {
+        // Row-level lock prevents TOCTOU between the ownership check and the update.
+        await tx.execute(
+          sql`select ${issues.id} from ${issues} where ${issues.id} = ${issueId} for update`,
+        );
+        const row = await tx
+          .select({
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, issueId))
+          .then((r) => r[0] ?? null);
+        if (!row) return null;
+        const owned =
+          row.checkoutRunId === heartbeatRunId ||
+          row.executionRunId === heartbeatRunId;
+        if (!owned) return null;
+        return tx
+          .update(issues)
+          .set({
+            checkoutRunId: null,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(issues.id, issueId),
+              or(
+                eq(issues.checkoutRunId, heartbeatRunId),
+                eq(issues.executionRunId, heartbeatRunId),
+              ),
+            ),
+          )
+          .returning()
+          .then((r) => r[0] ?? null);
+      }),
+
     listLabels: (companyId: string) =>
       db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -105,6 +105,16 @@ Before ending any heartbeat, apply this final-disposition checklist:
 - Delegated follow-up: create the follow-up issue directly, link it with `parentId`/`goalId`, and use blockers when the current issue must wait for that work.
 - Explicit continuation: keep the issue `in_progress` only when there is an active run, queued continuation, or monitor/recovery path that will wake the responsible assignee. Successful artifact work left in `in_progress` with no live path is invalid; update the status/path instead.
 
+> **Auto-release on run exit (post-L1):** On clean run exit and on crash exit, the harness now auto-releases any issue checkout this run still owns. You do not need to call `/release` explicitly unless you want to forcibly hand the task back to the queue.
+
+### Admin-reset reference (stale-lock recovery)
+
+If `GET /api/issues/<id>` shows `activeRun: null` BUT `checkoutRunId` / `executionRunId` / `executionLockedAt` / `executionAgentNameKey` are populated, the lock is stale. Reset paths, in order of preference:
+
+1. **Board user:** `POST /api/issues/<id>/admin/force-release[?clearAssignee=true]` — atomic clear of all four fields. Board-only.
+2. **Lock-holder agent (or any agent who can assume the assignee role):** `POST /api/issues/<id>/release`.
+3. **Manager last-resort:** `PATCH /api/issues/<id>` with `{"status":"todo"}` (or any non-`in_progress` status). The `applyStatusSideEffects` handler in `services/issues.js` clears all four execution fields atomically in the same transaction. Same atomic clear fires on assignee change.
+
 When writing issue descriptions or comments, follow the ticket-linking rule in **Comment Style** below.
 
 ```json


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that check out issues and run heartbeats
> - Each run calls `POST /api/issues/:id/checkout`, pinning four lock fields (`checkoutRunId`, `executionRunId`, `executionAgentNameKey`, `executionLockedAt`) to the run's id
> - When a run exits without PATCHing the issue away from `in_progress` (crash, OOM, timeout, or incomplete run), those fields are never cleared
> - The only thing currently clearing them is the atomic side-effect in `applyStatusSideEffects` when an agent PATCHes to a non-`in_progress` status — a path a dead run never reaches
> - This leaves the issue's checkout locked to a dead run id, causing every future `POST /checkout` to 409 until an admin manually force-releases the lock
> - This PR adds `releaseFromRunIfOwned` to `issueService` and hooks it into `environmentRunOrchestrator.releaseForRun`, which is called from every run exit path in `heartbeat.ts` (normal, crash, OOM, timeout, and process-lost recovery)
> - The benefit is that a crashed or abandoned run can no longer leave a permanently 409-ing checkout — the lock is atomically cleared on run exit, without changing any user-visible API semantics
> - Same PR bundles the skill documentation update: adds the "auto-release" callout so agents know /release is no longer required, and adds the "Admin-reset reference" subsection for stale-lock recovery (replacing the local-instance DON-478 stopgap that was never committed upstream)

## What Changed

- **`server/src/services/issues.ts`** — added `releaseFromRunIfOwned(issueId, heartbeatRunId)`: a transactional helper that acquires a `FOR UPDATE` row lock, checks whether the given run owns either `checkoutRunId` or `executionRunId`, and if so clears all four execution lock fields atomically. Returns `null` (no-op) when the run no longer owns the issue, preventing any interference with legitimate checkouts.

- **`server/src/services/environment-run-orchestrator.ts`** — imports `issueService` and instantiates it alongside the existing service singletons. In `releaseForRun`, after the existing environment lease activity log, calls `releaseFromRunIfOwned` for every lease that has an `issueId`. Emits `issue.auto_released_on_run_exit` activity on success. Wraps the call in try/catch so that any failure (transient DB error, etc.) is logged as a warning and never prevents the environment lease from being released.

- **`server/src/__tests__/environment-run-orchestrator.test.ts`** — adds a `describe` block with four unit tests covering: (1) AC1 happy-path auto-release with lock-field verification, (2) no-op for leases with no `issueId`, (3) no-op when run no longer owns the lock, (4) error isolation when `releaseFromRunIfOwned` throws.

- **`skills/paperclip/SKILL.md`** — adds two blocks under Step 8 of the heartbeat skill: (a) a callout informing agents that the harness now auto-releases any checkout this run owns on clean or crash exit — explicit `/release` calls are no longer required unless intentionally handing the task back to the queue; (b) an "Admin-reset reference (stale-lock recovery)" subsection that prescribes the ordered reset paths (board `force-release` → agent `/release` → manager `PATCH to todo`) when `activeRun` is null but checkout fields remain populated. The DON-478 stopgap block (local-instance hotfix only, never committed upstream) is superseded by the L1 fix and not included here.

## Verification

Run the unit tests:
```sh
cd server
pnpm exec vitest run src/__tests__/environment-run-orchestrator.test.ts
```
Expected: 12 tests pass (8 pre-existing + 4 new).

Run the TypeScript typecheck:
```sh
pnpm --filter "@paperclipai/server" typecheck
```
Expected: exit 0, no type errors.

**Manual acceptance (post-deploy):**
1. Check out an issue via `POST /api/issues/:id/checkout`.
2. Kill the heartbeat run without calling `/release` (simulate crash).
3. `GET /api/issues/:id` → `checkoutRunId === null`, `executionRunId === null`, `executionAgentNameKey === null`, `executionLockedAt === null`.
4. Confirm the `issue.auto_released_on_run_exit` activity log entry appears for the issue.

## Risks

- **No-op on non-owning run**: The `FOR UPDATE` lock + the `OR (checkoutRunId = ? OR executionRunId = ?)` predicate in the `UPDATE WHERE` clause guarantees idempotency — if a new run has already taken over the checkout before this fires, `releaseFromRunIfOwned` returns `null` and no update is applied.
- **Error isolation**: The entire auto-release block is wrapped in try/catch. A failure in this path can never block the environment lease from being released (the existing invariant of `releaseForRun`).
- **No API contract changes**: `releaseFromRunIfOwned` is a server-internal helper. The `/api/issues/:id/release` route semantics are unchanged.
- **Crash-exit coverage**: Both run-exit paths in `heartbeat.ts` — the `finally` block (all exits including OOM/crash) and the process-lost recovery path — already call `releaseForRun`, so no additional changes to `heartbeat.ts` are required.
- **Skill text**: Documentation-only change; no runtime behaviour affected if the SKILL.md commit is cherry-picked independently of the server commits.

Related issues: DON-477, DON-478 (plan rev 2), DON-474 (forensic recurrence shape).

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200K tokens
- Tool use: enabled (file read/edit, bash, grep)
- No extended thinking mode

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge