### PR TITLE
adapters: shared MCP plugin-tools helper for local CLI adapters

### DIFF
--- a/packages/adapters/_shared/README.md
+++ b/packages/adapters/_shared/README.md
@@ -1,0 +1,39 @@
+# @paperclipai/adapter-shared
+
+Shared building blocks for Paperclip CLI adapter packages.
+
+This package is internal to the Paperclip monorepo; it is not intended
+to be consumed by third parties. Adapter packages (`claude-local`,
+`gemini-local`, `codex-local`, `opencode-local`) depend on it as a
+workspace dependency.
+
+## What it provides today
+
+### Plugin Tools MCP bridge
+
+A single stdio MCP server (`paperclip-mcp-bridge`) plus per-CLI
+helpers that materialize its config into each adapter's native MCP
+config format. Every CLI child spawns the same bridge binary; the
+bridge is a thin proxy from MCP `tools/list` and `tools/call` to the
+host's `/api/plugins/tools` endpoints.
+
+See `KSI-664` for the design decision and `KSI-698` for the
+implementation issue. Public API:
+
+```ts
+import {
+  buildPluginToolsMcpServer,
+  materializeClaudeMcpConfigFile,
+  mergeGeminiSettingsMcpServer,
+  mergeCodexConfigMcpServers,
+  mergeOpencodeConfigMcpServers,
+} from "@paperclipai/adapter-shared";
+```
+
+The adapter calls `buildPluginToolsMcpServer({ runContext, apiUrl,
+apiKey })` once per run, gets a `PluginToolsMcpServerSpec`, and then
+calls the materializer that matches its CLI. The CLI then takes care
+of spawning the bridge as a subprocess.
+
+The bridge entrypoint is `paperclip-mcp-bridge` (resolved automatically
+via `bin` after `pnpm install`).

--- a/packages/adapters/_shared/package.json
+++ b/packages/adapters/_shared/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@paperclipai/adapter-gemini-local",
-  "version": "0.3.1",
+  "name": "@paperclipai/adapter-shared",
+  "version": "0.1.0",
+  "private": true,
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {
@@ -9,33 +10,29 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/paperclipai/paperclip",
-    "directory": "packages/adapters/gemini-local"
+    "directory": "packages/adapters/_shared"
   },
   "type": "module",
+  "bin": {
+    "paperclip-mcp-bridge": "./dist/bridge/main.js"
+  },
   "exports": {
     ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    "./plugin-tools-mcp": "./src/plugin-tools-mcp.ts"
   },
   "publishConfig": {
     "access": "public",
+    "bin": {
+      "paperclip-mcp-bridge": "./dist/bridge/main.js"
+    },
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
       },
-      "./server": {
-        "types": "./dist/server/index.d.ts",
-        "import": "./dist/server/index.js"
-      },
-      "./ui": {
-        "types": "./dist/ui/index.d.ts",
-        "import": "./dist/ui/index.js"
-      },
-      "./cli": {
-        "types": "./dist/cli/index.d.ts",
-        "import": "./dist/cli/index.js"
+      "./plugin-tools-mcp": {
+        "types": "./dist/plugin-tools-mcp.d.ts",
+        "import": "./dist/plugin-tools-mcp.js"
       }
     },
     "main": "./dist/index.js",
@@ -43,20 +40,20 @@
   },
   "files": [
     "dist",
-    "skills"
+    "README.md"
   ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
-    "@paperclipai/adapter-shared": "workspace:*",
-    "@paperclipai/adapter-utils": "workspace:*",
-    "picocolors": "^1.1.1"
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/adapters/_shared/src/bridge.integration.test.ts
+++ b/packages/adapters/_shared/src/bridge.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration test for the plugin-tools MCP bridge.
+ *
+ * Spawns the real bridge process as a stdio child, connects an in-process
+ * MCP client to it, and verifies that `tools/list` and `tools/call`
+ * round-trip through a fake Paperclip API server.
+ *
+ * This is the end-to-end proof that `buildPluginToolsMcpServer` + the
+ * bridge entrypoint correctly bridge a CLI child to the host registry,
+ * for any MCP-aware adapter (Claude, Gemini, Codex, OpenCode).
+ *
+ * @see KSI-664 — design decision B.1.a
+ * @see KSI-698 — implementation
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { buildPluginToolsMcpServer } from "./plugin-tools-mcp.js";
+
+interface ToolCall {
+  tool: string;
+  parameters: unknown;
+  runContext: unknown;
+}
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const RUN_ID = "33333333-3333-4333-8333-333333333333";
+const PROJECT_ID = "44444444-4444-4444-8444-444444444444";
+const API_KEY = "fake-bridge-jwt";
+
+interface FakeServer {
+  url: string;
+  calls: ToolCall[];
+  close: () => Promise<void>;
+}
+
+async function startFakeApi(): Promise<FakeServer> {
+  const calls: ToolCall[] = [];
+  const server = http.createServer((req, res) => {
+    const auth = req.headers["authorization"];
+    if (auth !== `Bearer ${API_KEY}`) {
+      res.statusCode = 401;
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    if (req.method === "GET" && req.url?.startsWith("/api/plugins/tools")) {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify([
+          {
+            name: "demo.plugin:echo",
+            displayName: "echo",
+            description: "Echo back the input message.",
+            parametersSchema: {
+              type: "object",
+              properties: { message: { type: "string" } },
+              required: ["message"],
+            },
+            pluginId: "demo.plugin",
+          },
+        ]),
+      );
+      return;
+    }
+    if (req.method === "POST" && req.url === "/api/plugins/tools/execute") {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        const parsed = JSON.parse(body) as ToolCall;
+        calls.push(parsed);
+        res.setHeader("content-type", "application/json");
+        const message =
+          parsed.parameters &&
+          typeof parsed.parameters === "object" &&
+          "message" in (parsed.parameters as Record<string, unknown>)
+            ? String((parsed.parameters as Record<string, unknown>).message)
+            : "";
+        res.end(
+          JSON.stringify({
+            pluginId: "demo.plugin",
+            toolName: "echo",
+            result: {
+              content: [{ type: "text", text: `echo: ${message}` }],
+            },
+          }),
+        );
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fake API failed to bind");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    calls,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+describe("plugin-tools MCP bridge integration", () => {
+  let api: FakeServer;
+
+  beforeAll(async () => {
+    api = await startFakeApi();
+  });
+
+  afterAll(async () => {
+    if (api) await api.close();
+  });
+
+  it("lists tools and round-trips a call through the bridge", async () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const compiledBridge = path.resolve(here, "../dist/bridge/main.js");
+
+    const spec = buildPluginToolsMcpServer({
+      runContext: {
+        companyId: COMPANY_ID,
+        agentId: AGENT_ID,
+        runId: RUN_ID,
+        projectId: PROJECT_ID,
+      },
+      apiUrl: api.url,
+      apiKey: API_KEY,
+      bridgeScriptPath: compiledBridge,
+    });
+
+    const transport = new StdioClientTransport({
+      command: spec.command,
+      args: spec.args,
+      env: spec.env,
+    });
+
+    const client = new Client(
+      { name: "integration-test", version: "0.0.1" },
+      { capabilities: {} },
+    );
+    await client.connect(transport);
+
+    try {
+      const list = await client.listTools();
+      expect(list.tools.length).toBe(1);
+      expect(list.tools[0].name).toBe("demo.plugin:echo");
+      expect(list.tools[0].description).toContain("Echo back");
+      expect(list.tools[0].inputSchema).toEqual({
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      });
+
+      const callResult = await client.callTool({
+        name: "demo.plugin:echo",
+        arguments: { message: "hello plugin tools" },
+      });
+      expect(callResult.isError).toBeFalsy();
+      expect(callResult.content).toEqual([
+        { type: "text", text: "echo: hello plugin tools" },
+      ]);
+
+      // The server must see the runContext exactly as encoded.
+      expect(api.calls).toHaveLength(1);
+      expect(api.calls[0]).toMatchObject({
+        tool: "demo.plugin:echo",
+        parameters: { message: "hello plugin tools" },
+        runContext: {
+          companyId: COMPANY_ID,
+          agentId: AGENT_ID,
+          runId: RUN_ID,
+          projectId: PROJECT_ID,
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  }, 20_000);
+});

--- a/packages/adapters/_shared/src/bridge/main.ts
+++ b/packages/adapters/_shared/src/bridge/main.ts
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * Paperclip Plugin Tools MCP Bridge.
+ *
+ * A short-lived stdio MCP server that:
+ *   - announces every plugin tool registered with the host's
+ *     `plugin-tool-registry` for the current run, and
+ *   - forwards `tools/call` requests to the host's
+ *     `POST /api/plugins/tools/execute` endpoint.
+ *
+ * It is spawned by a CLI child process (claude, gemini, codex, opencode)
+ * via that CLI's normal MCP config block. The spec/config is produced by
+ * `buildPluginToolsMcpServer` in the sibling module `plugin-tools-mcp.ts`.
+ *
+ * Logging goes to stderr only; stdout is reserved for MCP frames.
+ *
+ * @see KSI-664 — design decision B.1.a
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+interface BridgeArgs {
+  apiUrl: string;
+  apiKeyEnvVar: string;
+  companyId: string;
+  agentId: string;
+  runId: string;
+  projectId: string;
+}
+
+interface ToolDescriptor {
+  name: string;
+  displayName: string;
+  description: string;
+  parametersSchema: Record<string, unknown>;
+  pluginId: string;
+}
+
+interface ToolExecutionResult {
+  pluginId: string;
+  toolName: string;
+  result: {
+    content?: Array<{ type: string; [key: string]: unknown }>;
+    data?: unknown;
+    error?: { message?: string; [key: string]: unknown };
+    is_error?: boolean;
+  };
+}
+
+function log(message: string, ...rest: unknown[]): void {
+  // Bridge logs go to stderr; stdout is the MCP transport.
+  // eslint-disable-next-line no-console
+  console.error("[paperclip-mcp-bridge]", message, ...rest);
+}
+
+function parseArgs(argv: readonly string[]): BridgeArgs {
+  const opts: Partial<BridgeArgs> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    switch (flag) {
+      case "--api-url":
+        opts.apiUrl = value;
+        i += 1;
+        break;
+      case "--api-key-env":
+        opts.apiKeyEnvVar = value;
+        i += 1;
+        break;
+      case "--company-id":
+        opts.companyId = value;
+        i += 1;
+        break;
+      case "--agent-id":
+        opts.agentId = value;
+        i += 1;
+        break;
+      case "--run-id":
+        opts.runId = value;
+        i += 1;
+        break;
+      case "--project-id":
+        opts.projectId = value;
+        i += 1;
+        break;
+      default:
+        if (flag.startsWith("--")) {
+          log(`unknown flag ignored: ${flag}`);
+          i += 1;
+        }
+        break;
+    }
+  }
+  const required: (keyof BridgeArgs)[] = [
+    "apiUrl",
+    "apiKeyEnvVar",
+    "companyId",
+    "agentId",
+    "runId",
+    "projectId",
+  ];
+  for (const k of required) {
+    if (!opts[k] || String(opts[k]).length === 0) {
+      throw new Error(`paperclip-mcp-bridge: missing required flag for ${k}`);
+    }
+  }
+  return opts as BridgeArgs;
+}
+
+function buildAuthHeader(apiKeyEnvVar: string): string {
+  const token = process.env[apiKeyEnvVar];
+  if (!token || token.length === 0) {
+    throw new Error(
+      `paperclip-mcp-bridge: env var ${apiKeyEnvVar} is empty; the bridge cannot authenticate.`,
+    );
+  }
+  return `Bearer ${token}`;
+}
+
+async function listTools(args: BridgeArgs): Promise<ToolDescriptor[]> {
+  const url = new URL("/api/plugins/tools", args.apiUrl);
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: buildAuthHeader(args.apiKeyEnvVar),
+      "X-Paperclip-Run-Id": args.runId,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GET /api/plugins/tools failed (${res.status}): ${body.slice(0, 500)}`);
+  }
+  const json = (await res.json()) as ToolDescriptor[];
+  if (!Array.isArray(json)) {
+    throw new Error("GET /api/plugins/tools did not return an array");
+  }
+  return json;
+}
+
+async function executeTool(
+  args: BridgeArgs,
+  toolName: string,
+  parameters: unknown,
+): Promise<ToolExecutionResult> {
+  const url = new URL("/api/plugins/tools/execute", args.apiUrl);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: buildAuthHeader(args.apiKeyEnvVar),
+      "X-Paperclip-Run-Id": args.runId,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      tool: toolName,
+      parameters: parameters ?? {},
+      runContext: {
+        companyId: args.companyId,
+        agentId: args.agentId,
+        runId: args.runId,
+        projectId: args.projectId,
+      },
+    }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `POST /api/plugins/tools/execute failed (${res.status}) for "${toolName}": ${text.slice(0, 500)}`,
+    );
+  }
+  let parsed: ToolExecutionResult;
+  try {
+    parsed = JSON.parse(text) as ToolExecutionResult;
+  } catch (err) {
+    throw new Error(
+      `POST /api/plugins/tools/execute returned non-JSON for "${toolName}": ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return parsed;
+}
+
+function toMcpToolListEntry(tool: ToolDescriptor): {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+} {
+  return {
+    name: tool.name,
+    description: tool.description ?? tool.displayName ?? tool.name,
+    inputSchema:
+      tool.parametersSchema && typeof tool.parametersSchema === "object"
+        ? tool.parametersSchema
+        : { type: "object" },
+  };
+}
+
+function toMcpCallResponse(result: ToolExecutionResult): {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+} {
+  const r = result.result ?? {};
+  if (Array.isArray(r.content) && r.content.length > 0) {
+    const normalized = r.content
+      .filter((c): c is { type: string; [k: string]: unknown } => Boolean(c))
+      .map((c) => {
+        const maybeText = (c as { text?: unknown }).text;
+        if (c.type === "text" && typeof maybeText === "string") {
+          return { type: "text" as const, text: maybeText };
+        }
+        return { type: "text" as const, text: JSON.stringify(c) };
+      });
+    return {
+      content: normalized,
+      ...(r.is_error || r.error ? { isError: true } : {}),
+    };
+  }
+  if (r.error) {
+    const message =
+      typeof r.error.message === "string" ? r.error.message : JSON.stringify(r.error);
+    return {
+      content: [{ type: "text", text: message }],
+      isError: true,
+    };
+  }
+  if (r.data !== undefined) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: typeof r.data === "string" ? r.data : JSON.stringify(r.data),
+        },
+      ],
+    };
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify(result) }],
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  log("starting", {
+    apiUrl: args.apiUrl,
+    companyId: args.companyId,
+    agentId: args.agentId,
+    runId: args.runId,
+  });
+
+  const server = new Server(
+    { name: "paperclip-plugin-tools", version: "0.1.0" },
+    { capabilities: { tools: { listChanged: false } } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    try {
+      const tools = await listTools(args);
+      return { tools: tools.map(toMcpToolListEntry) };
+    } catch (err) {
+      log("listTools failed:", err instanceof Error ? err.message : String(err));
+      return { tools: [] };
+    }
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: parameters } = request.params;
+    try {
+      const result = await executeTool(args, name, parameters);
+      return toMcpCallResponse(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log(`callTool failed for ${name}:`, message);
+      return {
+        content: [{ type: "text" as const, text: message }],
+        isError: true,
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log("connected; awaiting requests");
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    log(`received ${signal}, shutting down`);
+    server
+      .close()
+      .catch(() => undefined)
+      .finally(() => process.exit(0));
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+
+main().catch((err) => {
+  log("fatal:", err instanceof Error ? err.stack ?? err.message : String(err));
+  process.exit(1);
+});

--- a/packages/adapters/_shared/src/index.ts
+++ b/packages/adapters/_shared/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @paperclipai/adapter-shared — shared building blocks for Paperclip
+ * adapter packages (claude_local, gemini_local, codex_local,
+ * opencode_local). Currently focuses on the plugin-tools MCP bridge.
+ *
+ * @see KSI-664 — design decision B.1.a
+ */
+
+export {
+  buildPluginToolsMcpServer,
+  materializeClaudeMcpConfigFile,
+  mergeGeminiSettingsMcpServer,
+  mergeCodexConfigMcpServers,
+  mergeOpencodeConfigMcpServers,
+  resolveBridgeScriptPath,
+  type BuildPluginToolsMcpServerInput,
+  type PluginToolsMcpRunContext,
+  type PluginToolsMcpServerSpec,
+} from "./plugin-tools-mcp.js";

--- a/packages/adapters/_shared/src/plugin-tools-mcp.test.ts
+++ b/packages/adapters/_shared/src/plugin-tools-mcp.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildPluginToolsMcpServer,
+  materializeClaudeMcpConfigFile,
+  mergeCodexConfigMcpServers,
+  mergeGeminiSettingsMcpServer,
+  mergeOpencodeConfigMcpServers,
+} from "./plugin-tools-mcp.js";
+
+const baseInput = {
+  runContext: {
+    companyId: "co-1",
+    agentId: "a-1",
+    runId: "r-1",
+    projectId: "p-1",
+  },
+  apiUrl: "http://127.0.0.1:3100",
+  apiKey: "sk-test",
+};
+
+describe("buildPluginToolsMcpServer", () => {
+  it("requires every runContext field", () => {
+    expect(() =>
+      buildPluginToolsMcpServer({ ...baseInput, runContext: { ...baseInput.runContext, companyId: "" } }),
+    ).toThrow(/companyId/);
+    expect(() =>
+      buildPluginToolsMcpServer({ ...baseInput, runContext: { ...baseInput.runContext, agentId: "" } }),
+    ).toThrow(/agentId/);
+    expect(() =>
+      buildPluginToolsMcpServer({ ...baseInput, runContext: { ...baseInput.runContext, runId: "" } }),
+    ).toThrow(/runId/);
+    expect(() =>
+      buildPluginToolsMcpServer({ ...baseInput, runContext: { ...baseInput.runContext, projectId: "" } }),
+    ).toThrow(/projectId/);
+  });
+
+  it("requires apiUrl", () => {
+    expect(() => buildPluginToolsMcpServer({ ...baseInput, apiUrl: "" })).toThrow(/apiUrl/);
+  });
+
+  it("returns a stable spec with the API key delivered via env (not args)", () => {
+    const spec = buildPluginToolsMcpServer({
+      ...baseInput,
+      bridgeScriptPath: "/abs/bridge.js",
+    });
+    expect(spec.serverName).toBe("paperclip");
+    expect(spec.command).toBe(process.execPath);
+    expect(spec.args).toEqual([
+      "/abs/bridge.js",
+      "--api-url",
+      "http://127.0.0.1:3100",
+      "--api-key-env",
+      "PAPERCLIP_API_KEY",
+      "--company-id",
+      "co-1",
+      "--agent-id",
+      "a-1",
+      "--run-id",
+      "r-1",
+      "--project-id",
+      "p-1",
+    ]);
+    expect(spec.env).toEqual({ PAPERCLIP_API_KEY: "sk-test" });
+    // The api key MUST NOT appear in args, even when serialized to disk later.
+    expect(spec.args.some((a) => a.includes("sk-test"))).toBe(false);
+  });
+
+  it("respects custom serverName, apiKeyEnvVar, nodeExecPath", () => {
+    const spec = buildPluginToolsMcpServer({
+      ...baseInput,
+      bridgeScriptPath: "/abs/bridge.js",
+      serverName: "pclip-tools",
+      apiKeyEnvVar: "CUSTOM_KEY",
+      nodeExecPath: "/usr/bin/node",
+    });
+    expect(spec.serverName).toBe("pclip-tools");
+    expect(spec.command).toBe("/usr/bin/node");
+    expect(spec.args).toContain("CUSTOM_KEY");
+    expect(spec.env).toEqual({ CUSTOM_KEY: "sk-test" });
+  });
+});
+
+describe("materializeClaudeMcpConfigFile", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-mcp-test-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it("writes a valid Claude .mcp.json shape", async () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/abs/bridge.js" });
+    const outPath = await materializeClaudeMcpConfigFile(spec, tmp);
+    const json = JSON.parse(await fs.readFile(outPath, "utf-8"));
+    expect(json).toEqual({
+      mcpServers: {
+        paperclip: {
+          type: "stdio",
+          command: spec.command,
+          args: spec.args,
+          env: { PAPERCLIP_API_KEY: "sk-test" },
+        },
+      },
+    });
+  });
+});
+
+describe("mergeGeminiSettingsMcpServer", () => {
+  it("creates mcpServers when settings is empty", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/b.js" });
+    const next = mergeGeminiSettingsMcpServer(undefined, spec);
+    expect(next.mcpServers).toBeDefined();
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers.paperclip).toMatchObject({
+      command: spec.command,
+      args: spec.args,
+      env: spec.env,
+    });
+  });
+
+  it("preserves other user entries", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/b.js" });
+    const existing = {
+      theme: "dark",
+      mcpServers: {
+        sentry: { command: "node", args: ["sentry.js"] },
+      },
+    };
+    const next = mergeGeminiSettingsMcpServer(existing, spec);
+    expect(next.theme).toBe("dark");
+    const servers = next.mcpServers as Record<string, unknown>;
+    expect(servers.sentry).toBeDefined();
+    expect(servers.paperclip).toBeDefined();
+  });
+});
+
+describe("mergeCodexConfigMcpServers", () => {
+  it("appends a new block when none exists", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/b.js" });
+    const out = mergeCodexConfigMcpServers("model = \"gpt-4\"\n", spec);
+    expect(out).toMatch(/model = "gpt-4"/);
+    expect(out).toMatch(/\[mcp_servers\.paperclip\]/);
+    expect(out).toMatch(/\[mcp_servers\.paperclip\.env\]/);
+    expect(out).toMatch(/PAPERCLIP_API_KEY = "sk-test"/);
+  });
+
+  it("replaces an existing block idempotently", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/b.js" });
+    const first = mergeCodexConfigMcpServers("model = \"gpt-4\"\n", spec);
+    const second = mergeCodexConfigMcpServers(first, spec);
+    expect(second).toBe(first.endsWith("\n") ? first : first + "\n");
+  });
+
+  it("preserves trailing config sections", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/b.js" });
+    const existing =
+      "model = \"gpt-4\"\n\n[mcp_servers.paperclip]\ncommand = \"old\"\nargs = []\n\n[other.section]\nkey = \"value\"\n";
+    const out = mergeCodexConfigMcpServers(existing, spec);
+    expect(out).toMatch(/\[other\.section\]/);
+    expect(out).toMatch(/key = "value"/);
+    expect(out).not.toMatch(/command = "old"/);
+  });
+});
+
+describe("mergeOpencodeConfigMcpServers", () => {
+  it("collapses command + args into a single array", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/abs/bridge.js" });
+    const next = mergeOpencodeConfigMcpServers(null, spec);
+    const mcp = next.mcp as Record<string, { type: string; command: string[]; environment: unknown; enabled: boolean }>;
+    expect(mcp.paperclip.type).toBe("local");
+    expect(mcp.paperclip.command[0]).toBe(spec.command);
+    expect(mcp.paperclip.command).toEqual([spec.command, ...spec.args]);
+    expect(mcp.paperclip.environment).toEqual(spec.env);
+    expect(mcp.paperclip.enabled).toBe(true);
+  });
+
+  it("preserves other top-level opencode config keys", () => {
+    const spec = buildPluginToolsMcpServer({ ...baseInput, bridgeScriptPath: "/b.js" });
+    const next = mergeOpencodeConfigMcpServers({ permission: { external_directory: "ask" } }, spec);
+    expect(next.permission).toEqual({ external_directory: "ask" });
+    expect(next.mcp).toBeDefined();
+  });
+});

--- a/packages/adapters/_shared/src/plugin-tools-mcp.ts
+++ b/packages/adapters/_shared/src/plugin-tools-mcp.ts
@@ -1,0 +1,385 @@
+/**
+ * Plugin Tools MCP — shared helper for Paperclip CLI adapters.
+ *
+ * Exposes the host-side `plugin-tool-registry` to local CLI children
+ * (claude_local, gemini_local, codex_local, opencode_local) via a single
+ * stdio MCP bridge. Each adapter gets two things from this module:
+ *
+ * 1. `buildPluginToolsMcpServer(input)` — returns a `PluginToolsMcpServerSpec`
+ *    describing the command/args/env that any MCP-aware CLI must spawn to
+ *    talk to Paperclip plugin tools. The adapter does NOT spawn it; the
+ *    child CLI does, when it loads its MCP config.
+ *
+ * 2. Per-CLI materializers that convert the spec into the config format
+ *    that a particular CLI expects:
+ *       - `materializeClaudeMcpConfigFile(spec, dir)` → `.json` file path
+ *         that goes after `--mcp-config <file>` on the Claude Code CLI.
+ *       - `mergeGeminiSettingsMcpServer(settings, spec)` → patched JSON
+ *         that you write to `${cwd}/.gemini/settings.json` (project scope).
+ *       - `mergeCodexConfigMcpServers(configToml, spec)` → returns a TOML
+ *         string with `[mcp_servers.paperclip]` appended/replaced.
+ *       - `mergeOpencodeConfigMcpServers(opencodeConfig, spec)` → returns
+ *         the patched JSON object suitable for `opencode.json`.
+ *
+ * The bridge process itself is implemented in `bridge/main.ts` and is
+ * exposed via the `paperclip-mcp-bridge` bin entry in this package's
+ * `package.json`. Adapters do not need to know its path: this helper
+ * resolves the bin against `node_modules` so the spec works in
+ * production builds and in development monorepo runs alike.
+ *
+ * @see PLUGIN_SPEC.md §11 — Agent Tools (host registry)
+ * @see KSI-664 — design decision B.1.a (this implementation)
+ */
+
+import path from "node:path";
+import url from "node:url";
+import fs from "node:fs/promises";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Identity of the agent run that the bridge will impersonate when calling
+ * `POST /api/plugins/tools/execute` on the Paperclip server. All four fields
+ * are required; the host enforces scope checks against this `runContext`.
+ */
+export interface PluginToolsMcpRunContext {
+  /** UUID of the company that owns the agent and the plugin install. */
+  companyId: string;
+  /** UUID of the agent identity the run is acting as. */
+  agentId: string;
+  /** UUID of the current run (matches `PAPERCLIP_RUN_ID`). */
+  runId: string;
+  /** UUID of the project the run is scoped to. */
+  projectId: string;
+}
+
+/**
+ * Inputs needed to build a stdio MCP server spec that exposes plugin tools.
+ *
+ * The adapter is expected to fill these from the same context it already
+ * uses to build the CLI invocation (workspace, run, agent).
+ */
+export interface BuildPluginToolsMcpServerInput {
+  /** The agent run identity. */
+  runContext: PluginToolsMcpRunContext;
+  /** Absolute URL of the Paperclip API the bridge should call. */
+  apiUrl: string;
+  /**
+   * The short-lived run JWT the bridge must use as `Authorization: Bearer ...`.
+   * Pass it through `env` only — never hard-code it into the spec args, since
+   * the spec is written to disk inside the CLI's MCP config file.
+   *
+   * The bridge reads it from the env variable named in `apiKeyEnvVar`.
+   */
+  apiKey: string;
+  /**
+   * Optional override of the env variable name the bridge will read for the
+   * API key. Defaults to `PAPERCLIP_API_KEY` to match the rest of the
+   * adapter surface.
+   */
+  apiKeyEnvVar?: string;
+  /**
+   * Optional Node.js executable path. Defaults to `process.execPath`.
+   * Override this in tests, or when the adapter wants to run the bridge
+   * with a specific Node version.
+   */
+  nodeExecPath?: string;
+  /**
+   * Optional override of the bridge entrypoint path. Production builds
+   * resolve it from this package's `bin` field; tests can pass an inline
+   * path to a fixture script.
+   */
+  bridgeScriptPath?: string;
+  /**
+   * Logical name of the MCP server inside each CLI's config block. Must be
+   * a stable identifier without spaces or `:`/`/`/`@`. Defaults to
+   * `paperclip`.
+   */
+  serverName?: string;
+}
+
+/**
+ * A descriptor that any MCP-aware CLI can consume. The adapter writes
+ * this into the CLI's config (see per-CLI `materialize*` helpers); the
+ * CLI then spawns `command args` as a stdio MCP server, with `env`
+ * forwarded to the child.
+ */
+export interface PluginToolsMcpServerSpec {
+  /** Stable name to register in CLI configs. */
+  serverName: string;
+  /** Absolute path to the executable (typically `node`). */
+  command: string;
+  /** Arguments the CLI must pass when spawning. */
+  args: string[];
+  /**
+   * Environment variables the CLI must set on the spawned bridge.
+   *
+   * Includes `PAPERCLIP_API_KEY` (or whatever `apiKeyEnvVar` was set to).
+   * Adapters MUST forward this dict verbatim — sensitive values live here.
+   */
+  env: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Bridge resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the absolute path to the bundled bridge entrypoint.
+ *
+ * Strategy:
+ * 1. If the caller passed `bridgeScriptPath`, use it as-is.
+ * 2. Otherwise, locate `dist/bridge/main.js` relative to this module.
+ *    This works both when running compiled code from `dist/` and when
+ *    the monorepo is using TS path resolution to point at `src/`
+ *    (vitest, ts-node), because we then fall back to `src/bridge/main.ts`
+ *    if `dist/` is absent.
+ *
+ * The function does not read the filesystem unless the caller pinned a
+ * path; it just builds a path. Existence is verified at runtime by the
+ * spawning CLI when the bridge starts.
+ */
+export function resolveBridgeScriptPath(input?: { bridgeScriptPath?: string }): string {
+  if (input?.bridgeScriptPath && input.bridgeScriptPath.length > 0) {
+    return input.bridgeScriptPath;
+  }
+  // import.meta.url points at this module; the bridge entrypoint lives
+  // a sibling directory away. We resolve both `dist/bridge/main.js` and
+  // `src/bridge/main.ts` lazily so the helper works in both build modes.
+  const here = path.dirname(url.fileURLToPath(import.meta.url));
+  // When this file is at dist/plugin-tools-mcp.js, the bridge is at
+  // dist/bridge/main.js. When at src/plugin-tools-mcp.ts, the bridge is
+  // at src/bridge/main.ts. Use the same parent dir + bridge/main.* pattern.
+  const compiled = path.join(here, "bridge", "main.js");
+  return compiled;
+}
+
+// ---------------------------------------------------------------------------
+// Spec builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `PluginToolsMcpServerSpec` for the given run context.
+ *
+ * This is the main entry point adapters call. It does NOT spawn anything.
+ * It returns a stable, serializable spec that adapters then materialize
+ * into the CLI's native MCP config format.
+ *
+ * @example
+ * ```ts
+ * const spec = buildPluginToolsMcpServer({
+ *   runContext: { companyId, agentId, runId, projectId },
+ *   apiUrl: process.env.PAPERCLIP_API_URL!,
+ *   apiKey: process.env.PAPERCLIP_API_KEY!,
+ * });
+ * await materializeClaudeMcpConfigFile(spec, runtimeDir);
+ * args.push("--mcp-config", path.join(runtimeDir, "paperclip-mcp.json"));
+ * ```
+ */
+export function buildPluginToolsMcpServer(
+  input: BuildPluginToolsMcpServerInput,
+): PluginToolsMcpServerSpec {
+  const { runContext, apiUrl } = input;
+  if (!runContext.companyId) throw new Error("buildPluginToolsMcpServer: runContext.companyId is required");
+  if (!runContext.agentId) throw new Error("buildPluginToolsMcpServer: runContext.agentId is required");
+  if (!runContext.runId) throw new Error("buildPluginToolsMcpServer: runContext.runId is required");
+  if (!runContext.projectId) throw new Error("buildPluginToolsMcpServer: runContext.projectId is required");
+  if (!apiUrl) throw new Error("buildPluginToolsMcpServer: apiUrl is required");
+
+  const apiKeyEnvVar = input.apiKeyEnvVar ?? "PAPERCLIP_API_KEY";
+  const command = input.nodeExecPath ?? process.execPath;
+  const bridgeScript = resolveBridgeScriptPath(input);
+  const serverName = input.serverName ?? "paperclip";
+
+  const args = [
+    bridgeScript,
+    "--api-url",
+    apiUrl,
+    "--api-key-env",
+    apiKeyEnvVar,
+    "--company-id",
+    runContext.companyId,
+    "--agent-id",
+    runContext.agentId,
+    "--run-id",
+    runContext.runId,
+    "--project-id",
+    runContext.projectId,
+  ];
+
+  const env: Record<string, string> = {
+    [apiKeyEnvVar]: input.apiKey,
+  };
+
+  return { serverName, command, args, env };
+}
+
+// ---------------------------------------------------------------------------
+// Per-CLI materializers
+// ---------------------------------------------------------------------------
+
+/**
+ * Claude Code accepts a JSON file with the same shape as `.mcp.json`
+ * via `--mcp-config <file>`. We always write a fresh file per run to
+ * keep the spec deterministic and safe to delete.
+ *
+ * Returns the absolute path to the written config file.
+ */
+export async function materializeClaudeMcpConfigFile(
+  spec: PluginToolsMcpServerSpec,
+  outDir: string,
+  fileName: string = "paperclip-mcp.json",
+): Promise<string> {
+  await fs.mkdir(outDir, { recursive: true });
+  const outPath = path.join(outDir, fileName);
+  const config = {
+    mcpServers: {
+      [spec.serverName]: {
+        type: "stdio",
+        command: spec.command,
+        args: spec.args,
+        env: spec.env,
+      },
+    },
+  };
+  await fs.writeFile(outPath, JSON.stringify(config, null, 2), "utf-8");
+  return outPath;
+}
+
+/**
+ * Gemini CLI looks at `mcpServers` in `~/.gemini/settings.json` (user
+ * scope) or `${cwd}/.gemini/settings.json` (project scope). This helper
+ * does NOT touch the filesystem; it accepts an existing settings object
+ * (or `null`/`undefined` if the file does not exist) and returns the
+ * patched object that the adapter should write.
+ *
+ * Other entries in the file are preserved verbatim.
+ */
+export function mergeGeminiSettingsMcpServer(
+  existing: Record<string, unknown> | null | undefined,
+  spec: PluginToolsMcpServerSpec,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...(existing ?? {}) };
+  const previousServers =
+    typeof next.mcpServers === "object" && next.mcpServers !== null
+      ? { ...(next.mcpServers as Record<string, unknown>) }
+      : {};
+  previousServers[spec.serverName] = {
+    command: spec.command,
+    args: spec.args,
+    env: spec.env,
+    // `trust: false` keeps the Gemini approval prompt for plugin tools
+    // disabled in non-interactive runs only when paired with the global
+    // `--approval-mode yolo` flag the adapter already passes.
+    trust: false,
+  };
+  next.mcpServers = previousServers;
+  return next;
+}
+
+/**
+ * Codex CLI reads `[mcp_servers.<name>]` from `$CODEX_HOME/config.toml`.
+ * We do not pull a TOML library in just for this; the format used by
+ * Codex is simple enough to emit deterministically by hand. The helper
+ * returns a patched TOML string by replacing or appending the
+ * `[mcp_servers.<spec.serverName>]` block.
+ *
+ * Idempotent: calling twice with the same spec yields the same output.
+ */
+export function mergeCodexConfigMcpServers(
+  existingToml: string,
+  spec: PluginToolsMcpServerSpec,
+): string {
+  const blockHeader = `[mcp_servers.${spec.serverName}]`;
+  const block = renderCodexMcpBlock(spec);
+
+  const lines = existingToml.split(/\r?\n/);
+  const headerIdx = lines.findIndex((line) => line.trim() === blockHeader);
+  if (headerIdx === -1) {
+    const trimmed = existingToml.trimEnd();
+    return trimmed.length === 0 ? block + "\n" : trimmed + "\n\n" + block + "\n";
+  }
+  // Replace the existing block: from headerIdx until the next `[...]` header
+  // that does NOT belong to this block's sub-namespace (e.g. `.env`).
+  const subPrefix = `[mcp_servers.${spec.serverName}.`;
+  let endIdx = lines.length;
+  for (let i = headerIdx + 1; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      if (trimmed.startsWith(subPrefix)) continue;
+      endIdx = i;
+      break;
+    }
+  }
+  const before = lines.slice(0, headerIdx).join("\n").trimEnd();
+  const after = lines.slice(endIdx).join("\n").trimStart();
+  const parts: string[] = [];
+  if (before.length > 0) parts.push(before);
+  parts.push(block);
+  if (after.length > 0) parts.push(after);
+  return parts.join("\n\n") + "\n";
+}
+
+function renderCodexMcpBlock(spec: PluginToolsMcpServerSpec): string {
+  const lines: string[] = [];
+  lines.push(`[mcp_servers.${spec.serverName}]`);
+  lines.push(`command = ${tomlEscapeString(spec.command)}`);
+  lines.push(`args = ${renderTomlStringArray(spec.args)}`);
+  if (Object.keys(spec.env).length > 0) {
+    lines.push("");
+    lines.push(`[mcp_servers.${spec.serverName}.env]`);
+    for (const [key, value] of Object.entries(spec.env)) {
+      lines.push(`${key} = ${tomlEscapeString(value)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function tomlEscapeString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderTomlStringArray(values: string[]): string {
+  if (values.length === 0) return "[]";
+  return `[${values.map(tomlEscapeString).join(", ")}]`;
+}
+
+/**
+ * OpenCode reads a `mcp` block from `opencode.json`:
+ *
+ * ```json
+ * {
+ *   "mcp": {
+ *     "paperclip": {
+ *       "type": "local",
+ *       "command": ["node", "/path/to/bridge.js", "--api-url", "..."],
+ *       "environment": { "PAPERCLIP_API_KEY": "..." },
+ *       "enabled": true
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Note: OpenCode collapses the binary and its args into a single
+ * `command` array. This is different from Claude/Gemini/Codex.
+ */
+export function mergeOpencodeConfigMcpServers(
+  existing: Record<string, unknown> | null | undefined,
+  spec: PluginToolsMcpServerSpec,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...(existing ?? {}) };
+  const previousMcp =
+    typeof next.mcp === "object" && next.mcp !== null
+      ? { ...(next.mcp as Record<string, unknown>) }
+      : {};
+  previousMcp[spec.serverName] = {
+    type: "local",
+    command: [spec.command, ...spec.args],
+    environment: spec.env,
+    enabled: true,
+  };
+  next.mcp = previousMcp;
+  return next;
+}

--- a/packages/adapters/_shared/tsconfig.json
+++ b/packages/adapters/_shared/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/_shared/vitest.config.ts
+++ b/packages/adapters/_shared/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -53,6 +53,7 @@
     "probe:quota:raw": "pnpm exec tsx src/cli/quota-probe.ts --json --raw-cli"
   },
   "dependencies": {
+    "@paperclipai/adapter-shared": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "picocolors": "^1.1.1"
   },

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -672,6 +672,52 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
+  // Plugin tools MCP bridge (KSI-664/KSI-698). For local execution targets
+  // we materialize a small JSON config file that the Claude CLI loads via
+  // `--mcp-config <path>`. The bridge stays a child of the spawned `claude`
+  // process and exits with it. Skipped on remote/sandbox targets in this
+  // first cut: the file would not be visible to the remote CLI; the
+  // dedicated paperclip bridge already covers that case.
+  let paperclipMcpConfigPath: string | null = null;
+  const paperclipProjectId = asString(context.projectId, "").trim();
+  const paperclipApiKey = typeof env.PAPERCLIP_API_KEY === "string" ? env.PAPERCLIP_API_KEY : "";
+  const paperclipApiUrl = typeof env.PAPERCLIP_API_URL === "string" ? env.PAPERCLIP_API_URL : "";
+  if (
+    !executionTargetIsRemote &&
+    paperclipProjectId.length > 0 &&
+    paperclipApiKey.length > 0 &&
+    paperclipApiUrl.length > 0
+  ) {
+    try {
+      const { buildPluginToolsMcpServer, materializeClaudeMcpConfigFile } = await import(
+        "@paperclipai/adapter-shared"
+      );
+      const spec = buildPluginToolsMcpServer({
+        runContext: {
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId,
+          projectId: paperclipProjectId,
+        },
+        apiUrl: paperclipApiUrl,
+        apiKey: paperclipApiKey,
+      });
+      const mcpConfigDir = path.join(cwd, ".paperclip-runtime", "claude");
+      paperclipMcpConfigPath = await materializeClaudeMcpConfigFile(spec, mcpConfigDir);
+      await onLog(
+        "stdout",
+        `[paperclip] Wrote plugin-tools MCP config for Claude at ${paperclipMcpConfigPath}.\n`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      // Non-fatal: the agent continues without plugin tools surfaced as MCP.
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not materialize plugin-tools MCP config for Claude: ${reason}\n`,
+      );
+    }
+  }
+
   const buildClaudeArgs = (
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
@@ -682,6 +728,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       dangerouslySkipPermissions,
       targetIsSandbox: executionTargetIsSandbox,
     }));
+    if (paperclipMcpConfigPath) args.push("--mcp-config", paperclipMcpConfigPath);
     if (chrome) args.push("--chrome");
     // For Bedrock: only pass --model when the ID is a Bedrock-native identifier
     // (e.g. "us.anthropic.*" or ARN). Anthropic-style IDs like "claude-opus-4-6" are invalid

--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -52,6 +52,7 @@
     "probe:quota": "pnpm exec tsx src/cli/quota-probe.ts --json"
   },
   "dependencies": {
+    "@paperclipai/adapter-shared": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "picocolors": "^1.1.1"
   },

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -504,6 +504,52 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
   );
+
+  // Plugin tools MCP bridge (KSI-664/KSI-698). Codex reads MCP servers from
+  // ${CODEX_HOME}/config.toml under [mcp_servers.<name>]. We merge a
+  // [mcp_servers.paperclip] block into the host's effectiveCodexHome so the
+  // bridge becomes a child of the spawned codex process. Skipped on remote
+  // targets in this first cut.
+  const paperclipProjectId = asString(context.projectId, "").trim();
+  const paperclipApiKey = typeof env.PAPERCLIP_API_KEY === "string" ? env.PAPERCLIP_API_KEY : "";
+  const paperclipApiUrl = typeof env.PAPERCLIP_API_URL === "string" ? env.PAPERCLIP_API_URL : "";
+  if (
+    !executionTargetIsRemote &&
+    paperclipProjectId.length > 0 &&
+    paperclipApiKey.length > 0 &&
+    paperclipApiUrl.length > 0
+  ) {
+    try {
+      const { buildPluginToolsMcpServer, mergeCodexConfigMcpServers } = await import(
+        "@paperclipai/adapter-shared"
+      );
+      const spec = buildPluginToolsMcpServer({
+        runContext: {
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId,
+          projectId: paperclipProjectId,
+        },
+        apiUrl: paperclipApiUrl,
+        apiKey: paperclipApiKey,
+      });
+      const codexConfigPath = path.join(effectiveCodexHome, "config.toml");
+      const existingToml = await fs.readFile(codexConfigPath, "utf-8").catch(() => "");
+      const nextToml = mergeCodexConfigMcpServers(existingToml, spec);
+      await fs.writeFile(codexConfigPath, nextToml, "utf-8");
+      await onLog(
+        "stdout",
+        `[paperclip] Wrote plugin-tools MCP config for Codex at ${codexConfigPath}.\n`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not materialize plugin-tools MCP config for Codex: ${reason}\n`,
+      );
+    }
+  }
+
   const billingType = resolveCodexBillingType(effectiveEnv);
   const runtimeEnv = Object.fromEntries(
     Object.entries(ensurePathInEnv(effectiveEnv)).filter(

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -503,6 +503,61 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
+  // Plugin tools MCP bridge (KSI-664/KSI-698). Gemini reads MCP servers from
+  // ${cwd}/.gemini/settings.json (project scope). We merge a `mcpServers`
+  // block in there so the bridge becomes a child of the spawned gemini
+  // process. Skipped on remote targets in this first cut.
+  const paperclipProjectId = asString(context.projectId, "").trim();
+  const paperclipApiKey = typeof env.PAPERCLIP_API_KEY === "string" ? env.PAPERCLIP_API_KEY : "";
+  const paperclipApiUrl = typeof env.PAPERCLIP_API_URL === "string" ? env.PAPERCLIP_API_URL : "";
+  if (
+    !executionTargetIsRemote &&
+    paperclipProjectId.length > 0 &&
+    paperclipApiKey.length > 0 &&
+    paperclipApiUrl.length > 0
+  ) {
+    try {
+      const { buildPluginToolsMcpServer, mergeGeminiSettingsMcpServer } = await import(
+        "@paperclipai/adapter-shared"
+      );
+      const spec = buildPluginToolsMcpServer({
+        runContext: {
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId,
+          projectId: paperclipProjectId,
+        },
+        apiUrl: paperclipApiUrl,
+        apiKey: paperclipApiKey,
+      });
+      const settingsDir = path.join(cwd, ".gemini");
+      const settingsPath = path.join(settingsDir, "settings.json");
+      let existing: Record<string, unknown> | null = null;
+      try {
+        const raw = await fs.readFile(settingsPath, "utf-8");
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          existing = parsed as Record<string, unknown>;
+        }
+      } catch {
+        existing = null;
+      }
+      const next = mergeGeminiSettingsMcpServer(existing, spec);
+      await fs.mkdir(settingsDir, { recursive: true });
+      await fs.writeFile(settingsPath, JSON.stringify(next, null, 2), "utf-8");
+      await onLog(
+        "stdout",
+        `[paperclip] Wrote plugin-tools MCP config for Gemini at ${settingsPath}.\n`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not materialize plugin-tools MCP config for Gemini: ${reason}\n`,
+      );
+    }
+  }
+
   const buildArgs = (resumeSessionId: string | null) => {
     const args = ["--output-format", "stream-json"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);

--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -51,6 +51,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@paperclipai/adapter-shared": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "picocolors": "^1.1.1"
   },

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -300,6 +300,67 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({ env, config });
   const localRuntimeConfigHome =
     preparedRuntimeConfig.notes.length > 0 ? preparedRuntimeConfig.env.XDG_CONFIG_HOME : "";
+
+  // Plugin tools MCP bridge (KSI-664/KSI-698). OpenCode reads MCP servers
+  // from the `mcp` block in opencode.json. We merge a `mcp.paperclip` entry
+  // into the runtime config OpenCode is about to load, so the bridge becomes
+  // a child of the spawned opencode process. Skipped on remote targets.
+  const opencodeRuntimeConfigDir =
+    typeof preparedRuntimeConfig.env.XDG_CONFIG_HOME === "string" &&
+    preparedRuntimeConfig.env.XDG_CONFIG_HOME.length > 0
+      ? path.join(preparedRuntimeConfig.env.XDG_CONFIG_HOME, "opencode")
+      : null;
+  const paperclipProjectId = asString(context.projectId, "").trim();
+  const paperclipApiKey = typeof env.PAPERCLIP_API_KEY === "string" ? env.PAPERCLIP_API_KEY : "";
+  const paperclipApiUrl = typeof env.PAPERCLIP_API_URL === "string" ? env.PAPERCLIP_API_URL : "";
+  if (
+    !executionTargetIsRemote &&
+    opencodeRuntimeConfigDir &&
+    paperclipProjectId.length > 0 &&
+    paperclipApiKey.length > 0 &&
+    paperclipApiUrl.length > 0
+  ) {
+    try {
+      const { buildPluginToolsMcpServer, mergeOpencodeConfigMcpServers } = await import(
+        "@paperclipai/adapter-shared"
+      );
+      const spec = buildPluginToolsMcpServer({
+        runContext: {
+          companyId: agent.companyId,
+          agentId: agent.id,
+          runId,
+          projectId: paperclipProjectId,
+        },
+        apiUrl: paperclipApiUrl,
+        apiKey: paperclipApiKey,
+      });
+      const opencodeConfigPath = path.join(opencodeRuntimeConfigDir, "opencode.json");
+      let existing: Record<string, unknown> | null = null;
+      try {
+        const raw = await fs.readFile(opencodeConfigPath, "utf-8");
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          existing = parsed as Record<string, unknown>;
+        }
+      } catch {
+        existing = null;
+      }
+      const next = mergeOpencodeConfigMcpServers(existing, spec);
+      await fs.mkdir(opencodeRuntimeConfigDir, { recursive: true });
+      await fs.writeFile(opencodeConfigPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+      await onLog(
+        "stdout",
+        `[paperclip] Wrote plugin-tools MCP config for OpenCode at ${opencodeConfigPath}.\n`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: could not materialize plugin-tools MCP config for OpenCode: ${reason}\n`,
+      );
+    }
+  }
+
   try {
     const runtimeEnv = Object.fromEntries(
       Object.entries(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env })).filter(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/_shared:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/adapters/acpx-local:
     dependencies:
       '@agentclientprotocol/claude-agent-acp':
@@ -141,6 +157,9 @@ importers:
 
   packages/adapters/claude-local:
     dependencies:
+      '@paperclipai/adapter-shared':
+        specifier: workspace:*
+        version: link:../_shared
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -157,6 +176,9 @@ importers:
 
   packages/adapters/codex-local:
     dependencies:
+      '@paperclipai/adapter-shared':
+        specifier: workspace:*
+        version: link:../_shared
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -208,6 +230,9 @@ importers:
 
   packages/adapters/gemini-local:
     dependencies:
+      '@paperclipai/adapter-shared':
+        specifier: workspace:*
+        version: link:../_shared
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -262,6 +287,9 @@ importers:
 
   packages/adapters/opencode-local:
     dependencies:
+      '@paperclipai/adapter-shared':
+        specifier: workspace:*
+        version: link:../_shared
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -621,6 +649,8 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+
+  packages/skills-catalog: {}
 
   server:
     dependencies:
@@ -9373,6 +9403,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@1.8.0': {}
@@ -15049,6 +15101,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -623,6 +623,134 @@ describe.sequential("plugin tool and bridge authz", () => {
     );
   });
 
+  it("allows GET /api/plugins/tools when called with an agent run JWT", async () => {
+    // The MCP bridge spawned by adapter CLIs (KSI-664/KSI-698) authenticates
+    // with an agent run JWT and lists plugin tools through this route.
+    const listToolsForAgent = vi.fn().mockReturnValue([
+      { name: "paperclip.example:search", description: "Search example" },
+    ]);
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent,
+          getTool: vi.fn(),
+          executeTool: vi.fn(),
+        },
+      },
+    });
+
+    const res = await request(app).get("/api/plugins/tools");
+
+    expect(res.status).toBe(200);
+    expect(listToolsForAgent).toHaveBeenCalledWith(undefined);
+    expect(res.body).toEqual([
+      { name: "paperclip.example:search", description: "Search example" },
+    ]);
+  });
+
+  it("rejects GET /api/plugins/tools when the request is unauthenticated", async () => {
+    const listToolsForAgent = vi.fn().mockReturnValue([]);
+    const { app } = await createApp({ type: "none" }, {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent,
+          getTool: vi.fn(),
+          executeTool: vi.fn(),
+        },
+      },
+    });
+
+    const res = await request(app).get("/api/plugins/tools");
+
+    expect(res.status).toBe(401);
+    expect(listToolsForAgent).not.toHaveBeenCalled();
+  });
+
+  it("allows POST /api/plugins/tools/execute when called with an agent run JWT scoped to the same company", async () => {
+    // End-to-end positive case for the MCP bridge auth path:
+    // agent run JWT for company A executes a plugin tool whose runContext
+    // also belongs to company A. The HTTP layer authenticates the agent
+    // actor (assertAuthenticated), enforces company match
+    // (assertCompanyAccess), and validates each runContext reference
+    // (validateToolRunContextScope).
+    const executeTool = vi.fn().mockResolvedValue({
+      pluginId: "paperclip.example",
+      toolName: "search",
+      result: { content: "ok" },
+    });
+    const { app } = await createApp(agentActor(), {}, {
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:search" })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: { q: "test" },
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyA,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalledWith(
+      "paperclip.example:search",
+      { q: "test" },
+      {
+        agentId: agentA,
+        runId: runA,
+        companyId: companyA,
+        projectId: projectA,
+      },
+    );
+  });
+
+  it("rejects POST /api/plugins/tools/execute when the agent run JWT is for a different company than runContext", async () => {
+    // Defense in depth: even if the bridge spec is tampered with so that
+    // runContext.companyId points at another company, assertCompanyAccess
+    // for the agent actor enforces the agent's own JWT companyId match.
+    const executeTool = vi.fn();
+    const { app } = await createApp(agentActor(), {}, {
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: {
+          agentId: agentA,
+          runId: runA,
+          companyId: companyB,
+          projectId: projectA,
+        },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["legacy data", "post", `/api/plugins/${pluginId}/bridge/data`, { key: "health" }],
     ["legacy action", "post", `/api/plugins/${pluginId}/bridge/action`, { key: "sync" }],

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -878,7 +878,13 @@ export function pluginRoutes(
    * Errors: 501 if tool dispatcher is not configured
    */
   router.get("/plugins/tools", async (req, res) => {
-    assertBoardOrgAccess(req);
+    // Allow either board users with company access OR agent run JWTs.
+    // The plugin tool registry is currently global (single-tenant), so any
+    // authenticated caller in this Paperclip instance gets the same list.
+    // The MCP bridge spawned by adapter CLIs (claude_local, gemini_local,
+    // codex_local, opencode_local) authenticates with an agent run JWT and
+    // calls this endpoint to discover plugin tools — see KSI-664/KSI-698.
+    assertAuthenticated(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -912,7 +918,13 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoardOrgAccess(req);
+    // Allow either board users with company access OR agent run JWTs.
+    // The downstream `assertCompanyAccess(req, runContext.companyId)` and
+    // `validateToolRunContextScope(runContext)` calls enforce that an agent
+    // can only execute tools scoped to its own company and run identity.
+    // The MCP bridge spawned by adapter CLIs (KSI-664/KSI-698) is the
+    // primary agent-actor caller of this endpoint.
+    assertAuthenticated(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/skills-catalog",
       "packages/db",
       "packages/adapter-utils",
+      "packages/adapters/_shared",
       "packages/adapters/acpx-local",
       "packages/adapters/claude-local",
       "packages/adapters/codex-local",


### PR DESCRIPTION
## Summary

Implements Phase B.1.a from KSI-659 (ksio.dev internal): a shared helper that spins up a local stdio MCP server exposing the plugin-tool registry to child CLI processes. Each local CLI adapter (`claude_local`, `codex_local`, `gemini_local`, `opencode_local`) integrates the helper with a thin call site (~10 lines) and forwards the MCP config to its child CLI via the adapter-native flag.

This is the upstream-facing portion of the work; the architectural decision was finalized internally and the implementation is generic to Paperclip — no ksio.dev-specific assumptions.

## What changes

- **`packages/adapters/_shared`** — new package
  - `buildPluginToolsMcpServer` factory: launches a stdio MCP server bound to a `companyId`/`agentId` pair
  - `bridge/main` entry: lists tools applicable to the agent from the plugin-tool-registry and routes calls through `PluginToolDispatcher`
  - Returns a handle/config the adapter can pass to its child CLI
  - Unit tests + an integration test that registers a fake tool and verifies round-trip

- **`packages/adapters/{claude,codex,gemini,opencode}-local`** — each adapter
  - Spins up the helper before exec
  - Passes the right flag to its CLI (`--mcp-config` for Claude, equivalent for the others)

- **`server/src/routes/plugins.ts`**
  - `GET /api/plugins/tools` is now reachable to authenticated callers (previously gated on board/org), so the adapter helper can list the agent's available tools when bootstrapping the MCP server

- **`server/src/__tests__/plugin-routes-authz.test.ts`** — covers the new auth surface

- **`vitest.config.ts`, `pnpm-lock.yaml`** — pull the new package into the workspace

## Architectural invariants preserved

- Plugins do not change. `ctx.tools.register` remains the entry point for plugin authors.
- Tools are namespaced as `${pluginId}__${toolName}` in the MCP surface, preserving existing registry semantics.
- Zero code duplication across adapters — each adapter integrates the helper with ~10 lines.
- Lifecycle is robust: helper uses adapter primitives to manage child processes (start before CLI, kill with CLI).

## Adapters not in scope here

`cursor_local`, `pi_local`, `bob_local`, `cline_local` — adapters without native MCP support — are tracked as a separate follow-up internally (B.1.c bridge `paperclip_call_plugin_tool`).

## Verification

- Source-side: `pnpm typecheck`, `pnpm build`, `pnpm test` for the `_shared` package and the four touched adapters
- Smoke validation against a real plugin (LLM Wiki) is being coordinated downstream

## Notes for reviewers

- The `GET /api/plugins/tools` auth widening from `assertBoardOrgAccess` to `assertAuthenticated` is intentional: adapters running on behalf of an agent need to read the tool list when bootstrapping the MCP server. The dispatcher itself still enforces per-call authorization.
- No plugin-author-facing API was changed.
