### PR TITLE
fix(server): malformed JSON body returns 500 instead of 400

### DIFF
--- a/server/src/__tests__/json-parse-error-handler.test.ts
+++ b/server/src/__tests__/json-parse-error-handler.test.ts
@@ -159,15 +159,16 @@ describe.sequential("JSON parse error handler", () => {
     expect(res.body.error).toBe("Bad Request");
   });
 
-  it("still returns 201 for valid JSON body", async () => {
+  it("does not intercept valid JSON body", async () => {
     const app = await createApp();
     const res = await request(app)
       .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
       .set("Content-Type", "application/json")
       .send('{"body": "valid comment"}');
 
-    // The route handler may fail for other reasons (missing mocks), but it
-    // must NOT be a 400 Bad Request from the JSON parser.
+    // The route handler may return other statuses (e.g. 404, 500 from mocks),
+    // but the response must NOT be the 400 Bad Request produced by our
+    // JSON-parse-error guard.
     expect(res.status).not.toBe(400);
     expect(res.body.error).not.toBe("Bad Request");
   });

--- a/server/src/__tests__/json-parse-error-handler.test.ts
+++ b/server/src/__tests__/json-parse-error-handler.test.ts
@@ -1,0 +1,174 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => ({
+      canUser: vi.fn(async () => true),
+      decide: vi.fn(async (input: { action?: string }) => ({
+        allowed: true,
+        action: input.action,
+        reason: "allow_explicit_grant",
+        explanation: "Allowed by test grant.",
+      })),
+      hasPermission: vi.fn(async () => true),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => null),
+      resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+        ambiguous: false,
+        agent: { id: raw },
+      })),
+    }),
+    clampIssueListLimit: (value: number) => value,
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    ISSUE_LIST_MAX_LIMIT: 1000,
+    documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+      })),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueRecoveryActionService: () => ({
+      getActiveForIssue: vi.fn(async () => null),
+      listActiveForIssues: vi.fn(async () => new Map()),
+    }),
+    issueService: () => ({
+      getById: vi.fn(),
+    }),
+    issueThreadInteractionService: () => ({
+      listForIssue: vi.fn(async () => []),
+      create: vi.fn(async () => ({})),
+      acceptInteraction: vi.fn(),
+      acceptSuggestedTasks: vi.fn(),
+      rejectInteraction: vi.fn(),
+      rejectSuggestedTasks: vi.fn(),
+      expireRequestConfirmationsSupersededByHistoricalComments: vi.fn(),
+      answerQuestions: vi.fn(),
+      cancelQuestions: vi.fn(),
+    }),
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe.sequential("JSON parse error handler", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    registerModuleMocks();
+  });
+
+  it("returns 400 for truncated JSON body", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .set("Content-Type", "application/json")
+      .send('{"body": "oops"'); // truncated JSON
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Bad Request");
+    expect(res.body.message).toMatch(/Unexpected end|Unexpected token|Expected ',' or '}'/i);
+  });
+
+  it("returns 400 for invalid JSON syntax", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .set("Content-Type", "application/json")
+      .send('not json at all');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Bad Request");
+    expect(res.body.message).toMatch(/Unexpected token/i);
+  });
+
+  it("returns 400 for JSON with trailing garbage", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .set("Content-Type", "application/json")
+      .send('{"body": "ok"} trailing');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Bad Request");
+  });
+
+  it("still returns 201 for valid JSON body", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .set("Content-Type", "application/json")
+      .send('{"body": "valid comment"}');
+
+    // The route handler may fail for other reasons (missing mocks), but it
+    // must NOT be a 400 Bad Request from the JSON parser.
+    expect(res.status).not.toBe(400);
+    expect(res.body.error).not.toBe("Bad Request");
+  });
+});

--- a/server/src/__tests__/json-parse-error-handler.test.ts
+++ b/server/src/__tests__/json-parse-error-handler.test.ts
@@ -1,133 +1,24 @@
 import express from "express";
 import request from "supertest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { errorHandler } from "../middleware/error-handler.js";
 
-const mockHeartbeatService = vi.hoisted(() => ({
-  wakeup: vi.fn(async () => undefined),
-}));
-
-vi.mock("@paperclipai/shared/telemetry", () => ({
-  trackErrorHandlerCrash: vi.fn(),
-}));
-
-vi.mock("../telemetry.js", () => ({
-  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
-}));
-
-function registerModuleMocks() {
-  vi.doMock("../services/index.js", () => ({
-    companyService: () => ({
-      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
-    }),
-    accessService: () => ({
-      canUser: vi.fn(async () => true),
-      decide: vi.fn(async (input: { action?: string }) => ({
-        allowed: true,
-        action: input.action,
-        reason: "allow_explicit_grant",
-        explanation: "Allowed by test grant.",
-      })),
-      hasPermission: vi.fn(async () => true),
-    }),
-    agentService: () => ({
-      getById: vi.fn(async () => null),
-      resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
-        ambiguous: false,
-        agent: { id: raw },
-      })),
-    }),
-    clampIssueListLimit: (value: number) => value,
-    ISSUE_LIST_DEFAULT_LIMIT: 500,
-    ISSUE_LIST_MAX_LIMIT: 1000,
-    documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
-    documentService: () => ({}),
-    executionWorkspaceService: () => ({}),
-    feedbackService: () => ({
-      listIssueVotesForUser: vi.fn(async () => []),
-      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
-    }),
-    goalService: () => ({}),
-    heartbeatService: () => mockHeartbeatService,
-    instanceSettingsService: () => ({
-      get: vi.fn(async () => ({
-        id: "instance-settings-1",
-        general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
-      })),
-    }),
-    issueApprovalService: () => ({}),
-    issueReferenceService: () => ({
-      deleteDocumentSource: async () => undefined,
-      diffIssueReferenceSummary: () => ({
-        addedReferencedIssues: [],
-        removedReferencedIssues: [],
-        currentReferencedIssues: [],
-      }),
-      emptySummary: () => ({ outbound: [], inbound: [] }),
-      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
-      syncComment: async () => undefined,
-      syncDocument: async () => undefined,
-      syncIssue: async () => undefined,
-    }),
-    issueRecoveryActionService: () => ({
-      getActiveForIssue: vi.fn(async () => null),
-      listActiveForIssues: vi.fn(async () => new Map()),
-    }),
-    issueService: () => ({
-      getById: vi.fn(),
-    }),
-    issueThreadInteractionService: () => ({
-      listForIssue: vi.fn(async () => []),
-      create: vi.fn(async () => ({})),
-      acceptInteraction: vi.fn(),
-      acceptSuggestedTasks: vi.fn(),
-      rejectInteraction: vi.fn(),
-      rejectSuggestedTasks: vi.fn(),
-      expireRequestConfirmationsSupersededByHistoricalComments: vi.fn(),
-      answerQuestions: vi.fn(),
-      cancelQuestions: vi.fn(),
-    }),
-    logActivity: vi.fn(async () => undefined),
-    projectService: () => ({}),
-    routineService: () => ({
-      syncRunStatusForIssue: vi.fn(async () => undefined),
-    }),
-    workProductService: () => ({}),
-  }));
-}
-
-async function createApp() {
-  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
-    import("../routes/issues.js"),
-    import("../middleware/index.js"),
-  ]);
+function createApp() {
   const app = express();
   app.use(express.json());
-  app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
-    next();
+  // Dummy route that only cares the JSON parser let the request through.
+  app.post("/api/echo", (req, res) => {
+    res.status(200).json({ received: req.body });
   });
-  app.use("/api", issueRoutes({} as any, {} as any));
   app.use(errorHandler);
   return app;
 }
 
-describe.sequential("JSON parse error handler", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    vi.doUnmock("../routes/issues.js");
-    registerModuleMocks();
-  });
-
+describe("JSON parse error handler", () => {
   it("returns 400 for truncated JSON body", async () => {
-    const app = await createApp();
+    const app = createApp();
     const res = await request(app)
-      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .post("/api/echo")
       .set("Content-Type", "application/json")
       .send('{"body": "oops"'); // truncated JSON
 
@@ -137,11 +28,11 @@ describe.sequential("JSON parse error handler", () => {
   });
 
   it("returns 400 for invalid JSON syntax", async () => {
-    const app = await createApp();
+    const app = createApp();
     const res = await request(app)
-      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .post("/api/echo")
       .set("Content-Type", "application/json")
-      .send('not json at all');
+      .send("not json at all");
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("Bad Request");
@@ -149,9 +40,9 @@ describe.sequential("JSON parse error handler", () => {
   });
 
   it("returns 400 for JSON with trailing garbage", async () => {
-    const app = await createApp();
+    const app = createApp();
     const res = await request(app)
-      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .post("/api/echo")
       .set("Content-Type", "application/json")
       .send('{"body": "ok"} trailing');
 
@@ -159,17 +50,14 @@ describe.sequential("JSON parse error handler", () => {
     expect(res.body.error).toBe("Bad Request");
   });
 
-  it("does not intercept valid JSON body", async () => {
-    const app = await createApp();
+  it("passes valid JSON through to the route handler", async () => {
+    const app = createApp();
     const res = await request(app)
-      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/comments")
+      .post("/api/echo")
       .set("Content-Type", "application/json")
       .send('{"body": "valid comment"}');
 
-    // The route handler may return other statuses (e.g. 404, 500 from mocks),
-    // but the response must NOT be the 400 Bad Request produced by our
-    // JSON-parse-error guard.
-    expect(res.status).not.toBe(400);
-    expect(res.body.error).not.toBe("Bad Request");
+    expect(res.status).toBe(200);
+    expect(res.body.received).toEqual({ body: "valid comment" });
   });
 });

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -62,6 +62,12 @@ export function errorHandler(
     return;
   }
 
+  // JSON body-parser errors (malformed JSON payloads) — map to 400 instead of 500.
+  if (err instanceof SyntaxError && (err as any).status === 400 && "body" in (err as any)) {
+    res.status(400).json({ error: "Bad Request", message: err.message });
+    return;
+  }
+
   const rootError = err instanceof Error ? err : new Error(String(err));
   attachErrorContext(
     req,


### PR DESCRIPTION
## Summary

Fixes #7390

When a POST/PATCH request body contains malformed JSON, `express.json()` throws a `SyntaxError` that falls through to the generic 500 error handler. This causes client errors (broken/truncated JSON) to be surfaced as server errors, polluting error monitoring and making automated agents treat recoverable mistakes as control-plane outages.

## Thinking Path

The issue reported that malformed JSON payloads (e.g. truncated `{", "body": "oops"`) on `POST /api/issues/:id/comments` returned 500 instead of 400. I traced this to the global error handler in `server/src/middleware/error-handler.ts`, which only had special-case handling for `HttpError` and `ZodError`, leaving body-parser `SyntaxError`s to hit the generic 500 fallback.

The fix is minimal and centralized: add a guard immediately after the `ZodError` branch that detects body-parser JSON parse errors by their fingerprint (`instanceof SyntaxError` + `.status === 400` + `body` property) and returns 400 Bad Request with the parse error message. This covers all JSON POST/PATCH routes that use `express.json()`.

## What Changed

- **server/src/middleware/error-handler.ts**: Added `SyntaxError` detection guard before the generic 500 fallback.
- **server/src/__tests__/json-parse-error-handler.test.ts**: New regression test suite with 4 tests (truncated JSON, invalid syntax, trailing garbage, valid JSON confirmation).

## Risks

- **Low risk**: The guard is narrowly scoped to body-parser `SyntaxError`s (checks `.status === 400` and `"body" in err`), so legitimate 500-throwing `SyntaxError`s from other code paths are unaffected.
- **Test coverage**: The happy-path test confirms valid JSON is not intercepted.

## Model Used

- Kimi Code CLI (kimi-cli) — research, implementation, and test authoring

## Verification

```bash
cd server
npx vitest run src/__tests__/json-parse-error-handler.test.ts
# 4 passed
```

## Checklist

- [x] I've read the Contributing Guide
- [x] I've added tests for my changes
- [x] I've run the test suite and all tests pass
- [x] My PR contains only changes related to this fix
