### PR TITLE
Recover claude_local modified-thinking resume failures

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -328,4 +328,83 @@ describe("claude remote execution", () => {
     expect(call?.[2]).toContain("session-123");
   });
 
+  it("retries modified-thinking resume failures with a fresh Claude session", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-modified-thinking-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const modifiedThinkingMessage =
+      "API Error: 400 messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.";
+
+    runChildProcess
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: JSON.stringify({
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          result: modifiedThinkingMessage,
+          errors: [{ message: modifiedThinkingMessage }],
+        }),
+        stderr: modifiedThinkingMessage,
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          JSON.stringify({ type: "system", subtype: "init", session_id: "fresh-session", model: "claude-sonnet" }),
+          JSON.stringify({
+            type: "result",
+            session_id: "fresh-session",
+            result: "recovered",
+            usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+          }),
+        ].join("\n"),
+        stderr: "",
+        pid: 124,
+        startedAt: new Date().toISOString(),
+      });
+
+    const result = await execute({
+      runId: "run-modified-thinking",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "poisoned-session",
+        sessionParams: null,
+        sessionDisplayId: "poisoned-session",
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(2);
+    const initialCall = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    const retryCall = runChildProcess.mock.calls[1] as unknown as [string, string, string[]] | undefined;
+    expect(initialCall?.[2]).toContain("--resume");
+    expect(initialCall?.[2]).toContain("poisoned-session");
+    expect(retryCall?.[2]).not.toContain("--resume");
+    expect(result.sessionId).toBe("fresh-session");
+    expect(result.clearSession).toBe(false);
+  });
+
 });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -51,6 +51,7 @@ import {
   describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
+  isClaudeModifiedThinkingReplayError,
   isClaudeMaxTurnsResult,
   isClaudeTransientUpstreamError,
   isClaudeUnknownSessionError,
@@ -948,11 +949,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       !initial.proc.timedOut &&
       (initial.proc.exitCode ?? 0) !== 0 &&
       initial.parsed &&
-      isClaudeUnknownSessionError(initial.parsed)
+      (isClaudeUnknownSessionError(initial.parsed) || isClaudeModifiedThinkingReplayError(initial.parsed))
     ) {
       await onLog(
         "stdout",
-        `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+        `[paperclip] Claude resume session "${sessionId}" failed during replay; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -6,6 +6,7 @@ export {
   parseClaudeStreamJson,
   describeClaudeFailure,
   isClaudeMaxTurnsResult,
+  isClaudeModifiedThinkingReplayError,
   isClaudeUnknownSessionError,
 } from "./parse.js";
 export {

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
+  isClaudeModifiedThinkingReplayError,
   isClaudeTransientUpstreamError,
 } from "./parse.js";
+
+describe("isClaudeModifiedThinkingReplayError", () => {
+  it("detects Anthropic's backtick-wrapped modified thinking resume failure", () => {
+    const message =
+      "API Error: 400 messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.";
+
+    expect(
+      isClaudeModifiedThinkingReplayError({
+        result: message,
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeModifiedThinkingReplayError({
+        errors: [{ message }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated validation errors as modified thinking replay failures", () => {
+    expect(
+      isClaudeModifiedThinkingReplayError({
+        result: "API Error: 400 messages.0.content.0.text is required.",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("isClaudeTransientUpstreamError", () => {
   it("classifies the 'out of extra usage' subscription window failure as transient", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -196,6 +196,18 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
   );
 }
 
+const CLAUDE_MODIFIED_THINKING_REPLAY_PATTERN =
+  /[`'"]?(?:thinking|redacted_thinking)[`'"]?(?:\s+or\s+[`'"]?(?:thinking|redacted_thinking)[`'"]?)?\s+blocks?\s+in\s+the\s+latest\s+assistant\s+message\s+cannot\s+be\s+modified/i;
+
+export function isClaudeModifiedThinkingReplayError(parsed: Record<string, unknown>): boolean {
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) => CLAUDE_MODIFIED_THINKING_REPLAY_PATTERN.test(msg));
+}
+
 function buildClaudeTransientHaystack(input: {
   parsed?: Record<string, unknown> | null;
   stdout?: string | null;


### PR DESCRIPTION
## Summary

Fixes claude_local resume recovery for Anthropic modified-thinking replay failures. The previous recovery path only treated unknown-session errors as recoverable, so a poisoned resumed session with modified `thinking` / `redacted_thinking` blocks would fail repeatedly.

## Changes

- Add `isClaudeModifiedThinkingReplayError` with a backtick-aware detector for Anthropic's literal error text.
- Reuse the existing fresh-session retry path when a resumed Claude session fails with that replay error.
- Add parser coverage and an execution recovery test using the literal backtick-wrapped API error.

## Verification

- `pnpm --filter @paperclipai/adapter-claude-local exec vitest run src/server/parse.test.ts src/server/execute.remote.test.ts`
- `pnpm --filter @paperclipai/adapter-claude-local typecheck`

Reported from Bedrok [BEDAAA-111](/BEDAAA/issues/BEDAAA-111).
