### PR TITLE
null author comment service label

### DIFF
--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -358,7 +358,9 @@ function CommentCard({
       } ${isPending ? "opacity-80" : ""}`}
     >
       <div className="flex items-center justify-between mb-1">
-        {comment.authorAgentId ? (
+        {comment.authorType === "system" ? (
+          <Identity name="System" size="sm" className="text-muted-foreground" />
+        ) : comment.authorAgentId ? (
           <Link to={`/agents/${comment.authorAgentId}`} className="hover:underline">
             <Identity
               name={agentMap?.get(comment.authorAgentId)?.name ?? comment.authorAgentId.slice(0, 8)}


### PR DESCRIPTION
Automated fix from overnight sprint. Branch: `fix/null-author-comment-service-label-clean`.