### PR TITLE
feat: wire project_workspaces.setup_command into worktree prep (DALA-249)

### DIFF
--- a/packages/shared/src/types/workspace-operation.ts
+++ b/packages/shared/src/types/workspace-operation.ts
@@ -1,6 +1,7 @@
 export type WorkspaceOperationPhase =
   | "worktree_prepare"
   | "workspace_provision"
+  | "workspace_setup"
   | "workspace_teardown"
   | "worktree_cleanup"
   | "workspace_finalize";

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3482,3 +3482,243 @@ describe("normalizeAdapterManagedRuntimeServices", () => {
     });
   });
 });
+
+describeEmbeddedPostgres("runProjectWorkspaceSetupCommand (via realizeExecutionWorkspace)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let projectId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-setup-command-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  afterEach(async () => {
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  async function setupCompanyAndProject() {
+    companyId = randomUUID();
+    projectId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Test Company",
+      issuePrefix: `TC${companyId.replace(/-/g, "").slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Test Project",
+      status: "in_progress",
+    });
+  }
+
+  it("fires when setup_command is set on the project workspace", async () => {
+    await setupCompanyAndProject();
+    const repoRoot = await createTempRepo();
+    const workspaceId = randomUUID();
+    const markerFile = path.join(repoRoot, "setup-ran.txt");
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: repoRoot,
+      isPrimary: false,
+      setupCommand: `printf 'setup ok' > ${markerFile}`,
+    });
+
+    await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-1", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+    });
+
+    await expect(fs.readFile(markerFile, "utf8")).resolves.toBe("setup ok");
+  });
+
+  it("is a no-op when setup_command is null on the project workspace", async () => {
+    await setupCompanyAndProject();
+    const repoRoot = await createTempRepo();
+    const workspaceId = randomUUID();
+    const markerFile = path.join(repoRoot, "setup-ran.txt");
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: repoRoot,
+      isPrimary: false,
+    });
+
+    await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-2", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+    });
+
+    await expect(fs.stat(markerFile)).rejects.toThrow();
+  });
+
+  it("is a no-op when db is not provided", async () => {
+    const repoRoot = await createTempRepo();
+    const markerFile = path.join(repoRoot, "setup-ran.txt");
+
+    const result = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-3", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId: "company-1" },
+    });
+
+    expect(result.warnings).toHaveLength(0);
+    await expect(fs.stat(markerFile)).rejects.toThrow();
+  });
+
+  it("fails open on non-zero exit: run proceeds and warning is returned", async () => {
+    await setupCompanyAndProject();
+    const repoRoot = await createTempRepo();
+    const workspaceId = randomUUID();
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: repoRoot,
+      isPrimary: false,
+      setupCommand: "exit 1",
+    });
+
+    const result = await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-4", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+    });
+
+    expect(result.worktreePath).toBeTruthy();
+    expect(result.warnings.some((w) => w.includes("setup command failed"))).toBe(true);
+  });
+
+  it("records a workspace_setup phase in the operation recorder", async () => {
+    await setupCompanyAndProject();
+    const repoRoot = await createTempRepo();
+    const workspaceId = randomUUID();
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: repoRoot,
+      isPrimary: false,
+      setupCommand: "printf 'ok'",
+    });
+
+    await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-5", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+      recorder,
+    });
+
+    expect(operations.some((op) => op.phase === "workspace_setup")).toBe(true);
+    const setupOp = operations.find((op) => op.phase === "workspace_setup");
+    expect(setupOp?.command).toBe("printf 'ok'");
+    expect(setupOp?.result.status).toBe("succeeded");
+  });
+
+  it("exposes PAPERCLIP_WORKSPACE_BASE_CWD in the setup command environment", async () => {
+    await setupCompanyAndProject();
+    const repoRoot = await createTempRepo();
+    const workspaceId = randomUUID();
+    const envFile = path.join(repoRoot, "env-dump.txt");
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: repoRoot,
+      isPrimary: false,
+      setupCommand: `printf '%s' "$PAPERCLIP_WORKSPACE_BASE_CWD" > ${envFile}`,
+    });
+
+    await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-6", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+    });
+
+    const written = await fs.readFile(envFile, "utf8");
+    expect(written).toBe(repoRoot);
+  });
+});

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3721,4 +3721,80 @@ describeEmbeddedPostgres("runProjectWorkspaceSetupCommand (via realizeExecutionW
     const written = await fs.readFile(envFile, "utf8");
     expect(written).toBe(repoRoot);
   });
+
+  it("fails open on spawn error (ENOENT from non-existent cwd): run proceeds and warning is returned", async () => {
+    await setupCompanyAndProject();
+    const workspaceId = randomUUID();
+    const missingCwd = path.join(os.tmpdir(), `paperclip-missing-${randomUUID()}`);
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: missingCwd,
+      isPrimary: false,
+      setupCommand: "printf ok",
+    });
+
+    // project_primary strategy — setup runs on baseCwd directly; if cwd is missing, spawn fails
+    const result = await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: missingCwd,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "project_primary" } },
+      issue: { id: "issue-1", identifier: "PAP-7", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+    });
+
+    expect(result.strategy).toBe("project_primary");
+    expect(result.warnings.some((w) => w.includes("setup command failed"))).toBe(true);
+  });
+
+  it("retries once on index.lock contention and still fails open when lock persists", async () => {
+    await setupCompanyAndProject();
+    const repoRoot = await createTempRepo();
+    const workspaceId = randomUUID();
+    const indexLockFile = path.join(repoRoot, ".git", "index.lock");
+
+    await fs.writeFile(indexLockFile, "locked");
+
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "default",
+      sourceType: "local_path",
+      cwd: repoRoot,
+      isPrimary: false,
+      setupCommand: "git checkout HEAD -- README.md",
+    });
+
+    const result = await realizeExecutionWorkspace({
+      db,
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId,
+        workspaceId,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}" } },
+      issue: { id: "issue-1", identifier: "PAP-8", title: "test" },
+      agent: { id: "agent-1", name: "Test Agent", companyId },
+    });
+
+    expect(result.worktreePath).toBeTruthy();
+    expect(result.warnings.some((w) => w.includes("setup command failed"))).toBe(true);
+
+    await fs.unlink(indexLockFile).catch(() => {});
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7453,6 +7453,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             companyId: agent.companyId,
           },
           recorder: workspaceOperationRecorder,
+          db,
         }) ?? buildRealizedExecutionWorkspaceFromPersisted({
           base: executionWorkspaceBase,
           workspace: existingExecutionWorkspace,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7468,6 +7468,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             companyId: agent.companyId,
           },
           recorder: workspaceOperationRecorder,
+          db,
         });
     const resolvedProjectId = executionWorkspace.projectId ?? issueRef?.projectId ?? executionProjectId ?? null;
     const resolvedProjectWorkspaceId = issueRef?.projectWorkspaceId ?? resolvedWorkspace.workspaceId ?? null;

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1117,31 +1117,45 @@ async function runProjectWorkspaceSetupCommand(
   const setupCommand = row?.setupCommand?.trim() ?? "";
   if (!setupCommand) return [];
 
-  try {
-    await recordWorkspaceCommandOperation(input.recorder, {
-      phase: "workspace_setup",
-      command: setupCommand,
+  const opts = {
+    phase: "workspace_setup" as const,
+    command: setupCommand,
+    cwd: input.cwd,
+    env: buildWorkspaceCommandEnv({
+      base: input.base,
+      repoRoot: input.repoRoot,
+      worktreePath: input.worktreePath,
+      branchName: input.branchName,
+      issue: input.issue,
+      agent: input.agent,
+      created: false,
+    }),
+    label: `Project workspace setup command`,
+    metadata: {
+      workspaceId: input.workspaceId,
       cwd: input.cwd,
-      env: buildWorkspaceCommandEnv({
-        base: input.base,
-        repoRoot: input.repoRoot,
-        worktreePath: input.worktreePath,
-        branchName: input.branchName,
-        issue: input.issue,
-        agent: input.agent,
-        created: false,
-      }),
-      label: `Project workspace setup command`,
-      metadata: {
-        workspaceId: input.workspaceId,
-        cwd: input.cwd,
-      },
-      successMessage: `Project workspace setup completed\n`,
-    });
+    },
+    successMessage: `Project workspace setup completed\n`,
+  };
+
+  const runOnce = () => recordWorkspaceCommandOperation(input.recorder, opts);
+
+  try {
+    await runOnce();
     return [];
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return [`Project workspace setup command failed (run continues): ${message}`];
+  } catch (firstError) {
+    const firstMsg = firstError instanceof Error ? firstError.message : String(firstError);
+    if (firstMsg.includes("index.lock")) {
+      await delay(100);
+      try {
+        await runOnce();
+        return [];
+      } catch (retryError) {
+        const retryMsg = retryError instanceof Error ? retryError.message : String(retryError);
+        return [`Project workspace setup command failed (run continues): ${retryMsg}`];
+      }
+    }
+    return [`Project workspace setup command failed (run continues): ${firstMsg}`];
   }
 }
 
@@ -1156,13 +1170,25 @@ export async function realizeExecutionWorkspace(input: {
   const rawStrategy = parseObject(input.config.workspaceStrategy);
   const strategyType = asString(rawStrategy.type, "project_primary");
   if (strategyType !== "git_worktree") {
+    // Run setup on baseCwd directly — project_primary workspaces use baseCwd as the repo root.
+    const setupWarnings = await runProjectWorkspaceSetupCommand(input.db, {
+      workspaceId: input.base.workspaceId,
+      cwd: input.base.baseCwd,
+      repoRoot: input.base.baseCwd,
+      branchName: "",
+      worktreePath: input.base.baseCwd,
+      base: input.base,
+      issue: input.issue,
+      agent: input.agent,
+      recorder: input.recorder,
+    });
     return {
       ...input.base,
       strategy: "project_primary",
       cwd: input.base.baseCwd,
       branchName: null,
       worktreePath: null,
-      warnings: [],
+      warnings: setupWarnings,
       created: false,
       baseRefSha: null,
     };
@@ -1378,6 +1404,7 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
   issue: ExecutionWorkspaceIssueRef | null;
   agent: ExecutionWorkspaceAgentRef;
   recorder?: WorkspaceOperationRecorder | null;
+  db?: Db;
 }): Promise<RealizedExecutionWorkspace | null> {
   const cwd = asString(input.workspace.cwd ?? input.workspace.providerRef, "").trim();
   if (!cwd) return null;
@@ -1400,8 +1427,20 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
   };
   const provisionCommand = asString(input.workspace.config?.provisionCommand, "").trim();
 
+  const persistedSetupWarnings = await runProjectWorkspaceSetupCommand(input.db, {
+    workspaceId: realized.workspaceId,
+    cwd: input.base.baseCwd,
+    repoRoot: input.base.baseCwd,
+    branchName: realized.branchName ?? "",
+    worktreePath: realized.worktreePath ?? realized.cwd,
+    base: input.base,
+    issue: input.issue,
+    agent: input.agent,
+    recorder: input.recorder ?? null,
+  });
+
   if (strategy !== "git_worktree") {
-    return realized;
+    return { ...realized, warnings: persistedSetupWarnings };
   }
   const repoRoot = await runGit(["rev-parse", "--show-toplevel"], input.base.baseCwd);
   const recordedBaseRefSha = readRecordedBaseRefSha(input.workspace.metadata);
@@ -1413,7 +1452,7 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
       baseRef: input.workspace.baseRef ?? input.base.repoRef ?? null,
       recordedBaseRefSha,
     });
-    realized.warnings = baseDrift.warnings;
+    realized.warnings = [...persistedSetupWarnings, ...baseDrift.warnings];
     realized.baseRefSha = recordedBaseRefSha ?? baseDrift.branchBaseRefSha ?? baseDrift.currentBaseRefSha;
     if (provisionCommand) {
       await provisionExecutionWorktree({
@@ -1521,7 +1560,7 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
     ...realized,
     cwd: worktreePath,
     worktreePath,
-    warnings: [...restoreRefreshWarnings, ...baseDrift.warnings],
+    warnings: [...persistedSetupWarnings, ...restoreRefreshWarnings, ...baseDrift.warnings],
     created,
     baseRefSha:
       recordedBaseRefSha

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -941,7 +941,7 @@ async function recordGitOperation(
 async function recordWorkspaceCommandOperation(
   recorder: WorkspaceOperationRecorder | null | undefined,
   input: {
-    phase: "workspace_provision" | "workspace_teardown";
+    phase: "workspace_provision" | "workspace_teardown" | "workspace_setup";
     command: string;
     resolvedCommand?: string;
     cwd: string;
@@ -1094,12 +1094,64 @@ async function resolveGitRepoRootForWorkspaceCleanup(
   return path.dirname(resolvedGitDir);
 }
 
+async function runProjectWorkspaceSetupCommand(
+  db: Db | undefined,
+  input: {
+    workspaceId: string | null;
+    cwd: string;
+    repoRoot: string;
+    branchName: string;
+    worktreePath: string;
+    base: ExecutionWorkspaceInput;
+    issue: ExecutionWorkspaceIssueRef | null;
+    agent: ExecutionWorkspaceAgentRef;
+    recorder: WorkspaceOperationRecorder | null | undefined;
+  },
+): Promise<string[]> {
+  if (!db || !input.workspaceId) return [];
+  const [row] = await db
+    .select({ setupCommand: projectWorkspaces.setupCommand })
+    .from(projectWorkspaces)
+    .where(eq(projectWorkspaces.id, input.workspaceId))
+    .limit(1);
+  const setupCommand = row?.setupCommand?.trim() ?? "";
+  if (!setupCommand) return [];
+
+  try {
+    await recordWorkspaceCommandOperation(input.recorder, {
+      phase: "workspace_setup",
+      command: setupCommand,
+      cwd: input.cwd,
+      env: buildWorkspaceCommandEnv({
+        base: input.base,
+        repoRoot: input.repoRoot,
+        worktreePath: input.worktreePath,
+        branchName: input.branchName,
+        issue: input.issue,
+        agent: input.agent,
+        created: false,
+      }),
+      label: `Project workspace setup command`,
+      metadata: {
+        workspaceId: input.workspaceId,
+        cwd: input.cwd,
+      },
+      successMessage: `Project workspace setup completed\n`,
+    });
+    return [];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return [`Project workspace setup command failed (run continues): ${message}`];
+  }
+}
+
 export async function realizeExecutionWorkspace(input: {
   base: ExecutionWorkspaceInput;
   config: Record<string, unknown>;
   issue: ExecutionWorkspaceIssueRef | null;
   agent: ExecutionWorkspaceAgentRef;
   recorder?: WorkspaceOperationRecorder | null;
+  db?: Db;
 }): Promise<RealizedExecutionWorkspace> {
   const rawStrategy = parseObject(input.config.workspaceStrategy);
   const strategyType = asString(rawStrategy.type, "project_primary");
@@ -1138,6 +1190,18 @@ export async function realizeExecutionWorkspace(input: {
     ?? "HEAD";
   const baseRefreshWarnings = await refreshRemoteTrackingBaseRef(repoRoot, baseRef);
   const currentBaseRefSha = await resolveBaseRefSha(repoRoot, baseRef);
+
+  const setupWarnings = await runProjectWorkspaceSetupCommand(input.db, {
+    workspaceId: input.base.workspaceId,
+    cwd: input.base.baseCwd,
+    repoRoot,
+    branchName,
+    worktreePath,
+    base: input.base,
+    issue: input.issue,
+    agent: input.agent,
+    recorder: input.recorder,
+  });
 
   await fs.mkdir(worktreeParentDir, { recursive: true });
 
@@ -1188,7 +1252,7 @@ export async function realizeExecutionWorkspace(input: {
       cwd: reusablePath,
       branchName,
       worktreePath: reusablePath,
-      warnings: [...baseRefreshWarnings, ...baseDrift.warnings],
+      warnings: [...baseRefreshWarnings, ...setupWarnings, ...baseDrift.warnings],
       created: false,
       baseRefSha: baseDrift.branchBaseRefSha ?? baseDrift.currentBaseRefSha,
     };
@@ -1288,7 +1352,7 @@ export async function realizeExecutionWorkspace(input: {
     cwd: worktreePath,
     branchName,
     worktreePath,
-    warnings: baseRefreshWarnings,
+    warnings: [...baseRefreshWarnings, ...setupWarnings],
     created: true,
     baseRefSha: currentBaseRefSha,
   };


### PR DESCRIPTION
## Summary

Wires `project_workspaces.setup_command` into workspace preparation so the content-curator agent's `_default` workspace stays in sync with `main` on every run.

- **Fixes placement**: setup now runs for ALL strategy types (including `project_primary` / `_default`) — not just `git_worktree`
- **Wires `ensurePersistedExecutionWorkspaceAvailable`**: setup runs on the reuse_existing path so persistent workspaces stay synced every run
- Reads `setup_command` from the `project_workspaces` row; no-ops when null or when no `db` is provided
- Fails open on non-zero exit with a single 100ms retry on `index.lock` contention
- Records a `workspace_setup` phase in the operation recorder
- 8 tests: fires when set, no-op when null, no-op without db, fail-open, phase recorded, BASE_CWD exposed, spawn ENOENT fail-open, index.lock retry

## Thinking Path

The original PR had a critical placement bug: `runProjectWorkspaceSetupCommand` was called **after** the `strategyType !== "git_worktree"` early return, so the `_default` workspace (which is `project_primary`) never ran setup. Additionally, `ensurePersistedExecutionWorkspaceAvailable` (the reuse_existing path for persistent workspaces) had no setup call at all — meaning the Curator's workspace would never sync even if the first placement bug were fixed. Both gaps were confirmed by adversarial review and direct diff analysis.

Fixes #7392

## What Changed

- `workspace-runtime.ts`: Added setup call inside the `project_primary` early return block in `realizeExecutionWorkspace`; added `db?: Db` param + setup call to `ensurePersistedExecutionWorkspaceAvailable` with warnings merged across all 3 return paths; added `index.lock` retry (single 100ms backoff)
- `heartbeat.ts`: Pass `db` to `ensurePersistedExecutionWorkspaceAvailable` (was already passed to `realizeExecutionWorkspace`)
- `workspace-runtime.test.ts`: Added 2 tests (spawn ENOENT fail-open + index.lock retry) for 8 total

## Verification

All 8 tests pass locally:
```
✓ fires when setup_command is set
✓ no-op when null
✓ no-op when db not provided
✓ fails open on non-zero exit
✓ records workspace_setup phase
✓ exposes PAPERCLIP_WORKSPACE_BASE_CWD
✓ fails open on ENOENT (non-existent cwd)
✓ retries on index.lock and still fails open when lock persists (217ms = retry delay exercised)
```
TypeScript check clean. Typecheck CI: ✓

## Risks

- **Behavior change for project_primary**: setups now fire for all strategy types. Workspaces without `setup_command` configured are unaffected (the function is a no-op with `setupCommand = ""`).
- **DB call on reuse path**: `ensurePersistedExecutionWorkspaceAvailable` now queries the DB once per run. Single lightweight `SELECT setup_command FROM project_workspaces WHERE id = ?`. Negligible overhead.
- **index.lock retry**: 100ms delay only fires when git reports lock contention. Clean runs are unaffected.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6)

## Part B — data change (after merge + deploy, do NOT commit)

After this PR is deployed, set `setup_command` on `_default` workspace (id `08f044f7-32ac-4810-bfa3-3701cc08fbd8`) via UI:

```bash
set -e
cd "$PAPERCLIP_WORKSPACE_BASE_CWD"
git fetch --no-tags origin main || { echo "[setup] fetch failed, continuing with stale instructions" >&2; exit 0; }
rm -rf agents/content-curator/
git checkout origin/main -- agents/content-curator/ || { echo "[setup] sparse checkout failed, continuing" >&2; exit 0; }
git restore --staged -- agents/content-curator/ 2>/dev/null || true
```

> **Why `rm -rf` before `git checkout`:** `git checkout origin/main -- <path>` does NOT delete files removed on main. Using `rm -rf` first mirrors deletions exactly.

**Only `_default` workspace. Do NOT set on the primary `tinai.dev` workspace.**

## Smoke test (Lead Engineer)

1. Set `setup_command` on `_default` via UI
2. Land a trivial `agents/content-curator/AGENTS.md` edit on main
3. Trigger next Curator run — do NOT manually sync `_default` first
4. Check run logs: `workspace_setup` phase exit 0
5. Verify `_default/agents/content-curator/AGENTS.md` matches `git show origin/main:agents/...`
6. Glob newest `claude-prompt-cache/<sha>/agent-instructions.md` by mtime; verify `pathDirective` references `_default/.../AGENTS.md`
7. **Deletion proof**: PR that deletes a file under `agents/content-curator/`; assert it's gone from `_default` after next Curator run

## Rollback

`UPDATE project_workspaces SET setup_command = NULL WHERE id = '08f044f7-...'` — no code rollback needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)