### PR TITLE
Fix project context inheritance for agent-created issues

### DIFF
--- a/server/src/__tests__/issue-create-project-context.test.ts
+++ b/server/src/__tests__/issue-create-project-context.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+  projectWorkspaces,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue create project-context tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue create project context inheritance", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-create-project-context-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedProjectIssueFixture() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Jersey Empire",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Worker",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Launch project",
+      status: "active",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      isPrimary: true,
+    });
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Launch source task",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      contextSnapshot: { issueId: sourceIssueId, taskId: sourceIssueId, wakeReason: "issue_assigned" },
+    });
+
+    return { agentId, companyId, projectId, projectWorkspaceId, runId, sourceIssueId };
+  }
+
+  function createAgentApp(input: { agentId: string; companyId: string; runId: string }) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "agent",
+        agentId: input.agentId,
+        companyId: input.companyId,
+        runId: input.runId,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("inherits project and project workspace when create() reuses another issue workspace", async () => {
+    const { companyId, projectId, projectWorkspaceId, sourceIssueId } = await seedProjectIssueFixture();
+
+    const created = await issueService(db).create(companyId, {
+      title: "Sibling follow-up",
+      status: "todo",
+      inheritExecutionWorkspaceFromIssueId: sourceIssueId,
+    });
+
+    expect(created.projectId).toBe(projectId);
+    expect(created.projectWorkspaceId).toBe(projectWorkspaceId);
+  });
+
+  it("inherits project context for agent-created follow-up issues from the current run issue", async () => {
+    const { agentId, companyId, projectId, projectWorkspaceId, runId, sourceIssueId } = await seedProjectIssueFixture();
+
+    const res = await request(createAgentApp({ agentId, companyId, runId }))
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Prepare merge follow-up",
+        description: "Root follow-up created while handling the source task.",
+        status: "todo",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body).toMatchObject({
+      title: "Prepare merge follow-up",
+      projectId,
+      projectWorkspaceId,
+      parentId: null,
+      createdByAgentId: agentId,
+    });
+
+    const stored = await db
+      .select({ projectId: issues.projectId, projectWorkspaceId: issues.projectWorkspaceId, parentId: issues.parentId })
+      .from(issues)
+      .where(eq(issues.id, res.body.id))
+      .then((rows) => rows[0] ?? null);
+
+    expect(stored).toEqual({ projectId, projectWorkspaceId, parentId: null });
+    expect(res.body.id).not.toBe(sourceIssueId);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7,6 +7,7 @@ import type { Db } from "@paperclipai/db";
 import {
   activityLog,
   executionWorkspaces,
+  heartbeatRuns,
   issueExecutionDecisions,
   issueRelations,
   issues as issueRows,
@@ -879,6 +880,48 @@ export function issueRoutes(
       environmentId,
       { allowedDrivers: ["local", "ssh", "sandbox"] },
     );
+  }
+
+  async function resolveAgentRunIssueCreationContext(input: {
+    companyId: string;
+    actor: ReturnType<typeof getActorInfo>;
+    body: Record<string, unknown>;
+  }) {
+    if (input.actor.actorType !== "agent" || !input.actor.runId) return null;
+    if (
+      input.body.parentId !== undefined ||
+      input.body.projectId !== undefined ||
+      input.body.projectWorkspaceId !== undefined ||
+      input.body.inheritExecutionWorkspaceFromIssueId !== undefined ||
+      input.body.executionWorkspaceId !== undefined
+    ) {
+      return null;
+    }
+
+    const run = await db
+      .select({
+        companyId: heartbeatRuns.companyId,
+        agentId: heartbeatRuns.agentId,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, input.actor.runId))
+      .then((rows) => rows[0] ?? null);
+    if (!run || run.companyId !== input.companyId || run.agentId !== input.actor.agentId) return null;
+
+    const snapshot = run.contextSnapshot && typeof run.contextSnapshot === "object"
+      ? run.contextSnapshot as Record<string, unknown>
+      : null;
+    const sourceIssueId =
+      readNonEmptyString(snapshot?.issueId) ??
+      readNonEmptyString(snapshot?.taskId) ??
+      readNonEmptyString(snapshot?.taskKey);
+    if (!sourceIssueId) return null;
+
+    const sourceIssue = await svc.getById(sourceIssueId);
+    if (!sourceIssue || sourceIssue.companyId !== input.companyId) return null;
+    if (!sourceIssue.projectId && !sourceIssue.projectWorkspaceId && !sourceIssue.executionWorkspaceId) return null;
+    return sourceIssue;
   }
 
   async function assertAgentInReviewReviewPath(input: {
@@ -2660,13 +2703,26 @@ export function issueRoutes(
     await assertIssueEnvironmentSelection(companyId, req.body.executionWorkspaceSettings?.environmentId);
 
     const actor = getActorInfo(req);
+    const inheritedIssueContext = await resolveAgentRunIssueCreationContext({
+      companyId,
+      actor,
+      body: req.body,
+    });
+    const issueCreateInput = inheritedIssueContext
+      ? {
+          ...req.body,
+          projectId: inheritedIssueContext.projectId ?? undefined,
+          projectWorkspaceId: inheritedIssueContext.projectWorkspaceId ?? undefined,
+          inheritExecutionWorkspaceFromIssueId: inheritedIssueContext.id,
+        }
+      : req.body;
     const executionPolicy = applyActorMonitorScheduledBy(
-      normalizeIssueExecutionPolicy(req.body.executionPolicy),
+      normalizeIssueExecutionPolicy(issueCreateInput.executionPolicy),
       actor.actorType,
     );
-    assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+    assertCanManageIssueMonitor(req, issueCreateInput.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
     const issue = await svc.create(companyId, {
-      ...req.body,
+      ...issueCreateInput,
       executionPolicy,
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4036,7 +4036,6 @@ export function issueService(db: Db) {
       }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
-        const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
         let executionWorkspaceId = issueData.executionWorkspaceId ?? null;
         let executionWorkspacePreference = issueData.executionWorkspacePreference ?? null;
@@ -4049,6 +4048,9 @@ export function issueService(db: Db) {
           issueData.executionWorkspaceSettings !== undefined;
         if (workspaceInheritanceIssueId) {
           const workspaceSource = await getWorkspaceInheritanceIssue(tx, companyId, workspaceInheritanceIssueId);
+          if (issueData.projectId == null && workspaceSource.projectId) {
+            issueData.projectId = workspaceSource.projectId;
+          }
           if (projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
             projectWorkspaceId = workspaceSource.projectWorkspaceId;
           }
@@ -4075,6 +4077,7 @@ export function issueService(db: Db) {
             }
           }
         }
+        const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         // Cache the project policy lookup for this insert. Both the
         // default-settings block and the assignee-environment-promotion block
         // need the same row; without caching they'd issue two round-trips.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so task context must stay anchored to the right company/project/workspace.
> - The issue subsystem owns task creation, child issues, assignment wakeups, and execution workspace inheritance.
> - JE launch-control agents exposed a bug where agent-created follow-up/root issues could be created without `projectId` / `projectWorkspaceId` even while the agent was working inside a project-scoped run.
> - Projectless follow-ups then route poorly, lose workspace context, and can trigger noisy recovery/continuation loops.
> - Existing child issue creation already had a parent path, but generic `/companies/:companyId/issues` creation did not infer the current run issue context.
> - This pull request preserves project/workspace context both in the service-level workspace inheritance path and in agent route creation when the request omits explicit project/workspace fields.
> - The benefit is safer autonomous follow-up/review/merge task creation without changing explicitly scoped or explicitly projectless requests.

Fixes #7384

## What Changed

- Fixed `issueService.create()` so `inheritExecutionWorkspaceFromIssueId` also inherits the source issue's `projectId`, not just workspace fields.
- Updated agent issue creation through `/companies/:companyId/issues` to infer project context from the current heartbeat run's `contextSnapshot.issueId` / `taskId` / `taskKey` when the agent omits explicit project/workspace fields.
- Preserved explicit caller intent: requests that include `parentId`, `projectId`, `projectWorkspaceId`, `inheritExecutionWorkspaceFromIssueId`, or `executionWorkspaceId` are not auto-inferred.
- Added embedded Postgres regression tests covering service-level inheritance and agent-created follow-up issue inheritance.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/issue-create-project-context.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low-to-medium behavioral risk: agent-created unscoped follow-up issues during a heartbeat will now inherit the current run issue's project/workspace. This is intentional for continuity, and explicit `projectId: null` / project fields still opt out.
- No database migration.
- No UI changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Hermes / openai-codex, tool-enabled coding session with local terminal, file edits, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
