### PR TITLE
fix(db): clarify embedded postgres port exhaustion

### DIFF
--- a/packages/db/src/migration-runtime.test.ts
+++ b/packages/db/src/migration-runtime.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatEmbeddedPostgresPortUnavailableError } from "./migration-runtime.js";
+
+describe("formatEmbeddedPostgresPortUnavailableError", () => {
+  it("includes the scanned range and WSL2 reserved-port guidance", () => {
+    const message = formatEmbeddedPostgresPortUnavailableError(54329, 20);
+
+    expect(message).toContain("54329 to 54348");
+    expect(message).toContain("Windows/WSL2");
+    expect(message).toContain("netsh interface ipv4 show excludedportrange protocol=tcp");
+    expect(message).toContain("database.embeddedPostgresPort");
+  });
+});

--- a/packages/db/src/migration-runtime.ts
+++ b/packages/db/src/migration-runtime.ts
@@ -66,15 +66,23 @@ async function isPortInUse(port: number): Promise<boolean> {
   });
 }
 
+export function formatEmbeddedPostgresPortUnavailableError(startPort: number, maxLookahead: number): string {
+  const endPort = startPort + maxLookahead - 1;
+  return [
+    `Embedded PostgreSQL could not find a free port from ${startPort} to ${endPort}.`,
+    "On Windows/WSL2 hosts this can be caused by Hyper-V reserved port ranges rather than a listening process.",
+    "Check Windows reserved ranges with: netsh interface ipv4 show excludedportrange protocol=tcp",
+    "Fix by setting database.embeddedPostgresPort in your Paperclip config to a port outside the excluded range.",
+  ].join("\n");
+}
+
 async function findAvailablePort(startPort: number): Promise<number> {
   const maxLookahead = 20;
   let port = startPort;
   for (let i = 0; i < maxLookahead; i += 1, port += 1) {
     if (!(await isPortInUse(port))) return port;
   }
-  throw new Error(
-    `Embedded PostgreSQL could not find a free port from ${startPort} to ${startPort + maxLookahead - 1}`,
-  );
+  throw new Error(formatEmbeddedPostgresPortUnavailableError(startPort, maxLookahead));
 }
 
 async function loadEmbeddedPostgresCtor(): Promise<EmbeddedPostgresCtor> {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Local development depends on reliable embedded PostgreSQL startup during database migrations.
> - The embedded PostgreSQL runtime scans a configured port range when choosing a local port.
> - On Windows/WSL2 hosts, Hyper-V can reserve TCP port ranges that overlap the embedded PostgreSQL scan range.
> - When that overlap exhausts the scan range, the existing error explains that no port was available but does not point users to the Windows/WSL2 diagnostic path.
> - This pull request keeps the existing port-selection behavior unchanged and makes the failure message more actionable.
> - The benefit is faster self-diagnosis for local setup failures without changing database runtime behavior.

## What Changed

- Extracted the embedded PostgreSQL port exhaustion message into `formatEmbeddedPostgresPortUnavailableError`.
- Added Windows/WSL2 guidance to check Hyper-V reserved TCP port ranges with `netsh interface ipv4 show excludedportrange protocol=tcp`.
- Pointed users to `database.embeddedPostgresPort` as the explicit-port workaround when the default scan range is unavailable.
- Added a focused unit test for the formatted error message and scanned range.

Refs #7047.

## Verification

- [x] `git diff --check`
- [x] `pnpm exec vitest run packages/db/src/migration-runtime.test.ts`
- [x] `pnpm --filter @paperclipai/db typecheck`
- [x] GitHub PR checks are green on the submitted branch.

## Risks

- Low risk. This changes only the diagnostic text emitted after the existing embedded PostgreSQL port scan is exhausted, plus a focused test.
- No port-selection behavior, database schema, credentials, auth, or runtime configuration is changed.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex GPT-5.5 via Hermes Agent, with repository/GitHub tool use and local command execution for inspection and verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: diagnostic message only)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
