### PR TITLE
SPC-6909: stamp calling run-id + idempotencyKey on POST /issues to kill phantom heartbeats

### DIFF
--- a/packages/db/src/migrations/0094_issue_idempotency_key.sql
+++ b/packages/db/src/migrations/0094_issue_idempotency_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "idempotency_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_company_idempotency_key_uq" ON "issues" USING btree ("company_id","idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1780040470886,
       "tag": "0093_giant_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1780281600000,
+      "tag": "0094_issue_idempotency_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -65,6 +65,7 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -139,5 +140,8 @@ export const issues = pgTable(
           and ${table.hiddenAt} is null
           and ${table.status} not in ('done', 'cancelled')`,
       ),
+    idempotencyKeyIdx: uniqueIndex("issues_company_idempotency_key_uq")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
   }),
 );

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -390,6 +390,7 @@ const createIssueBaseSchema = z.object({
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
+  idempotencyKey: z.string().trim().min(1).max(200).optional(),
 });
 
 export const createIssueInputSchema = createIssueBaseSchema.extend({

--- a/server/src/__tests__/issue-self-checkout-routes.test.ts
+++ b/server/src/__tests__/issue-self-checkout-routes.test.ts
@@ -1,0 +1,340 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selfAgentId = "33333333-3333-4333-8333-333333333333";
+const otherAgentId = "44444444-4444-4444-8444-444444444444";
+const callingRunId = "55555555-5555-4555-8555-555555555555";
+
+const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  createChild: vi.fn(),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getByIdempotencyKey: vi.fn(async () => null),
+  getComment: vi.fn(),
+  getCommentCursor: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  findMentionedAgents: vi.fn(async () => []),
+}));
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(async (id: string) => {
+    if (id === selfAgentId) {
+      return { id: selfAgentId, name: "TestAgent", companyId: "company-1" };
+    }
+    return null;
+  }),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(async () => true),
+    decide: vi.fn(async (input: { action?: string }) => ({
+      allowed: true,
+      action: input.action,
+      reason: "allow_explicit_grant",
+      explanation: "Allowed by test grant.",
+    })),
+    hasPermission: vi.fn(async () => true),
+  }),
+  agentService: () => mockAgentService,
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(async () => null),
+  }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+  }),
+  goalService: () => ({
+    getById: vi.fn(async () => null),
+    getDefaultCompanyGoal: vi.fn(async () => null),
+  }),
+  heartbeatService: () => ({
+    wakeup: mockWakeup,
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  getIssueContinuationSummaryDocument: vi.fn(async () => null),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => ({
+    getActiveForIssue: vi.fn(async () => null),
+    listActiveForIssues: vi.fn(async () => new Map()),
+  }),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueThreadInteractionService: () => ({
+    listForIssue: vi.fn(async () => []),
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({
+    getById: vi.fn(async () => null),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+async function createApp(opts: { actorAgentId?: string | null; actorRunId?: string | null } = {}) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (opts.actorAgentId) {
+      (req as any).actor = {
+        type: "agent",
+        agentId: opts.actorAgentId,
+        runId: opts.actorRunId ?? null,
+        companyId: "company-1",
+        companyIds: ["company-1"],
+        source: "agent_jwt",
+        isInstanceAdmin: false,
+      };
+    } else {
+      (req as any).actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: ["company-1"],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+    }
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(input: {
+  id: string;
+  title: string;
+  status?: string;
+  assigneeAgentId?: string | null;
+  idempotencyKey?: string | null;
+}) {
+  return {
+    id: input.id,
+    companyId: "company-1",
+    identifier: "SPC-6909-test",
+    title: input.title,
+    description: null,
+    status: input.status ?? "todo",
+    priority: "medium",
+    parentId: null,
+    assigneeAgentId: input.assigneeAgentId ?? null,
+    assigneeUserId: null,
+    createdByAgentId: input.assigneeAgentId ?? null,
+    createdByUserId: null,
+    executionWorkspaceId: null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    labels: [],
+    labelIds: [],
+  };
+}
+
+describe("SPC-6909 — issue create self-checkout + idempotency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.create.mockImplementation(async (_companyId: string, data: Record<string, unknown>) =>
+      makeIssue({
+        id: "issue-new",
+        title: String(data.title),
+        status: String(data.status),
+        assigneeAgentId: data.assigneeAgentId as string | null | undefined,
+        idempotencyKey: data.idempotencyKey as string | null | undefined,
+      }));
+    mockIssueService.getByIdempotencyKey.mockResolvedValue(null);
+  });
+
+  describe("self-checkout (ask #1)", () => {
+    it("agent posting in_progress + assigneeAgentId=self gets selfCheckoutRunId stamped and no wake fires", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Self-assigned in_progress",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          title: "Self-assigned in_progress",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+          selfCheckoutRunId: callingRunId,
+          selfCheckoutAgentNameKey: "testagent",
+        }),
+      );
+      expect(mockWakeup).not.toHaveBeenCalled();
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "issue.created",
+          details: expect.objectContaining({ selfCheckoutRunId: callingRunId }),
+        }),
+      );
+    });
+
+    it("agent posting in_progress + assigneeAgentId=ANOTHER_AGENT does NOT self-checkout and DOES wake", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Other-assigned in_progress",
+          assigneeAgentId: otherAgentId,
+          status: "in_progress",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          assigneeAgentId: otherAgentId,
+          selfCheckoutRunId: null,
+          selfCheckoutAgentNameKey: null,
+        }),
+      );
+      expect(mockWakeup).toHaveBeenCalledWith(
+        otherAgentId,
+        expect.objectContaining({ reason: "issue_assigned" }),
+      );
+    });
+
+    it("agent without run id does NOT self-checkout (defense in depth)", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: null }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "No run id",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ selfCheckoutRunId: null }),
+      );
+      expect(mockWakeup).toHaveBeenCalled();
+    });
+
+    it("agent posting todo (not in_progress) does NOT self-checkout — wake still fires", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Self-assigned todo",
+          assigneeAgentId: selfAgentId,
+          status: "todo",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          status: "todo",
+          selfCheckoutRunId: null,
+        }),
+      );
+      expect(mockWakeup).toHaveBeenCalled();
+    });
+  });
+
+  describe("idempotencyKey fast-path (ask #2)", () => {
+    it("returns the prior issue (200) when idempotencyKey matches and skips create + wake + activity log", async () => {
+      const existing = makeIssue({
+        id: "issue-prior",
+        title: "Prior umbrella",
+        status: "in_progress",
+        assigneeAgentId: selfAgentId,
+        idempotencyKey: "umbrella:eu:2026-06-01",
+      });
+      mockIssueService.getByIdempotencyKey.mockResolvedValue(existing);
+
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Umbrella second call",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+          idempotencyKey: "umbrella:eu:2026-06-01",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expect.objectContaining({
+        id: "issue-prior",
+        idempotentReturn: true,
+      }));
+      expect(mockIssueService.getByIdempotencyKey).toHaveBeenCalledWith(
+        "company-1",
+        "umbrella:eu:2026-06-01",
+      );
+      expect(mockIssueService.create).not.toHaveBeenCalled();
+      expect(mockWakeup).not.toHaveBeenCalled();
+      expect(mockLogActivity).not.toHaveBeenCalled();
+    });
+
+    it("creates as normal when idempotencyKey has not been seen yet", async () => {
+      mockIssueService.getByIdempotencyKey.mockResolvedValue(null);
+
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "First call with idempotencyKey",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+          idempotencyKey: "umbrella:na:2026-06-01",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          idempotencyKey: "umbrella:na:2026-06-01",
+          selfCheckoutRunId: callingRunId,
+        }),
+      );
+      // self-checkout suppresses the wake even when key is novel
+      expect(mockWakeup).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3527,11 +3527,54 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+
+    // SPC-6909 — fast-path idempotency. If this POST carries an
+    // idempotencyKey we've already accepted for this company, return the
+    // prior row without re-running activity log or wake fan-out.
+    const idempotencyKey = typeof req.body.idempotencyKey === "string"
+      ? req.body.idempotencyKey.trim()
+      : "";
+    if (idempotencyKey.length > 0) {
+      const existing = await svc.getByIdempotencyKey(companyId, idempotencyKey);
+      if (existing) {
+        const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(existing.id);
+        res.status(200).json({
+          ...existing,
+          relatedWork: referenceSummary,
+          referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+          idempotentReturn: true,
+        });
+        return;
+      }
+    }
+
+    // SPC-6909 — self-checkout. An agent calling under its own run id with
+    // assigneeAgentId=self+status=in_progress would otherwise trigger an
+    // implicit-checkout wake under a fresh run id and spawn a phantom
+    // heartbeat. Stamp checkoutRunId on insert and suppress the wake for
+    // this caller.
+    let selfCheckoutRunId: string | null = null;
+    let selfCheckoutAgentNameKey: string | null = null;
+    if (
+      actor.actorType === "agent"
+      && actor.agentId
+      && actor.runId
+      && req.body.assigneeAgentId === actor.agentId
+      && req.body.status === "in_progress"
+    ) {
+      selfCheckoutRunId = actor.runId;
+      const actorAgent = await agentsSvc.getById(actor.agentId);
+      const rawName = typeof actorAgent?.name === "string" ? actorAgent.name.trim().toLowerCase() : "";
+      selfCheckoutAgentNameKey = rawName.length > 0 ? rawName : null;
+    }
+
     const issue = await svc.create(companyId, {
       ...req.body,
       executionPolicy,
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      selfCheckoutRunId,
+      selfCheckoutAgentNameKey,
     });
     await issueReferencesSvc.syncIssue(issue.id);
     const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
@@ -3554,6 +3597,7 @@ export function issueRoutes(
         identifier: issue.identifier,
         ...buildCreateIssueActivityStatusDetails(issue, res),
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
+        ...(selfCheckoutRunId ? { selfCheckoutRunId } : {}),
         ...summarizeIssueReferenceActivityDetails({
           addedReferencedIssues: referenceDiff.addedReferencedIssues.map(summarizeIssueRelationForActivity),
           removedReferencedIssues: referenceDiff.removedReferencedIssues.map(summarizeIssueRelationForActivity),
@@ -3585,15 +3629,17 @@ export function issueRoutes(
       });
     }
 
-    void queueIssueAssignmentWakeup({
-      heartbeat,
-      issue,
-      reason: "issue_assigned",
-      mutation: "create",
-      contextSource: "issue.create",
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
+    if (!selfCheckoutRunId) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.create",
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json({
       ...issue,
@@ -3628,6 +3674,35 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+
+    // SPC-6909 — fast-path idempotency on POST /issues/:id/children.
+    const idempotencyKey = typeof req.body.idempotencyKey === "string"
+      ? req.body.idempotencyKey.trim()
+      : "";
+    if (idempotencyKey.length > 0) {
+      const existing = await svc.getByIdempotencyKey(parent.companyId, idempotencyKey);
+      if (existing) {
+        res.status(200).json({ ...existing, idempotentReturn: true });
+        return;
+      }
+    }
+
+    // SPC-6909 — self-checkout suppression for child create.
+    let childSelfCheckoutRunId: string | null = null;
+    let childSelfCheckoutAgentNameKey: string | null = null;
+    if (
+      actor.actorType === "agent"
+      && actor.agentId
+      && actor.runId
+      && req.body.assigneeAgentId === actor.agentId
+      && req.body.status === "in_progress"
+    ) {
+      childSelfCheckoutRunId = actor.runId;
+      const actorAgent = await agentsSvc.getById(actor.agentId);
+      const rawName = typeof actorAgent?.name === "string" ? actorAgent.name.trim().toLowerCase() : "";
+      childSelfCheckoutAgentNameKey = rawName.length > 0 ? rawName : null;
+    }
+
     const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
       ...req.body,
       executionPolicy,
@@ -3635,6 +3710,8 @@ export function issueRoutes(
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
       actorAgentId: actor.agentId,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      selfCheckoutRunId: childSelfCheckoutRunId,
+      selfCheckoutAgentNameKey: childSelfCheckoutAgentNameKey,
     });
 
     await logActivity(db, {
@@ -3654,6 +3731,7 @@ export function issueRoutes(
         inheritedExecutionWorkspaceFromIssueId: parent.id,
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
         ...(parentBlockerAdded ? { parentBlockerAdded: true } : {}),
+        ...(childSelfCheckoutRunId ? { selfCheckoutRunId: childSelfCheckoutRunId } : {}),
       },
     });
 
@@ -3681,15 +3759,17 @@ export function issueRoutes(
       });
     }
 
-    void queueIssueAssignmentWakeup({
-      heartbeat,
-      issue,
-      reason: "issue_assigned",
-      mutation: "create",
-      contextSource: "issue.child_create",
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
+    if (!childSelfCheckoutRunId) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.child_create",
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json(issue);
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -103,6 +103,15 @@ function assertTransition(from: string, to: string) {
   }
 }
 
+export const ISSUE_IDEMPOTENCY_KEY_CONSTRAINT = "issues_company_idempotency_key_uq";
+
+export function isIssueIdempotencyKeyConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const err = error as { code?: string; constraint?: string; constraint_name?: string };
+  const constraint = err.constraint ?? err.constraint_name;
+  return err.code === "23505" && constraint === ISSUE_IDEMPOTENCY_KEY_CONSTRAINT;
+}
+
 function applyStatusSideEffects(
   status: string | undefined,
   patch: Partial<typeof issues.$inferInsert>,
@@ -326,6 +335,14 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
   inheritExecutionWorkspaceFromIssueId?: string | null;
+  // When the calling agent's run wants to "self-check-out" the issue it's
+  // creating (status=in_progress + assigneeAgentId=self), the route layer
+  // passes the caller's run id and the assignee's lowercased name key here.
+  // create() will stamp checkoutRunId/executionRunId on insert so no
+  // issue_assigned wake spawns a phantom heartbeat for the same agent.
+  // See SPC-6909 / SPC-6801.
+  selfCheckoutRunId?: string | null;
+  selfCheckoutAgentNameKey?: string | null;
 };
 type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
@@ -1935,6 +1952,7 @@ const issueListSelect = {
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
   hiddenAt: issues.hiddenAt,
+  idempotencyKey: issues.idempotencyKey,
   createdAt: issues.createdAt,
   updatedAt: issues.updatedAt,
 };
@@ -4611,6 +4629,17 @@ export function issueService(db: Db) {
       });
     },
 
+    getByIdempotencyKey: async (companyId: string, idempotencyKey: string) => {
+      const row = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.idempotencyKey, idempotencyKey)))
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      const [enriched] = await withIssueLabels(db, [row]);
+      return enriched;
+    },
+
     create: async (
       companyId: string,
       data: IssueCreateInput,
@@ -4619,6 +4648,8 @@ export function issueService(db: Db) {
         labelIds: inputLabelIds,
         blockedByIssueIds,
         inheritExecutionWorkspaceFromIssueId,
+        selfCheckoutRunId,
+        selfCheckoutAgentNameKey,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -4639,7 +4670,31 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      return db.transaction(async (tx) => {
+      // SPC-6909 — collapse repeat POSTs that carry the same idempotencyKey
+      // to a single winner. The pre-check returns the prior row without
+      // touching activity log or wake; the post-insert catch handles the
+      // narrow race window between pre-check and insert.
+      const idempotencyKey =
+        typeof issueData.idempotencyKey === "string" && issueData.idempotencyKey.trim().length > 0
+          ? issueData.idempotencyKey.trim()
+          : null;
+      if (idempotencyKey) {
+        const existing = await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.idempotencyKey, idempotencyKey)))
+          .then((rows) => rows[0] ?? null);
+        if (existing) {
+          const [enriched] = await withIssueLabels(db, [existing]);
+          return enriched;
+        }
+      }
+      const selfCheckoutApplies =
+        Boolean(selfCheckoutRunId)
+        && typeof data.assigneeAgentId === "string"
+        && data.status === "in_progress";
+      try {
+      return await db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
@@ -4803,6 +4858,7 @@ export function issueService(db: Db) {
           companyId,
           issueNumber,
           identifier,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
         } as typeof issues.$inferInsert;
         if (values.status === "in_progress" && !values.startedAt) {
           values.startedAt = new Date();
@@ -4822,6 +4878,20 @@ export function issueService(db: Db) {
             assigneeUserId: values.assigneeUserId ?? null,
           }),
         );
+        // SPC-6909 — self-checkout: when the calling agent under its own run
+        // POSTs an issue with status=in_progress + assigneeAgentId=self, stamp
+        // checkoutRunId/executionRunId on insert so the route layer can skip
+        // the issue_assigned wake. Without this, the platform spawns a
+        // phantom heartbeat under a fresh run id concurrently with the
+        // calling run.
+        if (selfCheckoutApplies && selfCheckoutRunId) {
+          values.checkoutRunId = selfCheckoutRunId;
+          values.executionRunId = selfCheckoutRunId;
+          values.executionLockedAt = new Date();
+          if (typeof selfCheckoutAgentNameKey === "string" && selfCheckoutAgentNameKey.length > 0) {
+            values.executionAgentNameKey = selfCheckoutAgentNameKey;
+          }
+        }
 
         const [issue] = await tx.insert(issues).values(values).returning();
         if (inputLabelIds) {
@@ -4842,6 +4912,20 @@ export function issueService(db: Db) {
         const [enriched] = await withIssueLabels(tx, [issue]);
         return enriched;
       });
+      } catch (error) {
+        if (idempotencyKey && isIssueIdempotencyKeyConflict(error)) {
+          const existing = await db
+            .select()
+            .from(issues)
+            .where(and(eq(issues.companyId, companyId), eq(issues.idempotencyKey, idempotencyKey)))
+            .then((rows) => rows[0] ?? null);
+          if (existing) {
+            const [enriched] = await withIssueLabels(db, [existing]);
+            return enriched;
+          }
+        }
+        throw error;
+      }
     },
 
     update: async (


### PR DESCRIPTION
## Problem

When an agent POSTs `/api/companies/{companyId}/issues` with `status: "in_progress"` AND `assigneeAgentId: <self>` in the same call, the platform's `issue_assigned` wake fan-out spawns a fresh heartbeat run for the same agent concurrent with the calling run. Two runs race through pre-checks ("does a placeholder already exist?") and both proceed to write, producing duplicate children.

Hit in production:
- SPC-6863 — NA 2026-05-30 (initial)
- SPC-6887 — EU 2026-05-31 (recurrence)
- SPC-6906 — EU 2026-06-01 (recurrence again)

AGENTS.md mitigation (status=todo first, then `issue_assigned` wake drives the opener) closes the immediate hot path, but the structural fix is platform-side. This PR ships that defence-in-depth.

## Changes

### 1. Self-checkout on insert (Ask #1 — primary structural fix)

`POST /api/companies/{companyId}/issues` and `POST /issues/:id/children`:

- When the calling actor is an agent under its own `X-Paperclip-Run-Id`, `assigneeAgentId === actor.agentId`, and effective `status === \"in_progress\"`, the route stamps `selfCheckoutRunId` + `selfCheckoutAgentNameKey` on the insert.
- `svc.create()` writes `checkoutRunId`, `executionRunId`, `executionLockedAt`, and `executionAgentNameKey` directly on insert.
- The route **suppresses the `issue_assigned` wake** for this caller. The caller continues their existing run with ownership of the new issue; no phantom heartbeat starts.
- `issue.created` activity-log entry now carries `selfCheckoutRunId` when the path was taken.

### 2. idempotencyKey (Ask #2 — race collapse)

`POST /api/companies/{companyId}/issues` and `POST /issues/:id/children` now accept an optional `idempotencyKey` string (≤200 chars). Backed by:

- New `issues.idempotency_key` column.
- Partial unique index `issues_company_idempotency_key_uq ON (company_id, idempotency_key) WHERE idempotency_key IS NOT NULL`.
- Route fast-path: a repeat POST returns the prior row as **200** with `idempotentReturn: true`, skipping activity log and wake fan-out.
- `svc.create()` also catches the narrow pre-check-to-insert race window and re-fetches.

Example agent usage:
```json
POST /api/companies/<id>/issues
{ \"title\": \"...\", \"idempotencyKey\": \"umbrella:eu:2026-06-01\", ... }
```

A second POST inside the same race window returns the same issue — no second wake, no duplicate placeholder.

## Files

- `packages/db/src/migrations/0094_issue_idempotency_key.sql` — additive column + partial unique index.
- `packages/db/src/schema/issues.ts` — `idempotencyKey` column + index.
- `packages/db/src/migrations/meta/_journal.json` — journal entry.
- `packages/shared/src/validators/issue.ts` — `idempotencyKey: z.string().trim().min(1).max(200).optional()`.
- `server/src/services/issues.ts` — `IssueCreateInput.selfCheckoutRunId/selfCheckoutAgentNameKey`, `getByIdempotencyKey()`, pre-check + insert stamping + 23505 catch.
- `server/src/routes/issues.ts` — both create routes apply the self-checkout/idempotency fast paths and conditionally skip the wake.
- `server/src/__tests__/issue-self-checkout-routes.test.ts` — six tests covering the verification path.

## Verification (per issue body)

After deploy, simulate the unsafe POST in sandbox: same agent under one `X-Paperclip-Run-Id` POSTs an issue with `status=in_progress + assigneeAgentId=self`. Assert:

- [x] (a) issue created
- [x] (b) no `issue_assigned` wake to the same agent — see `selfCheckout (ask #1)` tests
- [x] (c) `checkoutRunId` on the issue equals the calling run id — service stamps `checkoutRunId = selfCheckoutRunId` on insert
- [ ] (d) the agent's run sees a single contiguous heartbeat — out-of-platform verification; HoEM to confirm in soak after deploy

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `pnpm --filter @paperclipai/db typecheck` (migration journal validated)
- [x] `pnpm --filter @paperclipai/shared typecheck`
- [ ] CI: `pnpm exec vitest run src/__tests__/issue-self-checkout-routes.test.ts` (local supertest blocked by IPv6 EADDRNOTAVAIL in this sandbox; CI environment expected to bind cleanly)
- [ ] Post-deploy: HoEM verification on a sandbox umbrella per the SPC-6909 verification path

## Related

- Closes SPC-6909
- Same workstream as SPC-6801 (`Assigned Orphan Blocker` + `issue_assigned` wake honouring `Placeholder anchor` marker)
- Sibling to SPC-6864 (idempotencyKey on routine create — that ticket covers routine create only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)