### PR TITLE
feat(adapter): add local inference adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/grok-local/package.json packages/adapters/grok-local/
+COPY packages/adapters/local/package.json packages/adapters/local/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/

--- a/docs/adapters/local.md
+++ b/docs/adapters/local.md
@@ -1,0 +1,59 @@
+---
+title: Local OpenAI-Compatible Adapter
+summary: Run a Paperclip heartbeat through a local OpenAI-compatible chat endpoint
+---
+
+The `local` adapter sends one OpenAI-compatible `/chat/completions` request per heartbeat. It is intended for local inference servers such as LM Studio that expose a `/v1` API.
+
+## Configuration
+
+```json
+{
+  "adapterType": "local",
+  "adapterConfig": {
+    "model": "qwen/qwen3-coder-30b",
+    "baseUrl": "http://localhost:1234/v1",
+    "instructionsFilePath": "/absolute/path/to/AGENTS.md",
+    "maxTurns": 20
+  }
+}
+```
+
+Fields:
+
+- `model` is the OpenAI-compatible chat model id.
+- `baseUrl` defaults to `http://localhost:1234/v1`.
+- `apiKey` is optional and is sent as a bearer token when configured.
+- `instructionsFilePath` is injected into the prompt.
+- `maxTurns` is used only by the `claude_local` fallback.
+
+## Availability And Fallback
+
+At the start of each run, Paperclip probes the local `/models` endpoint and honors the same override variables as the local inference flag script:
+
+- `INFERENCE_LOCAL_URL_OVERRIDE`
+- `INFERENCE_LOCAL_AVAILABLE=0`
+- `INFERENCE_LOCAL_AVAILABLE=1`
+- `INFERENCE_LOCAL_FORCE=on`
+- `INFERENCE_LOCAL_FORCE=off`
+- `INFERENCE_LOCAL_TIMEOUT_S`
+
+When local inference is unavailable, Paperclip routes that run through `claude_local` using the same `instructionsFilePath` and `maxTurns`. The agent record is not changed.
+
+## Health
+
+Check local inference from the server:
+
+```sh
+curl http://localhost:3100/api/inference/local/health
+```
+
+The response includes:
+
+```json
+{
+  "available": true,
+  "url": "http://localhost:1234/v1",
+  "models": ["qwen/qwen3-coder-30b"]
+}
+```

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -20,6 +20,7 @@ When a heartbeat fires, Paperclip:
 |---------|----------|-------------|
 | [Claude Local](/adapters/claude-local) | `claude_local` | Runs Claude Code CLI locally |
 | [Codex Local](/adapters/codex-local) | `codex_local` | Runs OpenAI Codex CLI locally |
+| [Local OpenAI-Compatible](/adapters/local) | `local` | Calls a local OpenAI-compatible `/chat/completions` endpoint, with `claude_local` fallback |
 | [Gemini Local](/adapters/gemini-local) | `gemini_local` | Runs Gemini CLI locally (experimental — adapter package exists, not yet in stable type enum) |
 | OpenCode Local | `opencode_local` | Runs OpenCode CLI locally (multi-provider `provider/model`) |
 | Cursor | `cursor` | Runs Cursor in background mode |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,6 +98,7 @@
               "adapters/overview",
               "adapters/claude-local",
               "adapters/codex-local",
+              "adapters/local",
               "adapters/process",
               "adapters/http",
               "adapters/external-adapters",

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -315,7 +315,7 @@ export interface ConfigFieldOption {
 export interface ConfigFieldSchema {
   key: string;
   label: string;
-  type: "text" | "select" | "toggle" | "number" | "textarea" | "combobox";
+  type: "text" | "password" | "select" | "toggle" | "number" | "textarea" | "combobox";
   options?: ConfigFieldOption[];
   default?: unknown;
   hint?: string;

--- a/packages/adapters/local/package.json
+++ b/packages/adapters/local/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@paperclipai/adapter-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -1,0 +1,28 @@
+export const type = "local";
+export const label = "Local OpenAI-compatible";
+export const DEFAULT_LOCAL_BASE_URL = "http://localhost:1234/v1";
+export const DEFAULT_LOCAL_MODEL = "qwen/qwen3-coder-30b";
+
+export const models = [
+  { id: DEFAULT_LOCAL_MODEL, label: "Qwen3 Coder 30B" },
+];
+
+export const agentConfigurationDoc = `# local agent configuration
+
+Adapter: local
+
+Core fields:
+- model (string, required): OpenAI-compatible chat model id
+- baseUrl (string, optional): OpenAI-compatible base URL; defaults to http://localhost:1234/v1
+- apiKey (string, optional): bearer token for the local endpoint when required
+- maxTurns (number, optional): passed through to the claude_local fallback as maxTurnsPerRun
+- instructionsFilePath (string, required): absolute path to a markdown instructions file injected at runtime
+- promptTemplate (string, optional): run prompt template
+
+Operational fields:
+- timeoutSec (number, optional): request timeout in seconds
+
+Notes:
+- Paperclip sends one /chat/completions request per heartbeat.
+- When local inference is unavailable, Paperclip transparently runs the heartbeat through claude_local with the same instructionsFilePath and maxTurns.
+`;

--- a/packages/adapters/local/src/server/execute.test.ts
+++ b/packages/adapters/local/src/server/execute.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { execute } from "./execute.js";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function makeContext(): AdapterExecutionContext {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Ada",
+      adapterType: "local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      model: "qwen/qwen3-coder-30b",
+      baseUrl: "http://localhost:1234/v1",
+    },
+    context: {
+      paperclipTaskMarkdown: "Do the smallest useful thing.",
+    },
+    onLog: vi.fn(async () => {}),
+    onMeta: vi.fn(async () => {}),
+  };
+}
+
+describe("local adapter execute", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts chat completions and returns the assistant summary", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: "Done: local smoke passed." } }],
+      usage: { prompt_tokens: 12, completion_tokens: 7 },
+    }), { status: 200 }));
+
+    const result = await execute(makeContext());
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      provider: "local",
+      biller: "local",
+      model: "qwen/qwen3-coder-30b",
+      summary: "Done: local smoke passed.",
+      usage: { inputTokens: 12, outputTokens: 7 },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:1234/v1/chat/completions",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.model).toBe("qwen/qwen3-coder-30b");
+  });
+
+  it("returns an adapter failure when the endpoint rejects the request", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      error: { message: "model not loaded" },
+    }), { status: 503 }));
+
+    const result = await execute(makeContext());
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      errorCode: "local_http_503",
+      errorMessage: "Local inference returned HTTP 503",
+    });
+  });
+});

--- a/packages/adapters/local/src/server/execute.ts
+++ b/packages/adapters/local/src/server/execute.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  asNumber,
+  asString,
+  joinPromptSections,
+  renderPaperclipWakePrompt,
+  renderTemplate,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_LOCAL_MODEL } from "../index.js";
+import { normalizeLocalBaseUrl, resolveLocalBaseUrl } from "./health.js";
+
+const DEFAULT_COMPLETION_TIMEOUT_MS = 120_000;
+const MS_PER_SECOND = 1_000;
+
+interface ChatChoice {
+  message?: { content?: unknown };
+}
+
+interface ChatCompletionResponse {
+  choices?: ChatChoice[];
+  usage?: {
+    prompt_tokens?: unknown;
+    completion_tokens?: unknown;
+    input_tokens?: unknown;
+    output_tokens?: unknown;
+  };
+}
+
+function timeoutMs(timeoutSec: number): number {
+  if (!Number.isFinite(timeoutSec) || timeoutSec <= 0) return DEFAULT_COMPLETION_TIMEOUT_MS;
+  return Math.trunc(timeoutSec * MS_PER_SECOND);
+}
+
+async function readInstructions(filePath: string, onLog: AdapterExecutionContext["onLog"]) {
+  if (!filePath) return "";
+  try {
+    const contents = await fs.readFile(filePath, "utf8");
+    const baseDir = `${path.dirname(filePath)}/`;
+    return `${contents}\n\nThe above agent instructions were loaded from ${filePath}. Resolve any relative file references from ${baseDir}.`;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    await onLog("stderr", `[paperclip] Warning: could not read local adapter instructions file "${filePath}": ${reason}\n`);
+    return "";
+  }
+}
+
+function usageFromResponse(response: ChatCompletionResponse): AdapterExecutionResult["usage"] {
+  const usage = response.usage ?? {};
+  const inputTokens = Number(usage.prompt_tokens ?? usage.input_tokens ?? 0);
+  const outputTokens = Number(usage.completion_tokens ?? usage.output_tokens ?? 0);
+  return {
+    inputTokens: Number.isFinite(inputTokens) ? inputTokens : 0,
+    outputTokens: Number.isFinite(outputTokens) ? outputTokens : 0,
+  };
+}
+
+function asChatResponse(payload: unknown): ChatCompletionResponse {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return {};
+  return payload as ChatCompletionResponse;
+}
+
+function buildPrompt(ctx: AdapterExecutionContext, instructions: string): string {
+  const template = asString(ctx.config.promptTemplate, DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE);
+  const wakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
+  const taskContext = asString(ctx.context.paperclipTaskMarkdown, "").trim();
+  const templateData = {
+    agentId: ctx.agent.id,
+    companyId: ctx.agent.companyId,
+    runId: ctx.runId,
+    company: { id: ctx.agent.companyId },
+    agent: ctx.agent,
+    run: { id: ctx.runId, source: "on_demand" },
+    context: ctx.context,
+  };
+  return joinPromptSections([
+    "Your response will be saved as this heartbeat run's issue-thread update. Be concise and factual.",
+    instructions,
+    wakePrompt,
+    taskContext,
+    renderTemplate(template, templateData),
+  ]);
+}
+
+function contentFromResponse(payload: unknown): string {
+  const parsed = asChatResponse(payload);
+  const content = parsed.choices?.[0]?.message?.content;
+  return typeof content === "string" ? content.trim() : "";
+}
+
+async function postChatCompletion(input: {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  prompt: string;
+  timeoutMs: number;
+}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (input.apiKey) headers.Authorization = `Bearer ${input.apiKey}`;
+  try {
+    return await fetch(`${input.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers,
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: input.model,
+        messages: [{ role: "user", content: input.prompt }],
+      }),
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const model = asString(ctx.config.model, DEFAULT_LOCAL_MODEL).trim() || DEFAULT_LOCAL_MODEL;
+  const baseUrl = normalizeLocalBaseUrl(resolveLocalBaseUrl(asString(ctx.config.baseUrl, "")));
+  const apiKey = asString(ctx.config.apiKey, "");
+  const instructions = await readInstructions(asString(ctx.config.instructionsFilePath, ""), ctx.onLog);
+  const prompt = buildPrompt(ctx, instructions);
+
+  await ctx.onMeta?.({
+    adapterType: "local",
+    command: `${baseUrl}/chat/completions`,
+    commandNotes: ["OpenAI-compatible local inference request"],
+    prompt,
+    promptMetrics: { promptChars: prompt.length, instructionsChars: instructions.length },
+    context: ctx.context,
+  });
+
+  try {
+    const response = await postChatCompletion({
+      baseUrl,
+      apiKey,
+      model,
+      prompt,
+      timeoutMs: timeoutMs(asNumber(ctx.config.timeoutSec, 0)),
+    });
+    const payload = await response.json();
+    const summary = contentFromResponse(payload);
+    if (!response.ok || !summary) return failedResponse(response.status, payload, summary);
+    await ctx.onLog("stdout", `assistant: ${summary}\n`);
+    return succeededResponse(model, payload, summary);
+  } catch (error) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "local_inference_request_failed",
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function failedResponse(status: number, payload: unknown, summary: string): AdapterExecutionResult {
+  const httpFailed = status >= 400;
+  const errorCode = httpFailed ? `local_http_${status}` : "local_empty_response";
+  const errorMessage = summary || (
+    httpFailed ? `Local inference returned HTTP ${status}` : "Local inference returned an empty response"
+  );
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    errorCode,
+    errorMessage,
+    resultJson: { response: payload },
+  };
+}
+
+function succeededResponse(
+  model: string,
+  payload: unknown,
+  summary: string,
+): AdapterExecutionResult {
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    provider: "local",
+    biller: "local",
+    billingType: "fixed",
+    costUsd: 0,
+    model,
+    usage: usageFromResponse(asChatResponse(payload)),
+    summary,
+    resultJson: { result: summary },
+  };
+}

--- a/packages/adapters/local/src/server/health.test.ts
+++ b/packages/adapters/local/src/server/health.test.ts
@@ -47,6 +47,25 @@ describe("local inference health", () => {
     );
   });
 
+  it("sends the configured API key as a bearer token", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      object: "list",
+      data: [{ id: "qwen/qwen3-coder-30b" }],
+    }), { status: 200 }));
+
+    await getLocalInferenceHealth({
+      apiKey: "local-secret",
+      baseUrl: "http://local.test/v1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://local.test/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer local-secret" },
+      }),
+    );
+  });
+
   it("keeps embedding models out of selectable chat models", async () => {
     fetchMock.mockResolvedValue(new Response(JSON.stringify({
       object: "list",

--- a/packages/adapters/local/src/server/health.test.ts
+++ b/packages/adapters/local/src/server/health.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLocalInferenceHealth, listLocalModels } from "./health.js";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+describe("local inference health", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    delete process.env.INFERENCE_LOCAL_FORCE;
+    delete process.env.INFERENCE_LOCAL_AVAILABLE;
+    delete process.env.INFERENCE_LOCAL_MODELS;
+    delete process.env.INFERENCE_LOCAL_URL_OVERRIDE;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("honors INFERENCE_LOCAL_FORCE=off for fallback testing", async () => {
+    process.env.INFERENCE_LOCAL_FORCE = "off";
+
+    await expect(getLocalInferenceHealth()).resolves.toEqual({
+      available: false,
+      url: "http://localhost:1234/v1",
+      models: [],
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("probes /models and returns served model ids", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      object: "list",
+      data: [{ id: "qwen/qwen3-coder-30b" }, { id: "text-embedding-bge-m3" }],
+    }), { status: 200 }));
+
+    const health = await getLocalInferenceHealth({ baseUrl: "http://local.test/v1/" });
+
+    expect(health).toEqual({
+      available: true,
+      url: "http://local.test/v1",
+      models: ["qwen/qwen3-coder-30b", "text-embedding-bge-m3"],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://local.test/v1/models",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("keeps embedding models out of selectable chat models", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      object: "list",
+      data: [{ id: "qwen/qwen3-coder-30b" }, { id: "text-embedding-bge-m3" }],
+    }), { status: 200 }));
+
+    await expect(listLocalModels()).resolves.toEqual([
+      { id: "qwen/qwen3-coder-30b", label: "qwen/qwen3-coder-30b" },
+    ]);
+  });
+});

--- a/packages/adapters/local/src/server/health.ts
+++ b/packages/adapters/local/src/server/health.ts
@@ -12,6 +12,7 @@ export interface LocalInferenceHealth {
 
 interface ProbeOptions {
   baseUrl?: string;
+  apiKey?: string;
   timeoutSec?: number;
 }
 
@@ -70,11 +71,13 @@ function parseModelIds(payload: unknown): string[] {
     .filter((id): id is string => typeof id === "string" && id.trim().length > 0);
 }
 
-async function fetchModels(url: string, timeoutMs: number): Promise<unknown> {
+async function fetchModels(url: string, timeoutMs: number, apiKey = ""): Promise<unknown> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const headers: Record<string, string> = {};
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
   try {
-    const response = await fetch(`${url}/models`, { signal: controller.signal });
+    const response = await fetch(`${url}/models`, { headers, signal: controller.signal });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return await response.json();
   } finally {
@@ -90,7 +93,11 @@ export async function getLocalInferenceHealth(
   if (forced) return forced;
 
   try {
-    const payload = await fetchModels(url, readTimeoutMs(options.timeoutSec ?? readEnvTimeoutSec()));
+    const payload = await fetchModels(
+      url,
+      readTimeoutMs(options.timeoutSec ?? readEnvTimeoutSec()),
+      options.apiKey,
+    );
     const models = parseModelIds(payload);
     return { available: true, url, models };
   } catch (error) {

--- a/packages/adapters/local/src/server/health.ts
+++ b/packages/adapters/local/src/server/health.ts
@@ -1,0 +1,111 @@
+import { DEFAULT_LOCAL_BASE_URL } from "../index.js";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const MS_PER_SECOND = 1_000;
+
+export interface LocalInferenceHealth {
+  available: boolean;
+  url: string;
+  models: string[];
+  error?: string;
+}
+
+interface ProbeOptions {
+  baseUrl?: string;
+  timeoutSec?: number;
+}
+
+interface ModelsResponse {
+  object?: string;
+  data?: Array<{ id?: unknown }>;
+}
+
+function readTimeoutMs(timeoutSec?: number): number {
+  if (!Number.isFinite(timeoutSec) || !timeoutSec || timeoutSec <= 0) {
+    return DEFAULT_PROBE_TIMEOUT_MS;
+  }
+  return Math.max(1, Math.trunc(timeoutSec * MS_PER_SECOND));
+}
+
+function readEnvTimeoutSec(): number | undefined {
+  const parsed = Number(process.env.INFERENCE_LOCAL_TIMEOUT_S);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function normalizeLocalBaseUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  return trimmed || DEFAULT_LOCAL_BASE_URL;
+}
+
+export function resolveLocalBaseUrl(baseUrl?: string): string {
+  return normalizeLocalBaseUrl(
+    process.env.INFERENCE_LOCAL_URL_OVERRIDE || baseUrl || DEFAULT_LOCAL_BASE_URL,
+  );
+}
+
+function forcedHealth(url: string): LocalInferenceHealth | null {
+  if (process.env.INFERENCE_LOCAL_FORCE === "on") {
+    const models = (process.env.INFERENCE_LOCAL_MODELS ?? "").split(",").filter(Boolean);
+    return { available: true, url, models };
+  }
+  if (process.env.INFERENCE_LOCAL_FORCE === "off") {
+    return { available: false, url, models: [] };
+  }
+  if (process.env.INFERENCE_LOCAL_AVAILABLE === "0") {
+    return { available: false, url, models: [] };
+  }
+  if (process.env.INFERENCE_LOCAL_AVAILABLE === "1") {
+    const models = (process.env.INFERENCE_LOCAL_MODELS ?? "").split(",").filter(Boolean);
+    return { available: true, url, models };
+  }
+  return null;
+}
+
+function parseModelIds(payload: unknown): string[] {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return [];
+  const parsed = payload as ModelsResponse;
+  if (parsed.object !== "list" || !Array.isArray(parsed.data)) return [];
+  return parsed.data
+    .map((entry) => entry.id)
+    .filter((id): id is string => typeof id === "string" && id.trim().length > 0);
+}
+
+async function fetchModels(url: string, timeoutMs: number): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${url}/models`, { signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getLocalInferenceHealth(
+  options: ProbeOptions = {},
+): Promise<LocalInferenceHealth> {
+  const url = resolveLocalBaseUrl(options.baseUrl);
+  const forced = forcedHealth(url);
+  if (forced) return forced;
+
+  try {
+    const payload = await fetchModels(url, readTimeoutMs(options.timeoutSec ?? readEnvTimeoutSec()));
+    const models = parseModelIds(payload);
+    return { available: true, url, models };
+  } catch (error) {
+    return {
+      available: false,
+      url,
+      models: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function listLocalModels(): Promise<Array<{ id: string; label: string }>> {
+  const health = await getLocalInferenceHealth();
+  return health.models
+    .filter((id) => !id.startsWith("text-embedding"))
+    .map((id) => ({ id, label: id }));
+}

--- a/packages/adapters/local/src/server/index.ts
+++ b/packages/adapters/local/src/server/index.ts
@@ -1,0 +1,9 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export {
+  getLocalInferenceHealth,
+  listLocalModels,
+  normalizeLocalBaseUrl,
+  resolveLocalBaseUrl,
+  type LocalInferenceHealth,
+} from "./health.js";

--- a/packages/adapters/local/src/server/test.ts
+++ b/packages/adapters/local/src/server/test.ts
@@ -1,0 +1,55 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asNumber, asString } from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_LOCAL_MODEL } from "../index.js";
+import { getLocalInferenceHealth, resolveLocalBaseUrl } from "./health.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const model = asString(ctx.config.model, DEFAULT_LOCAL_MODEL).trim() || DEFAULT_LOCAL_MODEL;
+  const baseUrl = asString(ctx.config.baseUrl, "");
+  const health = await getLocalInferenceHealth({
+    baseUrl,
+    timeoutSec: asNumber(ctx.config.timeoutSec, 0),
+  });
+  const checks: AdapterEnvironmentCheck[] = [
+    {
+      code: "local_model_configured",
+      level: model ? "info" : "error",
+      message: model ? `Configured model: ${model}` : "Local adapter requires a model.",
+    },
+    {
+      code: health.available ? "local_inference_available" : "local_inference_unavailable",
+      level: health.available ? "info" : "error",
+      message: health.available
+        ? `Local inference is available at ${health.url}.`
+        : `Local inference is unavailable at ${resolveLocalBaseUrl(baseUrl)}.`,
+      detail: health.error ?? null,
+    },
+  ];
+
+  if (health.models.length > 0 && !health.models.includes(model)) {
+    checks.push({
+      code: "local_model_not_listed",
+      level: "warn",
+      message: `Configured model "${model}" was not listed by the local endpoint.`,
+    });
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/local/src/ui/build-config.ts
+++ b/packages/adapters/local/src/ui/build-config.ts
@@ -1,0 +1,22 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_LOCAL_BASE_URL, DEFAULT_LOCAL_MODEL } from "../index.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+export function buildLocalConfig(values: CreateConfigValues): Record<string, unknown> {
+  const schemaValues = asRecord(values.adapterSchemaValues);
+  const config: Record<string, unknown> = {
+    model: values.model || DEFAULT_LOCAL_MODEL,
+    baseUrl: values.url || DEFAULT_LOCAL_BASE_URL,
+  };
+  if (values.instructionsFilePath) config.instructionsFilePath = values.instructionsFilePath;
+  if (values.promptTemplate) config.promptTemplate = values.promptTemplate;
+  if (values.maxTurnsPerRun > 0) config.maxTurns = values.maxTurnsPerRun;
+  if (typeof schemaValues.apiKey === "string" && schemaValues.apiKey) {
+    config.apiKey = schemaValues.apiKey;
+  }
+  return config;
+}

--- a/packages/adapters/local/src/ui/index.ts
+++ b/packages/adapters/local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { buildLocalConfig } from "./build-config.js";
+export { parseLocalStdoutLine } from "./parse-stdout.js";

--- a/packages/adapters/local/src/ui/parse-stdout.ts
+++ b/packages/adapters/local/src/ui/parse-stdout.ts
@@ -1,0 +1,13 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+export function parseLocalStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("assistant:")) {
+    return [{ kind: "assistant", ts, text: trimmed.slice("assistant:".length).trim() }];
+  }
+  if (trimmed.startsWith("[paperclip]")) {
+    return [{ kind: "system", ts, text: trimmed }];
+  }
+  return [{ kind: "stdout", ts, text: trimmed }];
+}

--- a/packages/adapters/local/tsconfig.json
+++ b/packages/adapters/local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/local/vitest.config.ts
+++ b/packages/adapters/local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "process",
   "http",
   "acpx_local",
+  "local",
   "claude_local",
   "codex_local",
   "cursor_cloud",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -622,6 +638,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':
@@ -648,6 +666,9 @@ importers:
       '@paperclipai/adapter-grok-local':
         specifier: workspace:*
         version: link:../packages/adapters/grok-local
+      '@paperclipai/adapter-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -814,6 +835,9 @@ importers:
       '@paperclipai/adapter-grok-local':
         specifier: workspace:*
         version: link:../packages/adapters/grok-local
+      '@paperclipai/adapter-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -40,6 +40,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/local",
+    "name": "@paperclipai/adapter-local",
+    "publishFromCi": false
+  },
+  {
     "dir": "packages/adapters/opencode-local",
     "name": "@paperclipai/adapter-opencode-local",
     "publishFromCi": true

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -14,6 +14,7 @@ const nonServerProjects = [
   "@paperclipai/adapter-utils",
   "@paperclipai/adapter-acpx-local",
   "@paperclipai/adapter-codex-local",
+  "@paperclipai/adapter-local",
   "@paperclipai/adapter-opencode-local",
   "@paperclipai/plugin-sdk",
   "@paperclipai/create-paperclip-plugin",

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
+    "@paperclipai/adapter-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/__tests__/local-adapter-fallback.test.ts
+++ b/server/src/__tests__/local-adapter-fallback.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AdapterExecutionContext } from "../adapters/index.js";
+
+const claudeExecuteMock = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  summary: "claude fallback completed",
+})));
+
+const localExecuteMock = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  summary: "local completed",
+})));
+
+const localHealthMock = vi.hoisted(() => vi.fn(async () => ({
+  available: true,
+  url: "http://localhost:1234/v1",
+  models: ["qwen/qwen3-coder-30b"],
+})));
+
+vi.mock("@paperclipai/adapter-claude-local/server", () => ({
+  execute: claudeExecuteMock,
+  listClaudeSkills: async () => ({ entries: [] }),
+  syncClaudeSkills: async () => ({ entries: [] }),
+  listClaudeModels: async () => [],
+  refreshClaudeModels: async () => [],
+  testEnvironment: async () => ({
+    adapterType: "claude_local",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  sessionCodec: null,
+  getQuotaWindows: async () => ({ provider: "anthropic", ok: true, windows: [] }),
+}));
+
+vi.mock("@paperclipai/adapter-local/server", () => ({
+  execute: localExecuteMock,
+  getLocalInferenceHealth: localHealthMock,
+  listLocalModels: async () => [],
+  testEnvironment: async () => ({
+    adapterType: "local",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+}));
+
+import { requireServerAdapter } from "../adapters/index.js";
+
+function makeContext(): AdapterExecutionContext {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Ada",
+      adapterType: "local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      model: "qwen/qwen3-coder-30b",
+      baseUrl: "http://localhost:1234/v1",
+      instructionsFilePath: "/tmp/AGENTS.md",
+      maxTurns: 3,
+    },
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+describe("local adapter fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs the local adapter when the inference probe is available", async () => {
+    localHealthMock.mockResolvedValue({
+      available: true,
+      url: "http://localhost:1234/v1",
+      models: ["qwen/qwen3-coder-30b"],
+    });
+
+    const result = await requireServerAdapter("local").execute(makeContext());
+
+    expect(result.summary).toBe("local completed");
+    expect(localExecuteMock).toHaveBeenCalledTimes(1);
+    expect(claudeExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to claude_local with instructions and max turns", async () => {
+    localHealthMock.mockResolvedValue({
+      available: false,
+      url: "http://localhost:1234/v1",
+      models: [],
+    });
+
+    const result = await requireServerAdapter("local").execute(makeContext());
+
+    expect(result.summary).toBe("claude fallback completed");
+    expect(localExecuteMock).not.toHaveBeenCalled();
+    expect(claudeExecuteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          instructionsFilePath: "/tmp/AGENTS.md",
+          maxTurnsPerRun: 3,
+        },
+      }),
+    );
+  });
+});

--- a/server/src/__tests__/local-inference-health-routes.test.ts
+++ b/server/src/__tests__/local-inference-health-routes.test.ts
@@ -35,13 +35,12 @@ describe("GET /api/inference/local/health", () => {
     });
   });
 
-  it("passes optional probe query settings to the health probe", async () => {
+  it("ignores client-supplied baseUrl and passes timeout only", async () => {
     await request(createApp())
       .get("/api/inference/local/health")
-      .query({ baseUrl: "http://local.test/v1", timeoutSec: "4" });
+      .query({ baseUrl: "http://evil.test/v1", timeoutSec: "4" });
 
     expect(localHealthMock).toHaveBeenCalledWith({
-      baseUrl: "http://local.test/v1",
       timeoutSec: 4,
     });
   });

--- a/server/src/__tests__/local-inference-health-routes.test.ts
+++ b/server/src/__tests__/local-inference-health-routes.test.ts
@@ -1,0 +1,48 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { localInferenceRoutes } from "../routes/local-inference.js";
+
+const localHealthMock = vi.hoisted(() => vi.fn(async () => ({
+  available: true,
+  url: "http://localhost:1234/v1",
+  models: ["qwen/qwen3-coder-30b"],
+})));
+
+vi.mock("@paperclipai/adapter-local/server", () => ({
+  getLocalInferenceHealth: localHealthMock,
+}));
+
+function createApp() {
+  const app = express();
+  app.use("/api", localInferenceRoutes());
+  return app;
+}
+
+describe("GET /api/inference/local/health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns local inference health", async () => {
+    const res = await request(createApp()).get("/api/inference/local/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      available: true,
+      url: "http://localhost:1234/v1",
+      models: ["qwen/qwen3-coder-30b"],
+    });
+  });
+
+  it("passes optional probe query settings to the health probe", async () => {
+    await request(createApp())
+      .get("/api/inference/local/health")
+      .query({ baseUrl: "http://local.test/v1", timeoutSec: "4" });
+
+    expect(localHealthMock).toHaveBeenCalledWith({
+      baseUrl: "http://local.test/v1",
+      timeoutSec: 4,
+    });
+  });
+});

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -6,6 +6,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "claude_local",
   "codex_local",
   "cursor_cloud",
+  "local",
   "cursor",
   "gemini_local",
   "grok_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -338,6 +338,7 @@ const localAdapter: ServerAdapterModule = {
   execute: async (ctx) => {
     const health = await getLocalInferenceHealth({
       baseUrl: readString(ctx.config.baseUrl),
+      apiKey: readString(ctx.config.apiKey),
     });
     if (health.available) return localExecute(ctx);
 
@@ -367,7 +368,7 @@ const localAdapter: ServerAdapterModule = {
   getConfigSchema: () => ({
     fields: [
       { key: "baseUrl", label: "Base URL", type: "text", default: "http://localhost:1234/v1" },
-      { key: "apiKey", label: "API key", type: "text" },
+      { key: "apiKey", label: "API key", type: "password" },
       { key: "maxTurns", label: "Max turns", type: "number" },
       { key: "instructionsFilePath", label: "Instructions file", type: "text", required: true },
     ],

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -91,6 +91,13 @@ import {
   models as grokModels,
 } from "@paperclipai/adapter-grok-local";
 import {
+  execute as localExecute,
+  getLocalInferenceHealth,
+  listLocalModels,
+  testEnvironment as localTestEnvironment,
+} from "@paperclipai/adapter-local/server";
+import { agentConfigurationDoc as localAgentConfigurationDoc, models as localModels } from "@paperclipai/adapter-local";
+import {
   execute as openCodeExecute,
   listOpenCodeSkills,
   syncOpenCodeSkills,
@@ -309,6 +316,64 @@ const codexLocalAdapter: ServerAdapterModule = {
   getQuotaWindows: codexGetQuotaWindows,
 };
 
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function buildClaudeLocalFallbackConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const fallback: Record<string, unknown> = {};
+  const instructionsFilePath = readString(config.instructionsFilePath);
+  const maxTurns = readNumber(config.maxTurns) ?? readNumber(config.maxTurnsPerRun);
+  if (instructionsFilePath) fallback.instructionsFilePath = instructionsFilePath;
+  if (maxTurns && maxTurns > 0) fallback.maxTurnsPerRun = maxTurns;
+  return fallback;
+}
+
+const localAdapter: ServerAdapterModule = {
+  type: "local",
+  execute: async (ctx) => {
+    const health = await getLocalInferenceHealth({
+      baseUrl: readString(ctx.config.baseUrl),
+    });
+    if (health.available) return localExecute(ctx);
+
+    await ctx.onLog(
+      "stdout",
+      `[paperclip] Local inference unavailable at ${health.url}; routing this run through claude_local fallback.\n`,
+    );
+    const fallbackConfig = buildClaudeLocalFallbackConfig(ctx.config);
+    return claudeExecute({
+      ...ctx,
+      agent: {
+        ...ctx.agent,
+        adapterType: "claude_local",
+        adapterConfig: fallbackConfig,
+      },
+      config: fallbackConfig,
+    });
+  },
+  testEnvironment: localTestEnvironment,
+  models: localModels,
+  listModels: listLocalModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: localAgentConfigurationDoc,
+  getConfigSchema: () => ({
+    fields: [
+      { key: "baseUrl", label: "Base URL", type: "text", default: "http://localhost:1234/v1" },
+      { key: "apiKey", label: "API key", type: "text" },
+      { key: "maxTurns", label: "Max turns", type: "number" },
+      { key: "instructionsFilePath", label: "Instructions file", type: "text", required: true },
+    ],
+  }),
+};
+
 const cursorLocalAdapter: ServerAdapterModule = {
   type: "cursor",
   execute: cursorExecute,
@@ -515,6 +580,7 @@ function registerBuiltInAdapters() {
     acpxLocalAdapter,
     claudeLocalAdapter,
     codexLocalAdapter,
+    localAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
     cursorCloudAdapter,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,7 @@ import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
+import { localInferenceRoutes } from "./routes/local-inference.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { readBrandedStaticIndexHtml } from "./static-index-html.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -306,6 +307,7 @@ export async function createApp(
     ),
   );
   api.use(adapterRoutes());
+  api.use(localInferenceRoutes());
   api.use(
     accessRoutes(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/local-inference.ts
+++ b/server/src/routes/local-inference.ts
@@ -6,12 +6,9 @@ export function localInferenceRoutes() {
   const router = Router();
 
   router.get("/inference/local/health", async (req, res) => {
-    const baseUrl =
-      typeof req.query.baseUrl === "string" ? req.query.baseUrl : undefined;
     const timeoutSec =
       typeof req.query.timeoutSec === "string" ? Number(req.query.timeoutSec) : undefined;
     const health = await getLocalInferenceHealth({
-      baseUrl,
       timeoutSec: asNumber(timeoutSec, 0),
     });
     res.json(health);

--- a/server/src/routes/local-inference.ts
+++ b/server/src/routes/local-inference.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { asNumber } from "@paperclipai/adapter-utils/server-utils";
+import { getLocalInferenceHealth } from "@paperclipai/adapter-local/server";
+
+export function localInferenceRoutes() {
+  const router = Router();
+
+  router.get("/inference/local/health", async (req, res) => {
+    const baseUrl =
+      typeof req.query.baseUrl === "string" ? req.query.baseUrl : undefined;
+    const timeoutSec =
+      typeof req.query.timeoutSec === "string" ? Number(req.query.timeoutSec) : undefined;
+    const health = await getLocalInferenceHealth({
+      baseUrl,
+      timeoutSec: asNumber(timeoutSec, 0),
+    });
+    res.json(health);
+  });
+
+  return router;
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
+    "@paperclipai/adapter-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -73,6 +73,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     icon: Code,
     recommended: true,
   },
+  local: {
+    label: "Local LLM",
+    description: "OpenAI-compatible local model",
+    icon: Cpu,
+  },
   gemini_local: {
     label: "Gemini CLI",
     description: "Local Gemini agent",

--- a/ui/src/adapters/local/config-fields.tsx
+++ b/ui/src/adapters/local/config-fields.tsx
@@ -61,7 +61,14 @@ function ApiKeyField({ isCreate, values, set, config, eff, mark, schemaValues }:
 
   return (
     <Field label="API key" hint="Optional bearer token for the local endpoint.">
-      <DraftInput value={value} onCommit={commit} immediate className={inputClass} placeholder="Optional" />
+      <DraftInput
+        value={value}
+        onCommit={commit}
+        immediate
+        className={inputClass}
+        placeholder="Optional"
+        type="password"
+      />
     </Field>
   );
 }

--- a/ui/src/adapters/local/config-fields.tsx
+++ b/ui/src/adapters/local/config-fields.tsx
@@ -1,0 +1,95 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  DraftNumberInput,
+  Field,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { DEFAULT_LOCAL_BASE_URL } from "@paperclipai/adapter-local";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior.";
+
+type LocalFieldProps = AdapterConfigFieldsProps & {
+  schemaValues: Record<string, unknown>;
+};
+
+function InstructionsField({ isCreate, values, set, config, eff, mark }: LocalFieldProps) {
+  const value = isCreate
+    ? values!.instructionsFilePath ?? ""
+    : eff("adapterConfig", "instructionsFilePath", String(config.instructionsFilePath ?? ""));
+  const commit = (v: string) =>
+    isCreate ? set!({ instructionsFilePath: v }) : mark("adapterConfig", "instructionsFilePath", v || undefined);
+
+  return (
+    <Field label="Agent instructions file" hint={instructionsHint}>
+      <div className="flex items-center gap-2">
+        <DraftInput
+          value={value}
+          onCommit={commit}
+          immediate
+          className={inputClass}
+          placeholder="/absolute/path/to/AGENTS.md"
+        />
+        <ChoosePathButton />
+      </div>
+    </Field>
+  );
+}
+
+function BaseUrlField({ isCreate, values, set, config, eff, mark }: LocalFieldProps) {
+  const value = isCreate
+    ? values!.url || DEFAULT_LOCAL_BASE_URL
+    : eff("adapterConfig", "baseUrl", String(config.baseUrl ?? DEFAULT_LOCAL_BASE_URL));
+  const commit = (v: string) =>
+    isCreate ? set!({ url: v }) : mark("adapterConfig", "baseUrl", v || undefined);
+
+  return (
+    <Field label="Base URL" hint="OpenAI-compatible local inference base URL.">
+      <DraftInput value={value} onCommit={commit} immediate className={inputClass} placeholder={DEFAULT_LOCAL_BASE_URL} />
+    </Field>
+  );
+}
+
+function ApiKeyField({ isCreate, values, set, config, eff, mark, schemaValues }: LocalFieldProps) {
+  const localApiKey = typeof schemaValues.apiKey === "string" ? schemaValues.apiKey : "";
+  const value = isCreate ? localApiKey : eff("adapterConfig", "apiKey", String(config.apiKey ?? ""));
+  const commit = (v: string) =>
+    isCreate ? set!({ adapterSchemaValues: { ...schemaValues, apiKey: v } }) : mark("adapterConfig", "apiKey", v || undefined);
+
+  return (
+    <Field label="API key" hint="Optional bearer token for the local endpoint.">
+      <DraftInput value={value} onCommit={commit} immediate className={inputClass} placeholder="Optional" />
+    </Field>
+  );
+}
+
+function FallbackTurnsField({ isCreate, values, set, config, eff, mark }: LocalFieldProps) {
+  const value = isCreate
+    ? values!.maxTurnsPerRun
+    : eff("adapterConfig", "maxTurns", Number(config.maxTurns ?? 0));
+  const commit = (v: number) =>
+    isCreate ? set!({ maxTurnsPerRun: v }) : mark("adapterConfig", "maxTurns", v || undefined);
+
+  return (
+    <Field label="Fallback max turns" hint="Passed to claude_local when local inference is unavailable.">
+      <DraftNumberInput value={value} onCommit={commit} className={inputClass} placeholder="0" />
+    </Field>
+  );
+}
+
+export function LocalConfigFields(props: AdapterConfigFieldsProps) {
+  const schemaValues = props.values?.adapterSchemaValues ?? {};
+  const fieldProps = { ...props, schemaValues };
+
+  return (
+    <>
+      {!props.hideInstructionsFile && <InstructionsField {...fieldProps} />}
+      <BaseUrlField {...fieldProps} />
+      <ApiKeyField {...fieldProps} />
+      <FallbackTurnsField {...fieldProps} />
+    </>
+  );
+}

--- a/ui/src/adapters/local/index.ts
+++ b/ui/src/adapters/local/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { buildLocalConfig, parseLocalStdoutLine } from "@paperclipai/adapter-local/ui";
+import { LocalConfigFields } from "./config-fields";
+
+export const localUIAdapter: UIAdapterModule = {
+  type: "local",
+  label: "Local LLM",
+  parseStdoutLine: parseLocalStdoutLine,
+  ConfigFields: LocalConfigFields,
+  buildAdapterConfig: buildLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -6,6 +6,7 @@ import { cursorCloudUIAdapter } from "./cursor-cloud";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
 import { grokLocalUIAdapter } from "./grok-local";
+import { localUIAdapter } from "./local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -56,6 +57,7 @@ function registerBuiltInUIAdapters() {
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     cursorCloudUIAdapter,
+    localUIAdapter,
     geminiLocalUIAdapter,
     grokLocalUIAdapter,
     hermesLocalUIAdapter,

--- a/ui/src/adapters/schema-config-fields.tsx
+++ b/ui/src/adapters/schema-config-fields.tsx
@@ -275,6 +275,7 @@ function getDefaultValue(field: ConfigFieldSchema): unknown {
       return false;
     case "number":
       return 0;
+    case "password":
     case "text":
     case "textarea":
       return "";
@@ -493,6 +494,19 @@ export function SchemaConfigFields({
                 </Field>
               );
             }
+
+            case "password":
+              return (
+                <Field key={field.key} label={field.label} hint={field.hint}>
+                  <DraftInput
+                    value={String(readValue(field) ?? "")}
+                    onCommit={(v) => writeValue(field, v || undefined)}
+                    immediate
+                    className={inputClass}
+                    type="password"
+                  />
+                </Field>
+              );
 
             case "text":
             default:

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -19,6 +19,7 @@ const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   acpx_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false },
   claude_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: true },
   codex_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: true },
+  local: { supportsInstructionsBundle: true, supportsSkills: false, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false },
   cursor: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   gemini_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   grok_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: false },

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -20,6 +20,7 @@ import {
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_LOCAL_MODEL } from "@paperclipai/adapter-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
 import {
   Popover,
@@ -580,7 +581,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
           : adapterType === "opencode_local"
             ? eff("adapterConfig", "variant", String(config.variant ?? ""))
             : eff("adapterConfig", "effort", String(config.effort ?? ""));
-  const showThinkingEffort = adapterType !== "gemini_local" && adapterType !== "cursor_cloud";
+  const showThinkingEffort = adapterType !== "gemini_local" && adapterType !== "cursor_cloud" && adapterType !== "local";
+  const showCommandFields = isLocal && adapterType !== "local";
   const codexSearchEnabled = adapterType === "codex_local"
     ? (isCreate ? Boolean(val!.search) : eff("adapterConfig", "search", Boolean(config.search)))
     : false;
@@ -857,6 +859,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                         DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
                     } else if (t === "gemini_local") {
                       nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
+                    } else if (t === "local") {
+                      nextValues.model = DEFAULT_LOCAL_MODEL;
                     } else if (t === "cursor") {
                       nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
                     } else if (t === "opencode_local") {
@@ -876,6 +880,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                             ? DEFAULT_CODEX_LOCAL_MODEL
                             : t === "gemini_local"
                               ? DEFAULT_GEMINI_LOCAL_MODEL
+                            : t === "local"
+                              ? DEFAULT_LOCAL_MODEL
                             : t === "opencode_local"
                               ? DEFAULT_OPENCODE_LOCAL_MODEL
                             : t === "cursor"
@@ -949,40 +955,42 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Permissions &amp; Configuration</div>
           }
           <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
-              <Field label="Command" hint={help.localCommand}>
-                <DraftInput
-                  value={
-                    isCreate
-                      ? val!.command
-                      : eff(
-                          "adapterConfig",
-                          adapterCommandField,
-                          String(
-                            (adapterType === "hermes_local"
-                              ? config.hermesCommand ?? config.command
-                              : config.command) ?? "",
-                          ),
-                        )
-                  }
-                  onCommit={(v) =>
-                    isCreate
-                      ? set!({ command: v })
-                      : mark("adapterConfig", adapterCommandField, v || null)
-                  }
-                  immediate
-                  className={inputClass}
-                  placeholder={
-                    ({
-                      claude_local: "claude",
-                      codex_local: "codex",
-                      gemini_local: "gemini",
-                      pi_local: "pi",
-                      cursor: "agent",
-                      opencode_local: "opencode",
-                    } as Record<string, string>)[adapterType] ?? adapterType.replace(/_local$/, "")
-                  }
-                />
-              </Field>
+              {showCommandFields && (
+                <Field label="Command" hint={help.localCommand}>
+                  <DraftInput
+                    value={
+                      isCreate
+                        ? val!.command
+                        : eff(
+                            "adapterConfig",
+                            adapterCommandField,
+                            String(
+                              (adapterType === "hermes_local"
+                                ? config.hermesCommand ?? config.command
+                                : config.command) ?? "",
+                            ),
+                          )
+                    }
+                    onCommit={(v) =>
+                      isCreate
+                        ? set!({ command: v })
+                        : mark("adapterConfig", adapterCommandField, v || null)
+                    }
+                    immediate
+                    className={inputClass}
+                    placeholder={
+                      ({
+                        claude_local: "claude",
+                        codex_local: "codex",
+                        gemini_local: "gemini",
+                        pi_local: "pi",
+                        cursor: "agent",
+                        opencode_local: "opencode",
+                      } as Record<string, string>)[adapterType] ?? adapterType.replace(/_local$/, "")
+                    }
+                  />
+                </Field>
+              )}
 
               {supportsModelProfiles && (
                 <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Primary model</div>
@@ -1101,23 +1109,25 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               )}
               <uiAdapter.ConfigFields {...adapterFieldProps} />
 
-              <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
-                <DraftInput
-                  value={
-                    isCreate
-                      ? val!.extraArgs
-                      : eff("adapterConfig", "extraArgs", formatArgList(config.extraArgs))
-                  }
-                  onCommit={(v) =>
-                    isCreate
-                      ? set!({ extraArgs: v })
-                      : mark("adapterConfig", "extraArgs", v?.trim() ? parseCommaArgs(v) : null)
-                  }
-                  immediate
-                  className={inputClass}
-                  placeholder="e.g. --verbose, --foo=bar"
-                />
-              </Field>
+              {showCommandFields && (
+                <Field label="Extra args (comma-separated)" hint={help.extraArgs}>
+                  <DraftInput
+                    value={
+                      isCreate
+                        ? val!.extraArgs
+                        : eff("adapterConfig", "extraArgs", formatArgList(config.extraArgs))
+                    }
+                    onCommit={(v) =>
+                      isCreate
+                        ? set!({ extraArgs: v })
+                        : mark("adapterConfig", "extraArgs", v?.trim() ? parseCommaArgs(v) : null)
+                    }
+                    immediate
+                    className={inputClass}
+                    placeholder="e.g. --verbose, --foo=bar"
+                  />
+                </Field>
+              )}
 
               <Field label="Environment variables" hint={help.envVars}>
                 <EnvVarEditor

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -43,6 +43,7 @@ import {
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_LOCAL_MODEL } from "@paperclipai/adapter-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
@@ -224,6 +225,7 @@ export function OnboardingWizard() {
     claude_local: "claude",
     codex_local: "codex",
     gemini_local: "gemini",
+    local: "",
     pi_local: "pi",
     cursor: "agent",
     opencode_local: "opencode",
@@ -326,6 +328,8 @@ export function OnboardingWizard() {
           ? model || DEFAULT_CODEX_LOCAL_MODEL
           : adapterType === "gemini_local"
             ? model || DEFAULT_GEMINI_LOCAL_MODEL
+          : adapterType === "local"
+            ? model || DEFAULT_LOCAL_MODEL
           : adapterType === "cursor"
             ? model || DEFAULT_CURSOR_LOCAL_MODEL
             : adapterType === "opencode_local"
@@ -763,6 +767,10 @@ export function OnboardingWizard() {
                               setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
                               return;
                             }
+                            if (nextType === "local") {
+                              setModel(DEFAULT_LOCAL_MODEL);
+                              return;
+                            }
                             setModel("");
                           }}
                         >
@@ -809,8 +817,12 @@ export function OnboardingWizard() {
                              )}
                              onClick={() => {
                                if (opt.comingSoon) return;
-                               const nextType = opt.type;
+                              const nextType = opt.type;
                               setAdapterType(nextType);
+                              if (nextType === "local") {
+                                setModel(DEFAULT_LOCAL_MODEL);
+                                return;
+                              }
                               if (nextType === "gemini_local" && !model) {
                                 setModel(DEFAULT_GEMINI_LOCAL_MODEL);
                                 return;

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -34,6 +34,7 @@ import {
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_LOCAL_MODEL } from "@paperclipai/adapter-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 
 function createValuesForAdapterType(
@@ -47,6 +48,8 @@ function createValuesForAdapterType(
       DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
   } else if (adapterType === "gemini_local") {
     nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
+  } else if (adapterType === "local") {
+    nextValues.model = DEFAULT_LOCAL_MODEL;
   } else if (adapterType === "cursor") {
     nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
   } else if (adapterType === "opencode_local") {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",
       "packages/adapters/grok-local",
+      "packages/adapters/local",
       "packages/adapters/opencode-local",
       "packages/adapters/pi-local",
       "packages/plugins/sdk",


### PR DESCRIPTION
Fixes #7520

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Agent adapters are the boundary between the control plane and the execution/inference surface.
> - Local-first deployments need a generic OpenAI-compatible inference option, not only CLI-specific adapters.
> - That local endpoint may be absent or unhealthy at heartbeat time, so availability has to be checked before each run.
> - When local inference is unavailable, Paperclip should continue productive work through the existing Claude-local path instead of failing the run.
> - This pull request adds the local adapter, health surface, UI configuration, docs, and fallback coverage.
> - The benefit is a reusable local inference adapter with controlled degradation and no permanent Ada configuration flip.

## What Changed

- Added a `local` adapter package for OpenAI-compatible chat-completions endpoints, defaulting to `http://localhost:1234/v1` and `qwen/qwen3-coder-30b`.
- Registered the adapter across server/shared/UI adapter registries and documentation.
- Added local inference health detection and `GET /api/inference/local/health`.
- Wired server execution so `local` probes availability before each run and falls back to `claude_local` when unavailable.
- Added New Agent and onboarding UI support for `Local LLM` configuration.

## Verification

- `pnpm run preflight:workspace-links`
- `pnpm --filter @paperclipai/adapter-local exec vitest run src/server/execute.test.ts src/server/health.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/local-adapter-fallback.test.ts src/__tests__/local-inference-health-routes.test.ts`
- `pnpm --filter @paperclipai/adapter-local typecheck`
- `pnpm --filter @paperclipai/adapter-local build`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm run check:tokens`
- `pnpm build`
- `node ./scripts/check-docker-deps-stage.mjs`
- `node ./scripts/release-package-map.mjs check`
- `PAPERCLIP_RELEASE_BOOTSTRAP_BASE_SHA=$(git merge-base origin/master HEAD) node ./scripts/check-release-package-bootstrap.mjs $(git diff --name-only origin/master...HEAD)`
- Verified `GET /api/inference/local/health?timeoutSec=1` in an isolated dev instance.
- Browser-verified New Agent local adapter selection and onboarding adapter discovery with Playwright.
- Screenshots captured locally:
  - `/tmp/dataaa45-local-adapter-new-agent.png`
  - `/tmp/dataaa45-local-adapter-onboarding.png`

Ada 2 live E2E was not run because the live installed Paperclip instance does not contain this branch's `local` adapter yet. I did not permanently flip Ada; the branch was verified in an isolated dev instance instead.

## Risks

- Low migration risk: no database migrations.
- The fallback path intentionally changes `local` run behavior when the health probe reports unavailable.
- Local endpoint compatibility depends on OpenAI-compatible `/models` and `/chat/completions` behavior.
- `@paperclipai/adapter-local` is listed in the release manifest with `publishFromCi: false` until the first npm bootstrap publish exists.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI, GPT-5.5, xhigh reasoning effort, tool use and code execution enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

