### PR TITLE
Treat cancelled blocker attention nodes as terminal

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -414,15 +414,15 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       status: "in_review",
       assigneeAgentId: agentId,
     });
-    const cancelledLeafId = await insertIssue({
+    const idleLeafId = await insertIssue({
       companyId,
       identifier: "PBQ-3",
-      title: "Cancelled blocker",
-      status: "cancelled",
+      title: "Idle blocker",
+      status: "todo",
       assigneeAgentId: agentId,
     });
     await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
-    await block({ companyId, blockerIssueId: cancelledLeafId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: idleLeafId, blockedIssueId: parentId });
 
     const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
 
@@ -433,6 +433,101 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       stalledBlockerCount: 1,
       attentionBlockerCount: 1,
       sampleStalledBlockerIdentifier: "PBQ-2",
+    });
+  });
+
+  it("excludes cancelled child issues from blocker attention counts and samples", async () => {
+    const { companyId, agentId } = await createCompany("PBN");
+    const parentId = await insertIssue({ companyId, identifier: "PBN-1", title: "Parent", status: "blocked" });
+    await insertIssue({
+      companyId,
+      identifier: "PBN-2",
+      title: "Cancelled child",
+      status: "cancelled",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 0,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: null,
+      sampleStalledBlockerIdentifier: null,
+    });
+  });
+
+  it("excludes cancelled explicit blockers from blocker attention counts and samples", async () => {
+    const { companyId, agentId } = await createCompany("PBD");
+    const parentId = await insertIssue({ companyId, identifier: "PBD-1", title: "Parent", status: "blocked" });
+    const cancelledBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBD-2",
+      title: "Cancelled dependency",
+      status: "cancelled",
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: cancelledBlockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 0,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: null,
+      sampleStalledBlockerIdentifier: null,
+    });
+  });
+
+  it("ignores cancelled blockers when choosing between stalled and attention paths", async () => {
+    const { companyId, agentId } = await createCompany("PBT");
+    const parentId = await insertIssue({ companyId, identifier: "PBT-1", title: "Parent", status: "blocked" });
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBT-2",
+      title: "Stalled review leaf",
+      status: "in_review",
+      assigneeAgentId: agentId,
+    });
+    const cancelledChildId = await insertIssue({
+      companyId,
+      identifier: "PBT-3",
+      title: "Cancelled child",
+      status: "cancelled",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    const cancelledDependencyId = await insertIssue({
+      companyId,
+      identifier: "PBT-4",
+      title: "Cancelled dependency",
+      status: "cancelled",
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: cancelledChildId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: cancelledDependencyId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "stalled",
+      reason: "stalled_review",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 1,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBT-2",
+      sampleStalledBlockerIdentifier: "PBT-2",
     });
   });
 
@@ -476,8 +571,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention).toMatchObject({
       state: "covered",
       reason: "active_dependency",
-      unresolvedBlockerCount: 2,
-      coveredBlockerCount: 2,
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
       attentionBlockerCount: 0,
     });
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1178,6 +1178,7 @@ const PRODUCTIVITY_REVIEW_TRIGGERS: readonly IssueProductivityReviewTrigger[] = 
   "long_active_duration",
   "high_churn",
 ];
+const BLOCKER_ATTENTION_TERMINAL_STATUSES = ["done", "cancelled"];
 const BLOCKER_ATTENTION_OPEN_RECOVERY_TERMINAL_STATUSES = ["done", "cancelled"];
 const BLOCKER_ATTENTION_MAX_DEPTH = 8;
 const BLOCKER_ATTENTION_MAX_NODES = 2000;
@@ -1272,6 +1273,10 @@ function blockerSampleIdentifier(node: IssueBlockerAttentionNode | null | undefi
   return node?.identifier ?? node?.id ?? null;
 }
 
+function isBlockerAttentionTerminalStatus(status: string) {
+  return BLOCKER_ATTENTION_TERMINAL_STATUSES.includes(status);
+}
+
 function appendBlockerAttentionEdges(
   edgesByIssueId: Map<string, IssueBlockerAttentionEdge[]>,
   rows: IssueBlockerAttentionEdge[],
@@ -1343,7 +1348,7 @@ async function terminalExplicitBlockersByRoot(
             eq(issueRelations.type, "blocks"),
             inArray(issueRelations.relatedIssueId, chunk),
             eq(issues.companyId, companyId),
-            ne(issues.status, "done"),
+            notInArray(issues.status, BLOCKER_ATTENTION_TERMINAL_STATUSES),
           ),
         );
 
@@ -1367,7 +1372,7 @@ async function terminalExplicitBlockersByRoot(
   const collectTerminal = (issueId: string, seen: Set<string>): IssueRelationIssueSummary[] => {
     if (seen.has(issueId)) return [];
     const node = nodesById.get(issueId);
-    if (!node || node.status === "done") return [];
+    if (!node || isBlockerAttentionTerminalStatus(node.status)) return [];
     const nextSeen = new Set(seen);
     nextSeen.add(issueId);
     const downstreamIds = edgesByIssueId.get(issueId) ?? [];
@@ -1544,7 +1549,7 @@ async function listIssueBlockerAttentionMap(
             eq(issueRelations.type, "blocks"),
             inArray(issueRelations.relatedIssueId, chunk),
             eq(issues.companyId, companyId),
-            ne(issues.status, "done"),
+            notInArray(issues.status, BLOCKER_ATTENTION_TERMINAL_STATUSES),
           ),
         );
       const childRowsPromise: Promise<IssueBlockerAttentionQueryRow[]> = dbOrTx
@@ -1566,7 +1571,7 @@ async function listIssueBlockerAttentionMap(
           and(
             eq(issues.companyId, companyId),
             inArray(issues.parentId, chunk),
-            ne(issues.status, "done"),
+            notInArray(issues.status, BLOCKER_ATTENTION_TERMINAL_STATUSES),
           ),
         );
       const [explicitBlockerRows, childRows] = await Promise.all([
@@ -1658,7 +1663,7 @@ async function listIssueBlockerAttentionMap(
   }
 
   const explicitWaitCandidateIds = [...nodesById.values()]
-    .filter((node) => node.status !== "done")
+    .filter((node) => !isBlockerAttentionTerminalStatus(node.status))
     .map((node) => node.id);
   const explicitWaitingIssueIds = new Set<string>();
   if (explicitWaitCandidateIds.length > 0) {
@@ -1755,13 +1760,13 @@ async function listIssueBlockerAttentionMap(
       return { covered: false, stalled: false, sampleBlockerIdentifier: nodeId, sampleStalledBlockerIdentifier: null };
     }
     const nodeSample = blockerSampleIdentifier(node);
-    if (node.status === "done") {
+    if (isBlockerAttentionTerminalStatus(node.status)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (explicitWaitingIssueIds.has(node.id)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
-    if (node.assigneeUserId && node.status !== "cancelled") {
+    if (node.assigneeUserId) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.status === "in_review") {
@@ -1774,14 +1779,14 @@ async function listIssueBlockerAttentionMap(
     if (activeIssueIds.has(node.id)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
-    if (node.status === "cancelled") {
-      return { covered: false, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
-    }
     if (node.status === "backlog" && node.assigneeAgentId) {
       return { covered: false, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
 
-    const downstream = (edgesByIssueId.get(node.id) ?? []).filter((edge) => nodesById.get(edge.blockerIssueId)?.status !== "done");
+    const downstream = (edgesByIssueId.get(node.id) ?? []).filter((edge) => {
+      const blockerStatus = nodesById.get(edge.blockerIssueId)?.status;
+      return blockerStatus ? !isBlockerAttentionTerminalStatus(blockerStatus) : false;
+    });
     if (downstream.length > 0) {
       const nextSeen = new Set(seen);
       nextSeen.add(nodeId);
@@ -1825,7 +1830,10 @@ async function listIssueBlockerAttentionMap(
   };
 
   for (const root of roots) {
-    const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => nodesById.get(edge.blockerIssueId)?.status !== "done");
+    const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => {
+      const blockerStatus = nodesById.get(edge.blockerIssueId)?.status;
+      return blockerStatus ? !isBlockerAttentionTerminalStatus(blockerStatus) : false;
+    });
     if (topLevelEdges.length === 0) {
       attentionMap.set(root.id, createIssueBlockerAttention({
         state: "needs_attention",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through issue ownership, dependencies, and heartbeat-driven execution.
> - The issue service computes blocker attention so operators and agents know whether blocked work is covered, stalled, or needs intervention.
> - Cancelled issues are terminal outcomes, but blocker-attention graph traversal still treated cancelled children and explicit blockers as unresolved attention paths.
> - That made resolved/cancelled blocker trees keep surfacing as live blocker attention and could sample cancelled issues instead of the remaining actionable blocker.
> - This pull request makes blocker-attention traversal use the same terminal-status rule for `done` and `cancelled` nodes.
> - The benefit is that blocked issue diagnostics reflect live actionable blockers instead of stale terminal nodes.

## What Changed

- Added a blocker-attention terminal-status helper for `done` and `cancelled`.
- Excluded terminal statuses while constructing explicit blocker and child traversal edges.
- Excluded terminal statuses from wait-candidate, downstream, and top-level blocker counting.
- Added embedded Postgres regressions for cancelled child issues, cancelled explicit blockers, and mixed stalled/cancelled blocker graphs.
- Updated the liveness escalation expectation so the open escalation remains covered while the cancelled leaf no longer contributes to unresolved/covered counts.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-blocker-attention.test.ts` -> 21 tests passed.
- `pnpm --filter @paperclipai/server typecheck` -> exit 0.
- Red check before implementation: the new cancelled child/dependency regressions failed with cancelled blockers counted as unresolved attention paths.

## Risks

- Low risk, scoped to blocker-attention enrichment and tests.
- Behavioral shift: blocked issues with only cancelled blockers still show `needs_attention`, but their blocker counts and samples are now zero/null instead of pointing at terminal work.
- Existing dependency readiness remains unchanged; this does not make cancelled blockers auto-unblock dependents.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, tool-enabled local repository editing and command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
