### PR TITLE
docs(codex-local): default fastMode=false guidance for Azure AI Foundry hires

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -70,7 +70,7 @@ Core fields:
 - modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...
 - promptTemplate (string, optional): run prompt template
 - search (boolean, optional): run codex with --search
-- fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and passed through for manual model IDs
+- fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and passed through for manual model IDs. **Set \`fastMode: false\` explicitly when the underlying Codex endpoint is Azure AI Foundry** (any \`*.openai.azure.com\` or \`*.cognitiveservices.azure.com\` base URL). Azure rejects the remote-compaction request that fast mode relies on (\`/openai/v1/responses/compact\` → 404 / \`Unknown parameter 'service_tier'\`), so leaving fast mode on can silently break long sessions once Codex hits its auto-compaction token threshold.
 - dangerouslyBypassApprovalsAndSandbox (boolean, optional): run with bypass flag
 - command (string, optional): defaults to "codex"
 - extraArgs (string[], optional): additional CLI args
@@ -90,5 +90,6 @@ Notes:
 - Unless explicitly overridden in adapter config, Paperclip runs Codex with a per-company managed CODEX_HOME under the active Paperclip instance and seeds auth/config from the shared Codex home (the CODEX_HOME env var, when set, or ~/.codex).
 - Some model/tool combinations reject certain effort levels (for example minimal with web search enabled).
 - Fast mode is supported on GPT-5.4 and manual model IDs. When enabled for those models, Paperclip applies \`service_tier="fast"\` and \`features.fast_mode=true\`.
+- Azure AI Foundry caveat: when the Codex endpoint is Azure (\`*.openai.azure.com\` or \`*.cognitiveservices.azure.com\`), hire agents with \`fastMode: false\` in \`adapterConfig\`. Azure does not support remote response compaction, so any session that crosses the auto-compaction token threshold can fail silently. This applies even when no \`model\` is pinned — declaring the intent in config protects you against later model swaps.
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
 `;

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -88,6 +88,10 @@ curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
 - instruction text such as `AGENTS.md` built from step 4; for local managed-bundle adapters, send this as top-level `instructionsBundle.files["AGENTS.md"]`. Do not set `adapterConfig.promptTemplate` or `bootstrapPromptTemplate` for new agents.
 - source issue linkage (`sourceIssueId` or `sourceIssueIds`) when this hire came from an issue
 
+#### Adapter-specific pitfalls
+
+- **`codex_local` on Azure AI Foundry** — when the Codex endpoint resolves to `*.openai.azure.com` or `*.cognitiveservices.azure.com` (check the active Codex home config), set `"fastMode": false` explicitly in `adapterConfig` for every new hire, even if no `model` is pinned. Azure does not support the remote response-compaction call (`/openai/v1/responses/compact` → 404 / `Unknown parameter 'service_tier'`) that fast mode relies on, so sessions silently break the first time Codex auto-compacts past its token threshold. Declaring `fastMode: false` at hire time documents the intent and survives later model swaps. See `/llms/agent-configuration/codex_local.txt` for the canonical adapter caveat.
+
 ### 7. Review the draft against the quality checklist
 
 Before submitting, walk the draft-review checklist end-to-end and fix any item that does not pass:

--- a/skills/paperclip-create-agent/references/draft-review-checklist.md
+++ b/skills/paperclip-create-agent/references/draft-review-checklist.md
@@ -58,6 +58,7 @@ Use it for every path: exact template, adjacent template, or generic fallback.
 - [ ] `desiredSkills` lists only skills that already exist in the company library, or will be installed first via the company-skills workflow
 - [ ] Adapter config matches this Paperclip instance (cwd, model, credentials) per `/llms/agent-configuration/<adapter>.txt`
 - [ ] Local managed-bundle adapters send custom instructions through top-level `instructionsBundle.files["AGENTS.md"]` and do not set `adapterConfig.promptTemplate` or `bootstrapPromptTemplate`
+- [ ] For `codex_local` hires backed by Azure AI Foundry (`*.openai.azure.com` / `*.cognitiveservices.azure.com`), `adapterConfig.fastMode` is set to `false` explicitly — even if no `model` is pinned (Azure does not support remote response compaction; leaving the default in place silently breaks long sessions)
 - [ ] Placeholders like `{{companyName}}`, `{{managerTitle}}`, `{{issuePrefix}}`, and any URL stubs are replaced with real values
 
 ## H. Safety and permissions (least privilege)


### PR DESCRIPTION
## Summary

Document the Azure AI Foundry fast-mode caveat for `codex_local` hires in three places:

- `packages/adapters/codex-local/src/index.ts` — extend the `fastMode` field description in `agentConfigurationDoc` (served by `/llms/agent-configuration/codex_local.txt`) and add a Notes entry covering the Azure caveat.
- `skills/paperclip-create-agent/SKILL.md` — add an "Adapter-specific pitfalls" subsection in step 6 (draft the hire config) calling out the rule.
- `skills/paperclip-create-agent/references/draft-review-checklist.md` — add a pre-submit checklist item under §G (Governance fields).

## Why

Azure's OpenAI-compatible endpoints (`*.openai.azure.com`, `*.cognitiveservices.azure.com`) do not implement the remote response-compaction call (`/openai/v1/responses/compact` → `404` / `Unknown parameter 'service_tier'`) that Codex fast mode relies on. When fast mode is left at its default, long sessions silently die the first time Codex auto-compacts past its model-side token threshold.

Doveaia traced 22+ silent runs on a `codex_local` fleet against Azure AI Foundry to exactly this failure mode (internal refs `DOV-583` / `DOV-792`). The runtime fixes were already in place on the fleet (a 404-declassification patch + a bounded fresh-session recovery patch), but every new hire kept regressing because the hiring guidance never called out the rule — so the fleet had to be patched by hand each time. This PR closes that gap upstream so the next `npx paperclipai update` propagates the fix into every operator's cache.

## Scope

Documentation-only. The runtime behaviour of fast mode is unchanged.

## Possible follow-up

A natural extension would be an API-level warning when a `codex_local` agent is hired without an explicit `fastMode` and the active Codex endpoint resolves to an Azure host. Happy to add that here or as a separate PR — flagging it now so reviewers can decide.

## Test plan

- [ ] Render `agentConfigurationDoc` via `/llms/agent-configuration/codex_local.txt` against a build of this branch and confirm the Azure caveat appears in both the `fastMode` line and the Notes section.
- [ ] Skim `skills/paperclip-create-agent/SKILL.md` and `references/draft-review-checklist.md` to confirm the new content reads cleanly inside its surrounding context.
- [ ] No code paths changed → existing test suite should be green.