### PR TITLE
Fix plugin manifest import cache busting

### DIFF
--- a/server/src/__tests__/plugin-loader-cache-bust.test.ts
+++ b/server/src/__tests__/plugin-loader-cache-bust.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Db } from "@paperclipai/db";
+import { afterEach, describe, expect, it } from "vitest";
+import { pluginLoader } from "../services/plugin-loader.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createPluginPackage(): Promise<string> {
+  const packageDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-plugin-cache-bust-"));
+  tempDirs.push(packageDir);
+
+  await mkdir(path.join(packageDir, "dist"));
+  await writeFile(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "paperclip-plugin-cache-bust-test",
+      version: "0.1.0",
+      type: "module",
+      paperclipPlugin: {
+        manifest: "./dist/manifest.js",
+      },
+    }),
+    "utf8",
+  );
+  await writeManifest(packageDir, "First manifest text");
+  return packageDir;
+}
+
+async function writeManifest(packageDir: string, description: string): Promise<void> {
+  await writeFile(
+    path.join(packageDir, "dist", "manifest.js"),
+    `export default ${JSON.stringify({
+      id: "paperclipai.plugin-cache-bust-test",
+      apiVersion: 1,
+      version: "0.1.0",
+      displayName: "Cache Bust Test",
+      description,
+      author: "Paperclip",
+      categories: ["automation"],
+      capabilities: ["issues.read"],
+      entrypoints: {
+        worker: "./dist/worker.js",
+      },
+    })};\n`,
+    "utf8",
+  );
+}
+
+describe("pluginLoader manifest imports", () => {
+  it("reloads manifest text from disk for the same manifest path", async () => {
+    const packageDir = await createPluginPackage();
+    const loader = pluginLoader({} as Db, {
+      enableLocalFilesystem: false,
+      enableNpmDiscovery: false,
+    });
+
+    await expect(loader.loadManifest(packageDir)).resolves.toMatchObject({
+      description: "First manifest text",
+    });
+
+    await writeManifest(packageDir, "Second manifest text");
+
+    await expect(loader.loadManifest(packageDir)).resolves.toMatchObject({
+      description: "Second manifest text",
+    });
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -52,6 +52,7 @@ import { pluginDatabaseService } from "./plugin-database.js";
 
 const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let pluginModuleImportCounter = 0;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -108,6 +109,12 @@ export function buildPluginWorkerEnv(input: {
     }
   }
   return env;
+}
+
+function createFreshFileImportSpecifier(filePath: string): string {
+  const url = pathToFileURL(filePath);
+  url.searchParams.set("paperclipCacheBust", `${Date.now()}-${++pluginModuleImportCounter}`);
+  return url.href;
 }
 
 // ---------------------------------------------------------------------------
@@ -964,11 +971,10 @@ export function pluginLoader(
     let raw: unknown;
 
     try {
-      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests
-      const manifestUrl = pathToFileURL(manifestPath);
-      const manifestStat = await stat(manifestPath);
-      manifestUrl.searchParams.set("mtime", String(Math.trunc(manifestStat.mtimeMs)));
-      const mod = await import(manifestUrl.href) as Record<string, unknown>;
+      // Dynamic import works for both .js (ESM) and .cjs (CJS) manifests.
+      // Use a fresh file URL so local-path reinstall/upgrade reads the current
+      // manifest from disk instead of Node's process-lifetime ESM cache.
+      const mod = await import(createFreshFileImportSpecifier(manifestPath)) as Record<string, unknown>;
       // The manifest may be the default export or the module itself
       raw = mod["default"] ?? mod;
     } catch (err) {


### PR DESCRIPTION
## Summary
- load plugin manifests through cache-busted file URLs so local-path reinstall/upgrade reads current dist/manifest.js
- add regression coverage for same-path manifest rewrites without process restart

## Validation
- pnpm exec vitest run server/src/__tests__/plugin-loader-cache-bust.test.ts --pool=forks
- pnpm --filter @paperclipai/server typecheck

Paperclip: [EDD-296](/EDD/issues/EDD-296)