### PR TITLE
[codex] Add standalone PWA browser controls

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -17,6 +17,7 @@ import { ToastViewport } from "./ToastViewport";
 import { MobileBottomNav } from "./MobileBottomNav";
 import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
+import { StandaloneBrowserControls } from "./StandaloneBrowserControls";
 import { ResizableSidebarPane } from "./ResizableSidebarPane";
 import { SidebarAccountMenu } from "./SidebarAccountMenu";
 import { useDialogActions } from "../context/DialogContext";
@@ -424,6 +425,7 @@ export function Layout() {
               isMobile && "sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85",
             )}
           >
+            <StandaloneBrowserControls mobile={isMobile} />
             <BreadcrumbBar />
             {isMobile && isCompanySettingsRoute ? (
               <div className="border-b border-border px-4 pb-3">

--- a/ui/src/components/StandaloneBrowserControls.test.tsx
+++ b/ui/src/components/StandaloneBrowserControls.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ToastProvider } from "../context/ToastContext";
+import { StandaloneBrowserControls } from "./StandaloneBrowserControls";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("StandaloneBrowserControls", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    Object.defineProperty(navigator, "standalone", { configurable: true, value: true });
+  });
+
+  afterEach(() => {
+    delete (navigator as Navigator & { standalone?: boolean }).standalone;
+    container.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("shows refresh, share, and open-in-browser controls in mobile standalone mode", async () => {
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <ToastProvider>
+            <StandaloneBrowserControls mobile />
+          </ToastProvider>
+        </TooltipProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.querySelector('[aria-label="Refresh"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Share"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Open in Browser"]')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/StandaloneBrowserControls.test.tsx
+++ b/ui/src/components/StandaloneBrowserControls.test.tsx
@@ -41,11 +41,19 @@ function installMatchMedia(initialMatches: Record<string, boolean> = {}) {
         return entry.matches;
       },
       media: query,
-      addEventListener: (_type: "change", listener: Listener) => entry.listeners.add(listener),
-      removeEventListener: (_type: "change", listener: Listener) => entry.listeners.delete(listener),
-      addListener: (listener: Listener) => entry.listeners.add(listener),
-      removeListener: (listener: Listener) => entry.listeners.delete(listener),
-    } as MediaQueryList;
+      addEventListener: (_type: "change", listener: Listener) => {
+        entry.listeners.add(listener);
+      },
+      removeEventListener: (_type: "change", listener: Listener) => {
+        entry.listeners.delete(listener);
+      },
+      addListener: (listener: Listener) => {
+        entry.listeners.add(listener);
+      },
+      removeListener: (listener: Listener) => {
+        entry.listeners.delete(listener);
+      },
+    } as unknown as MediaQueryList;
   }
 
   Object.defineProperty(window, "matchMedia", {
@@ -78,7 +86,7 @@ describe("StandaloneBrowserControls", () => {
     if (originalMatchMedia) {
       Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
     } else {
-      delete (window as Window & { matchMedia?: Window["matchMedia"] }).matchMedia;
+      Object.defineProperty(window, "matchMedia", { configurable: true, value: undefined });
     }
     container.remove();
     document.body.innerHTML = "";

--- a/ui/src/components/StandaloneBrowserControls.test.tsx
+++ b/ui/src/components/StandaloneBrowserControls.test.tsx
@@ -25,8 +25,47 @@ async function flushReact() {
   });
 }
 
+function installMatchMedia(initialMatches: Record<string, boolean> = {}) {
+  type Listener = (event: MediaQueryListEvent) => void;
+  const queries = new Map<string, { matches: boolean; listeners: Set<Listener> }>();
+
+  function getQuery(query: string) {
+    let entry = queries.get(query);
+    if (!entry) {
+      entry = { matches: initialMatches[query] ?? false, listeners: new Set<Listener>() };
+      queries.set(query, entry);
+    }
+
+    return {
+      get matches() {
+        return entry.matches;
+      },
+      media: query,
+      addEventListener: (_type: "change", listener: Listener) => entry.listeners.add(listener),
+      removeEventListener: (_type: "change", listener: Listener) => entry.listeners.delete(listener),
+      addListener: (listener: Listener) => entry.listeners.add(listener),
+      removeListener: (listener: Listener) => entry.listeners.delete(listener),
+    } as MediaQueryList;
+  }
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => getQuery(query),
+  });
+
+  return {
+    setMatches(query: string, matches: boolean) {
+      const entry = queries.get(query) ?? { matches: false, listeners: new Set<Listener>() };
+      entry.matches = matches;
+      queries.set(query, entry);
+      entry.listeners.forEach((listener) => listener({ matches, media: query } as MediaQueryListEvent));
+    },
+  };
+}
+
 describe("StandaloneBrowserControls", () => {
   let container: HTMLDivElement;
+  const originalMatchMedia = window.matchMedia;
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -36,6 +75,11 @@ describe("StandaloneBrowserControls", () => {
 
   afterEach(() => {
     delete (navigator as Navigator & { standalone?: boolean }).standalone;
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
+    } else {
+      delete (window as Window & { matchMedia?: Window["matchMedia"] }).matchMedia;
+    }
     container.remove();
     document.body.innerHTML = "";
   });
@@ -57,6 +101,59 @@ describe("StandaloneBrowserControls", () => {
     expect(container.querySelector('[aria-label="Refresh"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Share"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Open in Browser"]')).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides controls in normal mobile browser mode", async () => {
+    Object.defineProperty(navigator, "standalone", { configurable: true, value: false });
+    installMatchMedia();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <ToastProvider>
+            <StandaloneBrowserControls mobile />
+          </ToastProvider>
+        </TooltipProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.querySelector('[aria-label="Refresh"]')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("responds to all chromeless display-mode media query changes", async () => {
+    Object.defineProperty(navigator, "standalone", { configurable: true, value: false });
+    const media = installMatchMedia();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <ToastProvider>
+            <StandaloneBrowserControls mobile />
+          </ToastProvider>
+        </TooltipProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.querySelector('[aria-label="Refresh"]')).toBeNull();
+
+    await act(() => {
+      media.setMatches("(display-mode: fullscreen)", true);
+    });
+    await flushReact();
+
+    expect(container.querySelector('[aria-label="Refresh"]')).not.toBeNull();
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/StandaloneBrowserControls.tsx
+++ b/ui/src/components/StandaloneBrowserControls.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { ExternalLink, RefreshCw, Share2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useOptionalToastActions } from "../context/ToastContext";
+import { isChromelessDisplayMode } from "../lib/pwa-display-mode";
+
+function ControlButton({
+  label,
+  children,
+  onClick,
+}: {
+  label: string;
+  children: ReactNode;
+  onClick: () => void | Promise<void>;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="size-8 text-muted-foreground hover:text-foreground"
+          aria-label={label}
+          onClick={() => void onClick()}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function StandaloneBrowserControls({ mobile }: { mobile: boolean }) {
+  const [chromeless, setChromeless] = useState(false);
+  const toastActions = useOptionalToastActions();
+
+  useEffect(() => {
+    if (!mobile || typeof window === "undefined") {
+      setChromeless(false);
+      return;
+    }
+
+    const update = () => setChromeless(isChromelessDisplayMode());
+
+    update();
+    if (typeof window.matchMedia !== "function") return;
+
+    const media = window.matchMedia("(display-mode: standalone)");
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", update);
+      return () => media.removeEventListener("change", update);
+    }
+
+    media.addListener(update);
+    return () => media.removeListener(update);
+  }, [mobile]);
+
+  const refresh = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const share = useCallback(async () => {
+    const url = window.location.href;
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: document.title || "Paperclip", url });
+        return;
+      }
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        toastActions?.pushToast({ title: "Link copied", tone: "success" });
+        return;
+      }
+      toastActions?.pushToast({ title: "Sharing is unavailable", body: url, tone: "warn" });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      toastActions?.pushToast({ title: "Share failed", body: "Try opening the page in your browser.", tone: "error" });
+    }
+  }, [toastActions]);
+
+  const openInBrowser = useCallback(() => {
+    window.open(window.location.href, "_blank", "noopener,noreferrer");
+  }, []);
+
+  if (!mobile || !chromeless) return null;
+
+  return (
+    <div className="flex h-10 items-center justify-end gap-1 border-b border-border bg-background/95 px-3 backdrop-blur supports-[backdrop-filter]:bg-background/85">
+      <ControlButton label="Refresh" onClick={refresh}>
+        <RefreshCw className="h-4 w-4" />
+      </ControlButton>
+      <ControlButton label="Share" onClick={share}>
+        <Share2 className="h-4 w-4" />
+      </ControlButton>
+      <ControlButton label="Open in Browser" onClick={openInBrowser}>
+        <ExternalLink className="h-4 w-4" />
+      </ControlButton>
+    </div>
+  );
+}

--- a/ui/src/components/StandaloneBrowserControls.tsx
+++ b/ui/src/components/StandaloneBrowserControls.tsx
@@ -3,7 +3,7 @@ import { ExternalLink, RefreshCw, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useOptionalToastActions } from "../context/ToastContext";
-import { isChromelessDisplayMode } from "../lib/pwa-display-mode";
+import { CHROMELESS_DISPLAY_MODES, isChromelessDisplayMode } from "../lib/pwa-display-mode";
 
 function ControlButton({
   label,
@@ -48,14 +48,14 @@ export function StandaloneBrowserControls({ mobile }: { mobile: boolean }) {
     update();
     if (typeof window.matchMedia !== "function") return;
 
-    const media = window.matchMedia("(display-mode: standalone)");
-    if (typeof media.addEventListener === "function") {
-      media.addEventListener("change", update);
-      return () => media.removeEventListener("change", update);
+    const mediaQueries = CHROMELESS_DISPLAY_MODES.map((mode) => window.matchMedia(`(display-mode: ${mode})`));
+    if (mediaQueries.every((media) => typeof media.addEventListener === "function")) {
+      mediaQueries.forEach((media) => media.addEventListener("change", update));
+      return () => mediaQueries.forEach((media) => media.removeEventListener("change", update));
     }
 
-    media.addListener(update);
-    return () => media.removeListener(update);
+    mediaQueries.forEach((media) => media.addListener(update));
+    return () => mediaQueries.forEach((media) => media.removeListener(update));
   }, [mobile]);
 
   const refresh = useCallback(() => {

--- a/ui/src/components/StandaloneBrowserControls.tsx
+++ b/ui/src/components/StandaloneBrowserControls.tsx
@@ -34,7 +34,9 @@ function ControlButton({
 }
 
 export function StandaloneBrowserControls({ mobile }: { mobile: boolean }) {
-  const [chromeless, setChromeless] = useState(false);
+  const [chromeless, setChromeless] = useState(() =>
+    typeof window !== "undefined" && mobile ? isChromelessDisplayMode() : false,
+  );
   const toastActions = useOptionalToastActions();
 
   useEffect(() => {

--- a/ui/src/lib/pwa-display-mode.test.ts
+++ b/ui/src/lib/pwa-display-mode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isChromelessDisplayMode } from "./pwa-display-mode";
+
+function matchMode(activeMode: string | null) {
+  return (query: string) => ({ matches: query === `(display-mode: ${activeMode})` });
+}
+
+describe("isChromelessDisplayMode", () => {
+  it("detects standalone display mode from media queries", () => {
+    expect(isChromelessDisplayMode(matchMode("standalone"), false)).toBe(true);
+  });
+
+  it("detects iOS home-screen standalone launches", () => {
+    expect(isChromelessDisplayMode(matchMode(null), true)).toBe(true);
+  });
+
+  it("ignores normal browser launches", () => {
+    expect(isChromelessDisplayMode(matchMode("browser"), false)).toBe(false);
+  });
+});

--- a/ui/src/lib/pwa-display-mode.test.ts
+++ b/ui/src/lib/pwa-display-mode.test.ts
@@ -10,6 +10,14 @@ describe("isChromelessDisplayMode", () => {
     expect(isChromelessDisplayMode(matchMode("standalone"), false)).toBe(true);
   });
 
+  it("detects fullscreen display mode from media queries", () => {
+    expect(isChromelessDisplayMode(matchMode("fullscreen"), false)).toBe(true);
+  });
+
+  it("detects window-controls-overlay display mode from media queries", () => {
+    expect(isChromelessDisplayMode(matchMode("window-controls-overlay"), false)).toBe(true);
+  });
+
   it("detects iOS home-screen standalone launches", () => {
     expect(isChromelessDisplayMode(matchMode(null), true)).toBe(true);
   });

--- a/ui/src/lib/pwa-display-mode.ts
+++ b/ui/src/lib/pwa-display-mode.ts
@@ -1,0 +1,26 @@
+export const CHROMELESS_DISPLAY_MODES = ["standalone", "fullscreen", "window-controls-overlay"] as const;
+
+type DisplayMode = (typeof CHROMELESS_DISPLAY_MODES)[number];
+type MatchDisplayMode = (query: string) => Pick<MediaQueryList, "matches">;
+
+function displayModeQuery(mode: DisplayMode) {
+  return `(display-mode: ${mode})`;
+}
+
+function defaultMatchMedia(): MatchDisplayMode | undefined {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
+  return window.matchMedia.bind(window);
+}
+
+export function isChromelessDisplayMode(
+  matchMedia: MatchDisplayMode | undefined = defaultMatchMedia(),
+  iosStandalone: boolean | undefined =
+    typeof navigator === "undefined"
+      ? undefined
+      : (navigator as Navigator & { standalone?: boolean }).standalone,
+) {
+  if (iosStandalone === true) return true;
+  if (!matchMedia) return false;
+
+  return CHROMELESS_DISPLAY_MODES.some((mode) => matchMedia(displayModeQuery(mode)).matches);
+}


### PR DESCRIPTION
Fixes #7365

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Operators often use the board from installed mobile or standalone browser contexts
> - Standalone/PWA display mode can hide normal browser refresh/share/open affordances
> - That makes basic navigation recovery harder when Paperclip is running as an installed app
> - This pull request adds focused standalone browser controls in the UI shell
> - The benefit is a small operator quality-of-life improvement without changing normal browser layout

## What Changed

- Added display-mode detection helpers for standalone/PWA contexts.
- Added compact refresh, share, and open-in-browser controls for standalone mobile browser use.
- Mounted the controls in the app layout and added focused UI/unit coverage.

## Verification

- `pnpm exec vitest run --project @paperclipai/ui ui/src/components/StandaloneBrowserControls.test.tsx ui/src/lib/pwa-display-mode.test.ts`

## Risks

- Low risk. The controls are gated to standalone/mobile contexts and should not affect normal desktop browser usage.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex coding agent (Codex; exact served model ID/context window not exposed in runtime; tool use and local command execution enabled).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not included as repo artifacts; split task explicitly asked not to add design screenshots/images unless part of the work)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no docs behavior changed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge