### PR TITLE
docs(paperclip-skill): add "Superseding stale interactions" paragraph [NOC-1541]

### DIFF
--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -686,6 +686,21 @@ Rules:
 - A pending interaction is an explicit waiting path. Before ending the heartbeat, update the source issue into a visible waiting posture, normally `in_review`, and leave a comment that names what the board/user must decide.
 - For plan approval, update the `plan` issue document first, create the confirmation against the latest plan revision, set the source issue to `in_review`, and wait for acceptance before creating implementation subtasks.
 
+#### Superseding stale interactions
+
+When a board/user posts an inline ruling (comment, fresh interaction, or document update) that overrides a still-`pending` `request_confirmation` or `ask_user_questions`:
+
+1. Add a comment that names the stale interaction by id and states it is superseded by the inline ruling.
+2. If the question is now moot, that is enough — leave the stale interaction pending; readers see the supersession in the thread.
+3. If a fresh decision is still needed, post a **new** `request_confirmation` or `ask_user_questions` reflecting the current question and link both ids in the comment ("supersedes `<oldId>`").
+4. Do **not** try to retire the old interaction via API — there is no agent-side endpoint. Document the supersession in the thread instead.
+
+**Anti-pattern.** Leaving multiple `pending` interactions on one issue with overlapping or contradictory asks. Each `in_review` issue should expose **one** live question to the board.
+
+**Worked examples.** [NOC-755](/NOC/issues/NOC-755) (stale `b6e2e859`, `0717c9e0`; live ruling via board comment + G-1 codification). [NOC-1228](/NOC/issues/NOC-1228) (stale `49baae6b` with `continuationPolicy: none`; CEO posted fresh `1e3991fe` + "please ignore 49baae6b" comment).
+
+Source: [NOC-1539](/NOC/issues/NOC-1539), [NOC-1536](/NOC/issues/NOC-1536).
+
 ### Checking approval status
 
 ```


### PR DESCRIPTION
## Summary

Adds a `#### Superseding stale interactions` subsection to `skills/paperclip/references/api-reference.md` under `### Issue-thread confirmations`. Codifies the agent-side procedure when a board/user posts an inline ruling that overrides a still-`pending` `request_confirmation` or `ask_user_questions`.

The change is doc-only: comment the stale interaction id, leave it pending if moot, post a fresh interaction only if a decision is still needed. Includes the anti-pattern (multiple pending interactions per `in_review` issue) and worked examples (NOC-755, NOC-1228).

## Test plan

- [x] Diff is +15 lines, no other content reordered or rewritten
- [x] Renders correctly under existing `### Issue-thread confirmations` section
- [ ] Reviewer skim for tone / link correctness

## Refs

- Parent: NOC-1539 (Supersede-on-inline-ruling HIL patch)
- Implementation: NOC-1541
- Earlier discussion: NOC-1536