### PR TITLE
fix(opencode-local): respect user-specified OPENCODE_DISABLE_PROJECT_CONFIG override

### DIFF
--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -109,8 +109,9 @@ Notes:
 - Paperclip requires an explicit \`model\` value for \`opencode_local\` agents.
 - Runs are executed with: opencode run --format json ...
 - Sessions are resumed with --session when stored session cwd matches current cwd.
-- The adapter sets OPENCODE_DISABLE_PROJECT_CONFIG=true to prevent OpenCode from \
-  writing an opencode.json config file into the project working directory. Model \
+- The adapter sets OPENCODE_DISABLE_PROJECT_CONFIG=true by default to prevent OpenCode from \
+  writing an opencode.json config file into the project working directory. Override by \
+  setting env.OPENCODE_DISABLE_PROJECT_CONFIG=false in adapterConfig. Model \
   selection is passed via the --model CLI flag instead.
 - When \`dangerouslySkipPermissions\` is enabled, Paperclip injects a temporary \
   runtime config with \`permission.external_directory=allow\` so headless runs do \

--- a/packages/adapters/opencode-local/src/server/execute.env.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.env.test.ts
@@ -1,0 +1,102 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runChildProcess, ensureCommandResolvable, resolveCommandForLogs } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async (_runId: string, _command: string, args: string[]) => {
+    if (args.includes("models")) {
+      return { exitCode: 0, signal: null, timedOut: false, stdout: "openai/gpt-4.1\n", stderr: "", pid: 1, startedAt: new Date().toISOString() };
+    }
+    return {
+      exitCode: 0, signal: null, timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "step_start", sessionID: "s1" }),
+        JSON.stringify({ type: "text", sessionID: "s1", part: { text: "done" } }),
+        JSON.stringify({ type: "step_finish", sessionID: "s1", part: { cost: 0, tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } } } }),
+      ].join("\n"),
+      stderr: "", pid: 2, startedAt: new Date().toISOString(),
+    };
+  }),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "opencode"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return { ...actual, ensureCommandResolvable, resolveCommandForLogs, runChildProcess };
+});
+
+import { execute } from "./execute.js";
+
+describe("opencode execute env handling (GH#7290)", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function makeWorkspaceDir() {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-env-"));
+    cleanupDirs.push(dir);
+    await mkdir(dir, { recursive: true });
+    return dir;
+  }
+
+  const baseAgent = {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Test Agent",
+    adapterType: "opencode_local" as const,
+    adapterConfig: {},
+  };
+
+  const baseRuntime = { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null };
+  const noop = async () => {};
+
+  it("sets OPENCODE_DISABLE_PROJECT_CONFIG=true by default when not in adapterConfig.env", async () => {
+    const workspaceDir = await makeWorkspaceDir();
+
+    await execute({
+      runId: "run-default",
+      agent: baseAgent,
+      runtime: baseRuntime,
+      config: { model: "openai/gpt-4.1" },
+      context: { paperclipWorkspace: { cwd: workspaceDir, source: "local_path", workspaceId: "ws-1" } },
+      onLog: noop,
+      onMeta: noop,
+      onSpawn: noop,
+    });
+
+    const runCall = runChildProcess.mock.calls.find((c) => Array.isArray(c[2]) && c[2].includes("run")) as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(runCall?.[3].env.OPENCODE_DISABLE_PROJECT_CONFIG).toBe("true");
+  });
+
+  it("respects adapterConfig.env.OPENCODE_DISABLE_PROJECT_CONFIG=false override", async () => {
+    const workspaceDir = await makeWorkspaceDir();
+
+    await execute({
+      runId: "run-override",
+      agent: baseAgent,
+      runtime: baseRuntime,
+      config: { model: "openai/gpt-4.1", env: { OPENCODE_DISABLE_PROJECT_CONFIG: "false" } },
+      context: { paperclipWorkspace: { cwd: workspaceDir, source: "local_path", workspaceId: "ws-1" } },
+      onLog: noop,
+      onMeta: noop,
+      onSpawn: noop,
+    });
+
+    const runCall = runChildProcess.mock.calls.find((c) => Array.isArray(c[2]) && c[2].includes("run")) as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(runCall?.[3].env.OPENCODE_DISABLE_PROJECT_CONFIG).toBe("false");
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -290,10 +290,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionCwd: effectiveExecutionCwd,
   });
   // Prevent OpenCode from writing an opencode.json config file into the
-  // project working directory (which would pollute the git repo).  Model
-  // selection is already handled via the --model CLI flag.  Set after the
-  // envConfig loop so user overrides cannot disable this guard.
-  env.OPENCODE_DISABLE_PROJECT_CONFIG = "true";
+  // project working directory (which would pollute the git repo). Only
+  // apply the default when the operator has not explicitly overridden it
+  // via adapterConfig.env (GH#7290).
+  if (!("OPENCODE_DISABLE_PROJECT_CONFIG" in envConfig)) {
+    env.OPENCODE_DISABLE_PROJECT_CONFIG = "true";
+  }
   if (!hasExplicitApiKey && authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -125,7 +125,10 @@ export async function testEnvironment(
   }
 
   // Prevent OpenCode from writing an opencode.json into the working directory.
-  env.OPENCODE_DISABLE_PROJECT_CONFIG = "true";
+  // Honor explicit operator override via adapterConfig.env (GH#7290).
+  if (!("OPENCODE_DISABLE_PROJECT_CONFIG" in envConfig)) {
+    env.OPENCODE_DISABLE_PROJECT_CONFIG = "true";
+  }
   const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({ env, config });
   const localRuntimeConfigHome =
     preparedRuntimeConfig.notes.length > 0 ? preparedRuntimeConfig.env.XDG_CONFIG_HOME : "";


### PR DESCRIPTION
Fixes #7290

## Thinking Path

> - The adapter hardcodes `OPENCODE_DISABLE_PROJECT_CONFIG=true` after processing the user's env config, making it impossible for operators to opt out by setting `adapterConfig.env.OPENCODE_DISABLE_PROJECT_CONFIG=false`
> - The original design comment said "Set after the envConfig loop so user overrides cannot disable this guard" — this was intentional but too restrictive
> - Operators running in known-safe environments (local dev, controlled CI) may legitimately want OpenCode's project-level config to take effect
> - Fix: only apply the `true` default when the operator has not provided their own value; explicit overrides in `adapterConfig.env` are now respected
> - Same change applied to `test.ts` (adapter health check) for consistency; `models.ts` is left unchanged since it's an internal model-discovery call with no user env

## What Changed

**`packages/adapters/opencode-local/src/server/execute.ts`**
- Changed `env.OPENCODE_DISABLE_PROJECT_CONFIG = "true"` to a conditional: only set the default when `"OPENCODE_DISABLE_PROJECT_CONFIG"` is not already in `envConfig` (the parsed `adapterConfig.env`)

**`packages/adapters/opencode-local/src/server/test.ts`**
- Same conditional guard for the adapter health-check path

**`packages/adapters/opencode-local/src/index.ts`**
- Updated adapter documentation to document the override mechanism

**`packages/adapters/opencode-local/src/server/execute.env.test.ts`** (new)
- Tests that the default is `true` when not provided
- Tests that `false` survives when explicitly set in `adapterConfig.env`

## Verification

- Default behavior unchanged: when operator does not set `OPENCODE_DISABLE_PROJECT_CONFIG` in `adapterConfig.env`, the guard remains active (value = `true`)
- Override works: setting `adapterConfig.env.OPENCODE_DISABLE_PROJECT_CONFIG: "false"` now passes `false` to OpenCode, allowing project-level config
- Both test cases pass locally

## Risks

- Low: default behavior is unchanged for all existing deployments. Only operators who explicitly set the override in `adapterConfig.env` will see different behavior, which is exactly what they asked for.
- `models.ts` is intentionally not changed: it runs `opencode models` as an internal probe with no user env, so it's fine to always prevent config file creation there.

## Model Used

claude-sonnet-4-6

## Checklist

- [x] Default behavior unchanged — existing deployments unaffected
- [x] Override mechanism documented in adapter config docs
- [x] Unit tests added for both default and override paths