### PR TITLE
feat(ui/issue-detail): show project chip next to issue identifier

### DIFF
--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -453,16 +453,10 @@ function IssueDetailLoadingState({
               {identifier ? (
                 <span className="text-sm font-mono text-muted-foreground shrink-0">{identifier}</span>
               ) : null}
-              {headerSeed.originKind === "routine_execution" && headerSeed.originId ? (
-                <span className="inline-flex items-center gap-1 rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-600 dark:text-violet-400 shrink-0">
-                  <Repeat className="h-3 w-3" />
-                  Routine
-                </span>
-              ) : null}
               {headerSeed.projectId ? (
-                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground rounded px-1 -mx-1 py-0.5 min-w-0">
+                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground rounded px-1 -mx-1 py-0.5 min-w-0 max-w-[12rem]">
                   <Hexagon className="h-3 w-3 shrink-0" />
-                  <span className="truncate">
+                  <span className="truncate min-w-[5ch]">
                     {headerSeed.projectName ?? headerSeed.projectId.slice(0, 8)}
                   </span>
                 </span>
@@ -472,6 +466,12 @@ function IssueDetailLoadingState({
                   No project
                 </span>
               )}
+              {headerSeed.originKind === "routine_execution" && headerSeed.originId ? (
+                <span className="inline-flex items-center gap-1 rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-600 dark:text-violet-400 shrink-0">
+                  <Repeat className="h-3 w-3" />
+                  Routine
+                </span>
+              ) : null}
             </>
           ) : (
             <>
@@ -3351,6 +3351,21 @@ export function IssueDetail() {
           />
           <span className="text-sm font-mono text-muted-foreground shrink-0">{issue.identifier ?? issue.id.slice(0, 8)}</span>
 
+          {issue.projectId ? (
+            <Link
+              to={`/projects/${issue.projectId}`}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded px-1 -mx-1 py-0.5 min-w-0 max-w-[12rem]"
+            >
+              <Hexagon className="h-3 w-3 shrink-0" />
+              <span className="truncate min-w-[5ch]">{resolvedProject?.name ?? issue.project?.name ?? issue.projectId.slice(0, 8)}</span>
+            </Link>
+          ) : (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground opacity-50 px-1 -mx-1 py-0.5">
+              <Hexagon className="h-3 w-3 shrink-0" />
+              No project
+            </span>
+          )}
+
           {hasLiveRuns && (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/30 px-2 py-0.5 text-[10px] font-medium text-cyan-600 dark:text-cyan-400 shrink-0">
               <span className="relative flex h-1.5 w-1.5">
@@ -3404,21 +3419,6 @@ export function IssueDetail() {
               Blocked by parked work
             </span>
           ) : null}
-
-          {issue.projectId ? (
-            <Link
-              to={`/projects/${issue.projectId}`}
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded px-1 -mx-1 py-0.5 min-w-0"
-            >
-              <Hexagon className="h-3 w-3 shrink-0" />
-              <span className="truncate">{resolvedProject?.name ?? issue.project?.name ?? issue.projectId.slice(0, 8)}</span>
-            </Link>
-          ) : (
-            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground opacity-50 px-1 -mx-1 py-0.5">
-              <Hexagon className="h-3 w-3 shrink-0" />
-              No project
-            </span>
-          )}
 
           {(issue.labels ?? []).length > 0 && (
             <div className="hidden sm:flex items-center gap-1">


### PR DESCRIPTION
## Summary

이슈 detail 헤더에서 프로젝트 칩을 **이슈번호 바로 옆**으로 옮긴다. 기존엔 헤더 row 끝에 있어 Live/Routine/ProductivityReview/WorkMode/Blocked-parked 뱃지 6+개에 가려 시각적으로 멀어 안 보이는 문제가 있었음.

## Changes

- `ui/src/pages/IssueDetail.tsx`
  - 헤더 본체: 프로젝트 칩을 식별자 span 직후로 이동
  - 로딩 스켈레톤: 동일 순서로 정렬 (식별자 → 프로젝트 → Routine)
  - 칩 컨테이너: `max-w-[12rem]` → 너무 긴 프로젝트명은 컴팩트
  - 칩 텍스트: `truncate min-w-[5ch]` → 최소 5글자 보장 + 그 이상은 `…`로 잘림

23↑/23↓ jsx swap, 로직/props/이벤트 변경 없음.

## Test plan

- [ ] `IssueDetail.test.tsx` 통과 (헤더 클래스명/순서 강제 안 함, 회귀 없음 예상)
- [ ] 짧은 프로젝트명/긴 프로젝트명 모두 확인 — truncate 동작
- [ ] `projectId` 없는 이슈에서 "No project" 표시 유지
- [ ] Routine 이슈에서 Routine 뱃지가 프로젝트 칩 다음에 표시

Issue: OMO-2032