### PR TITLE
Install runtime qmd and Chromium deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,15 @@ WORKDIR /app
 COPY --chown=node:node --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
   && apt-get update \
-  && apt-get install -y --no-install-recommends openssh-client jq \
-  && rm -rf /var/lib/apt/lists/* \
+  && apt-get install -y --no-install-recommends openssh-client jq python3-venv \
+  && python3 -m venv /opt/qmd \
+  && /opt/qmd/bin/pip install --no-cache-dir qmd==0.1.2 \
+  && ln -s /opt/qmd/bin/qmd /usr/local/bin/qmd \
+  && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright pnpm exec playwright install --with-deps chromium \
   && mkdir -p /paperclip \
-  && chown node:node /paperclip
+  && chown -R node:node /paperclip /ms-playwright \
+  && HOME=/paperclip PLAYWRIGHT_BROWSERS_PATH=/ms-playwright gosu node node scripts/check-agent-runtime-tools.mjs \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
@@ -79,7 +84,8 @@ ENV NODE_ENV=production \
   PAPERCLIP_CONFIG=/paperclip/instances/default/config.json \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private \
-  OPENCODE_ALLOW_ALL_MODELS=true
+  OPENCODE_ALLOW_ALL_MODELS=true \
+  PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 VOLUME ["/paperclip"]
 EXPOSE 3100

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -54,6 +54,14 @@ The Docker image pre-installs:
 
 - `claude` (Anthropic Claude Code CLI)
 - `codex` (OpenAI Codex CLI)
+- `qmd` for agent memory recall
+- Playwright Chromium and its Linux system dependencies for screenshot and audit work
+
+Verify the runtime tooling after a build:
+
+```sh
+docker run --rm paperclip-local node scripts/check-agent-runtime-tools.mjs
+```
 
 Pass API keys to enable local adapter runs inside the container:
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "smoke:openclaw-join": "./scripts/smoke/openclaw-join.sh",
     "smoke:openclaw-docker-ui": "./scripts/smoke/openclaw-docker-ui.sh",
     "smoke:openclaw-sse-standalone": "./scripts/smoke/openclaw-sse-standalone.sh",
+    "smoke:agent-runtime-tools": "node scripts/check-agent-runtime-tools.mjs",
     "smoke:terminal-bench-loop-skill": "node scripts/smoke/terminal-bench-loop-skill-smoke.mjs",
     "test:release-registry": "node --test scripts/verify-release-registry-state.test.mjs scripts/release-package-map.test.mjs scripts/check-release-package-bootstrap.test.mjs scripts/check-no-git-push.test.mjs",
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.ts",

--- a/scripts/check-agent-runtime-tools.mjs
+++ b/scripts/check-agent-runtime-tools.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+function fail(message, detail) {
+  console.error(`FAIL: ${message}`);
+  if (detail) console.error(detail);
+  process.exit(1);
+}
+
+const qmd = spawnSync("qmd", ["--help"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+if (qmd.error) {
+  fail("qmd is not available on PATH.", qmd.error.message);
+}
+
+if (qmd.status !== 0) {
+  fail("qmd --help failed.", qmd.stderr || qmd.stdout);
+}
+
+try {
+  const { chromium } = await import("playwright");
+  const browser = await chromium.launch({ headless: true });
+  await browser.close();
+} catch (error) {
+  fail("Playwright Chromium could not launch.", error instanceof Error ? error.message : String(error));
+}
+
+console.log("PASS: qmd and Playwright Chromium launch are available.");

--- a/scripts/docker-build-test.sh
+++ b/scripts/docker-build-test.sh
@@ -40,6 +40,7 @@ echo "==> Verifying key binaries in image"
   rg --version
   python3 --version
   curl --version | head -1
+  node scripts/check-agent-runtime-tools.mjs
   claude --version 2>/dev/null || echo "claude CLI not found (OK in minimal builds)"
 '
 


### PR DESCRIPTION
## Summary\n- install qmd in the production Docker image via an isolated Python venv\n- install Playwright Chromium and supported Linux dependencies into a shared browser path\n- add a runtime tooling smoke script and wire it into Docker build testing/docs\n\n## Verification\n- node --check scripts/check-agent-runtime-tools.mjs\n- bash -n scripts/docker-build-test.sh\n- node scripts/check-docker-deps-stage.mjs\n- NODE_ENV=production pnpm run build\n- ./scripts/docker-build-test.sh (skipped: no docker/podman binary available in this heartbeat runtime)