### PR TITLE
fix(daytona): update @daytonaio/sdk pin from ^0.171.0 to ^0.183.0

### DIFF
--- a/packages/plugins/sandbox-providers/daytona/package.json
+++ b/packages/plugins/sandbox-providers/daytona/package.json
@@ -51,7 +51,7 @@
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
   },
   "dependencies": {
-    "@daytonaio/sdk": "^0.171.0"
+    "@daytonaio/sdk": "^0.183.0"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/packages/plugins/sandbox-providers/daytona/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/daytona/src/plugin.test.ts
@@ -468,6 +468,20 @@ describe("Daytona sandbox provider plugin", () => {
     expect(sandbox.process.executeCommand).not.toHaveBeenCalled();
   });
 
+  it("reports the minimum @daytonaio/sdk version boundary (GH#7317)", async () => {
+    // The SDK was bumped from ^0.171.0 (semver 0.x, meaning >=0.171.0 <0.172.0)
+    // to ^0.183.0 to access the fixes shipped in 0.172.0–0.183.x.
+    // This test pins the intent so a future accidental downgrade surfaces
+    // as a CI failure here rather than a silent runtime regression.
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies["@daytonaio/sdk"]).toBe("^0.183.0");
+  });
+
   it("returns a timed out execute result when the Daytona SDK times out", async () => {
     process.env.DAYTONA_API_KEY = "host-key";
     const sandbox = createMockSandbox();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source platform for managing AI agents — the Daytona plugin provides sandbox environments for executing agent heartbeats
> - The plugin pins `@daytonaio/sdk` at `^0.171.0`; in npm semver, `^0.x.y` allows only `0.x.*` patch updates, so `^0.171.0` resolves to `>=0.171.0 <0.172.0` — it can never resolve 0.172.0 or later
> - The SDK has since released 0.183.0 with critical fixes and improvements that the plugin cannot receive under the current pin
> - The fix is to bump the pin to `^0.183.0`, which allows 0.183.x patch releases while still following the caret rule
> - Before bumping, all API surfaces used by this plugin were diffed between 0.171.0 and 0.183.0: `Daytona.create()`, `.get()`, `sandbox.process.executeCommand()`, `sandbox.fs.*`, `sandbox.getWorkDir()`, `getUserHomeDir()`, `sandbox.start()`, `stop()`, `delete()`, `recover()`, `DaytonaNotFoundError`, `DaytonaTimeoutError`, `DaytonaConfig`, `Resources` — all unchanged
> - The only breaking change in 0.183.0 is `Daytona.list()` (new signature, `PaginatedSandboxes` removed) — this plugin does not call `list()`, so the bump is safe

## Linked Issues or Issue Description

Fixes #7317

## What Changed

- `packages/plugins/sandbox-providers/daytona/package.json`: updated `@daytonaio/sdk` version from `^0.171.0` to `^0.183.0`

## Verification

- Extracted and diffed both SDK versions from npm; all plugin-used APIs are present and signature-compatible in 0.183.0
- The sandbox-providers plugins are excluded from the root pnpm workspace (`standalone installable`) so no lockfile update is needed
- 0.183.0 ships proper dual ESM/CJS exports compatible with the plugin's `"type": "module"` setup

## Risks

Low: the only breaking change in 0.183.0 (`Daytona.list()`) is not called by this plugin. All other API surfaces are verified stable.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge