### PR TITLE
fix(recovery): dedup silent-run evaluations and skip terminal-source orphans

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -367,9 +367,9 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(event?.message).toContain("Source-resolved watchdog fold");
   });
 
-  it("still escalates terminal source issues without same-run terminal evidence", async () => {
+  it("skips terminal source issues without same-run terminal evidence and emits an orphan-run detection", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
-    const { companyId, runId } = await seedRunningRun({
+    const { companyId, issueId, runId } = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
       sourceStatus: "done",
@@ -378,18 +378,84 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
 
-    expect(result).toMatchObject({ created: 1, folded: 0 });
-    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
-    const [evaluation] = await db
+    expect(result).toMatchObject({ created: 0, folded: 0, skipped: 1 });
+    const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluation?.originId).toBe(runId);
-    expect(evaluation?.parentId).toBeNull();
+    expect(evaluations).toHaveLength(0);
+
+    const [detection] = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_orphan_run_detected"),
+        ),
+      );
+    expect(detection).toBeTruthy();
+    expect(detection?.details).toMatchObject({
+      sourceIssueId: issueId,
+      sourceIssueStatus: "done",
+      runId,
+      reason: "terminal_source_no_same_run_evidence",
+    });
   });
 
-  it("still escalates when a same-run comment is followed by another actor marking the source done", async () => {
+  it("skips silent-run evaluation creation when a prior evaluation for the same run was already disposed", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, managerId, runId, issuePrefix } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const priorEvaluationId = randomUUID();
+    await db.insert(issues).values({
+      id: priorEvaluationId,
+      companyId,
+      title: "Prior silent-run evaluation already closed",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "stale_active_run_evaluation",
+      originId: runId,
+      originRunId: runId,
+      originFingerprint: `stale_active_run:${companyId}:${runId}`,
+      completedAt: new Date(now.getTime() - 30 * 60 * 1000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ created: 0, existing: 0, skipped: 1 });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.id).toBe(priorEvaluationId);
+
+    const [dedup] = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_dedup_skipped"),
+        ),
+      );
+    expect(dedup).toBeTruthy();
+    expect(dedup?.details).toMatchObject({
+      priorEvaluationIssueId: priorEvaluationId,
+      priorEvaluationStatus: "done",
+      runId,
+      reason: "prior_evaluation_terminal",
+    });
+  });
+
+  it("skips with orphan-run detection when a same-run comment is followed by another actor marking the source done", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, issueId, runId, issuePrefix } = await seedRunningRun({
       now,
@@ -422,15 +488,28 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
 
-    expect(result).toMatchObject({ created: 1, folded: 0 });
-    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
-    const [evaluation] = await db
+    expect(result).toMatchObject({ created: 0, folded: 0, skipped: 1 });
+    const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluation?.originId).toBe(runId);
-    expect(evaluation?.parentId).toBeNull();
+    expect(evaluations).toHaveLength(0);
+
+    const [detection] = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_orphan_run_detected"),
+        ),
+      );
+    expect(detection?.details).toMatchObject({
+      sourceIssueId: issueId,
+      sourceIssueStatus: "done",
+      runId,
+      reason: "terminal_source_no_same_run_evidence",
+    });
   });
 
   it("folds existing evaluation and active watchdog recovery action idempotently", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -840,6 +840,43 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function findHistoricalStaleRunEvaluation(companyId: string, runId: string) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .orderBy(desc(issues.createdAt))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async function hasContinueWatchdogDecisionForRun(companyId: string, runId: string) {
+    const [row] = await db
+      .select({ id: heartbeatRunWatchdogDecisions.id })
+      .from(heartbeatRunWatchdogDecisions)
+      .where(
+        and(
+          eq(heartbeatRunWatchdogDecisions.companyId, companyId),
+          eq(heartbeatRunWatchdogDecisions.runId, runId),
+          eq(heartbeatRunWatchdogDecisions.decision, "continue"),
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -1471,6 +1508,35 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
       return { kind: "skipped" as const };
     }
+    if (!existing) {
+      const historical = await findHistoricalStaleRunEvaluation(input.run.companyId, input.run.id);
+      if (historical && isTerminalIssueStatus(historical.status)) {
+        const continueOptIn = await hasContinueWatchdogDecisionForRun(input.run.companyId, input.run.id);
+        if (!continueOptIn) {
+          await logActivity(db, {
+            companyId: input.run.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: input.run.agentId,
+            runId: input.run.id,
+            action: "heartbeat.output_stale_dedup_skipped",
+            entityType: "heartbeat_run",
+            entityId: input.run.id,
+            details: {
+              source: "recovery.scan_silent_active_runs",
+              reason: "prior_evaluation_terminal",
+              priorEvaluationIssueId: historical.id,
+              priorEvaluationIdentifier: historical.identifier,
+              priorEvaluationStatus: historical.status,
+              sourceIssueId: sourceIssue?.id ?? null,
+              sourceIssueStatus: sourceIssue?.status ?? null,
+              runId: input.run.id,
+            },
+          });
+          return { kind: "skipped" as const };
+        }
+      }
+    }
     const silenceStartedAt = silenceStartedAtForRun(input.run);
     if (sourceIssue && isTerminalIssueStatus(sourceIssue.status)) {
       const terminalEvidence = await latestSameRunSourceTerminalEvidence({
@@ -1489,6 +1555,32 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           silenceAgeMs: silenceAgeMsForRun(input.run, input.now),
           now: input.now,
         });
+      }
+      if (!existing) {
+        const cleanup = await cleanupSourceResolvedRunProcess({ run: input.run, runningAgent });
+        await logActivity(db, {
+          companyId: input.run.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: input.run.agentId,
+          runId: input.run.id,
+          action: "heartbeat.output_stale_orphan_run_detected",
+          entityType: "heartbeat_run",
+          entityId: input.run.id,
+          details: {
+            source: "recovery.scan_silent_active_runs",
+            reason: "terminal_source_no_same_run_evidence",
+            sourceIssueId: sourceIssue.id,
+            sourceIssueIdentifier: sourceIssue.identifier,
+            sourceIssueStatus: sourceIssue.status,
+            runId: input.run.id,
+            processPid: input.run.processPid ?? null,
+            processGroupId: input.run.processGroupId ?? null,
+            silenceAgeMs: silenceAgeMsForRun(input.run, input.now),
+            cleanup,
+          },
+        });
+        return { kind: "skipped" as const };
       }
     }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, including their recovery and self-healing behavior
> - The output watchdog inside `recoveryService` detects long-running heartbeat runs that have gone silent and files a "Review silent active run" evaluation issue so an owner can decide what to do
> - But the evaluation lifecycle had no dedup gate keyed on `(companyId, sourceIssueId, runId)`: once the prior evaluation was closed, the next scan tick created a brand-new evaluation for the same orphan run
> - In production this produced 50+ duplicate review issues over 19h for a single stale run (`979a51bf` on a completed source issue) — the originFingerprint was identical, yet no skip
> - This pull request adds two stop-the-bleed gates inside `createOrUpdateStaleRunEvaluation`: (1) a dedup gate that respects `done`/`cancelled` prior evaluations for the same run, and (2) a terminal-source auto-skip that emits an orphan-run detection instead of filing more evaluations when the source already finished and there is no same-run terminal evidence to fold against
> - The benefit is that the watchdog converges instead of spamming: it asks once per run, honors explicit `continue`/re-arm decisions, and surfaces orphan runs to a future reaper rather than burying them under duplicate review tasks

## What Changed

- `server/src/services/recovery/service.ts`
  - New `findHistoricalStaleRunEvaluation(companyId, runId)` returns the most recent non-hidden evaluation for a run regardless of status.
  - New `hasContinueWatchdogDecisionForRun(companyId, runId)` reads `heartbeat_run_watchdog_decisions` for an explicit `continue` record — the signal that the owner authorized re-arm.
  - `createOrUpdateStaleRunEvaluation` now:
    - **(Item 1 dedup gate)** When no open evaluation exists but a prior terminal evaluation does, skip creation and emit `heartbeat.output_stale_dedup_skipped` to the activity log — unless the owner already recorded a `continue` decision, in which case the legitimate re-arm path runs as before.
    - **(Item 2 terminal-source auto-skip)** When the source issue is `done`/`cancelled` and `latestSameRunSourceTerminalEvidence` cannot find a same-run disposition to fold against, attempt `cleanupSourceResolvedRunProcess` for local adapters and emit `heartbeat.output_stale_orphan_run_detected` with `pid` / `processGroupId` for a downstream reaper, instead of creating yet another evaluation issue.
- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`
  - Rewrote `"still escalates terminal source issues without same-run terminal evidence"` — old behavior was the bug. Now asserts `created: 0, skipped: 1` and verifies the `output_stale_orphan_run_detected` activity row.
  - Rewrote the sibling test where another actor marks the source `done` after a same-run comment — same flip from escalate-to-skip with the same activity assertion.
  - Added `"skips silent-run evaluation creation when a prior evaluation for the same run was already disposed"` covering the dedup gate path.
  - The existing `"re-arms continue decisions after the default quiet window"` test still passes — the `hasContinueWatchdogDecisionForRun` check preserves it.

## Verification

- `cd server && pnpm typecheck` — passes cleanly.
- `cd server && pnpm vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — **14/14 passing**, including the 2 new orphan-detection / dedup tests and the unchanged re-arm test.
- `cd server && pnpm vitest run src/__tests__/recovery-classifiers.test.ts src/__tests__/issue-recovery-actions.test.ts src/__tests__/heartbeat-process-recovery.test.ts` — **75/75 passing** across adjacent recovery suites; no regressions.
- Manual reasoning: production fingerprint `stale_active_run:${companyId}:${runId}` is unchanged; the dedup gate only fires when (a) an evaluation already exists in `done`/`cancelled` for the run AND (b) no `continue` watchdog decision was recorded. The terminal-source skip only fires when the source is `done`/`cancelled` AND `latestSameRunSourceTerminalEvidence` returns null AND there is no open evaluation — exactly the gap DIG-1432 captures.

## Risks

- **Low–medium risk.** Behavior changes only at the previously-buggy edges:
  - Dedup gate: if an owner closes an evaluation as `done` without recording a `continue` decision, subsequent scans will silently skip that run forever. This matches the intended semantic ("you already decided"). The activity-log row makes the skip observable.
  - Terminal-source skip: stops filing evaluations for runs whose source is already terminal. Until the downstream reaper lands, the orphan run may stay in `running` until its process actually exits. The cleanup call best-effort-terminates local adapter processes; remote adapters are not touched.
- No migration. No schema change. All new fields are activity-log `details`.
- Public surface (`scanSilentActiveRuns` return shape) unchanged; counts route to existing `skipped` bucket.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: standard
- Reasoning mode: extended thinking enabled
- Tool use: file edit, bash, grep, structured workflow planning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only change)
- [x] I have updated relevant documentation to reflect my changes — N/A (no doc paths affected; behavior change is captured in the renamed/added tests and the new `output_stale_dedup_skipped` / `output_stale_orphan_run_detected` activity actions)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
