### PR TITLE
fix(server): resolve skills catalog package manifest

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':
@@ -669,6 +671,9 @@ importers:
       '@paperclipai/shared':
         specifier: workspace:*
         version: link:../packages/shared
+      '@paperclipai/skills-catalog':
+        specifier: workspace:*
+        version: link:../packages/skills-catalog
       ajv:
         specifier: ^8.18.0
         version: 8.18.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,8 +622,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/skills-catalog: {}
-
   server:
     dependencies:
       '@aws-sdk/client-s3':
@@ -671,9 +669,6 @@ importers:
       '@paperclipai/shared':
         specifier: workspace:*
         version: link:../packages/shared
-      '@paperclipai/skills-catalog':
-        specifier: workspace:*
-        version: link:../packages/skills-catalog
       ajv:
         specifier: ^8.18.0
         version: 8.18.0

--- a/server/package.json
+++ b/server/package.json
@@ -57,6 +57,7 @@
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/skills-catalog": "workspace:*",
     "@paperclipai/shared": "workspace:*",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",

--- a/server/src/__tests__/skills-catalog-service.test.ts
+++ b/server/src/__tests__/skills-catalog-service.test.ts
@@ -5,6 +5,17 @@ const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockStatSync = vi.hoisted(() => vi.fn());
 const mockReadFile = vi.hoisted(() => vi.fn());
+const mockResolveCatalogJson = vi.hoisted(() => vi.fn());
+
+vi.doMock("node:module", async () => {
+  const actual = await vi.importActual<typeof import("node:module")>("node:module");
+  return {
+    ...actual,
+    createRequire: () => ({
+      resolve: mockResolveCatalogJson,
+    }),
+  };
+});
 
 vi.doMock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
@@ -61,6 +72,9 @@ describe("skills catalog service", () => {
     vi.clearAllMocks();
     manifestJson = manifest([catalogSkill("old-skill", "Old Skill")]);
     manifestMtimeMs = 1;
+    mockResolveCatalogJson.mockImplementation(() => {
+      throw new Error("package is not installed");
+    });
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockImplementation(() => manifestJson);
     mockStatSync.mockImplementation(() => ({
@@ -92,6 +106,24 @@ describe("skills catalog service", () => {
     expect(service.getCatalogPackageMetadata()).toEqual({
       packageName: "@paperclipai/skills-catalog",
       packageVersion: "0.3.2",
+    });
+  });
+
+  it("resolves the published skills catalog package manifest and skill files", async () => {
+    const publishedManifestPath =
+      "/install/node_modules/@paperclipai/skills-catalog/dist/generated/catalog.json";
+    mockResolveCatalogJson.mockReturnValue(publishedManifestPath);
+    const service = await import("../services/skills-catalog.js");
+
+    expect(service.listCatalogSkills().map((skill) => skill.key)).toEqual([
+      "paperclipai/bundled/software-development/old-skill",
+    ]);
+    expect(mockExistsSync).toHaveBeenCalledWith(publishedManifestPath);
+    expect(mockReadFileSync).toHaveBeenCalledWith(publishedManifestPath, "utf8");
+
+    await expect(service.readCatalogSkillFile("old-skill", "SKILL.md")).resolves.toMatchObject({
+      content:
+        "content:/install/node_modules/@paperclipai/skills-catalog/catalog/bundled/software-development/old-skill/SKILL.md",
     });
   });
 

--- a/server/src/services/skills-catalog.ts
+++ b/server/src/services/skills-catalog.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
@@ -18,32 +19,69 @@ interface CatalogManifestFile {
 
 const serviceDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(serviceDir, "../../..");
-const catalogPackageRoot = path.join(repoRoot, "packages/skills-catalog");
-const catalogManifestPath = path.join(catalogPackageRoot, "generated/catalog.json");
+const workspaceCatalogPackageRoot = path.join(repoRoot, "packages/skills-catalog");
+const workspaceCatalogManifestPath = path.join(workspaceCatalogPackageRoot, "generated/catalog.json");
+const require = createRequire(import.meta.url);
 let cachedCatalogManifest: {
   manifest: CatalogManifestFile;
+  path: string;
   mtimeMs: number;
   size: number;
 } | null = null;
 
+function resolvePublishedCatalogManifestPath() {
+  try {
+    return require.resolve("@paperclipai/skills-catalog/catalog.json");
+  } catch {
+    // Older published package layouts may ship generated/catalog.json without exposing
+    // it directly. Resolve the package entrypoint, then derive the package root.
+  }
+
+  try {
+    const packageEntrypoint = require.resolve("@paperclipai/skills-catalog");
+    const packageRootOrDist = path.resolve(path.dirname(packageEntrypoint), "../..");
+    const packageRoot = path.basename(packageRootOrDist) === "dist" ? path.dirname(packageRootOrDist) : packageRootOrDist;
+    return path.join(packageRoot, "generated/catalog.json");
+  } catch {
+    return null;
+  }
+}
+
+function resolveCatalogManifestPath() {
+  return resolvePublishedCatalogManifestPath() ?? workspaceCatalogManifestPath;
+}
+
+function resolveCatalogPackageRoot() {
+  const manifestPath = resolveCatalogManifestPath();
+  const manifestDir = path.dirname(manifestPath);
+  const packageRootOrDist = path.dirname(manifestDir);
+  if (path.basename(packageRootOrDist) === "dist") {
+    return path.dirname(packageRootOrDist);
+  }
+  return packageRootOrDist;
+}
+
+function missingCatalogManifestMessage(manifestPath: string) {
+  return `Skills catalog manifest not found at ${manifestPath}. Install @paperclipai/skills-catalog or run pnpm --filter @paperclipai/skills-catalog build:manifest.`;
+}
+
 function loadCatalogManifest(): CatalogManifestFile {
+  const catalogManifestPath = resolveCatalogManifestPath();
   if (!existsSync(catalogManifestPath)) {
-    throw new Error(
-      `Skills catalog manifest not found at ${catalogManifestPath}. Run pnpm --filter @paperclipai/skills-catalog build:manifest.`,
-    );
+    throw new Error(missingCatalogManifestMessage(catalogManifestPath));
   }
   return JSON.parse(readFileSync(catalogManifestPath, "utf8")) as CatalogManifestFile;
 }
 
 function getCatalogManifest() {
+  const catalogManifestPath = resolveCatalogManifestPath();
   if (!existsSync(catalogManifestPath)) {
-    throw new Error(
-      `Skills catalog manifest not found at ${catalogManifestPath}. Run pnpm --filter @paperclipai/skills-catalog build:manifest.`,
-    );
+    throw new Error(missingCatalogManifestMessage(catalogManifestPath));
   }
   const stats = statSync(catalogManifestPath);
   if (
     cachedCatalogManifest &&
+    cachedCatalogManifest.path === catalogManifestPath &&
     cachedCatalogManifest.mtimeMs === stats.mtimeMs &&
     cachedCatalogManifest.size === stats.size
   ) {
@@ -53,6 +91,7 @@ function getCatalogManifest() {
   const manifest = loadCatalogManifest();
   cachedCatalogManifest = {
     manifest,
+    path: catalogManifestPath,
     mtimeMs: stats.mtimeMs,
     size: stats.size,
   };
@@ -87,10 +126,6 @@ function inferLanguageFromPath(filePath: string) {
   if (fileName.endsWith(".html")) return "html";
   if (fileName.endsWith(".css")) return "css";
   return null;
-}
-
-function resolveCatalogPackageRoot() {
-  return catalogPackageRoot;
 }
 
 function searchText(skill: CatalogSkill) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The Skills Manager lets agents discover and use reusable skills through the bundled skills catalog.
> - The server-side catalog endpoint reads the generated catalog manifest and skill files from the skills catalog package.
> - Issue #7281 reports that published installs return a 500 because the server resolves the manifest through the monorepo-only `packages/skills-catalog` path.
> - Published installs should resolve `@paperclipai/skills-catalog` through normal Node package resolution while preserving the existing workspace fallback for local development.
> - This pull request adds that package dependency to the server and resolves the catalog manifest from the installed package first.
> - The benefit is that the Skills Catalog endpoint can work in published installs without changing local monorepo behavior.

## What Changed

- Added `@paperclipai/skills-catalog` as a runtime dependency of `@paperclipai/server`.
- Updated the skills catalog service to resolve the manifest from the installed package before falling back to the monorepo workspace path.
- Handles both exported `@paperclipai/skills-catalog/catalog.json` and entrypoint-derived `generated/catalog.json` package layouts.
- Added a focused regression test for published-package manifest and skill-file path resolution.

Refs #7281.

## Verification

- [x] `git diff --check`
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/skills-catalog-service.test.ts`
- [x] `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk. The change prefers normal package resolution for published installs and keeps the existing monorepo fallback for local development.
- Main compatibility risk is package-layout variance across published versions; the implementation covers both direct `catalog.json` export and entrypoint-derived `generated/catalog.json` fallback.
- No UI change; no screenshots are included.

## Model Used

- OpenAI Codex, model `gpt-5.5`, with tool use for public repository inspection, duplicate checks, code editing, GitHub operations, and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
