### PR TITLE
[codex] Guard blocker closeouts with issue edges

### DIFF
--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -181,6 +181,7 @@ describe("assigned backlog creation contract", () => {
       }),
       parentBlockerAdded: Boolean(data.blockParentUntilDone),
     }));
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
@@ -233,6 +234,33 @@ describe("assigned backlog creation contract", () => {
         }),
       }),
     );
+  });
+
+  it("rejects blocked issue creation when description names an unlinked required blocker", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValue({
+      id: "blocker-1",
+      companyId: "company-1",
+      identifier: "PAP-200",
+      title: "Launch gate",
+      status: "todo",
+      priority: "high",
+    });
+
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Blocked launch phase",
+        status: "blocked",
+        description: "Blocked by [PAP-200](/issues/PAP-200) before launch.",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      error: "Issue text names required blocker issues without first-class blocker edges",
+      requiredBlockerIssueIdentifiers: ["PAP-200"],
+    });
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
   });
 
   it("does not let a parent-blocking assigned child become an unwoken backlog leaf by default", async () => {

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
 const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
   getAncestors: vi.fn(),
   getById: vi.fn(),
   getByIdentifier: vi.fn(async () => null),
@@ -183,6 +184,56 @@ describe("issue dependency wakeups in issue routes", () => {
         }),
       );
     });
+  });
+
+  it("rejects blocker-naming closeouts without first-class blocker edges before wakeups", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-100",
+      title: "Finish source",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.getByIdentifier.mockResolvedValue({
+      id: "issue-2",
+      companyId: "company-1",
+      identifier: "PAP-200",
+      title: "Required downstream blocker",
+      status: "todo",
+      priority: "high",
+    });
+
+    const res = await request(await createApp())
+      .patch("/api/issues/issue-1")
+      .send({
+        status: "done",
+        comment: "Closeout blocked on [PAP-200](/issues/PAP-200) before launch.",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      error: "Issue text names required blocker issues without first-class blocker edges",
+      requiredBlockerIssueIdentifiers: ["PAP-200"],
+      missingBlockedByIssues: [
+        expect.objectContaining({
+          id: "issue-2",
+          identifier: "PAP-200",
+        }),
+      ],
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.listWakeableBlockedDependents).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
   });
 
   it("wakes the parent when all direct children become terminal", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2215,6 +2215,47 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     ]);
   });
 
+  it("rolls back helper-created child when parent blocker attachment fails", async () => {
+    const companyId = randomUUID();
+    const parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.createChild(parentIssueId, {
+        title: "Cycle child",
+        status: "todo",
+        blockedByIssueIds: [parentIssueId],
+        blockParentUntilDone: true,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    const children = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.parentId, parentIssueId));
+    const relations = await db
+      .select({ id: issueRelations.id })
+      .from(issueRelations)
+      .where(eq(issueRelations.companyId, companyId));
+
+    expect(children).toEqual([]);
+    expect(relations).toEqual([]);
+  });
+
   it("clamps helper-created child requestDepth to the safe maximum", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -118,6 +118,7 @@ import {
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { extractRequiredBlockerIssueIdentifiers } from "../services/issue-closeout-blockers.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -163,6 +164,67 @@ type SuccessfulRunHandoffActivityRow = {
   details: Record<string, unknown> | null;
   createdAt: Date;
 };
+type RequiredBlockerEdgeValidationIssue = {
+  id: string;
+  companyId: string;
+  identifier: string | null;
+  title: string;
+};
+
+async function validateRequiredBlockerReferencesHaveEdges(input: {
+  svc: ReturnType<typeof issueService>;
+  companyId: string;
+  text: string | null | undefined;
+  nextStatus: unknown;
+  currentBlockedByIssueIds?: string[] | null;
+  requestedBlockedByIssueIds?: unknown;
+  res: Response;
+}) {
+  if (input.nextStatus !== "blocked" && input.nextStatus !== "done") return true;
+
+  const requiredIdentifiers = extractRequiredBlockerIssueIdentifiers(input.text);
+  if (requiredIdentifiers.length === 0) return true;
+
+  const linkedIssueIds = new Set(
+    Array.isArray(input.requestedBlockedByIssueIds)
+      ? input.requestedBlockedByIssueIds.filter((value): value is string => typeof value === "string")
+      : input.currentBlockedByIssueIds ?? [],
+  );
+
+  const missing: RequiredBlockerEdgeValidationIssue[] = [];
+  const unknownIdentifiers: string[] = [];
+  for (const identifier of requiredIdentifiers) {
+    const issue = await input.svc.getByIdentifier(identifier);
+    if (!issue || issue.companyId !== input.companyId) {
+      unknownIdentifiers.push(identifier);
+      continue;
+    }
+    if (!linkedIssueIds.has(issue.id)) {
+      missing.push({
+        id: issue.id,
+        companyId: issue.companyId,
+        identifier: issue.identifier,
+        title: issue.title,
+      });
+    }
+  }
+
+  if (missing.length === 0 && unknownIdentifiers.length === 0) return true;
+
+  input.res.status(422).json({
+    error: "Issue text names required blocker issues without first-class blocker edges",
+    message:
+      "Add the referenced issues to blockedByIssueIds, or use the child issue helper with blockParentUntilDone so the blocker edge is created atomically.",
+    requiredBlockerIssueIdentifiers: requiredIdentifiers,
+    missingBlockedByIssues: missing.map((issue) => ({
+      id: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+    })),
+    unknownBlockerIssueIdentifiers: unknownIdentifiers,
+  });
+  return false;
+}
 
 function applyCreateIssueStatusDefault(req: Request, res: Response, next: () => void) {
   if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
@@ -3634,6 +3696,14 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+    if (!(await validateRequiredBlockerReferencesHaveEdges({
+      svc,
+      companyId,
+      text: req.body.description,
+      nextStatus: req.body.status,
+      requestedBlockedByIssueIds: req.body.blockedByIssueIds,
+      res,
+    }))) return;
     const issue = await svc.create(companyId, {
       ...req.body,
       executionPolicy,
@@ -3735,6 +3805,14 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+    if (!(await validateRequiredBlockerReferencesHaveEdges({
+      svc,
+      companyId: parent.companyId,
+      text: req.body.description,
+      nextStatus: req.body.status,
+      requestedBlockedByIssueIds: req.body.blockedByIssueIds,
+      res,
+    }))) return;
     const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
       ...req.body,
       executionPolicy,
@@ -4241,6 +4319,27 @@ export function issueRoutes(
       updateFields,
       actorType: req.actor.type,
     });
+
+    const closeoutNextStatus = typeof updateFields.status === "string" ? updateFields.status : existing.status;
+    let currentBlockedByIssueIds: string[] | null = null;
+    if (
+      commentBody &&
+      (closeoutNextStatus === "blocked" || closeoutNextStatus === "done") &&
+      !Array.isArray(req.body.blockedByIssueIds) &&
+      extractRequiredBlockerIssueIdentifiers(commentBody).length > 0
+    ) {
+      const relations = existingRelations ?? await svc.getRelationSummaries(existing.id);
+      currentBlockedByIssueIds = relations.blockedBy.map((relation) => relation.id);
+    }
+    if (!(await validateRequiredBlockerReferencesHaveEdges({
+      svc,
+      companyId: existing.companyId,
+      text: commentBody,
+      nextStatus: closeoutNextStatus,
+      currentBlockedByIssueIds,
+      requestedBlockedByIssueIds: req.body.blockedByIssueIds,
+      res,
+    }))) return;
 
     const nextAssigneeAgentId =
       updateFields.assigneeAgentId === undefined ? existing.assigneeAgentId : (updateFields.assigneeAgentId as string | null);

--- a/server/src/services/issue-closeout-blockers.test.ts
+++ b/server/src/services/issue-closeout-blockers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { extractRequiredBlockerIssueIdentifiers } from "./issue-closeout-blockers.js";
+
+describe("extractRequiredBlockerIssueIdentifiers", () => {
+  it("detects issue references on required blocker lines", () => {
+    expect(
+      extractRequiredBlockerIssueIdentifiers([
+        "Done with platform changes.",
+        "Remaining blocker: [DAT-5005](/DAT/issues/DAT-5005) must complete before launch.",
+      ].join("\n")),
+    ).toEqual(["DAT-5005"]);
+  });
+
+  it("ignores non-blocking issue references and negated blocker lines", () => {
+    expect(
+      extractRequiredBlockerIssueIdentifiers([
+        "Related context: [DAT-5005](/DAT/issues/DAT-5005).",
+        "No blockers: DAT-5006 is just background.",
+        "Follow-up DAT-5007 is not a blocker.",
+      ].join("\n")),
+    ).toEqual([]);
+  });
+});

--- a/server/src/services/issue-closeout-blockers.ts
+++ b/server/src/services/issue-closeout-blockers.ts
@@ -1,0 +1,46 @@
+import { extractIssueReferenceMatches } from "@paperclipai/shared";
+
+export type RequiredBlockerReference = {
+  identifier: string;
+  matchedText: string;
+  line: string;
+};
+
+const BLOCKER_INTENT_RE =
+  /\b(?:blocked\s+(?:by|on|until)|blockers?|blocking|blocks|depends?\s+on|dependenc(?:y|ies)|required(?:\s+downstream)?\s+blockers?|must\s+(?:complete|finish|land|ship))\b/i;
+const NON_BLOCKER_INTENT_RE =
+  /\b(?:no|none|without)\s+(?:required\s+)?blockers?\b|\b(?:not\s+(?:a\s+)?blocker|not\s+blocking|non[-\s]?blocking)\b/i;
+
+function lineForIndex(text: string, index: number) {
+  const lineStart = text.lastIndexOf("\n", Math.max(0, index - 1)) + 1;
+  const nextNewline = text.indexOf("\n", index);
+  const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+  return text.slice(lineStart, lineEnd).trim();
+}
+
+export function extractRequiredBlockerReferences(text: string | null | undefined): RequiredBlockerReference[] {
+  if (!text) return [];
+
+  const matches = extractIssueReferenceMatches(text);
+  const seen = new Set<string>();
+  const required: RequiredBlockerReference[] = [];
+
+  for (const match of matches) {
+    const line = lineForIndex(text, match.index);
+    if (!BLOCKER_INTENT_RE.test(line)) continue;
+    if (NON_BLOCKER_INTENT_RE.test(line)) continue;
+    if (seen.has(match.identifier)) continue;
+    seen.add(match.identifier);
+    required.push({
+      identifier: match.identifier,
+      matchedText: match.matchedText,
+      line,
+    });
+  }
+
+  return required;
+}
+
+export function extractRequiredBlockerIssueIdentifiers(text: string | null | undefined): string[] {
+  return extractRequiredBlockerReferences(text).map((reference) => reference.identifier);
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4286,57 +4286,60 @@ export function issueService(db: Db) {
       parentIssueId: string,
       data: IssueChildCreateInput,
     ) => {
-      const parent = await db
-        .select()
-        .from(issues)
-        .where(eq(issues.id, parentIssueId))
-        .then((rows) => rows[0] ?? null);
-      if (!parent) throw notFound("Parent issue not found");
+      return db.transaction(async (tx) => {
+        const parent = await tx
+          .select()
+          .from(issues)
+          .where(eq(issues.id, parentIssueId))
+          .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
+        if (!parent) throw notFound("Parent issue not found");
 
-      const [{ childCount }] = await db
-        .select({ childCount: sql<number>`count(*)::int` })
-        .from(issues)
-        .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parent.id)));
-      if (childCount >= MAX_CHILD_ISSUES_CREATED_BY_HELPER) {
-        throw unprocessable(`Parent issue already has the maximum ${MAX_CHILD_ISSUES_CREATED_BY_HELPER} child issues for this helper`);
-      }
+        const [{ childCount }] = await tx
+          .select({ childCount: sql<number>`count(*)::int` })
+          .from(issues)
+          .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parent.id)));
+        if (childCount >= MAX_CHILD_ISSUES_CREATED_BY_HELPER) {
+          throw unprocessable(`Parent issue already has the maximum ${MAX_CHILD_ISSUES_CREATED_BY_HELPER} child issues for this helper`);
+        }
 
-      const {
-        acceptanceCriteria,
-        blockParentUntilDone,
-        actorAgentId,
-        actorUserId,
-        ...issueData
-      } = data;
-      const child = await issueService(db).create(parent.companyId, {
-        ...issueData,
-        parentId: parent.id,
-        projectId: issueData.projectId ?? parent.projectId,
-        goalId: issueData.goalId ?? parent.goalId,
-        requestDepth: clampIssueRequestDepth(
-          Math.max(clampIssueRequestDepth(parent.requestDepth) + 1, issueData.requestDepth ?? 0),
-        ),
-        description: appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria),
-        inheritExecutionWorkspaceFromIssueId: parent.id,
+        const {
+          acceptanceCriteria,
+          blockParentUntilDone,
+          actorAgentId,
+          actorUserId,
+          ...issueData
+        } = data;
+        const child = await issueService(tx as unknown as Db).create(parent.companyId, {
+          ...issueData,
+          parentId: parent.id,
+          projectId: issueData.projectId ?? parent.projectId,
+          goalId: issueData.goalId ?? parent.goalId,
+          requestDepth: clampIssueRequestDepth(
+            Math.max(clampIssueRequestDepth(parent.requestDepth) + 1, issueData.requestDepth ?? 0),
+          ),
+          description: appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria),
+          inheritExecutionWorkspaceFromIssueId: parent.id,
+        });
+
+        if (blockParentUntilDone) {
+          const existingBlockers = await tx
+            .select({ blockerIssueId: issueRelations.issueId })
+            .from(issueRelations)
+            .where(and(eq(issueRelations.companyId, parent.companyId), eq(issueRelations.relatedIssueId, parent.id), eq(issueRelations.type, "blocks")));
+          await syncBlockedByIssueIds(
+            parent.id,
+            parent.companyId,
+            [...new Set([...existingBlockers.map((row: { blockerIssueId: string }) => row.blockerIssueId), child.id])],
+            { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
+            tx,
+          );
+        }
+
+        return {
+          issue: child,
+          parentBlockerAdded: Boolean(blockParentUntilDone),
+        };
       });
-
-      if (blockParentUntilDone) {
-        const existingBlockers = await db
-          .select({ blockerIssueId: issueRelations.issueId })
-          .from(issueRelations)
-          .where(and(eq(issueRelations.companyId, parent.companyId), eq(issueRelations.relatedIssueId, parent.id), eq(issueRelations.type, "blocks")));
-        await syncBlockedByIssueIds(
-          parent.id,
-          parent.companyId,
-          [...new Set([...existingBlockers.map((row) => row.blockerIssueId), child.id])],
-          { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
-        );
-      }
-
-      return {
-        issue: child,
-        parentBlockerAdded: Boolean(blockParentUntilDone),
-      };
     },
 
     decomposeAcceptedPlan: async (


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue dependencies are represented as first-class blocker edges so blocked work can wake only when real blockers resolve.
> - Agents can currently write closeout text that names a required blocker without creating the corresponding edge.
> - That makes the issue graph lie: later dependency wakeups may treat the work as unblocked because the blocker only lived in prose.
> - This pull request adds a server-side guard for blocker-naming issue text and closeouts.
> - It also makes the child issue helper's parent-blocking path atomic, so creating the child and attaching the parent blocker edge succeed or roll back together.
> - The benefit is fewer silent dropped blockers in agent handoffs and launch-gating work chains.

## What Changed

- Added `issue-closeout-blockers` text detection for issue-reference lines that explicitly name blockers or dependencies, while ignoring negated/non-blocking references.
- Rejected blocked/done issue creation or closeout updates when the text names required blocker issues but the referenced issues are not present in `blockedByIssueIds` or existing blocker edges.
- Wrapped `createChild(..., blockParentUntilDone: true)` in a transaction so the child issue and parent blocker edge are created atomically.
- Added regression tests for blocker-text rejection, no wakeups after rejected closeouts, issue creation validation, parser behavior, and atomic child rollback.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/services/issue-closeout-blockers.test.ts server/src/__tests__/issue-dependency-wakeups-routes.test.ts server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts server/src/__tests__/issues-service.test.ts` — 71 tests passed in the clean branch.
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm build` — passed. Existing Vite warnings appeared for CSS `::highlight`, dynamic `MarkdownEditor` import chunking, and large chunks.

## Risks

- Medium-low risk: the blocker detector is intentionally narrow but may reject a blocked/done closeout line that uses blocker language for a referenced issue without intending a dependency. The error explains the fix: add `blockedByIssueIds` or use the child helper.
- Low migration risk: no schema or data migration.
- Transaction behavior relies on Drizzle nested transaction/savepoint support already used elsewhere in the codebase.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent, tool-enabled local development session with shell, git, test, build, and GitHub connector access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
