### PR TITLE
[codex] Fix Hermes resume from truncated session displays

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -496,6 +496,26 @@ describe("buildExplicitResumeSessionOverride", () => {
       },
     });
   });
+
+  it("uses full session params from run result metadata when display ids are truncated", () => {
+    const result = buildExplicitResumeSessionOverride({
+      resumeFromRunId: "run-1",
+      resumeRunSessionIdBefore: null,
+      resumeRunSessionIdAfter: "20260531_142025_",
+      resumeRunSessionParams: {
+        sessionId: "20260531_142025_718561",
+      },
+      taskSession: null,
+      sessionCodec: codexSessionCodec,
+    });
+
+    expect(result).toEqual({
+      sessionDisplayId: "20260531_142025_",
+      sessionParams: {
+        sessionId: "20260531_142025_718561",
+      },
+    });
+  });
 });
 
 describe("formatRuntimeWorkspaceWarningLog", () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1422,11 +1422,19 @@ export function buildExplicitResumeSessionOverride(input: {
   resumeFromRunId: string;
   resumeRunSessionIdBefore: string | null;
   resumeRunSessionIdAfter: string | null;
+  resumeRunSessionParams?: Record<string, unknown> | null;
   taskSession: ResumeSessionRow | null;
   sessionCodec: AdapterSessionCodec;
 }) {
   const desiredDisplayId = truncateDisplayId(
     input.resumeRunSessionIdAfter ?? input.resumeRunSessionIdBefore,
+  );
+  const runSessionParams = normalizeSessionParams(
+    input.sessionCodec.deserialize(input.resumeRunSessionParams ?? null),
+  );
+  const runSessionDisplayId = truncateDisplayId(
+    (input.sessionCodec.getDisplayId ? input.sessionCodec.getDisplayId(runSessionParams) : null) ??
+      readNonEmptyString(runSessionParams?.sessionId),
   );
   const taskSessionParams = normalizeSessionParams(
     input.sessionCodec.deserialize(input.taskSession?.sessionParamsJson ?? null),
@@ -1445,10 +1453,9 @@ export function buildExplicitResumeSessionOverride(input: {
   const sessionParams =
     canReuseTaskSessionParams
       ? taskSessionParams
-      : desiredDisplayId
-        ? { sessionId: desiredDisplayId }
-        : null;
-  const sessionDisplayId = desiredDisplayId ?? (canReuseTaskSessionParams ? taskSessionDisplayId : null);
+      : (runSessionParams ?? (desiredDisplayId ? { sessionId: desiredDisplayId } : null));
+  const sessionDisplayId =
+    desiredDisplayId ?? (canReuseTaskSessionParams ? taskSessionDisplayId : runSessionDisplayId);
 
   if (!sessionDisplayId && !sessionParams) return null;
   return {
@@ -3623,6 +3630,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .select({
         id: heartbeatRuns.id,
         contextSnapshot: heartbeatRuns.contextSnapshot,
+        resultJson: heartbeatRuns.resultJson,
         sessionIdBefore: heartbeatRuns.sessionIdBefore,
         sessionIdAfter: heartbeatRuns.sessionIdAfter,
       })
@@ -3643,10 +3651,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, resumeTaskKey)
       : null;
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
+    const resumeRunResult = parseObject(resumeRun.resultJson);
+    const resumeRunSessionId =
+      readNonEmptyString(resumeRunResult.sessionId) ??
+      readNonEmptyString(resumeRunResult.session_id);
     const sessionOverride = buildExplicitResumeSessionOverride({
       resumeFromRunId,
       resumeRunSessionIdBefore: resumeRun.sessionIdBefore,
       resumeRunSessionIdAfter: resumeRun.sessionIdAfter,
+      resumeRunSessionParams: resumeRunSessionId ? { sessionId: resumeRunSessionId } : null,
       taskSession: resumeTaskSession,
       sessionCodec,
     });


### PR DESCRIPTION
## Summary

Fix Paperclip's explicit resume handoff path so Hermes runs resume with the full session id even when the persisted heartbeat display id is truncated.

## Why

During a Hermes/Paperclip run, the Hermes adapter persisted a full session id in `resultJson.session_id` but stored a shortened value in the run's display field. The successful-run handoff wake then fell back to the shortened display id when no matching task-session row was available yet, causing Hermes to fail with `Session not found` on the continuation run.

## What Changed

- Teach `buildExplicitResumeSessionOverride` to accept full session params from the source run metadata.
- Include `heartbeatRuns.resultJson` when resolving `resumeFromRunId` wake context.
- Prefer the full `resultJson.session_id`/`sessionId` as resume params while preserving the existing display id behavior.
- Add a regression test for truncated display id plus full result metadata.

## Validation

- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts`

The focused test file passed: 40 tests.
