### PR TITLE
Fix child-covered hub recovery assignee misroute to CEO

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -25,6 +25,10 @@ import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
 import { recoveryService } from "../services/recovery/service.js";
+import {
+  FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
+  SUCCESSFUL_RUN_MISSING_STATE_REASON,
+} from "../services/recovery/successful-run-handoff.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -263,6 +267,230 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(second.evidence).toMatchObject({ latestRunId: "run-2" });
     expect(await svc.getActiveForIssue(companyId, sourceIssueId)).toMatchObject({ id: first.id });
     expect(await svc.getActiveForIssue(randomUUID(), sourceIssueId)).toBeNull();
+  });
+
+  it("keeps child-covered program hubs on the hub owner instead of escalating to CEO", async () => {
+    const companyId = randomUUID();
+    const ceoId = randomUUID();
+    const ctoId = randomUUID();
+    const hubIssueId = randomUUID();
+    const childIssueId = randomUUID();
+    const prefix = `RH${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Hub Recovery Co",
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ceoId,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: ctoId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        reportsTo: ceoId,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: hubIssueId,
+        companyId,
+        title: "Program hub epic",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: ctoId,
+        createdByAgentId: ctoId,
+        issueNumber: 1,
+        identifier: `${prefix}-1`,
+      },
+      {
+        id: childIssueId,
+        companyId,
+        title: "Active child slice",
+        status: "in_progress",
+        priority: "medium",
+        parentId: hubIssueId,
+        assigneeAgentId: ctoId,
+        issueNumber: 2,
+        identifier: `${prefix}-2`,
+      },
+    ]);
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const [hubIssue] = await db.select().from(issues).where(eq(issues.id, hubIssueId));
+    const latestRun = {
+      id: randomUUID(),
+      agentId: ctoId,
+      status: "succeeded",
+      error: null,
+      errorCode: null,
+      contextSnapshot: { retryReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON },
+      livenessState: "needs_followup",
+    } as const;
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: hubIssue!,
+      previousStatus: "in_progress",
+      latestRun,
+      recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      successfulRunHandoffEvidence: {
+        sourceRunId: latestRun.id,
+        correctiveRunId: latestRun.id,
+        missingDisposition: "clear_next_step",
+        handoffAttempt: 3,
+        maxHandoffAttempts: 3,
+        exhausted: true,
+      },
+    });
+
+    const [updatedHub] = await db.select().from(issues).where(eq(issues.id, hubIssueId));
+    expect(updatedHub).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: ctoId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, hubIssueId));
+    expect(action).toMatchObject({
+      ownerAgentId: ctoId,
+      previousOwnerAgentId: ctoId,
+      returnOwnerAgentId: ctoId,
+      kind: "missing_disposition",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup.mock.calls[0]?.[0]).toBe(ctoId);
+  });
+
+  it("restores CTO hub monitor owner when a child-covered hub was misrouted to CEO", async () => {
+    const companyId = randomUUID();
+    const ceoId = randomUUID();
+    const ctoId = randomUUID();
+    const hubIssueId = randomUUID();
+    const childIssueId = randomUUID();
+    const prefix = `RH${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Misrouted Hub Recovery Co",
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ceoId,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: ctoId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        reportsTo: ceoId,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: hubIssueId,
+        companyId,
+        title: "Misrouted program hub epic",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: ceoId,
+        createdByAgentId: ctoId,
+        issueNumber: 1,
+        identifier: `${prefix}-1`,
+      },
+      {
+        id: childIssueId,
+        companyId,
+        title: "Active child slice",
+        status: "in_progress",
+        priority: "medium",
+        parentId: hubIssueId,
+        assigneeAgentId: ctoId,
+        issueNumber: 2,
+        identifier: `${prefix}-2`,
+      },
+    ]);
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const [hubIssue] = await db.select().from(issues).where(eq(issues.id, hubIssueId));
+    const latestRun = {
+      id: randomUUID(),
+      agentId: ceoId,
+      status: "succeeded",
+      error: null,
+      errorCode: null,
+      contextSnapshot: { retryReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON },
+      livenessState: "needs_followup",
+    } as const;
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: hubIssue!,
+      previousStatus: "blocked",
+      latestRun,
+      recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      successfulRunHandoffEvidence: {
+        sourceRunId: latestRun.id,
+        correctiveRunId: latestRun.id,
+        missingDisposition: "clear_next_step",
+        handoffAttempt: 3,
+        maxHandoffAttempts: 3,
+        exhausted: true,
+      },
+    });
+
+    const [updatedHub] = await db.select().from(issues).where(eq(issues.id, hubIssueId));
+    expect(updatedHub).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: ctoId,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, hubIssueId));
+    expect(action).toMatchObject({
+      ownerAgentId: ctoId,
+      previousOwnerAgentId: ceoId,
+      returnOwnerAgentId: ctoId,
+      kind: "missing_disposition",
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup.mock.calls[0]?.[0]).toBe(ctoId);
   });
 
   it("escalates stranded assigned work into a source action instead of a recovery issue", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -149,7 +149,7 @@ import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
-import { recoveryService } from "./recovery/service.js";
+import { asStrandedAssignedPreviousStatus, recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
 import {
@@ -8848,7 +8848,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return {
           kind: "blocked_recovery_in_place" as const,
           issue,
-          previousStatus: issue.status,
+          previousStatus: asStrandedAssignedPreviousStatus(issue.status),
         };
       }
 
@@ -8864,7 +8864,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return {
           kind: "blocked" as const,
           issue,
-          previousStatus: issue.status,
+          previousStatus: asStrandedAssignedPreviousStatus(issue.status),
           comment,
         };
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8945,7 +8945,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (promotionResult?.kind === "blocked") {
       await recovery.escalateStrandedAssignedIssue({
         issue: promotionResult.issue,
-        previousStatus: promotionResult.previousStatus as "todo" | "in_progress",
+        previousStatus: promotionResult.previousStatus,
         latestRun: run,
         comment: promotionResult.comment,
       });
@@ -8955,7 +8955,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (promotionResult?.kind === "blocked_recovery_in_place") {
       await recovery.escalateStrandedRecoveryIssueInPlace({
         issue: promotionResult.issue,
-        previousStatus: promotionResult.previousStatus as "todo" | "in_progress",
+        previousStatus: promotionResult.previousStatus,
         latestRun: run,
       });
       return;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -103,7 +103,12 @@ type LatestIssueRun = Pick<
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
 type StrandedRecoveryCause = "stranded_assigned_issue" | typeof SUCCESSFUL_RUN_MISSING_STATE_REASON;
-type StrandedAssignedPreviousStatus = "todo" | "in_progress" | "blocked";
+export type StrandedAssignedPreviousStatus = "todo" | "in_progress" | "blocked";
+
+export function asStrandedAssignedPreviousStatus(status: string): StrandedAssignedPreviousStatus {
+  if (status === "todo" || status === "in_progress" || status === "blocked") return status;
+  return "in_progress";
+}
 
 type SuccessfulRunHandoffRecoveryEvidence = {
   sourceRunId: string | null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2234,7 +2234,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   function buildRecoveryIssueInPlaceEscalationComment(input: {
     issue: typeof issues.$inferSelect;
-    previousStatus: "todo" | "in_progress";
+    previousStatus: StrandedAssignedPreviousStatus;
     latestRun: LatestIssueRun;
     prefix: string;
   }) {
@@ -2261,7 +2261,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function escalateStrandedRecoveryIssueInPlace(input: {
     issue: typeof issues.$inferSelect;
-    previousStatus: "todo" | "in_progress";
+    previousStatus: StrandedAssignedPreviousStatus;
     latestRun: LatestIssueRun;
   }) {
     const updated = await issuesSvc.update(input.issue.id, { status: "blocked" });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -103,6 +103,7 @@ type LatestIssueRun = Pick<
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
 type StrandedRecoveryCause = "stranded_assigned_issue" | typeof SUCCESSFUL_RUN_MISSING_STATE_REASON;
+type StrandedAssignedPreviousStatus = "todo" | "in_progress" | "blocked";
 
 type SuccessfulRunHandoffRecoveryEvidence = {
   sourceRunId: string | null;
@@ -1894,9 +1895,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return cto?.id ?? null;
   }
 
-  async function resolveStrandedIssueRecoveryOwnerAgentId(issue: typeof issues.$inferSelect) {
-    const childCoveredHub = await isChildCoveredProgramHub(issue);
-    if (childCoveredHub) {
+  async function resolveStrandedIssueRecoveryOwnerAgentId(
+    issue: typeof issues.$inferSelect,
+    childCoveredHub?: boolean,
+  ) {
+    const isChildCovered = childCoveredHub ?? await isChildCoveredProgramHub(issue);
+    if (isChildCovered) {
       return resolveChildCoveredHubMonitorOwnerAgentId(issue);
     }
 
@@ -2114,7 +2118,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   function buildStrandedRecoveryActionEvidence(input: {
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
-    previousStatus: "todo" | "in_progress";
+    previousStatus: StrandedAssignedPreviousStatus;
     recoveryCause: StrandedRecoveryCause;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
@@ -2140,16 +2144,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function ensureSourceScopedStrandedRecoveryAction(input: {
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
-    previousStatus: "todo" | "in_progress";
+    previousStatus: StrandedAssignedPreviousStatus;
     recoveryCause?: StrandedRecoveryCause;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
+    childCoveredHub?: boolean;
   }) {
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
-    const childCoveredHub = await isChildCoveredProgramHub(input.issue);
+    const childCoveredHub = input.childCoveredHub ?? await isChildCoveredProgramHub(input.issue);
     const hubMonitorOwnerAgentId = childCoveredHub
       ? await resolveChildCoveredHubMonitorOwnerAgentId(input.issue)
       : null;
-    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue, childCoveredHub);
     const now = new Date();
     const action = await recoveryActionsSvc.upsertSourceScoped({
       companyId: input.issue.companyId,
@@ -2337,7 +2342,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
-    previousStatus: "todo" | "in_progress";
+    previousStatus: StrandedAssignedPreviousStatus;
     latestRun: LatestIssueRun;
     comment?: string;
     recoveryCause?: StrandedRecoveryCause;
@@ -2352,15 +2357,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
+    const childCoveredHub = await isChildCoveredProgramHub(input.issue);
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,
       previousStatus: input.previousStatus,
       latestRun: input.latestRun,
       recoveryCause,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      childCoveredHub,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const childCoveredHub = await isChildCoveredProgramHub(input.issue);
     const preserveHubMonitorDisposition = childCoveredHub && blockerIds.length === 0;
     const hubOwnerAgentId =
       (childCoveredHub ? await resolveChildCoveredHubMonitorOwnerAgentId(input.issue) : null) ??

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1839,7 +1839,67 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ].join("\n");
   }
 
+  const CHILD_COVERED_HUB_CHILD_STATUSES = ["todo", "in_progress", "in_review", "blocked", "backlog"] as const;
+
+  async function isChildCoveredProgramHub(issue: typeof issues.$inferSelect) {
+    const [childRow] = await db
+      .select({ childCount: sql<number>`count(*)::int` })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          eq(issues.parentId, issue.id),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, [...CHILD_COVERED_HUB_CHILD_STATUSES]),
+        ),
+      );
+    if ((childRow?.childCount ?? 0) === 0) return false;
+
+    const unresolvedBlockerCount = await db
+      .select({ blockerIssueId: issueRelations.issueId })
+      .from(issueRelations)
+      .innerJoin(issues, and(eq(issues.companyId, issueRelations.companyId), eq(issues.id, issueRelations.issueId)))
+      .where(
+        and(
+          eq(issueRelations.companyId, issue.companyId),
+          eq(issueRelations.relatedIssueId, issue.id),
+          eq(issueRelations.type, "blocks"),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .then((rows) => rows.length);
+
+    return unresolvedBlockerCount === 0;
+  }
+
+  async function resolveChildCoveredHubMonitorOwnerAgentId(issue: typeof issues.$inferSelect) {
+    if (!issue.assigneeAgentId) return null;
+    const assignee = await getAgent(issue.assigneeAgentId);
+    if (!assignee || assignee.companyId !== issue.companyId) return null;
+    if (assignee.role !== "ceo") return assignee.id;
+
+    if (issue.createdByAgentId) {
+      const creator = await getAgent(issue.createdByAgentId);
+      if (creator && creator.companyId === issue.companyId && creator.role !== "ceo") {
+        return creator.id;
+      }
+    }
+
+    const [cto] = await db
+      .select()
+      .from(agents)
+      .where(and(eq(agents.companyId, issue.companyId), eq(agents.role, "cto")))
+      .orderBy(asc(agents.createdAt))
+      .limit(1);
+    return cto?.id ?? null;
+  }
+
   async function resolveStrandedIssueRecoveryOwnerAgentId(issue: typeof issues.$inferSelect) {
+    const childCoveredHub = await isChildCoveredProgramHub(issue);
+    if (childCoveredHub) {
+      return resolveChildCoveredHubMonitorOwnerAgentId(issue);
+    }
+
     const candidateIds: string[] = [];
     if (issue.assigneeAgentId) {
       const assignee = await getAgent(issue.assigneeAgentId);
@@ -2085,6 +2145,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
+    const childCoveredHub = await isChildCoveredProgramHub(input.issue);
+    const hubMonitorOwnerAgentId = childCoveredHub
+      ? await resolveChildCoveredHubMonitorOwnerAgentId(input.issue)
+      : null;
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     const now = new Date();
     const action = await recoveryActionsSvc.upsertSourceScoped({
@@ -2094,7 +2158,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       ownerType: ownerAgentId ? "agent" : "board",
       ownerAgentId,
       previousOwnerAgentId: input.issue.assigneeAgentId,
-      returnOwnerAgentId: input.issue.assigneeAgentId,
+      returnOwnerAgentId: hubMonitorOwnerAgentId ?? input.issue.assigneeAgentId,
       cause: recoveryCause,
       fingerprint: strandedRecoveryActionFingerprint({
         issue: input.issue,
@@ -2296,10 +2360,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const childCoveredHub = await isChildCoveredProgramHub(input.issue);
+    const preserveHubMonitorDisposition = childCoveredHub && blockerIds.length === 0;
+    const hubOwnerAgentId =
+      (childCoveredHub ? await resolveChildCoveredHubMonitorOwnerAgentId(input.issue) : null) ??
+      input.issue.assigneeAgentId ??
+      recoveryAction.returnOwnerAgentId ??
+      recoveryAction.ownerAgentId;
     const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
+      status: preserveHubMonitorDisposition ? "in_progress" : "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      assigneeAgentId: preserveHubMonitorDisposition
+        ? hubOwnerAgentId
+        : recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
 
@@ -2384,12 +2457,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityId: input.issue.id,
       details: {
         identifier: input.issue.identifier,
-        status: "blocked",
+        status: preserveHubMonitorDisposition ? "in_progress" : "blocked",
         previousStatus: input.previousStatus,
         source: input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
           ? "recovery.reconcile_successful_run_handoff_missing_state"
           : "recovery.reconcile_stranded_assigned_issue",
         recoveryCause: input.recoveryCause ?? "stranded_assigned_issue",
+        childCoveredHub: preserveHubMonitorDisposition,
         latestRunId: input.latestRun?.id ?? null,
         latestRunStatus: input.latestRun?.status ?? null,
         latestRunErrorCode: input.latestRun?.errorCode ?? null,
@@ -2408,7 +2482,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryCause,
     });
 
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+    if (
+      !preserveHubMonitorDisposition &&
+      recoveryAction.ownerAgentId &&
+      recoveryAction.ownerAgentId === input.issue.assigneeAgentId
+    ) {
       const [currentIssue] = await db
         .select({
           status: issues.status,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue recovery escalates stranded assigned work via `source_scoped_recovery_action`
> - Program hub epics with active children should stay monitor-only @ CTO per company orchestration rules
> - Recovery was misrouting child-covered hubs to CEO as `blocked` with zero formal blockers
> - This pull request keeps child-covered hubs `in_progress` on the hub monitor owner and restores CTO when misrouted to CEO
> - The benefit is fewer CEO recovery loops and stable hub disposition while children execute

## What Changed

- Add `isChildCoveredProgramHub` and `resolveChildCoveredHubMonitorOwnerAgentId` in recovery service
- Short-circuit stranded recovery owner resolution for child-covered hubs (no CEO escalation chain)
- Preserve hub `in_progress` disposition and restore CTO assignee on misrouted hubs
- Widen `previousStatus` to include `blocked`; remove heartbeat cast; dedupe hub detection queries
- Add 2 regression tests in `issue-recovery-actions.test.ts`

## Verification

- `pnpm exec vitest run src/__tests__/issue-recovery-actions.test.ts -t "child-covered"` — 2/2 pass
- Upstream PR CI green on commit `43fd709`

## Risks

Low risk. Scoped to recovery escalation when hub has active non-terminal children and zero unresolved blockers. Non-hub stranded issues keep existing CEO escalation behavior.

## Model Used

Cursor Composer — agent-assisted implementation and Greptile review follow-up.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge