### PR TITLE
[codex] Fix dev runner snapshot race

### DIFF
--- a/scripts/dev-runner-snapshot.mjs
+++ b/scripts/dev-runner-snapshot.mjs
@@ -1,0 +1,95 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { shouldTrackDevServerPath } from "./dev-runner-paths.mjs";
+
+const defaultFileSystem = {
+  existsSync,
+  readdirSync,
+  statSync,
+};
+
+export function isMissingPathError(error) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function toRelativePath(repoRoot, absolutePath) {
+  return path.relative(repoRoot, absolutePath).split(path.sep).join("/");
+}
+
+export function readSignature(absolutePath, fileSystem = defaultFileSystem) {
+  try {
+    const stats = fileSystem.statSync(absolutePath);
+    return `${Math.trunc(stats.mtimeMs)}:${stats.size}`;
+  } catch (error) {
+    if (isMissingPathError(error)) return null;
+    throw error;
+  }
+}
+
+export function addFileToSnapshot(snapshot, absolutePath, options) {
+  const relativePath = toRelativePath(options.repoRoot, absolutePath);
+  if (options.ignoredRelativePaths?.has(relativePath)) return;
+  if (!shouldTrackDevServerPath(relativePath)) return;
+
+  const signature = readSignature(absolutePath, options.fileSystem ?? defaultFileSystem);
+  if (signature === null) return;
+  snapshot.set(relativePath, signature);
+}
+
+export function walkDirectory(snapshot, absoluteDirectory, options) {
+  const fileSystem = options.fileSystem ?? defaultFileSystem;
+  if (!fileSystem.existsSync(absoluteDirectory)) return;
+
+  let entries;
+  try {
+    entries = fileSystem.readdirSync(absoluteDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    if (options.ignoredDirectoryNames?.has(entry.name)) continue;
+
+    const absolutePath = path.join(absoluteDirectory, entry.name);
+    if (entry.isDirectory()) {
+      walkDirectory(snapshot, absolutePath, options);
+      continue;
+    }
+    if (entry.isFile() || entry.isSymbolicLink()) {
+      addFileToSnapshot(snapshot, absolutePath, options);
+    }
+  }
+}
+
+export function collectWatchedSnapshot(options) {
+  const fileSystem = options.fileSystem ?? defaultFileSystem;
+  const snapshot = new Map();
+
+  for (const absoluteDirectory of options.watchedDirectories) {
+    walkDirectory(snapshot, absoluteDirectory, options);
+  }
+  for (const absoluteFile of options.watchedFiles) {
+    if (!fileSystem.existsSync(absoluteFile)) continue;
+    addFileToSnapshot(snapshot, absoluteFile, options);
+  }
+
+  return snapshot;
+}
+
+export function diffSnapshots(previous, next) {
+  const changed = new Set();
+
+  for (const [relativePath, signature] of next) {
+    if (previous.get(relativePath) !== signature) {
+      changed.add(relativePath);
+    }
+  }
+  for (const relativePath of previous.keys()) {
+    if (!next.has(relativePath)) {
+      changed.add(relativePath);
+    }
+  }
+
+  return [...changed].sort();
+}

--- a/scripts/dev-runner-snapshot.mjs
+++ b/scripts/dev-runner-snapshot.mjs
@@ -9,7 +9,12 @@ const defaultFileSystem = {
 };
 
 export function isMissingPathError(error) {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
 }
 
 function toRelativePath(repoRoot, absolutePath) {

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -265,8 +265,18 @@ function toRelativePath(absolutePath: string) {
   return path.relative(repoRoot, absolutePath).split(path.sep).join("/");
 }
 
+function isMissingPathError(error: unknown) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
 function readSignature(absolutePath: string) {
-  const stats = statSync(absolutePath);
+  let stats: ReturnType<typeof statSync>;
+  try {
+    stats = statSync(absolutePath);
+  } catch (error) {
+    if (isMissingPathError(error)) return null;
+    throw error;
+  }
   return `${Math.trunc(stats.mtimeMs)}:${stats.size}`;
 }
 
@@ -274,13 +284,23 @@ function addFileToSnapshot(snapshot: Map<string, string>, absolutePath: string) 
   const relativePath = toRelativePath(absolutePath);
   if (ignoredRelativePaths.has(relativePath)) return;
   if (!shouldTrackDevServerPath(relativePath)) return;
-  snapshot.set(relativePath, readSignature(absolutePath));
+  const signature = readSignature(absolutePath);
+  if (signature === null) return;
+  snapshot.set(relativePath, signature);
 }
 
 function walkDirectory(snapshot: Map<string, string>, absoluteDirectory: string) {
   if (!existsSync(absoluteDirectory)) return;
 
-  for (const entry of readdirSync(absoluteDirectory, { withFileTypes: true })) {
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(absoluteDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    throw error;
+  }
+
+  for (const entry of entries) {
     if (ignoredDirectoryNames.has(entry.name)) continue;
 
     const absolutePath = path.join(absoluteDirectory, entry.name);

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S node --import tsx
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { createCapturedOutputBuffer, parseJsonResponseWithLimit } from "./dev-runner-output.ts";
-import { shouldTrackDevServerPath } from "./dev-runner-paths.mjs";
+import { collectWatchedSnapshot as collectDevServerWatchedSnapshot, diffSnapshots } from "./dev-runner-snapshot.mjs";
 import { createDevServiceIdentity, repoRoot } from "./dev-service-profile.ts";
 import { bootstrapDevRunnerWorktreeEnv } from "../server/src/dev-runner-worktree.ts";
 import {
@@ -261,88 +261,14 @@ function exitForSignal(signal: NodeJS.Signals) {
   process.exit(1);
 }
 
-function toRelativePath(absolutePath: string) {
-  return path.relative(repoRoot, absolutePath).split(path.sep).join("/");
-}
-
-function isMissingPathError(error: unknown) {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
-}
-
-function readSignature(absolutePath: string) {
-  let stats: ReturnType<typeof statSync>;
-  try {
-    stats = statSync(absolutePath);
-  } catch (error) {
-    if (isMissingPathError(error)) return null;
-    throw error;
-  }
-  return `${Math.trunc(stats.mtimeMs)}:${stats.size}`;
-}
-
-function addFileToSnapshot(snapshot: Map<string, string>, absolutePath: string) {
-  const relativePath = toRelativePath(absolutePath);
-  if (ignoredRelativePaths.has(relativePath)) return;
-  if (!shouldTrackDevServerPath(relativePath)) return;
-  const signature = readSignature(absolutePath);
-  if (signature === null) return;
-  snapshot.set(relativePath, signature);
-}
-
-function walkDirectory(snapshot: Map<string, string>, absoluteDirectory: string) {
-  if (!existsSync(absoluteDirectory)) return;
-
-  let entries: ReturnType<typeof readdirSync>;
-  try {
-    entries = readdirSync(absoluteDirectory, { withFileTypes: true });
-  } catch (error) {
-    if (isMissingPathError(error)) return;
-    throw error;
-  }
-
-  for (const entry of entries) {
-    if (ignoredDirectoryNames.has(entry.name)) continue;
-
-    const absolutePath = path.join(absoluteDirectory, entry.name);
-    if (entry.isDirectory()) {
-      walkDirectory(snapshot, absolutePath);
-      continue;
-    }
-    if (entry.isFile() || entry.isSymbolicLink()) {
-      addFileToSnapshot(snapshot, absolutePath);
-    }
-  }
-}
-
 function collectWatchedSnapshot() {
-  const snapshot = new Map<string, string>();
-
-  for (const absoluteDirectory of watchedDirectories) {
-    walkDirectory(snapshot, absoluteDirectory);
-  }
-  for (const absoluteFile of watchedFiles) {
-    if (!existsSync(absoluteFile)) continue;
-    addFileToSnapshot(snapshot, absoluteFile);
-  }
-
-  return snapshot;
-}
-
-function diffSnapshots(previous: Map<string, string>, next: Map<string, string>) {
-  const changed = new Set<string>();
-
-  for (const [relativePath, signature] of next) {
-    if (previous.get(relativePath) !== signature) {
-      changed.add(relativePath);
-    }
-  }
-  for (const relativePath of previous.keys()) {
-    if (!next.has(relativePath)) {
-      changed.add(relativePath);
-    }
-  }
-
-  return [...changed].sort();
+  return collectDevServerWatchedSnapshot({
+    repoRoot,
+    watchedDirectories,
+    watchedFiles,
+    ignoredDirectoryNames,
+    ignoredRelativePaths,
+  }) as Map<string, string>;
 }
 
 function ensureDevStatusDirectory() {

--- a/server/src/__tests__/dev-runner-snapshot.test.ts
+++ b/server/src/__tests__/dev-runner-snapshot.test.ts
@@ -52,8 +52,9 @@ describe("dev-runner watched snapshot", () => {
       },
     };
 
-    expect(() => collectWatchedSnapshot({ ...createSnapshotOptions(root), fileSystem })).not.toThrow();
-    expect(collectWatchedSnapshot(createSnapshotOptions(root)).has("server/index.ts")).toBe(false);
+    const snapshot = collectWatchedSnapshot({ ...createSnapshotOptions(root), fileSystem });
+
+    expect(snapshot.has("server/index.ts")).toBe(false);
   });
 
   it("skips directories that disappear before they can be read", () => {
@@ -74,15 +75,27 @@ describe("dev-runner watched snapshot", () => {
       statSync: fs.statSync,
     };
 
-    expect(() => collectWatchedSnapshot({ ...createSnapshotOptions(root), fileSystem })).not.toThrow();
-    expect(collectWatchedSnapshot(createSnapshotOptions(root)).has("server/routes/health.ts")).toBe(false);
+    const snapshot = collectWatchedSnapshot({ ...createSnapshotOptions(root), fileSystem });
+
+    expect(snapshot.has("server/routes/health.ts")).toBe(false);
   });
 
-  it("returns null for missing file signatures and reports deleted paths in diffs", () => {
+  it("returns null for missing file signatures and not-directory races", () => {
     const root = createTempRoot("paperclip-dev-runner-snapshot-diff-");
     const missingPath = path.join(root, "server", "deleted.ts");
+    const fileSystem = {
+      statSync() {
+        const error = new Error("not a directory") as NodeJS.ErrnoException;
+        error.code = "ENOTDIR";
+        throw error;
+      },
+    };
 
     expect(readSignature(missingPath)).toBeNull();
+    expect(readSignature(missingPath, fileSystem)).toBeNull();
+  });
+
+  it("reports deleted paths in diffs", () => {
     expect(diffSnapshots(new Map([["server/deleted.ts", "1:1"]]), new Map())).toEqual(["server/deleted.ts"]);
   });
 });

--- a/server/src/__tests__/dev-runner-snapshot.test.ts
+++ b/server/src/__tests__/dev-runner-snapshot.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  collectWatchedSnapshot,
+  diffSnapshots,
+  readSignature,
+} from "../../../scripts/dev-runner-snapshot.mjs";
+
+const tempRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+function createTempRoot(prefix: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempRoots.add(root);
+  return root;
+}
+
+function createSnapshotOptions(root: string) {
+  return {
+    repoRoot: root,
+    watchedDirectories: [path.join(root, "server")],
+    watchedFiles: [path.join(root, "package.json")],
+    ignoredDirectoryNames: new Set(["node_modules"]),
+    ignoredRelativePaths: new Set([".paperclip/dev-server-status.json"]),
+  };
+}
+
+describe("dev-runner watched snapshot", () => {
+  it("skips files that disappear between directory listing and stat", () => {
+    const root = createTempRoot("paperclip-dev-runner-snapshot-file-race-");
+    const serverDir = path.join(root, "server");
+    const sourcePath = path.join(serverDir, "index.ts");
+    fs.mkdirSync(serverDir, { recursive: true });
+    fs.writeFileSync(sourcePath, "console.log('boot');\n", "utf8");
+
+    const fileSystem = {
+      existsSync: fs.existsSync,
+      readdirSync: fs.readdirSync,
+      statSync(target: fs.PathLike, options?: fs.StatOptions) {
+        if (target === sourcePath) {
+          fs.rmSync(sourcePath, { force: true });
+        }
+        return fs.statSync(target, options);
+      },
+    };
+
+    expect(() => collectWatchedSnapshot({ ...createSnapshotOptions(root), fileSystem })).not.toThrow();
+    expect(collectWatchedSnapshot(createSnapshotOptions(root)).has("server/index.ts")).toBe(false);
+  });
+
+  it("skips directories that disappear before they can be read", () => {
+    const root = createTempRoot("paperclip-dev-runner-snapshot-dir-race-");
+    const serverDir = path.join(root, "server");
+    const routesDir = path.join(serverDir, "routes");
+    fs.mkdirSync(routesDir, { recursive: true });
+    fs.writeFileSync(path.join(routesDir, "health.ts"), "export const ok = true;\n", "utf8");
+
+    const fileSystem = {
+      existsSync: fs.existsSync,
+      readdirSync(target: fs.PathLike, options?: fs.ObjectEncodingOptions & { withFileTypes: true }) {
+        if (target === routesDir) {
+          fs.rmSync(routesDir, { recursive: true, force: true });
+        }
+        return fs.readdirSync(target, options);
+      },
+      statSync: fs.statSync,
+    };
+
+    expect(() => collectWatchedSnapshot({ ...createSnapshotOptions(root), fileSystem })).not.toThrow();
+    expect(collectWatchedSnapshot(createSnapshotOptions(root)).has("server/routes/health.ts")).toBe(false);
+  });
+
+  it("returns null for missing file signatures and reports deleted paths in diffs", () => {
+    const root = createTempRoot("paperclip-dev-runner-snapshot-diff-");
+    const missingPath = path.join(root, "server", "deleted.ts");
+
+    expect(readSignature(missingPath)).toBeNull();
+    expect(diffSnapshots(new Map([["server/deleted.ts", "1:1"]]), new Map())).toEqual(["server/deleted.ts"]);
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The local dev runner keeps the API/UI process healthy while developers and agents work
> - Snapshot/status writes can race with process restart bookkeeping
> - A race there can leave stale or misleading dev server state during rapid restarts
> - This pull request tightens the dev-runner snapshot handling around that race
> - The benefit is more reliable local development runtime status without changing product behavior

Fixes #7364

## What Changed

- Updated `scripts/dev-runner.ts` to avoid the snapshot race during dev server process management.
- Extracted watched snapshot collection into `scripts/dev-runner-snapshot.mjs` so the race behavior can be tested directly.
- Added focused regression coverage for files/directories disappearing during snapshot scans.
- Kept the change isolated to the dev-runner script so it can merge independently of the UI PRs.

## Verification

- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/dev-runner-snapshot.test.ts server/src/__tests__/dev-runner-worktree.test.ts server/src/__tests__/dev-runner-output.test.ts server/src/__tests__/dev-runner-paths.test.ts --pool=forks --poolOptions.forks.isolate=true --no-file-parallelism --maxWorkers=1 --minWorkers=1`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low-to-moderate local development risk. The change affects dev server lifecycle bookkeeping, not production server routes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 Codex coding agent (Codex; exact served model ID/context window not exposed in runtime; tool use and local command execution enabled).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; no UI changes)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no docs behavior changed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge