### PR TITLE
fix(mcp-server): bundle stdio.js with esbuild instead of tsup (unblocks #7258)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -37,7 +37,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc && esbuild src/stdio.ts --bundle --platform=node --format=esm --outfile=dist/stdio.js --sourcemap --external:@modelcontextprotocol/* --external:zod",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"


### PR DESCRIPTION
## Problem

PR #7258 (`worktree-mcp-conditional-exports-fix`) has failed CI 3 consecutive times because `packages/mcp-server/package.json` adds `tsup@^8.0.0` as a devDependency, but `pnpm-lock.yaml` does not include that specifier. `pnpm --frozen-lockfile install` fails on all 11 CI jobs.

CI policy forbids manually committing `pnpm-lock.yaml` in PRs, and the `gboyles2paperclipAI` service account cannot push to the contributor's fork (`marcpbailey/paperclip`), so the lockfile cannot be updated on that branch.

## Solution

Replace `tsup` with `tsc + esbuild` to achieve the same outcome:

- `tsc` compiles the library entry (`src/index.ts` → `dist/index.js` + `dist/index.d.ts`)
- `esbuild` produces the standalone stdio bundle (`src/stdio.ts` → `dist/stdio.js` with `@paperclipai/shared` inlined)

`esbuild ^0.27.3` is already a workspace-root `devDependency`, so **no lockfile change is needed**.

## Changes

- `packages/mcp-server/package.json`: update `build` script; remove `tsup` devDependency

## Validation (from Backend Lead, verified in isolated checkout)

- `pnpm install --frozen-lockfile --ignore-scripts` → passes (no lockfile mismatch)
- `pnpm --filter @paperclipai/mcp-server build` → passes; generates `dist/stdio.js` as a bundled file
- `pnpm --filter @paperclipai/mcp-server typecheck` → passes

## Relation to PR #7258

This PR supersedes #7258 for the bundle fix. The conditional-exports changes in #7258 (`exports` field in `package.json`, `publishConfig`) are already present on `master` — only the build script change is needed here. PR #7258 can be closed.

Tracked by: [FUL-5586](/FUL/issues/FUL-5586)