### PR TITLE
fix(ci): upgrade GitHub Actions to Node.js 24 before June 16 deadline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PAPERCLIP_E2E_SKIP_LLM: ${{ inputs.skip_llm && 'true' || 'false' }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,9 @@ concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   policy:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -10,6 +10,9 @@ concurrency:
   group: refresh-lockfile-master
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   refresh:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Refresh pnpm lockfile

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -35,6 +35,9 @@ on:
         default: release-smoke
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ concurrency:
   group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   verify_canary:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` as a workflow-level env var to all 6 CI workflow files (`pr.yml`, `release.yml`, `release-smoke.yml`, `docker.yml`, `refresh-lockfile.yml`) and as a job-level env to `e2e.yml` — forces the runner to execute `actions/checkout@v4`, `pnpm/action-setup@v4`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` under Node.js 24 immediately, eliminating the deprecation warnings.
- Upgraded `node-version: 20 → 24` in `e2e.yml` and `refresh-lockfile.yml`, making all workflows consistent with the Node 24 baseline already in use in `pr.yml`, `release.yml`, and `release-smoke.yml`.

## Why

GitHub Actions is forcing Node.js 24 as the runner default on **June 16, 2026** (16 days away). Every CI run currently emits:

```
Node.js 20 actions are deprecated.
Actions will be FORCED to Node.js 24 by default starting June 16th, 2026.
```

Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` opts in proactively before the cutover so we can catch any compatibility issues now rather than on June 16.

## Test plan

- [ ] CI passes on this PR with no Node.js 20 deprecation warnings
- [ ] All existing test suites pass under Node.js 24

Resolves FUL-5479. Escalated from FUL-5475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)