### PR TITLE
fix(agents): treat non-agent reportsTo values as org-chart roots

### DIFF
--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -675,9 +675,12 @@ export function agentService(db: Db) {
         .from(agents)
         .where(and(eq(agents.companyId, companyId), ne(agents.status, "terminated")));
       const normalizedRows = rows.map(normalizeAgentRow);
+      const agentIds = new Set(normalizedRows.map((r) => r.id));
       const byManager = new Map<string | null, typeof normalizedRows>();
       for (const row of normalizedRows) {
-        const key = row.reportsTo ?? null;
+        // Treat reportsTo values that don't resolve to another agent (e.g. board
+        // user id) as roots so the org chart still renders.
+        const key = row.reportsTo && agentIds.has(row.reportsTo) ? row.reportsTo : null;
         const group = byManager.get(key) ?? [];
         group.push(row);
         byManager.set(key, group);


### PR DESCRIPTION
Fixes #7400.

## Summary

`orgForCompany` only treated agents with `reportsTo === null` as roots, so any company whose top-level agents report to a **board user** (string user id) returned an empty tree and the Org Chart page rendered the empty state.

This change builds a set of agent ids in the company and treats any `reportsTo` that doesn't resolve to one of those ids (i.e. points at a user, or at a now-deleted/terminated agent) as a root. Behaviour for `null` is unchanged.

## Test plan

- [x] In my own company (Vertex Studios) all 9 agents had `reportsTo = "<board-user-id>"` for the top tier; `GET /api/companies/:companyId/org` returned `[]` before, returns the full forest after.
- [ ] Existing `OrgChart` tests pass.
- [ ] `orgForCompany` returns the same shape as before for companies whose roots already use `null`.
