### PR TITLE
Allow chain-of-command reviewer to accept their own request_confirmation (SPC-6815)

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -772,9 +772,15 @@ export interface RequestConfirmationPayload {
 
 export interface RequestConfirmationResult {
   version: 1;
-  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target";
+  outcome:
+    | "accepted"
+    | "rejected"
+    | "superseded_by_comment"
+    | "superseded_by_terminal_issue"
+    | "stale_target";
   reason?: string | null;
   commentId?: string | null;
+  issueStatus?: string | null;
   staleTarget?: RequestConfirmationTarget | null;
 }
 

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -725,9 +725,16 @@ export const requestConfirmationPayloadSchema = z.object({
 
 export const requestConfirmationResultSchema = z.object({
   version: z.literal(1),
-  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target"]),
+  outcome: z.enum([
+    "accepted",
+    "rejected",
+    "superseded_by_comment",
+    "superseded_by_terminal_issue",
+    "stale_target",
+  ]),
   reason: z.string().trim().max(4000).nullable().optional(),
   commentId: z.string().uuid().nullable().optional(),
+  issueStatus: z.string().trim().max(40).nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),
 });
 

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
 
 const mockInteractionService = vi.hoisted(() => ({
   listForIssue: vi.fn(),
+  getById: vi.fn(),
   create: vi.fn(),
   acceptInteraction: vi.fn(),
   acceptSuggestedTasks: vi.fn(),
@@ -19,6 +20,13 @@ const mockInteractionService = vi.hoisted(() => ({
   expireRequestConfirmationsSupersededByHistoricalComments: vi.fn(),
   answerQuestions: vi.fn(),
   cancelQuestions: vi.fn(),
+  sweepPendingRequestConfirmationsOnTerminalIssues: vi.fn(),
+}));
+
+const mockAuthorizationService = vi.hoisted(() => ({
+  isManagerOf: vi.fn(async () => false),
+  decide: vi.fn(),
+  decidePrincipalGrant: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -58,6 +66,7 @@ function registerModuleMocks() {
         agent: { id: raw },
       })),
     }),
+    authorizationService: () => mockAuthorizationService,
     clampIssueListLimit: (value: number) => value,
     ISSUE_LIST_DEFAULT_LIMIT: 500,
     ISSUE_LIST_MAX_LIMIT: 1000,
@@ -264,6 +273,9 @@ describe.sequential("issue thread interaction routes", () => {
       updatedAt: "2026-04-20T12:06:00.000Z",
       resolvedAt: "2026-04-20T12:06:00.000Z",
     });
+    mockInteractionService.sweepPendingRequestConfirmationsOnTerminalIssues.mockResolvedValue({ expired: [] });
+    mockInteractionService.getById.mockResolvedValue(null);
+    mockAuthorizationService.isManagerOf.mockResolvedValue(false);
     mockInteractionService.cancelQuestions.mockResolvedValue({
       id: "interaction-2",
       companyId: "company-1",
@@ -812,5 +824,224 @@ describe.sequential("issue thread interaction routes", () => {
         userId: null,
       },
     );
+  });
+
+  describe("chain-of-command reviewer accept gate (SPC-6815)", () => {
+    const REVIEWER_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+    const STRANGER_AGENT_ID = "44444444-4444-4444-8444-444444444444";
+
+    function pendingRequestConfirmation(overrides: Record<string, unknown> = {}) {
+      return {
+        id: "interaction-confirmation",
+        companyId: "company-1",
+        issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee_on_accept",
+        idempotencyKey: null,
+        sourceCommentId: null,
+        sourceRunId: "run-confirm",
+        createdByAgentId: ASSIGNEE_AGENT_ID,
+        createdByUserId: null,
+        resolvedByAgentId: null,
+        resolvedByUserId: null,
+        title: null,
+        summary: null,
+        payload: { version: 1, prompt: "Confirm the work delivered for SPC-6776." },
+        result: null,
+        createdAt: "2026-05-30T12:00:00.000Z",
+        updatedAt: "2026-05-30T12:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("permits a chain-of-command reviewer agent to accept their own request_confirmation", async () => {
+      mockInteractionService.getById.mockResolvedValueOnce(pendingRequestConfirmation());
+      mockAuthorizationService.isManagerOf.mockImplementation(
+        async (_companyId: string, manager: string, target: string) =>
+          manager === REVIEWER_AGENT_ID && target === ASSIGNEE_AGENT_ID,
+      );
+      mockInteractionService.acceptInteraction.mockResolvedValueOnce({
+        interaction: { ...pendingRequestConfirmation(), status: "accepted", resolvedByAgentId: REVIEWER_AGENT_ID },
+        createdIssues: [],
+      });
+      const app = await createApp({
+        type: "agent",
+        agentId: REVIEWER_AGENT_ID,
+        companyId: "company-1",
+        runId: "run-cto",
+      });
+
+      const res = await request(app)
+        .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-confirmation/accept")
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(mockInteractionService.acceptInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+        "interaction-confirmation",
+        {},
+        expect.objectContaining({ agentId: REVIEWER_AGENT_ID, userId: null }),
+      );
+    });
+
+    it("permits a chain-of-command reviewer agent to reject their own request_confirmation", async () => {
+      mockInteractionService.getById.mockResolvedValueOnce(pendingRequestConfirmation());
+      mockAuthorizationService.isManagerOf.mockImplementation(
+        async (_companyId: string, manager: string, target: string) =>
+          manager === REVIEWER_AGENT_ID && target === ASSIGNEE_AGENT_ID,
+      );
+      mockInteractionService.rejectInteraction.mockResolvedValueOnce({
+        ...pendingRequestConfirmation(),
+        status: "rejected",
+        resolvedByAgentId: REVIEWER_AGENT_ID,
+        result: { version: 1, outcome: "rejected", reason: "Needs follow-up" },
+      });
+      const app = await createApp({
+        type: "agent",
+        agentId: REVIEWER_AGENT_ID,
+        companyId: "company-1",
+        runId: "run-cto",
+      });
+
+      const res = await request(app)
+        .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-confirmation/reject")
+        .send({ reason: "Needs follow-up" });
+
+      expect(res.status).toBe(200);
+      expect(mockInteractionService.rejectInteraction).toHaveBeenCalled();
+    });
+
+    it("denies a non-reviewer agent accept on request_confirmation", async () => {
+      mockInteractionService.getById.mockResolvedValueOnce(pendingRequestConfirmation());
+      mockAuthorizationService.isManagerOf.mockResolvedValue(false);
+      const app = await createApp({
+        type: "agent",
+        agentId: STRANGER_AGENT_ID,
+        companyId: "company-1",
+        runId: "run-stranger",
+      });
+
+      const res = await request(app)
+        .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-confirmation/accept")
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(mockInteractionService.acceptInteraction).not.toHaveBeenCalled();
+    });
+
+    it("denies an agent accept on suggest_tasks even when in chain-of-command", async () => {
+      mockInteractionService.getById.mockResolvedValueOnce({
+        ...pendingRequestConfirmation(),
+        id: "interaction-tasks",
+        kind: "suggest_tasks",
+        payload: { version: 1, tasks: [{ clientKey: "t", title: "T" }] },
+      });
+      mockAuthorizationService.isManagerOf.mockResolvedValue(true);
+      const app = await createApp({
+        type: "agent",
+        agentId: REVIEWER_AGENT_ID,
+        companyId: "company-1",
+        runId: "run-cto",
+      });
+
+      const res = await request(app)
+        .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-tasks/accept")
+        .send({ selectedClientKeys: ["t"] });
+
+      expect(res.status).toBe(403);
+      expect(mockInteractionService.acceptInteraction).not.toHaveBeenCalled();
+    });
+
+    it("denies an agent respond on ask_user_questions (board only kind)", async () => {
+      mockAuthorizationService.isManagerOf.mockResolvedValue(true);
+      const app = await createApp({
+        type: "agent",
+        agentId: REVIEWER_AGENT_ID,
+        companyId: "company-1",
+        runId: "run-cto",
+      });
+
+      const res = await request(app)
+        .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-questions/respond")
+        .send({ answers: [{ questionId: "scope", optionIds: ["phase-1"] }] });
+
+      expect(res.status).toBe(403);
+      expect(mockInteractionService.answerQuestions).not.toHaveBeenCalled();
+    });
+
+    it("preserves board acceptance for request_confirmation without consulting the manager check", async () => {
+      mockInteractionService.acceptInteraction.mockResolvedValueOnce({
+        interaction: { ...pendingRequestConfirmation(), status: "accepted" },
+        createdIssues: [],
+      });
+      const app = await createApp();
+
+      const res = await request(app)
+        .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-confirmation/accept")
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(mockAuthorizationService.isManagerOf).not.toHaveBeenCalled();
+      expect(mockInteractionService.getById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("admin sweep of pending request_confirmation on terminal issues", () => {
+    it("expires pending request_confirmation rows on done/cancelled issues for the company", async () => {
+      mockInteractionService.sweepPendingRequestConfirmationsOnTerminalIssues.mockResolvedValueOnce({
+        expired: [
+          {
+            id: "73ae1223",
+            issueId: "spc-6776-issue",
+            companyId: "company-1",
+            kind: "request_confirmation",
+            status: "expired",
+            result: { version: 1, outcome: "superseded_by_terminal_issue", issueStatus: "done" },
+          },
+        ],
+      });
+      const app = await createApp();
+
+      const res = await request(app)
+        .post("/api/admin/companies/company-1/issue-thread-interactions/sweep-pending-on-terminal-issues")
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        expiredCount: 1,
+        expired: [{ id: "73ae1223", issueId: "spc-6776-issue" }],
+      });
+      expect(mockInteractionService.sweepPendingRequestConfirmationsOnTerminalIssues).toHaveBeenCalledWith(
+        { companyId: "company-1" },
+        expect.objectContaining({ userId: "local-board" }),
+      );
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "issue.thread_interaction_expired",
+          details: expect.objectContaining({
+            interactionId: "73ae1223",
+            source: "admin.sweep_pending_on_terminal_issues",
+          }),
+        }),
+      );
+    });
+
+    it("rejects agents from invoking the sweep endpoint", async () => {
+      const app = await createApp({
+        type: "agent",
+        agentId: "44444444-4444-4444-8444-444444444444",
+        companyId: "company-1",
+        runId: "run-x",
+      });
+
+      const res = await request(app)
+        .post("/api/admin/companies/company-1/issue-thread-interactions/sweep-pending-on-terminal-issues")
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(mockInteractionService.sweepPendingRequestConfirmationsOnTerminalIssues).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -61,6 +61,7 @@ import * as serviceIndex from "../services/index.js";
 import {
   accessService,
   agentService,
+  authorizationService,
   companyService,
   companySearchService,
   executionWorkspaceService,
@@ -877,6 +878,53 @@ export function issueRoutes(
   const documentAnnotationsSvc = documentAnnotationService(db);
   const issueReferencesSvc = issueReferenceService(db);
   const issueThreadInteractionsSvc = issueThreadInteractionService(db);
+  const authorization = authorizationService(db);
+
+  async function assertCanResolveRequestConfirmation(args: {
+    req: Request;
+    res: Response;
+    issue: { id: string; companyId: string; assigneeAgentId: string | null };
+    interactionId: string;
+  }): Promise<boolean> {
+    if (args.req.actor.type === "board") {
+      assertBoard(args.req);
+      return true;
+    }
+    if (args.req.actor.type !== "agent") {
+      args.res.status(403).json({ error: "Board access required" });
+      return false;
+    }
+    const actorAgentId = args.req.actor.agentId ?? null;
+    if (!actorAgentId || args.req.actor.companyId !== args.issue.companyId) {
+      args.res.status(403).json({ error: "Board access required" });
+      return false;
+    }
+    const interaction = await issueThreadInteractionsSvc.getById(args.interactionId);
+    if (
+      !interaction
+      || interaction.issueId !== args.issue.id
+      || interaction.companyId !== args.issue.companyId
+    ) {
+      args.res.status(404).json({ error: "Interaction not found" });
+      return false;
+    }
+    if (interaction.kind !== "request_confirmation") {
+      args.res.status(403).json({ error: "Board access required" });
+      return false;
+    }
+    const candidateAssigneeIds = [
+      args.issue.assigneeAgentId,
+      interaction.createdByAgentId,
+    ].filter((value): value is string => typeof value === "string" && value.length > 0);
+    for (const candidateAssigneeId of candidateAssigneeIds) {
+      if (candidateAssigneeId === actorAgentId) continue;
+      if (await authorization.isManagerOf(args.issue.companyId, actorAgentId, candidateAssigneeId)) {
+        return true;
+      }
+    }
+    args.res.status(403).json({ error: "Board access required" });
+    return false;
+  }
   const routinesSvc = routineService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
@@ -5032,6 +5080,55 @@ export function issueRoutes(
     res.json(released);
   });
 
+  router.post(
+    "/admin/companies/:companyId/issue-thread-interactions/sweep-pending-on-terminal-issues",
+    async (req, res) => {
+      if (req.actor.type !== "board") {
+        res.status(403).json({ error: "Board access required" });
+        return;
+      }
+      if (!req.actor.userId) {
+        throw forbidden("Board user context required");
+      }
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+
+      const actor = getActorInfo(req);
+      const { expired } = await issueThreadInteractionsSvc.sweepPendingRequestConfirmationsOnTerminalIssues(
+        { companyId },
+        { agentId: actor.agentId, userId: actor.actorType === "user" ? actor.actorId : null },
+      );
+
+      for (const interaction of expired) {
+        await logActivity(db, {
+          companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "issue.thread_interaction_expired",
+          entityType: "issue",
+          entityId: interaction.issueId,
+          details: {
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            source: "admin.sweep_pending_on_terminal_issues",
+            result: interaction.result ?? null,
+          },
+        });
+      }
+
+      res.json({
+        expiredCount: expired.length,
+        expired: expired.map((interaction) => ({
+          id: interaction.id,
+          issueId: interaction.issueId,
+        })),
+      });
+    },
+  );
+
   router.post("/issues/:id/admin/force-release", async (req, res) => {
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board access required" });
@@ -5192,7 +5289,7 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (!(await assertCanResolveRequestConfirmation({ req, res, issue, interactionId }))) return;
 
       const actor = getActorInfo(req);
       const { interaction, createdIssues, continuationIssue } = await issueThreadInteractionService(db).acceptInteraction(issue, interactionId, req.body, {
@@ -5297,7 +5394,7 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (!(await assertCanResolveRequestConfirmation({ req, res, issue, interactionId }))) return;
 
       const actor = getActorInfo(req);
       const interaction = await issueThreadInteractionService(db).rejectInteraction(issue, interactionId, req.body, {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -819,5 +819,6 @@ export function authorizationService(db: Db) {
   return {
     decide,
     decidePrincipalGrant,
+    isManagerOf,
   };
 }

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1341,5 +1341,64 @@ export function issueThreadInteractionService(db: Db) {
       await touchIssue(db, issue.id);
       return hydrateInteraction(updated);
     },
+
+    sweepPendingRequestConfirmationsOnTerminalIssues: async (
+      args: { companyId: string },
+      actor: InteractionActor,
+    ) => {
+      const rows = await db
+        .select({
+          id: issueThreadInteractions.id,
+          issueId: issueThreadInteractions.issueId,
+          companyId: issueThreadInteractions.companyId,
+          issueStatus: issues.status,
+        })
+        .from(issueThreadInteractions)
+        .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+        .where(and(
+          eq(issueThreadInteractions.companyId, args.companyId),
+          eq(issueThreadInteractions.kind, "request_confirmation"),
+          eq(issueThreadInteractions.status, "pending"),
+          inArray(issues.status, ["done", "cancelled"]),
+        ));
+
+      if (rows.length === 0) {
+        return { expired: [] as IssueThreadInteraction[] };
+      }
+
+      const now = new Date();
+      const expired: IssueThreadInteraction[] = [];
+      const touchedIssueIds = new Set<string>();
+      for (const row of rows) {
+        const [updated] = await db
+          .update(issueThreadInteractions)
+          .set({
+            status: "expired",
+            result: {
+              version: 1,
+              outcome: "superseded_by_terminal_issue",
+              issueStatus: row.issueStatus,
+            },
+            resolvedByAgentId: actor.agentId ?? null,
+            resolvedByUserId: actor.userId ?? null,
+            resolvedAt: now,
+            updatedAt: now,
+          })
+          .where(and(
+            eq(issueThreadInteractions.id, row.id),
+            eq(issueThreadInteractions.status, "pending"),
+          ))
+          .returning();
+        if (updated) {
+          expired.push(hydrateInteraction(updated));
+          touchedIssueIds.add(row.issueId);
+        }
+      }
+
+      for (const issueId of touchedIssueIds) {
+        await touchIssue(db, issueId);
+      }
+      return { expired };
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Narrow `POST /api/issues/:id/interactions/:interactionId/{accept,reject}` so the chain-of-command reviewer above the issue's `assigneeAgentId` (or the interaction's `createdByAgentId`) can resolve a `request_confirmation` directly. Board users keep their current path. `suggest_tasks`, `ask_user_questions` (respond/cancel), and any other kind remain board-only.
- Add `POST /api/admin/companies/:companyId/issue-thread-interactions/sweep-pending-on-terminal-issues` (board-only) to bulk-expire orphaned `pending` `request_confirmation` rows whose source issue is in `done`/`cancelled`. Each expiry audit-logs and emits a new `superseded_by_terminal_issue` outcome on the existing `RequestConfirmationResult`.
- `resolvedByAgentId` already flowed through the service — no schema change needed.

## Why

Before this change, any agent who substantively reviewed work delivered via `request_confirmation` would 403 on accept and the interaction would sit `pending` forever, even after a board user closed the parent issue with `PATCH /api/issues/:id`. SPC-6776's `73ae1223` is the canonical example. Every BE delivery routed through the explicit review handoff would accumulate one orphaned pending interaction per close.

## Scope guardrails

- `request_board_approval` and other board-explicit payloads — unchanged. Only the `request_confirmation` kind benefits from the reviewer-chain widening.
- The reviewer must actually be in the manager subtree above either the current assignee agent or the interaction creator agent (via the existing `agents.reports_to` graph). Peers and unrelated agents continue to receive 403.
- Board acceptance short-circuits the reviewer-chain lookup so existing flows pay no extra DB cost.

## Test plan

- [ ] Reviewer agent (in chain-of-command above assignee) can `POST /accept` on a `request_confirmation` — 200, `resolvedByAgentId` populated.
- [ ] Same reviewer can `POST /reject` with a reason.
- [ ] Non-reviewer agent receives 403 on the same `request_confirmation`.
- [ ] Reviewer cannot `POST /accept` a `suggest_tasks` interaction — still 403.
- [ ] Reviewer cannot `POST /respond` to an `ask_user_questions` interaction — still 403.
- [ ] Board user accept on a `request_confirmation` works as before.
- [ ] `POST /api/admin/companies/:companyId/.../sweep-pending-on-terminal-issues` (board) expires only pending `request_confirmation` rows whose issue is `done`/`cancelled`, audit-logs each, and returns the list.
- [ ] Agents receive 403 on the sweep endpoint.

Vitest covering all of the above ships in `server/src/__tests__/issue-thread-interaction-routes.test.ts`. Typecheck is clean on both `server` and `packages/shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)