### PR TITLE
fix(server): redact cookie/session headers from log transports

### DIFF
--- a/server/src/__tests__/log-redaction-paths.test.ts
+++ b/server/src/__tests__/log-redaction-paths.test.ts
@@ -57,9 +57,19 @@ describe("HTTP_LOG_REDACT_PATHS (SOF-100)", () => {
       headers: {
         cookie: "session=another-secret",
         authorization: "Bearer another-token",
+        "set-cookie": "session=set-cookie-secret",
+        "proxy-authorization": "Basic proxy-secret",
+        "x-csrf-token": "bare-csrf-secret",
+        "x-xsrf-token": "bare-xsrf-secret",
+        "x-api-key": "bare-api-key-secret",
       },
     });
     expect(record.headers.cookie).toBe("[Redacted]");
     expect(record.headers.authorization).toBe("[Redacted]");
+    expect(record.headers["set-cookie"]).toBe("[Redacted]");
+    expect(record.headers["proxy-authorization"]).toBe("[Redacted]");
+    expect(record.headers["x-csrf-token"]).toBe("[Redacted]");
+    expect(record.headers["x-xsrf-token"]).toBe("[Redacted]");
+    expect(record.headers["x-api-key"]).toBe("[Redacted]");
   });
 });

--- a/server/src/__tests__/log-redaction-paths.test.ts
+++ b/server/src/__tests__/log-redaction-paths.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import pino from "pino";
+import { HTTP_LOG_REDACT_PATHS } from "../middleware/log-redaction-paths.js";
+
+/**
+ * Logs `value` through a pino instance configured with the production redact
+ * paths and returns both the parsed record and the raw serialized line, so we
+ * can assert structurally AND that no sensitive substring survives anywhere.
+ */
+function logWithRedaction(value: unknown): { record: any; raw: string } {
+  const lines: string[] = [];
+  const logger = pino(
+    { redact: [...HTTP_LOG_REDACT_PATHS] },
+    { write: (line: string) => lines.push(line) } as any,
+  );
+  logger.info(value as any);
+  const raw = lines.join("");
+  return { record: JSON.parse(raw), raw };
+}
+
+describe("HTTP_LOG_REDACT_PATHS (SOF-100)", () => {
+  it("redacts cookie, authorization, and CSRF headers on request logs", () => {
+    const { record } = logWithRedaction({
+      req: {
+        method: "GET",
+        url: "/api/test",
+        headers: {
+          authorization: "Bearer super-secret-token",
+          cookie: "paperclip_session=top-secret-session-value; other=1",
+          "x-csrf-token": "csrf-secret-value",
+          "x-xsrf-token": "xsrf-secret-value",
+          "x-api-key": "api-key-secret-value",
+          "user-agent": "vitest",
+        },
+      },
+    });
+
+    expect(record.req.headers.cookie).toBe("[Redacted]");
+    expect(record.req.headers.authorization).toBe("[Redacted]");
+    expect(record.req.headers["x-csrf-token"]).toBe("[Redacted]");
+    expect(record.req.headers["x-xsrf-token"]).toBe("[Redacted]");
+    expect(record.req.headers["x-api-key"]).toBe("[Redacted]");
+    // Non-sensitive headers are preserved for debuggability.
+    expect(record.req.headers["user-agent"]).toBe("vitest");
+  });
+
+  it("never serializes the raw cookie/session value anywhere in the line", () => {
+    const secret = "top-secret-session-value";
+    const { raw } = logWithRedaction({
+      req: { headers: { cookie: `paperclip_session=${secret}` } },
+    });
+    expect(raw).not.toContain(secret);
+  });
+
+  it("redacts sensitive headers even without the req envelope", () => {
+    const { record } = logWithRedaction({
+      headers: {
+        cookie: "session=another-secret",
+        authorization: "Bearer another-token",
+      },
+    });
+    expect(record.headers.cookie).toBe("[Redacted]");
+    expect(record.headers.authorization).toBe("[Redacted]");
+  });
+});

--- a/server/src/middleware/log-redaction-paths.ts
+++ b/server/src/middleware/log-redaction-paths.ts
@@ -1,0 +1,34 @@
+/**
+ * Header paths that must never be persisted to any log transport.
+ *
+ * pino applies `redact` in the main thread BEFORE the serialized value reaches
+ * stdout or the file transport, so a path listed here is censored on *all*
+ * targets (the file `server.log` included). Keep this list focused on
+ * credential- and session-bearing headers.
+ *
+ * Why each entry exists:
+ * - `authorization` / `proxy-authorization`: bearer tokens & basic-auth creds.
+ * - `cookie` / `set-cookie`: session identifiers — leaking these enables
+ *   session hijacking, which is the SOF-100 finding (cookies were written in
+ *   cleartext to `server.log` because only `authorization` was redacted).
+ * - `x-csrf-token` / `x-xsrf-token`: CSRF tokens paired with the session.
+ * - `x-api-key`: some clients pass API keys outside the Authorization header.
+ *
+ * The `headers.*` duplicates (without the `req.` prefix) are defensive: if a
+ * serializer ever emits headers without the `req` envelope, the sensitive
+ * values are still censored.
+ *
+ * See SOF-100.
+ */
+export const HTTP_LOG_REDACT_PATHS: string[] = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  'req.headers["set-cookie"]',
+  'req.headers["proxy-authorization"]',
+  'req.headers["x-csrf-token"]',
+  'req.headers["x-xsrf-token"]',
+  'req.headers["x-api-key"]',
+  "headers.authorization",
+  "headers.cookie",
+  'headers["set-cookie"]',
+];

--- a/server/src/middleware/log-redaction-paths.ts
+++ b/server/src/middleware/log-redaction-paths.ts
@@ -31,4 +31,8 @@ export const HTTP_LOG_REDACT_PATHS: string[] = [
   "headers.authorization",
   "headers.cookie",
   'headers["set-cookie"]',
+  'headers["proxy-authorization"]',
+  'headers["x-csrf-token"]',
+  'headers["x-xsrf-token"]',
+  'headers["x-api-key"]',
 ];

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -5,6 +5,7 @@ import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+import { HTTP_LOG_REDACT_PATHS } from "./log-redaction-paths.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -29,7 +30,7 @@ const sharedOpts = {
 
 export const logger = pino({
   level: "debug",
-  redact: ["req.headers.authorization"],
+  redact: [...HTTP_LOG_REDACT_PATHS],
 }, pino.transport({
   targets: [
     {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so server logs are part of the operator and agent trust boundary.
> - The server HTTP logger persists request metadata to stdout and `server.log` through pino transports.
> - The existing logger redacted `req.headers.authorization`, but still allowed session-bearing cookie and CSRF-style headers into persistent logs.
> - Persisted cookie/session headers can enable session hijacking for anyone with log access, so this needs a narrow security fix and a log-purge follow-up.
> - This pull request centralizes the HTTP redaction paths and applies them to all logger transports before serialization reaches stdout or the file target.
> - The branch also includes regression coverage for both normal `req.headers.*` request logs and defensive bare `headers.*` payloads.
> - The benefit is that future server traffic can be verified not to write these credential-bearing headers to `server.log`.

## What Changed

- Added `HTTP_LOG_REDACT_PATHS` for cookie, set-cookie, authorization, proxy-authorization, CSRF/XSRF, and API-key style headers.
- Wired the pino logger to use the shared redaction list for every transport.
- Added focused Vitest regression coverage for request-envelope and bare-header logging shapes.
- Added a follow-up correction so all documented bare `headers.*` sensitive paths are redacted, not only cookie/authorization/set-cookie.

## Verification

- `pnpm exec vitest run server/src/__tests__/log-redaction-paths.test.ts` failed before the bare-header correction with `expected 'Basic proxy-secret' to be '[Redacted]'`.
- `pnpm exec vitest run server/src/__tests__/log-redaction-paths.test.ts` passes: 1 file, 3 tests.
- `pnpm --filter @paperclipai/server typecheck` passes.

## Risks

- Low runtime risk: this only expands pino redaction paths and preserves non-sensitive headers for debuggability.
- Operational follow-up is still required: deploy the fixed build and purge historical `server.log` files that already contain leaked values.
- Rollback path: revert this PR if it causes unexpected logging issues; the safer forward-fix path is to add/remove specific redact paths in `HTTP_LOG_REDACT_PATHS`.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, tool use enabled. Exact hosted model ID and context-window size are not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details available in this runtime)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: no docs behavior or commands changed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
