### PR TITLE
feat(recovery): hard cap per source issue + Rule-3 watchdog template

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -503,6 +503,81 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(decisions).toHaveLength(1);
   });
 
+  it("emits CTO escalation and skips evaluation creation when source issue already has a prior stale evaluation", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, managerId, issueId, runId, issuePrefix } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const priorEvaluationId = randomUUID();
+    await db.insert(issues).values({
+      id: priorEvaluationId,
+      companyId,
+      title: "Prior silent-run evaluation (closed)",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      parentId: issueId,
+      originKind: "stale_active_run_evaluation",
+      originId: randomUUID(),
+      originRunId: randomUUID(),
+      originFingerprint: `stale_active_run:${companyId}:prior-run-id`,
+      completedAt: new Date(now.getTime() - 60 * 60 * 1000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ created: 0, skipped: 1 });
+    const newEvaluations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "stale_active_run_evaluation"),
+          sql`${issues.id} != ${priorEvaluationId}`,
+        ),
+      );
+    expect(newEvaluations).toHaveLength(0);
+
+    const [capLog] = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_cap_exceeded"),
+        ),
+      );
+    expect(capLog).toBeTruthy();
+    expect(capLog?.details).toMatchObject({
+      sourceIssueId: issueId,
+      priorEvalCount: 1,
+      reason: "source_issue_evaluation_cap_exceeded",
+    });
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.parentId, issueId),
+          sql`${issues.id} != ${priorEvaluationId}`,
+        ),
+      );
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0]).toMatchObject({
+      priority: "high",
+      assigneeAgentId: managerId,
+      originId: runId,
+    });
+    expect(escalations[0]?.description).toContain("Rule-2 Escalation Packet");
+  });
+
   it("refuses recovery-on-recovery stale-run recursion", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId } = await seedRunningRun({

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -617,6 +617,23 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       "- Close as productive if this pattern is expected.",
       "- Continue with a snooze window if the current work should keep running without repeat review spam.",
       "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
+      ...(evidence.trigger === "no_comment_streak" ? [
+        "",
+        "## Rule-3 Heartbeat Template",
+        "",
+        "If this issue is still live and should continue, the assignee must post a heartbeat comment using this template (Silent-Run Policy Rule 3):",
+        "",
+        "```",
+        "Status: still active / blocked / ready for review",
+        "Current step:",
+        "Last completed step:",
+        "Next step:",
+        "Blockers:",
+        "Evidence/logs:",
+        "```",
+        "",
+        "No heartbeat in a 30-45 min window = stale by policy. Silent `in_progress` is a Rule-3 violation, not a valid state.",
+      ] : []),
     ].join("\n");
   }
 

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -3,6 +3,7 @@ export const RECOVERY_ORIGIN_KINDS = {
   issueProductivityReview: "issue_productivity_review",
   strandedIssueRecovery: "stranded_issue_recovery",
   staleActiveRunEvaluation: "stale_active_run_evaluation",
+  staleRunCtoEscalation: "stale_run_cto_escalation",
 } as const;
 
 export const RECOVERY_REASON_KINDS = {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -69,6 +69,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const STALE_RUN_CTO_ESCALATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleRunCtoEscalation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
@@ -816,6 +817,57 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function countSourceIssueStaleEvaluations(companyId: string, sourceIssueId: string) {
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.parentId, sourceIssueId),
+          isNull(issues.hiddenAt),
+        ),
+      );
+    return Number(row?.count ?? 0);
+  }
+
+  function buildCtoEscalationDescription(input: {
+    sourceIssue: typeof issues.$inferSelect;
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+    prefix: string;
+    priorEvalCount: number;
+    silenceAgeMs: number | null;
+  }) {
+    return [
+      "Paperclip hard cap exceeded: this source issue has triggered more stale-run evaluations than the policy limit (Rule 2).",
+      "",
+      "## Rule-2 Escalation Packet",
+      "",
+      `- Source issue: ${issueUiLink({ identifier: input.sourceIssue.identifier, id: input.sourceIssue.id }, input.prefix)}`,
+      `- Stale run: \`${input.run.id}\``,
+      `- Assigned agent: ${agentUiLink(input.runningAgent, input.prefix)} (${input.runningAgent.adapterType})`,
+      `- Silent for: ${formatDuration(input.silenceAgeMs)}`,
+      `- Prior stale evaluations on this source issue: ${input.priorEvalCount} (cap: 1)`,
+      `- Process metadata: pid \`${input.run.processPid ?? "unknown"}\`, process group \`${input.run.processGroupId ?? "unknown"}\``,
+      "",
+      "## Required Fields (fill before closing)",
+      "",
+      "- Last known completed checkpoint (commit, file, flow name):",
+      "- Remaining acceptance criteria still unmet:",
+      "- Suspected blocker (with evidence):",
+      "- Recommended next action:",
+      "",
+      "## Next Action",
+      "",
+      "As CTO, review this escalation, fill in the packet fields above, then:",
+      "1. Kill the stale run if it is still alive (pid above).",
+      "2. Decide whether to restart from the last checkpoint or cancel the source issue.",
+      "3. Comment on the source issue with the decision and close this escalation `done`.",
+    ].join("\n");
+  }
+
   async function findOpenStaleRunEvaluation(companyId: string, runId: string) {
     const [row] = await db
       .select({
@@ -1492,6 +1544,97 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
     }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
+    if (sourceIssue && !existing && !isTerminalIssueStatus(sourceIssue.status)) {
+      const [priorEvalCount, hasContinueDecision] = await Promise.all([
+        countSourceIssueStaleEvaluations(input.run.companyId, sourceIssue.id),
+        db
+          .select({ id: heartbeatRunWatchdogDecisions.id })
+          .from(heartbeatRunWatchdogDecisions)
+          .where(
+            and(
+              eq(heartbeatRunWatchdogDecisions.companyId, input.run.companyId),
+              eq(heartbeatRunWatchdogDecisions.runId, input.run.id),
+              eq(heartbeatRunWatchdogDecisions.decision, "continue"),
+            ),
+          )
+          .limit(1)
+          .then((rows) => Boolean(rows[0])),
+      ]);
+      if (priorEvalCount >= 1 && !hasContinueDecision) {
+        const silenceAgeMs = silenceAgeMsForRun(input.run, input.now);
+        const ctoAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
+        let ctoEscalation: Awaited<ReturnType<typeof issuesSvc.create>> | null = null;
+        try {
+          ctoEscalation = await issuesSvc.create(input.run.companyId, {
+            title: `CTO escalation: stale-run hard cap exceeded for ${sourceIssue.identifier ?? sourceIssue.id}`,
+            description: buildCtoEscalationDescription({
+              sourceIssue,
+              run: input.run,
+              runningAgent,
+              prefix,
+              priorEvalCount,
+              silenceAgeMs,
+            }),
+            status: "todo",
+            priority: "high",
+            parentId: sourceIssue.id,
+            projectId: sourceIssue.projectId ?? null,
+            goalId: sourceIssue.goalId ?? null,
+            billingCode: sourceIssue.billingCode ?? null,
+            assigneeAgentId: ctoAgentId,
+            assigneeAdapterOverrides: recoveryAssigneeAdapterOverrides("status_only"),
+            originKind: STALE_RUN_CTO_ESCALATION_ORIGIN_KIND,
+            originId: input.run.id,
+            originRunId: input.run.id,
+            originFingerprint: `stale_cto_escalation:${input.run.companyId}:${sourceIssue.id}:${input.run.id}`,
+          });
+        } catch {
+          ctoEscalation = null;
+        }
+        await logActivity(db, {
+          companyId: input.run.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: input.run.agentId,
+          runId: input.run.id,
+          action: "heartbeat.output_stale_cap_exceeded",
+          entityType: "heartbeat_run",
+          entityId: input.run.id,
+          details: {
+            source: "recovery.scan_silent_active_runs",
+            reason: "source_issue_evaluation_cap_exceeded",
+            sourceIssueId: sourceIssue.id,
+            sourceIssueIdentifier: sourceIssue.identifier,
+            priorEvalCount,
+            ctoEscalationIssueId: ctoEscalation?.id ?? null,
+            silenceAgeMs,
+          },
+        });
+        if (ctoAgentId && ctoEscalation) {
+          await deps.enqueueWakeup(ctoAgentId, {
+            source: "assignment",
+            triggerDetail: "system",
+            reason: "issue_assigned",
+            payload: withRecoveryModelProfileHint({
+              issueId: ctoEscalation.id,
+              staleRunId: input.run.id,
+              sourceIssueId: sourceIssue.id,
+            }, "status_only"),
+            requestedByActorType: "system",
+            requestedByActorId: null,
+            contextSnapshot: withRecoveryModelProfileHint({
+              issueId: ctoEscalation.id,
+              taskId: ctoEscalation.id,
+              wakeReason: "issue_assigned",
+              source: "recovery.stale_run_cto_escalation",
+              staleRunId: input.run.id,
+              sourceIssueId: sourceIssue.id,
+            }, "status_only"),
+          });
+        }
+        return { kind: "skipped" as const };
+      }
+    }
     const evidence = await collectStaleRunEvidence({
       run: input.run,
       runningAgent,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, including automated recovery when agents go silent
> - The output watchdog creates "Review silent active run" issues when a heartbeat run produces no output for > 1h
> - Policy rule 2 (Silent-Run Policy, DIG-1427) says caps should be enforced: at most 1 evaluation per source issue before escalating to CTO; at most 2 reruns before escalating
> - Policy rule 3 says any task running > 30 minutes must post a heartbeat comment every 30-45 minutes using a specific template; the no-comment-streak productivity review is the surface where this applies
> - Neither the evaluation cap nor the Rule-3 template existed in code — both were agent-enforced only, which breaks down when agents themselves are stale
> - This PR implements the cap (item 4 from the planned changes) as a query-based count of prior evaluations parented to the source issue, and adds the Rule-3 template section to productivity review descriptions (item 5) when the trigger is `no_comment_streak`
> - No schema migration is needed — the cap uses existing `parent_id` and `origin_kind` fields; the new escalation originKind (`stale_run_cto_escalation`) is added to the enum in `origins.ts`
> - The benefit is that the watchdog converges rather than spamming, and silent-run handlers and CTO agents see the pre-filled Rule-2 packet immediately without having to source it from policy docs

## What Changed

- `server/src/services/recovery/origins.ts`
  - Added `staleRunCtoEscalation: "stale_run_cto_escalation"` to `RECOVERY_ORIGIN_KINDS` so CTO escalation issues use a distinct kind and do not count against their own cap.

- `server/src/services/recovery/service.ts`
  - New `countSourceIssueStaleEvaluations(companyId, sourceIssueId)` — counts non-hidden `stale_active_run_evaluation` issues parented to the source issue (any status).
  - New `buildCtoEscalationDescription(input)` — pre-fills the Rule-2 packet: source issue, stale run id, agent, silence duration, prior evaluation count, process pid/pgid, and the four required packet fields with blank lines for the CTO to fill.
  - `createOrUpdateStaleRunEvaluation` now: when no existing open evaluation exists and the source issue is not terminal, checks `priorEvalCount >= 1 && !hasContinueDecision`. If capped, creates a CTO escalation issue (priority `high`, parent = source issue, originKind = `stale_run_cto_escalation`) and emits `heartbeat.output_stale_cap_exceeded` activity log with `{ reason, sourceIssueId, priorEvalCount, ctoEscalationIssueId }`. The `hasContinueDecision` guard preserves the explicit re-arm path.

- `server/src/services/productivity-review.ts`
  - `buildReviewMarkdown` appends a `## Rule-3 Heartbeat Template` section when `evidence.trigger === "no_comment_streak"`. The section shows the exact five-field status comment (Status / Current step / Last completed step / Next step / Blockers / Evidence-logs) from Silent-Run Policy Rule 3, plus the 30-45 minute window reminder.

- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`
  - New test: `emits CTO escalation and skips evaluation creation when source issue already has a prior stale evaluation` — seeds a closed prior evaluation as a child of the source issue; asserts `created: 0, skipped: 1`, the `output_stale_cap_exceeded` activity log, the escalation issue with CTO assignee and Rule-2 packet in the description, and no second evaluation created.

## Verification

- `cd server && pnpm typecheck` — passes cleanly.
- `cd server && pnpm vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — **14/14 passing**, including the new CTO escalation test and the unchanged re-arm test (the `continue`-decision guard keeps it working).
- `cd server && pnpm vitest run src/__tests__/productivity-review-service.test.ts` — **11/11 passing**, no regressions on productivity review logic.
- This PR is independent of PR #7379 (dedup gate + terminal-source skip) — it builds on master and works standalone.

## Risks

- **Low risk.** No schema migration — the cap uses existing `parent_id` + `origin_kind` fields via a count query. The new `stale_run_cto_escalation` originKind is a new string value with no DB constraint; any existing code that checks `originKind` for specific values will not match it and will treat it as a regular issue (safe default).
- CTO escalation is best-effort (`try/catch` around `issuesSvc.create`); if creation fails the skip still fires and the activity log records `ctoEscalationIssueId: null`. This means the cap is still enforced even if the escalation cannot be created.
- The Rule-3 template section is string-only; it does not change any existing trigger thresholds or counters.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: standard
- Reasoning mode: extended thinking enabled
- Tool use: file edit, bash, grep

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only change)
- [x] I have updated relevant documentation to reflect my changes — N/A (behavior captured in new test and activity log actions)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
