### PR TITLE
chore(plugin-llm-wiki): enable npm publishing

### DIFF
--- a/packages/plugins/plugin-llm-wiki/package.json
+++ b/packages/plugins/plugin-llm-wiki/package.json
@@ -2,7 +2,6 @@
   "name": "@paperclipai/plugin-llm-wiki",
   "version": "0.1.0",
   "type": "module",
-  "private": true,
   "description": "Local-file LLM Wiki plugin for source ingestion, wiki browsing, query, lint, and maintenance workflows.",
   "files": [
     "agents",

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -120,6 +120,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/plugins/plugin-llm-wiki",
+    "name": "@paperclipai/plugin-llm-wiki",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/plugins/sandbox-providers/modal",
     "name": "@paperclipai/plugin-modal",
     "publishFromCi": true


### PR DESCRIPTION
## Summary

- Removes `"private": true` from `packages/plugins/plugin-llm-wiki/package.json` so the package can be published to npm
- Adds `@paperclipai/plugin-llm-wiki` to `scripts/release-package-manifest.json` so CI includes it in releases

PR #6010 already added the `files` field to the package.json, but left `private: true` in place, which blocks publishing. This PR completes the remaining packaging work.

Closes #5709

## Test plan

- [ ] Verify `packages/plugins/plugin-llm-wiki/package.json` no longer contains `"private": true`
- [ ] Verify `scripts/release-package-manifest.json` includes the `@paperclipai/plugin-llm-wiki` entry with `"publishFromCi": true`
- [ ] Confirm CI release pipeline picks up the package on next release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)