### PR TITLE
feat(claude_local): secrets:// scheme + EncryptedFileSecretStore (MYO-88)

### DIFF
--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -261,9 +261,15 @@ export function registerAgentCommands(program: Command): void {
               throw new Error(`--user-email must look like an email address (got: ${userEmail})`);
             }
             const tokenRef = opts.tokenRef?.trim() ?? "";
-            if (tokenRef && !/^env:[A-Za-z_][A-Za-z0-9_]*$/.test(tokenRef) && !tokenRef.startsWith("file:/")) {
+            if (
+              tokenRef &&
+              !/^env:[A-Za-z_][A-Za-z0-9_]*$/.test(tokenRef) &&
+              !tokenRef.startsWith("file:/") &&
+              !/^secrets:\/\/[A-Za-z0-9._\-/]+$/.test(tokenRef)
+            ) {
               throw new Error(
-                `--token-ref must use env:NAME (e.g. env:PAPERCLIP_GH_TOKEN_FOO) or file:/abs/path (got: ${tokenRef})`,
+                `--token-ref must use env:NAME (e.g. env:PAPERCLIP_GH_TOKEN_FOO), file:/abs/path, ` +
+                  `or secrets://<key> (e.g. secrets://gh/paperclip-foundingeng); got: ${tokenRef}`,
               );
             }
             const gitFields: Record<string, string> = {

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -217,6 +217,82 @@ export function registerAgentCommands(program: Command): void {
 
   addCommonClientOptions(
     agent
+      .command("set-git-identity")
+      .description(
+        "Set per-agent Git/GitHub identity (claude_local). Updates adapterConfig.git fields without touching other settings.",
+      )
+      .argument("<agentId>", "Agent ID")
+      .requiredOption("--user-name <name>", "Git author/committer name")
+      .requiredOption("--user-email <email>", "Git author/committer email")
+      .option(
+        "--token-ref <ref>",
+        "Token reference (env:NAME or file:/abs/path). Resolved at heartbeat time. Omit to clear.",
+      )
+      .option("--clear", "Remove the git identity from adapterConfig.git", false)
+      .action(
+        async (
+          agentId: string,
+          opts: BaseClientOptions & {
+            userName?: string;
+            userEmail?: string;
+            tokenRef?: string;
+            clear?: boolean;
+          },
+        ) => {
+          try {
+            const ctx = resolveCommandContext(opts);
+            if (opts.clear) {
+              const result = await ctx.api.patch<Agent>(`/api/agents/${agentId}`, {
+                adapterConfig: { git: null },
+              });
+              if (ctx.json) {
+                printOutput(result, { json: true });
+                return;
+              }
+              console.log(`Cleared adapterConfig.git on agent ${agentId}`);
+              return;
+            }
+            const userName = opts.userName?.trim();
+            const userEmail = opts.userEmail?.trim();
+            if (!userName || !userEmail) {
+              throw new Error("--user-name and --user-email are required (use --clear to remove)");
+            }
+            if (!userEmail.includes("@")) {
+              throw new Error(`--user-email must look like an email address (got: ${userEmail})`);
+            }
+            const tokenRef = opts.tokenRef?.trim() ?? "";
+            if (tokenRef && !/^env:[A-Za-z_][A-Za-z0-9_]*$/.test(tokenRef) && !tokenRef.startsWith("file:/")) {
+              throw new Error(
+                `--token-ref must use env:NAME (e.g. env:PAPERCLIP_GH_TOKEN_FOO) or file:/abs/path (got: ${tokenRef})`,
+              );
+            }
+            const gitFields: Record<string, string> = {
+              userName,
+              userEmail,
+            };
+            if (tokenRef) gitFields.tokenSecretRef = tokenRef;
+            const result = await ctx.api.patch<Agent>(`/api/agents/${agentId}`, {
+              adapterConfig: { git: gitFields },
+            });
+            if (ctx.json) {
+              printOutput(result, { json: true });
+              return;
+            }
+            console.log(
+              `Updated adapterConfig.git on agent ${agentId}: name="${userName}" email="${userEmail}" tokenSecretRef=${tokenRef ? `"${tokenRef}"` : "(unset)"}`,
+            );
+            console.log(
+              "Note: feature flag PAPERCLIP_ADAPTER_GIT_IDENTITY=true must be set on the Paperclip server for this to take effect.",
+            );
+          } catch (err) {
+            handleCommandError(err);
+          }
+        },
+      ),
+  );
+
+  addCommonClientOptions(
+    agent
       .command("local-cli")
       .description(
         "Create an agent API key, install local Paperclip skills for Codex/Claude, and print shell exports",

--- a/cli/src/commands/client/secrets.ts
+++ b/cli/src/commands/client/secrets.ts
@@ -1,0 +1,246 @@
+import { Command } from "commander";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import readline from "node:readline";
+
+import {
+  EncryptedFileSecretStore,
+  initMasterKey,
+  parseSecretsRef,
+  SECRETS_REF_SCHEME,
+  type SecretStore,
+} from "@paperclipai/adapter-claude-local/server";
+
+import {
+  addCommonClientOptions,
+  handleCommandError,
+  printOutput,
+  resolveCommandContext,
+  type BaseClientOptions,
+} from "./common.js";
+
+interface SecretsOptions extends BaseClientOptions {
+  companyId?: string;
+  rootDir?: string;
+}
+
+function resolveStore(opts: SecretsOptions): { store: EncryptedFileSecretStore; companyId: string; rootDir: string } {
+  const ctx = resolveCommandContext(opts, { requireCompany: true });
+  const companyId = ctx.companyId;
+  if (!companyId) {
+    throw new Error(
+      "--company-id is required (or set a default in your CLI context profile). " +
+        "Secrets are encrypted per company.",
+    );
+  }
+  const rootDir = opts.rootDir?.trim() || path.join(os.homedir(), ".paperclip", "secrets");
+  const store = new EncryptedFileSecretStore({ companyId, rootDir });
+  return { store, companyId, rootDir };
+}
+
+function normalizeKey(rawKey: string): string {
+  const ref = rawKey.startsWith(SECRETS_REF_SCHEME) ? rawKey : `${SECRETS_REF_SCHEME}${rawKey}`;
+  const key = parseSecretsRef(ref);
+  if (key === null) {
+    throw new Error(
+      `Invalid secret key "${rawKey}". Keys may contain letters, digits, dots, dashes, underscores, ` +
+        `and slashes — no "..", absolute paths, or null bytes.`,
+    );
+  }
+  return key;
+}
+
+async function readSecretFromStdin(promptText: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    // Piped input: read all stdin, take the first line (no trailing newline).
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    const raw = Buffer.concat(chunks).toString("utf8");
+    const first = raw.split(/\r?\n/, 1)[0] ?? "";
+    if (first.length === 0) {
+      throw new Error("Secret value was empty (stdin closed without data).");
+    }
+    return first;
+  }
+  // Interactive TTY: prompt with hidden echo.
+  process.stdout.write(promptText);
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: true });
+  // Patch the read-line _writeToOutput so the value is not echoed.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rlAny = rl as any;
+  rlAny._writeToOutput = (str: string) => {
+    if (str === "\n" || str === "\r\n" || str === "\r" || str === promptText) {
+      rlAny.output.write(str);
+      return;
+    }
+    rlAny.output.write("*");
+  };
+  try {
+    const value = await new Promise<string>((resolve) => {
+      rl.question("", (answer) => resolve(answer));
+    });
+    process.stdout.write("\n");
+    if (value.length === 0) {
+      throw new Error("Secret value cannot be empty.");
+    }
+    return value;
+  } finally {
+    rl.close();
+  }
+}
+
+export function registerSecretsCommands(program: Command): void {
+  const group = program
+    .command("secrets")
+    .description(
+      "Manage local encrypted secrets for claude_local adapters. " +
+        "Secrets are stored at ~/.paperclip/secrets/<companyId>.json encrypted with XSalsa20-Poly1305.",
+    );
+
+  addCommonClientOptions(
+    group
+      .command("init")
+      .description(
+        "Initialize the local secrets master key at ~/.paperclip/secrets/.master.key (idempotent). " +
+          "Safe to re-run.",
+      )
+      .option("--root-dir <path>", "Override the secrets root directory (default ~/.paperclip/secrets)")
+      .action(async (opts: SecretsOptions) => {
+        try {
+          const rootDir = opts.rootDir?.trim() || path.join(os.homedir(), ".paperclip", "secrets");
+          const result = await initMasterKey({ rootDir });
+          if (opts.json) {
+            printOutput(result, { json: true });
+            return;
+          }
+          if (result.created) {
+            console.log(`Created master key: ${result.path}`);
+            console.log("");
+            console.log("IMPORTANT: BACK THIS FILE UP TO A SAFE LOCATION.");
+            console.log("Losing it makes every stored secret unrecoverable. This file holds the only");
+            console.log("decryption key for everything you put with `paperclipai secrets put`.");
+            console.log("");
+            console.log("Mode is set to 0600 (owner-only). Do not chmod or copy it onto multi-user disks.");
+          } else {
+            console.log(`Master key already exists: ${result.path} (no change)`);
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+
+  addCommonClientOptions(
+    group
+      .command("put")
+      .description(
+        "Encrypt a secret value under a key. The value is read from stdin (no shell history leak). " +
+          "Reference it from adapterConfig as `secrets://<key>`.",
+      )
+      .argument("<key>", "Secret key, e.g. gh/paperclip-foundingeng")
+      .option("--root-dir <path>", "Override the secrets root directory")
+      .action(async (rawKey: string, opts: SecretsOptions) => {
+        try {
+          const { store, companyId } = resolveStore(opts);
+          const key = normalizeKey(rawKey);
+          const value = await readSecretFromStdin(`Secret value for ${SECRETS_REF_SCHEME}${key}: `);
+          await store.put(key, value);
+          if (opts.json) {
+            printOutput({ stored: true, companyId, key, ref: `${SECRETS_REF_SCHEME}${key}` }, { json: true });
+            return;
+          }
+          console.log(`Stored ${SECRETS_REF_SCHEME}${key} for company ${companyId}`);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    group
+      .command("list")
+      .description("List secret keys stored for the company.")
+      .option("--root-dir <path>", "Override the secrets root directory")
+      .action(async (opts: SecretsOptions) => {
+        try {
+          const { store, companyId } = resolveStore(opts);
+          const keys = await store.list();
+          if (opts.json) {
+            printOutput({ companyId, keys }, { json: true });
+            return;
+          }
+          if (keys.length === 0) {
+            console.log(`No secrets stored for company ${companyId}.`);
+            return;
+          }
+          for (const key of keys) {
+            console.log(`${SECRETS_REF_SCHEME}${key}`);
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    group
+      .command("delete")
+      .description("Delete a secret by key.")
+      .argument("<key>", "Secret key to delete")
+      .option("--root-dir <path>", "Override the secrets root directory")
+      .action(async (rawKey: string, opts: SecretsOptions) => {
+        try {
+          const { store, companyId } = resolveStore(opts);
+          const key = normalizeKey(rawKey);
+          await store.delete(key);
+          if (opts.json) {
+            printOutput({ deleted: true, companyId, key }, { json: true });
+            return;
+          }
+          console.log(`Deleted ${SECRETS_REF_SCHEME}${key} (if it existed) for company ${companyId}`);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  addCommonClientOptions(
+    group
+      .command("show-path")
+      .description("Print the master key and per-company secrets file paths.")
+      .option("--root-dir <path>", "Override the secrets root directory")
+      .action(async (opts: SecretsOptions) => {
+        try {
+          const { store, companyId, rootDir } = resolveStore(opts);
+          const payload = {
+            companyId,
+            rootDir,
+            masterKeyPath: store.masterKeyPath,
+            secretsFilePath: store.secretsFilePath,
+            masterKeyExists: fs.existsSync(store.masterKeyPath),
+            secretsFileExists: fs.existsSync(store.secretsFilePath),
+          };
+          if (opts.json) {
+            printOutput(payload, { json: true });
+            return;
+          }
+          console.log(`root            : ${payload.rootDir}`);
+          console.log(`master key      : ${payload.masterKeyPath} (${payload.masterKeyExists ? "present" : "missing"})`);
+          console.log(`secrets file    : ${payload.secretsFilePath} (${payload.secretsFileExists ? "present" : "missing"})`);
+          console.log(`company         : ${payload.companyId}`);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: true },
+  );
+
+  // Re-export the type to satisfy the linter (SecretStore unused otherwise).
+  void (null as SecretStore | null);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { initTelemetryFromConfigFile, flushTelemetry } from "./telemetry.js";
 import { registerWorktreeCommands } from "./commands/worktree.js";
 import { registerPluginCommands } from "./commands/client/plugin.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
+import { registerSecretsCommands } from "./commands/client/secrets.js";
 import { cliVersion } from "./version.js";
 
 const program = new Command();
@@ -150,6 +151,7 @@ registerFeedbackCommands(program);
 registerWorktreeCommands(program);
 registerEnvLabCommands(program);
 registerPluginCommands(program);
+registerSecretsCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -45,17 +45,41 @@ Supported `tokenSecretRef` schemes:
 
 - `env:VAR_NAME` — read from the Paperclip server process environment.
 - `file:/abs/path` — read the token from a chmod-600 file.
+- `secrets://<key>` — read from the local encrypted secrets store at `~/.paperclip/secrets/<companyId>.json`. Recommended for production.
 
-CLI helper (preferred for managing identities):
+### Local encrypted secrets store
+
+Phase 1 ships an `EncryptedFileSecretStore` (NaCl `crypto_secretbox` — XSalsa20-Poly1305 — via the audited `@noble/ciphers` library). A pluggable `SecretStore` interface keeps the door open for `KeyringSecretStore` later without touching call sites; selection is via `PAPERCLIP_SECRET_STORE` (default `file`).
+
+Layout:
+
+- `~/.paperclip/secrets/.master.key` — 32 random bytes, mode `0600`, owner-only. Boot-checked on every load: refuses to run if mode or owner is wrong.
+- `~/.paperclip/secrets/<companyId>.json` — per-company encrypted entries, mode `0600`. Boot-checked on every load.
+- The decrypted PAT lives only in the heartbeat subprocess `GH_TOKEN` env var. It is never written to disk or logs (sanitizer covers `ghp_*` and `github_pat_*`).
+
+CLI (no PAT is ever passed on argv — values are read from stdin or via TTY hidden-input prompt):
 
 ```sh
+# One-time on each host: create the master key.
+pnpm paperclipai secrets init
+# CRITICAL: back up ~/.paperclip/secrets/.master.key. Losing it = all stored secrets are unrecoverable.
+
+# Store a PAT under a key (value is read from stdin or prompted hidden).
+pnpm paperclipai secrets put gh/paperclip-foundingeng --company-id <companyId>
+
+# Reference it from an agent's adapterConfig.
 pnpm paperclipai agent set-git-identity <agentId> \
   --user-name paperclip-foundingeng \
   --user-email paperclip+foundingeng@openstudio.fr \
-  --token-ref env:PAPERCLIP_GH_TOKEN_FOUNDINGENG
+  --token-ref secrets://gh/paperclip-foundingeng
+
+# Manage secrets.
+pnpm paperclipai secrets list   --company-id <companyId>
+pnpm paperclipai secrets delete gh/paperclip-foundingeng --company-id <companyId>
+pnpm paperclipai secrets show-path --company-id <companyId>
 ```
 
-The CLI never persists the token — only the indirection ref. The actual PAT is supplied to the Paperclip server out-of-band (env var or secure file). Recommended PAT scopes (fine-grained): `contents:write`, `pull_requests:write`.
+The CLI never persists the token in plain form — only the indirection ref. With `secrets://`, the actual PAT is encrypted at rest under the master key. Recommended PAT scopes (fine-grained): `contents:write`, `pull_requests:write`.
 
 Mandatory operational notes:
 

--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -22,6 +22,47 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | `graceSec` | number | No | Grace period before force-kill |
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
+| `git` | object | No | Per-agent Git/GitHub identity (off by default — gated by `PAPERCLIP_ADAPTER_GIT_IDENTITY=true`). See [Per-agent Git identity](#per-agent-git-identity). |
+
+## Per-agent Git identity
+
+When the host feature flag `PAPERCLIP_ADAPTER_GIT_IDENTITY=true` is set on the Paperclip server, `claude_local` agents can carry their own Git/GitHub identity per agent. The adapter writes a per-run `.gitconfig` and exports `GIT_AUTHOR_NAME/EMAIL`, `GIT_COMMITTER_NAME/EMAIL`, `GIT_CONFIG_GLOBAL`, and (if a token resolves) `GH_TOKEN`. The host `~/.gitconfig` is **never** modified.
+
+```jsonc
+{
+  "adapterType": "claude_local",
+  "adapterConfig": {
+    "git": {
+      "userName": "paperclip-foundingeng",
+      "userEmail": "paperclip+foundingeng@openstudio.fr",
+      "tokenSecretRef": "env:PAPERCLIP_GH_TOKEN_FOUNDINGENG"
+    }
+  }
+}
+```
+
+Supported `tokenSecretRef` schemes:
+
+- `env:VAR_NAME` — read from the Paperclip server process environment.
+- `file:/abs/path` — read the token from a chmod-600 file.
+
+CLI helper (preferred for managing identities):
+
+```sh
+pnpm paperclipai agent set-git-identity <agentId> \
+  --user-name paperclip-foundingeng \
+  --user-email paperclip+foundingeng@openstudio.fr \
+  --token-ref env:PAPERCLIP_GH_TOKEN_FOUNDINGENG
+```
+
+The CLI never persists the token — only the indirection ref. The actual PAT is supplied to the Paperclip server out-of-band (env var or secure file). Recommended PAT scopes (fine-grained): `contents:write`, `pull_requests:write`.
+
+Mandatory operational notes:
+
+- Feature flag `PAPERCLIP_ADAPTER_GIT_IDENTITY` must be `true` on the server. Otherwise the field is ignored and the adapter inherits host Git config (legacy behavior).
+- Per-run `.gitconfig` files are written under `os.tmpdir()/paperclip-claude-git-identity/<agentId>/<runId>/.gitconfig` and removed at the end of each `execute()` call.
+- The credential helper in the per-run `.gitconfig` references `$GH_TOKEN` — the literal PAT is never embedded in the file.
+- PAT values are redacted from logs by Paperclip's redaction layer (regex covers both `ghp_*` classic and `github_pat_*` fine-grained tokens).
 
 ## Prompt Templates
 

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -53,6 +53,7 @@
     "probe:quota:raw": "pnpm exec tsx src/cli/quota-probe.ts --json --raw-cli"
   },
   "dependencies": {
+    "@noble/ciphers": "^2.1.1",
     "@paperclipai/adapter-utils": "workspace:*",
     "picocolors": "^1.1.1"
   },

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -28,6 +28,11 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- git (object, optional, off by default): per-agent Git/GitHub identity. Gated by the host feature flag PAPERCLIP_ADAPTER_GIT_IDENTITY=true (or context.paperclipAdapterGitIdentity.enabledOverride). Fields:
+  - userName (string, required when git is set): commit author/committer name
+  - userEmail (string, required when git is set): commit author/committer email
+  - tokenSecretRef (string, optional): token reference resolved at heartbeat time. Supported schemes: "env:VAR" (read from process env), "file:/abs/path" (read from a chmod 600 file). Resolved value is exported as GH_TOKEN and wired into a per-run .gitconfig credential helper for github.com.
+  When applied, the adapter writes a per-run isolated .gitconfig and exports GIT_AUTHOR_NAME/EMAIL, GIT_COMMITTER_NAME/EMAIL, GIT_CONFIG_GLOBAL, and (if a token resolved) GH_TOKEN — the host ~/.gitconfig is never modified.
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -52,9 +52,11 @@ import {
   isClaudeLocalGitIdentityEnabled,
   parseClaudeLocalGitConfig,
   prepareGitIdentityRuntime,
+  createTokenResolverWithSecretStore,
   type ClaudeLocalGitConfigParseError,
   type TokenResolver,
 } from "./git-identity.js";
+import { createDefaultSecretStore, type SecretStore } from "./secret-store.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -76,6 +78,12 @@ interface ClaudeExecutionInput {
     resolveToken?: TokenResolver;
     /** Override the per-run gitconfig root directory (used by tests). */
     runtimeRoot?: string;
+    /**
+     * Override the SecretStore used for `secrets://` refs (used by tests).
+     * When omitted, a `createDefaultSecretStore({ companyId: agent.companyId })`
+     * instance is built per run.
+     */
+    secretStore?: SecretStore | null;
   };
 }
 
@@ -269,12 +277,19 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     const parsed = parseClaudeLocalGitConfig((config as Record<string, unknown>).git);
     gitIdentityRuntime.parseErrors = parsed.errors;
     if (parsed.config !== null) {
+      const resolveToken =
+        gitIdentity?.resolveToken ??
+        createTokenResolverWithSecretStore(
+          gitIdentity?.secretStore !== undefined
+            ? gitIdentity.secretStore
+            : tryCreateDefaultSecretStore(agent.companyId, gitIdentityRuntime.warnings),
+        );
       const prepared = await prepareGitIdentityRuntime({
         runId,
         agentId: agent.id,
         cwd,
         config: parsed.config,
-        resolveToken: gitIdentity?.resolveToken,
+        resolveToken,
         runtimeRoot: gitIdentity?.runtimeRoot,
       });
       for (const [key, value] of Object.entries(prepared.env)) {
@@ -870,6 +885,31 @@ function readGitIdentityOverridesFromContext(
   if (typeof record.resolveToken === "function") {
     out.resolveToken = record.resolveToken as TokenResolver;
   }
+  if ("secretStore" in record) {
+    const raw = record.secretStore;
+    if (raw === null || (typeof raw === "object" && raw !== null && typeof (raw as SecretStore).resolve === "function")) {
+      out.secretStore = raw as SecretStore | null;
+    }
+  }
   if (Object.keys(out).length === 0) return undefined;
   return out;
+}
+
+/**
+ * Construct the default SecretStore for this run. If the env selector is misconfigured
+ * we emit a warning instead of hard-crashing the heartbeat — `secrets://` refs will then
+ * fall through to `null` and `prepareGitIdentityRuntime` will skip GH_TOKEN injection with
+ * its existing "did not resolve" warning. `env:` and `file:` refs continue to work.
+ */
+function tryCreateDefaultSecretStore(companyId: string, warnings: string[]): SecretStore | null {
+  try {
+    return createDefaultSecretStore({ companyId });
+  } catch (err) {
+    warnings.push(
+      `Could not construct default SecretStore for company ${companyId}: ${
+        err instanceof Error ? err.message : String(err)
+      }. "secrets://" refs will not resolve this run.`,
+    );
+    return null;
+  }
 }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -48,6 +48,13 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
+import {
+  isClaudeLocalGitIdentityEnabled,
+  parseClaudeLocalGitConfig,
+  prepareGitIdentityRuntime,
+  type ClaudeLocalGitConfigParseError,
+  type TokenResolver,
+} from "./git-identity.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -58,6 +65,18 @@ interface ClaudeExecutionInput {
   context: Record<string, unknown>;
   executionTarget?: ReturnType<typeof readAdapterExecutionTarget>;
   authToken?: string;
+  gitIdentity?: {
+    /**
+     * Override the host env-var feature flag check. When provided, this takes
+     * precedence over PAPERCLIP_ADAPTER_GIT_IDENTITY. Server-side callers can
+     * use this to plug a per-company feature flag.
+     */
+    enabledOverride?: boolean;
+    /** Override the default token resolver (used by tests). */
+    resolveToken?: TokenResolver;
+    /** Override the per-run gitconfig root directory (used by tests). */
+    runtimeRoot?: string;
+  };
 }
 
 interface ClaudeRuntimeConfig {
@@ -72,6 +91,13 @@ interface ClaudeRuntimeConfig {
   timeoutSec: number;
   graceSec: number;
   extraArgs: string[];
+  gitIdentity: {
+    applied: boolean;
+    gitConfigPath: string | null;
+    warnings: string[];
+    parseErrors: ClaudeLocalGitConfigParseError[];
+    cleanup: (() => Promise<void>) | null;
+  };
 }
 
 function buildLoginResult(input: {
@@ -107,7 +133,7 @@ function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscri
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
-  const { runId, agent, config, context, executionTarget, authToken } = input;
+  const { runId, agent, config, context, executionTarget, authToken, gitIdentity } = input;
 
   const command = asString(config.command, "claude");
   const workspaceContext = parseObject(context.paperclipWorkspace);
@@ -230,6 +256,37 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_API_KEY = authToken;
   }
 
+  const gitIdentityRuntime: ClaudeRuntimeConfig["gitIdentity"] = {
+    applied: false,
+    gitConfigPath: null,
+    warnings: [],
+    parseErrors: [],
+    cleanup: null,
+  };
+  const gitIdentityEnabled =
+    gitIdentity?.enabledOverride ?? isClaudeLocalGitIdentityEnabled(process.env);
+  if (gitIdentityEnabled) {
+    const parsed = parseClaudeLocalGitConfig((config as Record<string, unknown>).git);
+    gitIdentityRuntime.parseErrors = parsed.errors;
+    if (parsed.config !== null) {
+      const prepared = await prepareGitIdentityRuntime({
+        runId,
+        agentId: agent.id,
+        cwd,
+        config: parsed.config,
+        resolveToken: gitIdentity?.resolveToken,
+        runtimeRoot: gitIdentity?.runtimeRoot,
+      });
+      for (const [key, value] of Object.entries(prepared.env)) {
+        env[key] = value;
+      }
+      gitIdentityRuntime.applied = true;
+      gitIdentityRuntime.gitConfigPath = prepared.gitConfigPath;
+      gitIdentityRuntime.warnings = prepared.warnings;
+      gitIdentityRuntime.cleanup = prepared.cleanup;
+    }
+  }
+
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv);
   const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
@@ -259,6 +316,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     timeoutSec,
     graceSec,
     extraArgs,
+    gitIdentity: gitIdentityRuntime,
   };
 }
 
@@ -325,6 +383,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     context,
     executionTarget,
     authToken,
+    gitIdentity: readGitIdentityOverridesFromContext(context),
   });
   const {
     command,
@@ -344,6 +403,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     0,
     asNumber(config.terminalResultCleanupGraceMs, 5_000),
   );
+  if (runtimeConfig.gitIdentity.applied) {
+    await onLog(
+      "stdout",
+      `[paperclip] claude_local git identity applied: GIT_CONFIG_GLOBAL=${runtimeConfig.gitIdentity.gitConfigPath} (run-scoped)\n`,
+    );
+  }
+  for (const warning of runtimeConfig.gitIdentity.warnings) {
+    await onLog("stderr", `[paperclip] ${warning}\n`);
+  }
+  for (const parseError of runtimeConfig.gitIdentity.parseErrors) {
+    await onLog(
+      "stderr",
+      `[paperclip] adapterConfig.git ignored: ${parseError.message}\n`,
+    );
+  }
   const effectiveEnv = Object.fromEntries(
     Object.entries({ ...process.env, ...env }).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
@@ -773,5 +847,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
       await restoreRemoteWorkspace();
     }
+    if (runtimeConfig.gitIdentity.cleanup) {
+      await runtimeConfig.gitIdentity.cleanup();
+    }
   }
+}
+
+function readGitIdentityOverridesFromContext(
+  context: Record<string, unknown> | undefined,
+): ClaudeExecutionInput["gitIdentity"] | undefined {
+  if (!context || typeof context !== "object") return undefined;
+  const raw = (context as Record<string, unknown>).paperclipAdapterGitIdentity;
+  if (!raw || typeof raw !== "object") return undefined;
+  const record = raw as Record<string, unknown>;
+  const out: NonNullable<ClaudeExecutionInput["gitIdentity"]> = {};
+  if (typeof record.enabledOverride === "boolean") {
+    out.enabledOverride = record.enabledOverride;
+  }
+  if (typeof record.runtimeRoot === "string" && record.runtimeRoot.trim().length > 0) {
+    out.runtimeRoot = record.runtimeRoot;
+  }
+  if (typeof record.resolveToken === "function") {
+    out.resolveToken = record.resolveToken as TokenResolver;
+  }
+  if (Object.keys(out).length === 0) return undefined;
+  return out;
 }

--- a/packages/adapters/claude-local/src/server/git-identity.ts
+++ b/packages/adapters/claude-local/src/server/git-identity.ts
@@ -2,6 +2,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import type { SecretStore } from "./secret-store.js";
+import { SECRETS_REF_SCHEME, parseSecretsRef } from "./secret-store.js";
+
 export interface ClaudeLocalGitConfig {
   userName: string;
   userEmail: string;
@@ -97,6 +100,7 @@ function readNonEmptyString(value: unknown): string | null {
 function isSupportedTokenSecretRef(ref: string): boolean {
   if (ref.startsWith("env:")) return ref.slice(4).trim().length > 0;
   if (ref.startsWith("file:")) return ref.slice(5).trim().length > 0;
+  if (ref.startsWith(SECRETS_REF_SCHEME)) return parseSecretsRef(ref) !== null;
   return false;
 }
 
@@ -104,7 +108,9 @@ export interface TokenResolver {
   (ref: string): Promise<string | null>;
 }
 
-export const defaultTokenResolver: TokenResolver = async (ref) => {
+export const defaultTokenResolver: TokenResolver = async (ref) => resolveBuiltInTokenRef(ref);
+
+async function resolveBuiltInTokenRef(ref: string): Promise<string | null> {
   if (ref.startsWith("env:")) {
     const name = ref.slice(4).trim();
     if (!name) return null;
@@ -125,7 +131,22 @@ export const defaultTokenResolver: TokenResolver = async (ref) => {
     }
   }
   return null;
-};
+}
+
+/**
+ * Build a TokenResolver that recognizes `env:`, `file:`, and `secrets://` schemes.
+ * Used by `execute()` so the SecretStore can be injected per-run (carries the companyId
+ * needed to pick the right per-company encrypted file).
+ */
+export function createTokenResolverWithSecretStore(secretStore: SecretStore | null): TokenResolver {
+  if (secretStore === null) return defaultTokenResolver;
+  return async (ref) => {
+    if (ref.startsWith(SECRETS_REF_SCHEME)) {
+      return secretStore.resolve(ref);
+    }
+    return resolveBuiltInTokenRef(ref);
+  };
+}
 
 export interface PrepareGitIdentityRuntimeInput {
   runId: string;

--- a/packages/adapters/claude-local/src/server/git-identity.ts
+++ b/packages/adapters/claude-local/src/server/git-identity.ts
@@ -1,0 +1,254 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface ClaudeLocalGitConfig {
+  userName: string;
+  userEmail: string;
+  tokenSecretRef: string | null;
+}
+
+export interface ClaudeLocalGitConfigParseError {
+  field: "userName" | "userEmail" | "tokenSecretRef";
+  message: string;
+}
+
+export interface ClaudeLocalGitConfigParseResult {
+  config: ClaudeLocalGitConfig | null;
+  errors: ClaudeLocalGitConfigParseError[];
+}
+
+const FEATURE_FLAG_ENV = "PAPERCLIP_ADAPTER_GIT_IDENTITY";
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+export function isClaudeLocalGitIdentityEnabled(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = env[FEATURE_FLAG_ENV];
+  if (typeof raw !== "string") return false;
+  return TRUE_VALUES.has(raw.trim().toLowerCase());
+}
+
+export function parseClaudeLocalGitConfig(value: unknown): ClaudeLocalGitConfigParseResult {
+  if (value === null || value === undefined) {
+    return { config: null, errors: [] };
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return {
+      config: null,
+      errors: [{ field: "userName", message: "adapterConfig.git must be an object" }],
+    };
+  }
+  const record = value as Record<string, unknown>;
+  const errors: ClaudeLocalGitConfigParseError[] = [];
+
+  const userName = readNonEmptyString(record.userName);
+  if (userName === null) {
+    errors.push({
+      field: "userName",
+      message: "adapterConfig.git.userName must be a non-empty string",
+    });
+  }
+  const userEmail = readNonEmptyString(record.userEmail);
+  if (userEmail === null) {
+    errors.push({
+      field: "userEmail",
+      message: "adapterConfig.git.userEmail must be a non-empty string",
+    });
+  } else if (!userEmail.includes("@")) {
+    errors.push({
+      field: "userEmail",
+      message: "adapterConfig.git.userEmail must look like an email address",
+    });
+  }
+  let tokenSecretRef: string | null = null;
+  if (record.tokenSecretRef !== undefined && record.tokenSecretRef !== null) {
+    const raw = readNonEmptyString(record.tokenSecretRef);
+    if (raw === null) {
+      errors.push({
+        field: "tokenSecretRef",
+        message: "adapterConfig.git.tokenSecretRef must be a non-empty string when provided",
+      });
+    } else if (!isSupportedTokenSecretRef(raw)) {
+      errors.push({
+        field: "tokenSecretRef",
+        message:
+          "adapterConfig.git.tokenSecretRef must use a supported scheme (env:NAME, file:/abs/path)",
+      });
+    } else {
+      tokenSecretRef = raw;
+    }
+  }
+  if (errors.length > 0 || userName === null || userEmail === null) {
+    return { config: null, errors };
+  }
+  return {
+    config: { userName, userEmail, tokenSecretRef },
+    errors,
+  };
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isSupportedTokenSecretRef(ref: string): boolean {
+  if (ref.startsWith("env:")) return ref.slice(4).trim().length > 0;
+  if (ref.startsWith("file:")) return ref.slice(5).trim().length > 0;
+  return false;
+}
+
+export interface TokenResolver {
+  (ref: string): Promise<string | null>;
+}
+
+export const defaultTokenResolver: TokenResolver = async (ref) => {
+  if (ref.startsWith("env:")) {
+    const name = ref.slice(4).trim();
+    if (!name) return null;
+    const value = process.env[name];
+    if (typeof value !== "string" || value.length === 0) return null;
+    return value;
+  }
+  if (ref.startsWith("file:")) {
+    const filePath = ref.slice(5).trim();
+    if (!filePath) return null;
+    const absolute = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
+    try {
+      const raw = await fs.readFile(absolute, "utf8");
+      const trimmed = raw.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
+
+export interface PrepareGitIdentityRuntimeInput {
+  runId: string;
+  agentId: string;
+  cwd: string;
+  config: ClaudeLocalGitConfig;
+  resolveToken?: TokenResolver;
+  runtimeRoot?: string;
+}
+
+export interface PrepareGitIdentityRuntimeResult {
+  env: Record<string, string>;
+  gitConfigPath: string;
+  cleanup: () => Promise<void>;
+  resolvedTokenLength: number;
+  warnings: string[];
+}
+
+export async function prepareGitIdentityRuntime(
+  input: PrepareGitIdentityRuntimeInput,
+): Promise<PrepareGitIdentityRuntimeResult> {
+  const warnings: string[] = [];
+  const resolveToken = input.resolveToken ?? defaultTokenResolver;
+  const runtimeRoot = input.runtimeRoot
+    ? input.runtimeRoot
+    : path.join(os.tmpdir(), "paperclip-claude-git-identity");
+  const runDir = path.join(runtimeRoot, sanitizePathSegment(input.agentId), sanitizePathSegment(input.runId));
+  await fs.mkdir(runDir, { recursive: true, mode: 0o700 });
+  try {
+    await fs.chmod(runDir, 0o700);
+  } catch {
+    // Best-effort: chmod may fail on Windows or unusual filesystems.
+  }
+  const gitConfigPath = path.join(runDir, ".gitconfig");
+  let resolvedToken: string | null = null;
+  if (input.config.tokenSecretRef) {
+    try {
+      resolvedToken = await resolveToken(input.config.tokenSecretRef);
+    } catch (err) {
+      warnings.push(
+        `Failed to resolve adapter git tokenSecretRef "${input.config.tokenSecretRef}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      resolvedToken = null;
+    }
+    if (resolvedToken === null) {
+      warnings.push(
+        `Adapter git tokenSecretRef "${input.config.tokenSecretRef}" did not resolve to a value; ` +
+          "skipping GH_TOKEN injection.",
+      );
+    }
+  }
+  const gitConfigBody = buildGitConfigBody({
+    userName: input.config.userName,
+    userEmail: input.config.userEmail,
+    includeCredentialHelper: resolvedToken !== null,
+  });
+  await fs.writeFile(gitConfigPath, gitConfigBody, { encoding: "utf8", mode: 0o600 });
+  try {
+    await fs.chmod(gitConfigPath, 0o600);
+  } catch {
+    // Best-effort: chmod may fail on Windows or unusual filesystems.
+  }
+  const env: Record<string, string> = {
+    GIT_AUTHOR_NAME: input.config.userName,
+    GIT_AUTHOR_EMAIL: input.config.userEmail,
+    GIT_COMMITTER_NAME: input.config.userName,
+    GIT_COMMITTER_EMAIL: input.config.userEmail,
+    GIT_CONFIG_GLOBAL: gitConfigPath,
+  };
+  if (resolvedToken !== null) {
+    env.GH_TOKEN = resolvedToken;
+  }
+  return {
+    env,
+    gitConfigPath,
+    resolvedTokenLength: resolvedToken?.length ?? 0,
+    warnings,
+    cleanup: async () => {
+      try {
+        await fs.rm(runDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    },
+  };
+}
+
+interface BuildGitConfigBodyInput {
+  userName: string;
+  userEmail: string;
+  includeCredentialHelper: boolean;
+}
+
+function buildGitConfigBody(input: BuildGitConfigBodyInput): string {
+  const lines = [
+    `# Generated by Paperclip claude_local adapter. Per-run, do not edit.`,
+    `[user]`,
+    `\tname = ${quoteIniValue(input.userName)}`,
+    `\temail = ${quoteIniValue(input.userEmail)}`,
+  ];
+  if (input.includeCredentialHelper) {
+    lines.push(
+      `[credential "https://github.com"]`,
+      `\thelper = !f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function quoteIniValue(value: string): string {
+  const sanitized = value.replace(/[\r\n]+/g, " ").trim();
+  const escaped = sanitized.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 64) || "default";
+}
+
+export const __testing = {
+  FEATURE_FLAG_ENV,
+  buildGitConfigBody,
+};

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -4,11 +4,22 @@ export {
   parseClaudeLocalGitConfig,
   prepareGitIdentityRuntime,
   defaultTokenResolver,
+  createTokenResolverWithSecretStore,
   type ClaudeLocalGitConfig,
   type ClaudeLocalGitConfigParseError,
   type ClaudeLocalGitConfigParseResult,
   type TokenResolver,
 } from "./git-identity.js";
+export {
+  SECRETS_REF_SCHEME,
+  SECRET_STORE_SELECTOR_ENV,
+  parseSecretsRef,
+  EncryptedFileSecretStore,
+  initMasterKey,
+  createDefaultSecretStore,
+  type SecretStore,
+  type EncryptedFileSecretStoreOptions,
+} from "./secret-store.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
 export { listClaudeModels } from "./models.js";
 export { testEnvironment } from "./test.js";

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -1,4 +1,14 @@
 export { execute, runClaudeLogin } from "./execute.js";
+export {
+  isClaudeLocalGitIdentityEnabled,
+  parseClaudeLocalGitConfig,
+  prepareGitIdentityRuntime,
+  defaultTokenResolver,
+  type ClaudeLocalGitConfig,
+  type ClaudeLocalGitConfigParseError,
+  type ClaudeLocalGitConfigParseResult,
+  type TokenResolver,
+} from "./git-identity.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
 export { listClaudeModels } from "./models.js";
 export { testEnvironment } from "./test.js";

--- a/packages/adapters/claude-local/src/server/secret-store.ts
+++ b/packages/adapters/claude-local/src/server/secret-store.ts
@@ -1,0 +1,337 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { secretbox } from "@noble/ciphers/salsa.js";
+
+/**
+ * Pluggable secret store contract for `claude_local`.
+ *
+ * Phase 1 ships a single implementation (`EncryptedFileSecretStore`) backed
+ * by `~/.paperclip/secrets/<companyId>.json` encrypted with XSalsa20-Poly1305
+ * (NaCl `crypto_secretbox`). A future `KeyringSecretStore` can be added
+ * without touching call sites.
+ *
+ * Refs use the `secrets://<key>` scheme — for example
+ * `secrets://gh/paperclip-foundingeng`. The store sees just `<key>`
+ * (`gh/paperclip-foundingeng`).
+ */
+export interface SecretStore {
+  resolve(ref: string): Promise<string | null>;
+  put(ref: string, value: string): Promise<void>;
+  delete(ref: string): Promise<void>;
+  list(): Promise<string[]>;
+}
+
+export const SECRETS_REF_SCHEME = "secrets://";
+export const SECRET_STORE_SELECTOR_ENV = "PAPERCLIP_SECRET_STORE";
+
+const MASTER_KEY_LEN = 32;
+const NONCE_LEN = 24;
+
+/** Strip the `secrets://` scheme. Returns null when the ref is not a `secrets://` ref or the key is unsafe. */
+export function parseSecretsRef(ref: string): string | null {
+  if (typeof ref !== "string" || !ref.startsWith(SECRETS_REF_SCHEME)) return null;
+  const key = ref.slice(SECRETS_REF_SCHEME.length).trim();
+  if (key.length === 0) return null;
+  // Defense in depth: keys are looked up by name in a JSON map; reject anything that smells like a path.
+  if (key.includes("..") || key.startsWith("/") || key.includes("\\") || key.includes("\0")) {
+    return null;
+  }
+  return key;
+}
+
+function normalizeKey(refOrKey: string): string {
+  const key = parseSecretsRef(
+    refOrKey.startsWith(SECRETS_REF_SCHEME) ? refOrKey : `${SECRETS_REF_SCHEME}${refOrKey}`,
+  );
+  if (key === null) {
+    throw new Error(`invalid secret key "${refOrKey}"`);
+  }
+  return key;
+}
+
+export interface EncryptedFileSecretStoreOptions {
+  companyId: string;
+  /** Defaults to `~/.paperclip/secrets`. */
+  rootDir?: string;
+  /** Defaults to `<rootDir>/.master.key`. */
+  masterKeyPath?: string;
+}
+
+/**
+ * `EncryptedFileSecretStore` — Phase 1 implementation.
+ *
+ * - Master key: 32 random bytes, mode 0600, owner-only. Boot-checked on every load.
+ * - Per-company file: `<rootDir>/<companyId>.json`, mode 0600, owner-only.
+ * - AEAD: NaCl `crypto_secretbox` (XSalsa20-Poly1305) via `@noble/ciphers` — audited (Cure53),
+ *   pure JS, no native build. Equivalent primitive to libsodium `crypto_secretbox`; we picked
+ *   noble for the no-build-toolchain ergonomics (already in the workspace lockfile).
+ */
+export class EncryptedFileSecretStore implements SecretStore {
+  readonly companyId: string;
+  readonly rootDir: string;
+  readonly masterKeyPath: string;
+  readonly secretsFilePath: string;
+
+  constructor(opts: EncryptedFileSecretStoreOptions) {
+    if (!opts.companyId || !/^[A-Za-z0-9._-]+$/.test(opts.companyId)) {
+      throw new Error(`EncryptedFileSecretStore: invalid companyId "${opts.companyId}"`);
+    }
+    this.companyId = opts.companyId;
+    this.rootDir = opts.rootDir ?? path.join(os.homedir(), ".paperclip", "secrets");
+    this.masterKeyPath = opts.masterKeyPath ?? path.join(this.rootDir, ".master.key");
+    this.secretsFilePath = path.join(this.rootDir, `${this.companyId}.json`);
+  }
+
+  async resolve(ref: string): Promise<string | null> {
+    const key = parseSecretsRef(ref);
+    if (key === null) return null;
+    const master = await this.loadMasterKey();
+    let file: SecretsFile;
+    try {
+      file = await this.loadSecretsFile();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+    const entry = file.entries[key];
+    if (!entry) return null;
+    const nonce = decodeBase64(entry.nonce, `secret "${key}" nonce`);
+    const ciphertext = decodeBase64(entry.ciphertext, `secret "${key}" ciphertext`);
+    if (nonce.length !== NONCE_LEN) {
+      throw new Error(`secret "${key}" has invalid nonce length ${nonce.length} (expected ${NONCE_LEN})`);
+    }
+    try {
+      const plaintext = secretbox(master, nonce).open(ciphertext);
+      return Buffer.from(plaintext).toString("utf8");
+    } catch (err) {
+      throw new Error(
+        `secret "${key}" failed to decrypt — master key may be wrong or ciphertext is corrupted (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      );
+    }
+  }
+
+  async put(ref: string, value: string): Promise<void> {
+    if (typeof value !== "string" || value.length === 0) {
+      throw new Error("secret value must be a non-empty string");
+    }
+    const key = normalizeKey(ref);
+    const master = await this.loadMasterKey();
+    const nonce = crypto.randomBytes(NONCE_LEN);
+    const ciphertext = secretbox(master, nonce).seal(Buffer.from(value, "utf8"));
+    await ensureSecureDir(this.rootDir);
+    let file: SecretsFile;
+    try {
+      file = await this.loadSecretsFile();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        file = { version: 1, entries: {} };
+      } else {
+        throw err;
+      }
+    }
+    file.entries[key] = {
+      nonce: Buffer.from(nonce).toString("base64"),
+      ciphertext: Buffer.from(ciphertext).toString("base64"),
+      createdAt: new Date().toISOString(),
+    };
+    await this.writeSecretsFile(file);
+  }
+
+  async delete(ref: string): Promise<void> {
+    const key = normalizeKey(ref);
+    let file: SecretsFile;
+    try {
+      file = await this.loadSecretsFile();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+    if (!(key in file.entries)) return;
+    delete file.entries[key];
+    await this.writeSecretsFile(file);
+  }
+
+  async list(): Promise<string[]> {
+    try {
+      const file = await this.loadSecretsFile();
+      return Object.keys(file.entries).sort();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+  }
+
+  /** Exposed for tests + CLI surface; production callers should go through `resolve`. */
+  async loadMasterKey(): Promise<Buffer> {
+    await assertSecretFileMode(this.masterKeyPath, "master key");
+    const raw = await fs.readFile(this.masterKeyPath);
+    if (raw.length !== MASTER_KEY_LEN) {
+      throw new Error(
+        `master key at ${this.masterKeyPath} has invalid length ${raw.length} (expected ${MASTER_KEY_LEN})`,
+      );
+    }
+    return raw;
+  }
+
+  private async loadSecretsFile(): Promise<SecretsFile> {
+    await assertSecretFileMode(this.secretsFilePath, "secrets file");
+    const raw = await fs.readFile(this.secretsFilePath, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(
+        `secrets file ${this.secretsFilePath} contains invalid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    if (!isPlainObject(parsed) || parsed.version !== 1 || !isPlainObject(parsed.entries)) {
+      throw new Error(
+        `secrets file ${this.secretsFilePath} is not a recognized format (expected { version: 1, entries: {...} })`,
+      );
+    }
+    const entries: Record<string, SecretsEntry> = {};
+    for (const [k, v] of Object.entries(parsed.entries)) {
+      if (!isPlainObject(v) || typeof v.nonce !== "string" || typeof v.ciphertext !== "string") {
+        throw new Error(`secrets file ${this.secretsFilePath} has malformed entry "${k}"`);
+      }
+      entries[k] = {
+        nonce: v.nonce,
+        ciphertext: v.ciphertext,
+        createdAt: typeof v.createdAt === "string" ? v.createdAt : new Date(0).toISOString(),
+      };
+    }
+    return { version: 1, entries };
+  }
+
+  private async writeSecretsFile(file: SecretsFile): Promise<void> {
+    const body = `${JSON.stringify(file, null, 2)}\n`;
+    const tmpPath = `${this.secretsFilePath}.tmp-${process.pid}-${crypto.randomBytes(4).toString("hex")}`;
+    await fs.writeFile(tmpPath, body, { encoding: "utf8", mode: 0o600 });
+    try {
+      await fs.chmod(tmpPath, 0o600);
+    } catch {
+      // best-effort on filesystems without POSIX mode bits
+    }
+    await fs.rename(tmpPath, this.secretsFilePath);
+    try {
+      await fs.chmod(this.secretsFilePath, 0o600);
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+interface SecretsFile {
+  version: 1;
+  entries: Record<string, SecretsEntry>;
+}
+
+interface SecretsEntry {
+  nonce: string;
+  ciphertext: string;
+  createdAt: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeBase64(value: string, label: string): Buffer {
+  const buf = Buffer.from(value, "base64");
+  // Buffer.from("base64") silently strips invalid chars; sanity-check round-trip length.
+  if (buf.length === 0 && value.length > 0) {
+    throw new Error(`${label} is not valid base64`);
+  }
+  return buf;
+}
+
+async function ensureSecureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  try {
+    await fs.chmod(dir, 0o700);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Refuse to read the file if it is not 0600 or not owned by the current uid.
+ * No silent fallback — misconfigured permissions should fail loudly so the operator notices.
+ */
+async function assertSecretFileMode(file: string, label: string): Promise<void> {
+  if (process.platform === "win32") return; // POSIX mode bits are meaningless on Windows
+  const stat = await fs.stat(file);
+  const mode = stat.mode & 0o777;
+  if (mode !== 0o600) {
+    throw new Error(
+      `${label} at ${file} has unsafe permissions ${mode.toString(8).padStart(3, "0")} (expected 600). ` +
+        `Run: chmod 600 "${file}"`,
+    );
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (uid !== null && stat.uid !== uid) {
+    throw new Error(
+      `${label} at ${file} is owned by uid ${stat.uid} but current uid is ${uid}. ` +
+        `Refusing to read another user's secret material.`,
+    );
+  }
+}
+
+/**
+ * Idempotent master-key initializer used by `paperclipai secrets init`.
+ * Returns `{ created: false }` if the file already exists (no error — safe to re-run).
+ */
+export async function initMasterKey(
+  opts: { masterKeyPath?: string; rootDir?: string } = {},
+): Promise<{ path: string; created: boolean; rootDir: string }> {
+  const rootDir = opts.rootDir ?? path.join(os.homedir(), ".paperclip", "secrets");
+  const masterKeyPath = opts.masterKeyPath ?? path.join(rootDir, ".master.key");
+  await ensureSecureDir(rootDir);
+  try {
+    await fs.access(masterKeyPath);
+    return { path: masterKeyPath, created: false, rootDir };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  const key = crypto.randomBytes(MASTER_KEY_LEN);
+  // `wx` flag = fail if file exists, so two concurrent inits don't race.
+  await fs.writeFile(masterKeyPath, key, { mode: 0o600, flag: "wx" });
+  try {
+    await fs.chmod(masterKeyPath, 0o600);
+  } catch {
+    // best-effort
+  }
+  return { path: masterKeyPath, created: true, rootDir };
+}
+
+/**
+ * Factory: pick the right SecretStore based on the env selector.
+ * Phase 1 only supports `file`; unknown selectors throw loudly so misconfig is visible.
+ */
+export function createDefaultSecretStore(opts: {
+  companyId: string;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  rootDir?: string;
+}): SecretStore {
+  const env = opts.env ?? process.env;
+  const selector = (env[SECRET_STORE_SELECTOR_ENV] ?? "file").trim().toLowerCase();
+  if (selector === "file") {
+    return new EncryptedFileSecretStore({ companyId: opts.companyId, rootDir: opts.rootDir });
+  }
+  throw new Error(
+    `${SECRET_STORE_SELECTOR_ENV}=${selector} is not supported in Phase 1 (only "file" is available)`,
+  );
+}
+
+export const __testing = {
+  MASTER_KEY_LEN,
+  NONCE_LEN,
+  assertSecretFileMode,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
 
   packages/adapters/claude-local:
     dependencies:
+      '@noble/ciphers':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -168,6 +171,15 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+
+  packages/adapters/ollama-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
 
   packages/adapters/openclaw-gateway:
     dependencies:
@@ -10080,14 +10092,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -13088,7 +13092,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/server/src/__tests__/claude-local-git-identity.test.ts
+++ b/server/src/__tests__/claude-local-git-identity.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  execute,
+  isClaudeLocalGitIdentityEnabled,
+  parseClaudeLocalGitConfig,
+  prepareGitIdentityRuntime,
+} from "@paperclipai/adapter-claude-local/server";
+import { redactSensitiveText } from "../redaction.js";
+
+async function writeGitInspectingClaudeCommand(commandPath: string): Promise<void> {
+  // The fake claude binary writes the git-related env vars + the contents of
+  // the per-run .gitconfig back to a capture file so the test can assert on
+  // what the agent process would actually see.
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+let gitconfigContents = null;
+if (process.env.GIT_CONFIG_GLOBAL) {
+  try {
+    gitconfigContents = fs.readFileSync(process.env.GIT_CONFIG_GLOBAL, "utf8");
+  } catch (err) {
+    gitconfigContents = "ERROR:" + err.message;
+  }
+}
+const payload = {
+  argv: process.argv.slice(2),
+  env: {
+    GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? null,
+    GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? null,
+    GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? null,
+    GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? null,
+    GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL ?? null,
+    GH_TOKEN: process.env.GH_TOKEN ?? null,
+  },
+  gitconfigContents,
+  pid: process.pid,
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "assistant", session_id: "claude-session-1", message: { content: [{ type: "text", text: "hello" }] } }));
+console.log(JSON.stringify({ type: "result", session_id: "claude-session-1", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+interface ExecHarness {
+  workspace: string;
+  commandPath: string;
+  capturePath: string;
+  hostGitconfig: string;
+  hostGitconfigSentinel: string;
+  runtimeRoot: string;
+  restore: () => void;
+}
+
+async function setupExecuteEnv(root: string): Promise<ExecHarness> {
+  const workspace = path.join(root, "workspace");
+  const binDir = path.join(root, "bin");
+  const commandPath = path.join(binDir, "claude");
+  const capturePath = path.join(root, "capture.json");
+  const hostHome = path.join(root, "home");
+  const hostGitconfig = path.join(hostHome, ".gitconfig");
+  const hostGitconfigSentinel = "[user]\n\tname = host-original\n\temail = host@example.com\n";
+  const runtimeRoot = path.join(root, "git-identity-runtime");
+  await fs.mkdir(workspace, { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
+  await fs.mkdir(hostHome, { recursive: true });
+  await fs.writeFile(hostGitconfig, hostGitconfigSentinel, "utf8");
+  await writeGitInspectingClaudeCommand(commandPath);
+  const previousHome = process.env.HOME;
+  const previousPath = process.env.PATH;
+  const previousFlag = process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY;
+  process.env.HOME = hostHome;
+  process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  return {
+    workspace,
+    commandPath,
+    capturePath,
+    hostGitconfig,
+    hostGitconfigSentinel,
+    runtimeRoot,
+    restore: () => {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousFlag === undefined) delete process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY;
+      else process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY = previousFlag;
+    },
+  };
+}
+
+describe("claude_local git identity feature flag", () => {
+  it("isClaudeLocalGitIdentityEnabled defaults to false", () => {
+    expect(isClaudeLocalGitIdentityEnabled({})).toBe(false);
+    expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: "false" })).toBe(false);
+    expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: "0" })).toBe(false);
+    expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: "" })).toBe(false);
+  });
+
+  it("isClaudeLocalGitIdentityEnabled is true for truthy values", () => {
+    for (const value of ["true", "1", "yes", "on", "TRUE"]) {
+      expect(isClaudeLocalGitIdentityEnabled({ PAPERCLIP_ADAPTER_GIT_IDENTITY: value })).toBe(true);
+    }
+  });
+});
+
+describe("claude_local git identity schema", () => {
+  it("rejects non-object values", () => {
+    const result = parseClaudeLocalGitConfig("paperclip-foundingeng");
+    expect(result.config).toBeNull();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects missing or invalid email", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "paperclip-foundingeng",
+      userEmail: "not-an-email",
+    });
+    expect(result.config).toBeNull();
+    expect(result.errors.find((e) => e.field === "userEmail")).toBeDefined();
+  });
+
+  it("rejects unsupported tokenSecretRef schemes", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "x",
+      userEmail: "x@y.com",
+      tokenSecretRef: "vault://secret",
+    });
+    expect(result.config).toBeNull();
+    expect(result.errors.find((e) => e.field === "tokenSecretRef")).toBeDefined();
+  });
+
+  it("accepts a valid config with env: token ref", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "paperclip-foundingeng",
+      userEmail: "paperclip+foundingeng@openstudio.fr",
+      tokenSecretRef: "env:PAPERCLIP_GH_TOKEN_FOUNDINGENG",
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.config).toEqual({
+      userName: "paperclip-foundingeng",
+      userEmail: "paperclip+foundingeng@openstudio.fr",
+      tokenSecretRef: "env:PAPERCLIP_GH_TOKEN_FOUNDINGENG",
+    });
+  });
+
+  it("accepts an absent tokenSecretRef", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "x",
+      userEmail: "x@y.com",
+    });
+    expect(result.config).toEqual({
+      userName: "x",
+      userEmail: "x@y.com",
+      tokenSecretRef: null,
+    });
+  });
+});
+
+describe("claude_local prepareGitIdentityRuntime isolation", () => {
+  it("writes a per-run .gitconfig and never touches the host ~/.gitconfig", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-identity-iso-"));
+    const hostHome = path.join(root, "home");
+    const hostGitconfig = path.join(hostHome, ".gitconfig");
+    const hostSentinel = "[user]\n\tname = host-original\n\temail = host@example.com\n";
+    await fs.mkdir(hostHome, { recursive: true });
+    await fs.writeFile(hostGitconfig, hostSentinel, "utf8");
+    try {
+      const result = await prepareGitIdentityRuntime({
+        runId: "run-1",
+        agentId: "agent-A",
+        cwd: root,
+        config: {
+          userName: "paperclip-foundingeng",
+          userEmail: "paperclip+foundingeng@openstudio.fr",
+          tokenSecretRef: "env:GH_TOK_AGENT_A",
+        },
+        resolveToken: async (ref) => (ref === "env:GH_TOK_AGENT_A" ? "ghp_agentApat0000000000000000" : null),
+        runtimeRoot: path.join(root, "runtime"),
+      });
+      expect(result.env.GIT_AUTHOR_NAME).toBe("paperclip-foundingeng");
+      expect(result.env.GIT_AUTHOR_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(result.env.GIT_COMMITTER_NAME).toBe("paperclip-foundingeng");
+      expect(result.env.GIT_COMMITTER_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(result.env.GH_TOKEN).toBe("ghp_agentApat0000000000000000");
+      expect(result.env.GIT_CONFIG_GLOBAL).toBe(result.gitConfigPath);
+      const gitconfigBody = await fs.readFile(result.gitConfigPath, "utf8");
+      expect(gitconfigBody).toContain('name = "paperclip-foundingeng"');
+      expect(gitconfigBody).toContain("https://github.com");
+      expect(gitconfigBody).toContain("password=$GH_TOKEN");
+      // Host ~/.gitconfig must remain unchanged.
+      const hostBodyAfter = await fs.readFile(hostGitconfig, "utf8");
+      expect(hostBodyAfter).toBe(hostSentinel);
+      // The PAT itself must not appear inside the per-run .gitconfig — the helper
+      // shells out to $GH_TOKEN, never embeds the literal token.
+      expect(gitconfigBody).not.toContain("ghp_agentApat0000000000000000");
+      // chmod 600 on the file (best-effort, skipped on platforms without it).
+      const stat = await fs.stat(result.gitConfigPath);
+      if (process.platform !== "win32") {
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+      await result.cleanup();
+      await expect(fs.stat(result.gitConfigPath)).rejects.toBeDefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates two parallel agents — distinct GH_TOKEN values and distinct GIT_CONFIG_GLOBAL paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-identity-cross-"));
+    try {
+      const runtimeRoot = path.join(root, "runtime");
+      const [a, b] = await Promise.all([
+        prepareGitIdentityRuntime({
+          runId: "run-A",
+          agentId: "agent-A",
+          cwd: root,
+          config: {
+            userName: "agent-a",
+            userEmail: "a@x.com",
+            tokenSecretRef: "env:GH_TOK_A",
+          },
+          resolveToken: async (ref) => (ref === "env:GH_TOK_A" ? "ghp_AAAAAAAAAAAAAAAAAAAAAA" : null),
+          runtimeRoot,
+        }),
+        prepareGitIdentityRuntime({
+          runId: "run-B",
+          agentId: "agent-B",
+          cwd: root,
+          config: {
+            userName: "agent-b",
+            userEmail: "b@x.com",
+            tokenSecretRef: "env:GH_TOK_B",
+          },
+          resolveToken: async (ref) => (ref === "env:GH_TOK_B" ? "ghp_BBBBBBBBBBBBBBBBBBBBBB" : null),
+          runtimeRoot,
+        }),
+      ]);
+      expect(a.gitConfigPath).not.toBe(b.gitConfigPath);
+      expect(a.env.GH_TOKEN).toBe("ghp_AAAAAAAAAAAAAAAAAAAAAA");
+      expect(b.env.GH_TOKEN).toBe("ghp_BBBBBBBBBBBBBBBBBBBBBB");
+      const aBody = await fs.readFile(a.gitConfigPath, "utf8");
+      const bBody = await fs.readFile(b.gitConfigPath, "utf8");
+      expect(aBody).toContain('name = "agent-a"');
+      expect(bBody).toContain('name = "agent-b"');
+      // Cross-agent sanitizer: the gitconfig of agent A must not embed the PAT of B (or its own).
+      expect(aBody).not.toContain("ghp_BBBBBBBBBBBBBBBBBBBBBB");
+      expect(aBody).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAA");
+      expect(bBody).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAA");
+      expect(bBody).not.toContain("ghp_BBBBBBBBBBBBBBBBBBBBBB");
+      await Promise.all([a.cleanup(), b.cleanup()]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns and skips GH_TOKEN injection when tokenSecretRef does not resolve", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-identity-noresolve-"));
+    try {
+      const result = await prepareGitIdentityRuntime({
+        runId: "run-noresolve",
+        agentId: "agent-noresolve",
+        cwd: root,
+        config: {
+          userName: "x",
+          userEmail: "x@y.com",
+          tokenSecretRef: "env:DOES_NOT_EXIST_ABC",
+        },
+        resolveToken: async () => null,
+        runtimeRoot: path.join(root, "runtime"),
+      });
+      expect(result.env.GH_TOKEN).toBeUndefined();
+      expect(result.warnings.length).toBeGreaterThan(0);
+      const body = await fs.readFile(result.gitConfigPath, "utf8");
+      // Without a resolved token, the credential helper section is omitted.
+      expect(body).not.toContain("https://github.com");
+      await result.cleanup();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("claude_local execute git identity end-to-end", () => {
+  it("does not inject git env when feature flag is off, even with adapterConfig.git present", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-git-off-"));
+    const harness = await setupExecuteEnv(root);
+    delete process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY;
+    try {
+      await execute({
+        runId: "run-off",
+        agent: { id: "agent-off", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: harness.commandPath,
+          cwd: harness.workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: harness.capturePath },
+          promptTemplate: "Do work.",
+          git: {
+            userName: "paperclip-foundingeng",
+            userEmail: "paperclip+foundingeng@openstudio.fr",
+            tokenSecretRef: "env:GH_TOK_OFF",
+          },
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(harness.capturePath, "utf8"));
+      expect(captured.env.GIT_AUTHOR_NAME).toBeNull();
+      expect(captured.env.GIT_CONFIG_GLOBAL).toBeNull();
+      expect(captured.env.GH_TOKEN).toBeNull();
+      // Host ~/.gitconfig is untouched.
+      expect(await fs.readFile(harness.hostGitconfig, "utf8")).toBe(harness.hostGitconfigSentinel);
+    } finally {
+      harness.restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects per-run gitconfig + GH_TOKEN when feature flag is on, isolating from host ~/.gitconfig", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-git-on-"));
+    const harness = await setupExecuteEnv(root);
+    process.env.PAPERCLIP_ADAPTER_GIT_IDENTITY = "true";
+    process.env.GH_TOK_AGENT_FE = "ghp_pat_inject0000000000000000";
+    try {
+      await execute({
+        runId: "run-on",
+        agent: {
+          id: "agent-fe",
+          companyId: "co-1",
+          name: "Founding Engineer",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: harness.commandPath,
+          cwd: harness.workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: harness.capturePath },
+          promptTemplate: "Do work.",
+          git: {
+            userName: "paperclip-foundingeng",
+            userEmail: "paperclip+foundingeng@openstudio.fr",
+            tokenSecretRef: "env:GH_TOK_AGENT_FE",
+          },
+        },
+        context: {
+          paperclipAdapterGitIdentity: { runtimeRoot: harness.runtimeRoot },
+        },
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(harness.capturePath, "utf8"));
+      expect(captured.env.GIT_AUTHOR_NAME).toBe("paperclip-foundingeng");
+      expect(captured.env.GIT_AUTHOR_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(captured.env.GIT_COMMITTER_NAME).toBe("paperclip-foundingeng");
+      expect(captured.env.GIT_COMMITTER_EMAIL).toBe("paperclip+foundingeng@openstudio.fr");
+      expect(captured.env.GH_TOKEN).toBe("ghp_pat_inject0000000000000000");
+      expect(typeof captured.env.GIT_CONFIG_GLOBAL).toBe("string");
+      expect(captured.env.GIT_CONFIG_GLOBAL.startsWith(harness.runtimeRoot)).toBe(true);
+      expect(captured.gitconfigContents).toContain('name = "paperclip-foundingeng"');
+      expect(captured.gitconfigContents).toContain("https://github.com");
+      expect(captured.gitconfigContents).not.toContain("ghp_pat_inject0000000000000000");
+      // Host ~/.gitconfig still untouched.
+      expect(await fs.readFile(harness.hostGitconfig, "utf8")).toBe(harness.hostGitconfigSentinel);
+    } finally {
+      delete process.env.GH_TOK_AGENT_FE;
+      harness.restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("redaction: GitHub PATs are never echoed in logs", () => {
+  it("redacts ghp_ classic and github_pat_ fine-grained tokens via redactSensitiveText", () => {
+    const classic = "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789";
+    const fineGrained =
+      "github_pat_11ABCDEF0123456789_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH";
+    const sample = `Pushing with token ${classic} and fine-grained ${fineGrained} should never appear in logs.`;
+    const redacted = redactSensitiveText(sample);
+    expect(redacted).not.toContain(classic);
+    expect(redacted).not.toContain(fineGrained);
+    expect(redacted).toContain("***REDACTED***");
+  });
+});

--- a/server/src/__tests__/claude-local-secret-store.test.ts
+++ b/server/src/__tests__/claude-local-secret-store.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  EncryptedFileSecretStore,
+  createDefaultSecretStore,
+  createTokenResolverWithSecretStore,
+  defaultTokenResolver,
+  initMasterKey,
+  parseClaudeLocalGitConfig,
+  parseSecretsRef,
+  prepareGitIdentityRuntime,
+  SECRET_STORE_SELECTOR_ENV,
+  SECRETS_REF_SCHEME,
+} from "@paperclipai/adapter-claude-local/server";
+
+async function withTempRoot(fn: (root: string) => Promise<void>): Promise<void> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-secrets-test-"));
+  try {
+    await fn(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("parseClaudeLocalGitConfig accepts secrets:// scheme", () => {
+  it("accepts a valid config with a secrets:// tokenSecretRef", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "paperclip-foundingeng",
+      userEmail: "paperclip+foundingeng@openstudio.fr",
+      tokenSecretRef: `${SECRETS_REF_SCHEME}gh/paperclip-foundingeng`,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.config?.tokenSecretRef).toBe(`${SECRETS_REF_SCHEME}gh/paperclip-foundingeng`);
+  });
+
+  it("rejects a secrets:// ref with an empty key", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "x",
+      userEmail: "x@y.com",
+      tokenSecretRef: SECRETS_REF_SCHEME,
+    });
+    expect(result.config).toBeNull();
+    expect(result.errors.find((e) => e.field === "tokenSecretRef")).toBeDefined();
+  });
+
+  it("rejects a secrets:// ref with a path-traversal key", () => {
+    const result = parseClaudeLocalGitConfig({
+      userName: "x",
+      userEmail: "x@y.com",
+      tokenSecretRef: `${SECRETS_REF_SCHEME}../etc/passwd`,
+    });
+    expect(result.config).toBeNull();
+    expect(result.errors.find((e) => e.field === "tokenSecretRef")).toBeDefined();
+  });
+});
+
+describe("parseSecretsRef", () => {
+  it("strips the secrets:// scheme", () => {
+    expect(parseSecretsRef("secrets://gh/paperclip-foundingeng")).toBe("gh/paperclip-foundingeng");
+    expect(parseSecretsRef("secrets://flat-key")).toBe("flat-key");
+  });
+
+  it("rejects non-secrets refs", () => {
+    expect(parseSecretsRef("env:FOO")).toBeNull();
+    expect(parseSecretsRef("file:/abs/path")).toBeNull();
+    expect(parseSecretsRef("")).toBeNull();
+  });
+
+  it("rejects unsafe keys (path traversal, absolute, backslash, null byte)", () => {
+    expect(parseSecretsRef("secrets://../etc/passwd")).toBeNull();
+    expect(parseSecretsRef("secrets:///etc/shadow")).toBeNull();
+    expect(parseSecretsRef("secrets://foo\\bar")).toBeNull();
+    expect(parseSecretsRef("secrets://foo\0bar")).toBeNull();
+    expect(parseSecretsRef("secrets://   ")).toBeNull();
+  });
+});
+
+describe("EncryptedFileSecretStore round-trip", () => {
+  it("encrypts then decrypts a secret with libsodium-equivalent crypto_secretbox", async () => {
+    await withTempRoot(async (root) => {
+      const init = await initMasterKey({ rootDir: root });
+      expect(init.created).toBe(true);
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      const ref = `${SECRETS_REF_SCHEME}gh/example`;
+      await store.put(ref, "ghp_super_secret_pat_value_zzz");
+      const resolved = await store.resolve(ref);
+      expect(resolved).toBe("ghp_super_secret_pat_value_zzz");
+
+      // Re-running put with the same key overwrites without error.
+      await store.put(ref, "ghp_rotated_value");
+      expect(await store.resolve(ref)).toBe("ghp_rotated_value");
+
+      // list shows the key
+      expect(await store.list()).toContain("gh/example");
+
+      // delete removes it
+      await store.delete(ref);
+      expect(await store.list()).not.toContain("gh/example");
+      expect(await store.resolve(ref)).toBeNull();
+    });
+  });
+
+  it("isolates two companies into distinct files under the same root", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const a = new EncryptedFileSecretStore({ companyId: "co-a", rootDir: root });
+      const b = new EncryptedFileSecretStore({ companyId: "co-b", rootDir: root });
+      await a.put("gh/svc", "pat-a-aaaaaaaa");
+      await b.put("gh/svc", "pat-b-bbbbbbbb");
+      expect(await a.resolve(`${SECRETS_REF_SCHEME}gh/svc`)).toBe("pat-a-aaaaaaaa");
+      expect(await b.resolve(`${SECRETS_REF_SCHEME}gh/svc`)).toBe("pat-b-bbbbbbbb");
+      const stat = await fs.stat(a.secretsFilePath);
+      const stat2 = await fs.stat(b.secretsFilePath);
+      expect(a.secretsFilePath).not.toBe(b.secretsFilePath);
+      if (process.platform !== "win32") {
+        expect(stat.mode & 0o777).toBe(0o600);
+        expect(stat2.mode & 0o777).toBe(0o600);
+      }
+    });
+  });
+
+  it("returns null for an unknown key (no throw, no fallthrough)", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      expect(await store.resolve(`${SECRETS_REF_SCHEME}does-not-exist`)).toBeNull();
+      expect(await store.list()).toEqual([]);
+    });
+  });
+
+  it("returns null when called with a non-secrets ref (caller should layer with other resolvers)", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      expect(await store.resolve("env:FOO")).toBeNull();
+      expect(await store.resolve("file:/etc/passwd")).toBeNull();
+    });
+  });
+});
+
+describe("EncryptedFileSecretStore boot-check (master key permissions)", () => {
+  if (process.platform === "win32") {
+    it.skip("POSIX-only: skipped on Windows", () => undefined);
+    return;
+  }
+
+  it("refuses to read the master key when mode is not 0600", async () => {
+    await withTempRoot(async (root) => {
+      const init = await initMasterKey({ rootDir: root });
+      // Loosen the permissions and confirm the boot check fires.
+      await fs.chmod(init.path, 0o644);
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      await store.put.bind(store);
+      await expect(store.resolve(`${SECRETS_REF_SCHEME}whatever`)).rejects.toThrow(/unsafe permissions/);
+      await expect(store.put(`${SECRETS_REF_SCHEME}any`, "v")).rejects.toThrow(/unsafe permissions/);
+    });
+  });
+
+  it("refuses to read the secrets file when mode is not 0600", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      await store.put(`${SECRETS_REF_SCHEME}gh/svc`, "v");
+      await fs.chmod(store.secretsFilePath, 0o644);
+      await expect(store.resolve(`${SECRETS_REF_SCHEME}gh/svc`)).rejects.toThrow(/unsafe permissions/);
+    });
+  });
+});
+
+describe("EncryptedFileSecretStore corruption detection", () => {
+  it("throws a clear error when ciphertext is tampered with", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      await store.put(`${SECRETS_REF_SCHEME}gh/svc`, "pat-valid");
+      const raw = JSON.parse(await fs.readFile(store.secretsFilePath, "utf8")) as {
+        entries: Record<string, { nonce: string; ciphertext: string }>;
+      };
+      // Flip a single byte in the middle of the ciphertext (after base64-decoding)
+      // so the Poly1305 tag verification fails. Tampering the last base64 char can
+      // sometimes flip only padding bits and decode back to the same bytes.
+      const original = Buffer.from(raw.entries["gh/svc"].ciphertext, "base64");
+      const mid = Math.floor(original.length / 2);
+      original[mid] = original[mid] ^ 0x01;
+      raw.entries["gh/svc"].ciphertext = original.toString("base64");
+      await fs.writeFile(store.secretsFilePath, JSON.stringify(raw, null, 2), { mode: 0o600 });
+      await fs.chmod(store.secretsFilePath, 0o600);
+      await expect(store.resolve(`${SECRETS_REF_SCHEME}gh/svc`)).rejects.toThrow(/failed to decrypt/);
+    });
+  });
+
+  it("throws a clear error when the file is not valid JSON", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      await store.put(`${SECRETS_REF_SCHEME}gh/svc`, "v");
+      await fs.writeFile(store.secretsFilePath, "{not-json", { mode: 0o600 });
+      await fs.chmod(store.secretsFilePath, 0o600);
+      await expect(store.resolve(`${SECRETS_REF_SCHEME}gh/svc`)).rejects.toThrow(/invalid JSON/);
+    });
+  });
+});
+
+describe("initMasterKey", () => {
+  it("is idempotent and refuses to overwrite an existing key", async () => {
+    await withTempRoot(async (root) => {
+      const a = await initMasterKey({ rootDir: root });
+      expect(a.created).toBe(true);
+      const original = await fs.readFile(a.path);
+      const b = await initMasterKey({ rootDir: root });
+      expect(b.created).toBe(false);
+      const after = await fs.readFile(a.path);
+      expect(Buffer.compare(original, after)).toBe(0);
+    });
+  });
+
+  it("creates the master key with mode 0600", async () => {
+    if (process.platform === "win32") return;
+    await withTempRoot(async (root) => {
+      const r = await initMasterKey({ rootDir: root });
+      const stat = await fs.stat(r.path);
+      expect(stat.mode & 0o777).toBe(0o600);
+      expect(stat.size).toBe(32);
+    });
+  });
+});
+
+describe("createDefaultSecretStore selector", () => {
+  it("returns an EncryptedFileSecretStore by default", () => {
+    const store = createDefaultSecretStore({ companyId: "co-default", env: {} });
+    expect(store).toBeInstanceOf(EncryptedFileSecretStore);
+  });
+
+  it("returns an EncryptedFileSecretStore when selector=file", () => {
+    const store = createDefaultSecretStore({
+      companyId: "co-default",
+      env: { [SECRET_STORE_SELECTOR_ENV]: "file" },
+    });
+    expect(store).toBeInstanceOf(EncryptedFileSecretStore);
+  });
+
+  it("throws loudly on an unknown selector (no silent fallback)", () => {
+    expect(() =>
+      createDefaultSecretStore({
+        companyId: "co-default",
+        env: { [SECRET_STORE_SELECTOR_ENV]: "vault" },
+      }),
+    ).toThrow(/not supported/);
+  });
+});
+
+describe("createTokenResolverWithSecretStore", () => {
+  it("falls back to env:/file: resolution for non-secrets refs", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-test", rootDir: root });
+      await store.put(`${SECRETS_REF_SCHEME}gh/svc`, "from-secrets-store");
+
+      const resolver = createTokenResolverWithSecretStore(store);
+      process.env._PAPERCLIP_TEST_TOKEN_RESOLVER = "from-env-var";
+      try {
+        expect(await resolver("env:_PAPERCLIP_TEST_TOKEN_RESOLVER")).toBe("from-env-var");
+        expect(await resolver(`${SECRETS_REF_SCHEME}gh/svc`)).toBe("from-secrets-store");
+        expect(await resolver(`${SECRETS_REF_SCHEME}unknown`)).toBeNull();
+      } finally {
+        delete process.env._PAPERCLIP_TEST_TOKEN_RESOLVER;
+      }
+    });
+  });
+
+  it("returns the bare defaultTokenResolver when no store is provided", async () => {
+    const resolver = createTokenResolverWithSecretStore(null);
+    expect(resolver).toBe(defaultTokenResolver);
+  });
+});
+
+describe("prepareGitIdentityRuntime end-to-end with secrets:// scheme", () => {
+  it("resolves a secrets:// PAT and injects it as GH_TOKEN without writing it to .gitconfig", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-fe", rootDir: root });
+      const SECRET_PAT = "ghp_secrets_store_resolved_aaaaaaaa";
+      await store.put(`${SECRETS_REF_SCHEME}gh/paperclip-foundingeng`, SECRET_PAT);
+      const resolver = createTokenResolverWithSecretStore(store);
+
+      const result = await prepareGitIdentityRuntime({
+        runId: "run-secrets-e2e",
+        agentId: "agent-fe",
+        cwd: root,
+        config: {
+          userName: "paperclip-foundingeng",
+          userEmail: "paperclip+foundingeng@openstudio.fr",
+          tokenSecretRef: `${SECRETS_REF_SCHEME}gh/paperclip-foundingeng`,
+        },
+        resolveToken: resolver,
+        runtimeRoot: path.join(root, "git-identity-runtime"),
+      });
+      try {
+        expect(result.env.GH_TOKEN).toBe(SECRET_PAT);
+        const body = await fs.readFile(result.gitConfigPath, "utf8");
+        // The literal PAT must NOT appear in the gitconfig; the helper references $GH_TOKEN.
+        expect(body).not.toContain(SECRET_PAT);
+        expect(body).toContain("$GH_TOKEN");
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+
+  it("warns and skips GH_TOKEN injection when a secrets:// key is missing", async () => {
+    await withTempRoot(async (root) => {
+      await initMasterKey({ rootDir: root });
+      const store = new EncryptedFileSecretStore({ companyId: "co-fe", rootDir: root });
+      const resolver = createTokenResolverWithSecretStore(store);
+
+      const result = await prepareGitIdentityRuntime({
+        runId: "run-secrets-missing",
+        agentId: "agent-fe",
+        cwd: root,
+        config: {
+          userName: "x",
+          userEmail: "x@y.com",
+          tokenSecretRef: `${SECRETS_REF_SCHEME}does-not-exist`,
+        },
+        resolveToken: resolver,
+        runtimeRoot: path.join(root, "git-identity-runtime"),
+      });
+      try {
+        expect(result.env.GH_TOKEN).toBeUndefined();
+        expect(result.warnings.length).toBeGreaterThan(0);
+        const body = await fs.readFile(result.gitConfigPath, "utf8");
+        expect(body).not.toContain("https://github.com"); // no credential helper without a resolved token
+      } finally {
+        await result.cleanup();
+      }
+    });
+  });
+});

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -4,6 +4,7 @@ const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-
 const JWT_TEXT_RE = /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
 const OPENAI_KEY_TEXT_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const GITHUB_TOKEN_TEXT_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+const GITHUB_FINE_GRAINED_PAT_TEXT_RE = /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g;
 const AUTHORIZATION_BEARER_TEXT_RE = /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const ENV_SECRET_ASSIGNMENT_TEXT_RE =
   /(\b[A-Za-z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION|JWT)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
@@ -76,5 +77,6 @@ export function redactSensitiveText(input: string): string {
     .replace(ENV_SECRET_ASSIGNMENT_TEXT_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(OPENAI_KEY_TEXT_RE, REDACTED_EVENT_VALUE)
     .replace(GITHUB_TOKEN_TEXT_RE, REDACTED_EVENT_VALUE)
+    .replace(GITHUB_FINE_GRAINED_PAT_TEXT_RE, REDACTED_EVENT_VALUE)
     .replace(JWT_TEXT_RE, REDACTED_EVENT_VALUE);
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `claude_local` adapter spawns agent heartbeats locally and previously inherited the host's `~/.gitconfig` + `gh` credentials, making per-agent identity impossible (MYO-75 bottleneck: shared identity = serial approve/merge)
> - MYO-79 already added a per-agent `adapterConfig.git` schema with `tokenSecretRef` resolvable via `env:` and `file:` — but both leak the PAT to disk or env-dump
> - MYO-88 closes the gap by adding a `secrets://` scheme backed by a pluggable `SecretStore` interface so PATs sit encrypted on disk and never leave the resolver
> - This PR ships Phase 1 of the SecretStore: `EncryptedFileSecretStore` (NaCl `crypto_secretbox` = XSalsa20-Poly1305) + a `paperclipai secrets` CLI to manage entries, gated entirely behind the existing `PAPERCLIP_ADAPTER_GIT_IDENTITY` flag (off by default)
> - The benefit is each agent can now carry its own GitHub identity with a PAT that is encrypted at rest, never in argv/history, never in logs, never in the per-run `.gitconfig` — unblocking MYO-90 (Founding Engineer migration) and the broader Phase 2 rollout

## What Changed

- **MYO-79 (`f1efaa8`) — sibling commit, included for context:**
  - Adds `adapterConfig.git` schema (`{ userName, userEmail, tokenSecretRef? }`) and per-run `.gitconfig` writer for `claude_local`.
  - Exports `GIT_AUTHOR_*` / `GIT_COMMITTER_*` / `GH_TOKEN` / `GIT_CONFIG_GLOBAL` to the agent subprocess; cleans the run dir at end of `execute()`.
  - Extends the PAT redactor to cover `github_pat_*` fine-grained tokens.
  - Adds `paperclipai agent set-git-identity` CLI.
  - Gated by `PAPERCLIP_ADAPTER_GIT_IDENTITY=true`.

- **MYO-88 (`54ef73b`) — this PR's core:**
  - New `packages/adapters/claude-local/src/server/secret-store.ts`:
    - `SecretStore` interface (`resolve` / `put` / `delete` / `list`) — FE-mandated for Phase-2 pluggability (`KeyringSecretStore` later, no refactor).
    - `EncryptedFileSecretStore` — master key + per-company encrypted JSON, NaCl `crypto_secretbox` via `@noble/ciphers` (pure JS, no native build).
    - `initMasterKey()` — idempotent, refuses to overwrite (`wx`), mode `0600`.
    - **Boot check**: refuses to read master.key or secrets file unless mode is `0600` AND file is owned by the current uid. Clear error with `chmod 600` hint, no silent fallback.
    - Path-traversal defense on `secrets://<key>` (rejects `..`, leading `/`, backslash, NUL).
    - `createDefaultSecretStore()` env selector `PAPERCLIP_SECRET_STORE` (default `file`); unknown selectors throw loudly.
  - `git-identity.ts`: `isSupportedTokenSecretRef` now accepts `secrets://`; new `createTokenResolverWithSecretStore(store)` layered resolver (`env:` / `file:` keep existing semantics, `secrets://` delegates).
  - `execute.ts`: per-run resolver wired via `createDefaultSecretStore({ companyId })`; degrades gracefully (warn + skip) if store construction fails.
  - New CLI group `paperclipai secrets {init,put,list,delete,show-path}` — PAT values read from stdin (piped) or TTY hidden echo, **never** argv.
  - `paperclipai agent set-git-identity --token-ref` now accepts `secrets://<key>` alongside `env:NAME` / `file:/abs/path`.
  - Docs updated: `docs/adapters/claude-local.md` — `secrets://` scheme, master-key layout, boot-check semantics, CLI usage, master.key backup warning.

**Crypto choice — pragmatic deviation from spec:** FE spec preferred `libsodium` (or `age`). This PR uses `@noble/ciphers` instead because (a) same primitive — `crypto_secretbox` = XSalsa20-Poly1305, Cure53-audited; (b) already pinned in the workspace lockfile via `better-auth`, no new dep; (c) pure JS, no native rebuild per host (WSL/CI/Docker friendly). The FE comment ([`#comment-8c34fb8e`](/MYO/issues/MYO-88#comment-8c34fb8e-00ea-41eb-aa39-3096cb8dfc93)) explicitly allowed this trade-off: *« Backend, choisis ce qui te paraît le plus simple à wrapper en Node »*.

**Scope:** strict to `claude_local` adapter + CLI. The only touches outside `packages/adapters/claude-local` are (a) `server/src/__tests__/` (integration tests — required by acceptance) and (b) the MYO-79 `server/src/redaction.ts` PAT-regex extension (`github_pat_*`) needed by the sanitizer acceptance criterion.

## Verification

```bash
# MYO-88 + MYO-79 dedicated suites (36 tests)
cd server && pnpm vitest run claude-local-secret-store claude-local-git-identity
#  ✓ claude-local-git-identity.test.ts (13 tests)
#  ✓ claude-local-secret-store.test.ts (23 tests)
#  Test Files  2 passed (2)
#  Tests      36 passed (36)

# Adjacent regression sweep (32 tests)
cd server && pnpm vitest run claude-local-execute claude-local-adapter redaction json-schema-secret-refs
#  Test Files  6 passed (6)
#  Tests      32 passed (32)
```

Test coverage highlights:
- `EncryptedFileSecretStore` round-trip (put → resolve → list → delete + overwrite)
- Two-company isolation (distinct files, each `0600`)
- Boot check: master.key `0644` → explicit error; secrets file `0644` → explicit error
- Corruption: bit-flipped ciphertext → Poly1305 tag fails → clear `failed to decrypt` error (no silent crash)
- Invalid JSON file → clear error
- `initMasterKey` idempotency + correct 32-byte / 0600 file
- `createDefaultSecretStore` selectors (default, `file`, unknown `vault` → loud throw)
- `createTokenResolverWithSecretStore`: `env:` fallback works, `secrets://` delegates, `null` store returns bare default resolver
- End-to-end `prepareGitIdentityRuntime` with `secrets://` ref: resolves PAT, injects `GH_TOKEN`, and the literal PAT never appears in the per-run `.gitconfig` (helper still uses `$GH_TOKEN`)
- End-to-end miss case: missing `secrets://` key warns and skips `GH_TOKEN` injection without crashing

Manual: `paperclipai secrets init` then `printf '%s' "$PAT" | paperclipai secrets put gh/foundingeng` round-trips through `paperclipai secrets list` and the per-run env injection.

## Risks

- **Master-key compromise = all PATs exposed.** Mitigation: `0600` + boot check, recommend host-disk encryption. Backup/rotation runbook tracked on [MYO-91](/MYO/issues/MYO-91) (explicitly out of scope here per FE).
- **Backup oversight = full PAT loss on disk failure.** CLI `secrets init` prints a warning + the path to back up. Runbook on [MYO-91](/MYO/issues/MYO-91).
- **Multi-host (FE on two machines).** Out of scope Phase 1 — manual master.key copy. Central sync deferred post-MVP.
- **Behavioral shift:** Zero behavior change when `PAPERCLIP_ADAPTER_GIT_IDENTITY` is unset (default). With the flag on but no `adapterConfig.git`, behavior is identical to MYO-79 — `secrets://` is purely additive.
- **No migration impact.** No DB changes. No public API changes. CLI gains are net-new commands.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), Paperclip Heartbeat Agent harness, extended-thinking on long planning passes, tool use for vitest + git + Paperclip API.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (covered by MYO-76 plan, scoped per CEO authorization)
- [x] I have run tests locally and they pass (36 dedicated + 32 adjacent = 68/68 green)
- [x] I have added or updated tests where applicable (23 new tests for the SecretStore + resolver wiring)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — adapter + CLI only)
- [x] I have updated relevant documentation to reflect my changes (`docs/adapters/claude-local.md`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Refs: [MYO-88](/MYO/issues/MYO-88), [MYO-79](/MYO/issues/MYO-79), [MYO-76](/MYO/issues/MYO-76), [MYO-75](/MYO/issues/MYO-75).