### PR TITLE
fix(recovery): skip issues with open waiting interactions

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -473,6 +473,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  const WAITING_INTERACTION_KINDS = ["ask_user_questions", "request_confirmation", "suggest_tasks"] as const;
+  const WAITING_CONTINUATION_POLICIES = ["wake_assignee", "wake_on_response"] as const;
+
+  async function hasOpenWaitingInteraction(companyId: string, issueId: string) {
+    return db
+      .select({
+        id: issueThreadInteractions.id,
+        kind: issueThreadInteractions.kind,
+        continuationPolicy: issueThreadInteractions.continuationPolicy,
+      })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, companyId),
+          eq(issueThreadInteractions.issueId, issueId),
+          inArray(issueThreadInteractions.status, ["open", "pending"]),
+          inArray(issueThreadInteractions.kind, [...WAITING_INTERACTION_KINDS]),
+          inArray(issueThreadInteractions.continuationPolicy, [...WAITING_CONTINUATION_POLICIES]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -2016,6 +2040,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const openInteraction = await hasOpenWaitingInteraction(issue.companyId, issue.id);
+      if (openInteraction) {
+        logger.info(
+          { issueId: issue.id, kind: openInteraction.kind, continuationPolicy: openInteraction.continuationPolicy },
+          `skipped: open_interaction(${openInteraction.kind}, ${openInteraction.continuationPolicy})`,
+        );
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Problem

`reconcileStrandedAssignedIssues()` fired recovery wakes on issues that had an open `ask_user_questions` / `request_confirmation` / `suggest_tasks` interaction waiting for a board/user response. This caused issues like POE-3456 to be incorrectly flipped to `blocked` 5+ times per hour.

## Root Cause

The function checked for active execution paths and pause holds, but had no guard for open waiting interactions with `continuationPolicy: wake_assignee | wake_on_response`. These issues are not stalled — they are actively waiting for input.

## Fix

Added `hasOpenWaitingInteraction(companyId, issueId)` — a targeted DB query that returns an open/pending interaction of the relevant kinds. Placed after the existing `isAutomaticRecoverySuppressedByPauseHold` check, before the latestRun fetch.

Skip condition (all three must hold):
- `status` in (`open`, `pending`)
- `kind` in (`ask_user_questions`, `request_confirmation`, `suggest_tasks`)
- `continuationPolicy` in (`wake_assignee`, `wake_on_response`)

When skipped, the logger emits: `skipped: open_interaction(<kind>, <policy>)`

## Impact

- Recovery wakes no longer spam issues that are waiting for board/user interaction.
- Existing recovery paths for true stalls (max_turns, dead-run, stranded) are unchanged.
- One extra indexed DB query per candidate issue per recovery sweep.

Fixes: POE-3475 / POE-3474