### PR TITLE
Show issue work products on detail page

### DIFF
--- a/ui/src/context/LiveUpdatesProvider.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.test.ts
@@ -188,6 +188,40 @@ describe("LiveUpdatesProvider issue invalidation", () => {
     });
   });
 
+  it("refreshes issue work products when a work product activity event arrives", () => {
+    const invalidations: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: (input: unknown) => {
+        invalidations.push(input);
+      },
+      getQueryData: () => undefined,
+    };
+
+    __liveUpdatesTestUtils.invalidateActivityQueries(
+      queryClient as never,
+      "company-1",
+      {
+        entityType: "issue",
+        entityId: "issue-1",
+        action: "issue.work_product_created",
+        actorType: "agent",
+        actorId: "agent-1",
+        details: {
+          identifier: "PAP-9403",
+          workProductId: "work-product-1",
+        },
+      },
+      { userId: "user-1", agentId: null },
+    );
+
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.issues.workProducts("issue-1"),
+    });
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.issues.workProducts("PAP-9403"),
+    });
+  });
+
   it("keeps self-authored comment events from refetching the active issue tree", () => {
     const invalidations: unknown[] = [];
     const queryClient = {

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -710,6 +710,9 @@ function invalidateActivityQueries(
             queryClient.invalidateQueries({ queryKey: ["issues", "document-revisions", ref], ...invalidationOptions });
           }
         }
+        if (action?.startsWith("issue.work_product_")) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.issues.workProducts(ref), ...invalidationOptions });
+        }
         if (action?.startsWith("issue.thread_interaction_")) {
           queryClient.invalidateQueries({ queryKey: queryKeys.issues.interactions(ref), ...invalidationOptions });
         }

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Agent, Issue, IssueTreeControlPreview, IssueTreeHold } from "@paperclipai/shared";
+import type { Agent, Issue, IssueTreeControlPreview, IssueTreeHold, IssueWorkProduct } from "@paperclipai/shared";
 import { act, type AnchorHTMLAttributes, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +13,7 @@ const mockIssuesApi = vi.hoisted(() => ({
   listAcceptedPlanDecompositions: vi.fn(),
   listComments: vi.fn(),
   listAttachments: vi.fn(),
+  listWorkProducts: vi.fn(),
   listFeedbackVotes: vi.fn(),
   markRead: vi.fn(),
   update: vi.fn(),
@@ -441,6 +442,35 @@ function createAgent(overrides: Partial<Agent> = {}): Agent {
   };
 }
 
+function createWorkProduct(overrides: Partial<IssueWorkProduct> = {}): IssueWorkProduct {
+  return {
+    id: "work-product-1",
+    companyId: "company-1",
+    projectId: null,
+    issueId: "issue-1",
+    executionWorkspaceId: null,
+    runtimeServiceId: null,
+    type: "artifact",
+    provider: "paperclip",
+    externalId: null,
+    title: "coder_plan_fe.md",
+    url: null,
+    status: "ready_for_review",
+    reviewState: "needs_board_review",
+    isPrimary: false,
+    healthStatus: "unknown",
+    summary: "# Coder Plan: fe",
+    metadata: {
+      path: "artifacts/runs/demo/coder_plan_fe.md",
+      source: "leo-office",
+    },
+    createdByRunId: null,
+    createdAt: new Date("2026-04-21T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-21T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 function createPauseHold(overrides: Partial<IssueTreeHold> = {}): IssueTreeHold {
   const now = new Date("2026-04-21T00:00:00.000Z");
   return {
@@ -801,6 +831,7 @@ describe("IssueDetail", () => {
     mockIssuesApi.list.mockResolvedValue([]);
     mockIssuesApi.listComments.mockResolvedValue([]);
     mockIssuesApi.listAttachments.mockResolvedValue([]);
+    mockIssuesApi.listWorkProducts.mockResolvedValue([]);
     mockIssuesApi.listFeedbackVotes.mockResolvedValue([]);
     mockIssuesApi.markRead.mockResolvedValue({ id: "issue-1", lastReadAt: new Date().toISOString() });
     mockIssuesApi.getTreeControlState.mockResolvedValue({ activePauseHold: null });
@@ -1045,6 +1076,37 @@ describe("IssueDetail", () => {
     expect(container.textContent).toContain("Next");
     expect(container.textContent).toContain("First child");
     expect(mockIssueChatThreadRender.mock.calls.at(-1)?.[0].footer).toBeTruthy();
+  });
+
+  it("renders issue work products returned by the API", async () => {
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+    mockIssuesApi.listWorkProducts.mockResolvedValue([
+      createWorkProduct(),
+      createWorkProduct({
+        id: "work-product-2",
+        title: "pr_summary.md",
+        type: "document",
+        summary: "# PR Summary",
+        metadata: { path: "artifacts/runs/demo/pr_summary.md" },
+      }),
+    ]);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Work products");
+    expect(container.textContent).toContain("coder_plan_fe.md");
+    expect(container.textContent).toContain("ready for review");
+    expect(container.textContent).toContain("needs board review");
+    expect(container.textContent).toContain("artifacts/runs/demo/pr_summary.md");
   });
 
   it("passes blocker attention to the issue detail header status icon", async () => {

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -150,6 +150,7 @@ import {
   type Issue,
   type IssueAttachment,
   type IssueComment,
+  type IssueWorkProduct,
   type IssueWorkMode,
   type IssueThreadInteraction,
   type RequestConfirmationInteraction,
@@ -397,6 +398,77 @@ function IssueSectionSkeleton({
         {Array.from({ length: rows }).map((_, index) => (
           <Skeleton key={index} className="h-12 w-full rounded-md" />
         ))}
+      </div>
+    </div>
+  );
+}
+
+function formatWorkProductValue(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return value.replace(/_/g, " ");
+}
+
+function workProductMetadataPath(workProduct: IssueWorkProduct): string | null {
+  const path = workProduct.metadata?.path;
+  return typeof path === "string" && path.trim() ? path : null;
+}
+
+function IssueWorkProductsSection({
+  workProducts,
+}: {
+  workProducts: IssueWorkProduct[];
+}) {
+  if (workProducts.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium text-muted-foreground">Work products</h3>
+        <span className="text-xs text-muted-foreground">{workProducts.length}</span>
+      </div>
+      <div className="space-y-2">
+        {workProducts.map((workProduct) => {
+          const path = workProductMetadataPath(workProduct);
+          const reviewState = formatWorkProductValue(workProduct.reviewState);
+          const status = formatWorkProductValue(workProduct.status);
+          const type = formatWorkProductValue(workProduct.type);
+          const title = workProduct.url ? (
+            <a
+              href={workProduct.url}
+              target="_blank"
+              rel="noreferrer"
+              className="font-medium text-foreground underline-offset-4 hover:underline"
+            >
+              {workProduct.title}
+            </a>
+          ) : (
+            <span className="font-medium text-foreground">{workProduct.title}</span>
+          );
+
+          return (
+            <div key={workProduct.id} className="rounded-lg border border-border bg-card/40 p-3">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0 space-y-1">
+                  {title}
+                  {workProduct.summary ? (
+                    <p className="line-clamp-2 text-sm text-muted-foreground">{workProduct.summary}</p>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap justify-end gap-1 text-[11px] text-muted-foreground">
+                  {status ? <span className="rounded border border-border px-1.5 py-0.5">{status}</span> : null}
+                  {reviewState && reviewState !== "none" ? (
+                    <span className="rounded border border-border px-1.5 py-0.5">{reviewState}</span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                {type ? <span>{type}</span> : null}
+                <span>{workProduct.provider}</span>
+                {path ? <span className="break-all">{path}</span> : null}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -1337,6 +1409,13 @@ export function IssueDetail() {
     queryFn: () => issuesApi.listAttachments(issueId!),
     enabled: !!issueId,
     placeholderData: keepPreviousDataForSameQueryTail<IssueAttachment[]>(issueId ?? "pending"),
+  });
+
+  const { data: workProducts, isLoading: workProductsLoading } = useQuery({
+    queryKey: queryKeys.issues.workProducts(issueId!),
+    queryFn: () => issuesApi.listWorkProducts(issueId!),
+    enabled: !!issueId,
+    placeholderData: keepPreviousDataForSameQueryTail<IssueWorkProduct[]>(issueId ?? "pending"),
   });
 
   const { data: liveRunCount = 0 } = useQuery<LiveRunForIssue[], Error, number>({
@@ -2820,6 +2899,7 @@ export function IssueDetail() {
 
   const isImageAttachment = (attachment: IssueAttachment) => attachment.contentType.startsWith("image/");
   const attachmentList = attachments ?? [];
+  const workProductList = workProducts ?? [];
   const imageAttachments = attachmentList.filter(isImageAttachment);
   const nonImageAttachments = attachmentList.filter((a) => !isImageAttachment(a));
 
@@ -2921,6 +3001,7 @@ export function IssueDetail() {
   }, [showInboxToolbar, backHref, issue?.id, issueHidden, archivePending, setMobileToolbar]);
 
   const attachmentsInitialLoading = attachmentsLoading && attachments === undefined;
+  const workProductsInitialLoading = workProductsLoading && workProducts === undefined;
   const loadOlderComments = useCallback(() => {
     void fetchOlderComments();
   }, [fetchOlderComments]);
@@ -3756,6 +3837,12 @@ export function IssueDetail() {
         agentMap={agentMap}
         userProfileMap={userProfileMap}
       />
+
+      {workProductsInitialLoading ? (
+        <IssueSectionSkeleton titleWidth="w-28" rows={2} />
+      ) : (
+        <IssueWorkProductsSection workProducts={workProductList} />
+      )}
 
       {attachmentsInitialLoading ? (
         <IssueSectionSkeleton titleWidth="w-24" rows={2} />


### PR DESCRIPTION
## Summary
- Render issue work products on the issue detail page using the existing work-products API endpoint.
- Show title, summary, status, review state, provider/type, and artifact path metadata.
- Add IssueDetail coverage proving API-returned work products are visible.

## Verification
- pnpm.cmd vitest run ui/src/pages/IssueDetail.test.tsx

## Notes
- pnpm.cmd --filter @paperclipai/ui typecheck currently fails before this change is evaluated because ui/src/adapters/grok-local/index.ts cannot resolve @paperclipai/adapter-grok-local/ui.