### PR TITLE
gemini unknown session regex clean rebased

### DIFF
--- a/packages/adapters/gemini-local/src/server/parse.test.ts
+++ b/packages/adapters/gemini-local/src/server/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseGeminiJsonl } from "./parse.js";
+import { isGeminiUnknownSessionError, parseGeminiJsonl } from "./parse.js";
 
 describe("parseGeminiJsonl", () => {
   it("collects assistant text from message events with string content", () => {
@@ -129,5 +129,26 @@ describe("parseGeminiJsonl", () => {
 
     const result = parseGeminiJsonl(stdout);
     expect(result.errorMessage).toBe("boom");
+  });
+});
+
+describe("isGeminiUnknownSessionError", () => {
+  it("returns true for 'No previous sessions found' message (Gemini CLI v0.43+)", () => {
+    expect(
+      isGeminiUnknownSessionError(
+        "",
+        "Error resuming session: No previous sessions found for this project.",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for existing patterns", () => {
+    expect(isGeminiUnknownSessionError("", "unknown session xyz")).toBe(true);
+    expect(isGeminiUnknownSessionError("", "cannot resume")).toBe(true);
+    expect(isGeminiUnknownSessionError("", "failed to resume session")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isGeminiUnknownSessionError("", "rate limit exceeded")).toBe(false);
   });
 });

--- a/packages/adapters/gemini-local/src/server/parse.ts
+++ b/packages/adapters/gemini-local/src/server/parse.ts
@@ -206,7 +206,7 @@ export function isGeminiUnknownSessionError(stdout: string, stderr: string): boo
     .filter(Boolean)
     .join("\n");
 
-  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume/i.test(
+  return /unknown\s+session|session\s+.*\s+not\s+found|resume\s+.*\s+not\s+found|checkpoint\s+.*\s+not\s+found|cannot\s+resume|failed\s+to\s+resume|no\s+previous\s+sessions\s+found/i.test(
     haystack,
   );
 }


### PR DESCRIPTION
Automated fix from overnight sprint. Branch: `fix/gemini-unknown-session-regex-clean-rebased`.