### PR TITLE
Suppress assignee self-wakes for own-run actors (EDD-303)

### DIFF
--- a/server/src/__tests__/is-assignee-own-run.test.ts
+++ b/server/src/__tests__/is-assignee-own-run.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { isAssigneeOwnRun } from "../routes/is-assignee-own-run.js";
+
+const issue = {
+  assigneeAgentId: "agent-A",
+  checkoutRunId: "run-1",
+  executionRunId: "run-2",
+};
+
+describe("isAssigneeOwnRun", () => {
+  it("returns false when issue has no assignee", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-A", runId: "run-1" },
+        issue: { assigneeAgentId: null, checkoutRunId: "run-1", executionRunId: null },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-agent actors", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "board", actorId: "agent-A", runId: "run-1" },
+        issue,
+      }),
+    ).toBe(false);
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "user", actorId: "agent-A", runId: "run-1" },
+        issue,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when actor agent id matches assignee", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-A", runId: null },
+        issue,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for proxy/sub-agent whose runId matches checkoutRunId", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-Proxy", runId: "run-1" },
+        issue,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for proxy/sub-agent whose runId matches executionRunId", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-Proxy", runId: "run-2" },
+        issue,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a different agent with an unrelated runId", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-B", runId: "run-other" },
+        issue,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for a different agent with no runId", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-B", runId: null },
+        issue,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when both run ids on the issue are null and ids differ", () => {
+    expect(
+      isAssigneeOwnRun({
+        actor: { actorType: "agent", actorId: "agent-B", runId: "run-1" },
+        issue: { assigneeAgentId: "agent-A", checkoutRunId: null, executionRunId: null },
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/routes/is-assignee-own-run.ts
+++ b/server/src/routes/is-assignee-own-run.ts
@@ -1,0 +1,33 @@
+export interface IsAssigneeOwnRunActor {
+  actorType: "agent" | "board" | "user" | string;
+  actorId: string;
+  runId?: string | null;
+}
+
+export interface IsAssigneeOwnRunIssue {
+  assigneeAgentId?: string | null;
+  checkoutRunId?: string | null;
+  executionRunId?: string | null;
+}
+
+/**
+ * Returns true when `actor` is the assignee of `issue` itself, OR when the
+ * actor is acting under the assignee's currently-active checkout or execution
+ * run (covers sub-agent / proxy posts authored on behalf of the assignee).
+ *
+ * Used to suppress phantom self-wakes (`issue_commented`, `issue_status_changed`)
+ * that would otherwise re-fire the same agent's heartbeat in a loop.
+ */
+export function isAssigneeOwnRun(input: {
+  actor: IsAssigneeOwnRunActor;
+  issue: IsAssigneeOwnRunIssue;
+}): boolean {
+  const { actor, issue } = input;
+  const assigneeId = issue.assigneeAgentId;
+  if (!assigneeId) return false;
+  if (actor.actorType !== "agent") return false;
+  if (actor.actorId === assigneeId) return true;
+  const runId = actor.runId;
+  if (!runId) return false;
+  return runId === issue.checkoutRunId || runId === issue.executionRunId;
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -89,6 +89,7 @@ import {
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { isAssigneeOwnRun } from "./is-assignee-own-run.js";
 import {
   isInlineAttachmentContentType,
   normalizeIssueAttachmentMaxBytes,
@@ -1137,14 +1138,20 @@ export function issueRoutes(
   }
 
   function queueAnnotationCommentWakeup(input: {
-    issue: { id: string; assigneeAgentId: string | null; status: string };
-    actor: { actorType: "user" | "agent"; actorId: string };
+    issue: {
+      id: string;
+      assigneeAgentId: string | null;
+      checkoutRunId?: string | null;
+      executionRunId?: string | null;
+      status: string;
+    };
+    actor: { actorType: "user" | "agent"; actorId: string; runId?: string | null };
     threadId: string;
     commentId: string;
     documentKey: string;
   }) {
     const assigneeId = input.issue.assigneeAgentId;
-    const selfComment = input.actor.actorType === "agent" && input.actor.actorId === assigneeId;
+    const selfComment = isAssigneeOwnRun({ actor: input.actor, issue: input.issue });
     if (!assigneeId || selfComment || isClosedIssueStatus(input.issue.status)) return;
     void heartbeat.wakeup(assigneeId, {
       source: "automation",
@@ -4716,7 +4723,8 @@ export function issueRoutes(
       if (
         !assigneeChanged &&
         (statusChangedFromBacklog || statusChangedFromBlockedToTodo || statusChangedFromClosedToTodo) &&
-        issue.assigneeAgentId
+        issue.assigneeAgentId &&
+        !isAssigneeOwnRun({ actor, issue })
       ) {
         addWakeup(issue.assigneeAgentId, {
           source: "automation",
@@ -4742,7 +4750,7 @@ export function issueRoutes(
       if (commentBody && comment) {
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
-        const selfComment = actorIsAgent && actor.actorId === assigneeId;
+        const selfComment = isAssigneeOwnRun({ actor, issue });
         const skipAssigneeCommentWake = selfComment || isClosed;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
@@ -5831,7 +5839,7 @@ export function issueRoutes(
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
-      const selfComment = actorIsAgent && actor.actorId === assigneeId;
+      const selfComment = isAssigneeOwnRun({ actor, issue: currentIssue });
       const skipWake = selfComment || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {


### PR DESCRIPTION
Closes the SCB OPERATOR ATTENTION REQUIRED recursion loop logged in EDD-303 / EDD-304.

## Problem

SCB-class agents loop because `issue_commented` (and to a lesser extent `issue_status_changed`) wakes fire on actions taken *by the assignee's own active run* -- including sub-agents/proxies posting under that run. The existing self-comment guard in `server/src/routes/issues.ts` only checks `actor.actorId === assigneeId`, which misses the sub-agent author path. Result: ~10 self-triggered runs over 30 min on EDD-191 (04:40Z-05:11Z) and the same pattern on EDD-205.

## Fix

New `isAssigneeOwnRun({ actor, issue })` helper in `server/src/routes/is-assignee-own-run.ts` returning true when:

- `actor.actorType === 'agent' && actor.actorId === issue.assigneeAgentId`, OR
- `actor.runId` matches `issue.checkoutRunId` or `issue.executionRunId`.

Wired into:

1. `PATCH /api/issues/:id` `statusChangedFromBacklog` wake -- no more self-wake on own-run backlog->todo flips.
2. `POST /api/issues/:id/comments` `selfComment` calc -- proxy/sub-agent comments on behalf of the assignee no longer fire `issue_commented` back at the assignee. Reopen-via-comment branch preserved.

`PATCH /api/issues/:id` `issue_assigned` wake intentionally not wrapped -- it only fires on a real assignee change, where the helper would already return false for the new assignee. @-mention wakes left untouched (they already self-skip and are an explicit cross-agent signal).

## Tests

`server/src/__tests__/is-assignee-own-run.test.ts` -- 8 unit cases (null assignee, non-agent actors, direct id match, proxy via checkoutRunId, proxy via executionRunId, unrelated agent with/without runId, both run ids null).

`pnpm exec tsc --noEmit` clean.

## Verification

Per [EDD-303 plan](https://your.paperclip/EDD/issues/EDD-303) Verification section:

1. Deploy.
2. Reassign EDD-191 back to SCB, status `in_progress`.
3. Trigger one SCB heartbeat.
4. Confirm exactly one new `OPERATOR ATTENTION REQUIRED` comment posts and no follow-up SCB run wakes from that comment.