### PR TITLE
feat(SPC-6864): add idempotencyKey to POST /api/companies/{companyId}/routines

### DIFF
--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -34,7 +34,8 @@ POST /api/companies/{companyId}/routines
   "priority": "medium",
   "status": "active",
   "concurrencyPolicy": "coalesce_if_active",
-  "catchUpPolicy": "skip_missed"
+  "catchUpPolicy": "skip_missed",
+  "idempotencyKey": "eod-wake:{umbrella-id}"
 }
 ```
 
@@ -54,6 +55,7 @@ Fields:
 | `status` | no | `active` (default), `paused`, `archived` |
 | `concurrencyPolicy` | no | Behaviour when a run fires while a previous one is still active |
 | `catchUpPolicy` | no | Behaviour for missed scheduled runs |
+| `idempotencyKey` | no | Dedupe key (max 255 chars) scoped to `(companyId, assigneeAgentId)` — returns **200** with the existing routine if a non-archived match is found, **409** if archived |
 
 **Concurrency policies:**
 

--- a/packages/db/src/migrations/0084_routine_idempotency_key.sql
+++ b/packages/db/src/migrations/0084_routine_idempotency_key.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "routines" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "routines_company_assignee_idempotency_key_uq" ON "routines" USING btree ("company_id","assignee_agent_id","idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1778074536410,
       "tag": "0083_company_secret_provider_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1748649600000,
+      "tag": "0084_routine_idempotency_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
   boolean,
@@ -41,6 +42,7 @@ export const routines = pgTable(
     createdByUserId: text("created_by_user_id"),
     updatedByAgentId: uuid("updated_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
     updatedByUserId: text("updated_by_user_id"),
+    idempotencyKey: text("idempotency_key"),
     lastTriggeredAt: timestamp("last_triggered_at", { withTimezone: true }),
     lastEnqueuedAt: timestamp("last_enqueued_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -50,6 +52,9 @@ export const routines = pgTable(
     companyStatusIdx: index("routines_company_status_idx").on(table.companyId, table.status),
     companyAssigneeIdx: index("routines_company_assignee_idx").on(table.companyId, table.assigneeAgentId),
     companyProjectIdx: index("routines_company_project_idx").on(table.companyId, table.projectId),
+    idempotencyUq: uniqueIndex("routines_company_assignee_idempotency_key_uq")
+      .on(table.companyId, table.assigneeAgentId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
   }),
 );
 

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1074,6 +1074,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
             concurrencyPolicy: declaration.concurrencyPolicy ?? "coalesce_if_active",
             catchUpPolicy: declaration.catchUpPolicy ?? "skip_missed",
             variables: declaration.variables ?? [],
+            idempotencyKey: null,
             latestRevisionId: null,
             latestRevisionNumber: 1,
             createdByAgentId: null,

--- a/packages/shared/src/types/routine.ts
+++ b/packages/shared/src/types/routine.ts
@@ -59,6 +59,7 @@ export interface Routine {
   concurrencyPolicy: string;
   catchUpPolicy: string;
   variables: RoutineVariable[];
+  idempotencyKey: string | null;
   latestRevisionId: string | null;
   latestRevisionNumber: number;
   createdByAgentId: string | null;

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -60,6 +60,7 @@ export const createRoutineSchema = z.object({
   concurrencyPolicy: z.enum(ROUTINE_CONCURRENCY_POLICIES).optional().default("coalesce_if_active"),
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES).optional().default("skip_missed"),
   variables: z.array(routineVariableSchema).optional().default([]),
+  idempotencyKey: z.string().trim().min(1).max(255).optional().nullable(),
 });
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -23,6 +23,7 @@ const routine = {
   concurrencyPolicy: "coalesce_if_active",
   catchUpPolicy: "skip_missed",
   variables: [],
+  idempotencyKey: null,
   latestRevisionId: revisionId,
   latestRevisionNumber: 1,
   createdByAgentId: null,
@@ -186,7 +187,7 @@ describe("routine routes", () => {
     vi.clearAllMocks();
     mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
     mockRoutineService.list.mockResolvedValue([routine]);
-    mockRoutineService.create.mockResolvedValue(routine);
+    mockRoutineService.create.mockResolvedValue({ routine, idempotent: false });
     mockRoutineService.get.mockResolvedValue(routine);
     mockRoutineService.getTrigger.mockResolvedValue(trigger);
     mockRoutineService.update.mockResolvedValue({ ...routine, assigneeAgentId: otherAgentId });
@@ -466,5 +467,51 @@ describe("routine routes", () => {
       runId: null,
     });
     expect(mockTrackRoutineCreated).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it("returns 200 and existing routine when create is idempotent", async () => {
+    mockRoutineService.create.mockResolvedValue({ routine, idempotent: true });
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+    });
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Daily routine",
+        assigneeAgentId: agentId,
+        idempotencyKey: "eod-wake:test-umbrella",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: routineId });
+    expect(mockLogActivity).not.toHaveBeenCalled();
+    expect(mockTrackRoutineCreated).not.toHaveBeenCalled();
+  });
+
+  it("passes idempotencyKey to the create service", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+    });
+
+    await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Daily routine",
+        assigneeAgentId: agentId,
+        idempotencyKey: "eod-wake:test-umbrella",
+      });
+
+    expect(mockRoutineService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ idempotencyKey: "eod-wake:test-umbrella" }),
+      expect.any(Object),
+    );
   });
 });

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -97,36 +97,38 @@ export function routineRoutes(
     const companyId = req.params.companyId as string;
     await assertBoardCanAssignTasks(req, companyId);
     assertCanManageCompanyRoutine(req, companyId, req.body.assigneeAgentId);
-    const created = await svc.create(companyId, req.body, {
+    const { routine: created, idempotent } = await svc.create(companyId, req.body, {
       agentId: req.actor.type === "agent" ? req.actor.agentId : null,
       userId: req.actor.type === "board" ? req.actor.userId ?? "board" : null,
       runId: req.actor.runId ?? null,
     });
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-      action: "routine.created",
-      entityType: "routine",
-      entityId: created.id,
-      details: { title: created.title, assigneeAgentId: created.assigneeAgentId },
-    });
-    const telemetryClient = getTelemetryClient();
-    if (telemetryClient) {
-      trackRoutineCreated(telemetryClient);
+    if (!idempotent) {
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "routine.created",
+        entityType: "routine",
+        entityId: created.id,
+        details: { title: created.title, assigneeAgentId: created.assigneeAgentId },
+      });
+      const telemetryClient = getTelemetryClient();
+      if (telemetryClient) {
+        trackRoutineCreated(telemetryClient);
+      }
+      await logRoutineRevisionCreated(req, {
+        companyId,
+        routineId: created.id,
+        revisionId: created.latestRevisionId,
+        revisionNumber: created.latestRevisionNumber,
+        changeSummary: "Created routine",
+        triggerCount: 0,
+      });
     }
-    await logRoutineRevisionCreated(req, {
-      companyId,
-      routineId: created.id,
-      revisionId: created.latestRevisionId,
-      revisionNumber: created.latestRevisionNumber,
-      changeSummary: "Created routine",
-      triggerCount: 0,
-    });
-    res.status(201).json(created);
+    res.status(idempotent ? 200 : 201).json(created);
   });
 
   router.get("/routines/:id", async (req, res) => {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -4535,7 +4535,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             variables: null,
             triggers: [],
           };
-          const createdRoutine = await routines.create(targetCompany.id, {
+          const { routine: createdRoutine } = await routines.create(targetCompany.id, {
             projectId,
             goalId: null,
             parentIssueId: null,

--- a/server/src/services/plugin-managed-routines.ts
+++ b/server/src/services/plugin-managed-routines.ts
@@ -360,7 +360,7 @@ export function pluginManagedRoutineService(
       return resolution(companyId, declaration, null, "missing_refs", refs.missingRefs);
     }
 
-    const created = await routinesSvc.create(companyId, {
+    const { routine: created } = await routinesSvc.create(companyId, {
       projectId: refs.projectId,
       goalId: declaration.goalId ?? null,
       title: declaration.title,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1503,7 +1503,29 @@ export function routineService(
       };
     },
 
-    create: async (companyId: string, input: CreateRoutine, actor: Actor): Promise<Routine> => {
+    create: async (companyId: string, input: CreateRoutine, actor: Actor): Promise<{ routine: Routine; idempotent: boolean }> => {
+      if (input.idempotencyKey) {
+        const assigneeCondition = input.assigneeAgentId
+          ? eq(routines.assigneeAgentId, input.assigneeAgentId)
+          : isNull(routines.assigneeAgentId);
+        const existing = await db
+          .select()
+          .from(routines)
+          .where(
+            and(
+              eq(routines.companyId, companyId),
+              assigneeCondition,
+              eq(routines.idempotencyKey, input.idempotencyKey),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (existing) {
+          if (existing.status === "archived") {
+            throw conflict("A routine with this idempotencyKey already exists but is archived");
+          }
+          return { routine: existing, idempotent: true };
+        }
+      }
       await assertProject(companyId, input.projectId ?? null);
       await assertAssignableAgent(companyId, input.assigneeAgentId ?? null);
       if (input.goalId) await assertGoal(companyId, input.goalId);
@@ -1514,7 +1536,7 @@ export function routineService(
       );
       assertRoutineVariableDefinitions(variables);
       const status = normalizeDraftRoutineStatus(input.status, input.assigneeAgentId);
-      return db.transaction(async (tx) => {
+      const routine = await db.transaction(async (tx) => {
         const txDb = tx as unknown as Db;
         const [created] = await txDb
           .insert(routines)
@@ -1531,17 +1553,19 @@ export function routineService(
             concurrencyPolicy: input.concurrencyPolicy,
             catchUpPolicy: input.catchUpPolicy,
             variables,
+            idempotencyKey: input.idempotencyKey ?? null,
             createdByAgentId: actor.agentId ?? null,
             createdByUserId: actor.userId ?? null,
             updatedByAgentId: actor.agentId ?? null,
             updatedByUserId: actor.userId ?? null,
           })
           .returning();
-        const { routine } = await appendRoutineRevision(txDb, created, actor, {
+        const { routine: updated } = await appendRoutineRevision(txDb, created, actor, {
           changeSummary: "Created routine",
         });
-        return routine;
+        return updated;
       });
+      return { routine, idempotent: false };
     },
 
     update: async (id: string, patch: UpdateRoutine, actor: Actor): Promise<Routine | null> => {

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -37,7 +37,8 @@ POST /api/companies/{companyId}/routines
   "priority": "medium",
   "status": "active",
   "concurrencyPolicy": "coalesce_if_active",
-  "catchUpPolicy": "skip_missed"
+  "catchUpPolicy": "skip_missed",
+  "idempotencyKey": "eod-wake:{umbrella-identifier}"  // optional — prevents duplicate creation
 }
 ```
 
@@ -53,6 +54,17 @@ POST /api/companies/{companyId}/routines
 | `status` | no | `active` (default) `paused` `archived` |
 | `concurrencyPolicy` | no | See below |
 | `catchUpPolicy` | no | See below |
+| `idempotencyKey` | no | Max 255 chars. See below. |
+
+### Create idempotency
+
+Supply `idempotencyKey` to make routine creation idempotent within the scope of `(companyId, assigneeAgentId)`.
+
+- **200** — a non-archived routine with the same `(companyId, assigneeAgentId, idempotencyKey)` already exists; the existing routine is returned unchanged.
+- **201** — a new routine was created.
+- **409** — a routine with that key exists but is `archived`; unarchive or use a different key.
+
+Agents should use a stable, deterministic key that embeds the umbrella or context identifier, e.g. `eod-wake:{umbrella-issue-id}`. This prevents duplicate routines when a heartbeat retries after creating the routine but before recording the ID.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds optional `idempotencyKey` field to `POST /api/companies/{companyId}/routines`
- Dedupe scope: `(companyId, assigneeAgentId, idempotencyKey)` — **200** with existing routine when non-archived match found, **409** if archived, **201** on first create
- Unique partial index (`WHERE idempotency_key IS NOT NULL`) on `routines` enforces race safety at DB layer
- Activity log and telemetry skipped on idempotent hits
- Migration `0084_routine_idempotency_key.sql` adds column and index
- All callers of `routineService.create()` updated for new `{ routine, idempotent }` return shape
- `skills/paperclip/references/routines.md` and `docs/api/routines.md` updated

Closes [SPC-6864](https://work.standardpower.co/SPC/issues/SPC-6864). Wire contract already in place from [SPC-6863](https://work.standardpower.co/SPC/issues/SPC-6863) runbook.

## Test plan

- [x] New unit tests: idempotent 200 response, idempotencyKey forwarded to service, activity/telemetry not fired on idempotent hit
- [x] 15/15 general route test files pass
- [x] TypeScript clean (pre-existing plugin-host-services errors unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)