### PR TITLE
fix: prevent terminal comment reopen regressions

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -106,6 +106,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
+    processPid?: number | null;
+    processGroupId?: number | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -179,6 +181,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       contextSnapshot: { issueId },
       stdoutExcerpt: "OPENAI_API_KEY=sk-test-secret-value should not leak",
       logBytes: 0,
+      processPid: opts.processPid ?? null,
+      processGroupId: opts.processGroupId ?? null,
     });
     if (opts.logChunk) {
       const store = getRunLogStore();
@@ -387,6 +391,48 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
     expect(evaluation?.originId).toBe(runId);
     expect(evaluation?.parentId).toBeNull();
+  });
+
+  it("finalizes dead local runs and releases execution locks before creating repeat watchdog issues", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      processPid: 999_999,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(first).toMatchObject({ created: 0, folded: 1 });
+    expect(second).toMatchObject({ scanned: 0, created: 0, folded: 0 });
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+    expect(run?.finishedAt?.toISOString()).toBe(now.toISOString());
+    expect(run?.resultJson).toMatchObject({
+      deadLocalProcessWatchdogFinalization: {
+        processPid: 999_999,
+        sourceIssueId: issueId,
+      },
+    });
+
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.executionRunId).toBeNull();
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+
+    const [event] = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(event?.message).toContain("released issue execution lock");
   });
 
   it("still escalates when a same-run comment is followed by another actor marking the source done", async () => {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -631,7 +631,7 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("does not reopen done issues when promoting deferred plain comment wakes", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -787,7 +787,7 @@ describe("heartbeat comment wake batching", () => {
         );
       }, 90_000);
 
-      const reopenedIssue = await db
+      const promotedIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -796,10 +796,8 @@ describe("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
-      });
+      expect(promotedIssue).toMatchObject({ status: "done" });
+      expect(promotedIssue?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toMatchObject({
@@ -811,7 +809,7 @@ describe("heartbeat comment wake batching", () => {
             id: issueId,
             identifier: `${issuePrefix}-1`,
             title: "Reopen after deferred comment",
-            status: "in_progress",
+            status: "done",
             priority: "medium",
           },
         },

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -375,7 +375,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  it("does not implicitly reopen done issues via the PATCH comment path when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -387,23 +387,23 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
 
     expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledTimes(1);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
     );
+    const patch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(patch?.status).toBeUndefined();
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({
+        details: expect.not.objectContaining({
           reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
         }),
       }),
     );
@@ -487,7 +487,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("does not implicitly reopen done issues via POST comments when an agent is assigned", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -499,19 +499,8 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
-    );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -625,10 +625,10 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   actorType: "agent" | "user";
   actorId: string;
 }) {
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Only human comments on blocked issues implicitly move work back to todo.
+  // Terminal issues require explicit reopen/resume intent.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8689,15 +8689,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        const deferredResumeIntent =
+          deferredContextSeed.resumeIntent === true || deferredContextSeed.followUpRequested === true;
+        // Only explicit reopen/resume comment wakes should revive completed issues.
+        // Plain comment wakes remain communicative and must not reactivate closed work.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
+          (deferredWakeReason === "issue_reopened_via_comment" || deferredResumeIntent);
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1058,13 +1058,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
   }
 
-  async function finalizeAgentAfterSourceResolvedRun(run: typeof heartbeatRuns.$inferSelect, status: "succeeded" | "cancelled") {
+  async function finalizeAgentAfterSettledRun(
+    run: typeof heartbeatRuns.$inferSelect,
+    status: "succeeded" | "cancelled" | "failed" | "timed_out",
+  ) {
     const [runningCountRow] = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(heartbeatRuns)
       .where(and(eq(heartbeatRuns.agentId, run.agentId), eq(heartbeatRuns.status, "running")));
     const runningCount = Number(runningCountRow?.count ?? 0);
-    const nextStatus = runningCount > 0 ? "running" : status === "succeeded" || status === "cancelled" ? "idle" : "error";
+    const nextStatus = runningCount > 0
+      ? "running"
+      : status === "succeeded" || status === "cancelled"
+        ? "idle"
+        : "error";
     await db
       .update(agents)
       .set({
@@ -1125,10 +1132,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           .set({
             status: finalRunStatus === "succeeded" ? "completed" : "cancelled",
             finishedAt: input.now,
-            error: null,
-            updatedAt: input.now,
-          })
-          .where(and(eq(agentWakeupRequests.id, input.run.wakeupRequestId), eq(agentWakeupRequests.companyId, input.run.companyId)));
+        error: null,
+        updatedAt: input.now,
+      })
+      .where(and(eq(agentWakeupRequests.id, input.run.wakeupRequestId), eq(agentWakeupRequests.companyId, input.run.companyId)));
       }
 
       await tx
@@ -1214,8 +1221,155 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         cleanup,
       },
     });
-    await finalizeAgentAfterSourceResolvedRun(finalizedRun, finalRunStatus);
+    await finalizeAgentAfterSettledRun(finalizedRun, finalRunStatus);
     return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation?.id ?? null };
+  }
+
+  async function finalizeDeadLocalRunFromWatchdog(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    existingEvaluation: Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>;
+    now: Date;
+  }) {
+    if (!SESSIONED_LOCAL_ADAPTERS.has(input.runningAgent.adapterType)) return null;
+
+    const running = runningProcesses.get(input.run.id);
+    const pid = running?.child.pid ?? input.run.processPid ?? null;
+    const processGroupId = running?.processGroupId ?? input.run.processGroupId ?? null;
+    if (typeof pid !== "number" && typeof processGroupId !== "number") return null;
+
+    const processAlive =
+      (typeof pid === "number" && isPidAlive(pid)) ||
+      (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+    if (processAlive) return null;
+
+    runningProcesses.delete(input.run.id);
+    const lockReleaseNow = input.now;
+    const errorMessage = (() => {
+      if (typeof pid === "number" && typeof processGroupId === "number") {
+        return `Watchdog finalized dead local run: pid ${pid} and process group ${processGroupId} are no longer alive`;
+      }
+      if (typeof pid === "number") {
+        return `Watchdog finalized dead local run: pid ${pid} is no longer alive`;
+      }
+      return `Watchdog finalized dead local run: process group ${processGroupId} is no longer alive`;
+    })();
+
+    const resultJson = {
+      ...parseObject(input.run.resultJson),
+      deadLocalProcessWatchdogFinalization: {
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        sourceIssueIdentifier: input.sourceIssue?.identifier ?? null,
+        sourceIssueStatus: input.sourceIssue?.status ?? null,
+        evaluationIssueId: input.existingEvaluation?.id ?? null,
+        evaluationIssueIdentifier: input.existingEvaluation?.identifier ?? null,
+        adapterType: input.runningAgent.adapterType,
+        processPid: pid,
+        processGroupId,
+        detectedAt: lockReleaseNow.toISOString(),
+      },
+    };
+
+    const finalized = await db.transaction(async (tx) => {
+      const [updatedRun] = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "failed",
+          finishedAt: lockReleaseNow,
+          error: errorMessage,
+          errorCode: "process_lost",
+          resultJson,
+          updatedAt: lockReleaseNow,
+        })
+        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.status, "running")))
+        .returning();
+      if (!updatedRun) return null;
+
+      if (input.run.wakeupRequestId) {
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            status: "failed",
+            finishedAt: lockReleaseNow,
+            error: errorMessage,
+            updatedAt: lockReleaseNow,
+          })
+          .where(
+            and(
+              eq(agentWakeupRequests.id, input.run.wakeupRequestId),
+              eq(agentWakeupRequests.companyId, input.run.companyId),
+            ),
+          );
+      }
+
+      const releasedLocks = await tx
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: lockReleaseNow,
+        })
+        .where(and(eq(issues.companyId, input.run.companyId), eq(issues.executionRunId, input.run.id)))
+        .returning({ id: issues.id, identifier: issues.identifier });
+
+      return {
+        run: updatedRun,
+        releasedLocks,
+      };
+    });
+    if (!finalized) return null;
+
+    if (input.existingEvaluation && !isTerminalIssueStatus(input.existingEvaluation.status)) {
+      await issuesSvc.update(input.existingEvaluation.id, { status: "done" });
+      await issuesSvc.addComment(input.existingEvaluation.id, [
+        "Watchdog finalized this stale-run evaluation automatically.",
+        "",
+        `- Run: \`${input.run.id}\``,
+        `- Detection: ${errorMessage}`,
+        `- Lock release: ${finalized.releasedLocks.length > 0 ? "cleared execution lock(s)" : "no matching issue lock found"}`,
+        "- Outcome: no further stale-run evaluation should be created for this run id.",
+      ].join("\n"), { runId: input.run.id });
+    }
+
+    await appendRecoveryRunEvent(finalized.run, {
+      level: "warn",
+      message: "Watchdog finalized dead local run and released issue execution lock",
+      payload: {
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        sourceIssueIdentifier: input.sourceIssue?.identifier ?? null,
+        sourceIssueStatus: input.sourceIssue?.status ?? null,
+        evaluationIssueId: input.existingEvaluation?.id ?? null,
+        evaluationIssueIdentifier: input.existingEvaluation?.identifier ?? null,
+        processPid: pid,
+        processGroupId,
+        releasedIssueLockIds: finalized.releasedLocks.map((issue) => issue.id),
+        releasedIssueLockIdentifiers: finalized.releasedLocks.map((issue) => issue.identifier),
+      },
+    });
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_dead_process_finalized",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        sourceIssueIdentifier: input.sourceIssue?.identifier ?? null,
+        evaluationIssueId: input.existingEvaluation?.id ?? null,
+        processPid: pid,
+        processGroupId,
+        releasedIssueLockIds: finalized.releasedLocks.map((issue) => issue.id),
+      },
+    });
+    await finalizeAgentAfterSettledRun(finalized.run, "failed");
+
+    return { evaluationIssueId: input.existingEvaluation?.id ?? null };
   }
 
   async function resolveStaleRunOwnerAgentId(input: {
@@ -1451,6 +1605,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
+    const deadLocalFinalization = await finalizeDeadLocalRunFromWatchdog({
+      run: input.run,
+      runningAgent,
+      sourceIssue,
+      existingEvaluation: existing,
+      now: input.now,
+    });
+    if (deadLocalFinalization) {
+      return { kind: "folded" as const, evaluationIssueId: deadLocalFinalization.evaluationIssueId };
+    }
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
       await logActivity(db, {
         companyId: input.run.companyId,


### PR DESCRIPTION
## Summary
- limit implicit comment reopen behavior to `blocked` issues only; plain comments on `done`/`cancelled` no longer auto-move to `todo`
- require explicit reopen/resume intent before deferred comment-wake promotion can revive terminal issues
- update regression coverage for both PATCH/POST comment flows and heartbeat deferred wake promotion

## Verification
- `pnpm vitest server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts`
