### PR TITLE
fix(scheduler): self-heal bounded retries past cap (STOA-181b)

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -20,6 +20,8 @@ import {
 } from "./helpers/embedded-postgres.js";
 import {
   BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS,
+  BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS,
+  BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_LOG_EVERY,
   MAX_TURN_CONTINUATION_RETRY_REASON,
   MAX_TURN_CONTINUATION_WAKE_REASON,
   heartbeatService,
@@ -1091,7 +1093,11 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(issue?.executionRunId).toBeNull();
   });
 
-  it("exhausts bounded retries after the hard cap", async () => {
+  it("queues sustained-outage retries at a flat 15m interval after the bounded cap", async () => {
+    // STOA-181b: a sustained Anthropic outage must never strand the customer
+    // past the self-healing SLA, so the default transient-retry path stays in
+    // a 15m retry cycle (with jitter) past the bounded cap instead of returning
+    // retry_exhausted.
     const companyId = randomUUID();
     const agentId = randomUUID();
     const cappedRunId = randomUUID();
@@ -1139,40 +1145,184 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       createdAt: now,
     });
 
-    const exhausted = await heartbeat.scheduleBoundedRetry(cappedRunId, {
+    const scheduled = await heartbeat.scheduleBoundedRetry(cappedRunId, {
       now,
       random: () => 0.5,
     });
 
-    expect(exhausted).toEqual({
-      outcome: "retry_exhausted",
-      attempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length + 1,
-      maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
-    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+    expect(scheduled.attempt).toBe(BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length + 1);
+    expect(scheduled.dueAt.toISOString()).toBe(
+      new Date(now.getTime() + BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS).toISOString(),
+    );
 
-    const runCount = await db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.companyId, companyId))
-      .then((rows) => rows[0]?.count ?? 0);
-    expect(runCount).toBe(1);
-
-    const exhaustionEvent = await db
+    const sustainedEvent = await db
       .select({
         message: heartbeatRunEvents.message,
         payload: heartbeatRunEvents.payload,
       })
       .from(heartbeatRunEvents)
-      .where(eq(heartbeatRunEvents.runId, cappedRunId))
+      .where(
+        and(
+          eq(heartbeatRunEvents.runId, cappedRunId),
+          sql`${heartbeatRunEvents.message} like 'Sustained transient-upstream outage:%'`,
+        ),
+      )
       .orderBy(sql`${heartbeatRunEvents.id} desc`)
       .then((rows) => rows[0] ?? null);
 
-    expect(exhaustionEvent?.message).toContain("Bounded retry exhausted");
-    expect(exhaustionEvent?.payload).toMatchObject({
+    expect(sustainedEvent?.message).toContain("Sustained transient-upstream outage");
+    expect(sustainedEvent?.payload).toMatchObject({
       retryReason: "transient_failure",
-      scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length + 1,
+      sustainedFallbackAttempt: 1,
       maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+      circuitBreakerLogEvery: BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_LOG_EVERY,
+      sustainedIntervalMs: BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS,
     });
+  });
+
+  it("only emits the sustained-outage circuit-breaker warning on the first sustained attempt and every Nth thereafter", async () => {
+    // STOA-181b: log spam guard — observability without flooding events.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const now = new Date("2026-04-20T18:30:00.000Z");
+    const maxBounded = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+      },
+      permissions: {},
+    });
+
+    async function scheduleAt(sustainedAttempt: number) {
+      const runId = randomUUID();
+      const scheduledRetryAttempt = maxBounded + sustainedAttempt - 1;
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        status: "failed",
+        error: "still transient",
+        errorCode: "adapter_failed",
+        finishedAt: now,
+        scheduledRetryAttempt,
+        scheduledRetryReason: "transient_failure",
+        contextSnapshot: { wakeReason: "transient_failure_retry" },
+        updatedAt: now,
+        createdAt: now,
+      });
+      const result = await heartbeat.scheduleBoundedRetry(runId, { now, random: () => 0.5 });
+      const sustainedEvents = await db
+        .select({ message: heartbeatRunEvents.message })
+        .from(heartbeatRunEvents)
+        .where(
+          and(
+            eq(heartbeatRunEvents.runId, runId),
+            sql`${heartbeatRunEvents.message} like 'Sustained transient-upstream outage:%'`,
+          ),
+        );
+      return { result, sustainedLogCount: sustainedEvents.length };
+    }
+
+    // First sustained attempt → logs once.
+    const first = await scheduleAt(1);
+    expect(first.result.outcome).toBe("scheduled");
+    expect(first.sustainedLogCount).toBe(1);
+
+    // Second sustained attempt → still scheduled, no new log (between cadence ticks).
+    const second = await scheduleAt(2);
+    expect(second.result.outcome).toBe("scheduled");
+    expect(second.sustainedLogCount).toBe(0);
+
+    // 12th sustained attempt → logs again (circuit-breaker cadence).
+    const twelfth = await scheduleAt(BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_LOG_EVERY);
+    expect(twelfth.result.outcome).toBe("scheduled");
+    expect(twelfth.sustainedLogCount).toBe(1);
+  });
+
+  it("still exhausts retries at the cap when callers pass an explicit maxAttempts override", async () => {
+    // Sustained-outage fallback is scoped to the default transient-retry path.
+    // Callers like max-turn continuation, which pass their own maxAttempts and
+    // delayMs, must still receive retry_exhausted at their configured cap.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const cappedRunId = randomUUID();
+    const now = new Date("2026-04-20T19:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+      },
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: cappedRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "max-turns wall",
+      errorCode: "adapter_failed",
+      finishedAt: now,
+      scheduledRetryAttempt: 2,
+      scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      resultJson: { stopReason: "max_turns_exhausted" },
+      contextSnapshot: { wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const exhausted = await heartbeat.scheduleBoundedRetry(cappedRunId, {
+      now,
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      maxAttempts: 2,
+      delayMs: 1_000,
+    });
+
+    expect(exhausted).toEqual({
+      outcome: "retry_exhausted",
+      attempt: 3,
+      maxAttempts: 2,
+    });
+
+    const exhaustionEvent = await db
+      .select({ message: heartbeatRunEvents.message })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, cappedRunId))
+      .orderBy(sql`${heartbeatRunEvents.id} desc`)
+      .then((rows) => rows[0] ?? null);
+    expect(exhaustionEvent?.message).toContain("Bounded retry exhausted");
   });
 
   it("advances codex transient fallback stages across bounded retry attempts", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -218,16 +218,29 @@ export {
   ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
 } from "./recovery/service.js";
 export const ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS = 60 * 1000;
+// Bounded retry cap is [2m, 5m, 10m, 15m] so transient blips clear within
+// ~32 min worst case (sum + jitter). When this table is exhausted on the
+// default transient-retry path, scheduleBoundedRetryForRun falls back to a
+// flat sustained-outage interval (BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS)
+// instead of abandoning, so a sustained upstream outage never strands a
+// customer past the self-healing SLA.
 export const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS = [
   2 * 60 * 1000,
+  5 * 60 * 1000,
   10 * 60 * 1000,
-  30 * 60 * 1000,
-  2 * 60 * 60 * 1000,
+  15 * 60 * 1000,
 ] as const;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+// Sustained-outage fallback. After the bounded retry table is exhausted on
+// the default transient-retry path, scheduleBoundedRetryForRun keeps queuing
+// retries at this flat interval (with ±25% jitter). A circuit-breaker
+// warning is emitted on the first sustained attempt and every Nth attempt
+// thereafter so the outage stays observable without stalling the customer.
+export const BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS = 15 * 60 * 1000;
+export const BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_LOG_EVERY = 12;
 export const MAX_TURN_CONTINUATION_RETRY_REASON = "max_turns_continuation";
 export const MAX_TURN_CONTINUATION_WAKE_REASON = "max_turns_continuation_retry";
 const MAX_TURN_CONTINUATION_DEFAULT_MAX_ATTEMPTS = 2;
@@ -5371,7 +5384,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
     const maxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
-    const baseSchedule = opts?.delayMs != null
+    let baseSchedule = opts?.delayMs != null
       ? nextAttempt <= maxAttempts
         ? {
             attempt: nextAttempt,
@@ -5393,6 +5406,54 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? resolveCodexTransientFallbackMode(nextAttempt)
         : null;
     const transientRetryNotBefore = transientRecovery?.retryNotBefore ?? null;
+
+    // Sustained-outage fallback. Only applies to the default transient-retry
+    // path (no caller-supplied delayMs / maxAttempts override and the default
+    // retry reason). Callers that pass their own retryReason or delayMs —
+    // e.g. max-turn continuation — still see retry_exhausted at their cap.
+    const isSustainedTransientFallback =
+      !baseSchedule
+      && opts?.delayMs == null
+      && opts?.maxAttempts == null
+      && retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON;
+    let sustainedFallbackAttempt = 0;
+    if (isSustainedTransientFallback) {
+      sustainedFallbackAttempt = nextAttempt - maxAttempts;
+      const random = opts?.random ?? Math.random;
+      const sample = Math.min(1, Math.max(0, random()));
+      const jitterMultiplier =
+        1 + (((sample * 2) - 1) * BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO);
+      const delayMs = Math.max(
+        1_000,
+        Math.round(BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS * jitterMultiplier),
+      );
+      baseSchedule = {
+        attempt: nextAttempt,
+        baseDelayMs: BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS,
+        delayMs,
+        dueAt: new Date(now.getTime() + delayMs),
+        maxAttempts,
+      };
+      if (
+        sustainedFallbackAttempt === 1
+        || sustainedFallbackAttempt % BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_LOG_EVERY === 0
+      ) {
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: `Sustained transient-upstream outage: ${sustainedFallbackAttempt} retries past bounded max=${maxAttempts}; continuing at flat ${Math.round(BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS / 60_000)}m interval`,
+          payload: {
+            retryReason,
+            scheduledRetryAttempt: nextAttempt,
+            sustainedFallbackAttempt,
+            maxAttempts,
+            circuitBreakerLogEvery: BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_LOG_EVERY,
+            sustainedIntervalMs: BOUNDED_TRANSIENT_HEARTBEAT_SUSTAINED_RETRY_INTERVAL_MS,
+          },
+        });
+      }
+    }
 
     if (!baseSchedule) {
       await appendRunEvent(run, await nextRunEventSeq(run.id), {


### PR DESCRIPTION
## Summary

Scheduler self-healing so a sustained Anthropic outage never strands a customer past the ~15 min self-healing SLA. Fixes the STOA-181 incident pattern (~4h worst-case stall + silent coalescing of 17 manual wakes).

- **Part A** — Cap bounded-retry tail: `BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS` `[2m, 10m, 30m, 2h]` → `[2m, 5m, 10m, 15m]`. Transient blips clear within ~32 min worst case instead of ~2h 42 min.
- **Part B (b)** — After the bounded cap is exhausted on the default transient-retry path, fall back to a flat 15 min interval (±25% jitter) instead of returning `retry_exhausted`. Circuit-breaker warning event on the first sustained attempt and every 12th thereafter — observable without flooding.
- **Part B (a)** — `HEARTBEAT_SCHEDULER_INTERVAL_MS=900000` already set in the Mac Mini instance `.env` (board belt-and-suspenders pick (c)).

Scoping: sustained fallback only activates on the default transient-retry path (no caller-supplied `delayMs`/`maxAttempts` and the default retry reason). Max-turn continuation and other callers with their own cap still receive `retry_exhausted` at their configured cap (covered by test).

## Test plan

- [x] `vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts` — 21/21 passing
- [x] `pnpm --filter @paperclipai/server typecheck` — clean
- New tests cover:
  - Sustained-outage retries queue at flat 15 min interval past the bounded cap
  - Circuit-breaker warning fires on attempt 1 + every 12th (cadence guard)
  - Callers passing their own `maxAttempts`/`delayMs` still hit `retry_exhausted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)