### PR TITLE
fix(import): parse YAML single-quoted scalars in company imports

### DIFF
--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -1985,6 +1985,72 @@ describe("company portability", () => {
     }));
   });
 
+  it("strips YAML single quotes from imported agent display fields", async () => {
+    const portability = companyPortabilityService({} as any);
+
+    companySvc.create.mockResolvedValue({
+      id: "company-imported",
+      name: "Imported Paperclip",
+    });
+    accessSvc.ensureMembership.mockResolvedValue(undefined);
+    agentSvc.create.mockResolvedValue({
+      id: "agent-created",
+      name: "CEO / Editor",
+    });
+
+    const files = {
+      "COMPANY.md": [
+        "---",
+        "schema: agentcompanies/v1",
+        "name: 'Imported Paperclip'",
+        "---",
+        "",
+      ].join("\n"),
+      "agents/ceo/AGENTS.md": [
+        "---",
+        "name: 'CEO / Editor'",
+        "title: 'Editor''s Desk'",
+        "---",
+        "",
+        "# CEO / Editor",
+        "",
+        "You edit the company newsletter.",
+        "",
+      ].join("\n"),
+    };
+
+    const preview = await portability.previewImport({
+      source: { type: "inline", rootPath: "paperclip-demo", files },
+      include: { company: true, agents: true, projects: false, issues: false },
+      target: { mode: "new_company", newCompanyName: "Imported Paperclip" },
+      agents: "all",
+      collisionStrategy: "rename",
+    });
+
+    expect(preview.errors).toEqual([]);
+    expect(preview.manifest.company?.name).toBe("Imported Paperclip");
+    expect(preview.manifest.agents).toEqual([
+      expect.objectContaining({
+        slug: "ceo",
+        name: "CEO / Editor",
+        title: "Editor's Desk",
+      }),
+    ]);
+
+    await portability.importBundle({
+      source: { type: "inline", rootPath: "paperclip-demo", files },
+      include: { company: true, agents: true, projects: false, issues: false },
+      target: { mode: "new_company", newCompanyName: "Imported Paperclip" },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1");
+
+    expect(agentSvc.create).toHaveBeenCalledWith("company-imported", expect.objectContaining({
+      name: "CEO / Editor",
+      title: "Editor's Desk",
+    }));
+  });
+
   it("preserves agent role from frontmatter when extension block omits it", async () => {
     const portability = companyPortabilityService({} as any);
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2168,6 +2168,9 @@ function parseYamlScalar(rawValue: string): unknown {
   if (trimmed === "[]") return [];
   if (trimmed === "{}") return {};
   if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
   if (
     trimmed.startsWith("\"") ||
     trimmed.startsWith("[") ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Company bundle import reads AGENTS.md frontmatter and maps fields into imported agent configuration.
> - Public issue #7268 reports that YAML single-quoted `name` and `title` values import with the quote delimiters visible in Paperclip.
> - YAML single quotes are scalar syntax, not part of the intended display value.
> - The server company-portability parser has its own YAML scalar parsing path for company imports.
> - This pull request decodes single-quoted scalars in that import parser and adds regression coverage around the reported AGENTS.md import path.
> - The benefit is cleaner imported company templates without changing unrelated parsing behavior.

## What Changed

- Decode YAML single-quoted scalar values in `server/src/services/company-portability.ts`, including doubled single-quote escaping (`''` -> `'`).
- Add regression coverage for previewing and importing an agent whose `name` and `title` are single-quoted in `AGENTS.md`.
- Refs #7268.
- Related duplicate check: #7286 is open for the skills-catalog frontmatter parser; this PR covers the server company-portability import parser used by the reported company import path and includes focused regression coverage.

## Verification

- `git diff --check origin/master...HEAD`
- `pnpm exec vitest run server/src/__tests__/company-portability.test.ts --testNamePattern "single quotes"`
- `pnpm exec vitest run server/src/__tests__/company-portability.test.ts`

## Risks

- Low risk. The change only affects scalar parsing when a value is wrapped in YAML single quotes. Existing unquoted, double-quoted/JSON, numeric, boolean, null, array, and object parsing paths are unchanged.

> ROADMAP.md mentions company import/export and AGENTS.md configuration as core capabilities; this is a targeted bug fix for that area, not a new overlapping feature.

## Model Used

- OpenAI Codex, gpt-5.5, with repository inspection, GitHub CLI checks, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
