### PR TITLE
fix(heartbeat): return pending empty payload instead of 404 when run log not yet initialized (FUL-5424)

### DIFF
--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { compactRunLogChunk } from "../services/heartbeat.js";
+import type { Db } from "@paperclipai/db";
+import { compactRunLogChunk, heartbeatService } from "../services/heartbeat.js";
 
 describe("compactRunLogChunk", () => {
   it("redacts inline base64 image data from structured log chunks", () => {
@@ -37,5 +38,26 @@ describe("compactRunLogChunk", () => {
     expect(compacted).not.toContain("paperclip-shell-secret");
     expect(compacted).not.toContain("paperclip-json-secret");
     expect(compacted).not.toContain("paperclip-flag-secret");
+  });
+});
+
+describe("heartbeat run log reads", () => {
+  it("returns a pending empty payload when an existing run has no initialized log yet", async () => {
+    const service = heartbeatService({} as Db);
+
+    await expect(
+      service.readLog({
+        id: "run-pending-log",
+        companyId: "company-1",
+        logStore: null,
+        logRef: null,
+      }),
+    ).resolves.toEqual({
+      runId: "run-pending-log",
+      store: null,
+      logRef: null,
+      content: "",
+      pending: true,
+    });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10116,7 +10116,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const run = typeof runOrLookup === "string" ? await getRunLogAccess(runOrLookup) : runOrLookup;
       const runId = typeof runOrLookup === "string" ? runOrLookup : runOrLookup.id;
       if (!run) throw notFound("Heartbeat run not found");
-      if (!run.logStore || !run.logRef) throw notFound("Run log not found");
+      if (!run.logStore || !run.logRef) {
+        return {
+          runId,
+          store: run.logStore,
+          logRef: run.logRef,
+          content: "",
+          pending: true,
+        };
+      }
 
       const result = await runLogStore.read(
         {

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -84,7 +84,7 @@ export const heartbeatsApi = {
       `/heartbeat-runs/${runId}/events?afterSeq=${encodeURIComponent(String(afterSeq))}&limit=${encodeURIComponent(String(limit))}`,
     ),
   log: (runId: string, offset = 0, limitBytes = 256000) =>
-    api.get<{ runId: string; store: string; logRef: string; content: string; nextOffset?: number }>(
+    api.get<{ runId: string; store: string | null; logRef: string | null; content: string; nextOffset?: number; pending?: boolean }>(
       `/heartbeat-runs/${runId}/log?offset=${encodeURIComponent(String(offset))}&limitBytes=${encodeURIComponent(String(limitBytes))}`,
     ),
   workspaceOperations: (runId: string) =>

--- a/ui/src/components/transcript/useLiveRunTranscripts.test.tsx
+++ b/ui/src/components/transcript/useLiveRunTranscripts.test.tsx
@@ -81,6 +81,7 @@ describe("useLiveRunTranscripts", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     globalThis.WebSocket = OriginalWebSocket;
   });
 
@@ -218,6 +219,44 @@ describe("useLiveRunTranscripts", () => {
 
     await act(async () => {
       root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    expect(logMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("stops polling active runs after a persisted-log 404", async () => {
+    vi.useFakeTimers();
+    logMock.mockReset();
+    logMock.mockRejectedValue(new ApiError("Run log not found", 404, { error: "Run log not found" }));
+
+    function Harness() {
+      useLiveRunTranscripts({
+        companyId: "company-1",
+        runs: [{ id: "run-stale", status: "running", adapterType: "codex_local" }],
+        logPollIntervalMs: 10,
+      });
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    expect(logMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(30);
       await Promise.resolve();
     });
 

--- a/ui/src/components/transcript/useLiveRunTranscripts.ts
+++ b/ui/src/components/transcript/useLiveRunTranscripts.ts
@@ -113,7 +113,7 @@ export function useLiveRunTranscripts({
   const seenChunkKeysRef = useRef(new Set<string>());
   const pendingLogRowsByRunRef = useRef(new Map<string, string>());
   const logOffsetByRunRef = useRef(new Map<string, number>());
-  const missingTerminalLogRunIdsRef = useRef(new Set<string>());
+  const missingLogRunIdsRef = useRef(new Set<string>());
   const transcriptCacheRef = useRef(new Map<string, {
     adapterType: string;
     chunks: RunLogChunk[];
@@ -196,9 +196,9 @@ export function useLiveRunTranscripts({
         logOffsetByRunRef.current.delete(runId);
       }
     }
-    for (const runId of missingTerminalLogRunIdsRef.current.keys()) {
+    for (const runId of missingLogRunIdsRef.current.keys()) {
       if (!knownRunIds.has(runId)) {
-        missingTerminalLogRunIdsRef.current.delete(runId);
+        missingLogRunIdsRef.current.delete(runId);
       }
     }
     for (const runId of transcriptCacheRef.current.keys()) {
@@ -214,7 +214,7 @@ export function useLiveRunTranscripts({
     let cancelled = false;
 
     const readRunLog = async (run: RunTranscriptSource) => {
-      if (missingTerminalLogRunIdsRef.current.has(run.id)) {
+      if (missingLogRunIdsRef.current.has(run.id)) {
         return;
       }
       const offset = logOffsetByRunRef.current.get(run.id) ?? resolveInitialLogOffset(run, logReadLimitBytes);
@@ -232,8 +232,8 @@ export function useLiveRunTranscripts({
           logOffsetByRunRef.current.set(run.id, offset + result.content.length);
         }
       } catch (error) {
-        if (error instanceof ApiError && error.status === 404 && isTerminalStatus(run.status)) {
-          missingTerminalLogRunIdsRef.current.add(run.id);
+        if (error instanceof ApiError && error.status === 404) {
+          missingLogRunIdsRef.current.add(run.id);
         }
       } finally {
         if (!cancelled) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each agent run emits a structured log that the UI polls to display the transcript in real time
> - Agent runs that have been claimed but haven't started writing yet have no `logStore`/`logRef` set in the DB
> - The `readLog` endpoint was throwing a 404 in this case, which the UI's log-polling hook treated as "run missing" for terminal runs only
> - For non-terminal (active) runs, the 404 was never suppressed, so the hook kept re-requesting and generating a 404 storm in logs
> - This pull request changes `readLog` to return `{ content: "", pending: true }` when the log isn't initialized yet, and widens the UI suppression gate from "terminal runs only" to "any 404"
> - The benefit is that newly-queued runs never generate 404 storms, and stale run IDs always stop polling after one miss

## What Changed

- **`server/src/services/heartbeat.ts`**: `readLog` returns `{ runId, store: null, logRef: null, content: "", pending: true }` when `logStore`/`logRef` not yet set, instead of throwing a `notFound` 404
- **`ui/src/components/transcript/useLiveRunTranscripts.ts`**: Stop polling after any 404 (not only terminal runs); rename `missingTerminalLogRunIdsRef` → `missingLogRunIdsRef` to reflect broadened behavior
- **`ui/src/api/heartbeats.ts`**: Mark `store` and `logRef` as `string | null`; add `pending?: boolean` to the log response type
- **`server/src/__tests__/heartbeat-run-log.test.ts`**: New test: pending-log path returns expected shape
- **`ui/src/components/transcript/useLiveRunTranscripts.test.tsx`**: New test: 404 stops active-run log polling

## Verification

```bash
# Server test (covers pending-log path)
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-run-log.test.ts
# Result: 4/4 PASS

# UI test (covers 404-stops-polling behavior)
pnpm --filter @paperclipai/ui exec vitest run src/components/transcript/useLiveRunTranscripts.test.tsx
# Result: 8/8 PASS

# Typecheck
pnpm --filter @paperclipai/server typecheck  # PASS
pnpm --filter @paperclipai/ui typecheck      # PASS
```

## Risks

Low risk. The change is backward-compatible:
- Callers that previously received a 404 now receive `{ content: "", pending: true }` — this is a non-breaking extension
- UI callers already handle `content: ""` (renders as empty transcript)
- The `pending` flag is optional; existing callers that ignore it continue to work correctly
- No database migrations, no schema changes, no auth changes

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200K tokens
- Capabilities: extended reasoning, tool use, code execution in heartbeat loop
- Role: Identified the fix, separated clean hunks from mixed working tree, applied and verified changes

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

> Note on UI screenshots: This fix changes error-suppression behavior (no visible UI state change in the happy path). The observable change is that the UI transcript panel no longer shows a 404-induced spinner loop for runs whose log hasn't been written yet.