### PR TITLE
fix(issues): preserve assigneeAgentId on routine_execution issue release (GH#6981)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5426,3 +5426,114 @@ describeEmbeddedPostgres("issueService.assertCheckoutOwner stale checkout adopti
   });
 
 });
+
+describeEmbeddedPostgres("issueService.release preserves assigneeAgentId for routine_execution", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-release-assignee-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("preserves assigneeAgentId when originKind is routine_execution", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      title: "Test",
+      status: "running",
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "TEST-1",
+      title: "Routine test issue",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      originKind: "routine_execution",
+      originId: "routine-1",
+      priority: "medium",
+    });
+
+    const released = await svc.release(issueId, agentId);
+    expect(released).not.toBeNull();
+    expect(released!.status).toBe("todo");
+    expect(released!.assigneeAgentId).toBe(agentId);
+  });
+
+  it("clears assigneeAgentId for non-routine_execution issues", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      title: "Test",
+      status: "running",
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "TEST-2",
+      title: "Manual test issue",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      originKind: "manual",
+      originId: issueId,
+      priority: "medium",
+    });
+
+    const released = await svc.release(issueId, agentId);
+    expect(released).not.toBeNull();
+    expect(released!.status).toBe("todo");
+    expect(released!.assigneeAgentId).toBeNull();
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5855,7 +5855,7 @@ export function issueService(db: Db) {
           .update(issues)
           .set({
             status: "todo",
-            assigneeAgentId: null,
+            assigneeAgentId: existing.originKind === "routine_execution" ? existing.assigneeAgentId : null,
             checkoutRunId: null,
             executionRunId: null,
             executionAgentNameKey: null,


### PR DESCRIPTION
## Thinking Path

> Upstream issue GH#6981 (PAP-256): `POST /api/issues/:id/release` unconditionally sets `assigneeAgentId: null`, which breaks the agent handoff workflow for `routine_execution` lifecycle issues.
> The issue becomes orphaned between routine fires because the routine system expects the agent assignment to survive the release-and-requeue cycle.
> The fix is a 1-line conditional: when `originKind === 'routine_execution'`, preserve the existing `assigneeAgentId`. All other issue types continue to clear it as before.

## Linked Issues or Issue Description

Fixes #6981

## What Changed

- `server/src/services/issues.ts` (1 line): Changed `assigneeAgentId: null` to `existing.originKind === "routine_execution" ? existing.assigneeAgentId : null` in the release function
- `server/src/__tests__/issues-service.test.ts`: Added 2 regression tests verifying the behavior for routine_execution (preserves) and non-routine_execution (clears) issues

## Verification

1. `pnpm test -- server/src/__tests__/issues-service.test.ts` — all tests pass including 2 new regression tests
2. Release function conditionally preserves assigneeAgentId based on originKind
3. Clean cherry-pick on upstream/master — only 2 files changed

## Risks

- Minimal: only affects the release() path for routine_execution issues
- Non-routine_execution behavior is unchanged (assigneeAgentId still cleared as before)

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Checklist

- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] Fixes GH#6981
- [x] Single-concern PR (2 files: service + test)
- [x] Tests pass
- [x] No pnpm-lock.yaml
- [x] No AGENTS.md / .gitignore changes