### PR TITLE
fix(claude-local): read OAuth quota token from macOS Keychain

### DIFF
--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -137,13 +137,40 @@ function describeClaudeSubscriptionAuth(status: ClaudeAuthStatus | null): string
     : "Claude is logged in via claude.ai";
 }
 
+/** macOS stores the Claude Code OAuth credentials in the login Keychain rather
+ *  than in ~/.claude/.credentials.json, so fall back to reading it from there. */
+async function readClaudeTokenFromKeychain(): Promise<string | null> {
+  if (process.platform !== "darwin") return null;
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync(
+      "security",
+      ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+      { timeout: 5_000, maxBuffer: 1024 * 1024 },
+    ));
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const oauth = (parsed as Record<string, unknown>)["claudeAiOauth"];
+  if (typeof oauth !== "object" || oauth === null) return null;
+  const token = (oauth as Record<string, unknown>)["accessToken"];
+  return typeof token === "string" && token.length > 0 ? token : null;
+}
+
 export async function readClaudeToken(): Promise<string | null> {
   const configDir = claudeConfigDir();
   for (const filename of [".credentials.json", "credentials.json"]) {
     const token = await readClaudeTokenFromFile(path.join(configDir, filename));
     if (token) return token;
   }
-  return null;
+  return readClaudeTokenFromKeychain();
 }
 
 interface AnthropicUsageWindow {


### PR DESCRIPTION
## Problem

On macOS, the Subscription Quota panel always fails for the Anthropic provider with:

> Claude is logged in via claude.ai (max), but quota polling failed (Claude CLI /usage: Command failed: ...)

while the OpenAI provider works fine.

## Root cause

`getQuotaWindows()` prefers a direct call to `https://api.anthropic.com/api/oauth/usage` using the token from `readClaudeToken()`, and only falls back to the interactive `claude /usage` TUI screen-scrape when no token is found.

`readClaudeToken()` reads the token only from `~/.claude/.credentials.json`. On macOS, Claude Code stores the claude.ai OAuth credentials in the **login Keychain** (a generic password under service `Claude Code-credentials`), so that file does not exist. `readClaudeToken()` therefore returns `null`, the OAuth path is skipped on every Mac, and polling always falls through to the screen-scrape.

The scrape then fails on the current Claude CLI for three independent reasons:
- the hard-coded `sleep 2` fires before the prompt is ready, so the typed `/usage` is dropped;
- a single `\x03` (Ctrl-C) no longer exits the TUI — it requires two ("Press Ctrl-C again to exit") — so the process is killed by pipe-close and exits non-zero ("Command failed");
- in an untrusted working directory the first-run "trust this folder" dialog consumes the keystrokes.

A tell for this bug: the error only ever shows the *CLI* failure with no "Anthropic OAuth usage" error — because that branch only records an error `if (token)`, and `token` was null.

## Fix

When the credentials file is absent on macOS, fall back to reading the token from the Keychain via `security find-generic-password -s "Claude Code-credentials" -w` and parse `claudeAiOauth.accessToken`. The existing `fetchClaudeQuota()` OAuth path then succeeds; the CLI scrape remains as a last-resort fallback. No-op on non-darwin platforms.

## Verification

On macOS, `pnpm --filter @paperclipai/adapter-claude-local probe:quota`:
- before: `tokenAvailable: false`, OAuth skipped, CLI fallback errors;
- after: `tokenAvailable: true`, `oauth.ok: true` with the usage windows.

`tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
