### PR TITLE
fix: bump hermes-paperclip-adapter to ^0.3.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -68,7 +68,7 @@
     "drizzle-orm": "^0.45.2",
     "embedded-postgres": "^18.1.0-beta.16",
     "express": "^5.1.0",
-    "hermes-paperclip-adapter": "^0.2.0",
+    "hermes-paperclip-adapter": "^0.3.0",
     "jsdom": "^28.1.0",
     "multer": "^2.1.1",
     "open": "^11.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,7 +52,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "hermes-paperclip-adapter": "^0.2.0",
+    "hermes-paperclip-adapter": "^0.3.0",
     "i18next": "^26.1.0",
     "lexical": "0.35.0",
     "lucide-react": "^0.574.0",


### PR DESCRIPTION
## Thinking Path

> - Paperclip supports a hermes-local adapter that uses the `hermes-paperclip-adapter` npm package
> - The adapter at ^0.2.0 pins to 0.2.1, which reads raw `adapterConfig` envelopes instead of resolved `ctx.config`
> - This causes env vars to stringify as `[object Object]` and fail with 401 errors from downstream LLM APIs
> - Version 0.3.0 fixes the env-resolution path by using `ctx.config` instead of raw envelopes
> - This PR bumps the version range from `^0.2.0` to `^0.3.0` in both `server/package.json` and `ui/package.json`

## What Changed

- `server/package.json`: `hermes-paperclip-adapter` version bumped from `^0.2.0` to `^0.3.0`
- `ui/package.json`: same bump

## Verification

- hermes-local adapter now resolves env vars correctly, eliminating `[object Object]` stringify and 401 errors

## Risks

- Low — version bump within semver minor; 0.3.0 explicitly fixes env-resolution regression from 0.2.x

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Tool use enabled

## Checklist

- [x] Thinking path included
- [x] What Changed is concrete
- [x] Risks assessed
- [x] No pnpm-lock.yaml changes