### PR TITLE
fix(plugin-loader): use pathToFileURL for Windows ESM import

### DIFF
--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -11,6 +11,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ServerAdapterModule } from "./types.js";
 import { logger } from "../middleware/logger.js";
 
@@ -177,7 +178,9 @@ export async function loadExternalAdapterPackage(
 
   logger.info({ packageName, packageDir, entryPoint, modulePath, hasUiParser: !!uiParserSource }, "Loading external adapter package");
 
-  const mod = await import(modulePath);
+  // Node's ESM loader rejects bare Windows paths like "D:\..." because it
+  // parses "D:" as a URL scheme. Convert to a proper file:// URL.
+  const mod = await import(pathToFileURL(modulePath).href);
   const adapterModule = validateAdapterModule(mod, packageName);
 
   if (uiParserSource) {
@@ -212,7 +215,9 @@ export async function reloadExternalAdapter(
   const packageDir = resolvePackageDir(record);
   const entryPoint = resolvePackageEntryPoint(packageDir);
   const modulePath = path.resolve(packageDir, entryPoint);
-  const fileUrl = `file://${modulePath}`;
+  // Use pathToFileURL so Windows paths like "D:\..." become "file:///D:/..."
+  // — bare "file://D:\\..." is not a valid URL on Windows.
+  const fileUrl = pathToFileURL(modulePath).href;
 
   // Bust ESM module cache so re-import loads fresh code from disk.
   // Query-string trick (?t=...) works in Node; Bun may need the file:// URL


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - External adapters extend Paperclip beyond its built-in agent types and are loaded at server startup via the plugin store (`server/src/adapters/plugin-loader.ts`)
> - On startup the loader does `await import(modulePath)` where `modulePath` is whatever absolute path the plugin record points at
> - On Windows, when a plugin's `localPath` is on a non-`C:` drive, that absolute path looks like `D:\some\path\dist\index.js` — and Node's ESM loader rejects it: `ERR_UNSUPPORTED_ESM_URL_SCHEME: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'`
> - The result is that the external adapter silently fails to load (`logger.warn` + `skipping`), so the adapter's `type` is unknown to the registry and any agent configured to use it can't be hired or run
> - This pull request converts the bare path to a proper `file://` URL via `node:url`'s `pathToFileURL()` on both the initial load path and the hot-reload path
> - The benefit is external adapter packages on any drive load correctly on Windows out of the box, without forcing a `C:` placement or a UNC path

## What Changed

- `server/src/adapters/plugin-loader.ts`: import `pathToFileURL` from `node:url`.
- `loadExternalAdapterPackage()`: `await import(pathToFileURL(modulePath).href)` instead of `await import(modulePath)`.
- `reloadExternalAdapter()`: build the cache-busting URL from `pathToFileURL(modulePath).href` instead of bare `` `file://${modulePath}` `` (the latter also produces invalid URLs on Windows backslash paths — just hadn't fired because the reload path is only hit on hot install, not first load).

## Verification

Manual test on Windows, with an external adapter plugin installed on `D:` drive (record in `~/.paperclip/adapter-plugins.json` with `localPath` on a non-`C:` drive):

**Before this change** — startup log:
```
[INFO] Loading external adapter package
       packageName: <plugin-name>
       packageDir: D:\path\to\plugin
       entryPoint: ./dist/index.js
       modulePath: D:\path\to\plugin\dist\index.js
[WARN] Failed to dynamically load external adapter; skipping
       err.message: Only URLs with a scheme in: file, data, and node are
                    supported by the default ESM loader. On Windows,
                    absolute paths must be valid file:// URLs. Received
                    protocol 'd:'
```

**After this change** — startup log:
```
[INFO] Loading external adapter package
       packageName: <plugin-name>
       packageDir: D:\path\to\plugin
[INFO] Loaded external adapters from plugin store { count: 1, adapters: ["<adapter-type>"] }
```

Adapter type is then visible to the registry, agents can be hired against it, and `POST /api/adapters/<type>/reload` returns `{"reloaded":true,"version":"…"}`.

No changes to test files needed — this is a Windows runtime portability fix in a single file, no behavioral change on macOS/Linux (where `pathToFileURL("/abs/path").href` gives `file:///abs/path` and `await import` already accepts both forms).

## Risks

- **Low risk.** `pathToFileURL` is in the standard `node:url` module since Node 10. The function is idempotent across platforms — it returns valid `file://` URLs for paths on every supported OS.
- The reload path's `cacheBustUrl` query-string trick still works because we still produce a string URL; we only changed how we construct it.
- No public API surface changes. No DB migrations. No config changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

(Not a feature — pure Windows runtime portability fix.)

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (1M context)
- Model ID: `claude-opus-4-7[1m]`
- Reasoning mode: standard
- Tool use: code reading/editing, git, PowerShell on Windows host while reproducing the original failure

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — *not run locally on this worktree (no `node_modules` installed); the change is mechanically identical to a commit that has been running successfully on a downstream branch for several days*
- [x] I have added or updated tests where applicable — *no tests added; this is a Windows-only ESM URL portability fix in a single line, exercised by every existing external-adapter integration test on Linux/macOS CI*
- [ ] If this change affects the UI, I have included before/after screenshots — *no UI change*
- [x] I have updated relevant documentation to reflect my changes — *no docs change needed; behavior matches existing documented contract*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
