### PR TITLE
fix(productivity-review): orphan reaper + Manager Decision moved to top (GH#7266, GH#7267)

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -537,6 +537,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(activities[0]?.entityId).toBe(seeded.issueId);
   });
 
+  it("reaps orphaned productivity reviews (null assigneeAgentId, stuck in_review) on next reconcile", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+
+    // Insert a stuck orphaned review: originKind=productivity_review, status=in_review, assigneeAgentId=null
+    const orphanId = randomUUID();
+    await db.insert(issues).values({
+      id: orphanId,
+      companyId: seeded.companyId,
+      title: "Orphaned productivity review (no assignee)",
+      status: "in_review",
+      priority: "high",
+      originKind: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+      originId: seeded.issueId,
+      originFingerprint: `productivity-review:${seeded.issueId}`,
+      parentId: seeded.issueId,
+      issueNumber: 99,
+      identifier: `${seeded.issuePrefix}-99`,
+      assigneeAgentId: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.reaped).toBe(1);
+
+    const [orphan] = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, orphanId));
+    expect(orphan?.status).toBe("done");
+  });
+
   it("clamps poisoned requestDepth metadata instead of aborting productivity reconciliation", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -573,6 +573,12 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return [
       "Paperclip detected an unusual productivity/progression pattern on an assigned issue.",
       "",
+      "## Manager Decision",
+      "",
+      "- Close as productive if this pattern is expected.",
+      "- Continue with a snooze window if the current work should keep running without repeat review spam.",
+      "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
+      "",
       "## Source",
       "",
       `- Source issue: ${issueUiLink(evidence.sourceIssue, prefix)}`,
@@ -611,12 +617,6 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       "## Usage Samples",
       "",
       usage,
-      "",
-      "## Manager Decision",
-      "",
-      "- Close as productive if this pattern is expected.",
-      "- Continue with a snooze window if the current work should keep running without repeat review spam.",
-      "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
     ].join("\n");
   }
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -679,6 +679,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     }
 
     const ownerAgentId = await resolveReviewOwnerAgentId(evidence.sourceIssue, evidence.sourceAgent);
+    if (!ownerAgentId) {
+      // No invokable reviewer found — skip creation rather than creating an orphaned
+      // review with null assignee that would be stuck in_review forever.
+      return { kind: "no_owner" as const, reviewIssueId: null };
+    }
     let review: Awaited<ReturnType<typeof issuesSvc.create>>;
     try {
       review = await issuesSvc.create(evidence.sourceIssue.companyId, {
@@ -781,6 +786,21 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .orderBy(asc(issues.updatedAt), asc(issues.id))
       .limit(MAX_CANDIDATE_ISSUES);
 
+    // Reap existing orphaned reviews (null assignee, stuck in_review) to prevent permanent noise.
+    const orphanedReviews = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          isNull(issues.assigneeAgentId),
+          eq(issues.status, "in_review"),
+          eq(issues.originKind, PRODUCTIVITY_REVIEW_ORIGIN_KIND),
+        ),
+      );
+    for (const orphan of orphanedReviews) {
+      await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, orphan.id));
+    }
+
     const result = {
       scanned: candidates.length,
       created: 0,
@@ -788,8 +808,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       existing: 0,
       snoozed: 0,
       creationCapped: 0,
+      noOwner: 0,
       skipped: 0,
       failed: 0,
+      reaped: orphanedReviews.length,
       reviewIssueIds: [] as string[],
       failedIssueIds: [] as string[],
     };
@@ -828,6 +850,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         if (outcome.kind === "created") result.created += 1;
         else if (outcome.kind === "updated") result.updated += 1;
         else if (outcome.kind === "creation_capped") result.creationCapped += 1;
+        else if (outcome.kind === "no_owner") result.noOwner += 1;
         else result.existing += 1;
         if (outcome.reviewIssueId) result.reviewIssueIds.push(outcome.reviewIssueId);
       } catch (err) {


### PR DESCRIPTION
## GH#7267 — Orphaned reviews stuck forever

When `resolveReviewOwnerAgentId` returns `null`, `createOrUpdateReview` was still creating a `productivity_review` issue with `assigneeAgentId: null`, leaving it permanently in `in_review` with nobody to act on it.

Fix:
- Guard `createOrUpdateReview`: when `resolveReviewOwnerAgentId` returns null, return `{ kind: "no_owner" }` and skip creation
- Add a reaper at the start of `reconcileProductivityReviews` that closes existing stuck orphaned reviews (kind=`productivity_review`, status=`in_review`, `assigneeAgentId IS NULL`) before scanning new candidates
- Track `no_owner` and `reaped` counts in reconcile result

## GH#7266 — Manager Decision inert at bottom

The Manager Decision block was at the bottom of the review description, below all evidence data. Reviewers had to scroll past everything to reach the actionable section.

Fix: move Manager Decision immediately after the intro paragraph so the required action is visible at first glance.

## Thinking Path

> - Paperclip runs `reconcileProductivityReviews` on a schedule to create peer review issues for underperforming agents
> - `resolveReviewOwnerAgentId` looks up who should own the review (the agent's manager or reviewer)
> - When an agent has no manager, this returns `null`, but `createOrUpdateReview` was not guarding against null — it created the issue with `assigneeAgentId: null`
> - An issue in `in_review` with no assignee is permanently stuck: no agent will claim it, no heartbeat will advance it, and it blocks future review cycles for the same agent
> - The fix requires two parts: (1) skip creation when `resolveReviewOwnerAgentId` returns null, and (2) reap existing orphans that accumulated before this fix
> - The reaper runs at the start of each reconcile so the cleanup is eventually consistent — no one-time migration needed
> - GH#7266 is independent: the Manager Decision block is the only actionable section in the review description, but it was rendered last after all evidence tables — a UX issue causing reviewers to miss the required action

## What Changed

- `server/src/services/productivity-review.ts`:
  - `createOrUpdateReview`: added early return `{ kind: "no_owner" }` when `resolveReviewOwnerAgentId` returns null; review issue is not created
  - `reconcileProductivityReviews`: added reaper query at the start that finds all existing `productivity_review` issues with `status=in_review` and `assigneeAgentId IS NULL`, closes them as `done`, and increments a `reaped` counter
  - Reconcile result type extended with `no_owner: number` and `reaped: number` fields
  - Manager Decision template block moved from end of review description to immediately after the intro paragraph

## Verification

- `pnpm --filter @paperclipai/server typecheck` passes
- Create a productivity review cycle for an agent whose manager is null → `no_owner` count incremented, no review issue created
- Pre-existing orphaned review issues are closed as `done` on the next reconcile run
- Manager Decision appears at the top of the rendered review description

## Risks

Low risk for the orphan guard — purely additive null check. The reaper introduces a DB write on each reconcile cycle, but only for orphaned reviews (`assigneeAgentId IS NULL`). In normal operation after this fix no such reviews will exist, so the reaper runs cheaply. The Manager Decision move is a pure string/template reorder with no semantic change.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) — extended reasoning mode, tool use enabled, 200k context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #7267, #7266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)