### PR TITLE
ui: fix React 19 `act` import in vitest by forcing dev build (KSI-712)

### DIFF
--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -3,9 +3,21 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
+    // Force Vite/Vitest to pick the development export for libraries that ship
+    // separate dev/prod bundles via package.json `exports` conditions (e.g. all
+    // `lexical*` packages). Without this, `lexical` and `@lexical/link` resolve
+    // through their `Lexical*.mjs` runtime dispatcher that keys on
+    // `process.env.NODE_ENV` — and the CI test runner (root `vitest.config.ts`
+    // + `scripts/run-vitest-stable.mjs`) sets `NODE_ENV=test`, which makes the
+    // dispatcher pull a mix of dev/prod singletons across `lexical` and
+    // `@lexical/link` in the same worker. That mix surfaces as
+    // "LexicalNode: Node LexicalNode does not implement .getType()". Pinning
+    // the `development` condition keeps all lexical packages on the same dev
+    // singleton, matching the React 19 dev build that is forced in
+    // `vitest.setup.ts` to expose `act`. Tracked in KSI-712.
+    conditions: ["development", "import", "module", "node", "default"],
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      lexical: path.resolve(__dirname, "./node_modules/lexical/Lexical.mjs"),
     },
   },
   test: {

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -1,3 +1,12 @@
+// React 19 only exposes `act` from the development build of `react`. Vitest by default
+// runs with NODE_ENV=test, which makes Node resolve `react` to its production CJS bundle
+// — that bundle does not export `act`, so any test using `import { act } from "react"`
+// fails with "(0 , act) is not a function". Force the development build here, before
+// any test file imports `react`. Tracked in KSI-712.
+if (process.env.NODE_ENV !== "development") {
+  process.env.NODE_ENV = "development";
+}
+
 const storageEntries = new Map<string, string>();
 
 function installStorageMock(target: Record<string, unknown>) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The web UI (`@paperclipai/ui`) ships on React 19 and is exercised by ~1,120 vitest cases that gate every release
> - 73 of those test files import `{ act } from "react"` to drive `createRoot` updates inside `IS_REACT_ACT_ENVIRONMENT`. Under React 19 that named export only exists in the development bundle of `react`
> - `scripts/run-vitest-stable.mjs` (the canonical CI runner) sets `NODE_ENV=test`, so Node resolves `react/index.js` to `react.production.js`, which does not export `act`. Result: 443 of 1,120 UI tests fail with `(0 , act) is not a function`, blocking refactors and releases
> - This pull request flips `process.env.NODE_ENV` to `development` from inside `ui/vitest.setup.ts` before any test file imports `react`, and pins `resolve.conditions` to the `development` bundle for the whole `@paperclipai/ui` test runner so all `lexical*` packages (which ship dev/prod via exports conditions and a runtime dispatcher) stay on a single dev singleton — otherwise mixing dev `lexical` with prod `@lexical/link` (or the inverse) registers two conflicting `LexicalNode` classes in the same worker and surfaces as "Node LexicalNode does not implement .getType()"
> - The benefit is a fully green `@paperclipai/ui` test suite (1,120/1,120) without touching any source or test code, and without changing the build/dev pipeline

## What Changed

- `ui/vitest.setup.ts`: prepend `process.env.NODE_ENV = "development"` (idempotent guard) before any other code so React 19's dev bundle is loaded by the test runner. Comment cross-links to KSI-712.
- `ui/vitest.config.ts`: add `resolve.conditions = ["development", "import", "module", "node", "default"]`. This makes Vite/Vitest pick each lexical package's `*.dev.mjs` entry through the package.json `exports` map directly, instead of going through `Lexical.mjs` / `LexicalLink.mjs` runtime dispatchers that branch on `process.env.NODE_ENV`. Comment explains the coupling with the React fix and the previous CI failure mode.

No source code, no tests, no production build paths were modified. The `vite.config.ts` (used by build/dev) is untouched on purpose.

## Verification

Inside the running Paperclip dev tree at `/app/ui` (single-project shape):

```
$ cd ui && npx vitest run
Test Files  178 passed (178)
Tests       1120 passed (1120)
```

Reproducing the CI shape (root + `--project` + `NODE_ENV=test`, exactly how `scripts/run-vitest-stable.mjs` invokes it):

```
$ NODE_ENV=test pnpm exec vitest run --project @paperclipai/ui
Test Files  178 passed (178)
Tests       1120 passed (1120)
```

Before the fix in this branch, the same root invocation produced:

```
Test Files  73 failed | 105 passed (178)
Tests       443 failed | 677 passed (1120)
TypeError: (0 , act) is not a function
```

After the first iteration (alias `lexical` → `Lexical.prod.mjs` only) the root invocation still produced 3 lexical singleton conflicts that did **not** show up when running from inside `ui/`:

```
Error: LexicalNode: Node LexicalNode does not implement .getType().
 ❯ formatDevErrorMessage Lexical.dev.mjs:20
 ❯ LexicalNode.getType Lexical.dev.mjs:3181
 ❯ Do Lexical.prod.mjs:9
```

That dev/prod stack mix only happens from the root because `--project @paperclipai/ui` uses the project config but the package alias only covered `lexical`, not the sibling `@lexical/link`. Pinning `resolve.conditions` to the `development` set covers every `lexical*` package's exports map at once, so they all agree on the same singleton.

`npx tsc -b` in `ui/` is also clean.

## Risks

- Low risk. The change is scoped to the test runner of a single workspace package (`@paperclipai/ui`):
  - `process.env.NODE_ENV = "development"` only takes effect inside the vitest worker that loads `vitest.setup.ts`. Production builds (`pnpm --filter @paperclipai/ui build`) and the Vite dev server are unaffected — they have their own NODE_ENV handling and a separate `vite.config.ts`.
  - `resolve.conditions` here only changes how Vite resolves `exports` maps for the test runtime. It does not affect the production bundle or the dev server. The order keeps `import`, `module`, `node`, `default` after `development`, matching Vitest defaults aside from the prefixed `development` condition.
- No public API changes, no dependency bumps, no migrations.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4 (Bedrock Converse, model ID `bedrock_converse/claude-opus-4-7`)
- Reasoning: Auto thinking effort (default for Bedrock Converse on ksio.dev)
- Tool use: yes (file read/edit, vitest, git, gh)
- Used by Callisto, Paperclip Infra Architect at ksio.dev, while operating on issue KSI-712.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (1120/1120 in `@paperclipai/ui`, both single-project and root `--project` invocations)
- [x] I have added or updated tests where applicable (no new tests needed — this change unblocks the existing 443 broken tests as-is)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — this is a test infra change, not a visual change; before/after test counts included above)
- [x] I have updated relevant documentation to reflect my changes (inline comments in both modified files cross-link to KSI-712)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
