### PR TITLE
fix(openclaw-gateway): strip paperclip agent param

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -42,11 +42,9 @@ Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
-Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+Paperclip context transport:
+- Paperclip context is delivered through wake text and PAPERCLIP_* env vars, not as an agent params object.
+- agentParams.paperclip is intentionally omitted because OpenClaw v4 rejects unknown top-level agent fields.
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -162,10 +162,8 @@ describe("execute", () => {
 
       expect(result.exitCode).toBe(0);
       expect(agentParams).not.toHaveProperty("paperclip");
-      expect(agentParams).toMatchObject({
-        idempotencyKey: "run-1",
-        sessionKey: "agent:agent-1:paperclip:issue:issue-1",
-      });
+      expect(agentParams).toMatchObject({ idempotencyKey: "run-1" });
+      expect(agentParams.sessionKey).toBe(["agent:agent-1", "paperclip:issue:issue-1"].join(":"));
       expect(logs.join("")).toContain("run completed");
     } finally {
       await new Promise<void>((resolve, reject) => {

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,21 @@
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import { WebSocketServer } from "ws";
+import { execute, resolveSessionKey } from "./execute.js";
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -48,5 +64,113 @@ describe("resolveSessionKey", () => {
         issueId: null,
       }),
     ).toBe("agent:meridian:paperclip");
+  });
+});
+
+describe("execute", () => {
+  it("does not send paperclip as a root agent param", async () => {
+    const server = new WebSocketServer({ port: 0 });
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected a TCP server address");
+    }
+
+    const agentParamsPromise = new Promise<Record<string, unknown>>((resolve) => {
+      server.on("connection", (socket) => {
+        socket.send(
+          JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "test-nonce" },
+          }),
+        );
+
+        socket.on("message", (raw) => {
+          const frame = JSON.parse(raw.toString()) as {
+            id: string;
+            method: string;
+            params?: Record<string, unknown>;
+          };
+
+          if (frame.method === "connect") {
+            socket.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { protocol: 3 } }));
+            return;
+          }
+
+          if (frame.method === "agent") {
+            resolve(frame.params ?? {});
+            socket.send(
+              JSON.stringify({
+                type: "res",
+                id: frame.id,
+                ok: true,
+                payload: { status: "ok", runId: "run-1" },
+              }),
+            );
+          }
+        });
+      });
+    });
+
+    const logs: string[] = [];
+    const ctx: AdapterExecutionContext = {
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenClaw Agent",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        url: `ws://127.0.0.1:${address.port}`,
+        agentId: "agent-1",
+        authToken: "test-token",
+        disableDeviceAuth: true,
+        payloadTemplate: {
+          paperclip: { legacy: true },
+        },
+      },
+      context: {
+        issueId: "issue-1",
+        wakeReason: "issue_assigned",
+        paperclipWake: {
+          reason: "issue_assigned",
+          issue: { id: "issue-1", identifier: "NOX-1" },
+        },
+      },
+      onLog: async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+    };
+
+    try {
+      // The mock gateway resolves agentParams before replying to the agent request, so a successful execute()
+      // guarantees the captured params are available while the timeout still guards failure paths.
+      const result = await execute(ctx);
+      const agentParams = await withTimeout(
+        agentParamsPromise,
+        500,
+        "timed out waiting for OpenClaw gateway agent params",
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(agentParams).not.toHaveProperty("paperclip");
+      expect(agentParams).toMatchObject({
+        idempotencyKey: "run-1",
+        sessionKey: "agent:agent-1:paperclip:issue:issue-1",
+      });
+      expect(logs.join("")).toContain("run completed");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -466,62 +466,6 @@ function joinWakePayloadSections(structuredWakePrompt: string, structuredWakeJso
   return sections.join("\n");
 }
 
-function buildStandardPaperclipPayload(
-  ctx: AdapterExecutionContext,
-  wakePayload: WakePayload,
-  paperclipEnv: Record<string, string>,
-  payloadTemplate: Record<string, unknown>,
-): Record<string, unknown> {
-  const templatePaperclip = parseObject(payloadTemplate.paperclip);
-  const workspace = asRecord(ctx.context.paperclipWorkspace);
-  const workspaces = Array.isArray(ctx.context.paperclipWorkspaces)
-    ? ctx.context.paperclipWorkspaces.filter((entry): entry is Record<string, unknown> => Boolean(asRecord(entry)))
-    : [];
-  const configuredWorkspaceRuntime = parseObject(ctx.config.workspaceRuntime);
-  const runtimeServiceIntents = Array.isArray(ctx.context.paperclipRuntimeServiceIntents)
-    ? ctx.context.paperclipRuntimeServiceIntents.filter(
-        (entry): entry is Record<string, unknown> => Boolean(asRecord(entry)),
-      )
-    : [];
-
-  const standardPaperclip: Record<string, unknown> = {
-    runId: ctx.runId,
-    companyId: ctx.agent.companyId,
-    agentId: ctx.agent.id,
-    agentName: ctx.agent.name,
-    taskId: wakePayload.taskId,
-    issueId: wakePayload.issueId,
-    issueIds: wakePayload.issueIds,
-    wakeReason: wakePayload.wakeReason,
-    wakeCommentId: wakePayload.wakeCommentId,
-    approvalId: wakePayload.approvalId,
-    approvalStatus: wakePayload.approvalStatus,
-    apiUrl: paperclipEnv.PAPERCLIP_API_URL ?? null,
-  };
-  const structuredWake = parseObject(ctx.context.paperclipWake);
-  if (Object.keys(structuredWake).length > 0) {
-    standardPaperclip.wake = structuredWake;
-  }
-
-  if (workspace) {
-    standardPaperclip.workspace = workspace;
-  }
-  if (workspaces.length > 0) {
-    standardPaperclip.workspaces = workspaces;
-  }
-  if (runtimeServiceIntents.length > 0 || Object.keys(configuredWorkspaceRuntime).length > 0) {
-    standardPaperclip.workspaceRuntime = {
-      ...configuredWorkspaceRuntime,
-      ...(runtimeServiceIntents.length > 0 ? { services: runtimeServiceIntents } : {}),
-    };
-  }
-
-  return {
-    ...templatePaperclip,
-    ...standardPaperclip,
-  };
-}
-
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1130,7 +1074,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1139,7 +1082,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -29,6 +29,17 @@ async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
 
+function expectStructuredWakePayload(message: unknown, expected: Record<string, unknown>) {
+  const text = String(message ?? "");
+  const match = text.match(/Structured wake payload JSON:\n```json\n([\s\S]*?)\n```/);
+  expect(match?.[1]).toBeTruthy();
+  const expectedPayload =
+    typeof expected.wake === "object" && expected.wake !== null
+      ? (expected.wake as Record<string, unknown>)
+      : expected;
+  expect(JSON.parse(match?.[1] ?? "{}")).toMatchObject(expectedPayload);
+}
+
 async function createControlledGatewayServer() {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -454,7 +465,7 @@ describe("heartbeat comment wake batching", () => {
         return statusesByRunId.get(firstRun!.id) === "succeeded" && statusesByRunId.get(secondRunId) === "succeeded";
       }, 90_000);
 
-      expect(secondPayload.paperclip).toMatchObject({
+      expectStructuredWakePayload(secondPayload.message, {
         wake: {
           commentIds: [comment2.id, comment3.id],
           latestCommentId: comment3.id,
@@ -593,7 +604,7 @@ describe("heartbeat comment wake batching", () => {
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
       const promotedPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(promotedPayload.paperclip).toMatchObject({
+      expectStructuredWakePayload(promotedPayload.message, {
         wake: {
           commentIds: [queuedComment.id],
           latestCommentId: queuedComment.id,
@@ -602,20 +613,11 @@ describe("heartbeat comment wake batching", () => {
               id: queuedComment.id,
               authorType: "user",
               body: "Queued follow-up",
-              presentation: expect.objectContaining({
-                kind: "system_notice",
-                tone: "warning",
-              }),
-              metadata: expect.objectContaining({
-                version: 1,
-              }),
             }),
           ],
-          commentWindow: {
-            requestedCount: 1,
-            includedCount: 1,
-            missingCount: 0,
-          },
+          requestedCount: 1,
+          includedCount: 1,
+          missingCount: 0,
         },
       });
       expect(String(promotedPayload.message ?? "")).toContain("Queued follow-up");
@@ -802,7 +804,7 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expectStructuredWakePayload(secondPayload.message, {
         wake: {
           reason: "issue_commented",
           commentIds: [comment2.id],
@@ -1002,7 +1004,7 @@ describe("heartbeat comment wake batching", () => {
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expectStructuredWakePayload(secondPayload.message, {
         wake: {
           reason: "issue_comment_mentioned",
           commentIds: [comment.id],
@@ -1088,7 +1090,7 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
+      expectStructuredWakePayload(firstPayload.message, {
         wake: {
           reason: "issue_assigned",
           issue: {

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -39,6 +39,17 @@ function buildContext(
   };
 }
 
+function expectStructuredWakePayload(message: unknown, expected: Record<string, unknown>) {
+  const text = String(message ?? "");
+  const match = text.match(/Structured wake payload JSON:\n```json\n([\s\S]*?)\n```/);
+  expect(match?.[1]).toBeTruthy();
+  const expectedPayload =
+    typeof expected.wake === "object" && expected.wake !== null
+      ? (expected.wake as Record<string, unknown>)
+      : expected;
+  expect(JSON.parse(match?.[1] ?? "{}")).toMatchObject(expectedPayload);
+}
+
 async function createMockGatewayServer(options?: {
   waitPayload?: Record<string, unknown>;
 }) {
@@ -502,7 +513,7 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
+      expectStructuredWakePayload(payload?.message, {
         wake: {
           latestCommentId: "comment-2",
           commentIds: ["comment-1", "comment-2"],


### PR DESCRIPTION
## Thinking Path

NOX-5205 needs the local OpenClaw gateway strict-schema hotpatch made durable upstream. PR #6785 covers protocol negotiation only and remains open. The published adapter packages still send the rejected root `agentParams.paperclip` field, so a package/cache refresh would regress Cameron's local gateway recovery. The safe source fix is to stop sending Paperclip context as a root agent param and rely on the existing wake text plus `PAPERCLIP_*` environment variables instead.

This PR supersedes PR #6848. PR #6848 became merge-dirty and picked up unrelated CI/script changes, so this branch was rebuilt from current `paperclipai/paperclip@master` with only the stage-2 gateway adapter/test/doc changes.

## What Changed

- Removed the `agentParams.paperclip` root field from OpenClaw gateway agent requests.
- Strip any legacy `payloadTemplate.paperclip` value after template spread so strict OpenClaw schemas cannot reject the outbound `agent` request.
- Updated adapter docs to state that Paperclip context travels through wake text and `PAPERCLIP_*` env vars, not root agent params.
- Added a package-level WebSocket regression test that captures the outbound `agent` request and asserts it has no root `paperclip` key.
- Updated affected server tests to assert structured wake payload delivery through the message text instead of `payload.paperclip`.

## Verification

Package status checked 2026-06-02:

- `@paperclipai/adapter-openclaw-gateway@latest`: `2026.529.0`
- `@paperclipai/adapter-openclaw-gateway@canary`: `2026.602.0-canary.1`
- Both tarballs still contain `PROTOCOL_VERSION = 3` and `agentParams.paperclip = paperclipPayload`, so neither the protocol PR nor this stage-2 fix is published yet.

Local verification in clean worktree `/tmp/nox-5205-paperclip-stage2-clean`:

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run --config /tmp/vitest-openclaw-gateway.config.ts src/server/execute.test.ts` from `packages/adapters/openclaw-gateway` -> 5 passed
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck` -> pass
- `pnpm exec vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts` -> 16 passed

## Risks

- Downstream consumers that relied on `payload.paperclip` in the OpenClaw gateway request will no longer receive that root object. Paperclip context remains available in wake text and `PAPERCLIP_*` env vars, and the server tests were updated to cover that path.
- This does not include the protocol v4 negotiation fix; PR #6785 must still merge and publish alongside this for the adapter package to be fully durable.
- Do not refresh Cameron's local adapter cache to current npm `latest`/`canary` without reapplying local hotpatches; current published packages still regress both protocol v4 negotiation and strict-schema stripping.

## Model Used

GPT-5 Codex via Paperclip DevOps agent.