### PR TITLE
[codex] fix embedded postgres loader env leakage

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -388,6 +388,111 @@ describe("adapter skill snapshots", () => {
 });
 
 describe("runChildProcess", () => {
+  async function captureChildRuntimeLoaderEnv() {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        "process.stdout.write(JSON.stringify({LD_LIBRARY_PATH:process.env.LD_LIBRARY_PATH||null,LD_PRELOAD:process.env.LD_PRELOAD||null,DYLD_LIBRARY_PATH:process.env.DYLD_LIBRARY_PATH||null}))",
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    return JSON.parse(result.stdout) as {
+      LD_LIBRARY_PATH: string | null;
+      LD_PRELOAD: string | null;
+      DYLD_LIBRARY_PATH: string | null;
+    };
+  }
+
+  it.skipIf(process.platform === "win32")("scrubs embedded-postgres loader env from spawned children", async () => {
+    const previousLdLibraryPath = process.env.LD_LIBRARY_PATH;
+    const previousLdPreload = process.env.LD_PRELOAD;
+    const previousDyldLibraryPath = process.env.DYLD_LIBRARY_PATH;
+
+    try {
+      process.env.LD_LIBRARY_PATH = [
+        "/tmp/@embedded-postgres/linux-x64/native/lib",
+        "/home/agent/.local/lib",
+      ].join(path.delimiter);
+      process.env.LD_PRELOAD = [
+        "/tmp/@embedded-postgres/linux-x64/native/lib/libcrypto.so.1.1",
+        "/opt/agent/libcustom.so",
+      ].join(" ");
+      process.env.DYLD_LIBRARY_PATH = "/tmp/@embedded-postgres/darwin-arm64/native/lib";
+
+      expect(await captureChildRuntimeLoaderEnv()).toEqual({
+        LD_LIBRARY_PATH: "/home/agent/.local/lib",
+        LD_PRELOAD: "/opt/agent/libcustom.so",
+        DYLD_LIBRARY_PATH: null,
+      });
+    } finally {
+      if (previousLdLibraryPath === undefined) delete process.env.LD_LIBRARY_PATH;
+      else process.env.LD_LIBRARY_PATH = previousLdLibraryPath;
+      if (previousLdPreload === undefined) delete process.env.LD_PRELOAD;
+      else process.env.LD_PRELOAD = previousLdPreload;
+      if (previousDyldLibraryPath === undefined) delete process.env.DYLD_LIBRARY_PATH;
+      else process.env.DYLD_LIBRARY_PATH = previousDyldLibraryPath;
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("scrubs colon-separated LD_PRELOAD values", async () => {
+    const previousLdPreload = process.env.LD_PRELOAD;
+
+    try {
+      process.env.LD_PRELOAD = [
+        "/tmp/@embedded-postgres/linux-x64/native/lib/libcrypto.so.1.1",
+        "/opt/agent/libcustom.so",
+      ].join(":");
+
+      expect(await captureChildRuntimeLoaderEnv()).toMatchObject({
+        LD_PRELOAD: "/opt/agent/libcustom.so",
+      });
+    } finally {
+      if (previousLdPreload === undefined) delete process.env.LD_PRELOAD;
+      else process.env.LD_PRELOAD = previousLdPreload;
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("preserves clean runtime loader env values", async () => {
+    const previousLdLibraryPath = process.env.LD_LIBRARY_PATH;
+    const previousLdPreload = process.env.LD_PRELOAD;
+    const previousDyldLibraryPath = process.env.DYLD_LIBRARY_PATH;
+
+    try {
+      process.env.LD_LIBRARY_PATH = [
+        "/home/agent/.local/lib",
+        "/opt/agent/lib",
+      ].join(path.delimiter);
+      process.env.LD_PRELOAD = "/opt/agent/libcustom.so";
+      process.env.DYLD_LIBRARY_PATH = "/opt/agent/dyld";
+
+      expect(await captureChildRuntimeLoaderEnv()).toEqual({
+        LD_LIBRARY_PATH: [
+          "/home/agent/.local/lib",
+          "/opt/agent/lib",
+        ].join(path.delimiter),
+        LD_PRELOAD: "/opt/agent/libcustom.so",
+        DYLD_LIBRARY_PATH: "/opt/agent/dyld",
+      });
+    } finally {
+      if (previousLdLibraryPath === undefined) delete process.env.LD_LIBRARY_PATH;
+      else process.env.LD_LIBRARY_PATH = previousLdLibraryPath;
+      if (previousLdPreload === undefined) delete process.env.LD_PRELOAD;
+      else process.env.LD_PRELOAD = previousLdPreload;
+      if (previousDyldLibraryPath === undefined) delete process.env.DYLD_LIBRARY_PATH;
+      else process.env.DYLD_LIBRARY_PATH = previousDyldLibraryPath;
+    }
+  });
+
   it("does not arm a timeout when timeoutSec is 0", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -83,6 +83,11 @@ const DEFAULT_PAPERCLIP_INSTANCE_ID = "default";
 const PATH_SEGMENT_RE = /^[a-zA-Z0-9_-]+$/;
 const SENSITIVE_ENV_KEY = /(key|token|secret|password|passwd|authorization|cookie)/i;
 const REDACTED_LOG_VALUE = "***REDACTED***";
+const EMBEDDED_POSTGRES_RUNTIME_ENV_KEYS = [
+  "LD_LIBRARY_PATH",
+  "LD_PRELOAD",
+  "DYLD_LIBRARY_PATH",
+] as const;
 const PAPERCLIP_SKILL_ROOT_RELATIVE_CANDIDATES = [
   "../../skills",
   "../../../../../skills",
@@ -1169,6 +1174,35 @@ export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJ
   return env;
 }
 
+function isEmbeddedPostgresRuntimePathSegment(value: string): boolean {
+  return value.includes("@embedded-postgres/");
+}
+
+function splitRuntimeLoaderEnv(key: string, value: string): string[] {
+  if (key === "LD_PRELOAD") return value.split(/[\s:]+/).filter(Boolean);
+  return value.split(path.delimiter).filter(Boolean);
+}
+
+function joinRuntimeLoaderEnv(key: string, values: string[]): string {
+  return values.join(key === "LD_PRELOAD" ? " " : path.delimiter);
+}
+
+function scrubEmbeddedPostgresRuntimeEnv(env: NodeJS.ProcessEnv): void {
+  for (const key of EMBEDDED_POSTGRES_RUNTIME_ENV_KEYS) {
+    const raw = env[key];
+    if (typeof raw !== "string" || raw.length === 0) continue;
+
+    const kept = splitRuntimeLoaderEnv(key, raw).filter(
+      (part) => !isEmbeddedPostgresRuntimePathSegment(part),
+    );
+    if (kept.length === 0) {
+      delete env[key];
+      continue;
+    }
+    env[key] = joinRuntimeLoaderEnv(key, kept);
+  }
+}
+
 export function defaultPathForPlatform() {
   if (process.platform === "win32") {
     return "C:\\Windows\\System32;C:\\Windows;C:\\Windows\\System32\\Wbem";
@@ -2110,6 +2144,8 @@ export async function runChildProcess(
     for (const key of CLAUDE_CODE_NESTING_VARS) {
       delete rawMerged[key];
     }
+
+    scrubEmbeddedPostgresRuntimeEnv(rawMerged);
 
     const mergedEnv = ensurePathInEnv(rawMerged);
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Local agent execution uses `@paperclipai/adapter-utils` to spawn provider CLIs and helper tools with a controlled child process environment.
> - The native embedded Postgres bootstrap prepends its native library directory to runtime loader environment variables in the long-lived server process.
> - Spawned agent children inherited those embedded Postgres runtime loader paths, which can make unrelated tools resolve incompatible native libraries.
> - The child process spawn boundary is the right place to clean this up because the server may still need its embedded Postgres runtime environment, while agent children should not inherit database-specific loader state.
> - This pull request removes only embedded Postgres runtime loader path segments from spawned child environments and keeps unrelated loader entries intact.
> - The benefit is safer local agent execution without changing embedded Postgres startup or normal PATH handling.

## What Changed

- Added a child-process environment scrubber for embedded Postgres runtime loader variables: `LD_LIBRARY_PATH`, `LD_PRELOAD`, and `DYLD_LIBRARY_PATH`.
- Applied the scrubber inside `runChildProcess` after Paperclip env normalization and before PATH repair.
- Added tests for embedded Postgres loader leakage, colon-separated `LD_PRELOAD` values, and clean runtime loader values that should be preserved.

## Verification

- `COREPACK_HOME=/Users/lishixi/Documents/base/.corepack corepack pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts -t "embedded-postgres|LD_PRELOAD|clean runtime loader"`: 3 tests passed
- `COREPACK_HOME=/Users/lishixi/Documents/base/.corepack corepack pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts`: 42 tests passed
- `COREPACK_HOME=/Users/lishixi/Documents/base/.corepack corepack pnpm --filter @paperclipai/adapter-utils typecheck`: passed
- `COREPACK_HOME=/Users/lishixi/Documents/base/.corepack corepack pnpm --filter @paperclipai/adapter-utils build`: passed
- `COREPACK_HOME=/Users/lishixi/Documents/base/.corepack corepack pnpm exec vitest run packages/adapter-utils/src`: 101 tests passed

## Risks

- Low risk. The change is scoped to spawned child process environments and only removes runtime loader entries that contain `@embedded-postgres/`.
- It intentionally leaves unrelated runtime loader entries intact and does not change the parent server process environment used by embedded Postgres itself.
- No database migration or UI behavior changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex GPT-5 coding agent with local shell, git, code editing, and test execution.
- Claude Code Sonnet review was used as a secondary reviewer via `claude -p --model sonnet`.
- The Codex session context window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: no UI changes)
- [x] I have updated relevant documentation to reflect my changes (not applicable: internal process environment behavior covered by tests)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
