### PR TITLE
feat: add useLightweightMode flag to agent runtime config

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -150,7 +150,7 @@ Invariant: every business record belongs to exactly one company.
 - `capabilities` text null
 - `adapter_type` text; built-ins include `process`, `http`, `claude_local`, `codex_local`, `gemini_local`, `opencode_local`, `pi_local`, `cursor`, and `openclaw_gateway`
 - `adapter_config` jsonb not null
-- `runtime_config` jsonb not null default `{}`; may include Paperclip runtime policy such as `modelProfiles.cheap.adapterConfig` for an optional low-cost model lane that does not change the primary adapter config
+- `runtime_config` jsonb not null default `{}`; may include Paperclip runtime policy such as `modelProfiles.cheap.adapterConfig` for an optional low-cost model lane that does not change the primary adapter config, and `useLightweightMode` boolean to enable automatic use of the cheap model profile for simple heartbeat checks
 - `default_environment_id` uuid fk `environments.id` null
 - `context_mode` enum: `thin | fat` default `thin`
 - `budget_monthly_cents` int not null default 0

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -22,6 +22,7 @@ export interface AgentModelProfileConfig {
 
 export interface AgentRuntimeConfig extends Record<string, unknown> {
   modelProfiles?: Partial<Record<ModelProfileKey, AgentModelProfileConfig>>;
+  useLightweightMode?: boolean;
 }
 
 export type AgentInstructionsBundleMode = "managed" | "external";

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -61,6 +61,7 @@ export const agentRuntimeConfigSchema = z.object({
   modelProfiles: z.object({
     cheap: agentModelProfileConfigSchema.optional(),
   }).strict().optional(),
+  useLightweightMode: z.boolean().optional(),
 }).catchall(z.unknown());
 
 export const createAgentSchema = z.object({

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -144,4 +144,81 @@ describe("heartbeat model profile application", () => {
 
     expect(contextSnapshot).toMatchObject({ modelProfile: "cheap" });
   });
+
+  it("applies cheap profile automatically when useLightweightMode is true", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [cheapProfile],
+      agentRuntimeConfig: {
+        useLightweightMode: true,
+      },
+      issueModelProfile: null,
+      contextSnapshot: {},
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "agent_runtime",
+      applied: "cheap",
+      configSource: "adapter_default",
+      fallbackReason: null,
+      adapterConfig: {
+        model: "adapter-cheap",
+        modelReasoningEffort: "low",
+      },
+    });
+  });
+
+  it("does not apply cheap profile when useLightweightMode is false", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [cheapProfile],
+      agentRuntimeConfig: {
+        useLightweightMode: false,
+      },
+      issueModelProfile: null,
+      contextSnapshot: {},
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: null,
+      requestedBy: null,
+      applied: null,
+      configSource: null,
+      fallbackReason: null,
+      adapterConfig: null,
+    });
+  });
+
+  it("prefers explicit issue profile over lightweight mode default", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [cheapProfile],
+      agentRuntimeConfig: {
+        useLightweightMode: true,
+      },
+      issueModelProfile: "cheap",
+      contextSnapshot: {},
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "issue_override",
+      applied: "cheap",
+    });
+  });
+
+  it("prefers context profile over lightweight mode default", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [cheapProfile],
+      agentRuntimeConfig: {
+        useLightweightMode: true,
+      },
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap" },
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "wake_context",
+      applied: "cheap",
+    });
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1161,12 +1161,21 @@ export function resolveModelProfileApplication(input: {
 }): ModelProfileApplication {
   const issueModelProfile = input.issueModelProfile ?? null;
   const contextModelProfile = readContextModelProfile(input.contextSnapshot);
-  const requested = issueModelProfile ?? contextModelProfile;
+  const runtimeConfig = parseObject(input.agentRuntimeConfig);
+  const useLightweightMode = asBoolean(runtimeConfig.useLightweightMode, false);
+
+  // Apply lightweight mode default if enabled and no explicit profile requested
+  const lightweightDefault: ModelProfileKey | null =
+    useLightweightMode && !issueModelProfile && !contextModelProfile ? "cheap" : null;
+
+  const requested = issueModelProfile ?? contextModelProfile ?? lightweightDefault;
   const requestedBy: ModelProfileRequestSource | null = issueModelProfile
     ? "issue_override"
     : contextModelProfile
       ? "wake_context"
-      : null;
+      : lightweightDefault
+        ? "agent_runtime"
+        : null;
 
   if (!requested) {
     return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents execute heartbeats to check status, process tasks, and maintain liveness
> - Many heartbeats are simple status checks that don't require full context or expensive models
> - Running all heartbeats with the primary model wastes tokens and increases latency
> - Paperclip supports "cheap" model profiles for cost-effective operation
> - Currently, agents must explicitly request the cheap profile via issue overrides or wake context
> - This pull request adds `useLightweightMode` to agent runtime config for automatic cheap profile usage
> - The benefit is reduced cost and latency for status-check heartbeats without manual per-wake configuration

## What Changed

- Added `useLightweightMode` optional boolean field to `AgentRuntimeConfig` TypeScript interface
- Updated `agentRuntimeConfigSchema` Zod validator to accept the new flag
- Modified `resolveModelProfileApplication` in heartbeat service to check `useLightweightMode` and automatically apply "cheap" profile when no explicit profile is requested
- Added comprehensive test coverage with 4 new test cases in `heartbeat-model-profile.test.ts`
- Documented the new flag in `doc/SPEC-implementation.md`

## Verification

Run the model profile tests to verify the new behavior:

```bash
pnpm test -- heartbeat-model-profile
```

Expected results:
- All existing tests continue to pass
- New tests verify useLightweightMode enables cheap profile automatically
- New tests verify explicit profiles take precedence over useLightweightMode
- New tests verify useLightweightMode=false maintains existing behavior

Manual verification:
1. Create an agent with `runtimeConfig.useLightweightMode: true`
2. Trigger a heartbeat without explicit model profile override
3. Check run metadata confirms cheap profile was applied

## Risks

Low risk:
- Feature is opt-in via explicit `useLightweightMode` flag (defaults to false)
- Existing behavior unchanged when flag is not set or set to false
- Explicit model profile overrides (issue or wake context) take precedence
- No database migration required (runtime_config is already JSONB)
- Test coverage validates priority order and edge cases

## Model Used

- Provider: Anthropic Claude
- Model ID: claude-sonnet-4-5-20250929
- Capabilities: Extended reasoning, tool use, code execution
- Context: Full Paperclip codebase context with skill-based workflows

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge