### PR TITLE
Draft: add QA evidence packet publish lane

### DIFF
--- a/cli/src/__tests__/http.test.ts
+++ b/cli/src/__tests__/http.test.ts
@@ -30,6 +30,28 @@ describe("PaperclipApiClient", () => {
     expect(headers["content-type"]).toBe("application/json");
   });
 
+  it("does not force a JSON content-type for multipart form uploads", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PaperclipApiClient({
+      apiBase: "http://localhost:3100",
+      apiKey: "token-123",
+    });
+    const form = new FormData();
+    form.set("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    await client.postForm("/api/upload", form);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer token-123");
+    expect(headers.accept).toBe("application/json");
+    expect(headers["content-type"]).toBeUndefined();
+  });
+
   it("returns null on ignoreNotFound", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: "Not found" }), { status: 404 }),

--- a/cli/src/__tests__/issue-evidence-packet.test.ts
+++ b/cli/src/__tests__/issue-evidence-packet.test.ts
@@ -1,11 +1,14 @@
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Issue, IssueDocument, IssueWorkProduct } from "@paperclipai/shared";
 import {
   registerIssueCommands,
   renderQaEvidencePacket,
   renderQaEvidencePacketComment,
+  validateQaEvidencePacketInput,
 } from "../commands/client/issue.js";
+
+const ORIGINAL_EXIT = process.exit;
 
 function makeIssue(): Issue {
   return {
@@ -52,6 +55,11 @@ function makeIssue(): Issue {
 }
 
 describe("issue evidence packet command", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exit = ORIGINAL_EXIT;
+  });
+
   it("registers the publisher under issue commands", () => {
     const program = new Command();
 
@@ -154,5 +162,64 @@ describe("issue evidence packet command", () => {
     expect(comment).toContain("`qa-evidence-packet` revision 3 (revision-1)");
     expect(comment).toContain("attachment-1 (/api/attachments/attachment-1/content)");
     expect(comment).toContain("PR work product: work-product-1");
+  });
+
+  it("rejects incomplete QA evidence packets before publishing", () => {
+    expect(() => validateQaEvidencePacketInput({
+      prUrl: "https://github.com/example/paperclip/pull/26",
+      commitSha: "abc123",
+      changedFiles: [],
+      checks: [],
+      screenshotPaths: [],
+      logPaths: [],
+      residualRisks: [],
+      diffSummary: null,
+      workerLog: null,
+    })).toThrow(
+      "QA evidence packet is incomplete. Missing required evidence: diff summary or changed-file list, exact checks/output, screenshot artifacts, log excerpt or attachment, residual risks.",
+    );
+  });
+
+  it("does not create uploads, documents, work products, or comments for incomplete packets", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(makeIssue()), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit ${code}`);
+    });
+
+    const program = new Command();
+    registerIssueCommands(program);
+
+    await expect(program.parseAsync([
+      "node",
+      "paperclipai",
+      "issue",
+      "evidence:publish",
+      "CLI-28",
+      "--api-base",
+      "http://localhost:3100",
+      "--api-key",
+      "token-123",
+      "--pr-url",
+      "https://github.com/example/paperclip/pull/28",
+      "--commit-sha",
+      "abc123",
+      "--changed-file",
+      "cli/src/client/http.ts",
+      "--check",
+      "vitest passed",
+      "--worker-log",
+      "worker log excerpt",
+      "--risk",
+      "No residual risks beyond targeted CLI scope.",
+    ])).rejects.toThrow("process.exit 1");
+
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Missing required evidence: screenshot artifacts."));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:3100/api/issues/CLI-28");
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("GET");
   });
 });

--- a/cli/src/__tests__/issue-evidence-packet.test.ts
+++ b/cli/src/__tests__/issue-evidence-packet.test.ts
@@ -1,0 +1,158 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import type { Issue, IssueDocument, IssueWorkProduct } from "@paperclipai/shared";
+import {
+  registerIssueCommands,
+  renderQaEvidencePacket,
+  renderQaEvidencePacketComment,
+} from "../commands/client/issue.js";
+
+function makeIssue(): Issue {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "22222222-2222-4222-8222-222222222222",
+    projectId: null,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    title: "Ship QA evidence packets",
+    description: null,
+    status: "in_review",
+    workMode: "standard",
+    priority: "medium",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: 26,
+    identifier: "CLI-26",
+    originKind: undefined,
+    originId: null,
+    originRunId: null,
+    originFingerprint: null,
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionPolicy: null,
+    executionState: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: new Date("2026-05-30T20:00:00.000Z"),
+    updatedAt: new Date("2026-05-30T20:00:00.000Z"),
+  };
+}
+
+describe("issue evidence packet command", () => {
+  it("registers the publisher under issue commands", () => {
+    const program = new Command();
+
+    registerIssueCommands(program);
+
+    const issue = program.commands.find((command) => command.name() === "issue");
+    expect(issue?.commands.map((command) => command.name())).toContain("evidence:publish");
+  });
+
+  it("renders all QA-required packet sections with Paperclip attachment paths", () => {
+    const body = renderQaEvidencePacket({
+      issue: makeIssue(),
+      prUrl: "https://github.com/example/paperclip/pull/26",
+      commitSha: "abc123",
+      changedFiles: ["cli/src/commands/client/issue.ts"],
+      checks: ["pnpm --filter paperclipai typecheck: passed"],
+      screenshots: [{
+        id: "attachment-shot",
+        originalFilename: "packet.png",
+        contentPath: "/api/attachments/attachment-shot/content",
+        contentType: "image/png",
+        byteSize: 123,
+        kind: "screenshot",
+      }],
+      logs: [{
+        id: "attachment-log",
+        originalFilename: "worker.log",
+        contentPath: "/api/attachments/attachment-log/content",
+        contentType: "text/plain",
+        byteSize: 456,
+        kind: "log",
+      }],
+      residualRisks: ["No live server smoke was run."],
+      diffSummary: "Added CLI evidence publisher.",
+      workerLog: "Implemented and typechecked.",
+    });
+
+    expect(body).toContain("PR URL: https://github.com/example/paperclip/pull/26");
+    expect(body).toContain("Commit SHA: abc123");
+    expect(body).toContain("- cli/src/commands/client/issue.ts");
+    expect(body).toContain("pnpm --filter paperclipai typecheck: passed");
+    expect(body).toContain("/api/attachments/attachment-shot/content");
+    expect(body).toContain("/api/attachments/attachment-log/content");
+    expect(body).toContain("No live server smoke was run.");
+  });
+
+  it("renders a concise QA pointer comment with revision and attachment ids", () => {
+    const document = {
+      id: "document-1",
+      companyId: "company-1",
+      issueId: "issue-1",
+      key: "qa-evidence-packet",
+      title: "QA Evidence Packet",
+      format: "markdown",
+      body: "packet",
+      latestRevisionId: "revision-1",
+      latestRevisionNumber: 3,
+      createdByAgentId: null,
+      createdByUserId: null,
+      updatedByAgentId: null,
+      updatedByUserId: null,
+      lockedAt: null,
+      lockedByAgentId: null,
+      lockedByUserId: null,
+      createdAt: new Date("2026-05-30T20:00:00.000Z"),
+      updatedAt: new Date("2026-05-30T20:00:00.000Z"),
+    } satisfies IssueDocument;
+    const workProduct = {
+      id: "work-product-1",
+      companyId: "company-1",
+      projectId: null,
+      issueId: "issue-1",
+      executionWorkspaceId: null,
+      runtimeServiceId: null,
+      type: "pull_request",
+      provider: "github",
+      externalId: "https://github.com/example/paperclip/pull/26",
+      title: "PR evidence",
+      url: "https://github.com/example/paperclip/pull/26",
+      status: "ready_for_review",
+      reviewState: "needs_board_review",
+      isPrimary: true,
+      healthStatus: "unknown",
+      summary: null,
+      metadata: null,
+      createdByRunId: null,
+      createdAt: new Date("2026-05-30T20:00:00.000Z"),
+      updatedAt: new Date("2026-05-30T20:00:00.000Z"),
+    } satisfies IssueWorkProduct;
+
+    const comment = renderQaEvidencePacketComment(document, [{
+      id: "attachment-1",
+      originalFilename: "worker.log",
+      contentPath: "/api/attachments/attachment-1/content",
+      contentType: "text/plain",
+      byteSize: 1,
+      kind: "log",
+    }], workProduct);
+
+    expect(comment).toContain("`qa-evidence-packet` revision 3 (revision-1)");
+    expect(comment).toContain("attachment-1 (/api/attachments/attachment-1/content)");
+    expect(comment).toContain("PR work product: work-product-1");
+  });
+});

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -117,7 +117,7 @@ export class PaperclipApiClient {
       ...toStringRecord(init.headers),
     };
 
-    if (init.body !== undefined) {
+    if (init.body !== undefined && !(init.body instanceof FormData)) {
       headers["content-type"] = headers["content-type"] ?? "application/json";
     }
 

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -74,6 +74,20 @@ export class PaperclipApiClient {
     }, opts);
   }
 
+  put<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T | null> {
+    return this.request<T>(path, {
+      method: "PUT",
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }, opts);
+  }
+
+  postForm<T>(path: string, body: FormData, opts?: RequestOptions): Promise<T | null> {
+    return this.request<T>(path, {
+      method: "POST",
+      body,
+    }, opts);
+  }
+
   patch<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T | null> {
     return this.request<T>(path, {
       method: "PATCH",

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -128,6 +128,18 @@ interface EvidencePacketInput {
   workerLog?: string | null;
 }
 
+interface ValidateQaEvidencePacketInput {
+  prUrl: string;
+  commitSha: string;
+  changedFiles: string[];
+  checks: string[];
+  screenshotPaths: string[];
+  logPaths: string[];
+  residualRisks: string[];
+  diffSummary?: string | null;
+  workerLog?: string | null;
+}
+
 interface PublishedEvidencePacket {
   document: IssueDocument;
   workProduct: IssueWorkProduct | null;
@@ -346,6 +358,17 @@ export function registerIssueCommands(program: Command): void {
             ...normalizeList(opts.screenshot).map((filePath) => ({ kind: "screenshot" as const, path: filePath })),
             ...normalizeList(opts.log).map((filePath) => ({ kind: "log" as const, path: filePath })),
           ];
+          validateQaEvidencePacketInput({
+            prUrl: opts.prUrl,
+            commitSha,
+            changedFiles: effectiveChangedFiles,
+            checks,
+            screenshotPaths: attachmentInputs.filter((attachment) => attachment.kind === "screenshot").map((attachment) => attachment.path),
+            logPaths: attachmentInputs.filter((attachment) => attachment.kind === "log").map((attachment) => attachment.path),
+            residualRisks: risks,
+            diffSummary: opts.summary ?? null,
+            workerLog: opts.workerLog ?? null,
+          });
 
           const attachments: EvidenceAttachmentSummary[] = [];
           for (const attachment of attachmentInputs) {
@@ -616,6 +639,23 @@ export function renderQaEvidencePacketComment(
     `Attachments: ${attachmentSummary}.`,
     workProduct ? `PR work product: ${workProduct.id}.` : "PR work product: not created.",
   ].join("\n");
+}
+
+export function validateQaEvidencePacketInput(input: ValidateQaEvidencePacketInput): void {
+  const missing: string[] = [];
+  if (!input.prUrl.trim()) missing.push("PR URL");
+  if (!input.commitSha.trim()) missing.push("commit SHA");
+  if (input.changedFiles.length === 0 && !input.diffSummary?.trim()) {
+    missing.push("diff summary or changed-file list");
+  }
+  if (input.checks.length === 0) missing.push("exact checks/output");
+  if (input.screenshotPaths.length === 0) missing.push("screenshot artifacts");
+  if (input.logPaths.length === 0 && !input.workerLog?.trim()) missing.push("log excerpt or attachment");
+  if (input.residualRisks.length === 0) missing.push("residual risks");
+
+  if (missing.length > 0) {
+    throw new Error(`QA evidence packet is incomplete. Missing required evidence: ${missing.join(", ")}.`);
+  }
 }
 
 function parseCsv(value: string | undefined): string[] {

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -1,13 +1,21 @@
 import { Command } from "commander";
-import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import {
   addIssueCommentSchema,
   checkoutIssueSchema,
   createIssueSchema,
+  createIssueWorkProductSchema,
   type FeedbackTrace,
   updateIssueSchema,
+  upsertIssueDocumentSchema,
   type Issue,
+  type IssueAttachment,
   type IssueComment,
+  type IssueDocument,
+  type IssueWorkProduct,
 } from "@paperclipai/shared";
 import {
   addCommonClientOptions,
@@ -80,6 +88,55 @@ interface IssueFeedbackOptions extends BaseClientOptions {
   out?: string;
   format?: string;
 }
+
+interface IssueEvidencePublishOptions extends BaseClientOptions {
+  prUrl: string;
+  commitSha?: string;
+  changedFile?: string[];
+  check?: string[];
+  screenshot?: string[];
+  log?: string[];
+  risk?: string[];
+  summary?: string;
+  workerLog?: string;
+}
+
+interface EvidenceAttachmentInput {
+  kind: "screenshot" | "log";
+  path: string;
+}
+
+interface EvidenceAttachmentSummary {
+  id: string;
+  originalFilename: string | null;
+  contentPath: string;
+  contentType: string;
+  byteSize: number;
+  kind: "screenshot" | "log";
+}
+
+interface EvidencePacketInput {
+  issue: Issue;
+  prUrl: string;
+  commitSha: string;
+  changedFiles: string[];
+  checks: string[];
+  screenshots: EvidenceAttachmentSummary[];
+  logs: EvidenceAttachmentSummary[];
+  residualRisks: string[];
+  diffSummary?: string | null;
+  workerLog?: string | null;
+}
+
+interface PublishedEvidencePacket {
+  document: IssueDocument;
+  workProduct: IssueWorkProduct | null;
+  comment: IssueComment | null;
+  attachments: EvidenceAttachmentSummary[];
+}
+
+const execFileAsync = promisify(execFile);
+const QA_EVIDENCE_PACKET_DOCUMENT_KEY = "qa-evidence-packet";
 
 export function registerIssueCommands(program: Command): void {
   const issue = program.command("issue").description("Issue operations");
@@ -261,6 +318,121 @@ export function registerIssueCommands(program: Command): void {
 
   addCommonClientOptions(
     issue
+      .command("evidence:publish")
+      .description("Publish a QA evidence packet document, attachments, PR work product, and issue comment")
+      .argument("<issueId>", "Issue ID or identifier")
+      .requiredOption("--pr-url <url>", "Pull request URL")
+      .option("--commit-sha <sha>", "Commit SHA (defaults to HEAD)")
+      .option("--changed-file <path...>", "Changed file path; repeat or pass multiple values")
+      .option("--check <text...>", "Exact verification command/output line; repeat or pass multiple values")
+      .option("--screenshot <path...>", "Screenshot file to upload; repeat or pass multiple values")
+      .option("--log <path...>", "Log file to upload; repeat or pass multiple values")
+      .option("--risk <text...>", "Residual risk line; repeat or pass multiple values")
+      .option("--summary <text>", "Diff summary override (defaults to changed-file list)")
+      .option("--worker-log <text>", "Short worker log excerpt to include in the packet")
+      .action(async (issueId: string, opts: IssueEvidencePublishOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const issueRow = await ctx.api.get<Issue>(`/api/issues/${issueId}`);
+          if (!issueRow) throw new Error("Issue not found");
+          const commitSha = opts.commitSha?.trim() || await gitOutput(["rev-parse", "HEAD"]);
+          const changedFiles = normalizeList(opts.changedFile);
+          const effectiveChangedFiles = changedFiles.length > 0
+            ? changedFiles
+            : await gitChangedFiles();
+          const checks = normalizeList(opts.check);
+          const risks = normalizeList(opts.risk);
+          const attachmentInputs = [
+            ...normalizeList(opts.screenshot).map((filePath) => ({ kind: "screenshot" as const, path: filePath })),
+            ...normalizeList(opts.log).map((filePath) => ({ kind: "log" as const, path: filePath })),
+          ];
+
+          const attachments: EvidenceAttachmentSummary[] = [];
+          for (const attachment of attachmentInputs) {
+            attachments.push(await uploadEvidenceAttachment(ctx.api, issueRow, attachment));
+          }
+
+          const packetBody = renderQaEvidencePacket({
+            issue: issueRow,
+            prUrl: opts.prUrl,
+            commitSha,
+            changedFiles: effectiveChangedFiles,
+            checks,
+            screenshots: attachments.filter((attachment) => attachment.kind === "screenshot"),
+            logs: attachments.filter((attachment) => attachment.kind === "log"),
+            residualRisks: risks,
+            diffSummary: opts.summary ?? null,
+            workerLog: opts.workerLog ?? null,
+          });
+
+          const existingPacket = await ctx.api.get<IssueDocument>(
+            `/api/issues/${issueRow.id}/documents/${QA_EVIDENCE_PACKET_DOCUMENT_KEY}`,
+            { ignoreNotFound: true },
+          );
+          const documentPayload = upsertIssueDocumentSchema.parse({
+            title: "QA Evidence Packet",
+            format: "markdown",
+            body: packetBody,
+            changeSummary: "Publish QA evidence packet",
+            baseRevisionId: existingPacket?.latestRevisionId ?? null,
+          });
+          const document = await ctx.api.put<IssueDocument>(
+            `/api/issues/${issueRow.id}/documents/${QA_EVIDENCE_PACKET_DOCUMENT_KEY}`,
+            documentPayload,
+          );
+          if (!document) throw new Error("Paperclip did not return the evidence document");
+
+          const workProductPayload = createIssueWorkProductSchema.parse({
+            type: "pull_request",
+            provider: "github",
+            externalId: opts.prUrl,
+            title: `PR evidence for ${issueRow.identifier ?? issueRow.id}`,
+            url: opts.prUrl,
+            status: "ready_for_review",
+            reviewState: "needs_board_review",
+            isPrimary: true,
+            summary: `QA evidence packet ${QA_EVIDENCE_PACKET_DOCUMENT_KEY} r${document.latestRevisionNumber}`,
+            metadata: {
+              evidencePacketDocumentKey: document.key,
+              evidencePacketRevisionId: document.latestRevisionId,
+              evidencePacketRevisionNumber: document.latestRevisionNumber,
+              commitSha,
+              attachmentIds: attachments.map((attachment) => attachment.id),
+            },
+          });
+          const workProduct = await ctx.api.post<IssueWorkProduct>(
+            `/api/issues/${issueRow.id}/work-products`,
+            workProductPayload,
+          );
+
+          const commentBody = renderQaEvidencePacketComment(document, attachments, workProduct);
+          const comment = await ctx.api.post<IssueComment>(
+            `/api/issues/${issueRow.id}/comments`,
+            addIssueCommentSchema.parse({ body: commentBody }),
+          );
+
+          const result: PublishedEvidencePacket = {
+            document,
+            workProduct,
+            comment,
+            attachments,
+          };
+          if (ctx.json) {
+            printOutput(result, { json: true });
+            return;
+          }
+          console.log(`Published QA evidence packet: issue=${issueRow.identifier ?? issueRow.id} document=${document.key} revision=${document.latestRevisionNumber} revisionId=${document.latestRevisionId}`);
+          console.log(`Attachments: ${attachments.length === 0 ? "(none)" : attachments.map((attachment) => `${attachment.id}:${attachment.contentPath}`).join(", ")}`);
+          if (workProduct) console.log(`PR work product: ${workProduct.id}`);
+          if (comment) console.log(`Comment: ${comment.id}`);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+
+  addCommonClientOptions(
+    issue
       .command("feedback:list")
       .description("List feedback traces for an issue")
       .argument("<issueId>", "Issue ID")
@@ -381,6 +553,71 @@ export function registerIssueCommands(program: Command): void {
   );
 }
 
+export function renderQaEvidencePacket(input: EvidencePacketInput): string {
+  const issueLabel = input.issue.identifier ?? input.issue.id;
+  const diffSummary = input.diffSummary?.trim() || (
+    input.changedFiles.length > 0
+      ? `${input.changedFiles.length} changed file(s): ${input.changedFiles.join(", ")}`
+      : "No changed files were provided or detected."
+  );
+  const workerLog = input.workerLog?.trim();
+  const logExcerpt = workerLog || (
+    input.logs.length > 0
+      ? "See attached log artifact(s)."
+      : "No log excerpt or log attachment was provided."
+  );
+
+  return [
+    "# QA Evidence Packet",
+    "",
+    `Issue: ${issueLabel}`,
+    `PR URL: ${input.prUrl}`,
+    `Commit SHA: ${input.commitSha}`,
+    "",
+    "## Diff Summary",
+    "",
+    diffSummary,
+    "",
+    "## Changed Files",
+    "",
+    renderBulletList(input.changedFiles, "No changed files were provided or detected."),
+    "",
+    "## Checks And Output",
+    "",
+    renderBulletList(input.checks, "No checks were provided."),
+    "",
+    "## Screenshot Artifacts",
+    "",
+    renderAttachmentList(input.screenshots, "No screenshot artifacts were attached."),
+    "",
+    "## Log Evidence",
+    "",
+    logExcerpt,
+    "",
+    renderAttachmentList(input.logs, "No log artifacts were attached."),
+    "",
+    "## Residual Risks",
+    "",
+    renderBulletList(input.residualRisks, "None reported."),
+    "",
+  ].join("\n");
+}
+
+export function renderQaEvidencePacketComment(
+  document: IssueDocument,
+  attachments: EvidenceAttachmentSummary[],
+  workProduct: IssueWorkProduct | null,
+): string {
+  const attachmentSummary = attachments.length > 0
+    ? attachments.map((attachment) => `${attachment.id} (${attachment.contentPath})`).join(", ")
+    : "none";
+  return [
+    `QA evidence packet published: document \`${document.key}\` revision ${document.latestRevisionNumber} (${document.latestRevisionId}).`,
+    `Attachments: ${attachmentSummary}.`,
+    workProduct ? `PR work product: ${workProduct.id}.` : "PR work product: not created.",
+  ].join("\n");
+}
+
 function parseCsv(value: string | undefined): string[] {
   if (!value) return [];
   return value.split(",").map((v) => v.trim()).filter(Boolean);
@@ -411,4 +648,75 @@ function filterIssueRows(rows: Issue[], match: string | undefined): Issue[] {
       .toLowerCase();
     return text.includes(needle);
   });
+}
+
+function normalizeList(value: string[] | string | undefined): string[] {
+  if (!value) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values.map((item) => item.trim()).filter(Boolean);
+}
+
+function renderBulletList(items: string[], empty: string): string {
+  if (items.length === 0) return empty;
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function renderAttachmentList(items: EvidenceAttachmentSummary[], empty: string): string {
+  if (items.length === 0) return empty;
+  return items.map((item) => `- ${item.originalFilename ?? item.id}: ${item.contentPath} (${item.id})`).join("\n");
+}
+
+async function gitOutput(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd: process.cwd() });
+  return stdout.trim();
+}
+
+async function gitChangedFiles(): Promise<string[]> {
+  const mergeBase = await gitOutput(["merge-base", "HEAD", "master"]).catch(() => "");
+  const args = mergeBase ? ["diff", "--name-only", mergeBase, "HEAD"] : ["diff", "--name-only", "HEAD~1", "HEAD"];
+  return (await gitOutput(args).catch(() => ""))
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function uploadEvidenceAttachment(
+  api: { postForm<T>(path: string, body: FormData): Promise<T | null> },
+  issue: Issue,
+  input: EvidenceAttachmentInput,
+): Promise<EvidenceAttachmentSummary> {
+  const filePath = path.resolve(input.path);
+  const info = await stat(filePath);
+  if (!info.isFile()) throw new Error(`Attachment path is not a file: ${input.path}`);
+  const bytes = await readFile(filePath);
+  const filename = path.basename(filePath);
+  const form = new FormData();
+  form.set("file", new Blob([bytes], { type: inferContentType(filename) }), filename);
+  const attachment = await api.postForm<IssueAttachment>(
+    `/api/companies/${issue.companyId}/issues/${issue.id}/attachments`,
+    form,
+  );
+  if (!attachment) throw new Error(`Paperclip did not return attachment metadata for ${input.path}`);
+  return {
+    id: attachment.id,
+    originalFilename: attachment.originalFilename,
+    contentPath: attachment.contentPath,
+    contentType: attachment.contentType,
+    byteSize: attachment.byteSize,
+    kind: input.kind,
+  };
+}
+
+function inferContentType(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  if (ext === ".png") return "image/png";
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".webp") return "image/webp";
+  if (ext === ".gif") return "image/gif";
+  if (ext === ".svg") return "image/svg+xml";
+  if (ext === ".html") return "text/html";
+  if (ext === ".json") return "application/json";
+  if (ext === ".md") return "text/markdown";
+  if (ext === ".txt" || ext === ".log") return "text/plain";
+  return "application/octet-stream";
 }


### PR DESCRIPTION
Implements the minimal QA evidence packet publish lane for Paperclip issue artifacts. Evidence: branch feat/qa-evidence-packet, commit 947af7f6, focused tests passed in worker, worker log /docker/paperclip-hvpg/data/coder-logs/worker-20260530T202302Z.log.