### PR TITLE
Add TTL/auto-expiry fallback to clearExecutionRunIfTerminal()

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3316,7 +3316,7 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     await tempDb?.cleanup();
   });
 
-  async function seedIssueWithRun(status: string | null) {
+  async function seedIssueWithRun(status: string | null, opts: { lockedAt?: Date } = {}) {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const issueId = randomUUID();
@@ -3357,10 +3357,10 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       assigneeAgentId: agentId,
       executionRunId: runId,
       executionAgentNameKey: runId ? "codexcoder" : null,
-      executionLockedAt: runId ? new Date() : null,
+      executionLockedAt: runId ? (opts.lockedAt ?? new Date()) : null,
     });
 
-    return { issueId, runId };
+    return { issueId, runId, companyId, agentId };
   }
 
   it("clears execution locks owned by terminal runs", async () => {
@@ -3414,6 +3414,60 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0]);
     expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
+  });
+
+  it("clears expired locks held by non-terminal runs (TTL > 30 min)", async () => {
+    const expiredAt = new Date(Date.now() - 31 * 60 * 1000);
+    const { issueId } = await seedIssueWithRun("running", { lockedAt: expiredAt });
+
+    await expect(svc.clearExecutionRunIfTerminal(issueId)).resolves.toBe(true);
+
+    const row = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+  });
+
+  it("clears execution locks when the run row is missing", async () => {
+    // Seed an issue with a real run, then bypass the FK to point it at a non-existent run.
+    // The FK is onDelete: "set null", so direct delete would null the column; we use
+    // session_replication_role to produce the orphaned-reference state instead.
+    const { issueId } = await seedIssueWithRun("running");
+    const orphanRunId = randomUUID();
+
+    await db.execute(sql`set session_replication_role = 'replica'`);
+    await db
+      .update(issues)
+      .set({ executionRunId: orphanRunId })
+      .where(eq(issues.id, issueId));
+    await db.execute(sql`set session_replication_role = 'origin'`);
+
+    await expect(svc.clearExecutionRunIfTerminal(issueId)).resolves.toBe(true);
+
+    const row = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
   });
 });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3691,7 +3691,7 @@ export function issueService(db: Db) {
         sql`select ${issues.id} from ${issues} where ${issues.id} = ${issueId} for update`,
       );
       const issue = await tx
-        .select({ executionRunId: issues.executionRunId })
+        .select({ executionRunId: issues.executionRunId, executionLockedAt: issues.executionLockedAt })
         .from(issues)
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
@@ -3705,7 +3705,12 @@ export function issueService(db: Db) {
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.executionRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) {
+        const TTL_MS = 30 * 60 * 1000; // 30 minutes
+        const lockAge = Date.now() - issue.executionLockedAt!.getTime();
+        if (lockAge < TTL_MS) return false; // active lock within TTL — do not expire
+        // lock is expired — fall through to the clear below
+      }
 
       const updated = await tx
         .update(issues)


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue execution is coordinated through `executionRunId` / `executionLockedAt` lock fields on issue rows
> - When an agent heartbeat run crashes (OOM, SIGKILL, process loss) without updating its `heartbeat_runs.status`, the lock stays non-terminal and wedges the issue permanently
> - `clearExecutionRunIfTerminal()` only releases the lock when the run status is terminal — there is no time-based fallback
> - `executionLockedAt` is already written at every checkout but was never compared against a TTL
> - This PR adds a 30-minute TTL guard: if the owning run is non-terminal and the lock is ≥ 30 minutes old, treat it as an abandoned run and clear the lock on the next checkout
> - The benefit is that a crashed agent no longer wedges an issue permanently; the lock self-heals on the next checkout attempt

## What Changed

- `server/src/services/issues.ts` — `clearExecutionRunIfTerminal()`:
  - Added `executionLockedAt` to the SELECT that fetches the issue's current lock state
  - Replaced unconditional `return false` for non-terminal runs with a TTL guard (30 min): locks within TTL are left in place; expired locks fall through to the existing clear logic

- `server/src/__tests__/issues-service.test.ts`:
  - Extended `seedIssueWithRun` helper to accept an optional `lockedAt` date
  - Added test: expired lock (non-terminal run, lock age > 30 min) → clears
  - Added test: missing run row (executionRunId set but run doesn't exist) → clears

## Verification

```bash
# Run the targeted test suite
cd server
pnpm exec vitest run src/__tests__/issues-service.test.ts -t "clearExecutionRunIfTerminal"
# All 5 tests pass:
# ✓ clears execution locks owned by terminal runs
# ✓ does not clear execution locks owned by live runs
# ✓ does not update issues without an execution lock
# ✓ clears expired locks held by non-terminal runs (TTL > 30 min)
# ✓ clears execution locks when the run row is missing
```

TypeScript: no new errors in the modified files (pre-existing `plugin-sdk` resolution errors are unrelated).

## Risks

- **TTL value (30 min)**: Chosen to be safely above the longest expected legitimate heartbeat run. If very long-running agents exist, this may need tuning. The constant is clearly named `TTL_MS` and easy to adjust.
- **Low risk to existing behavior**: The only behavioral change is for the previously-uncovered case of a non-terminal run with a lock older than 30 minutes. All other paths (terminal run, missing run, fresh lock, no lock) are unchanged.
- No schema migration needed — `execution_locked_at` already exists.

## Model Used

- Claude Sonnet 4.6 (`claude-sonnet-4-6`) with tool use, operating as agent Ada via the Paperclip claude_local adapter. Issue: OY-19.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above