### PR TITLE
SPC-6991: honor idempotencyKey on POST /api/companies/:id/routines

### DIFF
--- a/packages/db/src/migrations/0094_issue_idempotency_key.sql
+++ b/packages/db/src/migrations/0094_issue_idempotency_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "idempotency_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_company_idempotency_key_uq" ON "issues" USING btree ("company_id","idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/0095_routine_idempotency_key.sql
+++ b/packages/db/src/migrations/0095_routine_idempotency_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "routines" ADD COLUMN IF NOT EXISTS "idempotency_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "routines_company_idempotency_key_uq" ON "routines" USING btree ("company_id","idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1780040470886,
       "tag": "0093_giant_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1780281600000,
+      "tag": "0094_issue_idempotency_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1780281600000,
       "tag": "0094_issue_idempotency_key",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1780281600001,
+      "tag": "0095_routine_idempotency_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -65,6 +65,7 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -139,5 +140,8 @@ export const issues = pgTable(
           and ${table.hiddenAt} is null
           and ${table.status} not in ('done', 'cancelled')`,
       ),
+    idempotencyKeyIdx: uniqueIndex("issues_company_idempotency_key_uq")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
   }),
 );

--- a/packages/db/src/schema/routines.ts
+++ b/packages/db/src/schema/routines.ts
@@ -10,6 +10,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { agents } from "./agents.js";
 import { companies } from "./companies.js";
 import { companySecrets } from "./company_secrets.js";
@@ -44,6 +45,7 @@ export const routines = pgTable(
     updatedByUserId: text("updated_by_user_id"),
     lastTriggeredAt: timestamp("last_triggered_at", { withTimezone: true }),
     lastEnqueuedAt: timestamp("last_enqueued_at", { withTimezone: true }),
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -51,6 +53,9 @@ export const routines = pgTable(
     companyStatusIdx: index("routines_company_status_idx").on(table.companyId, table.status),
     companyAssigneeIdx: index("routines_company_assignee_idx").on(table.companyId, table.assigneeAgentId),
     companyProjectIdx: index("routines_company_project_idx").on(table.companyId, table.projectId),
+    idempotencyKeyIdx: uniqueIndex("routines_company_idempotency_key_uq")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
   }),
 );
 

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -390,6 +390,7 @@ const createIssueBaseSchema = z.object({
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
+  idempotencyKey: z.string().trim().min(1).max(200).optional(),
 });
 
 export const createIssueInputSchema = createIssueBaseSchema.extend({

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -62,6 +62,7 @@ export const createRoutineSchema = z.object({
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES).optional().default("skip_missed"),
   variables: z.array(routineVariableSchema).optional().default([]),
   env: envConfigSchema.optional().nullable(),
+  idempotencyKey: z.string().trim().max(255).optional().nullable(),
 });
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;

--- a/server/src/__tests__/issue-self-checkout-routes.test.ts
+++ b/server/src/__tests__/issue-self-checkout-routes.test.ts
@@ -1,0 +1,340 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selfAgentId = "33333333-3333-4333-8333-333333333333";
+const otherAgentId = "44444444-4444-4444-8444-444444444444";
+const callingRunId = "55555555-5555-4555-8555-555555555555";
+
+const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  createChild: vi.fn(),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getByIdempotencyKey: vi.fn(async () => null),
+  getComment: vi.fn(),
+  getCommentCursor: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  findMentionedAgents: vi.fn(async () => []),
+}));
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(async (id: string) => {
+    if (id === selfAgentId) {
+      return { id: selfAgentId, name: "TestAgent", companyId: "company-1" };
+    }
+    return null;
+  }),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(async () => true),
+    decide: vi.fn(async (input: { action?: string }) => ({
+      allowed: true,
+      action: input.action,
+      reason: "allow_explicit_grant",
+      explanation: "Allowed by test grant.",
+    })),
+    hasPermission: vi.fn(async () => true),
+  }),
+  agentService: () => mockAgentService,
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(async () => null),
+  }),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+  }),
+  goalService: () => ({
+    getById: vi.fn(async () => null),
+    getDefaultCompanyGoal: vi.fn(async () => null),
+  }),
+  heartbeatService: () => ({
+    wakeup: mockWakeup,
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  getIssueContinuationSummaryDocument: vi.fn(async () => null),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => ({
+    getActiveForIssue: vi.fn(async () => null),
+    listActiveForIssues: vi.fn(async () => new Map()),
+  }),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueThreadInteractionService: () => ({
+    listForIssue: vi.fn(async () => []),
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  projectService: () => ({
+    getById: vi.fn(async () => null),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+async function createApp(opts: { actorAgentId?: string | null; actorRunId?: string | null } = {}) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (opts.actorAgentId) {
+      (req as any).actor = {
+        type: "agent",
+        agentId: opts.actorAgentId,
+        runId: opts.actorRunId ?? null,
+        companyId: "company-1",
+        companyIds: ["company-1"],
+        source: "agent_jwt",
+        isInstanceAdmin: false,
+      };
+    } else {
+      (req as any).actor = {
+        type: "board",
+        userId: "local-board",
+        companyIds: ["company-1"],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      };
+    }
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(input: {
+  id: string;
+  title: string;
+  status?: string;
+  assigneeAgentId?: string | null;
+  idempotencyKey?: string | null;
+}) {
+  return {
+    id: input.id,
+    companyId: "company-1",
+    identifier: "SPC-6909-test",
+    title: input.title,
+    description: null,
+    status: input.status ?? "todo",
+    priority: "medium",
+    parentId: null,
+    assigneeAgentId: input.assigneeAgentId ?? null,
+    assigneeUserId: null,
+    createdByAgentId: input.assigneeAgentId ?? null,
+    createdByUserId: null,
+    executionWorkspaceId: null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    labels: [],
+    labelIds: [],
+  };
+}
+
+describe("SPC-6909 — issue create self-checkout + idempotency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.create.mockImplementation(async (_companyId: string, data: Record<string, unknown>) =>
+      makeIssue({
+        id: "issue-new",
+        title: String(data.title),
+        status: String(data.status),
+        assigneeAgentId: data.assigneeAgentId as string | null | undefined,
+        idempotencyKey: data.idempotencyKey as string | null | undefined,
+      }));
+    mockIssueService.getByIdempotencyKey.mockResolvedValue(null);
+  });
+
+  describe("self-checkout (ask #1)", () => {
+    it("agent posting in_progress + assigneeAgentId=self gets selfCheckoutRunId stamped and no wake fires", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Self-assigned in_progress",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          title: "Self-assigned in_progress",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+          selfCheckoutRunId: callingRunId,
+          selfCheckoutAgentNameKey: "testagent",
+        }),
+      );
+      expect(mockWakeup).not.toHaveBeenCalled();
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "issue.created",
+          details: expect.objectContaining({ selfCheckoutRunId: callingRunId }),
+        }),
+      );
+    });
+
+    it("agent posting in_progress + assigneeAgentId=ANOTHER_AGENT does NOT self-checkout and DOES wake", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Other-assigned in_progress",
+          assigneeAgentId: otherAgentId,
+          status: "in_progress",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          assigneeAgentId: otherAgentId,
+          selfCheckoutRunId: null,
+          selfCheckoutAgentNameKey: null,
+        }),
+      );
+      expect(mockWakeup).toHaveBeenCalledWith(
+        otherAgentId,
+        expect.objectContaining({ reason: "issue_assigned" }),
+      );
+    });
+
+    it("agent without run id does NOT self-checkout (defense in depth)", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: null }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "No run id",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ selfCheckoutRunId: null }),
+      );
+      expect(mockWakeup).toHaveBeenCalled();
+    });
+
+    it("agent posting todo (not in_progress) does NOT self-checkout — wake still fires", async () => {
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Self-assigned todo",
+          assigneeAgentId: selfAgentId,
+          status: "todo",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          status: "todo",
+          selfCheckoutRunId: null,
+        }),
+      );
+      expect(mockWakeup).toHaveBeenCalled();
+    });
+  });
+
+  describe("idempotencyKey fast-path (ask #2)", () => {
+    it("returns the prior issue (200) when idempotencyKey matches and skips create + wake + activity log", async () => {
+      const existing = makeIssue({
+        id: "issue-prior",
+        title: "Prior umbrella",
+        status: "in_progress",
+        assigneeAgentId: selfAgentId,
+        idempotencyKey: "umbrella:eu:2026-06-01",
+      });
+      mockIssueService.getByIdempotencyKey.mockResolvedValue(existing);
+
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "Umbrella second call",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+          idempotencyKey: "umbrella:eu:2026-06-01",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expect.objectContaining({
+        id: "issue-prior",
+        idempotentReturn: true,
+      }));
+      expect(mockIssueService.getByIdempotencyKey).toHaveBeenCalledWith(
+        "company-1",
+        "umbrella:eu:2026-06-01",
+      );
+      expect(mockIssueService.create).not.toHaveBeenCalled();
+      expect(mockWakeup).not.toHaveBeenCalled();
+      expect(mockLogActivity).not.toHaveBeenCalled();
+    });
+
+    it("creates as normal when idempotencyKey has not been seen yet", async () => {
+      mockIssueService.getByIdempotencyKey.mockResolvedValue(null);
+
+      const res = await request(await createApp({ actorAgentId: selfAgentId, actorRunId: callingRunId }))
+        .post("/api/companies/company-1/issues")
+        .send({
+          title: "First call with idempotencyKey",
+          assigneeAgentId: selfAgentId,
+          status: "in_progress",
+          idempotencyKey: "umbrella:na:2026-06-01",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.create).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({
+          idempotencyKey: "umbrella:na:2026-06-01",
+          selfCheckoutRunId: callingRunId,
+        }),
+      );
+      // self-checkout suppresses the wake even when key is novel
+      expect(mockWakeup).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -499,4 +499,65 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
       executionWorkspaceSettings: { mode: "isolated_workspace" },
     });
   });
+
+  // SPC-6991 — routine create dedup at the platform layer. Racing
+  // heartbeats that author the same routine with the same idempotencyKey
+  // should collapse to a single row; the second POST returns 200 with
+  // idempotentReturn=true and no second routine.created activity-log row.
+  it("dedups POST /companies/:id/routines on idempotencyKey across racing callers", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const idempotencyKey = "eod-wake:trading-day-2026-06-01";
+    const body = {
+      projectId,
+      title: "EU EOD wake",
+      assigneeAgentId: agentId,
+      idempotencyKey,
+    };
+
+    const first = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send(body);
+    expect([200, 201]).toContain(first.status);
+    expect(first.body.id).toBeTruthy();
+    const routineId = first.body.id as string;
+
+    const second = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send(body);
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(routineId);
+    expect(second.body.idempotentReturn).toBe(true);
+
+    const persistedRoutines = await db
+      .select({ id: routines.id, idempotencyKey: routines.idempotencyKey })
+      .from(routines)
+      .where(eq(routines.companyId, companyId));
+    expect(persistedRoutines).toHaveLength(1);
+    expect(persistedRoutines[0]?.idempotencyKey).toBe(idempotencyKey);
+
+    const createdEvents = await db
+      .select({ entityId: activityLog.entityId })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId));
+    const routineCreatedRows = createdEvents.filter((row) => row.entityId === routineId);
+    expect(routineCreatedRows).toHaveLength(1);
+
+    const third = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Different routine",
+        assigneeAgentId: agentId,
+      });
+    expect([200, 201]).toContain(third.status);
+    expect(third.body.id).not.toBe(routineId);
+  }, 15_000);
 });

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -101,6 +101,7 @@ const mockRoutineService = vi.hoisted(() => ({
   list: vi.fn(),
   get: vi.fn(),
   getDetail: vi.fn(),
+  getByIdempotencyKey: vi.fn(),
   update: vi.fn(),
   create: vi.fn(),
   listRevisions: vi.fn(),
@@ -203,6 +204,7 @@ describe("routine routes", () => {
       source: "manual",
       status: "issue_created",
     });
+    mockRoutineService.getByIdempotencyKey.mockResolvedValue(null);
     mockAccessService.canUser.mockResolvedValue(false);
     mockLogActivity.mockResolvedValue(undefined);
   });
@@ -466,5 +468,101 @@ describe("routine routes", () => {
       runId: null,
     });
     expect(mockTrackRoutineCreated).toHaveBeenCalledWith(expect.anything());
+  });
+
+  // SPC-6991 — fast-path idempotency. Racing heartbeats that send the same
+  // idempotencyKey on POST /api/companies/:id/routines should collapse to a
+  // single create + a 200 idempotent return on the second call, with no
+  // duplicate activity-log or telemetry side effects.
+  it("returns 200 + idempotentReturn=true when POST replays a known idempotencyKey", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockRoutineService.getByIdempotencyKey.mockResolvedValue({
+      ...routine,
+      idempotencyKey: "eod-wake:trading-day-2026-06-01",
+    });
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Daily routine",
+        assigneeAgentId: agentId,
+        idempotencyKey: "eod-wake:trading-day-2026-06-01",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(routineId);
+    expect(res.body.idempotentReturn).toBe(true);
+    expect(mockRoutineService.getByIdempotencyKey).toHaveBeenCalledWith(
+      companyId,
+      "eod-wake:trading-day-2026-06-01",
+    );
+    expect(mockRoutineService.create).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+    expect(mockTrackRoutineCreated).not.toHaveBeenCalled();
+  });
+
+  it("creates a new routine when idempotencyKey has not been seen yet", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockRoutineService.getByIdempotencyKey.mockResolvedValue(null);
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Daily routine",
+        assigneeAgentId: agentId,
+        idempotencyKey: "eod-wake:trading-day-2026-06-01",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockRoutineService.getByIdempotencyKey).toHaveBeenCalledWith(
+      companyId,
+      "eod-wake:trading-day-2026-06-01",
+    );
+    expect(mockRoutineService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ idempotencyKey: "eod-wake:trading-day-2026-06-01" }),
+      expect.anything(),
+    );
+    expect(mockLogActivity).toHaveBeenCalled();
+    expect(mockTrackRoutineCreated).toHaveBeenCalled();
+  });
+
+  it("skips the idempotency lookup when no idempotencyKey is supplied", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Daily routine",
+        assigneeAgentId: agentId,
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockRoutineService.getByIdempotencyKey).not.toHaveBeenCalled();
+    expect(mockRoutineService.create).toHaveBeenCalled();
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3527,11 +3527,54 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+
+    // SPC-6909 — fast-path idempotency. If this POST carries an
+    // idempotencyKey we've already accepted for this company, return the
+    // prior row without re-running activity log or wake fan-out.
+    const idempotencyKey = typeof req.body.idempotencyKey === "string"
+      ? req.body.idempotencyKey.trim()
+      : "";
+    if (idempotencyKey.length > 0) {
+      const existing = await svc.getByIdempotencyKey(companyId, idempotencyKey);
+      if (existing) {
+        const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(existing.id);
+        res.status(200).json({
+          ...existing,
+          relatedWork: referenceSummary,
+          referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+          idempotentReturn: true,
+        });
+        return;
+      }
+    }
+
+    // SPC-6909 — self-checkout. An agent calling under its own run id with
+    // assigneeAgentId=self+status=in_progress would otherwise trigger an
+    // implicit-checkout wake under a fresh run id and spawn a phantom
+    // heartbeat. Stamp checkoutRunId on insert and suppress the wake for
+    // this caller.
+    let selfCheckoutRunId: string | null = null;
+    let selfCheckoutAgentNameKey: string | null = null;
+    if (
+      actor.actorType === "agent"
+      && actor.agentId
+      && actor.runId
+      && req.body.assigneeAgentId === actor.agentId
+      && req.body.status === "in_progress"
+    ) {
+      selfCheckoutRunId = actor.runId;
+      const actorAgent = await agentsSvc.getById(actor.agentId);
+      const rawName = typeof actorAgent?.name === "string" ? actorAgent.name.trim().toLowerCase() : "";
+      selfCheckoutAgentNameKey = rawName.length > 0 ? rawName : null;
+    }
+
     const issue = await svc.create(companyId, {
       ...req.body,
       executionPolicy,
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      selfCheckoutRunId,
+      selfCheckoutAgentNameKey,
     });
     await issueReferencesSvc.syncIssue(issue.id);
     const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
@@ -3554,6 +3597,7 @@ export function issueRoutes(
         identifier: issue.identifier,
         ...buildCreateIssueActivityStatusDetails(issue, res),
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
+        ...(selfCheckoutRunId ? { selfCheckoutRunId } : {}),
         ...summarizeIssueReferenceActivityDetails({
           addedReferencedIssues: referenceDiff.addedReferencedIssues.map(summarizeIssueRelationForActivity),
           removedReferencedIssues: referenceDiff.removedReferencedIssues.map(summarizeIssueRelationForActivity),
@@ -3585,15 +3629,17 @@ export function issueRoutes(
       });
     }
 
-    void queueIssueAssignmentWakeup({
-      heartbeat,
-      issue,
-      reason: "issue_assigned",
-      mutation: "create",
-      contextSource: "issue.create",
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
+    if (!selfCheckoutRunId) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.create",
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json({
       ...issue,
@@ -3628,6 +3674,35 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+
+    // SPC-6909 — fast-path idempotency on POST /issues/:id/children.
+    const idempotencyKey = typeof req.body.idempotencyKey === "string"
+      ? req.body.idempotencyKey.trim()
+      : "";
+    if (idempotencyKey.length > 0) {
+      const existing = await svc.getByIdempotencyKey(parent.companyId, idempotencyKey);
+      if (existing) {
+        res.status(200).json({ ...existing, idempotentReturn: true });
+        return;
+      }
+    }
+
+    // SPC-6909 — self-checkout suppression for child create.
+    let childSelfCheckoutRunId: string | null = null;
+    let childSelfCheckoutAgentNameKey: string | null = null;
+    if (
+      actor.actorType === "agent"
+      && actor.agentId
+      && actor.runId
+      && req.body.assigneeAgentId === actor.agentId
+      && req.body.status === "in_progress"
+    ) {
+      childSelfCheckoutRunId = actor.runId;
+      const actorAgent = await agentsSvc.getById(actor.agentId);
+      const rawName = typeof actorAgent?.name === "string" ? actorAgent.name.trim().toLowerCase() : "";
+      childSelfCheckoutAgentNameKey = rawName.length > 0 ? rawName : null;
+    }
+
     const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
       ...req.body,
       executionPolicy,
@@ -3635,6 +3710,8 @@ export function issueRoutes(
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
       actorAgentId: actor.agentId,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      selfCheckoutRunId: childSelfCheckoutRunId,
+      selfCheckoutAgentNameKey: childSelfCheckoutAgentNameKey,
     });
 
     await logActivity(db, {
@@ -3654,6 +3731,7 @@ export function issueRoutes(
         inheritedExecutionWorkspaceFromIssueId: parent.id,
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
         ...(parentBlockerAdded ? { parentBlockerAdded: true } : {}),
+        ...(childSelfCheckoutRunId ? { selfCheckoutRunId: childSelfCheckoutRunId } : {}),
       },
     });
 
@@ -3681,15 +3759,17 @@ export function issueRoutes(
       });
     }
 
-    void queueIssueAssignmentWakeup({
-      heartbeat,
-      issue,
-      reason: "issue_assigned",
-      mutation: "create",
-      contextSource: "issue.child_create",
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
+    if (!childSelfCheckoutRunId) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.child_create",
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json(issue);
   });

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -97,6 +97,21 @@ export function routineRoutes(
     const companyId = req.params.companyId as string;
     await assertBoardCanAssignTasks(req, companyId);
     assertCanManageCompanyRoutine(req, companyId, req.body.assigneeAgentId);
+
+    // SPC-6991 — fast-path idempotency. If this POST carries an
+    // idempotencyKey we've already accepted for this company, return the
+    // prior row without re-running activity log or telemetry.
+    const idempotencyKey = typeof req.body.idempotencyKey === "string"
+      ? req.body.idempotencyKey.trim()
+      : "";
+    if (idempotencyKey.length > 0) {
+      const existing = await svc.getByIdempotencyKey(companyId, idempotencyKey);
+      if (existing) {
+        res.status(200).json({ ...existing, idempotentReturn: true });
+        return;
+      }
+    }
+
     const created = await svc.create(companyId, req.body, {
       agentId: req.actor.type === "agent" ? req.actor.agentId : null,
       userId: req.actor.type === "board" ? req.actor.userId ?? "board" : null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -103,6 +103,15 @@ function assertTransition(from: string, to: string) {
   }
 }
 
+export const ISSUE_IDEMPOTENCY_KEY_CONSTRAINT = "issues_company_idempotency_key_uq";
+
+export function isIssueIdempotencyKeyConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const err = error as { code?: string; constraint?: string; constraint_name?: string };
+  const constraint = err.constraint ?? err.constraint_name;
+  return err.code === "23505" && constraint === ISSUE_IDEMPOTENCY_KEY_CONSTRAINT;
+}
+
 function applyStatusSideEffects(
   status: string | undefined,
   patch: Partial<typeof issues.$inferInsert>,
@@ -326,6 +335,14 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
   inheritExecutionWorkspaceFromIssueId?: string | null;
+  // When the calling agent's run wants to "self-check-out" the issue it's
+  // creating (status=in_progress + assigneeAgentId=self), the route layer
+  // passes the caller's run id and the assignee's lowercased name key here.
+  // create() will stamp checkoutRunId/executionRunId on insert so no
+  // issue_assigned wake spawns a phantom heartbeat for the same agent.
+  // See SPC-6909 / SPC-6801.
+  selfCheckoutRunId?: string | null;
+  selfCheckoutAgentNameKey?: string | null;
 };
 type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
@@ -1935,6 +1952,7 @@ const issueListSelect = {
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
   hiddenAt: issues.hiddenAt,
+  idempotencyKey: issues.idempotencyKey,
   createdAt: issues.createdAt,
   updatedAt: issues.updatedAt,
 };
@@ -4611,6 +4629,17 @@ export function issueService(db: Db) {
       });
     },
 
+    getByIdempotencyKey: async (companyId: string, idempotencyKey: string) => {
+      const row = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.idempotencyKey, idempotencyKey)))
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      const [enriched] = await withIssueLabels(db, [row]);
+      return enriched;
+    },
+
     create: async (
       companyId: string,
       data: IssueCreateInput,
@@ -4619,6 +4648,8 @@ export function issueService(db: Db) {
         labelIds: inputLabelIds,
         blockedByIssueIds,
         inheritExecutionWorkspaceFromIssueId,
+        selfCheckoutRunId,
+        selfCheckoutAgentNameKey,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -4639,7 +4670,31 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      return db.transaction(async (tx) => {
+      // SPC-6909 — collapse repeat POSTs that carry the same idempotencyKey
+      // to a single winner. The pre-check returns the prior row without
+      // touching activity log or wake; the post-insert catch handles the
+      // narrow race window between pre-check and insert.
+      const idempotencyKey =
+        typeof issueData.idempotencyKey === "string" && issueData.idempotencyKey.trim().length > 0
+          ? issueData.idempotencyKey.trim()
+          : null;
+      if (idempotencyKey) {
+        const existing = await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.idempotencyKey, idempotencyKey)))
+          .then((rows) => rows[0] ?? null);
+        if (existing) {
+          const [enriched] = await withIssueLabels(db, [existing]);
+          return enriched;
+        }
+      }
+      const selfCheckoutApplies =
+        Boolean(selfCheckoutRunId)
+        && typeof data.assigneeAgentId === "string"
+        && data.status === "in_progress";
+      try {
+      return await db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
@@ -4803,6 +4858,7 @@ export function issueService(db: Db) {
           companyId,
           issueNumber,
           identifier,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
         } as typeof issues.$inferInsert;
         if (values.status === "in_progress" && !values.startedAt) {
           values.startedAt = new Date();
@@ -4822,6 +4878,20 @@ export function issueService(db: Db) {
             assigneeUserId: values.assigneeUserId ?? null,
           }),
         );
+        // SPC-6909 — self-checkout: when the calling agent under its own run
+        // POSTs an issue with status=in_progress + assigneeAgentId=self, stamp
+        // checkoutRunId/executionRunId on insert so the route layer can skip
+        // the issue_assigned wake. Without this, the platform spawns a
+        // phantom heartbeat under a fresh run id concurrently with the
+        // calling run.
+        if (selfCheckoutApplies && selfCheckoutRunId) {
+          values.checkoutRunId = selfCheckoutRunId;
+          values.executionRunId = selfCheckoutRunId;
+          values.executionLockedAt = new Date();
+          if (typeof selfCheckoutAgentNameKey === "string" && selfCheckoutAgentNameKey.length > 0) {
+            values.executionAgentNameKey = selfCheckoutAgentNameKey;
+          }
+        }
 
         const [issue] = await tx.insert(issues).values(values).returning();
         if (inputLabelIds) {
@@ -4842,6 +4912,20 @@ export function issueService(db: Db) {
         const [enriched] = await withIssueLabels(tx, [issue]);
         return enriched;
       });
+      } catch (error) {
+        if (idempotencyKey && isIssueIdempotencyKeyConflict(error)) {
+          const existing = await db
+            .select()
+            .from(issues)
+            .where(and(eq(issues.companyId, companyId), eq(issues.idempotencyKey, idempotencyKey)))
+            .then((rows) => rows[0] ?? null);
+          if (existing) {
+            const [enriched] = await withIssueLabels(db, [existing]);
+            return enriched;
+          }
+        }
+        throw error;
+      }
     },
 
     update: async (

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -79,6 +79,19 @@ type Actor = { agentId?: string | null; userId?: string | null; runId?: string |
 type RoutineRow = typeof routines.$inferSelect;
 type RoutineTriggerRow = typeof routineTriggers.$inferSelect;
 
+// SPC-6991 — name of the partial unique index that enforces (company_id,
+// idempotency_key) on the routines table. Matches the index name in the
+// 0095 migration. The post-insert catch in `create` uses this to detect
+// the narrow race between the pre-check and the insert.
+export const ROUTINE_IDEMPOTENCY_KEY_CONSTRAINT = "routines_company_idempotency_key_uq";
+
+export function isRoutineIdempotencyKeyConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const err = error as { code?: string; constraint?: string; constraint_name?: string };
+  const constraint = err.constraint ?? err.constraint_name;
+  return err.code === "23505" && constraint === ROUTINE_IDEMPOTENCY_KEY_CONSTRAINT;
+}
+
 interface RoutineTriggerSecretRestoreMaterial extends RoutineTriggerSecretMaterial {
   triggerId: string;
 }
@@ -1518,7 +1531,31 @@ export function routineService(
       };
     },
 
+    getByIdempotencyKey: async (companyId: string, idempotencyKey: string): Promise<Routine | null> => {
+      return await db
+        .select()
+        .from(routines)
+        .where(and(eq(routines.companyId, companyId), eq(routines.idempotencyKey, idempotencyKey)))
+        .then((rows) => rows[0] ?? null);
+    },
+
     create: async (companyId: string, input: CreateRoutine, actor: Actor): Promise<Routine> => {
+      // SPC-6991 — honor idempotencyKey on routine create so racing heartbeats
+      // that author the same routine collapse to one row. The pre-check is a
+      // fast-path; the post-insert catch handles the narrow race window
+      // between pre-check and insert against the partial unique index.
+      const idempotencyKey =
+        typeof input.idempotencyKey === "string" && input.idempotencyKey.trim().length > 0
+          ? input.idempotencyKey.trim()
+          : null;
+      if (idempotencyKey) {
+        const existing = await db
+          .select()
+          .from(routines)
+          .where(and(eq(routines.companyId, companyId), eq(routines.idempotencyKey, idempotencyKey)))
+          .then((rows) => rows[0] ?? null);
+        if (existing) return existing;
+      }
       await assertProject(companyId, input.projectId ?? null);
       await assertAssignableAgent(companyId, input.assigneeAgentId ?? null);
       if (input.goalId) await assertGoal(companyId, input.goalId);
@@ -1535,44 +1572,57 @@ export function routineService(
       );
       assertRoutineVariableDefinitions(variables);
       const status = normalizeDraftRoutineStatus(input.status, input.assigneeAgentId);
-      const createdRoutine = await db.transaction(async (tx) => {
-        const txDb = tx as unknown as Db;
-        const [created] = await txDb
-          .insert(routines)
-          .values({
-            companyId,
-            projectId: input.projectId ?? null,
-            goalId: input.goalId ?? null,
-            parentIssueId: input.parentIssueId ?? null,
-            title: input.title,
-            description: input.description ?? null,
-            assigneeAgentId: input.assigneeAgentId ?? null,
-            priority: input.priority,
-            status,
-            concurrencyPolicy: input.concurrencyPolicy,
-            catchUpPolicy: input.catchUpPolicy,
-            variables,
-            env,
-            createdByAgentId: actor.agentId ?? null,
-            createdByUserId: actor.userId ?? null,
-            updatedByAgentId: actor.agentId ?? null,
-            updatedByUserId: actor.userId ?? null,
-          })
-          .returning();
-        const { routine } = await appendRoutineRevision(txDb, created, actor, {
-          changeSummary: "Created routine",
+      try {
+        const createdRoutine = await db.transaction(async (tx) => {
+          const txDb = tx as unknown as Db;
+          const [created] = await txDb
+            .insert(routines)
+            .values({
+              companyId,
+              projectId: input.projectId ?? null,
+              goalId: input.goalId ?? null,
+              parentIssueId: input.parentIssueId ?? null,
+              title: input.title,
+              description: input.description ?? null,
+              assigneeAgentId: input.assigneeAgentId ?? null,
+              priority: input.priority,
+              status,
+              concurrencyPolicy: input.concurrencyPolicy,
+              catchUpPolicy: input.catchUpPolicy,
+              variables,
+              env,
+              createdByAgentId: actor.agentId ?? null,
+              createdByUserId: actor.userId ?? null,
+              updatedByAgentId: actor.agentId ?? null,
+              updatedByUserId: actor.userId ?? null,
+              idempotencyKey,
+            })
+            .returning();
+          const { routine } = await appendRoutineRevision(txDb, created, actor, {
+            changeSummary: "Created routine",
+          });
+          if (env) {
+            await secretsSvc.syncEnvBindingsForTarget(
+              companyId,
+              { targetType: "routine", targetId: routine.id },
+              env,
+              { db: tx },
+            );
+          }
+          return routine;
         });
-        if (env) {
-          await secretsSvc.syncEnvBindingsForTarget(
-            companyId,
-            { targetType: "routine", targetId: routine.id },
-            env,
-            { db: tx },
-          );
+        return createdRoutine;
+      } catch (error) {
+        if (idempotencyKey && isRoutineIdempotencyKeyConflict(error)) {
+          const existing = await db
+            .select()
+            .from(routines)
+            .where(and(eq(routines.companyId, companyId), eq(routines.idempotencyKey, idempotencyKey)))
+            .then((rows) => rows[0] ?? null);
+          if (existing) return existing;
         }
-        return routine;
-      });
-      return createdRoutine;
+        throw error;
+      }
     },
 
     update: async (id: string, patch: UpdateRoutine, actor: Actor): Promise<Routine | null> => {


### PR DESCRIPTION
## Summary

Closes the routine-create race that produced the 2026-06-01 wake duplicate at the platform layer, so the runbook-side morning-sweep amendment shipped in  becomes pure defence-in-depth.

The runbook already wires `idempotencyKey: eod-wake:{umbrella-identifier}` on the create body (Desk Lead EU and Desk Lead NA AGENTS.md step 6). The platform silently dropped it — this PR makes the existing wire-level contract load-bearing using the same shape  (#7285)](https://github.com/paperclipai/paperclip/pull/7285) shipped for `POST /api/issues`.


### Changes

- **Migration `0095_routine_idempotency_key.sql`** — adds `routines.idempotency_key` + partial unique index `routines_company_idempotency_key_uq` on `(company_id, idempotency_key) WHERE idempotency_key IS NOT NULL`. Mirrors `0094_issue_idempotency_key.sql` from SPC-6909.
- **`createRoutineSchema`** — accepts `idempotencyKey: z.string().trim().max(255).optional().nullable()`.
- **`routineService.create`** — pre-checks for an existing row keyed by `(companyId, idempotencyKey)` and short-circuits; a post-insert catch on Postgres error `23505` against the new constraint resolves the narrow race window between pre-check and insert.
- **`routineService.getByIdempotencyKey`** — exported for the route-level fast path.
- **`POST /api/companies/:id/routines`** — returns `200` + `idempotentReturn: true` with the prior row when the key matches (instead of `201` + new row), and suppresses the activity-log and telemetry side effects on the replay.

### Race shape this closes

Two heartbeats author the same EOD-wake routine in the same ~1s window:

| | Before | After |
|---|---|---|
| Rows in `routines` | 2 | 1 |
| Activity-log `routine.created` rows | 2 | 1 |
| Telemetry `routine.created` events | 2 | 1 |
| Wake routines firing at 21:00 CEST | 2 | 1 |
| Loser caller sees | `201` + new id | `200` + `idempotentReturn: true` + winner's id |

### Depends on

This branch is based on because that PR introduces migration `0094_issue_idempotency_key.sql` and the audited helper pattern (`ISSUE_IDEMPOTENCY_KEY_CONSTRAINT` / `isIssueIdempotencyKeyConflict`) that this PR mirrors as `ROUTINE_IDEMPOTENCY_KEY_CONSTRAINT` / `isRoutineIdempotencyKeyConflict`. **Wait for #7285 to merge before merging this PR**; the diff will then collapse to only the SPC-6991 changes.

## Test plan

- [x] `pnpm --filter @paperclipai/db run build` — passes (`check:migrations` validates journal/file ordering for 0095)
- [x] `pnpm --filter @paperclipai/shared run build` — passes
- [x] `pnpm --filter @paperclipai/server run build` — passes
- [x] `tsc --noEmit` in `server/` — passes
- [ ] `server/src/__tests__/routines-routes.test.ts` — 3 new cases (fast-path 200, first-write 201, no-key 201). Could not run locally — this sandbox blocks IPv6 loopback connects (`EADDRNOTAVAIL ::1:* - Local (:::0)`), which fails every existing supertest-based test too, not specific to this change. CI will run.
- [ ] `server/src/__tests__/routines-e2e.test.ts` — 1 new embedded-postgres dedup smoke. Same sandbox limitation.

## Out of scope

- `idempotencyKey` plumbing into `updateRoutineSchema.partial()` is inherited from the create schema; the update service does not read it.
- The HoEM option 2 fallback (unique constraint on `(assigneeAgentId, name, status=active)`) is unnecessary if option 1 lands and the runbook keeps sending `idempotencyKey`. We can revisit if a non-runbook caller starts authoring duplicate routines without keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)