### PR TITLE
docker: cap compose log rotation

### DIFF
--- a/docker/docker-compose.quickstart.yml
+++ b/docker/docker-compose.quickstart.yml
@@ -3,6 +3,11 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "${PAPERCLIP_PORT:-3100}:3100"
     environment:

--- a/docker/docker-compose.untrusted-review.yml
+++ b/docker/docker-compose.untrusted-review.yml
@@ -3,6 +3,11 @@ services:
     build:
       context: ..
       dockerfile: docker/untrusted-review/Dockerfile
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     init: true
     tty: true
     stdin_open: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   db:
     image: postgres:17-alpine
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     environment:
       POSTGRES_USER: paperclip
       POSTGRES_PASSWORD: paperclip
@@ -19,6 +24,11 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       - "3100:3100"
     environment:


### PR DESCRIPTION
## Description

Adds Docker `json-file` log rotation to every service in the repository's Docker Compose files:

```yaml
logging:
  driver: json-file
  options:
    max-size: "10m"
    max-file: "3"
```

This keeps local/dev containers from accumulating unbounded JSON logs while preserving the default Docker logging driver.

## Testing

- `docker compose -f <compose-file> config`
- YAML audit confirmed every service has `driver: json-file`, `max-size: 10m`, and `max-file: 3`
