### PR TITLE
fix(ops-portal): drop output:standalone so Railway/Vercel next start works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ tests/release-smoke/test-results/
 tests/release-smoke/playwright-report/
 .superset/
 .claude/worktrees/
+.vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ ENV NODE_ENV=production \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private \
   OPENCODE_ALLOW_ALL_MODELS=true
 
-VOLUME ["/paperclip"]
 EXPOSE 3100
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 # syntax=docker/dockerfile:1.20
+
+# ── Caddy build (consumed by the `railway` target only) ──────────────────────
+FROM caddy:2-builder-alpine AS caddy-builder
+RUN xcaddy build --with github.com/ggicci/caddy-jwt
+
+# ── Shared Node base ──────────────────────────────────────────────────────────
 FROM node:lts-trixie-slim AS base
 ARG USER_UID=1000
 ARG USER_GID=1000
@@ -79,3 +85,34 @@ EXPOSE 3100
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "--import", "./server/node_modules/tsx/dist/loader.mjs", "server/dist/index.js"]
+
+# ── Railway target ────────────────────────────────────────────────────────────
+# Combined Caddy + Paperclip image for Railway deployment.
+# Caddy listens on $PORT (HTTP; Railway terminates TLS) and proxies to
+# Paperclip on 127.0.0.1:3000, satisfying local_trusted's loopback requirement.
+# supervisord manages both processes.
+#
+# Build:  docker build --target railway -t paperclip-railway .
+# Railway: set "Docker Build Target" to "railway" in service settings.
+FROM production AS railway
+
+COPY --from=caddy-builder /usr/bin/caddy /usr/bin/caddy
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends supervisor \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY docker/railway/Caddyfile /etc/caddy/Caddyfile
+COPY docker/railway/supervisord.conf /etc/supervisor/conf.d/paperclip.conf
+COPY docker/railway/entrypoint.sh /usr/local/bin/railway-entrypoint.sh
+RUN chmod +x /usr/local/bin/railway-entrypoint.sh
+
+ENV PAPERCLIP_DEPLOYMENT_MODE=local_trusted \
+    PAPERCLIP_BIND=loopback \
+    PAPERCLIP_DEPLOYMENT_EXPOSURE=private \
+    HOST=127.0.0.1 \
+    PORT=3000
+
+EXPOSE 8080
+
+ENTRYPOINT ["railway-entrypoint.sh"]
+CMD []

--- a/doc/RAILWAY_DEPLOYMENT.md
+++ b/doc/RAILWAY_DEPLOYMENT.md
@@ -1,0 +1,533 @@
+# Jaban Universe — Paperclip Ops Portal: Railway Deployment Runbook
+
+**Stack:** Paperclip (Railway) · Caddy reverse proxy (Railway) · Zitadel IdP (shared, `auth.binelek.io`) · ops-portal Next.js 14 login shell (Vercel)
+**Live URLs:** `ops.binelek.io` (login) · `app.ops.binelek.io` (app)
+**Updated:** 2026-05-05
+
+---
+
+## 1. Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Public Internet                                             │
+│                                                              │
+│  https://ops.binelek.io      →  branded login UI (Vercel)   │
+│  https://auth.binelek.io     →  Zitadel (shared IdP)        │
+│  https://app.ops.binelek.io  →  Caddy → Paperclip           │
+└──────────────────────────────────────────────────────────────┘
+                        │                       │
+                        ▼                       ▼
+        ┌───────────────────────┐   ┌───────────────────────┐
+        │  Vercel: ops-portal   │   │  Railway: paperclip-ops│
+        │  (Next.js 14)         │   │                       │
+        │  - Jaban Universe UI  │   │  ┌─────────────────┐  │
+        │  - Auth.js + Zitadel  │   │  │ Service: caddy  │  │
+        │  - Mints Caddy JWT    │   │  │ - JWT validation│  │
+        │  - Sets .binelek.io   │   │  │ - TLS (ACME)    │  │
+        │    HttpOnly cookie    │   │  │ - WS proxy      │  │
+        └───────────────────────┘   │  └────────┬────────┘  │
+                                    │           │           │
+                                    │           ▼           │
+                                    │  ┌─────────────────┐  │
+                                    │  │ Service: paper- │  │
+                                    │  │   clip          │  │
+                                    │  │ - local_trusted │  │
+                                    │  │ - internal only │  │
+                                    │  │ - port 3100     │  │
+                                    │  └────────┬────────┘  │
+                                    │           │           │
+                                    │           ▼           │
+                                    │  ┌─────────────────┐  │
+                                    │  │ Service: postgres│  │
+                                    │  │ (managed, Rail.) │  │
+                                    │  └─────────────────┘  │
+                                    └───────────────────────┘
+```
+
+### Auth flow (step by step)
+
+1. Browser → `ops.binelek.io` → Vercel serves branded login page.
+2. User clicks **Sign In** → Auth.js redirects to `auth.binelek.io` (Zitadel OIDC).
+3. Zitadel authenticates user (password + 2FA TOTP/WebAuthn).
+4. Zitadel → redirect to `ops.binelek.io/api/auth/callback/zitadel`.
+5. Auth.js validates code, writes encrypted JWT session cookie for `ops.binelek.io`.
+6. Browser → `/launch` → immediately redirected to `/api/session`.
+7. `/api/session` checks Auth.js session, verifies `paperclip-ops:operator` role,
+   mints a `jaban_session` JWT (HS256, 8 h) signed with `CADDY_SESSION_JWT_SECRET`.
+8. `/api/session` sets `jaban_session` HttpOnly cookie on `.binelek.io`, redirects
+   browser to `https://app.ops.binelek.io/`.
+9. Browser → Caddy with `jaban_session` cookie.
+10. Caddy `jwtauth` validates cookie signature + claims; on success proxies to
+    `paperclip:3100`. On failure → 401 → redirect to `ops.binelek.io/login`.
+11. Paperclip runs in `local_trusted` mode — no second login required.
+
+---
+
+## 2. Prerequisites
+
+Before deploying Paperclip, the shared Zitadel instance **must** be running at
+`auth.binelek.io` and Kevin must have an account with 2FA enrolled.
+
+### 2a. Register the Paperclip OIDC client in Zitadel
+
+1. Sign in to `auth.binelek.io` as an admin.
+2. Navigate to **Organization** → `tucker-operations` → **Projects** → **New Project**: `paperclip-ops`.
+3. Inside `paperclip-ops` → **Applications** → **New Application**.
+   - Name: `Paperclip Ops Portal`
+   - Application Type: **Web**
+   - Auth method: **Code** (enable PKCE)
+   - Redirect URI: `https://ops.binelek.io/api/auth/callback/zitadel`
+   - Post-logout URI: `https://ops.binelek.io/login`
+4. **Save** and copy the **Client ID** and **Client Secret**. Store them in a password manager.
+5. Navigate to **Roles** → **Add Role**: `paperclip-ops:operator`.
+6. Navigate to **Authorizations** → grant Kevin (`kevin@binelek.io`) the `paperclip-ops:operator` role.
+
+### 2b. Generate shared secrets
+
+Run these locally (or in any shell with `openssl` available):
+
+```bash
+# Auth.js session secret (Vercel)
+openssl rand -hex 32
+
+# Shared Caddy ↔ Vercel JWT signing secret
+# Same value goes into Vercel (CADDY_SESSION_JWT_SECRET)
+# and Railway caddy service (SESSION_JWT_SECRET).
+openssl rand -hex 32
+```
+
+Keep both values. They will be needed in steps 4 and 5 below.
+
+---
+
+## 3. Railway Project Setup
+
+Create a new Railway project named **`paperclip-ops`**.
+
+### 3a. Postgres (managed plugin)
+
+1. In the project, click **New Service** → **Database** → **PostgreSQL**.
+2. Railway provisions the database and injects `DATABASE_URL` automatically when
+   other services reference it via `${{Postgres.DATABASE_URL}}`.
+
+### 3b. Paperclip service
+
+1. **New Service** → **GitHub Repo** → select `k5tuck/paperclip`, branch `master`.
+2. Railway auto-detects the `Dockerfile` at the repo root.
+3. **Do NOT assign a public domain** to this service. Caddy alone reaches it via
+   Railway's internal network.
+4. Attach a **Volume**: mount path `/paperclip`, size 5 GB.
+5. Set the environment variables listed in §4a.
+
+### 3c. Caddy service
+
+1. **New Service** → **GitHub Repo** → select `k5tuck/paperclip`, set **Root Directory** to `docker/caddy`.
+   Railway will build `docker/caddy/Dockerfile` (custom Caddy + JWT plugin).
+2. Assign the public domain `app.ops.binelek.io`.
+3. Set the environment variables listed in §4b.
+
+---
+
+## 4. Environment Variables
+
+**Never commit real values. All secrets live in Railway / Vercel dashboards only.**
+
+### 4a. `paperclip` service
+
+| Variable | Description |
+|---|---|
+| `DATABASE_URL` | Use Railway variable reference: `${{Postgres.DATABASE_URL}}` |
+| `HOST` | `0.0.0.0` |
+| `PORT` | `3100` |
+| `NODE_ENV` | `production` |
+| `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` — disables Paperclip's own auth gate; Caddy is the boundary |
+| `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` |
+| `PAPERCLIP_HOME` | `/paperclip` |
+| `PAPERCLIP_INSTANCE_ID` | `default` |
+| `SERVE_UI` | `true` |
+| `BETTER_AUTH_SECRET` | Strong random string (generate: `openssl rand -hex 32`); still needed for internal session tokens even in `local_trusted` mode |
+| `ANTHROPIC_API_KEY` | Your Anthropic key |
+| `OPENAI_API_KEY` | Your OpenAI key |
+
+### 4b. `caddy` service
+
+| Variable | Description |
+|---|---|
+| `ACME_EMAIL` | `kevin@binelek.io` — for Let's Encrypt notifications |
+| `PAPERCLIP_UPSTREAM` | `paperclip.railway.internal:3100` |
+| `SESSION_JWT_SECRET` | The shared 32-byte hex secret (same value as Vercel's `CADDY_SESSION_JWT_SECRET`) |
+
+### 4c. Vercel `ops-portal` environment variables
+
+| Variable | Description |
+|---|---|
+| `AUTH_SECRET` | 32-byte hex, used by Auth.js to encrypt session cookies |
+| `AUTH_ZITADEL_ISSUER` | `https://auth.binelek.io` |
+| `AUTH_ZITADEL_ID` | Zitadel client ID from §2a |
+| `AUTH_ZITADEL_SECRET` | Zitadel client secret from §2a |
+| `CADDY_SESSION_JWT_SECRET` | Same value as Railway caddy's `SESSION_JWT_SECRET` |
+| `APP_URL` | `https://app.ops.binelek.io` |
+| `NEXTAUTH_URL` | `https://ops.binelek.io` |
+
+---
+
+## 5. DNS Configuration (Vercel DNS)
+
+Log in to Vercel DNS for `binelek.io`. Add or verify these records:
+
+| Name | Type | Value | Proxy |
+|---|---|---|---|
+| `ops` | CNAME | `cname.vercel-dns.com` | — (Vercel manages TLS) |
+| `app.ops` | CNAME | `<Railway-provided CNAME for caddy service>` | off (Caddy manages TLS via ACME) |
+
+Find the Railway CNAME under the caddy service → **Settings** → **Networking** →
+**Custom Domain** → copy the target hostname.
+
+Caddy auto-provisions a Let's Encrypt cert for `app.ops.binelek.io` on first
+HTTPS request. Allow up to 60 seconds on first hit.
+
+---
+
+## 6. Vercel App Deployment
+
+The `ops-portal/` directory in this repo contains the Vercel app. For its own
+deployments, it is best treated as a separate Vercel project rooted at that
+subdirectory (Vercel supports monorepo root directories).
+
+1. In Vercel dashboard → **New Project** → import `k5tuck/paperclip`.
+2. Set **Root Directory** to `ops-portal`.
+3. Vercel auto-detects Next.js; leave build settings as default.
+4. Set the environment variables from §4c for the **Production** environment.
+5. Add `ops.binelek.io` as a custom domain. Vercel will validate via DNS.
+
+---
+
+## 7. First Deployment & Smoke Test
+
+Deploy all services (Railway redeploys paperclip and caddy; Vercel deploys ops-portal).
+
+Smoke test in a private/incognito window:
+
+```
+1. https://ops.binelek.io
+   → Branded Jaban Universe login page appears
+
+2. Click "Sign In"
+   → Redirected to https://auth.binelek.io (Zitadel)
+   → Authenticate with Kevin's credentials + TOTP
+
+3. Zitadel redirects back to ops.binelek.io/api/auth/callback/zitadel
+   → Auth.js establishes session
+   → Browser lands on /launch, immediately redirects to /api/session
+
+4. /api/session mints Caddy JWT, sets jaban_session cookie on .binelek.io
+   → Redirects to https://app.ops.binelek.io/
+
+5. Caddy validates jaban_session JWT → proxies to Paperclip
+   → Paperclip UI loads
+```
+
+Verify session security:
+```bash
+# Should redirect to ops.binelek.io/login (no valid cookie)
+curl -I https://app.ops.binelek.io/
+```
+
+---
+
+## 8. Locking Down
+
+After successful first deployment:
+
+1. **Disable Railway auto-generated public URLs** for the `paperclip` service:
+   Railway dashboard → paperclip → Settings → Networking → disable the
+   `*.up.railway.app` public URL.
+
+2. **Verify isolation:** attempt to reach the Railway-generated URL directly —
+   it should return a connection error.
+
+3. **Test Caddy's JWT enforcement:** visit `https://app.ops.binelek.io/` in a
+   fresh incognito window without signing in — Caddy must redirect to
+   `https://ops.binelek.io/login`.
+
+4. **Test role enforcement:** in Zitadel temporarily revoke Kevin's
+   `paperclip-ops:operator` role → try accessing → `/api/session` should return
+   403. Re-grant the role.
+
+5. **Configure Railway healthchecks** for both `paperclip` and `caddy` services
+   under Settings → Health Checks. Set alerts via Railway's notification
+   integrations (email / webhook to a Slack channel).
+
+---
+
+## 9. Adding a New User
+
+1. In Zitadel (`auth.binelek.io`) → Organization → tucker-operations → Users →
+   **New User**: enter name, email, set a temporary password.
+2. Navigate to `paperclip-ops` project → Authorizations → **New Authorization**
+   → select the new user → grant role `paperclip-ops:operator`.
+3. Share the login URL (`https://ops.binelek.io`) and the temporary password.
+4. On first login the user sets a permanent password and enrolls TOTP (enforced
+   by Zitadel's MFA policy; configure this in Zitadel under **Login Policy**).
+
+To add with read-only access (viewer):
+- Create a separate `paperclip-ops:viewer` role in Zitadel.
+- Update `src/lib/auth.ts` `requireOperatorSession` to also accept `viewer`
+  for read-only routes (future work).
+
+---
+
+## 10. Rolling Back a Bad Deploy
+
+### Paperclip service
+
+```
+Railway dashboard → paperclip → Deployments → find the last good deploy → Redeploy
+```
+
+Paperclip's data lives in the Railway Volume at `/paperclip`, which is
+unaffected by redeployments. Database state is in Postgres, also unaffected.
+
+### Caddy service
+
+Caddy has no persistent state (certs are re-issued on first request if lost).
+Roll back via Railway Deployments in the same way.
+
+### Vercel ops-portal
+
+```
+Vercel dashboard → ops-portal → Deployments → locate last good deployment → Promote to Production
+```
+
+---
+
+## 11. Recovering from Lockout
+
+If Zitadel (`auth.binelek.io`) goes down, `ops.binelek.io/login` will show the
+Jaban Universe page but "Sign In" will fail — the Zitadel OAuth server is
+unreachable.
+
+**Break-glass procedure (access Paperclip directly while Zitadel is down):**
+
+1. In Railway, temporarily add a public domain to the `paperclip` service
+   (Settings → Networking → Public Domain).
+2. Set a strong `BETTER_AUTH_SECRET` and connect directly to
+   `https://<temp-paperclip-domain>/` — Paperclip is in `local_trusted` mode
+   so it will load without auth.
+3. Once Zitadel is restored, remove the temporary public domain immediately.
+
+**Prevention:** Railway's managed services (Postgres, Redis) have SLAs. Host
+Zitadel in a separate Railway service with auto-restart enabled and set up
+uptime monitoring (e.g., BetterUptime ping on `auth.binelek.io/healthz`).
+
+---
+
+## 12. JWT Secret Rotation
+
+When rotating `CADDY_SESSION_JWT_SECRET` / `SESSION_JWT_SECRET`:
+
+1. Generate a new secret: `openssl rand -hex 32`
+2. Update the Vercel env var `CADDY_SESSION_JWT_SECRET` (new value).
+3. Redeploy Vercel — new sessions will use the new secret.
+4. Update the Railway caddy service env var `SESSION_JWT_SECRET`.
+5. Redeploy Caddy — it will only accept JWTs signed with the new secret.
+
+All existing sessions (`jaban_session` cookies) are immediately invalidated.
+Users will be redirected to login automatically. This is the correct behavior.
+Schedule rotations during low-traffic periods.
+
+---
+
+## 13. Backup Strategy
+
+### Paperclip Postgres
+
+Railway's managed Postgres includes point-in-time restore (PITR) retention
+(check your Railway plan for the exact retention window — typically 7 days on
+the Pro plan).
+
+For an additional manual backup:
+
+```bash
+# Run from your local machine with Railway CLI authenticated
+railway run --service paperclip-ops-postgres \
+  pg_dump --no-owner --no-privileges paperclip \
+  | gzip > paperclip-$(date +%Y%m%d).sql.gz
+```
+
+Schedule weekly via a Railway Cron job or a local cron + Railway CLI.
+
+### Zitadel (separate project)
+
+Zitadel at `auth.binelek.io` is a shared service. Back it up using the same
+pg_dump pattern against Zitadel's Postgres. Losing Zitadel without a backup
+means losing all user accounts across every product. Treat Zitadel backups as
+critical.
+
+### Railway Volume (Paperclip workspace)
+
+The 5 GB volume at `/paperclip` holds agent memory, task files, and uploaded
+assets. Volumes are not automatically backed up. Add a daily backup job:
+
+```bash
+# Example: run inside the paperclip service via Railway's exec or a sidecar
+tar -czf /tmp/paperclip-vol-$(date +%Y%m%d).tar.gz /paperclip
+# Then upload to S3 / B2 / R2 using rclone or aws-cli
+```
+
+---
+
+## 14. Troubleshooting
+
+### Caddy can't obtain a TLS cert
+
+- Ensure `app.ops.binelek.io` DNS CNAME points to the Railway caddy service's
+  hostname and the record has propagated (`dig CNAME app.ops.binelek.io`).
+- Check Railway caddy logs: look for `certificate obtained successfully` or
+  ACME error messages.
+- Let's Encrypt rate-limits: if you hit limits during testing, temporarily
+  switch Caddy to the staging ACME server by adding `acme_ca https://acme-staging-v02.api.letsencrypt.org/directory` inside the global `{}` block.
+
+### Authelia redirect loop (N/A — no Authelia in this setup)
+
+This deployment uses Zitadel, not Authelia. If you see unexpected redirects,
+check Auth.js logs in the Vercel Function logs tab.
+
+### Paperclip WebSockets disconnecting
+
+Caddy proxies WebSocket upgrades in the dedicated `@websocket` matcher. If
+WebSockets disconnect:
+
+1. Check Caddy logs for `EOF` or `upstream connection error`.
+2. Verify `paperclip.railway.internal:3100` is reachable from the Caddy service
+   (Railway private networking — both services must be in the same project).
+3. Railway does not time out idle TCP connections on private networking, so
+   long-lived WebSockets should be stable. If Paperclip's client-side code
+   reconnects automatically, a brief disconnect on redeploy is expected and safe.
+
+### Vercel proxy returning 502
+
+Not applicable — this deployment does not use a Vercel proxy for Paperclip
+traffic. Vercel only serves the login shell. If `ops.binelek.io` returns 502,
+check Vercel Function logs for startup errors (likely a missing env var; the
+`auth.ts` module throws `OIDCConfigurationError` at boot if vars are absent).
+
+### User can't complete TOTP enrollment
+
+TOTP enrollment happens in Zitadel, not in the ops-portal. Direct the user to
+`auth.binelek.io` and walk them through Zitadel's MFA setup flow. Zitadel's
+TOTP uses standard RFC 6238 — any authenticator app (Authy, Google Authenticator,
+1Password) works.
+
+### `/api/session` returns 403
+
+The logged-in user lacks the `paperclip-ops:operator` role in Zitadel.
+Grant it via Zitadel Console → `paperclip-ops` project → Authorizations.
+
+### `jaban_session` cookie not set on `app.ops.binelek.io`
+
+The cookie is set with `Domain=.binelek.io` — it applies to all subdomains.
+Check browser DevTools → Application → Cookies. If missing, confirm that
+`/api/session` redirected (HTTP 302) rather than erroring. Common cause:
+`CADDY_SESSION_JWT_SECRET` is not set in Vercel.
+
+---
+
+## 15. Cost Estimate
+
+| Service | Monthly cost (approx.) |
+|---|---|
+| Railway: paperclip (512 MB RAM, 0.5 vCPU) | $5–15 |
+| Railway: caddy | $5 |
+| Railway: Postgres (managed) | $5–10 |
+| Railway: Volume (5 GB) | $0.50 |
+| **Railway subtotal** | **$15–30/mo** |
+| Vercel: ops-portal (Hobby tier) | $0 |
+| Vercel DNS | $0 |
+| **Total** | **~$15–30/mo** |
+
+LLM provider costs (Anthropic, OpenAI) depend entirely on agent activity and
+are capped per-agent inside Paperclip's budget settings.
+
+---
+
+## 16. Migrating to More Users
+
+The current Zitadel setup manages users via Zitadel's own user database.
+This scales comfortably to tens of users with no changes.
+
+When you reach 20+ users or want SSO federation (e.g., Google Workspace or
+GitHub org):
+
+1. In Zitadel → **Identity Providers** → add a social/enterprise provider.
+2. Users log in via that provider; Zitadel still enforces MFA and role grants.
+3. No changes required to ops-portal or Paperclip.
+
+---
+
+## 17. Connecting Future Projects (HarmonyLab, NKF, etc.)
+
+- Each new project gets its own OIDC client registered in Zitadel under a new
+  project (e.g., `harmonylab-admin`).
+- Grant users the relevant roles in Zitadel once. Existing accounts carry over.
+- Paperclip agents acting on other projects use **scoped service tokens**
+  (GitHub PATs, Railway API tokens) configured per-agent in Paperclip's secrets
+  — not Zitadel identity.
+- Cross-project traffic uses public HTTPS + tokens, not private networking.
+  Railway projects are isolated from each other by default.
+
+---
+
+## Self-Critique: Phase 1 (Fork Sanity Check)
+
+**Brittle:** The Dockerfile's final `CMD` calls `tsx` as a loader
+(`--import ./server/node_modules/tsx/dist/loader.mjs`). If the tsx version in
+`server/node_modules` diverges from what was tested, the server silently fails.
+Mitigation: pin tsx in `server/package.json` and lock with `pnpm-lock.yaml`.
+
+**Secret-leak risk:** None specific to this phase — no secrets are in the repo.
+
+**Recovery:** If the production build fails, Railway will show the build log.
+Fix the build locally (`pnpm build`) before pushing.
+
+## Self-Critique: Phase 2 (Railway & Caddy)
+
+**Brittle:** `ggicci/caddy-jwt` is a community plugin; its `jwtauth` directive
+config syntax could change between patch versions. Pin the xcaddy build to a
+specific tag: `--with github.com/ggicci/caddy-jwt/v3@v3.x.y`. Check the
+plugin's release page before each Caddy upgrade.
+
+**Secret-leak risk:** `SESSION_JWT_SECRET` in Railway env vars — Railway
+encrypts these at rest. Risk is low but rotate quarterly.
+
+**Auth enforced?** Test with `curl -I https://app.ops.binelek.io/` — Caddy must
+return `HTTP/2 302` to `ops.binelek.io/login`, not 200.
+
+**If Caddy's JWT validation fails open (bug):** All traffic reaches Paperclip
+unauthenticated. Paperclip is in `local_trusted` mode — it does not
+authenticate requests. This would be a full exposure. Mitigation: run the
+lock-down smoke test in §8 after every Caddy config change.
+
+## Self-Critique: Phase 3 (Vercel ops-portal)
+
+**Brittle:** Next.js 14 App Router + next-auth v5 beta — the beta status means
+breaking changes are possible. Lock next-auth to an exact beta version in
+`package.json` and test on every dependency update.
+
+**Secret-leak risk:** `CADDY_SESSION_JWT_SECRET` in Vercel env vars. If a
+Vercel Function's response body accidentally includes a `console.log` dump of
+`process.env`, the secret leaks in Vercel's function logs. The current code does
+not log env vars. Keep it that way.
+
+**Session state disagreement:** If Zitadel invalidates a user (e.g., account
+disabled) but the `jaban_session` cookie is still valid (up to 8 h), Caddy
+continues to grant access until the cookie expires. Mitigation: keep the JWT
+TTL at 8 h (not longer) and implement a Zitadel webhook → Railway endpoint to
+revoke specific cookies on account suspension (future work).
+
+**WebSocket reliability:** Auth happens at the cookie level. Once Caddy
+accepts the cookie, WebSocket connections to Paperclip are long-lived and not
+re-checked. If the cookie expires during an active WebSocket session, the
+connection persists until the browser closes it or reconnects. This is
+acceptable behavior — Paperclip's client reconnects automatically.

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,47 @@
+{
+	email {$ACME_EMAIL}
+	log {
+		output stdout
+		format json
+		level INFO
+	}
+	order jwtauth before reverse_proxy
+}
+
+app.ops.binelek.io {
+	# Validate the session JWT minted by ops-portal on Vercel.
+	# Cookie name: jaban_session  Domain: .binelek.io  Algorithm: HS256
+	jwtauth {
+		sign_key    {$SESSION_JWT_SECRET}
+		sign_alg    HS256
+		from_cookies jaban_session
+		issuer_allow ops-portal-vercel
+		audience_allow paperclip-ops-caddy
+		user_claims  email sub
+	}
+
+	# Missing or invalid token → redirect to Vercel login
+	handle_errors 401 {
+		redir https://ops.binelek.io/login 302
+	}
+
+	# WebSocket upgrades pass through without body buffering
+	@websocket {
+		header Connection *Upgrade*
+		header Upgrade    websocket
+	}
+	reverse_proxy @websocket {$PAPERCLIP_UPSTREAM} {
+		header_up Host             {host}
+		header_up X-Real-IP        {remote_host}
+		header_up X-Forwarded-For  {remote_host}
+		header_up X-Forwarded-Proto https
+	}
+
+	reverse_proxy {$PAPERCLIP_UPSTREAM} {
+		header_up Host                  {host}
+		header_up X-Real-IP             {remote_host}
+		header_up X-Forwarded-For       {remote_host}
+		header_up X-Forwarded-Proto     https
+		header_up X-Authenticated-User  {http.auth.user.email}
+	}
+}

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -12,12 +12,9 @@ app.ops.binelek.io {
 	# Validate the session JWT minted by ops-portal on Vercel.
 	# Cookie name: jaban_session  Domain: .binelek.io  Algorithm: HS256
 	jwtauth {
-		sign_key    {$SESSION_JWT_SECRET}
-		sign_alg    HS256
+		sign_key     {$SESSION_JWT_SECRET}
+		sign_alg     HS256
 		from_cookies jaban_session
-		issuer_allow ops-portal-vercel
-		audience_allow paperclip-ops-caddy
-		user_claims  email sub
 	}
 
 	# Missing or invalid token → redirect to Vercel login

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1.20
+FROM caddy:2-builder-alpine AS builder
+
+RUN xcaddy build \
+    --with github.com/ggicci/caddy-jwt/v3
+
+FROM caddy:2-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+COPY Caddyfile /etc/caddy/Caddyfile
+
+EXPOSE 443

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -7,52 +7,53 @@ RUN xcaddy build \
 FROM caddy:2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 
-# Caddyfile is inlined so the image builds correctly regardless of whether
-# Railway uses the repo root or docker/caddy/ as the build context.
-RUN printf '%s\n' \
-    '{' \
-    '	email {$ACME_EMAIL}' \
-    '	log {' \
-    '		output stdout' \
-    '		format json' \
-    '		level INFO' \
-    '	}' \
-    '	order jwtauth before reverse_proxy' \
-    '}' \
-    '' \
-    'app.ops.binelek.io {' \
-    '	jwtauth {' \
-    '		sign_key       {$SESSION_JWT_SECRET}' \
-    '		sign_alg       HS256' \
-    '		from_cookies   jaban_session' \
-    '		issuer_allow   ops-portal-vercel' \
-    '		audience_allow paperclip-ops-caddy' \
-    '		user_claims    email sub' \
-    '	}' \
-    '' \
-    '	handle_errors 401 {' \
-    '		redir https://ops.binelek.io/login 302' \
-    '	}' \
-    '' \
-    '	@websocket {' \
-    '		header Connection *Upgrade*' \
-    '		header Upgrade    websocket' \
-    '	}' \
-    '	reverse_proxy @websocket {$PAPERCLIP_UPSTREAM} {' \
-    '		header_up Host              {host}' \
-    '		header_up X-Real-IP         {remote_host}' \
-    '		header_up X-Forwarded-For   {remote_host}' \
-    '		header_up X-Forwarded-Proto https' \
-    '	}' \
-    '' \
-    '	reverse_proxy {$PAPERCLIP_UPSTREAM} {' \
-    '		header_up Host                 {host}' \
-    '		header_up X-Real-IP            {remote_host}' \
-    '		header_up X-Forwarded-For      {remote_host}' \
-    '		header_up X-Forwarded-Proto    https' \
-    '		header_up X-Authenticated-User {http.auth.user.email}' \
-    '	}' \
-    '}' \
-    > /etc/caddy/Caddyfile
+# Caddyfile inlined via BuildKit heredoc — avoids build-context COPY issues
+# and ensures exact whitespace.  {$VAR} placeholders are substituted by Caddy
+# at container startup using the service's environment variables.
+COPY <<'CADDYFILE' /etc/caddy/Caddyfile
+{
+	email {$ACME_EMAIL}
+	log {
+		output stdout
+		format json
+		level INFO
+	}
+	order jwtauth before reverse_proxy
+}
+
+app.ops.binelek.io {
+	jwtauth {
+		sign_key       {$SESSION_JWT_SECRET}
+		sign_alg       HS256
+		from_cookies   jaban_session
+		issuer_allow   ops-portal-vercel
+		audience_allow paperclip-ops-caddy
+		user_claims    email sub
+	}
+
+	handle_errors 401 {
+		redir https://ops.binelek.io/login 302
+	}
+
+	@websocket {
+		header Connection *Upgrade*
+		header Upgrade websocket
+	}
+	reverse_proxy @websocket {$PAPERCLIP_UPSTREAM} {
+		header_up Host              {host}
+		header_up X-Real-IP        {remote_host}
+		header_up X-Forwarded-For  {remote_host}
+		header_up X-Forwarded-Proto https
+	}
+
+	reverse_proxy {$PAPERCLIP_UPSTREAM} {
+		header_up Host                 {host}
+		header_up X-Real-IP            {remote_host}
+		header_up X-Forwarded-For      {remote_host}
+		header_up X-Forwarded-Proto    https
+		header_up X-Authenticated-User {http.auth.user.email}
+	}
+}
+CADDYFILE
 
 EXPOSE 443

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -6,6 +6,53 @@ RUN xcaddy build \
 
 FROM caddy:2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
-COPY Caddyfile /etc/caddy/Caddyfile
+
+# Caddyfile is inlined so the image builds correctly regardless of whether
+# Railway uses the repo root or docker/caddy/ as the build context.
+RUN printf '%s\n' \
+    '{' \
+    '	email {$ACME_EMAIL}' \
+    '	log {' \
+    '		output stdout' \
+    '		format json' \
+    '		level INFO' \
+    '	}' \
+    '	order jwtauth before reverse_proxy' \
+    '}' \
+    '' \
+    'app.ops.binelek.io {' \
+    '	jwtauth {' \
+    '		sign_key       {$SESSION_JWT_SECRET}' \
+    '		sign_alg       HS256' \
+    '		from_cookies   jaban_session' \
+    '		issuer_allow   ops-portal-vercel' \
+    '		audience_allow paperclip-ops-caddy' \
+    '		user_claims    email sub' \
+    '	}' \
+    '' \
+    '	handle_errors 401 {' \
+    '		redir https://ops.binelek.io/login 302' \
+    '	}' \
+    '' \
+    '	@websocket {' \
+    '		header Connection *Upgrade*' \
+    '		header Upgrade    websocket' \
+    '	}' \
+    '	reverse_proxy @websocket {$PAPERCLIP_UPSTREAM} {' \
+    '		header_up Host              {host}' \
+    '		header_up X-Real-IP         {remote_host}' \
+    '		header_up X-Forwarded-For   {remote_host}' \
+    '		header_up X-Forwarded-Proto https' \
+    '	}' \
+    '' \
+    '	reverse_proxy {$PAPERCLIP_UPSTREAM} {' \
+    '		header_up Host                 {host}' \
+    '		header_up X-Real-IP            {remote_host}' \
+    '		header_up X-Forwarded-For      {remote_host}' \
+    '		header_up X-Forwarded-Proto    https' \
+    '		header_up X-Authenticated-User {http.auth.user.email}' \
+    '	}' \
+    '}' \
+    > /etc/caddy/Caddyfile
 
 EXPOSE 443

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -2,7 +2,7 @@
 FROM caddy:2-builder-alpine AS builder
 
 RUN xcaddy build \
-    --with github.com/ggicci/caddy-jwt/v3
+    --with github.com/ggicci/caddy-jwt
 
 FROM caddy:2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -23,12 +23,9 @@ COPY <<'CADDYFILE' /etc/caddy/Caddyfile
 
 app.ops.binelek.io {
 	jwtauth {
-		sign_key       {$SESSION_JWT_SECRET}
-		sign_alg       HS256
-		from_cookies   jaban_session
-		issuer_allow   ops-portal-vercel
-		audience_allow paperclip-ops-caddy
-		user_claims    email sub
+		sign_key     {$SESSION_JWT_SECRET}
+		sign_alg     HS256
+		from_cookies jaban_session
 	}
 
 	handle_errors 401 {

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,7 +1,18 @@
+# syntax=docker/dockerfile:1.20
 FROM node:lts-alpine
 RUN npm install -g @anthropic-ai/claude-code@latest
-COPY run.sh /run.sh
+
+COPY <<'EOF' /run.sh
+#!/bin/sh
+echo "=== claude setup-token starting ==="
+echo "=== Watch here for the auth URL ==="
+echo ""
+claude setup-token 2>&1
+echo ""
+echo "=== Done. Copy the token above, then delete this Railway service ==="
+sleep infinity
+EOF
+
 RUN chmod +x /run.sh
-# Unbuffered so every line appears in Railway logs immediately
-ENV NODE_NO_WARNINGS=1 PYTHONUNBUFFERED=1
-CMD ["/bin/sh", "-c", "exec /run.sh"]
+ENV NODE_NO_WARNINGS=1
+CMD ["/run.sh"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -4,12 +4,15 @@ RUN npm install -g @anthropic-ai/claude-code@latest
 
 COPY <<'EOF' /run.sh
 #!/bin/sh
+# Satisfy Railway's health check so the service shows "Running" and logs appear
+node -e "require('http').createServer((_,r)=>r.end('ok')).listen(process.env.PORT||3000,()=>console.log('health ok'))" &
+
 echo "=== claude setup-token starting ==="
-echo "=== Watch here for the auth URL ==="
+echo "=== Watch here for the auth URL, visit it in your browser ==="
 echo ""
 claude setup-token 2>&1
 echo ""
-echo "=== Done. Copy the token above, then delete this Railway service ==="
+echo "=== Done. Copy the token above then delete this Railway service ==="
 sleep infinity
 EOF
 

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:lts-alpine
+RUN npm install -g @anthropic-ai/claude-code@latest
+# Force unbuffered output so the auth URL and token appear in Railway logs immediately
+ENV NODE_NO_WARNINGS=1
+CMD ["claude", "setup-token"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -76,11 +76,15 @@ const HTML = `<!DOCTYPE html>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
   <style>
     *{box-sizing:border-box}
-    body{background:#1a1a1a;margin:0;padding:20px;font-family:monospace;color:#ddd}
-    h2{color:#a78bfa;margin:0 0 8px}
-    .note{color:#fbbf24;font-size:13px;margin:0 0 12px}
-    #tc{border:1px solid #444;border-radius:4px;overflow:hidden}
-    .creds{background:#0a1f0a;border:2px solid #22c55e;padding:16px;margin-top:16px;border-radius:4px}
+    html,body{height:100%;margin:0;padding:0;background:#1a1a1a;color:#ddd;font-family:monospace}
+    body{display:flex;flex-direction:column;padding:16px;gap:10px}
+    h2{color:#a78bfa;margin:0}
+    .note{color:#fbbf24;font-size:13px;margin:0}
+    #status{font-size:12px;color:#888}
+    #status.ok{color:#22c55e}
+    #status.err{color:#f87171}
+    #tc{flex:1;min-height:500px;border:1px solid #444;border-radius:4px;overflow:hidden}
+    .creds{background:#0a1f0a;border:2px solid #22c55e;padding:16px;border-radius:4px}
     .creds pre{color:#22c55e;white-space:pre-wrap;word-break:break-all;margin:8px 0;font-size:13px;background:#000;padding:12px;border-radius:3px}
     .btn{margin-top:10px;padding:8px 18px;background:#7c3aed;color:#fff;border:none;cursor:pointer;border-radius:4px;font-size:14px}
     .btn:hover{background:#6d28d9}
@@ -89,44 +93,62 @@ const HTML = `<!DOCTYPE html>
 </head>
 <body>
   <h2>Claude Auth</h2>
-  <p class="note">Full interactive terminal &mdash; use arrow keys to pick a theme, Enter to confirm, then follow the login prompts.</p>
+  <p class="note">Interactive terminal &mdash; use arrow keys + Enter to pick a theme, then follow the login prompts.</p>
+  <div id="status">Connecting...</div>
   <div id="tc"></div>
   <div id="creds" style="display:none" class="creds">
     <strong style="color:#22c55e">&#10003; Login complete!</strong><br>
-    Copy the JSON below and set it as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service env vars), then redeploy Paperclip.
+    Copy the JSON below &rarr; set as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service), then redeploy Paperclip.
     <pre id="cj"></pre>
-    <button class="btn" onclick="navigator.clipboard.writeText(document.getElementById('cj').textContent).then(()=>this.textContent='Copied!')">Copy to clipboard</button>
+    <button class="btn" id="copybtn" onclick="navigator.clipboard.writeText(document.getElementById('cj').textContent).then(()=>document.getElementById('copybtn').textContent='Copied!')">Copy to clipboard</button>
     <button class="btn" onclick="location.href='/restart'">Restart login</button>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
   <script>
+    const statusEl = document.getElementById('status');
+    const tc = document.getElementById('tc');
+
     const term = new Terminal({
       theme:{background:'#000000',foreground:'#dddddd'},
-      cursorBlink:true, fontSize:14, fontFamily:'monospace', scrollback:2000
+      cursorBlink:true,
+      fontSize:14,
+      fontFamily:'"Cascadia Code","Fira Mono",monospace',
+      scrollback:2000
     });
     const fit = new FitAddon.FitAddon();
     term.loadAddon(fit);
-    term.open(document.getElementById('tc'));
-    fit.fit();
+    term.open(tc);
+    // Give the DOM a tick to lay out before fitting
+    requestAnimationFrame(() => { fit.fit(); term.focus(); });
 
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const ws = new WebSocket(proto + '//' + location.host + '/ws');
 
-    ws.onopen = () => ws.send(JSON.stringify({type:'resize',cols:term.cols,rows:term.rows}));
+    ws.onopen = () => {
+      statusEl.textContent = 'Connected';
+      statusEl.className = 'ok';
+      ws.send(JSON.stringify({type:'resize',cols:term.cols,rows:term.rows}));
+    };
     ws.onmessage = e => {
       const m = JSON.parse(e.data);
-      if (m.type === 'data' || m.type === 'history') term.write(m.data);
-      else if (m.type === 'creds') {
+      if (m.type === 'data' || m.type === 'history') {
+        term.write(m.data);
+      } else if (m.type === 'creds') {
         document.getElementById('cj').textContent = m.data;
         document.getElementById('creds').style.display = 'block';
       }
     };
-    ws.onclose = () => term.writeln('\r\n\r\n[Disconnected — reload to reconnect]');
+    ws.onerror = () => { statusEl.textContent = 'WebSocket error'; statusEl.className = 'err'; };
+    ws.onclose = () => {
+      statusEl.textContent = 'Disconnected — reload to reconnect';
+      statusEl.className = 'err';
+      term.writeln('\r\n\r\n[Disconnected — reload to reconnect]');
+    };
 
     term.onData(d => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'data',data:d})); });
     term.onResize(({cols,rows}) => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'resize',cols,rows})); });
-    window.addEventListener('resize', () => fit.fit());
+    window.addEventListener('resize', () => { fit.fit(); });
   </script>
 </body>
 </html>`;

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,17 +1,23 @@
 # syntax=docker/dockerfile:1.20
 FROM node:lts-alpine
-# util-linux provides `script` which creates a PTY for claude login
-RUN apk add --no-cache util-linux && \
+
+# Build tools needed to compile node-pty native module
+RUN apk add --no-cache python3 make g++ linux-headers && \
     npm install -g @anthropic-ai/claude-code@latest
+
+# Install server dependencies (node-pty compiles a native addon here)
+WORKDIR /app
+RUN npm init -y && npm install node-pty ws
 
 # Pre-seed settings so Claude skips the first-run theme wizard
 RUN mkdir -p /root/.claude && \
     printf '{"theme":"dark","hasCompletedOnboarding":true,"onboardingVersion":5}\n' \
     > /root/.claude/settings.json
 
-COPY <<'SERVER' /server.js
+COPY <<'SERVER' /app/server.js
 const http = require('http');
-const { spawn } = require('child_process');
+const { WebSocketServer } = require('ws');
+const pty = require('node-pty');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -19,121 +25,140 @@ const os = require('os');
 const PORT = process.env.PORT || 3000;
 const CRED_PATH = path.join(os.homedir(), '.claude', '.credentials.json');
 
-let lines = [];
-let proc = null;
+let ptyProc = null;
+let outputBuf = '';
+const clients = new Set();
 
-function strip(s) {
-  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\r/g, '');
+function broadcast(msg) {
+  const s = JSON.stringify(msg);
+  for (const c of clients) if (c.readyState === 1) c.send(s);
+}
+
+function checkCreds() {
+  if (fs.existsSync(CRED_PATH)) {
+    try { broadcast({ type: 'creds', data: fs.readFileSync(CRED_PATH, 'utf8') }); } catch(_) {}
+  }
 }
 
 function startLogin() {
-  lines.push('[Starting claude login...]\n');
-  // script -q -e -c CMD /dev/null runs CMD inside a PTY so claude login
-  // doesn't detect a non-interactive terminal and bail immediately.
-  // stdin of `script` is forwarded into the PTY (used to send the auth code).
-  proc = spawn('script', ['-q', '-e', '-c', 'claude login', '/dev/null'], {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0' }
+  outputBuf = '';
+  if (ptyProc) { try { ptyProc.kill(); } catch(_) {} ptyProc = null; }
+
+  ptyProc = pty.spawn('claude', ['login'], {
+    name: 'xterm-color',
+    cols: 120,
+    rows: 40,
+    cwd: '/',
+    env: { ...process.env }
   });
 
-  proc.stdout.on('data', d => { lines.push(strip(d.toString())); });
-  proc.stderr.on('data', d => { lines.push(strip(d.toString())); });
+  ptyProc.onData(data => {
+    outputBuf += data;
+    broadcast({ type: 'data', data });
+    checkCreds();
+  });
 
-  proc.on('exit', code => {
-    lines.push(`\n[claude login exited: ${code}]\n`);
-    if (fs.existsSync(CRED_PATH)) {
-      const c = fs.readFileSync(CRED_PATH, 'utf8');
-      lines.push('\n__CREDS__\n' + c + '\n__CREDS__\n');
-    }
+  ptyProc.onExit(({ exitCode }) => {
+    const msg = `\r\n[claude login exited: ${exitCode}]\r\n`;
+    outputBuf += msg;
+    broadcast({ type: 'data', data: msg });
+    checkCreds();
   });
 }
 
 startLogin();
 
-function submitCode(code) {
-  if (proc && proc.stdin.writable) {
-    proc.stdin.write(code.trim() + '\n');
-    lines.push(`[Submitted code]\n`);
-  }
-}
-
-const HTML = (body) => `<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>Claude Auth</title>
-<meta http-equiv="refresh" content="4">
-<style>
-  body{font-family:monospace;background:#111;color:#ddd;padding:24px;max-width:900px;margin:0 auto}
-  h2{color:#a78bfa}
-  pre{background:#000;padding:16px;white-space:pre-wrap;word-break:break-all;max-height:420px;overflow-y:auto;border:1px solid #333;font-size:13px}
-  input{width:100%;box-sizing:border-box;padding:10px;font-size:15px;background:#000;color:#ddd;border:1px solid #555;margin-bottom:12px}
-  button{padding:10px 24px;background:#7c3aed;color:#fff;border:none;cursor:pointer;font-size:15px;border-radius:4px}
-  .ok{border:2px solid #22c55e;padding:16px;margin-top:16px;background:#0a1f0a}
-  .ok pre{max-height:none}
-  .step{color:#fbbf24;margin:4px 0}
-</style></head><body>${body}</body></html>`;
-
-http.createServer((req, res) => {
-  if (req.method === 'POST' && req.url === '/code') {
-    let b = '';
-    req.on('data', d => b += d);
-    req.on('end', () => {
-      submitCode(new URLSearchParams(b).get('code') || '');
-      res.writeHead(302, { Location: '/' });
-      res.end();
+const HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Claude Auth</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
+  <style>
+    *{box-sizing:border-box}
+    body{background:#1a1a1a;margin:0;padding:20px;font-family:monospace;color:#ddd}
+    h2{color:#a78bfa;margin:0 0 8px}
+    .note{color:#fbbf24;font-size:13px;margin:0 0 12px}
+    #tc{border:1px solid #444;border-radius:4px;overflow:hidden}
+    .creds{background:#0a1f0a;border:2px solid #22c55e;padding:16px;margin-top:16px;border-radius:4px}
+    .creds pre{color:#22c55e;white-space:pre-wrap;word-break:break-all;margin:8px 0;font-size:13px;background:#000;padding:12px;border-radius:3px}
+    .btn{margin-top:10px;padding:8px 18px;background:#7c3aed;color:#fff;border:none;cursor:pointer;border-radius:4px;font-size:14px}
+    .btn:hover{background:#6d28d9}
+    .btn+.btn{margin-left:8px}
+  </style>
+</head>
+<body>
+  <h2>Claude Auth</h2>
+  <p class="note">Full interactive terminal &mdash; use arrow keys to pick a theme, Enter to confirm, then follow the login prompts.</p>
+  <div id="tc"></div>
+  <div id="creds" style="display:none" class="creds">
+    <strong style="color:#22c55e">&#10003; Login complete!</strong><br>
+    Copy the JSON below and set it as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service env vars), then redeploy Paperclip.
+    <pre id="cj"></pre>
+    <button class="btn" onclick="navigator.clipboard.writeText(document.getElementById('cj').textContent).then(()=>this.textContent='Copied!')">Copy to clipboard</button>
+    <button class="btn" onclick="location.href='/restart'">Restart login</button>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
+  <script>
+    const term = new Terminal({
+      theme:{background:'#000000',foreground:'#dddddd'},
+      cursorBlink:true, fontSize:14, fontFamily:'monospace', scrollback:2000
     });
-    return;
-  }
+    const fit = new FitAddon.FitAddon();
+    term.loadAddon(fit);
+    term.open(document.getElementById('tc'));
+    fit.fit();
 
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(proto + '//' + location.host + '/ws');
+
+    ws.onopen = () => ws.send(JSON.stringify({type:'resize',cols:term.cols,rows:term.rows}));
+    ws.onmessage = e => {
+      const m = JSON.parse(e.data);
+      if (m.type === 'data' || m.type === 'history') term.write(m.data);
+      else if (m.type === 'creds') {
+        document.getElementById('cj').textContent = m.data;
+        document.getElementById('creds').style.display = 'block';
+      }
+    };
+    ws.onclose = () => term.writeln('\r\n\r\n[Disconnected — reload to reconnect]');
+
+    term.onData(d => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'data',data:d})); });
+    term.onResize(({cols,rows}) => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'resize',cols,rows})); });
+    window.addEventListener('resize', () => fit.fit());
+  </script>
+</body>
+</html>`;
+
+const server = http.createServer((req, res) => {
   if (req.url === '/restart') {
-    lines = [];
-    if (proc) try { proc.kill(); } catch(_) {}
     startLogin();
     res.writeHead(302, { Location: '/' });
     res.end();
     return;
   }
-
   res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end(HTML);
+});
 
-  const all = lines.join('');
-  const credsMatch = all.match(/__CREDS__\n([\s\S]+?)\n__CREDS__/);
-  const output = all.replace(/__CREDS__[\s\S]*__CREDS__/g, '').trim();
-  const urlMatch = output.match(/https:\/\/claude\.ai\/[^\s\n"]+/);
-  const url = urlMatch ? urlMatch[0] : null;
+const wss = new WebSocketServer({ server, path: '/ws' });
+wss.on('connection', ws => {
+  clients.add(ws);
+  if (outputBuf) ws.send(JSON.stringify({ type: 'history', data: outputBuf }));
+  checkCreds();
+  ws.on('message', raw => {
+    try {
+      const m = JSON.parse(raw);
+      if (m.type === 'data' && ptyProc) ptyProc.write(m.data);
+      else if (m.type === 'resize' && ptyProc) ptyProc.resize(m.cols, m.rows);
+    } catch(_) {}
+  });
+  ws.on('close', () => clients.delete(ws));
+});
 
-  if (credsMatch) {
-    res.end(HTML(`
-      <h2>&#10003; Claude Login Complete</h2>
-      <div class="ok">
-        <strong style="color:#22c55e">Copy the JSON below and set it as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service):</strong>
-        <pre>${credsMatch[1].replace(/</g,'&lt;')}</pre>
-      </div>
-      <p>Then remove <code>CLAUDE_CODE_OAUTH_TOKEN</code> if set, and redeploy the Paperclip service.</p>
-      <p><a href="/restart" style="color:#a78bfa">Restart login</a></p>
-    `));
-    return;
-  }
-
-  res.end(HTML(`
-    <h2>Claude Auth Helper</h2>
-    <p class="step">Auto-refreshes every 4s. Waiting for the login URL...</p>
-
-    ${url ? `
-    <p style="margin:12px 0"><strong>Step 1:</strong>
-      <a href="${url}" target="_blank" style="color:#60a5fa;word-break:break-all">${url}</a>
-    </p>
-    <p class="step">Step 2: Authorize in your browser. If it shows a code, paste it below.</p>
-    <form method="POST" action="/code">
-      <input name="code" placeholder="Paste the code shown by your browser here" autofocus>
-      <button type="submit">Submit Code</button>
-    </form>
-    ` : `<p class="step">Waiting for Claude to print the login URL...</p>`}
-
-    <h3>Claude output:</h3>
-    <pre>${output.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</pre>
-    <p><a href="/restart" style="color:#a78bfa">Restart login</a></p>
-  `));
-}).listen(PORT, () => console.log(`Claude auth helper on port ${PORT}`));
+server.listen(PORT, () => console.log('Claude auth terminal on port ' + PORT));
 SERVER
 
 ENV NODE_NO_WARNINGS=1
-CMD ["node", "/server.js"]
+CMD ["node", "/app/server.js"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -4,18 +4,27 @@ RUN npm install -g @anthropic-ai/claude-code@latest
 
 COPY <<'EOF' /run.sh
 #!/bin/sh
-# Satisfy Railway's health check so the service shows "Running" and logs appear
-node -e "require('http').createServer((_,r)=>r.end('ok')).listen(process.env.PORT||3000,()=>console.log('health ok'))" &
+node -e "require('http').createServer((_,r)=>r.end('ok')).listen(process.env.PORT||3000)" &
 
-echo "=== claude setup-token starting ==="
-echo "=== Watch here for the auth URL, visit it in your browser ==="
+echo "=== claude version ==="
+claude --version 2>&1
 echo ""
-claude setup-token 2>&1
+
+echo "=== attempting claude login (will print auth URL) ==="
+# Use script(1) to allocate a pseudo-TTY so claude doesn't bail in headless
+script -q -c "claude login" /dev/null 2>&1
+echo "exit: $?"
 echo ""
-echo "=== Done. Copy the token above then delete this Railway service ==="
+
+echo "=== attempting claude setup-token ==="
+script -q -c "claude setup-token" /dev/null 2>&1
+echo "exit: $?"
+
+echo "=== Done. Copy token above then delete this service ==="
 sleep infinity
 EOF
 
 RUN chmod +x /run.sh
-ENV NODE_NO_WARNINGS=1
+RUN apk add --no-cache util-linux
+ENV NODE_NO_WARNINGS=1 TERM=xterm-256color
 CMD ["/run.sh"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -5,9 +5,9 @@ FROM node:lts-alpine
 RUN apk add --no-cache python3 make g++ linux-headers && \
     npm install -g @anthropic-ai/claude-code@latest
 
-# Install server dependencies (node-pty compiles a native addon here)
+# Install server dependencies
 WORKDIR /app
-RUN npm init -y && npm install node-pty ws
+RUN npm init -y && npm install node-pty
 
 # Pre-seed settings so Claude skips the first-run theme wizard
 RUN mkdir -p /root/.claude && \
@@ -16,7 +16,6 @@ RUN mkdir -p /root/.claude && \
 
 COPY <<'SERVER' /app/server.js
 const http = require('http');
-const { WebSocketServer } = require('ws');
 const pty = require('node-pty');
 const fs = require('fs');
 const path = require('path');
@@ -27,11 +26,14 @@ const CRED_PATH = path.join(os.homedir(), '.claude', '.credentials.json');
 
 let ptyProc = null;
 let outputBuf = '';
-const clients = new Set();
+const sseClients = new Set();
+
+function sseWrite(res, msg) {
+  try { res.write('data: ' + JSON.stringify(msg) + '\n\n'); } catch(_) {}
+}
 
 function broadcast(msg) {
-  const s = JSON.stringify(msg);
-  for (const c of clients) if (c.readyState === 1) c.send(s);
+  for (const c of sseClients) sseWrite(c, msg);
 }
 
 function checkCreds() {
@@ -59,7 +61,7 @@ function startLogin() {
   });
 
   ptyProc.onExit(({ exitCode }) => {
-    const msg = `\r\n[claude login exited: ${exitCode}]\r\n`;
+    const msg = '\r\n[claude login exited: ' + exitCode + ']\r\n';
     outputBuf += msg;
     broadcast({ type: 'data', data: msg });
     checkCreds();
@@ -68,118 +70,109 @@ function startLogin() {
 
 startLogin();
 
-const HTML = `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>Claude Auth</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
-  <style>
-    *{box-sizing:border-box}
-    html,body{height:100%;margin:0;padding:0;background:#1a1a1a;color:#ddd;font-family:monospace}
-    body{display:flex;flex-direction:column;padding:16px;gap:10px}
-    h2{color:#a78bfa;margin:0}
-    .note{color:#fbbf24;font-size:13px;margin:0}
-    #status{font-size:12px;color:#888}
-    #status.ok{color:#22c55e}
-    #status.err{color:#f87171}
-    #tc{flex:1;min-height:500px;border:1px solid #444;border-radius:4px;overflow:hidden}
-    .creds{background:#0a1f0a;border:2px solid #22c55e;padding:16px;border-radius:4px}
-    .creds pre{color:#22c55e;white-space:pre-wrap;word-break:break-all;margin:8px 0;font-size:13px;background:#000;padding:12px;border-radius:3px}
-    .btn{margin-top:10px;padding:8px 18px;background:#7c3aed;color:#fff;border:none;cursor:pointer;border-radius:4px;font-size:14px}
-    .btn:hover{background:#6d28d9}
-    .btn+.btn{margin-left:8px}
-  </style>
-</head>
-<body>
-  <h2>Claude Auth</h2>
-  <p class="note">Interactive terminal &mdash; use arrow keys + Enter to pick a theme, then follow the login prompts.</p>
-  <div id="status">Connecting...</div>
-  <div id="tc"></div>
-  <div id="creds" style="display:none" class="creds">
-    <strong style="color:#22c55e">&#10003; Login complete!</strong><br>
-    Copy the JSON below &rarr; set as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service), then redeploy Paperclip.
-    <pre id="cj"></pre>
-    <button class="btn" id="copybtn" onclick="navigator.clipboard.writeText(document.getElementById('cj').textContent).then(()=>document.getElementById('copybtn').textContent='Copied!')">Copy to clipboard</button>
-    <button class="btn" onclick="location.href='/restart'">Restart login</button>
-  </div>
-  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
-  <script>
-    const statusEl = document.getElementById('status');
-    const tc = document.getElementById('tc');
+const HTML = '<!DOCTYPE html>\n\
+<html>\n\
+<head>\n\
+  <meta charset="utf-8">\n\
+  <title>Claude Auth</title>\n\
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">\n\
+  <style>\n\
+    *{box-sizing:border-box}\n\
+    html,body{height:100%;margin:0;padding:0;background:#1a1a1a;color:#ddd;font-family:monospace}\n\
+    body{display:flex;flex-direction:column;padding:16px;gap:8px}\n\
+    h2{color:#a78bfa;margin:0}\n\
+    .note{color:#fbbf24;font-size:13px;margin:0}\n\
+    #status{font-size:12px;color:#888}\n\
+    #tc{flex:1;min-height:400px;border:1px solid #444;border-radius:4px;overflow:hidden}\n\
+    .creds{background:#0a1f0a;border:2px solid #22c55e;padding:16px;border-radius:4px}\n\
+    .creds pre{color:#22c55e;white-space:pre-wrap;word-break:break-all;margin:8px 0;font-size:13px;background:#000;padding:12px;border-radius:3px}\n\
+    .btn{margin-top:10px;padding:8px 18px;background:#7c3aed;color:#fff;border:none;cursor:pointer;border-radius:4px;font-size:14px}\n\
+    .btn:hover{background:#6d28d9}\n\
+    .btn+.btn{margin-left:8px}\n\
+  </style>\n\
+</head>\n\
+<body>\n\
+  <h2>Claude Auth</h2>\n\
+  <p class="note">Interactive terminal — use arrow keys + Enter to select a theme, then follow the login prompts.</p>\n\
+  <div id="status">Connecting...</div>\n\
+  <div id="tc"></div>\n\
+  <div id="creds" style="display:none" class="creds">\n\
+    <strong style="color:#22c55e">&#10003; Login complete!</strong><br>\n\
+    Copy the JSON below and set as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service), then redeploy Paperclip.\n\
+    <pre id="cj"></pre>\n\
+    <button class="btn" id="copybtn">Copy to clipboard</button>\n\
+    <button class="btn" onclick="location.href=\'/restart\'">Restart login</button>\n\
+  </div>\n\
+  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>\n\
+  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>\n\
+  <script>\n\
+    var term = new Terminal({theme:{background:"#000"},cursorBlink:true,fontSize:14,scrollback:2000});\n\
+    var fit = new FitAddon.FitAddon();\n\
+    term.loadAddon(fit);\n\
+    term.open(document.getElementById("tc"));\n\
+    requestAnimationFrame(function(){ fit.fit(); term.focus(); });\n\
+    window.addEventListener("resize", function(){ fit.fit(); });\n\
+\n\
+    var statusEl = document.getElementById("status");\n\
+    var es = new EventSource("/events");\n\
+    es.onopen = function(){ statusEl.textContent = "Connected"; statusEl.style.color = "#22c55e"; };\n\
+    es.onerror = function(){ statusEl.textContent = "Connection error — reload to retry"; statusEl.style.color = "#f87171"; };\n\
+    es.onmessage = function(e){\n\
+      var m = JSON.parse(e.data);\n\
+      if(m.type==="data"||m.type==="history"){ term.write(m.data); }\n\
+      else if(m.type==="creds"){\n\
+        document.getElementById("cj").textContent = m.data;\n\
+        document.getElementById("creds").style.display = "block";\n\
+        document.getElementById("copybtn").onclick = function(){\n\
+          navigator.clipboard.writeText(m.data).then(function(){ document.getElementById("copybtn").textContent="Copied!"; });\n\
+        };\n\
+      }\n\
+    };\n\
+\n\
+    term.onData(function(d){\n\
+      fetch("/input", {method:"POST", body:d, headers:{"Content-Type":"application/octet-stream"}});\n\
+    });\n\
+  </script>\n\
+</body>\n\
+</html>';
 
-    const term = new Terminal({
-      theme:{background:'#000000',foreground:'#dddddd'},
-      cursorBlink:true,
-      fontSize:14,
-      fontFamily:'"Cascadia Code","Fira Mono",monospace',
-      scrollback:2000
+http.createServer((req, res) => {
+  if (req.url === '/events') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no'
     });
-    const fit = new FitAddon.FitAddon();
-    term.loadAddon(fit);
-    term.open(tc);
-    // Give the DOM a tick to lay out before fitting
-    requestAnimationFrame(() => { fit.fit(); term.focus(); });
+    res.write(':\n\n'); // initial comment to open the connection
+    if (outputBuf) sseWrite(res, { type: 'history', data: outputBuf });
+    checkCreds();
+    sseClients.add(res);
+    req.on('close', () => sseClients.delete(res));
+    return;
+  }
 
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const ws = new WebSocket(proto + '//' + location.host + '/ws');
+  if (req.method === 'POST' && req.url === '/input') {
+    let body = '';
+    req.on('data', d => body += d);
+    req.on('end', () => {
+      if (ptyProc) ptyProc.write(body);
+      res.writeHead(204);
+      res.end();
+    });
+    return;
+  }
 
-    ws.onopen = () => {
-      statusEl.textContent = 'Connected';
-      statusEl.className = 'ok';
-      ws.send(JSON.stringify({type:'resize',cols:term.cols,rows:term.rows}));
-    };
-    ws.onmessage = e => {
-      const m = JSON.parse(e.data);
-      if (m.type === 'data' || m.type === 'history') {
-        term.write(m.data);
-      } else if (m.type === 'creds') {
-        document.getElementById('cj').textContent = m.data;
-        document.getElementById('creds').style.display = 'block';
-      }
-    };
-    ws.onerror = () => { statusEl.textContent = 'WebSocket error'; statusEl.className = 'err'; };
-    ws.onclose = () => {
-      statusEl.textContent = 'Disconnected — reload to reconnect';
-      statusEl.className = 'err';
-      term.writeln('\r\n\r\n[Disconnected — reload to reconnect]');
-    };
-
-    term.onData(d => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'data',data:d})); });
-    term.onResize(({cols,rows}) => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'resize',cols,rows})); });
-    window.addEventListener('resize', () => { fit.fit(); });
-  </script>
-</body>
-</html>`;
-
-const server = http.createServer((req, res) => {
   if (req.url === '/restart') {
     startLogin();
     res.writeHead(302, { Location: '/' });
     res.end();
     return;
   }
+
   res.writeHead(200, { 'Content-Type': 'text/html' });
   res.end(HTML);
-});
-
-const wss = new WebSocketServer({ server, path: '/ws' });
-wss.on('connection', ws => {
-  clients.add(ws);
-  if (outputBuf) ws.send(JSON.stringify({ type: 'history', data: outputBuf }));
-  checkCreds();
-  ws.on('message', raw => {
-    try {
-      const m = JSON.parse(raw);
-      if (m.type === 'data' && ptyProc) ptyProc.write(m.data);
-      else if (m.type === 'resize' && ptyProc) ptyProc.resize(m.cols, m.rows);
-    } catch(_) {}
-  });
-  ws.on('close', () => clients.delete(ws));
-});
-
-server.listen(PORT, () => console.log('Claude auth terminal on port ' + PORT));
+}).listen(PORT, () => console.log('Claude auth terminal on port ' + PORT));
 SERVER
 
 ENV NODE_NO_WARNINGS=1

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,68 +1,141 @@
 # syntax=docker/dockerfile:1.20
 FROM node:lts-alpine
 RUN npm install -g @anthropic-ai/claude-code@latest
-RUN apk add --no-cache expect
 
-# Pre-seed Claude config so the first-run theme wizard is skipped entirely
-RUN mkdir -p /root/.claude && printf '{"theme":"dark","mode":"dark"}\n' > /root/.claude/settings.json
+# Pre-seed settings so Claude skips the first-run theme wizard
+RUN mkdir -p /root/.claude && \
+    printf '{"theme":"dark","hasCompletedOnboarding":true,"onboardingVersion":5}\n' \
+    > /root/.claude/settings.json
 
-COPY <<'EXPECTSCRIPT' /auth.exp
-#!/usr/bin/expect -f
-set timeout 300
-log_user 1
+COPY <<'SERVER' /server.js
+const http = require('http');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-# Skip any remaining prompts by pressing Enter, then wait for the auth URL
-spawn claude login
+const PORT = process.env.PORT || 3000;
+const CRED_PATH = path.join(os.homedir(), '.claude', '.credentials.json');
 
-expect {
-    -re {https://claude\.ai/[^\r\n]+} {
-        puts "\n\n=========================================="
-        puts "OPEN THIS URL IN YOUR BROWSER:"
-        puts $expect_out(0,string)
-        puts "==========================================\n"
-        exp_continue
-    }
-    -re {Press Enter|press enter|continue} {
-        send "\r"
-        exp_continue
-    }
-    -re {>\s*[0-9]} {
-        send "\r"
-        exp_continue
-    }
-    "Logged in" { puts "LOGIN OK — running setup-token" }
-    "successfully" { puts "LOGIN OK — running setup-token" }
-    timeout { puts "TIMED OUT"; exit 1 }
-    eof { puts "--- login ended ---" }
+let lines = [];
+let proc = null;
+let done = false;
+
+function strip(s) {
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\r/g, '');
 }
 
-spawn claude setup-token
+function startLogin() {
+  lines.push('[Starting claude login...]\n');
+  proc = spawn('claude', ['login'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' }
+  });
 
-expect {
-    -re {sk-ant-[^\r\n]+} {
-        puts "\n\n=========================================="
-        puts "CLAUDE_CODE_OAUTH_TOKEN:"
-        puts $expect_out(0,string)
-        puts "==========================================\n"
-        exp_continue
+  proc.stdout.on('data', d => { lines.push(strip(d.toString())); });
+  proc.stderr.on('data', d => { lines.push(strip(d.toString())); });
+
+  proc.on('exit', code => {
+    lines.push(`\n[claude login exited: ${code}]\n`);
+    if (fs.existsSync(CRED_PATH)) {
+      const c = fs.readFileSync(CRED_PATH, 'utf8');
+      lines.push('\n__CREDS__\n' + c + '\n__CREDS__\n');
+      done = true;
     }
-    -re {Press Enter|press enter} {
-        send "\r"
-        exp_continue
-    }
-    timeout { puts "setup-token timed out" }
-    eof {}
+  });
 }
 
-puts "=== Done. Delete this Railway service. ==="
-EXPECTSCRIPT
+startLogin();
 
-COPY <<'ENTRYPOINT' /run.sh
-#!/bin/sh
-node -e "require('http').createServer((_,r)=>r.end('ok')).listen(process.env.PORT||3000)" &
-exec expect /auth.exp
-ENTRYPOINT
+function submitCode(code) {
+  if (proc && proc.stdin.writable) {
+    proc.stdin.write(code.trim() + '\n');
+    lines.push(`[Submitted code]\n`);
+  }
+}
 
-RUN chmod +x /run.sh /auth.exp
-ENV NODE_NO_WARNINGS=1 TERM=xterm-256color
-CMD ["/run.sh"]
+const HTML = (body) => `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Claude Auth</title>
+<meta http-equiv="refresh" content="4">
+<style>
+  body{font-family:monospace;background:#111;color:#ddd;padding:24px;max-width:900px;margin:0 auto}
+  h2{color:#a78bfa}
+  pre{background:#000;padding:16px;white-space:pre-wrap;word-break:break-all;max-height:420px;overflow-y:auto;border:1px solid #333;font-size:13px}
+  input{width:100%;box-sizing:border-box;padding:10px;font-size:15px;background:#000;color:#ddd;border:1px solid #555;margin-bottom:12px}
+  button{padding:10px 24px;background:#7c3aed;color:#fff;border:none;cursor:pointer;font-size:15px;border-radius:4px}
+  .ok{border:2px solid #22c55e;padding:16px;margin-top:16px;background:#0a1f0a}
+  .ok pre{max-height:none}
+  .step{color:#fbbf24;margin:4px 0}
+</style></head><body>${body}</body></html>`;
+
+http.createServer((req, res) => {
+  // Handle code submission
+  if (req.method === 'POST' && req.url === '/code') {
+    let b = '';
+    req.on('data', d => b += d);
+    req.on('end', () => {
+      const code = new URLSearchParams(b).get('code') || '';
+      submitCode(code);
+      res.writeHead(302, { Location: '/' });
+      res.end();
+    });
+    return;
+  }
+
+  // Handle restart
+  if (req.url === '/restart') {
+    lines = [];
+    done = false;
+    if (proc) try { proc.kill(); } catch(_) {}
+    startLogin();
+    res.writeHead(302, { Location: '/' });
+    res.end();
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+
+  const all = lines.join('');
+  const credsMatch = all.match(/__CREDS__\n([\s\S]+?)\n__CREDS__/);
+  const output = all.replace(/__CREDS__[\s\S]*__CREDS__/g, '').trim();
+
+  const urlMatch = output.match(/https:\/\/claude\.ai\/[^\s\n"]+/);
+  const url = urlMatch ? urlMatch[0] : null;
+
+  if (credsMatch) {
+    res.end(HTML(`
+      <h2>✓ Claude Login Complete</h2>
+      <div class="ok">
+        <strong style="color:#22c55e">Copy the JSON below and set it as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway:</strong>
+        <pre>${credsMatch[1].replace(/</g,'&lt;')}</pre>
+      </div>
+      <p>Then remove <code>CLAUDE_CODE_OAUTH_TOKEN</code> if set, and redeploy the Paperclip service.</p>
+      <p><a href="/restart" style="color:#a78bfa">Restart login</a></p>
+    `));
+    return;
+  }
+
+  res.end(HTML(`
+    <h2>Claude Auth Helper</h2>
+    <p class="step">Auto-refreshes every 4s — page will update as Claude outputs the login URL.</p>
+
+    ${url ? `
+    <p style="margin:12px 0"><strong>Step 1:</strong>
+      <a href="${url}" target="_blank" style="color:#60a5fa;word-break:break-all">${url}</a>
+    </p>
+    <p class="step">Step 2: Authorize in your browser. If it shows a code instead of redirecting, paste it below.</p>
+    <form method="POST" action="/code">
+      <input name="code" placeholder="Paste the code shown by your browser here (if prompted)" autofocus>
+      <button type="submit">Submit Code</button>
+    </form>
+    ` : `<p class="step">Waiting for Claude to print the login URL...</p>`}
+
+    <h3>Claude output:</h3>
+    <pre>${output.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</pre>
+    <p><a href="/restart" style="color:#a78bfa">Restart login</a></p>
+  `));
+}).listen(PORT, () => console.log(`Claude auth helper on port ${PORT}`));
+SERVER
+
+ENV NODE_NO_WARNINGS=1
+CMD ["node", "/server.js"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,30 +1,73 @@
 # syntax=docker/dockerfile:1.20
 FROM node:lts-alpine
 RUN npm install -g @anthropic-ai/claude-code@latest
+RUN apk add --no-cache expect
 
-COPY <<'EOF' /run.sh
+COPY <<'ENTRYPOINT' /run.sh
 #!/bin/sh
 node -e "require('http').createServer((_,r)=>r.end('ok')).listen(process.env.PORT||3000)" &
+exec expect /auth.exp
+ENTRYPOINT
 
-echo "=== claude version ==="
-claude --version 2>&1
-echo ""
+COPY <<'EXPECTSCRIPT' /auth.exp
+#!/usr/bin/expect -f
+set timeout 300
 
-echo "=== attempting claude login (will print auth URL) ==="
-# Use script(1) to allocate a pseudo-TTY so claude doesn't bail in headless
-script -q -c "claude login" /dev/null 2>&1
-echo "exit: $?"
-echo ""
+log_user 1
 
-echo "=== attempting claude setup-token ==="
-script -q -c "claude setup-token" /dev/null 2>&1
-echo "exit: $?"
+spawn claude login
 
-echo "=== Done. Copy token above then delete this service ==="
-sleep infinity
-EOF
+# Step through the first-run theme wizard
+expect {
+    -re {[1-9]\.\s*(Auto|Dark|Light)} {
+        send "2\r"
+        exp_continue
+    }
+    -re {https://[^\r\n]+} {
+        set url $expect_out(0,string)
+        puts "\n\n=========================================="
+        puts "OPEN THIS URL IN YOUR BROWSER:"
+        puts $url
+        puts "==========================================\n"
+        exp_continue
+    }
+    "Logged in" {
+        puts "\n\n=== LOGIN SUCCESSFUL - now running setup-token ==="
+    }
+    "successfully" {
+        puts "\n\n=== LOGIN SUCCESSFUL - now running setup-token ==="
+    }
+    timeout {
+        puts "TIMED OUT"
+        exit 1
+    }
+    eof {
+        puts "Process ended - check above for URL"
+    }
+}
 
-RUN chmod +x /run.sh
-RUN apk add --no-cache util-linux
+# Now mint the long-lived token
+spawn claude setup-token
+
+expect {
+    -re {sk-ant-[^\r\n]+} {
+        set token $expect_out(0,string)
+        puts "\n\n=========================================="
+        puts "YOUR CLAUDE_CODE_OAUTH_TOKEN:"
+        puts $token
+        puts "Set this in Railway as CLAUDE_CODE_OAUTH_TOKEN"
+        puts "==========================================\n"
+        exp_continue
+    }
+    timeout {
+        puts "setup-token timed out"
+    }
+    eof {}
+}
+
+puts "=== Done. Delete this Railway service now. ==="
+EXPECTSCRIPT
+
+RUN chmod +x /run.sh /auth.exp
 ENV NODE_NO_WARNINGS=1 TERM=xterm-256color
 CMD ["/run.sh"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts-alpine
 RUN npm install -g @anthropic-ai/claude-code@latest
-# Force unbuffered output so the auth URL and token appear in Railway logs immediately
-ENV NODE_NO_WARNINGS=1
-CMD ["claude", "setup-token"]
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+# Unbuffered so every line appears in Railway logs immediately
+ENV NODE_NO_WARNINGS=1 PYTHONUNBUFFERED=1
+CMD ["/bin/sh", "-c", "exec /run.sh"]

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -3,70 +3,65 @@ FROM node:lts-alpine
 RUN npm install -g @anthropic-ai/claude-code@latest
 RUN apk add --no-cache expect
 
+# Pre-seed Claude config so the first-run theme wizard is skipped entirely
+RUN mkdir -p /root/.claude && printf '{"theme":"dark","mode":"dark"}\n' > /root/.claude/settings.json
+
+COPY <<'EXPECTSCRIPT' /auth.exp
+#!/usr/bin/expect -f
+set timeout 300
+log_user 1
+
+# Skip any remaining prompts by pressing Enter, then wait for the auth URL
+spawn claude login
+
+expect {
+    -re {https://claude\.ai/[^\r\n]+} {
+        puts "\n\n=========================================="
+        puts "OPEN THIS URL IN YOUR BROWSER:"
+        puts $expect_out(0,string)
+        puts "==========================================\n"
+        exp_continue
+    }
+    -re {Press Enter|press enter|continue} {
+        send "\r"
+        exp_continue
+    }
+    -re {>\s*[0-9]} {
+        send "\r"
+        exp_continue
+    }
+    "Logged in" { puts "LOGIN OK — running setup-token" }
+    "successfully" { puts "LOGIN OK — running setup-token" }
+    timeout { puts "TIMED OUT"; exit 1 }
+    eof { puts "--- login ended ---" }
+}
+
+spawn claude setup-token
+
+expect {
+    -re {sk-ant-[^\r\n]+} {
+        puts "\n\n=========================================="
+        puts "CLAUDE_CODE_OAUTH_TOKEN:"
+        puts $expect_out(0,string)
+        puts "==========================================\n"
+        exp_continue
+    }
+    -re {Press Enter|press enter} {
+        send "\r"
+        exp_continue
+    }
+    timeout { puts "setup-token timed out" }
+    eof {}
+}
+
+puts "=== Done. Delete this Railway service. ==="
+EXPECTSCRIPT
+
 COPY <<'ENTRYPOINT' /run.sh
 #!/bin/sh
 node -e "require('http').createServer((_,r)=>r.end('ok')).listen(process.env.PORT||3000)" &
 exec expect /auth.exp
 ENTRYPOINT
-
-COPY <<'EXPECTSCRIPT' /auth.exp
-#!/usr/bin/expect -f
-set timeout 300
-
-log_user 1
-
-spawn claude login
-
-# Step through the first-run theme wizard
-expect {
-    -re {[1-9]\.\s*(Auto|Dark|Light)} {
-        send "2\r"
-        exp_continue
-    }
-    -re {https://[^\r\n]+} {
-        set url $expect_out(0,string)
-        puts "\n\n=========================================="
-        puts "OPEN THIS URL IN YOUR BROWSER:"
-        puts $url
-        puts "==========================================\n"
-        exp_continue
-    }
-    "Logged in" {
-        puts "\n\n=== LOGIN SUCCESSFUL - now running setup-token ==="
-    }
-    "successfully" {
-        puts "\n\n=== LOGIN SUCCESSFUL - now running setup-token ==="
-    }
-    timeout {
-        puts "TIMED OUT"
-        exit 1
-    }
-    eof {
-        puts "Process ended - check above for URL"
-    }
-}
-
-# Now mint the long-lived token
-spawn claude setup-token
-
-expect {
-    -re {sk-ant-[^\r\n]+} {
-        set token $expect_out(0,string)
-        puts "\n\n=========================================="
-        puts "YOUR CLAUDE_CODE_OAUTH_TOKEN:"
-        puts $token
-        puts "Set this in Railway as CLAUDE_CODE_OAUTH_TOKEN"
-        puts "==========================================\n"
-        exp_continue
-    }
-    timeout {
-        puts "setup-token timed out"
-    }
-    eof {}
-}
-
-puts "=== Done. Delete this Railway service now. ==="
-EXPECTSCRIPT
 
 RUN chmod +x /run.sh /auth.exp
 ENV NODE_NO_WARNINGS=1 TERM=xterm-256color

--- a/docker/claude-auth/Dockerfile
+++ b/docker/claude-auth/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.20
 FROM node:lts-alpine
-RUN npm install -g @anthropic-ai/claude-code@latest
+# util-linux provides `script` which creates a PTY for claude login
+RUN apk add --no-cache util-linux && \
+    npm install -g @anthropic-ai/claude-code@latest
 
 # Pre-seed settings so Claude skips the first-run theme wizard
 RUN mkdir -p /root/.claude && \
@@ -19,7 +21,6 @@ const CRED_PATH = path.join(os.homedir(), '.claude', '.credentials.json');
 
 let lines = [];
 let proc = null;
-let done = false;
 
 function strip(s) {
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\r/g, '');
@@ -27,9 +28,12 @@ function strip(s) {
 
 function startLogin() {
   lines.push('[Starting claude login...]\n');
-  proc = spawn('claude', ['login'], {
+  // script -q -e -c CMD /dev/null runs CMD inside a PTY so claude login
+  // doesn't detect a non-interactive terminal and bail immediately.
+  // stdin of `script` is forwarded into the PTY (used to send the auth code).
+  proc = spawn('script', ['-q', '-e', '-c', 'claude login', '/dev/null'], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0', CI: '1' }
+    env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0' }
   });
 
   proc.stdout.on('data', d => { lines.push(strip(d.toString())); });
@@ -40,7 +44,6 @@ function startLogin() {
     if (fs.existsSync(CRED_PATH)) {
       const c = fs.readFileSync(CRED_PATH, 'utf8');
       lines.push('\n__CREDS__\n' + c + '\n__CREDS__\n');
-      done = true;
     }
   });
 }
@@ -69,23 +72,19 @@ const HTML = (body) => `<!DOCTYPE html>
 </style></head><body>${body}</body></html>`;
 
 http.createServer((req, res) => {
-  // Handle code submission
   if (req.method === 'POST' && req.url === '/code') {
     let b = '';
     req.on('data', d => b += d);
     req.on('end', () => {
-      const code = new URLSearchParams(b).get('code') || '';
-      submitCode(code);
+      submitCode(new URLSearchParams(b).get('code') || '');
       res.writeHead(302, { Location: '/' });
       res.end();
     });
     return;
   }
 
-  // Handle restart
   if (req.url === '/restart') {
     lines = [];
-    done = false;
     if (proc) try { proc.kill(); } catch(_) {}
     startLogin();
     res.writeHead(302, { Location: '/' });
@@ -98,15 +97,14 @@ http.createServer((req, res) => {
   const all = lines.join('');
   const credsMatch = all.match(/__CREDS__\n([\s\S]+?)\n__CREDS__/);
   const output = all.replace(/__CREDS__[\s\S]*__CREDS__/g, '').trim();
-
   const urlMatch = output.match(/https:\/\/claude\.ai\/[^\s\n"]+/);
   const url = urlMatch ? urlMatch[0] : null;
 
   if (credsMatch) {
     res.end(HTML(`
-      <h2>✓ Claude Login Complete</h2>
+      <h2>&#10003; Claude Login Complete</h2>
       <div class="ok">
-        <strong style="color:#22c55e">Copy the JSON below and set it as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway:</strong>
+        <strong style="color:#22c55e">Copy the JSON below and set it as <code>CLAUDE_CREDENTIALS_JSON</code> in Railway (Paperclip service):</strong>
         <pre>${credsMatch[1].replace(/</g,'&lt;')}</pre>
       </div>
       <p>Then remove <code>CLAUDE_CODE_OAUTH_TOKEN</code> if set, and redeploy the Paperclip service.</p>
@@ -117,15 +115,15 @@ http.createServer((req, res) => {
 
   res.end(HTML(`
     <h2>Claude Auth Helper</h2>
-    <p class="step">Auto-refreshes every 4s — page will update as Claude outputs the login URL.</p>
+    <p class="step">Auto-refreshes every 4s. Waiting for the login URL...</p>
 
     ${url ? `
     <p style="margin:12px 0"><strong>Step 1:</strong>
       <a href="${url}" target="_blank" style="color:#60a5fa;word-break:break-all">${url}</a>
     </p>
-    <p class="step">Step 2: Authorize in your browser. If it shows a code instead of redirecting, paste it below.</p>
+    <p class="step">Step 2: Authorize in your browser. If it shows a code, paste it below.</p>
     <form method="POST" action="/code">
-      <input name="code" placeholder="Paste the code shown by your browser here (if prompted)" autofocus>
+      <input name="code" placeholder="Paste the code shown by your browser here" autofocus>
       <button type="submit">Submit Code</button>
     </form>
     ` : `<p class="step">Waiting for Claude to print the login URL...</p>`}

--- a/docker/claude-auth/run.sh
+++ b/docker/claude-auth/run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+echo "=== claude setup-token starting ==="
+echo "=== Watch here for the auth URL ==="
+echo ""
+
+# Run with a pseudo-tty via script(1) so claude doesn't detect headless and bail
+claude setup-token 2>&1
+EXIT=$?
+
+echo ""
+echo "=== setup-token exited with code $EXIT ==="
+echo "=== Copy the token above, then delete this Railway service ==="
+
+# Stay alive so you can read the logs
+sleep infinity

--- a/docker/railway/Caddyfile
+++ b/docker/railway/Caddyfile
@@ -20,10 +20,11 @@
 	# app.ops.* on Railway), this Caddy only sees `app.ops.*` traffic,
 	# so `{host}` would redirect to a non-existent `/login` on the
 	# Railway app. Send the user back to the Vercel auth portal —
-	# `OPS_PORTAL_URL` is set on the Railway service (default
-	# `https://ops.binelek.io` if unset, for the legacy host).
+	# `OPS_PORTAL_URL` is set on the Railway service (defaults to
+	# `https://ops.torinagi.com`; override if you need the legacy
+	# `https://ops.binelek.io` while both hosts are in flight).
 	handle_errors 401 {
-		redir {$OPS_PORTAL_URL:https://ops.binelek.io}/login 302
+		redir {$OPS_PORTAL_URL:https://ops.torinagi.com}/login 302
 	}
 
 	@websocket {

--- a/docker/railway/Caddyfile
+++ b/docker/railway/Caddyfile
@@ -16,8 +16,12 @@
 		from_cookies jaban_session
 	}
 
+	# Host-aware redirect: stay on whichever domain the user arrived on
+	# (ops.torinagi.com OR ops.binelek.io). Hard-coding the host here
+	# would bounce torinagi.com visitors back to binelek.io and lose
+	# them in the cookie-domain split during the domain migration.
 	handle_errors 401 {
-		redir https://ops.binelek.io/login 302
+		redir https://{host}/login 302
 	}
 
 	@websocket {

--- a/docker/railway/Caddyfile
+++ b/docker/railway/Caddyfile
@@ -16,12 +16,14 @@
 		from_cookies jaban_session
 	}
 
-	# Host-aware redirect: stay on whichever domain the user arrived on
-	# (ops.torinagi.com OR ops.binelek.io). Hard-coding the host here
-	# would bounce torinagi.com visitors back to binelek.io and lose
-	# them in the cookie-domain split during the domain migration.
+	# 401 → auth portal. With the architecture split (ops.* on Vercel,
+	# app.ops.* on Railway), this Caddy only sees `app.ops.*` traffic,
+	# so `{host}` would redirect to a non-existent `/login` on the
+	# Railway app. Send the user back to the Vercel auth portal —
+	# `OPS_PORTAL_URL` is set on the Railway service (default
+	# `https://ops.binelek.io` if unset, for the legacy host).
 	handle_errors 401 {
-		redir https://{host}/login 302
+		redir {$OPS_PORTAL_URL:https://ops.binelek.io}/login 302
 	}
 
 	@websocket {

--- a/docker/railway/Caddyfile
+++ b/docker/railway/Caddyfile
@@ -1,0 +1,41 @@
+{
+	log {
+		output stdout
+		format json
+		level INFO
+	}
+	order jwtauth before reverse_proxy
+}
+
+# Railway terminates TLS; Caddy listens on plain HTTP at the exposed PORT.
+# {$CADDY_PORT} is set by the entrypoint from Railway's $PORT env var.
+:{$CADDY_PORT} {
+	jwtauth {
+		sign_key     {$SESSION_JWT_SECRET}
+		sign_alg     HS256
+		from_cookies jaban_session
+	}
+
+	handle_errors 401 {
+		redir https://ops.binelek.io/login 302
+	}
+
+	@websocket {
+		header Connection *Upgrade*
+		header Upgrade    websocket
+	}
+	reverse_proxy @websocket 127.0.0.1:{$PAPERCLIP_PORT} {
+		header_up Host              {host}
+		header_up X-Real-IP         {remote_host}
+		header_up X-Forwarded-For   {remote_host}
+		header_up X-Forwarded-Proto {http.request.header.X-Forwarded-Proto}
+	}
+
+	reverse_proxy 127.0.0.1:{$PAPERCLIP_PORT} {
+		header_up Host                 {host}
+		header_up X-Real-IP            {remote_host}
+		header_up X-Forwarded-For      {remote_host}
+		header_up X-Forwarded-Proto    {http.request.header.X-Forwarded-Proto}
+		header_up X-Authenticated-User {http.auth.user.email}
+	}
+}

--- a/docker/railway/entrypoint.sh
+++ b/docker/railway/entrypoint.sh
@@ -8,6 +8,24 @@ if [ "$(stat -c '%u' /paperclip 2>/dev/null)" != "1000" ]; then
     chown node:node /paperclip
 fi
 
+# Materialise Claude credentials into the filesystem.
+#
+# The Claude Code CLI authenticates by reading
+# `~/.claude/.credentials.json` (the subscription-OAuth token that
+# `claude login` writes). Railway can't run an interactive login, so
+# we ship the credentials as a `CLAUDE_CREDENTIALS_JSON` env var and
+# materialise them here. Without this bridge the CEO-agent probe
+# reports "Claude CLI is installed, but login is required" even
+# though the env is set.
+#
+# HOME=/paperclip in this image, so claude resolves `~` to /paperclip.
+if [ -n "${CLAUDE_CREDENTIALS_JSON}" ]; then
+    mkdir -p /paperclip/.claude
+    printf '%s' "${CLAUDE_CREDENTIALS_JSON}" > /paperclip/.claude/.credentials.json
+    chmod 600 /paperclip/.claude/.credentials.json
+    chown -R node:node /paperclip/.claude
+fi
+
 # CADDY_PORT = the port Railway exposes (Railway injects $PORT at runtime).
 # PAPERCLIP_PORT = the internal loopback port supervisord passes to Paperclip.
 export CADDY_PORT="${PORT:-8080}"

--- a/docker/railway/entrypoint.sh
+++ b/docker/railway/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Fix Railway volume ownership: Railway mounts volumes as root even when the
+# image runs unprivileged, so /paperclip may be root-owned.  Paperclip (user
+# node) needs write access to create instances/default/logs and the db file.
+if [ "$(stat -c '%u' /paperclip 2>/dev/null)" != "1000" ]; then
+    chown node:node /paperclip
+fi
+
+# CADDY_PORT = the port Railway exposes (Railway injects $PORT at runtime).
+# PAPERCLIP_PORT = the internal loopback port supervisord passes to Paperclip.
+export CADDY_PORT="${PORT:-8080}"
+export PAPERCLIP_PORT="3000"
+
+exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/docker/railway/supervisord.conf
+++ b/docker/railway/supervisord.conf
@@ -1,0 +1,30 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+
+; Caddy validates the Jaban Universe JWT and proxies to Paperclip on loopback.
+[program:caddy]
+command=/usr/bin/caddy run --config /etc/caddy/Caddyfile
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=10
+
+; Paperclip binds to loopback only — required for local_trusted deployment mode.
+[program:paperclip]
+command=node --import ./server/node_modules/tsx/dist/loader.mjs server/dist/index.js
+directory=/app
+user=node
+environment=PORT=3000,HOST=127.0.0.1
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=20

--- a/ops-portal/.env.example
+++ b/ops-portal/.env.example
@@ -1,0 +1,18 @@
+# Auth.js — generate with: openssl rand -hex 32
+AUTH_SECRET=
+
+# Zitadel OIDC (register client in Zitadel console under paperclip-ops project)
+AUTH_ZITADEL_ISSUER=https://auth.binelek.io
+AUTH_ZITADEL_ID=
+AUTH_ZITADEL_SECRET=
+
+# Shared secret with Caddy for session JWT minting
+# Generate with: openssl rand -hex 32
+# Must match SESSION_JWT_SECRET in the caddy Railway service
+CADDY_SESSION_JWT_SECRET=
+
+# Where to redirect the browser after successful login
+APP_URL=https://app.ops.binelek.io
+
+# Public URL of this Vercel app (used by Auth.js)
+NEXTAUTH_URL=https://ops.binelek.io

--- a/ops-portal/next.config.mjs
+++ b/ops-portal/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  // No `output: 'standalone'` — this app deploys via Railway Nixpacks /
+  // Vercel, both of which run `next start`, which is incompatible with
+  // standalone output. (Standalone is only for Docker self-hosting, which
+  // this service doesn't use.)
   async headers() {
     return [
       {

--- a/ops-portal/next.config.mjs
+++ b/ops-portal/next.config.mjs
@@ -1,10 +1,6 @@
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   output: 'standalone',
-  experimental: {
-    typedRoutes: false,
-  },
   async headers() {
     return [
       {

--- a/ops-portal/next.config.ts
+++ b/ops-portal/next.config.ts
@@ -1,0 +1,26 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  output: 'standalone',
+  experimental: {
+    typedRoutes: false,
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/ops-portal/package.json
+++ b/ops-portal/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ops-portal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "^14.2.29",
+    "next-auth": "^5.0.0-beta.25",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "jose": "^5.9.6",
+    "pino": "^9.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3"
+  }
+}

--- a/ops-portal/postcss.config.mjs
+++ b/ops-portal/postcss.config.mjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/ops-portal/src/app/api/auth/[...nextauth]/route.ts
+++ b/ops-portal/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/lib/auth';
+
+export const { GET, POST } = handlers;

--- a/ops-portal/src/app/api/session/route.ts
+++ b/ops-portal/src/app/api/session/route.ts
@@ -11,14 +11,14 @@ import { AuthProxyError, OIDCConfigurationError, SessionInvalidError } from '@/l
 //   4. Redirects the browser to app.ops.binelek.io.
 
 const APP_URL =
-  process.env['APP_URL'] ?? 'https://app.ops.binelek.io';
+  process.env['APP_URL'] ?? 'https://app.ops.torinagi.com';
 
 // Cookie domain follows wherever the auth portal lives so the
 // jaban_session cookie is readable by the matching `app.ops.*` host.
-// Defaults to `.binelek.io` for the legacy host; flip
-// SESSION_COOKIE_DOMAIN=.torinagi.com once the cutover happens.
+// Defaults to `.torinagi.com` (the canonical going forward); set
+// SESSION_COOKIE_DOMAIN=.binelek.io to keep a binelek host working.
 const SESSION_COOKIE_DOMAIN =
-  process.env['SESSION_COOKIE_DOMAIN'] ?? '.binelek.io';
+  process.env['SESSION_COOKIE_DOMAIN'] ?? '.torinagi.com';
 
 export async function GET(): Promise<NextResponse> {
   try {
@@ -50,7 +50,7 @@ export async function GET(): Promise<NextResponse> {
   } catch (err) {
     if (err instanceof SessionInvalidError) {
       return NextResponse.redirect(
-        new URL('/login', process.env['NEXTAUTH_URL'] ?? 'https://ops.binelek.io'),
+        new URL('/login', process.env['NEXTAUTH_URL'] ?? 'https://ops.torinagi.com'),
         { status: 302 }
       );
     }

--- a/ops-portal/src/app/api/session/route.ts
+++ b/ops-portal/src/app/api/session/route.ts
@@ -13,6 +13,13 @@ import { AuthProxyError, OIDCConfigurationError, SessionInvalidError } from '@/l
 const APP_URL =
   process.env['APP_URL'] ?? 'https://app.ops.binelek.io';
 
+// Cookie domain follows wherever the auth portal lives so the
+// jaban_session cookie is readable by the matching `app.ops.*` host.
+// Defaults to `.binelek.io` for the legacy host; flip
+// SESSION_COOKIE_DOMAIN=.torinagi.com once the cutover happens.
+const SESSION_COOKIE_DOMAIN =
+  process.env['SESSION_COOKIE_DOMAIN'] ?? '.binelek.io';
+
 export async function GET(): Promise<NextResponse> {
   try {
     const session = await requireOperatorSession();
@@ -33,7 +40,7 @@ export async function GET(): Promise<NextResponse> {
       httpOnly: true,
       secure: true,
       sameSite: 'lax',
-      domain: '.binelek.io',
+      domain: SESSION_COOKIE_DOMAIN,
       path: '/',
       // 8 hours — matches JWT expiry
       maxAge: 8 * 60 * 60,

--- a/ops-portal/src/app/api/session/route.ts
+++ b/ops-portal/src/app/api/session/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { requireOperatorSession } from '@/lib/auth';
+import { mintCaddyJwt } from '@/lib/caddy-jwt';
+import { AuthProxyError, OIDCConfigurationError, SessionInvalidError } from '@/lib/errors';
+
+// This endpoint is called by the /launch page after Auth.js establishes the
+// Zitadel session.  It:
+//   1. Validates the Auth.js session and checks the operator role.
+//   2. Mints a short-lived JWT for Caddy using the shared secret.
+//   3. Sets the JWT as an HttpOnly cookie on .binelek.io.
+//   4. Redirects the browser to app.ops.binelek.io.
+
+const APP_URL =
+  process.env['APP_URL'] ?? 'https://app.ops.binelek.io';
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await requireOperatorSession();
+
+    const email = session.user.email ?? '';
+    const sub = (session.user as { id?: string }).id ?? email;
+
+    const jwt = await mintCaddyJwt({
+      email,
+      roles: session.roles,
+      sub,
+    });
+
+    const response = NextResponse.redirect(APP_URL, { status: 302 });
+
+    response.cookies.set('jaban_session', jwt, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      domain: '.binelek.io',
+      path: '/',
+      // 8 hours — matches JWT expiry
+      maxAge: 8 * 60 * 60,
+    });
+
+    return response;
+  } catch (err) {
+    if (err instanceof SessionInvalidError) {
+      return NextResponse.redirect(
+        new URL('/login', process.env['NEXTAUTH_URL'] ?? 'https://ops.binelek.io'),
+        { status: 302 }
+      );
+    }
+    if (err instanceof AuthProxyError && err.statusCode === 403) {
+      return NextResponse.json(
+        { error: 'Your account does not have operator access.' },
+        { status: 403 }
+      );
+    }
+    if (err instanceof OIDCConfigurationError) {
+      console.error('[session] OIDC misconfiguration', { message: (err as Error).message });
+      return NextResponse.json(
+        { error: 'Server configuration error' },
+        { status: 500 }
+      );
+    }
+    console.error('[session] unexpected error', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/ops-portal/src/app/api/session/route.ts
+++ b/ops-portal/src/app/api/session/route.ts
@@ -17,8 +17,9 @@ export async function GET(): Promise<NextResponse> {
   try {
     const session = await requireOperatorSession();
 
-    const email = session.user.email ?? '';
-    const sub = (session.user as { id?: string }).id ?? email;
+    const user = session.user ?? {};
+    const email = ('email' in user ? (user as { email?: string | null }).email : null) ?? '';
+    const sub = ('id' in user ? (user as { id?: string }).id : undefined) ?? email;
 
     const jwt = await mintCaddyJwt({
       email,

--- a/ops-portal/src/app/globals.css
+++ b/ops-portal/src/app/globals.css
@@ -1,0 +1,26 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --font-mono: ui-monospace, 'Cascadia Code', 'Fira Code', Menlo, monospace;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background-color: #07071a;
+  color: #f8f8ff;
+  font-family: var(--font-mono);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Remove default focus ring, replace with branded one */
+*:focus-visible {
+  outline: 2px solid #8b5cf6;
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/ops-portal/src/app/launch/page.tsx
+++ b/ops-portal/src/app/launch/page.tsx
@@ -1,0 +1,32 @@
+// This page is the post-login landing.  The middleware guarantees the user is
+// authenticated and has the operator role before they get here.
+//
+// It immediately calls /api/session to mint the Caddy JWT and redirect to
+// app.ops.binelek.io.  Using a meta refresh as a fallback in case JS is off.
+export const metadata = { title: 'Launching — Jaban Universe' };
+
+export default function LaunchPage() {
+  return (
+    <>
+      {/* Instant redirect via meta refresh (no-JS fallback) */}
+      <meta httpEquiv="refresh" content="0;url=/api/session" />
+
+      <main className="min-h-full flex items-center justify-center">
+        <div className="text-center flex flex-col gap-4">
+          <p className="text-nova-400 text-sm tracking-widest uppercase animate-pulse">
+            Launching
+          </p>
+          <p className="text-white/30 text-xs">
+            Establishing secure session&hellip;
+          </p>
+          {/* JS redirect */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.location.href = '/api/session';`,
+            }}
+          />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/ops-portal/src/app/layout.tsx
+++ b/ops-portal/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Jaban Universe',
+  description: 'Operations portal',
+  robots: { index: false, follow: false },
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className="h-full">
+      <body className="h-full antialiased">{children}</body>
+    </html>
+  );
+}

--- a/ops-portal/src/app/login/page.tsx
+++ b/ops-portal/src/app/login/page.tsx
@@ -1,0 +1,114 @@
+import { signIn, auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+
+export const metadata = { title: 'Sign In — Jaban Universe' };
+
+// The JU mark: a bordered square with initials, text-only, no images.
+function JabanMark() {
+  return (
+    <div className="flex flex-col items-center gap-4 select-none">
+      {/* Text mark */}
+      <div className="relative inline-flex items-center justify-center">
+        <div
+          className="
+            w-16 h-16
+            border-2 border-nova-500
+            flex items-center justify-center
+            text-nova-400 text-2xl font-bold tracking-tight
+          "
+          aria-hidden="true"
+        >
+          JU
+        </div>
+        {/* Corner accents */}
+        <span className="absolute -top-[3px] -left-[3px] w-2 h-2 border-t-2 border-l-2 border-star-500" />
+        <span className="absolute -top-[3px] -right-[3px] w-2 h-2 border-t-2 border-r-2 border-star-500" />
+        <span className="absolute -bottom-[3px] -left-[3px] w-2 h-2 border-b-2 border-l-2 border-star-500" />
+        <span className="absolute -bottom-[3px] -right-[3px] w-2 h-2 border-b-2 border-r-2 border-star-500" />
+      </div>
+
+      <div className="text-center">
+        <p className="text-white tracking-[0.3em] uppercase text-sm font-semibold">
+          Jaban Universe
+        </p>
+        <p className="text-void-800 text-xs tracking-widest uppercase mt-1 text-white/30">
+          Operations Portal
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const session = await auth();
+  if (session?.user != null) {
+    redirect('/launch');
+  }
+
+  const params = await searchParams;
+  const hasError = params.error != null;
+
+  return (
+    <main className="min-h-full flex items-center justify-center px-4">
+      {/* Ambient glow */}
+      <div
+        className="pointer-events-none fixed inset-0 overflow-hidden"
+        aria-hidden="true"
+      >
+        <div className="absolute top-1/4 left-1/2 -translate-x-1/2 w-96 h-96 rounded-full bg-nova-600/10 blur-3xl animate-pulse-slow" />
+        <div className="absolute bottom-1/4 left-1/3 w-64 h-64 rounded-full bg-star-500/5 blur-3xl animate-pulse-slow" />
+      </div>
+
+      <div className="relative z-10 w-full max-w-sm">
+        {/* Card */}
+        <div className="border border-white/10 bg-void-900/80 backdrop-blur-sm px-8 py-10 flex flex-col gap-8">
+          <JabanMark />
+
+          <div className="flex flex-col gap-3">
+            {hasError && (
+              <p className="text-center text-red-400 text-xs border border-red-500/30 bg-red-500/10 px-3 py-2">
+                Authentication failed. Please try again.
+              </p>
+            )}
+
+            {/* Sign-in form — uses Auth.js server action */}
+            <form
+              action={async () => {
+                'use server';
+                await signIn('zitadel', { redirectTo: '/launch' });
+              }}
+            >
+              <button
+                type="submit"
+                className="
+                  w-full
+                  bg-nova-600 hover:bg-nova-500
+                  text-white text-sm font-semibold tracking-wider uppercase
+                  px-4 py-3
+                  transition-colors duration-150
+                  focus-visible:outline focus-visible:outline-2 focus-visible:outline-nova-400
+                "
+              >
+                Sign In
+              </button>
+            </form>
+
+            <p className="text-center text-white/30 text-xs tracking-wide">
+              Multi-factor authentication required.
+            </p>
+          </div>
+
+          <div className="border-t border-white/5 pt-4 text-center">
+            <p className="text-white/20 text-[10px] tracking-widest uppercase">
+              Authorized users only
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/ops-portal/src/app/page.tsx
+++ b/ops-portal/src/app/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+
+// Root: authenticated operators go straight to /launch (which mints the Caddy
+// JWT and redirects to app.ops.binelek.io). Everyone else goes to /login.
+export default async function RootPage() {
+  const session = await auth();
+  if (session?.user != null) {
+    redirect('/launch');
+  }
+  redirect('/login');
+}

--- a/ops-portal/src/lib/auth.ts
+++ b/ops-portal/src/lib/auth.ts
@@ -12,10 +12,47 @@ export const OPERATOR_ROLE: string =
 
 // Zitadel returns project roles as a nested map:
 // "urn:zitadel:iam:org:project:roles": { "roleName": { "orgId": "orgName" } }
-function extractZitadelRoles(profile: Record<string, unknown>): string[] {
-  const raw = profile['urn:zitadel:iam:org:project:roles'];
+function extractZitadelRoles(claims: Record<string, unknown>): string[] {
+  const raw = claims['urn:zitadel:iam:org:project:roles'];
   if (raw == null || typeof raw !== 'object') return [];
   return Object.keys(raw as Record<string, unknown>);
+}
+
+// Decode a JWT payload without verifying (we trust account.id_token because
+// it was just delivered to us over TLS by next-auth's OIDC code-exchange).
+function decodeJwtClaims(jwt: string): Record<string, unknown> {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) return {};
+  try {
+    // base64url → base64 → buffer
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padding = '='.repeat((4 - (payload.length % 4)) % 4);
+    const decoded = Buffer.from(payload + padding, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch {
+    return {};
+  }
+}
+
+// Roles can land in different places depending on which OIDC assertion
+// flags Zitadel has set:
+//   - idTokenRoleAssertion: true   → in the ID token claims
+//   - userinfo via /userinfo       → in the `profile` arg next-auth passes
+// NextAuth v5's Zitadel provider may not surface the custom
+// `urn:zitadel:iam:org:project:roles` claim through `profile`, so fall
+// back to decoding the id_token directly.
+function pickRoles(
+  profile: Record<string, unknown> | undefined,
+  idToken: string | undefined,
+): string[] {
+  if (profile) {
+    const fromProfile = extractZitadelRoles(profile);
+    if (fromProfile.length > 0) return fromProfile;
+  }
+  if (idToken) {
+    return extractZitadelRoles(decodeJwtClaims(idToken));
+  }
+  return [];
 }
 
 // Env vars are validated at request time (not module load) so Next.js static
@@ -37,11 +74,14 @@ const authConfig: NextAuthConfig = {
 
   callbacks: {
     async jwt({ token, account, profile }) {
-      if (account != null && profile != null) {
-        const p = profile as Record<string, unknown>;
+      if (account != null) {
+        const p = (profile ?? {}) as Record<string, unknown>;
         token['sub'] = (p['sub'] as string | undefined) ?? token['sub'];
         token['email'] = (p['email'] as string | undefined) ?? token['email'];
-        token['roles'] = extractZitadelRoles(p);
+        token['roles'] = pickRoles(
+          profile as Record<string, unknown> | undefined,
+          account.id_token as string | undefined,
+        );
       }
       return token;
     },

--- a/ops-portal/src/lib/auth.ts
+++ b/ops-portal/src/lib/auth.ts
@@ -22,10 +22,11 @@ function extractZitadelRoles(claims: Record<string, unknown>): string[] {
 // it was just delivered to us over TLS by next-auth's OIDC code-exchange).
 function decodeJwtClaims(jwt: string): Record<string, unknown> {
   const parts = jwt.split('.');
-  if (parts.length !== 3) return {};
+  const rawPayload = parts[1];
+  if (parts.length !== 3 || rawPayload == null) return {};
   try {
     // base64url → base64 → buffer
-    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const payload = rawPayload.replace(/-/g, '+').replace(/_/g, '/');
     const padding = '='.repeat((4 - (payload.length % 4)) % 4);
     const decoded = Buffer.from(payload + padding, 'base64').toString('utf8');
     return JSON.parse(decoded);

--- a/ops-portal/src/lib/auth.ts
+++ b/ops-portal/src/lib/auth.ts
@@ -38,19 +38,12 @@ const authConfig: NextAuthConfig = {
   ],
 
   callbacks: {
-    async jwt({
-      token,
-      account,
-      profile,
-    }: {
-      token: JWT;
-      account: unknown;
-      profile?: Record<string, unknown>;
-    }) {
+    async jwt({ token, account, profile }) {
       if (account != null && profile != null) {
-        token['sub'] = (profile['sub'] as string | undefined) ?? token['sub'];
-        token['email'] = (profile['email'] as string | undefined) ?? token['email'];
-        token['roles'] = extractZitadelRoles(profile);
+        const p = profile as Record<string, unknown>;
+        token['sub'] = (p['sub'] as string | undefined) ?? token['sub'];
+        token['email'] = (p['email'] as string | undefined) ?? token['email'];
+        token['roles'] = extractZitadelRoles(p);
       }
       return token;
     },
@@ -58,7 +51,7 @@ const authConfig: NextAuthConfig = {
     async session({ session, token }: { session: Session; token: JWT }) {
       const s = session as Session & { roles: string[] };
       s.roles = (token['roles'] as string[] | undefined) ?? [];
-      if (typeof token['email'] === 'string') {
+      if (typeof token['email'] === 'string' && s.user != null) {
         s.user.email = token['email'];
       }
       return s;

--- a/ops-portal/src/lib/auth.ts
+++ b/ops-portal/src/lib/auth.ts
@@ -1,0 +1,120 @@
+import NextAuth from 'next-auth';
+import type { NextAuthConfig, Session, User } from 'next-auth';
+import type { JWT } from 'next-auth/jwt';
+import Zitadel from 'next-auth/providers/zitadel';
+import { OIDCConfigurationError } from './errors';
+
+// Zitadel returns project roles as a nested map:
+// "urn:zitadel:iam:org:project:roles": { "roleName": { "orgId": "orgName" } }
+function extractZitadelRoles(profile: Record<string, unknown>): string[] {
+  const raw = profile['urn:zitadel:iam:org:project:roles'];
+  if (raw == null || typeof raw !== 'object') return [];
+  return Object.keys(raw as Record<string, unknown>);
+}
+
+if (!process.env['AUTH_ZITADEL_ISSUER']) {
+  throw new OIDCConfigurationError('AUTH_ZITADEL_ISSUER is not set');
+}
+if (!process.env['AUTH_ZITADEL_ID']) {
+  throw new OIDCConfigurationError('AUTH_ZITADEL_ID is not set');
+}
+if (!process.env['AUTH_ZITADEL_SECRET']) {
+  throw new OIDCConfigurationError('AUTH_ZITADEL_SECRET is not set');
+}
+
+const authConfig: NextAuthConfig = {
+  providers: [
+    Zitadel({
+      issuer: process.env['AUTH_ZITADEL_ISSUER'],
+      clientId: process.env['AUTH_ZITADEL_ID'],
+      clientSecret: process.env['AUTH_ZITADEL_SECRET'],
+      authorization: {
+        params: {
+          scope:
+            'openid profile email urn:zitadel:iam:org:project:roles',
+        },
+      },
+    }),
+  ],
+
+  callbacks: {
+    async jwt({
+      token,
+      account,
+      profile,
+    }: {
+      token: JWT;
+      account: unknown;
+      profile?: Record<string, unknown>;
+    }) {
+      if (account != null && profile != null) {
+        token['sub'] = (profile['sub'] as string | undefined) ?? token['sub'];
+        token['email'] = (profile['email'] as string | undefined) ?? token['email'];
+        token['roles'] = extractZitadelRoles(profile);
+      }
+      return token;
+    },
+
+    async session({ session, token }: { session: Session; token: JWT }) {
+      const s = session as Session & { roles: string[] };
+      s.roles = (token['roles'] as string[] | undefined) ?? [];
+      if (typeof token['email'] === 'string') {
+        s.user.email = token['email'];
+      }
+      return s;
+    },
+
+    authorized({
+      auth,
+      request,
+    }: {
+      auth: (Session & { roles?: string[] }) | null;
+      request: { nextUrl: URL };
+    }) {
+      const { nextUrl } = request;
+      const isLoggedIn = auth?.user != null;
+      const hasRole = (auth?.roles ?? []).includes('paperclip-ops:operator');
+      const protectedPaths = ['/launch'];
+      const isProtected = protectedPaths.some((p) =>
+        nextUrl.pathname.startsWith(p)
+      );
+      if (isProtected) return isLoggedIn && hasRole;
+      return true;
+    },
+  },
+
+  session: {
+    strategy: 'jwt',
+    maxAge: 8 * 60 * 60, // 8 hours
+  },
+
+  pages: {
+    signIn: '/login',
+    error: '/login',
+  },
+
+  trustHost: true,
+};
+
+export type AppSession = Session & { roles: string[] };
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);
+
+// Type-safe session accessor used in server components and route handlers.
+export async function requireSession(): Promise<AppSession> {
+  const session = (await auth()) as AppSession | null;
+  if (session == null) {
+    const { SessionInvalidError } = await import('./errors');
+    throw new SessionInvalidError('No active session');
+  }
+  return session;
+}
+
+export async function requireOperatorSession(): Promise<AppSession> {
+  const session = await requireSession();
+  if (!session.roles.includes('paperclip-ops:operator')) {
+    const { AuthProxyError } = await import('./errors');
+    throw new AuthProxyError('Missing paperclip-ops:operator role', 403);
+  }
+  return session;
+}

--- a/ops-portal/src/lib/auth.ts
+++ b/ops-portal/src/lib/auth.ts
@@ -12,22 +12,14 @@ function extractZitadelRoles(profile: Record<string, unknown>): string[] {
   return Object.keys(raw as Record<string, unknown>);
 }
 
-if (!process.env['AUTH_ZITADEL_ISSUER']) {
-  throw new OIDCConfigurationError('AUTH_ZITADEL_ISSUER is not set');
-}
-if (!process.env['AUTH_ZITADEL_ID']) {
-  throw new OIDCConfigurationError('AUTH_ZITADEL_ID is not set');
-}
-if (!process.env['AUTH_ZITADEL_SECRET']) {
-  throw new OIDCConfigurationError('AUTH_ZITADEL_SECRET is not set');
-}
-
+// Env vars are validated at request time (not module load) so Next.js static
+// analysis during build doesn't throw when the vars aren't set yet.
 const authConfig: NextAuthConfig = {
   providers: [
     Zitadel({
-      issuer: process.env['AUTH_ZITADEL_ISSUER'],
-      clientId: process.env['AUTH_ZITADEL_ID'],
-      clientSecret: process.env['AUTH_ZITADEL_SECRET'],
+      issuer: process.env['AUTH_ZITADEL_ISSUER'] ?? '',
+      clientId: process.env['AUTH_ZITADEL_ID'] ?? '',
+      clientSecret: process.env['AUTH_ZITADEL_SECRET'] ?? '',
       authorization: {
         params: {
           scope:
@@ -95,6 +87,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);
 
 // Type-safe session accessor used in server components and route handlers.
 export async function requireSession(): Promise<AppSession> {
+  if (!process.env['AUTH_ZITADEL_ISSUER'] || !process.env['AUTH_ZITADEL_ID'] || !process.env['AUTH_ZITADEL_SECRET']) {
+    throw new OIDCConfigurationError('AUTH_ZITADEL_ISSUER / AUTH_ZITADEL_ID / AUTH_ZITADEL_SECRET are not set');
+  }
   const session = (await auth()) as AppSession | null;
   if (session == null) {
     const { SessionInvalidError } = await import('./errors');

--- a/ops-portal/src/lib/auth.ts
+++ b/ops-portal/src/lib/auth.ts
@@ -4,6 +4,12 @@ import type { JWT } from 'next-auth/jwt';
 import Zitadel from 'next-auth/providers/zitadel';
 import { OIDCConfigurationError } from './errors';
 
+// The Zitadel role key that grants operator access.  Override via
+// OPERATOR_ROLE env var to match whatever key you created in Zitadel.
+// Zitadel role keys appear as-is in the token (no project-name prefix).
+export const OPERATOR_ROLE: string =
+  process.env['OPERATOR_ROLE'] ?? 'paperclip-ops:operator';
+
 // Zitadel returns project roles as a nested map:
 // "urn:zitadel:iam:org:project:roles": { "roleName": { "orgId": "orgName" } }
 function extractZitadelRoles(profile: Record<string, unknown>): string[] {
@@ -58,7 +64,7 @@ const authConfig: NextAuthConfig = {
     }) {
       const { nextUrl } = request;
       const isLoggedIn = auth?.user != null;
-      const hasRole = (auth?.roles ?? []).includes('paperclip-ops:operator');
+      const hasRole = (auth?.roles ?? []).includes(OPERATOR_ROLE);
       const protectedPaths = ['/launch'];
       const isProtected = protectedPaths.some((p) =>
         nextUrl.pathname.startsWith(p)
@@ -100,7 +106,7 @@ export async function requireSession(): Promise<AppSession> {
 
 export async function requireOperatorSession(): Promise<AppSession> {
   const session = await requireSession();
-  if (!session.roles.includes('paperclip-ops:operator')) {
+  if (!session.roles.includes(OPERATOR_ROLE)) {
     const { AuthProxyError } = await import('./errors');
     throw new AuthProxyError('Missing paperclip-ops:operator role', 403);
   }

--- a/ops-portal/src/lib/caddy-jwt.ts
+++ b/ops-portal/src/lib/caddy-jwt.ts
@@ -10,7 +10,9 @@ function getSecret(): Uint8Array {
       `${SECRET_ENV} is not set — Caddy session JWT cannot be minted`
     );
   }
-  return new TextEncoder().encode(raw);
+  // ggicci/caddy-jwt base64-decodes sign_key before using it as the HMAC key,
+  // so we must decode here to get the same key bytes Caddy will verify against.
+  return new Uint8Array(Buffer.from(raw, 'base64'));
 }
 
 export interface CaddyJwtPayload {

--- a/ops-portal/src/lib/caddy-jwt.ts
+++ b/ops-portal/src/lib/caddy-jwt.ts
@@ -1,0 +1,35 @@
+import { SignJWT } from 'jose';
+import { OIDCConfigurationError } from './errors';
+
+const SECRET_ENV = 'CADDY_SESSION_JWT_SECRET';
+
+function getSecret(): Uint8Array {
+  const raw = process.env[SECRET_ENV];
+  if (!raw) {
+    throw new OIDCConfigurationError(
+      `${SECRET_ENV} is not set — Caddy session JWT cannot be minted`
+    );
+  }
+  return new TextEncoder().encode(raw);
+}
+
+export interface CaddyJwtPayload {
+  email: string;
+  roles: string[];
+  sub: string;
+}
+
+export async function mintCaddyJwt(payload: CaddyJwtPayload): Promise<string> {
+  const secret = getSecret();
+  return new SignJWT({
+    email: payload.email,
+    roles: payload.roles,
+    sub: payload.sub,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('8h')
+    .setIssuer('ops-portal-vercel')
+    .setAudience('paperclip-ops-caddy')
+    .sign(secret);
+}

--- a/ops-portal/src/lib/errors.ts
+++ b/ops-portal/src/lib/errors.ts
@@ -1,0 +1,36 @@
+export class AuthProxyError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode = 500) {
+    super(message);
+    this.name = 'AuthProxyError';
+    this.statusCode = statusCode;
+  }
+}
+
+export class UpstreamUnreachableError extends Error {
+  readonly statusCode = 502;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'UpstreamUnreachableError';
+  }
+}
+
+export class SessionInvalidError extends Error {
+  readonly statusCode = 401;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionInvalidError';
+  }
+}
+
+export class OIDCConfigurationError extends Error {
+  readonly statusCode = 500;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'OIDCConfigurationError';
+  }
+}

--- a/ops-portal/src/middleware.ts
+++ b/ops-portal/src/middleware.ts
@@ -1,20 +1,17 @@
 import { auth } from '@/lib/auth';
-import type { AppSession } from '@/lib/auth';
+import type { Session } from 'next-auth';
 import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
 
 // Paths that require an active Auth.js session with the operator role.
 const PROTECTED = ['/launch', '/api/session'];
 
-export default auth(function middleware(
-  req: NextRequest & { auth: AppSession | null }
-) {
+export default auth((req) => {
   const { pathname } = req.nextUrl;
   const isProtected = PROTECTED.some((p) => pathname.startsWith(p));
 
   if (!isProtected) return NextResponse.next();
 
-  const session = req.auth;
+  const session = req.auth as (Session & { roles?: string[] }) | null;
   if (session == null) {
     const loginUrl = new URL('/login', req.url);
     return NextResponse.redirect(loginUrl);

--- a/ops-portal/src/middleware.ts
+++ b/ops-portal/src/middleware.ts
@@ -1,4 +1,4 @@
-import { auth } from '@/lib/auth';
+import { auth, OPERATOR_ROLE } from '@/lib/auth';
 import type { Session } from 'next-auth';
 import { NextResponse } from 'next/server';
 
@@ -17,7 +17,7 @@ export default auth((req) => {
     return NextResponse.redirect(loginUrl);
   }
 
-  const hasRole = session.roles?.includes('paperclip-ops:operator') ?? false;
+  const hasRole = session.roles?.includes(OPERATOR_ROLE) ?? false;
   if (!hasRole) {
     return NextResponse.json(
       { error: 'Insufficient role — paperclip-ops:operator required.' },

--- a/ops-portal/src/middleware.ts
+++ b/ops-portal/src/middleware.ts
@@ -1,0 +1,36 @@
+import { auth } from '@/lib/auth';
+import type { AppSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Paths that require an active Auth.js session with the operator role.
+const PROTECTED = ['/launch', '/api/session'];
+
+export default auth(function middleware(
+  req: NextRequest & { auth: AppSession | null }
+) {
+  const { pathname } = req.nextUrl;
+  const isProtected = PROTECTED.some((p) => pathname.startsWith(p));
+
+  if (!isProtected) return NextResponse.next();
+
+  const session = req.auth;
+  if (session == null) {
+    const loginUrl = new URL('/login', req.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const hasRole = session.roles?.includes('paperclip-ops:operator') ?? false;
+  if (!hasRole) {
+    return NextResponse.json(
+      { error: 'Insufficient role — paperclip-ops:operator required.' },
+      { status: 403 }
+    );
+  }
+
+  return NextResponse.next();
+});
+
+export const config = {
+  matcher: ['/launch', '/api/session'],
+};

--- a/ops-portal/tailwind.config.ts
+++ b/ops-portal/tailwind.config.ts
@@ -1,0 +1,34 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        void: {
+          950: '#07071a',
+          900: '#0d0d2b',
+          800: '#13133d',
+        },
+        nova: {
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7c3aed',
+        },
+        star: {
+          400: '#fbbf24',
+          500: '#f59e0b',
+        },
+      },
+      fontFamily: {
+        mono: ['var(--font-mono)', 'ui-monospace', 'Menlo', 'monospace'],
+      },
+      animation: {
+        'pulse-slow': 'pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/ops-portal/tsconfig.json
+++ b/ops-portal/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,49 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  ops-portal:
+    dependencies:
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+      next:
+        specifier: ^14.2.29
+        version: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth:
+        specifier: ^5.0.0-beta.25
+        version: 5.0.0-beta.31(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.6)
+      postcss:
+        specifier: ^8.4.47
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^3.4.14
+        version: 3.4.19(tsx@4.21.0)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
   packages/adapter-utils:
     devDependencies:
       '@types/node':
@@ -553,7 +596,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(next@14.2.35(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -813,6 +856,10 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
@@ -932,6 +979,20 @@ packages:
       '@types/react':
         optional: true
       react:
+        optional: true
+
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
         optional: true
 
   '@aws-crypto/crc32@5.2.0':
@@ -2282,6 +2343,63 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@next/env@14.2.35':
+    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
+
+  '@next/swc-darwin-arm64@14.2.33':
+    resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@14.2.33':
+    resolution: {integrity: sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@14.2.33':
+    resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@14.2.33':
+    resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@14.2.33':
+    resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    resolution: {integrity: sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@14.2.33':
+    resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@noble/ciphers@2.1.1':
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
@@ -2294,8 +2412,23 @@ packages:
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@paperclipai/adapter-utils@2026.325.0':
     resolution: {integrity: sha512-YDVSAgjkeJ0PvxXDJVN9MZDX7oYRzidLtGHmGgRGd6gSk/bF2ygAKvND4FI1YxDc/cRLQjqAFCpCYaC/9wqIEA==}
@@ -3500,6 +3633,12 @@ packages:
       typescript:
         optional: true
 
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.5':
+    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
 
@@ -3785,6 +3924,9 @@ packages:
   '@types/multer@2.0.0':
     resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
 
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
@@ -3794,16 +3936,27 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -3972,8 +4125,18 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4016,6 +4179,13 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
 
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
@@ -4079,6 +4249,11 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
@@ -4157,6 +4332,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -4168,8 +4347,17 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -4203,8 +4391,15 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4237,6 +4432,10 @@ packages:
   chevrotain@11.1.2:
     resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
 
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -4249,6 +4448,9 @@ packages:
 
   clean-set@1.1.2:
     resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -4288,6 +4490,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -4618,9 +4824,15 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -4754,6 +4966,9 @@ packages:
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  electron-to-chromium@1.5.351:
+    resolution: {integrity: sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==}
 
   embedded-postgres@18.1.0-beta.16:
     resolution: {integrity: sha512-TDp7Ld0h84x5fzIIZFyreYWqZrxUNjuXB6OxqJCmV6PodB2vzQ+1hlL6n4uK1de7bIAxYt5OkDykwcuIONQdQg==}
@@ -4914,6 +5129,10 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
@@ -4933,6 +5152,9 @@ packages:
     resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
     hasBin: true
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
 
@@ -4944,6 +5166,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -4964,6 +5190,9 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -5004,6 +5233,14 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -5113,6 +5350,10 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -5124,6 +5365,14 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -5139,6 +5388,10 @@ packages:
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -5160,9 +5413,16 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -5313,6 +5573,13 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
@@ -5428,6 +5695,10 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
 
   mermaid@11.12.3:
     resolution: {integrity: sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==}
@@ -5550,6 +5821,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -5600,6 +5875,9 @@ packages:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5618,15 +5896,63 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-auth@5.0.0-beta.31:
+    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
+  next@14.2.35:
+    resolution: {integrity: sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -5731,9 +6057,17 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
 
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
@@ -5754,6 +6088,10 @@ packages:
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -5778,9 +6116,56 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -5809,6 +6194,14 @@ packages:
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -5841,6 +6234,9 @@ packages:
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -5877,6 +6273,11 @@ packages:
   react-docgen@8.0.3:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -5964,13 +6365,24 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -6012,6 +6424,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
@@ -6034,6 +6450,9 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -6054,6 +6473,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -6213,8 +6635,26 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  styled-jsx@5.1.1:
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
 
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
@@ -6237,6 +6677,11 @@ packages:
   tailwind-merge@3.4.1:
     resolution: {integrity: sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q==}
 
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
@@ -6252,6 +6697,13 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -6292,6 +6744,10 @@ packages:
     resolution: {integrity: sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -6316,6 +6772,9 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -6742,6 +7201,8 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@alloc/quick-lru@5.2.0': {}
+
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
@@ -6864,6 +7325,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.4
+
+  '@auth/core@0.41.2':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.1.3
+      oauth4webapi: 3.8.6
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -8660,13 +9129,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@next/env@14.2.35': {}
+
+  '@next/swc-darwin-arm64@14.2.33':
+    optional: true
+
+  '@next/swc-darwin-x64@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-musl@14.2.33':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@14.2.33':
+    optional: true
+
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@open-draft/deferred-promise@2.2.0': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@paperclipai/adapter-utils@2026.325.0': {}
 
@@ -10003,6 +10515,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.5':
+    dependencies:
+      '@swc/counter': 0.1.3
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -10319,6 +10838,10 @@ snapshots:
     dependencies:
       '@types/express': 5.0.6
 
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -10331,13 +10854,24 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/prop-types@15.7.15': {}
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@types/react@19.2.14':
     dependencies:
@@ -10520,7 +11054,16 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
   append-field@1.0.0: {}
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -10557,6 +11100,15 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
+
+  autoprefixer@10.5.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001791
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
 
   axe-core@4.11.3: {}
 
@@ -10600,9 +11152,11 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.27: {}
+
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(next@14.2.35(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10619,6 +11173,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.9
       drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      next: 14.2.35(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10636,6 +11191,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  binary-extensions@2.3.0: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -10657,6 +11214,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
@@ -10664,6 +11225,14 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.351
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
 
@@ -10694,7 +11263,11 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  camelcase-css@2.0.1: {}
+
   caniuse-lite@1.0.30001770: {}
+
+  caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
 
@@ -10730,6 +11303,18 @@ snapshots:
       '@chevrotain/utils': 11.1.2
       lodash-es: 4.17.23
 
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -10741,6 +11326,8 @@ snapshots:
   classnames@2.5.1: {}
 
   clean-set@1.1.2: {}
+
+  client-only@0.0.1: {}
 
   clsx@2.1.1: {}
 
@@ -10784,6 +11371,8 @@ snapshots:
   commander@13.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@4.1.1: {}
 
   commander@7.2.0: {}
 
@@ -11112,7 +11701,11 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
+  didyoumean@1.2.2: {}
+
   diff@5.2.2: {}
+
+  dlv@1.1.3: {}
 
   doctrine@3.0.0:
     dependencies:
@@ -11166,6 +11759,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.286: {}
+
+  electron-to-chromium@1.5.351: {}
 
   embedded-postgres@18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei):
     dependencies:
@@ -11426,6 +12021,14 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-safe-stringify@2.1.1: {}
 
   fast-string-truncated-width@3.0.3: {}
@@ -11444,6 +12047,10 @@ snapshots:
     dependencies:
       strnum: 2.1.2
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fault@2.0.1:
     dependencies:
       format: 0.2.2
@@ -11451,6 +12058,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -11480,6 +12091,8 @@ snapshots:
       once: 1.4.0
 
   forwarded@0.2.0: {}
+
+  fraction.js@5.3.4: {}
 
   fresh@2.0.0: {}
 
@@ -11518,6 +12131,14 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@13.0.6:
     dependencies:
@@ -11637,6 +12258,10 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -11644,6 +12269,12 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
 
@@ -11654,6 +12285,8 @@ snapshots:
       is-docker: 3.0.0
 
   is-module@1.0.0: {}
+
+  is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -11669,7 +12302,11 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
+  jiti@1.21.7: {}
+
   jiti@2.6.1: {}
+
+  jose@5.10.0: {}
 
   jose@6.1.3: {}
 
@@ -11799,6 +12436,10 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
 
   lodash-es@4.17.23: {}
 
@@ -12031,6 +12672,8 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge2@1.4.1: {}
 
   mermaid@11.12.3:
     dependencies:
@@ -12347,6 +12990,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -12389,6 +13037,12 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.11: {}
 
   nanoid@5.1.7: {}
@@ -12397,11 +13051,78 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-auth@5.0.0-beta.31(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@auth/core': 0.41.2
+      next: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+
   next-tick@1.1.0: {}
+
+  next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.35
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001770
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+      '@playwright/test': 1.58.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@14.2.35(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 14.2.35
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001770
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.1(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+      '@playwright/test': 1.58.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
 
   node-releases@2.0.27: {}
 
+  node-releases@2.0.38: {}
+
+  normalize-path@3.0.0: {}
+
+  oauth4webapi@3.8.6: {}
+
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -12509,7 +13230,11 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.3: {}
+
+  pify@2.3.0: {}
 
   pino-abstract-transport@2.0.0:
     dependencies:
@@ -12558,6 +13283,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
+  pirates@4.0.7: {}
+
   pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
@@ -12581,10 +13308,48 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  postcss-import@15.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.11
+
+  postcss-js@4.1.0(postcss@8.5.6):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.6
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.6
+      tsx: 4.21.0
+
+  postcss-nested@6.2.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   postcss-selector-parser@6.0.10:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.6:
     dependencies:
@@ -12605,6 +13370,12 @@ snapshots:
   postgres@3.4.8: {}
 
   powershell-utils@0.1.0: {}
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -12639,6 +13410,8 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -12737,6 +13510,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -12825,13 +13604,25 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   react@19.2.4: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
 
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -12894,6 +13685,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  reusify@1.1.0: {}
+
   robust-predicates@3.0.2: {}
 
   rollup@4.60.1:
@@ -12948,6 +13741,10 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   rw@1.3.3: {}
 
   sade@1.8.1:
@@ -12963,6 +13760,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -13179,7 +13980,28 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+
+  styled-jsx@5.1.1(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+    optional: true
+
   stylis@4.3.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
 
   superagent@10.3.0:
     dependencies:
@@ -13211,6 +14033,34 @@ snapshots:
 
   tailwind-merge@3.4.1: {}
 
+  tailwindcss@3.4.19(tsx@4.21.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-import: 15.1.0(postcss@8.5.6)
+      postcss-js: 4.1.0(postcss@8.5.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)
+      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.11
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
@@ -13238,6 +14088,14 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thread-stream@3.1.0:
     dependencies:
@@ -13268,6 +14126,10 @@ snapshots:
     dependencies:
       tldts-core: 7.0.26
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   toidentifier@1.0.1: {}
 
   tough-cookie@6.0.1:
@@ -13285,6 +14147,8 @@ snapshots:
   ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
+
+  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -13381,6 +14245,12 @@ snapshots:
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,4 @@ packages:
   - server
   - ui
   - cli
+  - ops-portal

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -26,4 +26,12 @@ if [ "$changed" = "1" ]; then
     chown -R node:node /paperclip
 fi
 
+# Railway (and some other runtimes) mount volumes as root after the image
+# layers are applied, so /paperclip may be root-owned even when no UID remap
+# occurred.  Chown just the top-level directory so the node process can create
+# its own subdirectories.  Not recursive — avoids slowdown on large volumes.
+if [ "$(stat -c '%u' /paperclip)" != "$PUID" ]; then
+    chown node:node /paperclip
+fi
+
 exec gosu node "$@"


### PR DESCRIPTION
Railway (Nixpacks) and Vercel both run `next start`, which is incompatible with `output: 'standalone'` — the paperclip-ops-portal Railway service logs `"next start" does not work with "output: standalone"` and fails to serve. Standalone is only for Docker self-hosting (not used here); removing it lets `next start` serve the app + static assets on both targets. Unblocks the Railway paperclip-ops-portal (ops.torinagi.com login shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)