### PR TITLE
fix(portability): strip YAML single-quote delimiters in imported agent names (GH#7268)

### DIFF
--- a/server/src/__tests__/yaml-scalar-parsing.test.ts
+++ b/server/src/__tests__/yaml-scalar-parsing.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseYamlSingleQuotedScalar } from "../services/company-portability.js";
+
+describe("parseYamlSingleQuotedScalar", () => {
+  it("strips surrounding single quotes", () => {
+    expect(parseYamlSingleQuotedScalar("'CEO / Editor'")).toBe("CEO / Editor");
+  });
+
+  it("unescapes doubled single quotes per YAML spec", () => {
+    expect(parseYamlSingleQuotedScalar("'it''s alive'")).toBe("it's alive");
+  });
+
+  it("handles value with no special chars", () => {
+    expect(parseYamlSingleQuotedScalar("'hello'")).toBe("hello");
+  });
+
+  it("handles empty quoted string", () => {
+    expect(parseYamlSingleQuotedScalar("''")).toBe("");
+  });
+
+  it("returns short strings unchanged", () => {
+    expect(parseYamlSingleQuotedScalar("'")).toBe("'");
+  });
+});

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2159,6 +2159,14 @@ async function withSkillSourceMetadata(skill: CompanySkill, markdown: string) {
 }
 
 
+function parseYamlSingleQuotedScalar(value: string): string {
+  // YAML single-quoted scalars: '' inside is escaped by doubling.
+  // e.g. 'CEO / Editor' -> CEO / Editor, 'it''s' -> it's
+  if (value.length < 2) return value;
+  const inner = value.slice(1, -1);
+  return inner.replace(/''/g, "'");
+}
+
 function parseYamlScalar(rawValue: string): unknown {
   const trimmed = rawValue.trim();
   if (trimmed === "") return "";
@@ -2168,6 +2176,9 @@ function parseYamlScalar(rawValue: string): unknown {
   if (trimmed === "[]") return [];
   if (trimmed === "{}") return {};
   if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return parseYamlSingleQuotedScalar(trimmed);
+  }
   if (
     trimmed.startsWith("\"") ||
     trimmed.startsWith("[") ||

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2159,7 +2159,7 @@ async function withSkillSourceMetadata(skill: CompanySkill, markdown: string) {
 }
 
 
-function parseYamlSingleQuotedScalar(value: string): string {
+export function parseYamlSingleQuotedScalar(value: string): string {
   // YAML single-quoted scalars: '' inside is escaped by doubling.
   // e.g. 'CEO / Editor' -> CEO / Editor, 'it''s' -> it's
   if (value.length < 2) return value;


### PR DESCRIPTION
## Problem

`parseYamlScalar` handled double-quoted strings via `JSON.parse` but did not handle YAML single-quoted scalars. Values like `name: 'CEO / Editor'` fell through to `return trimmed`, producing the string `'CEO / Editor'` (with surrounding quote characters). This rendered in the UI as `'CEO / Editor'` — literal single quotes that should not be visible.

Affects every community bundle that uses single-quoting for agent names/titles containing `/`, `&`, or other YAML-special characters. Reported for `newsletter-press`, `niche-site-empire`, `agency-engine`, and others.

## Fix

- Add `parseYamlSingleQuotedScalar(value)` helper: strips the surrounding `'` delimiters and unescapes `''` → `'` per the YAML spec
- Call it in `parseYamlScalar` before the double-quote `JSON.parse` block

## Thinking Path

> - Paperclip imports company bundles from YAML-format `.paperclip.yaml` files; agent names, titles, and other string fields are read by `parseYamlScalar`
> - YAML has two quoting styles: double-quoted (JSON-compatible, handled by `JSON.parse`) and single-quoted (simpler escaping: `''` → `'`, everything else literal)
> - `JSON.parse("'hello'")` throws — so single-quoted values fell through to the bare `return trimmed` branch, returning the raw string including the surrounding apostrophes
> - Community bundles use single-quoting for names containing `/` or `&` (YAML flow-sequence special chars), so imported agent names appeared with literal quote chars in the UI
> - The fix is minimal: detect single-quoted values (starts and ends with `'`), strip the outer quotes, and unescape `''` → `'` — two simple string operations with no external dependency

## What Changed

- `server/src/services/company-portability.ts`: added `parseYamlSingleQuotedScalar(value)` helper (now exported for testability), and added a branch in `parseYamlScalar` that routes single-quoted values through this helper before the double-quote/JSON.parse path
- `server/src/__tests__/yaml-scalar-parsing.test.ts`: unit tests for the helper covering outer-quote stripping, `''` unescape, empty quoted string, and boundary case

## Verification

- `pnpm --filter @paperclipai/server test` — all tests pass including new yaml-scalar-parsing tests
- Import `newsletter-press` bundle → agent names render without surrounding quote characters
- Value `'it''s a test'` → `it's a test` (double-apostrophe unescape works)

## Risks

Low risk — new branch in `parseYamlScalar` only fires when value starts AND ends with `'`. Existing behaviour for all other value types (null, bool, number, double-quoted, array, object, plain string) is unchanged.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) — extended reasoning mode, tool use enabled, 200k context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #7268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)