### PR TITLE
Redact session cookie headers from server.log

### DIFF
--- a/server/src/__tests__/http-logger-redaction.test.ts
+++ b/server/src/__tests__/http-logger-redaction.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import pino from "pino";
+import { Writable } from "node:stream";
+
+import { HTTP_LOG_REDACT_PATHS } from "../middleware/logger.js";
+
+/**
+ * Regression test for KSI-641: redact session cookies from server.log.
+ *
+ * The server emits HTTP logs through pino-http, which inherits the redact
+ * config of the base logger declared in `server/src/middleware/logger.ts`.
+ * Better-Auth issues session tokens as request `Cookie` headers and response
+ * `Set-Cookie` headers; both must never be written to disk in plaintext.
+ *
+ * Strategy:
+ *
+ * 1. Asserção estrutural — `HTTP_LOG_REDACT_PATHS` cobre `cookie`,
+ *    `set-cookie` e mantém `authorization` (proteção pré-existente).
+ * 2. Asserção funcional — instanciar um pino real com a constante apontando
+ *    para um buffer e logar um payload sintético equivalente ao que pino-http
+ *    serializa. O JSON resultante NÃO pode conter o valor do token.
+ */
+
+describe("HTTP logger redact configuration", () => {
+  it("includes the session-cookie request and response headers plus authorization", () => {
+    expect(HTTP_LOG_REDACT_PATHS).toEqual(
+      expect.arrayContaining([
+        "req.headers.authorization",
+        "req.headers.cookie",
+        'res.headers["set-cookie"]',
+      ]),
+    );
+  });
+});
+
+describe("HTTP logger redaction at runtime", () => {
+  function captureLog(payload: unknown): string {
+    const chunks: Buffer[] = [];
+    const sink = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        cb();
+      },
+    });
+
+    const localLogger = pino(
+      { level: "info", redact: HTTP_LOG_REDACT_PATHS },
+      sink,
+    );
+    localLogger.info(payload as Record<string, unknown>, "request");
+    return Buffer.concat(chunks).toString("utf8");
+  }
+
+  it("redacts the session cookie value from the request Cookie header", () => {
+    const cookieValue =
+      "paperclip-ksio-dev.session_token=ABC.DEF.GHI; other=keep";
+    const output = captureLog({
+      req: {
+        method: "GET",
+        url: "/api/agents/me",
+        headers: {
+          cookie: cookieValue,
+          authorization: "Bearer secret-bearer-token",
+          "user-agent": "vitest",
+        },
+      },
+      res: {
+        statusCode: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+    });
+
+    // pino's default redact replacement is "[Redacted]" (mixed case) and it
+    // preserves the field key — only the value is rewritten.
+    expect(output).toContain('"cookie":"[Redacted]"');
+    expect(output).toContain('"authorization":"[Redacted]"');
+
+    // The actual token value (and any substring of it) must not survive.
+    expect(output).not.toContain("ABC.DEF.GHI");
+    expect(output).not.toContain("session_token=ABC");
+    expect(output).not.toContain("secret-bearer-token");
+
+    // Non-sensitive headers stay intact for debugging.
+    expect(output).toContain('"user-agent":"vitest"');
+    expect(output).toContain('"method":"GET"');
+    expect(output).toContain('"url":"/api/agents/me"');
+  });
+
+  it("redacts Set-Cookie response headers (array form, as Node sets them)", () => {
+    const setCookieValue = [
+      "paperclip-ksio-dev.session_token=ZZZ.WWW.YYY; Path=/; HttpOnly",
+      "paperclip-ksio-dev.session_data=opaque-data; Path=/; HttpOnly",
+    ];
+    const output = captureLog({
+      req: {
+        method: "POST",
+        url: "/api/auth/sign-in/email",
+        headers: { "user-agent": "vitest" },
+      },
+      res: {
+        statusCode: 200,
+        headers: {
+          "set-cookie": setCookieValue,
+          "content-type": "application/json",
+        },
+      },
+    });
+
+    expect(output).toContain('"set-cookie":"[Redacted]"');
+    expect(output).not.toContain("ZZZ.WWW.YYY");
+    expect(output).not.toContain("session_token=ZZZ");
+    expect(output).not.toContain("opaque-data");
+
+    // The neighboring response header survives so we can still see status/body
+    // shape from the log.
+    expect(output).toContain('"content-type":"application/json"');
+  });
+
+  it("does not over-redact: only the configured paths are rewritten", () => {
+    const output = captureLog({
+      req: {
+        method: "GET",
+        url: "/api/issues/KSI-641",
+        headers: {
+          "x-paperclip-run-id": "run-42",
+          "content-type": "application/json",
+        },
+      },
+      res: {
+        statusCode: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-trace-id": "trace-abc",
+        },
+      },
+    });
+
+    // No redaction marker should appear when no sensitive fields are present.
+    expect(output).not.toContain("[Redacted]");
+    expect(output).toContain('"x-paperclip-run-id":"run-42"');
+    expect(output).toContain('"x-trace-id":"trace-abc"');
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -27,9 +27,31 @@ const sharedOpts = {
   singleLine: true,
 };
 
+/**
+ * Pino redact paths applied to every log record produced by the server logger
+ * (and inherited by the {@link httpLogger} below).
+ *
+ * Goal: keep session-bearing headers out of `server.log`. Better-Auth issues
+ * its session token as the `Cookie: paperclip-...session_token=...` header on
+ * the request and as `Set-Cookie` on the response; both must never land in
+ * persisted logs in plaintext. Authorization bearer tokens are also redacted
+ * for the same reason.
+ *
+ * The path strings follow pino's redact path syntax — bracket notation is
+ * required for keys with non-identifier characters such as `set-cookie`.
+ * Pino preserves the field name and replaces only the value with `[Redacted]`
+ * (default), so debug context "did this request carry a cookie?" is still
+ * answerable from the log.
+ */
+export const HTTP_LOG_REDACT_PATHS = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  'res.headers["set-cookie"]',
+];
+
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: HTTP_LOG_REDACT_PATHS,
 }, pino.transport({
   targets: [
     {


### PR DESCRIPTION
## Summary

The base pino logger in `server/src/middleware/logger.ts` redacted only `req.headers.authorization`. Because `pino-http` serializes both request and response headers into every HTTP log line, the request `Cookie` header (Better-Auth session token: `paperclip-...session_token=...`) and the response `Set-Cookie` header were written to `server.log` in plaintext. On a LAN-exposed deployment, exporting or attaching that log to a ticket leaks an active session token.

This PR extracts the redact list to an exported constant `HTTP_LOG_REDACT_PATHS` and adds two paths:

- `req.headers.cookie`
- `res.headers["set-cookie"]`

Pino preserves the field name and replaces only the value with `[Redacted]`, so logs still tell operators that a request carried a cookie without exposing the token.

## Diff shape

`server/src/middleware/logger.ts`:

```diff
+export const HTTP_LOG_REDACT_PATHS = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  'res.headers["set-cookie"]',
+];

 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: HTTP_LOG_REDACT_PATHS,
 }, pino.transport({ ... }));
```

`server/src/__tests__/http-logger-redaction.test.ts` (new): structural assertion on the constant, plus three runtime assertions piping a real `pino()` instance into a `Writable` buffer to prove that:

- a request with a session `Cookie` and `Authorization` header has both values rewritten to `[Redacted]`, while neighbouring headers (`user-agent`, `method`, `url`) remain intact;
- a response with `Set-Cookie` (array form, as Node sets it) has the value rewritten, while `content-type` stays;
- no `[Redacted]` marker is emitted when no sensitive fields are present (no over-redaction).

## Verification

Run from repo root:

- `NODE_ENV=development pnpm exec vitest run server/src/__tests__/http-logger-redaction.test.ts` → 4/4 passing.
- `NODE_ENV=development pnpm exec vitest run server/src/__tests__/logger-tz.test.ts server/src/__tests__/log-redaction.test.ts server/src/__tests__/redaction.test.ts server/src/__tests__/http-log-policy.test.ts` → 18/18 passing (regression on neighbouring logger/redaction tests).
- `NODE_ENV=development pnpm --filter @paperclipai/server typecheck` → clean.

## Out of scope

- Existing `server.log` files on disk: this patch does not rotate or scrub historical log content. If a deployment needs that, it is a separate operational task.
- Other log surfaces (heartbeat run logs, event payloads, attachments) are already covered by `server/src/redaction.ts` for cookie-shaped fields. This PR is scoped to the HTTP logger.

## Origin and approvals

- Issue: KSI-641 — "[governanca] Hardening: redigir cookies de sessão nos logs do servidor".
- Source review: KSI-638, risk R3.
- Plan: revision 1 of the `plan` document on KSI-641.
- D5 governance approvals: Callisto (DevOps, technical) + Andromeda (COO, governance), with CEO acknowledgement; board acceptance of plan via `request_confirmation` `435b2bb1-cca4-423b-ab66-f1e5e1b3119b` (idempotency `confirmation:KSI-641:plan:493407d5-a520-432a-a9c7-021f344252a2`) on 2026-05-30.