### PR TITLE
feat: surface Hermes org visibility

### DIFF
--- a/server/src/__tests__/hermes-org-visibility.test.ts
+++ b/server/src/__tests__/hermes-org-visibility.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { buildHermesOrgVisibility } from "../routes/hermes-org-visibility.js";
+
+describe("Hermes org visibility summary", () => {
+  it("groups Hermes lead agents by division and pod, summarizes bridge state, and keeps reviews visible", () => {
+    const summary = buildHermesOrgVisibility({
+      agents: [
+        {
+          id: "agent-coo",
+          name: "COO / Mission Control Lead",
+          title: "COO / Mission Control Lead",
+          status: "active",
+          adapterType: "http",
+          lastHeartbeatAt: new Date("2026-06-01T10:00:00.000Z"),
+          metadata: {
+            hermesOrg: "full-lead-org",
+            profile: "leadcoo",
+            division: "Executive / Coordination",
+            charter: "Own the operating cadence.",
+            cadence: "daily",
+            skills: ["kanban-orchestrator"],
+            review: ["Audit Lead"],
+            bridgeUrl: "http://hermes-paperclip-org-bridge:8650/invoke",
+          },
+        },
+        {
+          id: "agent-research",
+          name: "Research Lead",
+          title: "Research Lead",
+          status: "active",
+          adapterType: "http",
+          lastHeartbeatAt: null,
+          metadata: {
+            hermesOrg: "full-lead-org",
+            profile: "leadresearch",
+            division: "Research / Intelligence",
+            charter: "Own research briefs.",
+            cadence: "daily",
+            skills: ["arxiv", "blogwatcher"],
+            review: ["SEO Lead", "COO / Mission Control Lead"],
+            bridgeUrl: "http://hermes-paperclip-org-bridge:8650/invoke",
+          },
+        },
+      ],
+      runs: [
+        {
+          id: "run-1",
+          agentId: "agent-research",
+          status: "completed",
+          invocationSource: "on_demand",
+          triggerDetail: "manual",
+          startedAt: new Date("2026-06-01T10:01:00.000Z"),
+          finishedAt: new Date("2026-06-01T10:02:00.000Z"),
+          createdAt: new Date("2026-06-01T10:00:30.000Z"),
+          error: null,
+        },
+      ],
+    });
+
+    expect(summary.totalAgents).toBe(2);
+    expect(summary.activeAgents).toBe(2);
+    expect(summary.bridgeAgents).toBe(2);
+    expect(summary.divisions).toEqual([
+      {
+        name: "Executive / Coordination",
+        agentCount: 1,
+        activeCount: 1,
+        runningRunCount: 0,
+        agents: [expect.objectContaining({ profile: "leadcoo", review: ["Audit Lead"] })],
+      },
+      {
+        name: "Research / Intelligence",
+        agentCount: 1,
+        activeCount: 1,
+        runningRunCount: 0,
+        agents: [expect.objectContaining({ profile: "leadresearch", recentRuns: [expect.objectContaining({ id: "run-1" })] })],
+      },
+    ]);
+    expect(summary.firstActivationPod.map((agent) => agent.profile)).toEqual(["leadcoo", "leadresearch"]);
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -99,6 +99,7 @@ import {
 import { getTelemetryClient } from "../telemetry.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 import { recoveryService } from "../services/recovery/service.js";
+import { buildHermesOrgVisibility, type HermesOrgAgentRow, type HermesOrgRunRow } from "./hermes-org-visibility.js";
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
@@ -1676,6 +1677,21 @@ export function agentRoutes(
       });
 
     res.json(items);
+  });
+
+  router.get("/companies/:companyId/hermes-org", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const [agents, runs] = await Promise.all([
+      svc.list(companyId),
+      heartbeat.list(companyId, undefined, 200),
+    ]);
+
+    res.json(buildHermesOrgVisibility({
+      agents: agents as HermesOrgAgentRow[],
+      runs: runs as HermesOrgRunRow[],
+    }));
   });
 
   router.get("/companies/:companyId/org", async (req, res) => {

--- a/server/src/routes/hermes-org-visibility.ts
+++ b/server/src/routes/hermes-org-visibility.ts
@@ -1,0 +1,180 @@
+type HermesMetadata = {
+  hermesOrg?: unknown;
+  profile?: unknown;
+  division?: unknown;
+  charter?: unknown;
+  cadence?: unknown;
+  skills?: unknown;
+  review?: unknown;
+  bridgeUrl?: unknown;
+};
+
+export type HermesOrgAgentRow = {
+  id: string;
+  name: string;
+  title: string | null;
+  status: string;
+  adapterType: string;
+  lastHeartbeatAt: Date | string | null;
+  metadata: HermesMetadata | null;
+};
+
+export type HermesOrgRunRow = {
+  id: string;
+  agentId: string;
+  status: string;
+  invocationSource: string;
+  triggerDetail: string | null;
+  startedAt: Date | string | null;
+  finishedAt: Date | string | null;
+  createdAt: Date | string;
+  error: string | null;
+};
+
+export type HermesOrgVisibleAgent = {
+  id: string;
+  name: string;
+  title: string | null;
+  profile: string;
+  division: string;
+  status: string;
+  adapterType: string;
+  bridgeConnected: boolean;
+  charter: string | null;
+  cadence: string | null;
+  skills: string[];
+  review: string[];
+  lastHeartbeatAt: Date | string | null;
+  recentRuns: Array<{
+    id: string;
+    status: string;
+    invocationSource: string;
+    triggerDetail: string | null;
+    startedAt: Date | string | null;
+    finishedAt: Date | string | null;
+    createdAt: Date | string;
+    error: string | null;
+  }>;
+};
+
+export type HermesOrgVisibility = {
+  orgKey: "full-lead-org";
+  totalAgents: number;
+  activeAgents: number;
+  bridgeAgents: number;
+  runningRuns: number;
+  divisions: Array<{
+    name: string;
+    agentCount: number;
+    activeCount: number;
+    runningRunCount: number;
+    agents: HermesOrgVisibleAgent[];
+  }>;
+  firstActivationPod: HermesOrgVisibleAgent[];
+};
+
+const FIRST_ACTIVATION_POD_PROFILES = [
+  "leadcoo",
+  "leadresearch",
+  "leadseo",
+  "leadcontent",
+  "leadvisual",
+  "leadqa",
+  "leadsecurity",
+];
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function isActiveAgent(status: string): boolean {
+  return status === "active" || status === "running" || status === "idle";
+}
+
+function isRunningRun(status: string): boolean {
+  return status === "queued" || status === "running";
+}
+
+export function buildHermesOrgVisibility(input: {
+  agents: HermesOrgAgentRow[];
+  runs: HermesOrgRunRow[];
+}): HermesOrgVisibility {
+  const runsByAgent = new Map<string, HermesOrgRunRow[]>();
+  for (const run of input.runs) {
+    const existing = runsByAgent.get(run.agentId) ?? [];
+    existing.push(run);
+    runsByAgent.set(run.agentId, existing);
+  }
+
+  const visibleAgents: HermesOrgVisibleAgent[] = input.agents
+    .filter((agent) => agent.metadata?.hermesOrg === "full-lead-org")
+    .map((agent) => {
+      const metadata = agent.metadata ?? {};
+      const profile = asString(metadata.profile) ?? agent.name;
+      const recentRuns = (runsByAgent.get(agent.id) ?? []).slice(0, 5).map((run) => ({
+        id: run.id,
+        status: run.status,
+        invocationSource: run.invocationSource,
+        triggerDetail: run.triggerDetail,
+        startedAt: run.startedAt,
+        finishedAt: run.finishedAt,
+        createdAt: run.createdAt,
+        error: run.error,
+      }));
+
+      return {
+        id: agent.id,
+        name: agent.name,
+        title: agent.title,
+        profile,
+        division: asString(metadata.division) ?? "Unassigned",
+        status: agent.status,
+        adapterType: agent.adapterType,
+        bridgeConnected: agent.adapterType === "http" && Boolean(asString(metadata.bridgeUrl)),
+        charter: asString(metadata.charter),
+        cadence: asString(metadata.cadence),
+        skills: asStringArray(metadata.skills),
+        review: asStringArray(metadata.review),
+        lastHeartbeatAt: agent.lastHeartbeatAt,
+        recentRuns,
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const divisions = new Map<string, HermesOrgVisibleAgent[]>();
+  for (const agent of visibleAgents) {
+    const existing = divisions.get(agent.division) ?? [];
+    existing.push(agent);
+    divisions.set(agent.division, existing);
+  }
+
+  const firstActivationPod = FIRST_ACTIVATION_POD_PROFILES
+    .map((profile) => visibleAgents.find((agent) => agent.profile === profile))
+    .filter((agent): agent is HermesOrgVisibleAgent => Boolean(agent));
+
+  return {
+    orgKey: "full-lead-org",
+    totalAgents: visibleAgents.length,
+    activeAgents: visibleAgents.filter((agent) => isActiveAgent(agent.status)).length,
+    bridgeAgents: visibleAgents.filter((agent) => agent.bridgeConnected).length,
+    runningRuns: input.runs.filter((run) => isRunningRun(run.status)).length,
+    divisions: Array.from(divisions.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, agents]) => ({
+        name,
+        agentCount: agents.length,
+        activeCount: agents.filter((agent) => isActiveAgent(agent.status)).length,
+        runningRunCount: agents.reduce(
+          (count, agent) => count + agent.recentRuns.filter((run) => isRunningRun(run.status)).length,
+          0,
+        ),
+        agents,
+      })),
+    firstActivationPod,
+  };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -51,6 +51,7 @@ import { PluginSettings } from "./pages/PluginSettings";
 import { AdapterManager } from "./pages/AdapterManager";
 import { PluginPage } from "./pages/PluginPage";
 import { OrgChart } from "./pages/OrgChart";
+import { HermesOrg } from "./pages/HermesOrg";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
@@ -87,6 +88,7 @@ function boardRoutes() {
       <Route path="settings/*" element={<LegacySettingsRedirect />} />
       <Route path="plugins/:pluginId" element={<PluginPage />} />
       <Route path="org" element={<OrgChart />} />
+      <Route path="hermes-org" element={<HermesOrg />} />
       <Route path="agents" element={<Navigate to="/agents/all" replace />} />
       <Route path="agents/all" element={<Agents />} />
       <Route path="agents/active" element={<Agents />} />

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -59,6 +59,52 @@ export interface OrgNode {
   reports: OrgNode[];
 }
 
+export interface HermesOrgRunSummary {
+  id: string;
+  status: string;
+  invocationSource: string;
+  triggerDetail: string | null;
+  startedAt: Date | string | null;
+  finishedAt: Date | string | null;
+  createdAt: Date | string;
+  error: string | null;
+}
+
+export interface HermesOrgAgentSummary {
+  id: string;
+  name: string;
+  title: string | null;
+  profile: string;
+  division: string;
+  status: string;
+  adapterType: string;
+  bridgeConnected: boolean;
+  charter: string | null;
+  cadence: string | null;
+  skills: string[];
+  review: string[];
+  lastHeartbeatAt: Date | string | null;
+  recentRuns: HermesOrgRunSummary[];
+}
+
+export interface HermesOrgDivisionSummary {
+  name: string;
+  agentCount: number;
+  activeCount: number;
+  runningRunCount: number;
+  agents: HermesOrgAgentSummary[];
+}
+
+export interface HermesOrgVisibilitySummary {
+  orgKey: "full-lead-org";
+  totalAgents: number;
+  activeAgents: number;
+  bridgeAgents: number;
+  runningRuns: number;
+  divisions: HermesOrgDivisionSummary[];
+  firstActivationPod: HermesOrgAgentSummary[];
+}
+
 export interface AgentHireResponse {
   agent: Agent;
   approval: Approval | null;
@@ -91,6 +137,7 @@ function agentPath(id: string, companyId?: string, suffix = "") {
 export const agentsApi = {
   list: (companyId: string) => api.get<Agent[]>(`/companies/${companyId}/agents`),
   org: (companyId: string) => api.get<OrgNode[]>(`/companies/${companyId}/org`),
+  hermesOrg: (companyId: string) => api.get<HermesOrgVisibilitySummary>(`/companies/${companyId}/hermes-org`),
   listConfigurations: (companyId: string) =>
     api.get<Record<string, unknown>[]>(`/companies/${companyId}/agent-configurations`),
   get: async (id: string, companyId?: string) => {

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   SquarePen,
   Network,
+  Workflow,
   Boxes,
   Repeat,
   GitBranch,
@@ -121,6 +122,7 @@ export function Sidebar() {
 
         <SidebarSection label="Company">
           <SidebarNavItem to="/org" label="Org" icon={Network} />
+          <SidebarNavItem to="/hermes-org" label="Hermes Org" icon={Workflow} />
           <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
           <SidebarNavItem to="/activity" label="Activity" icon={History} />

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -19,6 +19,7 @@ export const queryKeys = {
   },
   agents: {
     list: (companyId: string) => ["agents", companyId] as const,
+    hermesOrg: (companyId: string) => ["agents", companyId, "hermes-org"] as const,
     detail: (id: string) => ["agents", "detail", id] as const,
     runtimeState: (id: string) => ["agents", "runtime-state", id] as const,
     taskSessions: (id: string) => ["agents", "task-sessions", id] as const,

--- a/ui/src/pages/HermesOrg.test.tsx
+++ b/ui/src/pages/HermesOrg.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HermesOrg } from "./HermesOrg";
+
+const hermesOrgMock = vi.fn();
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: vi.fn() }),
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: {
+    hermesOrg: () => hermesOrgMock(),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("HermesOrg", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    hermesOrgMock.mockResolvedValue({
+      orgKey: "full-lead-org",
+      totalAgents: 64,
+      activeAgents: 64,
+      bridgeAgents: 64,
+      runningRuns: 1,
+      firstActivationPod: [
+        {
+          id: "agent-coo",
+          name: "COO / Mission Control Lead",
+          title: "COO / Mission Control Lead",
+          profile: "leadcoo",
+          division: "Executive / Coordination",
+          status: "active",
+          adapterType: "http",
+          bridgeConnected: true,
+          charter: "Own operating cadence.",
+          cadence: "daily",
+          skills: ["kanban-orchestrator"],
+          review: ["Audit Lead"],
+          lastHeartbeatAt: null,
+          recentRuns: [],
+        },
+      ],
+      divisions: [
+        {
+          name: "Executive / Coordination",
+          agentCount: 8,
+          activeCount: 8,
+          runningRunCount: 1,
+          agents: [
+            {
+              id: "agent-coo",
+              name: "COO / Mission Control Lead",
+              title: "COO / Mission Control Lead",
+              profile: "leadcoo",
+              division: "Executive / Coordination",
+              status: "active",
+              adapterType: "http",
+              bridgeConnected: true,
+              charter: "Own operating cadence.",
+              cadence: "daily",
+              skills: ["kanban-orchestrator"],
+              review: ["Audit Lead"],
+              lastHeartbeatAt: null,
+              recentRuns: [{
+                id: "run-1",
+                status: "running",
+                invocationSource: "on_demand",
+                triggerDetail: "manual",
+                startedAt: "2026-06-01T10:00:00.000Z",
+                finishedAt: null,
+                createdAt: "2026-06-01T09:59:58.000Z",
+                error: null,
+              }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root.unmount());
+    }
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  async function renderPage() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <HermesOrg />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+  }
+
+  it("renders operating org metrics, pod membership, reviews, and run status", async () => {
+    await renderPage();
+
+    expect(container.textContent).toContain("Hermes Operating Org");
+    expect(container.textContent).toContain("64 lead agents");
+    expect(container.textContent).toContain("64 bridge-connected");
+    expect(container.textContent).toContain("First activation pod");
+    expect(container.textContent).toContain("leadcoo");
+    expect(container.textContent).toContain("Review: Audit Lead");
+    expect(container.textContent).toContain("Executive / Coordination");
+    expect(container.textContent).toContain("1 running");
+  });
+});

--- a/ui/src/pages/HermesOrg.tsx
+++ b/ui/src/pages/HermesOrg.tsx
@@ -1,0 +1,125 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Bot, GitBranch, ShieldCheck, Activity } from "lucide-react";
+import { agentsApi, type HermesOrgAgentSummary } from "../api/agents";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { StatusBadge } from "../components/StatusBadge";
+import { relativeTime } from "../lib/utils";
+
+function MetricCard({ label, value, icon: Icon }: { label: string; value: string; icon: typeof Bot }) {
+  return (
+    <div className="border border-border bg-card p-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold tracking-tight">{value}</div>
+    </div>
+  );
+}
+
+function AgentCard({ agent }: { agent: HermesOrgAgentSummary }) {
+  const latestRun = agent.recentRuns[0] ?? null;
+  return (
+    <div className="border border-border bg-background p-3 space-y-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-medium text-sm truncate">{agent.name}</div>
+          <div className="text-xs text-muted-foreground font-mono">{agent.profile}</div>
+        </div>
+        <StatusBadge status={agent.status} />
+      </div>
+      {agent.charter ? <p className="text-xs text-muted-foreground leading-relaxed">{agent.charter}</p> : null}
+      <div className="flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+        <span className="border border-border px-1.5 py-0.5">{agent.cadence ?? "cadence unset"}</span>
+        <span className="border border-border px-1.5 py-0.5">{agent.bridgeConnected ? "bridge connected" : "bridge not connected"}</span>
+        {latestRun ? (
+          <span className="border border-border px-1.5 py-0.5">
+            last run: {latestRun.status} · {relativeTime(latestRun.createdAt)}
+          </span>
+        ) : (
+          <span className="border border-border px-1.5 py-0.5">no recent runs</span>
+        )}
+      </div>
+      {agent.review.length > 0 ? (
+        <div className="text-xs text-muted-foreground">Review: {agent.review.join(", ")}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export function HermesOrg() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Hermes Org" }]);
+  }, [setBreadcrumbs]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.agents.hermesOrg(selectedCompanyId!),
+    queryFn: () => agentsApi.hermesOrg(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 15_000,
+  });
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={Bot} message="Select a company to view the Hermes operating org." />;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton variant="dashboard" />;
+  }
+
+  if (error || !data) {
+    return <EmptyState icon={Bot} message="Unable to load the Hermes operating org." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Hermes Operating Org</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Private Paperclip visibility for Hermes department leads, bridge health, pod membership, reviews, and recent runs.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <MetricCard label="Lead agents" value={`${data.totalAgents} lead agents`} icon={Bot} />
+        <MetricCard label="Active" value={`${data.activeAgents} active`} icon={ShieldCheck} />
+        <MetricCard label="Bridge" value={`${data.bridgeAgents} bridge-connected`} icon={GitBranch} />
+        <MetricCard label="Live work" value={`${data.runningRuns} running`} icon={Activity} />
+      </div>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold">First activation pod</h2>
+          <p className="text-sm text-muted-foreground">Command pod verified for Research → SEO → Content → Visual → QA → Security → COO workflows.</p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {data.firstActivationPod.map((agent) => <AgentCard key={agent.id} agent={agent} />)}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Divisions</h2>
+        <div className="space-y-3">
+          {data.divisions.map((division) => (
+            <details key={division.name} className="border border-border bg-card" open={division.runningRunCount > 0}>
+              <summary className="cursor-pointer px-4 py-3 text-sm font-medium">
+                {division.name} · {division.agentCount} agents · {division.activeCount} active · {division.runningRunCount} running
+              </summary>
+              <div className="grid gap-3 border-t border-border p-3 md:grid-cols-2 xl:grid-cols-3">
+                {division.agents.map((agent) => <AgentCard key={agent.id} agent={agent} />)}
+              </div>
+            </details>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add authenticated Hermes Org visibility API with lead/pod/run rollups.
- Add Hermes Org UI page and sidebar entry.
- Cover API/UI behavior with targeted tests.

## Test Plan
- pnpm vitest run server/src/__tests__/hermes-org-visibility.test.ts ui/src/pages/HermesOrg.test.tsx
- Live private Paperclip verification: /api/companies/4297a23d-3137-5208-a081-fe9b3ba89710/hermes-org returned totalAgents=64, bridgeAgents=64, divisions=8.
