### PR TITLE
feat(issues): server-side duplicate-issue guard on POST /companies/:companyId/issues

### DIFF
--- a/packages/db/src/migrations/0094_uneven_red_wolf.sql
+++ b/packages/db/src/migrations/0094_uneven_red_wolf.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "issues_company_created_by_agent_idx" ON "issues" USING btree ("company_id","created_by_agent_id","parent_id","created_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1780040470886,
       "tag": "0093_giant_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1780315840663,
+      "tag": "0094_uneven_red_wolf",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -86,6 +86,12 @@ export const issues = pgTable(
     projectWorkspaceIdx: index("issues_company_project_workspace_idx").on(table.companyId, table.projectWorkspaceId),
     executionWorkspaceIdx: index("issues_company_execution_workspace_idx").on(table.companyId, table.executionWorkspaceId),
     dueMonitorIdx: index("issues_company_monitor_due_idx").on(table.companyId, table.monitorNextCheckAt),
+    createdByAgentIdx: index("issues_company_created_by_agent_idx").on(
+      table.companyId,
+      table.createdByAgentId,
+      table.parentId,
+      table.createdAt,
+    ),
     identifierIdx: uniqueIndex("issues_identifier_idx").on(table.identifier),
     titleSearchIdx: index("issues_title_search_idx").using("gin", table.title.op("gin_trgm_ops")),
     identifierSearchIdx: index("issues_identifier_search_idx").using("gin", table.identifier.op("gin_trgm_ops")),

--- a/server/src/__tests__/issue-dedup-guard.test.ts
+++ b/server/src/__tests__/issue-dedup-guard.test.ts
@@ -1,0 +1,245 @@
+/**
+ * FOC-956: Tests for the server-side duplicate-issue guard on POST /api/companies/:companyId/issues.
+ */
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const AGENT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+  list: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+const mockQueueWakeup = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+vi.mock("../services/issue-assignment-wakeup.js", () => ({
+  queueIssueAssignmentWakeup: mockQueueWakeup,
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      canUser: vi.fn(async () => true),
+      decide: vi.fn(async (input: { action?: string }) => ({
+        allowed: true,
+        action: input.action,
+        reason: "allow_explicit_grant",
+        explanation: "Allowed by test grant.",
+      })),
+      hasPermission: vi.fn(async () => true),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => null),
+      resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+        ambiguous: false,
+        agent: { id: raw },
+      })),
+    }),
+    clampIssueListLimit: (value: number) => value,
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: COMPANY_ID, attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    ISSUE_LIST_MAX_LIMIT: 1000,
+    documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => ({
+      wakeup: vi.fn(async () => undefined),
+    }),
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+      })),
+      listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueRecoveryActionService: () => ({
+      getActiveForIssue: vi.fn(async () => null),
+      listActiveForIssues: vi.fn(async () => new Map()),
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => ({}),
+    logActivity: mockLogActivity,
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+function makeChainableQuery(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  const terminus = {
+    limit: vi.fn().mockReturnValue(
+      new Promise<unknown[]>((resolve) => resolve(rows)),
+    ),
+  };
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.where = vi.fn().mockReturnValue(terminus);
+  return chain;
+}
+
+function makeDb(candidateRows: unknown[] = []) {
+  return {
+    select: vi.fn().mockImplementation(() => makeChainableQuery(candidateRows)),
+  };
+}
+
+async function createApp(db: ReturnType<typeof makeDb>) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: AGENT_ID,
+      companyId: COMPANY_ID,
+      source: "agent_key",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(db as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const BASE_ISSUE_BODY = {
+  title: "Deploy the widget",
+  status: "todo",
+  priority: "medium",
+};
+
+const EXISTING_ISSUE = {
+  id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  identifier: "FOC-1",
+  title: "Deploy the widget",
+  createdAt: new Date(Date.now() - 5000), // 5 seconds ago
+};
+
+describe.sequential("issue dedup guard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockIssueService.create.mockReset();
+    mockLogActivity.mockReset();
+    mockQueueWakeup.mockReset();
+    registerModuleMocks();
+  });
+
+  it("returns 409 when the same agent creates a duplicate title under the same parent within the window", async () => {
+    const db = makeDb([EXISTING_ISSUE]);
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send(BASE_ISSUE_BODY);
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: "duplicate_issue",
+      existingIssueId: EXISTING_ISSUE.id,
+      existingIssueIdentifier: EXISTING_ISSUE.identifier,
+    });
+    expect(res.body.message).toMatch(/created \d+s ago/);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("passes through when no recent issues match the normalized title", async () => {
+    const CREATED_ISSUE = { id: "new-id", identifier: "FOC-2", title: "Deploy the widget", companyId: COMPANY_ID };
+    mockIssueService.create.mockResolvedValueOnce(CREATED_ISSUE);
+    const db = makeDb([]); // no candidates
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send(BASE_ISSUE_BODY);
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledOnce();
+  });
+
+  it("is case-insensitive and whitespace-tolerant when matching titles", async () => {
+    const db = makeDb([{ ...EXISTING_ISSUE, title: "  DEPLOY  THE  WIDGET  " }]);
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send({ ...BASE_ISSUE_BODY, title: "deploy the widget" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("duplicate_issue");
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("passes through when actor is a user (not an agent)", async () => {
+    const CREATED_ISSUE = { id: "new-id", identifier: "FOC-3", title: "Deploy the widget", companyId: COMPANY_ID };
+    mockIssueService.create.mockResolvedValueOnce(CREATED_ISSUE);
+    const db = makeDb([EXISTING_ISSUE]);
+
+    const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+      import("../routes/issues.js"),
+      import("../middleware/index.js"),
+    ]);
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      // User actor — agentId absent
+      (req as any).actor = {
+        type: "board",
+        userId: "user-1",
+        companyIds: [COMPANY_ID],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db as any, {} as any));
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post(`/api/companies/${COMPANY_ID}/issues`)
+      .send(BASE_ISSUE_BODY);
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { z } from "zod";
-import { and, desc, eq, inArray, notInArray } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -3629,6 +3629,46 @@ export function issueRoutes(
     await assertIssueEnvironmentSelection(companyId, req.body.executionWorkspaceSettings?.environmentId);
 
     const actor = getActorInfo(req);
+
+    // Duplicate-issue guard: reject same-agent same-parent same-title creates within the dedup window.
+    if (actor.agentId) {
+      const windowSeconds = Math.max(1, parseInt(process.env["PAPERCLIP_DEDUP_WINDOW_SECONDS"] ?? "30", 10) || 30);
+      const since = new Date(Date.now() - windowSeconds * 1000);
+      const normalizedIncoming = String(req.body.title ?? "").trim().replace(/\s+/g, " ").toLowerCase();
+      const parentId: string | null = req.body.parentId ?? null;
+
+      const candidates = await db
+        .select({ id: issueRows.id, identifier: issueRows.identifier, title: issueRows.title, createdAt: issueRows.createdAt })
+        .from(issueRows)
+        .where(
+          and(
+            eq(issueRows.companyId, companyId),
+            eq(issueRows.createdByAgentId, actor.agentId),
+            parentId ? eq(issueRows.parentId, parentId) : isNull(issueRows.parentId),
+            inArray(issueRows.status, ["backlog", "todo", "in_progress", "in_review", "blocked"]),
+            gte(issueRows.createdAt, since),
+          ),
+        )
+        .limit(20);
+
+      const match = candidates.find(
+        (c) => c.title.trim().replace(/\s+/g, " ").toLowerCase() === normalizedIncoming,
+      );
+      if (match) {
+        const ageSec = Math.round((Date.now() - match.createdAt.getTime()) / 1000);
+        logger.warn(
+          `[dedup-guard] Rejected duplicate issue creation: agent=${actor.agentId} title=${req.body.title} existingId=${match.id} window=${windowSeconds}s`,
+        );
+        res.status(409).json({
+          error: "duplicate_issue",
+          existingIssueId: match.id,
+          existingIssueIdentifier: match.identifier,
+          message: `An issue with this title under the same parent was created ${ageSec}s ago by the same agent`,
+        });
+        return;
+      }
+    }
+
     const executionPolicy = applyActorMonitorScheduledBy(
       normalizeIssueExecutionPolicy(req.body.executionPolicy),
       actor.actorType,


### PR DESCRIPTION
## Summary

Implements a server-side deduplication guard on the issue creation endpoint to prevent agent heartbeat storms from creating duplicate issues within a short time window.

- Normalizes title (lowercase, trim, collapse whitespace) and queries for recent issues created by the **same agent** under the **same parent** within a configurable window (default 30s, `PAPERCLIP_DEDUP_WINDOW_SECONDS` env var)
- Returns `409 Conflict` with `{ error: "duplicate_issue", existingIssueId, existingIssueIdentifier, message }` on match
- Guard is **agent-only** — user-created issues bypass it entirely
- Logs a WARN on rejection: `[dedup-guard] Rejected duplicate issue creation: agent=… title=… existingId=… window=Ns`

## Files changed

| File | Change |
|------|--------|
| `server/src/routes/issues.ts` | Dedup guard inserted before `svc.create()` |
| `packages/db/src/schema/issues.ts` | Added `issues_company_created_by_agent_idx` on `(company_id, created_by_agent_id, parent_id, created_at)` |
| `packages/db/src/migrations/0094_uneven_red_wolf.sql` | Drizzle-generated migration for the new index |
| `server/src/__tests__/issue-dedup-guard.test.ts` | 4 new tests covering 409 path, pass-through, case-insensitive title match, and user bypass |

## Test results

```
Test Files  1 passed (1)
     Tests  4 passed (4)
  Duration  1.33s
```

Full server typecheck: `Done` (no errors)

## Linked issue

Implements FOC-956 — server-side duplicate-issue guard spec from FOC-955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)