### PR TITLE
Enforce heartbeat cooldown on automatic agent wakeups

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -65,7 +65,7 @@ V1 implementation extends this baseline into a company-centric, governance-aware
 - Task lifecycle with parent/child hierarchy and comments
 - Atomic task checkout and explicit task status transitions
 - Board approvals for hires and CEO strategy proposal
-- Heartbeat invocation, status tracking, and cancellation
+- Heartbeat invocation, status tracking, cancellation, and optional cooldown deferral of automatic wakeups
 - Cost event ingestion and rollups (agent/task/project/company)
 - Budget settings and hard-stop enforcement
 - Board web UI for dashboard, org chart, tasks, agents, approvals, costs
@@ -104,7 +104,8 @@ V1 implementation extends this baseline into a company-centric, governance-aware
 
 A lightweight scheduler/worker in the server process handles:
 
-- heartbeat trigger checks
+- heartbeat timer ticks and wakeup enqueue
+- promotion of due `agent_wakeup_requests` (`deferred_issue_execution`, `deferred_cooldown`, scheduled retries)
 - stuck run detection
 - budget threshold checks
 
@@ -166,7 +167,17 @@ Invariants:
 - no cycles in reporting tree
 - `terminated` agents cannot be resumed
 
-## 7.3 `agent_api_keys`
+### 7.2.1 Heartbeat cooldown (`runtime_config.heartbeat.cooldownSec`)
+
+The server enforces optional pacing of **automatic** agent wakeups (see `doc/spec/agent-runs.md` §8.4.1).
+
+- **Config:** `agents.runtime_config.heartbeat.cooldownSec` (integer seconds; `0` = off). Default for newly created agents is `0`.
+- **Behavior:** assignment/automation `enqueueWakeup` calls defer until cooldown elapses after the agent's last finished assignment/automation run; wakeups coalesce into one `deferred_cooldown` request per agent.
+- **Bypass:** critical-priority issue, timer heartbeat, manual board invoke (`on_demand` + user actor).
+- **API/UI:** `GET` agent list/detail includes `runtimeThrottle`; board config field **Cooldown (sec)**; activity `agent.heartbeat_cooldown_deferred`.
+- **Complements budgets:** hard-stop still blocks invocation when spend limits are exceeded.
+
+### 7.3 `agent_api_keys`
 
 - `id` uuid pk
 - `agent_id` uuid fk `agents.id` not null
@@ -984,6 +995,7 @@ Current implementation note: the milestones below describe the original V1 seque
 - ship `process` adapter with cancel semantics
 - ship `http` adapter with timeout/error handling
 - persist heartbeat runs and statuses
+- enforce `heartbeat.cooldownSec` on assignment/automation wakeups (`deferred_cooldown` + scheduler promotion)
 
 ## Milestone 4: Cost and Budget Controls
 

--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -380,7 +380,7 @@ Agent-level control-plane settings (not adapter-specific):
     "wakeOnAssignment": true,
     "wakeOnOnDemand": true,
     "wakeOnAutomation": true,
-    "cooldownSec": 10
+    "cooldownSec": 0
   }
 }
 ```
@@ -392,6 +392,25 @@ Defaults:
 - `wakeOnAssignment: true`
 - `wakeOnOnDemand: true`
 - `wakeOnAutomation: true`
+- `cooldownSec: 0` (disabled until explicitly set; new agents use `0` so behavior matches pre-enforcement installs)
+
+### 8.4.1 Heartbeat cooldown enforcement
+
+`cooldownSec` is enforced server-side in `enqueueWakeup` (see `server/src/services/heartbeat-cooldown.ts`).
+
+When `cooldownSec > 0`:
+
+1. **Throttled sources** — only `assignment` and `automation` wakeups are delayed.
+2. **Clock** — eligibility is `lastFinishedAt + cooldownSec`, where `lastFinishedAt` is the most recent terminal `heartbeat_runs.finished_at` for that agent with `invocation_source` in `assignment | automation`.
+3. **Deferral** — a blocked wakeup is stored as `agent_wakeup_requests.status = deferred_cooldown` (coalesced per agent), not dropped. The scheduler promotes due rows when `payload.cooldownEligibleAt <= now`.
+4. **Bypass** (no delay):
+   - `timer` heartbeats
+   - `on_demand` wakeups with `requested_by_actor_type = user` (board manual invoke: Run Heartbeat, Retry, Resume)
+   - assignment/automation wakeups for issues with `priority = critical`
+5. **Visibility** — activity `agent.heartbeat_cooldown_deferred`; agent list/detail expose `runtimeThrottle` (`active`, `eligibleAt`, `cooldownSec`) for UI “Cooling down”.
+6. **Budgets** — cooldown paces automatic churn; budget hard-stop remains the spend ceiling.
+
+`cooldownSec: 0` disables enforcement for that agent.
 
 ## 8.5 Trigger integration rules
 
@@ -468,7 +487,7 @@ Queue + audit for wakeups.
 - `trigger_detail` text null (`manual|ping|callback|system`)
 - `reason` text null
 - `payload` jsonb null
-- `status` text not null (`queued|claimed|coalesced|skipped|completed|failed|cancelled`)
+- `status` text not null (`queued|deferred_issue_execution|deferred_cooldown|claimed|coalesced|skipped|completed|failed|cancelled`)
 - `coalesced_count` int not null default `0`
 - `requested_by_actor_type` text null (`user|agent|system`)
 - `requested_by_actor_id` text null

--- a/doc/spec/agents-runtime.md
+++ b/doc/spec/agents-runtime.md
@@ -50,6 +50,7 @@ In agent runtime settings, configure heartbeat policy:
 - `wakeOnAssignment`: wake when assigned work
 - `wakeOnOnDemand`: allow ping-style on-demand wakeups
 - `wakeOnAutomation`: allow system automation wakeups
+- `cooldownSec`: minimum seconds between automatic assignment/automation wakeups (`0` = disabled). Manual Run Heartbeat, timer heartbeats, and critical issues bypass. See `doc/spec/agent-runs.md` §8.4.1.
 
 ## 3.3 Working directory and execution limits
 

--- a/docs/guides/board-operator/managing-agents.md
+++ b/docs/guides/board-operator/managing-agents.md
@@ -44,7 +44,7 @@ Agents can request to hire subordinates. When this happens, you'll see a `hire_a
 Edit an agent's configuration from the agent detail page:
 
 - **Adapter config** — change model, prompt template, working directory, environment variables
-- **Heartbeat settings** — interval, cooldown, max concurrent runs, wake triggers
+- **Heartbeat settings** — interval, cooldown (minimum seconds between automatic assignment/automation wakeups; critical issues bypass; manual Run Heartbeat and timer bypass), max concurrent runs, wake triggers
 - **Budget** — monthly spend limit
 
 Use the "Test Environment" button to validate that the agent's adapter config is correct before running.

--- a/docs/specs/agent-config-ui.md
+++ b/docs/specs/agent-config-ui.md
@@ -133,7 +133,7 @@ Editable form with the same sections as the creation dialog (Adapter, Runtime, H
 Sections:
 - **Identity**: name, title, role, reports to, capabilities
 - **Adapter Config**: all adapter-specific fields for the current adapter type
-- **Heartbeat Policy**: enable/disable, interval, wake-on triggers, cooldown
+- **Heartbeat Policy**: enable/disable, interval, wake-on triggers, cooldown (sec between automatic wakeups; 0 = off; manual/timer/critical bypass)
 - **Runtime**: context mode, budget, timeout, grace, env vars, extra args
 
 Each section is a collapsible card. Save happens per-field (PATCH on blur/enter), not a single form submit. Validation errors show inline.

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -578,6 +578,7 @@ export type WakeupTriggerDetail = (typeof WAKEUP_TRIGGER_DETAILS)[number];
 export const WAKEUP_REQUEST_STATUSES = [
   "queued",
   "deferred_issue_execution",
+  "deferred_cooldown",
   "claimed",
   "coalesced",
   "skipped",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -336,6 +336,7 @@ export type {
   AgentAccessState,
   AgentChainOfCommandEntry,
   AgentDetail,
+  AgentRuntimeThrottle,
   AgentPermissions,
   AgentInstructionsBundleMode,
   AgentInstructionsFileSummary,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -92,8 +92,15 @@ export interface Agent {
   permissions: AgentPermissions;
   lastHeartbeatAt: Date | null;
   metadata: Record<string, unknown> | null;
+  runtimeThrottle?: AgentRuntimeThrottle;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface AgentRuntimeThrottle {
+  active: boolean;
+  eligibleAt: string | null;
+  cooldownSec: number;
 }
 
 export interface AgentDetail extends Agent {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -92,6 +92,7 @@ export type {
   AgentModelProfileConfig,
   AgentPermissions,
   AgentRuntimeConfig,
+  AgentRuntimeThrottle,
   AgentInstructionsBundleMode,
   AgentInstructionsFileSummary,
   AgentInstructionsFileDetail,

--- a/server/src/__tests__/heartbeat-cooldown.test.ts
+++ b/server/src/__tests__/heartbeat-cooldown.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeHeartbeatCooldownEligibleAt,
+  isHeartbeatCooldownThrottledSource,
+  parseHeartbeatCooldownPolicy,
+  shouldBypassHeartbeatCooldown,
+} from "../services/heartbeat-cooldown.js";
+
+describe("heartbeat-cooldown policy", () => {
+  it("parses cooldownSec from runtime config", () => {
+    expect(
+      parseHeartbeatCooldownPolicy({
+        heartbeat: { cooldownSec: 600 },
+      }).cooldownSec,
+    ).toBe(600);
+    expect(parseHeartbeatCooldownPolicy({}).cooldownSec).toBe(0);
+  });
+
+  it("identifies throttled invocation sources", () => {
+    expect(isHeartbeatCooldownThrottledSource("assignment")).toBe(true);
+    expect(isHeartbeatCooldownThrottledSource("automation")).toBe(true);
+    expect(isHeartbeatCooldownThrottledSource("on_demand")).toBe(false);
+    expect(isHeartbeatCooldownThrottledSource("timer")).toBe(false);
+  });
+
+  it("bypasses timer and manual board wakeups", () => {
+    expect(shouldBypassHeartbeatCooldown({ source: "timer" })).toBe(true);
+    expect(
+      shouldBypassHeartbeatCooldown({
+        source: "on_demand",
+        requestedByActorType: "user",
+      }),
+    ).toBe(true);
+    expect(
+      shouldBypassHeartbeatCooldown({
+        source: "on_demand",
+        requestedByActorType: "system",
+      }),
+    ).toBe(false);
+  });
+
+  it("computes eligibleAt from last finished run", () => {
+    const lastFinishedAt = new Date("2026-06-02T12:00:00.000Z");
+    const now = new Date("2026-06-02T12:05:00.000Z");
+    const eligibleAt = computeHeartbeatCooldownEligibleAt(lastFinishedAt, 600, now);
+    expect(eligibleAt?.toISOString()).toBe("2026-06-02T12:10:00.000Z");
+
+    const afterCooldown = new Date("2026-06-02T12:11:00.000Z");
+    expect(computeHeartbeatCooldownEligibleAt(lastFinishedAt, 600, afterCooldown)).toBeNull();
+  });
+});

--- a/server/src/__tests__/heartbeat-cooldown.test.ts
+++ b/server/src/__tests__/heartbeat-cooldown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildAgentRuntimeThrottle,
   computeHeartbeatCooldownEligibleAt,
   isHeartbeatCooldownThrottledSource,
   parseHeartbeatCooldownPolicy,
@@ -37,6 +38,17 @@ describe("heartbeat-cooldown policy", () => {
         requestedByActorType: "system",
       }),
     ).toBe(false);
+  });
+
+  it("builds active runtime throttle from deferral eligibleAt", () => {
+    const throttle = buildAgentRuntimeThrottle({
+      cooldownSec: 60,
+      deferralEligibleAt: new Date("2026-06-02T12:10:00.000Z"),
+      lastFinishedAt: null,
+      now: new Date("2026-06-02T12:05:00.000Z"),
+    });
+    expect(throttle.active).toBe(true);
+    expect(throttle.eligibleAt).toBe("2026-06-02T12:10:00.000Z");
   });
 
   it("computes eligibleAt from last finished run", () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -725,11 +725,13 @@ export async function startServer(): Promise<StartedServer> {
     void heartbeat
       .reapOrphanedRuns()
       .then(() => heartbeat.promoteDueScheduledRetries())
-      .then(async (promotion) => {
+      .then(async (scheduledPromotion) => {
+        const cooldownPromotion = await heartbeat.promoteDueCooldownDeferredRuns();
         await heartbeat.resumeQueuedRuns();
         const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
         if (
-          promotion.promoted > 0 ||
+          scheduledPromotion.promoted > 0 ||
+          cooldownPromotion.promoted > 0 ||
           reconciled.assignmentDispatched > 0 ||
           reconciled.dispatchRequeued > 0 ||
           reconciled.continuationRequeued > 0 ||
@@ -737,7 +739,13 @@ export async function startServer(): Promise<StartedServer> {
           reconciled.escalated > 0
         ) {
           logger.warn(
-            { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
+            {
+              promotedScheduledRetries: scheduledPromotion.promoted,
+              promotedScheduledRetryRunIds: scheduledPromotion.runIds,
+              promotedCooldownDeferred: cooldownPromotion.promoted,
+              promotedCooldownDeferredRequestIds: cooldownPromotion.requestIds,
+              ...reconciled,
+            },
             "startup heartbeat recovery changed assigned issue state",
           );
         }
@@ -791,11 +799,13 @@ export async function startServer(): Promise<StartedServer> {
       void heartbeat
         .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
         .then(() => heartbeat.promoteDueScheduledRetries())
-        .then(async (promotion) => {
+        .then(async (scheduledPromotion) => {
+          const cooldownPromotion = await heartbeat.promoteDueCooldownDeferredRuns();
           await heartbeat.resumeQueuedRuns();
           const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
           if (
-            promotion.promoted > 0 ||
+            scheduledPromotion.promoted > 0 ||
+            cooldownPromotion.promoted > 0 ||
             reconciled.assignmentDispatched > 0 ||
             reconciled.dispatchRequeued > 0 ||
             reconciled.continuationRequeued > 0 ||
@@ -803,7 +813,13 @@ export async function startServer(): Promise<StartedServer> {
             reconciled.escalated > 0
           ) {
             logger.warn(
-              { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
+              {
+                promotedScheduledRetries: scheduledPromotion.promoted,
+                promotedScheduledRetryRunIds: scheduledPromotion.runIds,
+                promotedCooldownDeferred: cooldownPromotion.promoted,
+                promotedCooldownDeferredRequestIds: cooldownPromotion.requestIds,
+                ...reconciled,
+              },
               "periodic heartbeat recovery changed assigned issue state",
             );
           }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -32,7 +32,10 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { computeAgentRuntimeThrottle } from "../services/heartbeat-cooldown.js";
+import {
+  computeAgentRuntimeThrottle,
+  computeAgentRuntimeThrottlesForAgents,
+} from "../services/heartbeat-cooldown.js";
 import {
   agentService,
   agentInstructionsService,
@@ -1610,12 +1613,14 @@ export function agentRoutes(
       return;
     }
     const result = await svc.list(companyId);
-    const runtimeThrottles = await Promise.all(
-      result.map((agent) => computeAgentRuntimeThrottle(db, agent)),
-    );
-    const withRuntimeThrottle = result.map((agent, index) => ({
+    const runtimeThrottleByAgentId = await computeAgentRuntimeThrottlesForAgents(db, result);
+    const withRuntimeThrottle = result.map((agent) => ({
       ...agent,
-      runtimeThrottle: runtimeThrottles[index],
+      runtimeThrottle: runtimeThrottleByAgentId.get(agent.id) ?? {
+        active: false,
+        eligibleAt: null,
+        cooldownSec: 0,
+      },
     }));
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -32,6 +32,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
+import { computeAgentRuntimeThrottle } from "../services/heartbeat-cooldown.js";
 import {
   agentService,
   agentInstructionsService,
@@ -522,15 +523,17 @@ export function agentRoutes(
     agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
     options?: { restricted?: boolean },
   ) {
-    const [chainOfCommand, accessState] = await Promise.all([
+    const [chainOfCommand, accessState, runtimeThrottle] = await Promise.all([
       svc.getChainOfCommand(agent.id),
       buildAgentAccessState(agent),
+      computeAgentRuntimeThrottle(db, agent),
     ]);
 
     return {
       ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
       chainOfCommand,
       access: accessState,
+      runtimeThrottle,
     };
   }
 
@@ -1607,12 +1610,19 @@ export function agentRoutes(
       return;
     }
     const result = await svc.list(companyId);
+    const runtimeThrottles = await Promise.all(
+      result.map((agent) => computeAgentRuntimeThrottle(db, agent)),
+    );
+    const withRuntimeThrottle = result.map((agent, index) => ({
+      ...agent,
+      runtimeThrottle: runtimeThrottles[index],
+    }));
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(withRuntimeThrottle);
       return;
     }
-    res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
+    res.json(withRuntimeThrottle.map((agent) => redactForRestrictedAgentView(agent)));
   });
 
   router.get("/instance/scheduler-heartbeats", async (req, res) => {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -617,7 +617,7 @@ const COMPANY_LOGO_CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
 const COMPANY_LOGO_FILE_NAME = "company-logo";
 
 const RUNTIME_DEFAULT_RULES: Array<{ path: string[]; value: unknown }> = [
-  { path: ["heartbeat", "cooldownSec"], value: 10 },
+  { path: ["heartbeat", "cooldownSec"], value: 0 },
   { path: ["heartbeat", "intervalSec"], value: 3600 },
   { path: ["heartbeat", "wakeOnOnDemand"], value: true },
   { path: ["heartbeat", "wakeOnAssignment"], value: true },

--- a/server/src/services/heartbeat-cooldown.ts
+++ b/server/src/services/heartbeat-cooldown.ts
@@ -1,0 +1,266 @@
+import type { Db } from "@paperclipai/db";
+import {
+  agentWakeupRequests,
+  agents,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
+
+export const HEARTBEAT_COOLDOWN_DEFERRED_STATUS = "deferred_cooldown";
+export const COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY = "cooldownEligibleAt";
+export const COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+
+export const COOLDOWN_THROTTLED_INVOCATION_SOURCES = ["assignment", "automation"] as const;
+export type CooldownThrottledInvocationSource = (typeof COOLDOWN_THROTTLED_INVOCATION_SOURCES)[number];
+
+export const PENDING_AGENT_WAKEUP_STATUSES = [
+  "queued",
+  "deferred_issue_execution",
+  HEARTBEAT_COOLDOWN_DEFERRED_STATUS,
+] as const;
+
+export interface HeartbeatCooldownPolicy {
+  cooldownSec: number;
+}
+
+export interface AgentRuntimeThrottle {
+  active: boolean;
+  eligibleAt: string | null;
+  cooldownSec: number;
+}
+
+function parseObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function asNumber(value: unknown, fallback: number) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export function parseHeartbeatCooldownPolicy(runtimeConfig: unknown): HeartbeatCooldownPolicy {
+  const heartbeat = parseObject(parseObject(runtimeConfig).heartbeat);
+  return {
+    cooldownSec: Math.max(0, Math.floor(asNumber(heartbeat.cooldownSec, 0))),
+  };
+}
+
+export function shouldBypassHeartbeatCooldown(input: {
+  source: string;
+  requestedByActorType?: string | null;
+}): boolean {
+  if (input.source === "timer") return true;
+  if (input.source === "on_demand" && input.requestedByActorType === "user") return true;
+  return false;
+}
+
+export function isHeartbeatCooldownThrottledSource(
+  source: string,
+): source is CooldownThrottledInvocationSource {
+  return (COOLDOWN_THROTTLED_INVOCATION_SOURCES as readonly string[]).includes(source);
+}
+
+export async function getLastThrottledHeartbeatFinishedAt(
+  db: Db,
+  agentId: string,
+): Promise<Date | null> {
+  const row = await db
+    .select({ finishedAt: heartbeatRuns.finishedAt })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.agentId, agentId),
+        inArray(heartbeatRuns.invocationSource, [...COOLDOWN_THROTTLED_INVOCATION_SOURCES]),
+        sql`${heartbeatRuns.finishedAt} is not null`,
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.finishedAt))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  return row?.finishedAt ?? null;
+}
+
+export function computeHeartbeatCooldownEligibleAt(
+  lastFinishedAt: Date | null,
+  cooldownSec: number,
+  now = new Date(),
+): Date | null {
+  if (cooldownSec <= 0 || !lastFinishedAt) return null;
+  const eligibleMs = lastFinishedAt.getTime() + cooldownSec * 1000;
+  if (now.getTime() >= eligibleMs) return null;
+  return new Date(eligibleMs);
+}
+
+function readEligibleAtFromPayload(payload: unknown): Date | null {
+  const parsed = parseObject(payload);
+  const raw = parsed[COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY];
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export async function getActiveCooldownDeferral(db: Db, agentId: string) {
+  return db
+    .select()
+    .from(agentWakeupRequests)
+    .where(
+      and(
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.status, HEARTBEAT_COOLDOWN_DEFERRED_STATUS),
+      ),
+    )
+    .orderBy(desc(agentWakeupRequests.requestedAt))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+export async function resolveIssuePriorityForCooldown(
+  db: Db,
+  companyId: string,
+  issueId: string | null,
+): Promise<string | null> {
+  if (!issueId) return null;
+  const row = await db
+    .select({ priority: issues.priority })
+    .from(issues)
+    .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
+    .then((rows) => rows[0] ?? null);
+  return row?.priority ?? null;
+}
+
+export async function evaluateHeartbeatCooldownGate(
+  db: Db,
+  input: {
+    agentId: string;
+    companyId: string;
+    source: string;
+    cooldownSec: number;
+    issueId: string | null;
+    requestedByActorType?: string | null;
+    now?: Date;
+  },
+): Promise<{ blocked: boolean; eligibleAt: Date | null; bypassed: boolean }> {
+  const now = input.now ?? new Date();
+  if (input.cooldownSec <= 0 || shouldBypassHeartbeatCooldown(input)) {
+    return { blocked: false, eligibleAt: null, bypassed: true };
+  }
+  if (!isHeartbeatCooldownThrottledSource(input.source)) {
+    return { blocked: false, eligibleAt: null, bypassed: false };
+  }
+
+  const priority = await resolveIssuePriorityForCooldown(db, input.companyId, input.issueId);
+  if (priority === "critical") {
+    return { blocked: false, eligibleAt: null, bypassed: true };
+  }
+
+  const activeDeferral = await getActiveCooldownDeferral(db, input.agentId);
+  const deferralEligibleAt = activeDeferral
+    ? readEligibleAtFromPayload(activeDeferral.payload)
+    : null;
+  if (deferralEligibleAt && now.getTime() < deferralEligibleAt.getTime()) {
+    return { blocked: true, eligibleAt: deferralEligibleAt, bypassed: false };
+  }
+
+  const lastFinishedAt = await getLastThrottledHeartbeatFinishedAt(db, input.agentId);
+  const eligibleAt = computeHeartbeatCooldownEligibleAt(lastFinishedAt, input.cooldownSec, now);
+  if (!eligibleAt) {
+    return { blocked: false, eligibleAt: null, bypassed: false };
+  }
+
+  return { blocked: true, eligibleAt, bypassed: false };
+}
+
+export async function computeAgentRuntimeThrottle(
+  db: Db,
+  agent: { id: string; runtimeConfig: unknown },
+  now = new Date(),
+): Promise<AgentRuntimeThrottle> {
+  const { cooldownSec } = parseHeartbeatCooldownPolicy(agent.runtimeConfig);
+  if (cooldownSec <= 0) {
+    return { active: false, eligibleAt: null, cooldownSec: 0 };
+  }
+
+  const activeDeferral = await getActiveCooldownDeferral(db, agent.id);
+  const deferralEligibleAt = activeDeferral
+    ? readEligibleAtFromPayload(activeDeferral.payload)
+    : null;
+  if (deferralEligibleAt && now.getTime() < deferralEligibleAt.getTime()) {
+    return {
+      active: true,
+      eligibleAt: deferralEligibleAt.toISOString(),
+      cooldownSec,
+    };
+  }
+
+  const lastFinishedAt = await getLastThrottledHeartbeatFinishedAt(db, agent.id);
+  const eligibleAt = computeHeartbeatCooldownEligibleAt(lastFinishedAt, cooldownSec, now);
+  if (!eligibleAt) {
+    return { active: false, eligibleAt: null, cooldownSec };
+  }
+
+  return {
+    active: true,
+    eligibleAt: eligibleAt.toISOString(),
+    cooldownSec,
+  };
+}
+
+export async function promoteDueCooldownDeferred(
+  db: Db,
+  promote: (request: typeof agentWakeupRequests.$inferSelect) => Promise<boolean>,
+  now = new Date(),
+) {
+  const dueRequests = await db
+    .select()
+    .from(agentWakeupRequests)
+    .where(
+      and(
+        eq(agentWakeupRequests.status, HEARTBEAT_COOLDOWN_DEFERRED_STATUS),
+        lte(
+          sql`(${agentWakeupRequests.payload} ->> 'cooldownEligibleAt')::timestamptz`,
+          now,
+        ),
+      ),
+    )
+    .orderBy(agentWakeupRequests.requestedAt)
+    .limit(50);
+
+  const promotedRequestIds: string[] = [];
+  for (const request of dueRequests) {
+    const promoted = await promote(request);
+    if (promoted) promotedRequestIds.push(request.id);
+  }
+
+  return {
+    promoted: promotedRequestIds.length,
+    requestIds: promotedRequestIds,
+  };
+}
+
+export async function assertAgentInvokableForCooldownPromotion(
+  db: Db,
+  agentId: string,
+) {
+  const agent = await db
+    .select({
+      id: agents.id,
+      companyId: agents.companyId,
+      status: agents.status,
+    })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .then((rows) => rows[0] ?? null);
+
+  if (!agent) return { ok: false as const, reason: "Agent not found" };
+  if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
+    return { ok: false as const, reason: "Agent is not invokable" };
+  }
+  return { ok: true as const, agent };
+}

--- a/server/src/services/heartbeat-cooldown.ts
+++ b/server/src/services/heartbeat-cooldown.ts
@@ -5,7 +5,7 @@ import {
   heartbeatRuns,
   issues,
 } from "@paperclipai/db";
-import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, lte, max, sql } from "drizzle-orm";
 
 export const HEARTBEAT_COOLDOWN_DEFERRED_STATUS = "deferred_cooldown";
 export const COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY = "cooldownEligibleAt";
@@ -177,6 +177,41 @@ export async function evaluateHeartbeatCooldownGate(
   return { blocked: true, eligibleAt, bypassed: false };
 }
 
+export function buildAgentRuntimeThrottle(input: {
+  cooldownSec: number;
+  deferralEligibleAt: Date | null;
+  lastFinishedAt: Date | null;
+  now?: Date;
+}): AgentRuntimeThrottle {
+  const now = input.now ?? new Date();
+  if (input.cooldownSec <= 0) {
+    return { active: false, eligibleAt: null, cooldownSec: 0 };
+  }
+
+  if (input.deferralEligibleAt && now.getTime() < input.deferralEligibleAt.getTime()) {
+    return {
+      active: true,
+      eligibleAt: input.deferralEligibleAt.toISOString(),
+      cooldownSec: input.cooldownSec,
+    };
+  }
+
+  const eligibleAt = computeHeartbeatCooldownEligibleAt(
+    input.lastFinishedAt,
+    input.cooldownSec,
+    now,
+  );
+  if (!eligibleAt) {
+    return { active: false, eligibleAt: null, cooldownSec: input.cooldownSec };
+  }
+
+  return {
+    active: true,
+    eligibleAt: eligibleAt.toISOString(),
+    cooldownSec: input.cooldownSec,
+  };
+}
+
 export async function computeAgentRuntimeThrottle(
   db: Db,
   agent: { id: string; runtimeConfig: unknown },
@@ -188,28 +223,93 @@ export async function computeAgentRuntimeThrottle(
   }
 
   const activeDeferral = await getActiveCooldownDeferral(db, agent.id);
-  const deferralEligibleAt = activeDeferral
-    ? readEligibleAtFromPayload(activeDeferral.payload)
-    : null;
-  if (deferralEligibleAt && now.getTime() < deferralEligibleAt.getTime()) {
-    return {
-      active: true,
-      eligibleAt: deferralEligibleAt.toISOString(),
-      cooldownSec,
-    };
-  }
-
   const lastFinishedAt = await getLastThrottledHeartbeatFinishedAt(db, agent.id);
-  const eligibleAt = computeHeartbeatCooldownEligibleAt(lastFinishedAt, cooldownSec, now);
-  if (!eligibleAt) {
-    return { active: false, eligibleAt: null, cooldownSec };
+  return buildAgentRuntimeThrottle({
+    cooldownSec,
+    deferralEligibleAt: activeDeferral
+      ? readEligibleAtFromPayload(activeDeferral.payload)
+      : null,
+    lastFinishedAt,
+    now,
+  });
+}
+
+export async function computeAgentRuntimeThrottlesForAgents(
+  db: Db,
+  agentsInput: Array<{ id: string; runtimeConfig: unknown }>,
+  now = new Date(),
+): Promise<Map<string, AgentRuntimeThrottle>> {
+  const throttles = new Map<string, AgentRuntimeThrottle>();
+  const throttledAgentIds: string[] = [];
+  const cooldownSecByAgentId = new Map<string, number>();
+
+  for (const agent of agentsInput) {
+    const { cooldownSec } = parseHeartbeatCooldownPolicy(agent.runtimeConfig);
+    if (cooldownSec <= 0) {
+      throttles.set(agent.id, { active: false, eligibleAt: null, cooldownSec: 0 });
+      continue;
+    }
+    throttledAgentIds.push(agent.id);
+    cooldownSecByAgentId.set(agent.id, cooldownSec);
   }
 
-  return {
-    active: true,
-    eligibleAt: eligibleAt.toISOString(),
-    cooldownSec,
-  };
+  if (throttledAgentIds.length === 0) {
+    return throttles;
+  }
+
+  const deferralRows = await db
+    .select()
+    .from(agentWakeupRequests)
+    .where(
+      and(
+        inArray(agentWakeupRequests.agentId, throttledAgentIds),
+        eq(agentWakeupRequests.status, HEARTBEAT_COOLDOWN_DEFERRED_STATUS),
+      ),
+    )
+    .orderBy(desc(agentWakeupRequests.requestedAt));
+
+  const deferralEligibleAtByAgentId = new Map<string, Date | null>();
+  for (const row of deferralRows) {
+    if (deferralEligibleAtByAgentId.has(row.agentId)) continue;
+    deferralEligibleAtByAgentId.set(
+      row.agentId,
+      readEligibleAtFromPayload(row.payload),
+    );
+  }
+
+  const lastFinishedRows = await db
+    .select({
+      agentId: heartbeatRuns.agentId,
+      finishedAt: max(heartbeatRuns.finishedAt),
+    })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        inArray(heartbeatRuns.agentId, throttledAgentIds),
+        inArray(heartbeatRuns.invocationSource, [...COOLDOWN_THROTTLED_INVOCATION_SOURCES]),
+        sql`${heartbeatRuns.finishedAt} is not null`,
+      ),
+    )
+    .groupBy(heartbeatRuns.agentId);
+
+  const lastFinishedAtByAgentId = new Map(
+    lastFinishedRows.map((row) => [row.agentId, row.finishedAt ?? null]),
+  );
+
+  for (const agentId of throttledAgentIds) {
+    const cooldownSec = cooldownSecByAgentId.get(agentId) ?? 0;
+    throttles.set(
+      agentId,
+      buildAgentRuntimeThrottle({
+        cooldownSec,
+        deferralEligibleAt: deferralEligibleAtByAgentId.get(agentId) ?? null,
+        lastFinishedAt: lastFinishedAtByAgentId.get(agentId) ?? null,
+        now,
+      }),
+    );
+  }
+
+  return throttles;
 }
 
 export async function promoteDueCooldownDeferred(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -173,6 +173,16 @@ import { environmentRuntimeService } from "./environment-runtime.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
 import { isUnsafeSessionWorkspaceCwd } from "./session-workspace-cwd.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import {
+  COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY,
+  COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY,
+  HEARTBEAT_COOLDOWN_DEFERRED_STATUS,
+  PENDING_AGENT_WAKEUP_STATUSES,
+  assertAgentInvokableForCooldownPromotion,
+  evaluateHeartbeatCooldownGate,
+  parseHeartbeatCooldownPolicy,
+  promoteDueCooldownDeferred,
+} from "./heartbeat-cooldown.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
@@ -5969,12 +5979,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   function parseHeartbeatPolicy(agent: typeof agents.$inferSelect) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
+    const cooldown = parseHeartbeatCooldownPolicy(agent.runtimeConfig);
 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
+      cooldownSec: cooldown.cooldownSec,
     };
   }
 
@@ -8983,6 +8995,154 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await startNextQueuedRunForAgent(promotedRun.agentId);
   }
 
+  async function deferHeartbeatCooldownWakeup(input: {
+    agent: typeof agents.$inferSelect;
+    agentId: string;
+    source: string;
+    triggerDetail: WakeupOptions["triggerDetail"] | null;
+    reason: string | null;
+    payload: Record<string, unknown> | null;
+    enrichedContextSnapshot: Record<string, unknown>;
+    eligibleAt: Date;
+    opts: WakeupOptions;
+  }) {
+    const eligibleAtIso = input.eligibleAt.toISOString();
+    const deferredPayload: Record<string, unknown> = {
+      ...(input.payload ?? {}),
+      [COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY]: eligibleAtIso,
+      [COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY]: input.enrichedContextSnapshot,
+    };
+    const deferredIssueId = readNonEmptyString(input.enrichedContextSnapshot.issueId);
+    if (deferredIssueId) deferredPayload.issueId = deferredIssueId;
+
+    const existingDeferred = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, input.agent.companyId),
+          eq(agentWakeupRequests.agentId, input.agentId),
+          eq(agentWakeupRequests.status, HEARTBEAT_COOLDOWN_DEFERRED_STATUS),
+        ),
+      )
+      .orderBy(asc(agentWakeupRequests.requestedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (existingDeferred) {
+      const existingPayload = parseObject(existingDeferred.payload);
+      const existingContext = parseObject(existingPayload[COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY]);
+      const mergedContext = mergeCoalescedContextSnapshot(existingContext, input.enrichedContextSnapshot);
+      const existingEligibleAtRaw = existingPayload[COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY];
+      const existingEligibleAt =
+        typeof existingEligibleAtRaw === "string" ? new Date(existingEligibleAtRaw) : null;
+      const mergedEligibleAt =
+        existingEligibleAt && !Number.isNaN(existingEligibleAt.getTime())
+          ? new Date(Math.min(existingEligibleAt.getTime(), input.eligibleAt.getTime()))
+          : input.eligibleAt;
+
+      await db
+        .update(agentWakeupRequests)
+        .set({
+          source: input.source,
+          triggerDetail: input.triggerDetail,
+          reason: input.reason ?? existingDeferred.reason,
+          payload: {
+            ...existingPayload,
+            ...(input.payload ?? {}),
+            issueId: deferredIssueId ?? existingPayload.issueId,
+            [COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY]: mergedEligibleAt.toISOString(),
+            [COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY]: mergedContext,
+          },
+          coalescedCount: (existingDeferred.coalescedCount ?? 0) + 1,
+          updatedAt: new Date(),
+        })
+        .where(eq(agentWakeupRequests.id, existingDeferred.id));
+    } else {
+      await db.insert(agentWakeupRequests).values({
+        companyId: input.agent.companyId,
+        agentId: input.agentId,
+        source: input.source,
+        triggerDetail: input.triggerDetail,
+        reason: input.reason ?? "heartbeat_cooldown_deferred",
+        payload: deferredPayload,
+        status: HEARTBEAT_COOLDOWN_DEFERRED_STATUS,
+        requestedByActorType: input.opts.requestedByActorType ?? null,
+        requestedByActorId: input.opts.requestedByActorId ?? null,
+        idempotencyKey: input.opts.idempotencyKey ?? null,
+      });
+    }
+
+    await logActivity(db, {
+      companyId: input.agent.companyId,
+      actorType: "system",
+      actorId: "heartbeat",
+      agentId: input.agentId,
+      runId: null,
+      action: "agent.heartbeat_cooldown_deferred",
+      entityType: "agent",
+      entityId: input.agentId,
+      details: {
+        eligibleAt: eligibleAtIso,
+        cooldownSec: parseHeartbeatPolicy(input.agent).cooldownSec,
+        source: input.source,
+        triggerDetail: input.triggerDetail,
+        issueId: deferredIssueId,
+        reason: input.reason,
+      },
+    });
+  }
+
+  async function promoteCooldownDeferredRequest(request: typeof agentWakeupRequests.$inferSelect) {
+    const invokable = await assertAgentInvokableForCooldownPromotion(db, request.agentId);
+    if (!invokable.ok) {
+      await db
+        .update(agentWakeupRequests)
+        .set({
+          status: "failed",
+          finishedAt: new Date(),
+          error: invokable.reason,
+          updatedAt: new Date(),
+        })
+        .where(eq(agentWakeupRequests.id, request.id));
+      return false;
+    }
+
+    const deferredPayload = parseObject(request.payload);
+    const deferredContext = parseObject(deferredPayload[COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY]);
+    const promotionPayload = { ...deferredPayload };
+    delete promotionPayload[COOLDOWN_DEFERRED_WAKE_CONTEXT_KEY];
+    delete promotionPayload[COOLDOWN_ELIGIBLE_AT_PAYLOAD_KEY];
+
+    const run = await enqueueWakeup(request.agentId, {
+      source: (readNonEmptyString(request.source) as WakeupOptions["source"]) ?? "automation",
+      triggerDetail: (readNonEmptyString(request.triggerDetail) as WakeupOptions["triggerDetail"]) ?? undefined,
+      reason: readNonEmptyString(request.reason),
+      payload: Object.keys(promotionPayload).length > 0 ? promotionPayload : null,
+      contextSnapshot: deferredContext,
+      requestedByActorType: request.requestedByActorType as WakeupOptions["requestedByActorType"],
+      requestedByActorId: request.requestedByActorId,
+      idempotencyKey: request.idempotencyKey,
+    });
+
+    const now = new Date();
+    await db
+      .update(agentWakeupRequests)
+      .set({
+        status: "completed",
+        finishedAt: now,
+        runId: run?.id ?? null,
+        updatedAt: now,
+      })
+      .where(eq(agentWakeupRequests.id, request.id));
+
+    return true;
+  }
+
+  async function promoteDueCooldownDeferredRuns(now = new Date()) {
+    return promoteDueCooldownDeferred(db, promoteCooldownDeferredRequest, now);
+  }
+
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
@@ -9106,6 +9266,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
     if (source !== "timer" && !policy.wakeOnDemand) {
       await writeSkippedRequest("heartbeat.wakeOnDemand.disabled");
+      return null;
+    }
+
+    const cooldownGate = await evaluateHeartbeatCooldownGate(db, {
+      agentId,
+      companyId: agent.companyId,
+      source,
+      cooldownSec: policy.cooldownSec,
+      issueId,
+      requestedByActorType: opts.requestedByActorType ?? null,
+    });
+    if (cooldownGate.blocked && cooldownGate.eligibleAt) {
+      await deferHeartbeatCooldownWakeup({
+        agent,
+        agentId,
+        source,
+        triggerDetail,
+        reason,
+        payload,
+        enrichedContextSnapshot,
+        eligibleAt: cooldownGate.eligibleAt,
+        opts,
+      });
       return null;
     }
 
@@ -9742,7 +9925,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(
         and(
           eq(agentWakeupRequests.companyId, companyId),
-          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          inArray(agentWakeupRequests.status, [...PENDING_AGENT_WAKEUP_STATUSES]),
           sql`${agentWakeupRequests.runId} is null`,
           sql`${effectiveProjectId} = ${projectId}`,
         ),
@@ -9762,7 +9945,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(
           and(
             eq(agentWakeupRequests.companyId, scope.companyId),
-            inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+            inArray(agentWakeupRequests.status, [...PENDING_AGENT_WAKEUP_STATUSES]),
             sql`${agentWakeupRequests.runId} is null`,
           ),
         )
@@ -9775,7 +9958,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           and(
             eq(agentWakeupRequests.companyId, scope.companyId),
             eq(agentWakeupRequests.agentId, scope.scopeId),
-            inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+            inArray(agentWakeupRequests.status, [...PENDING_AGENT_WAKEUP_STATUSES]),
             sql`${agentWakeupRequests.runId} is null`,
           ),
         )
@@ -10160,6 +10343,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reapOrphanedRuns,
 
     promoteDueScheduledRetries,
+    promoteDueCooldownDeferredRuns,
     retryScheduledRetryNow,
 
     resumeQueuedRuns,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9125,13 +9125,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       idempotencyKey: request.idempotencyKey,
     });
 
+    if (!run) {
+      // Cooldown may have re-deferred this row (updated eligibleAt). Do not mark completed.
+      return false;
+    }
+
     const now = new Date();
     await db
       .update(agentWakeupRequests)
       .set({
         status: "completed",
         finishedAt: now,
-        runId: run?.id ?? null,
+        runId: run.id,
         updatedAt: now,
       })
       .where(eq(agentWakeupRequests.id, request.id));

--- a/server/src/services/issue-tree-control.ts
+++ b/server/src/services/issue-tree-control.ts
@@ -1170,7 +1170,7 @@ export function issueTreeControlService(db: Db) {
       .where(
         and(
           eq(agentWakeupRequests.companyId, companyId),
-          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "deferred_cooldown"]),
           isNull(agentWakeupRequests.runId),
           inArray(sql<string | null>`${agentWakeupRequests.payload} ->> 'issueId'`, issueIds),
         ),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1163,7 +1163,7 @@ async function withIssueLabels(dbOrTx: any, rows: IssueRow[]): Promise<IssueWith
 
 const ACTIVE_RUN_STATUSES = ["queued", "running"];
 const BLOCKER_ATTENTION_ACTIVE_RUN_STATUSES = ["queued", "running"];
-const BLOCKER_ATTENTION_ACTIVE_WAKE_STATUSES = ["queued", "deferred_issue_execution"];
+const BLOCKER_ATTENTION_ACTIVE_WAKE_STATUSES = ["queued", "deferred_issue_execution", "deferred_cooldown"];
 const BLOCKER_ATTENTION_PENDING_INTERACTION_STATUSES = ["pending"];
 const BLOCKER_ATTENTION_PENDING_APPROVAL_STATUSES = ["pending", "revision_requested"];
 const BLOCKER_ATTENTION_OPEN_RECOVERY_ORIGIN_KIND = "harness_liveness_escalation";
@@ -2133,7 +2133,7 @@ async function blockedByMapForIssues(
 
 const BLOCKED_INBOX_TERMINAL_STATUSES = ["done", "cancelled"] as const;
 const BLOCKED_INBOX_ACTIVE_RUN_STATUSES = ["queued", "running"] as const;
-const BLOCKED_INBOX_ACTIVE_WAKE_STATUSES = ["queued", "deferred_issue_execution"] as const;
+const BLOCKED_INBOX_ACTIVE_WAKE_STATUSES = ["queued", "deferred_issue_execution", "deferred_cooldown"] as const;
 const BLOCKED_INBOX_PENDING_INTERACTION_STATUSES = ["pending"] as const;
 const BLOCKED_INBOX_PENDING_APPROVAL_STATUSES = ["pending", "revision_requested"] as const;
 const BLOCKED_INBOX_RECOVERY_ORIGIN_KINDS = ["harness_liveness_escalation", "stranded_issue_recovery"] as const;

--- a/server/src/services/recovery/run-liveness-continuations.ts
+++ b/server/src/services/recovery/run-liveness-continuations.ts
@@ -13,7 +13,7 @@ const CONTINUATION_ACTIVE_ISSUE_STATUSES = new Set(["todo", "in_progress"]);
 // A prior adapter error should not permanently suppress bounded liveness
 // continuations; the max-attempt/idempotency guards prevent unbounded retries.
 const CONTINUATION_AGENT_STATUSES = new Set(["active", "idle", "running", "error"]);
-const IDEMPOTENT_WAKE_STATUSES = ["queued", "deferred_issue_execution", "completed"];
+const IDEMPOTENT_WAKE_STATUSES = ["queued", "deferred_issue_execution", "deferred_cooldown", "completed"];
 
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -33,6 +33,7 @@ const PRODUCTIVE_SUCCESS_LIVENESS_STATES = new Set<RunLivenessState>([
 const IDEMPOTENT_HANDOFF_WAKE_STATUSES = [
   "queued",
   "deferred_issue_execution",
+  "deferred_cooldown",
   "claimed",
   "completed",
 ];

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -1238,7 +1238,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   value={eff(
                     "heartbeat",
                     "cooldownSec",
-                    Number(heartbeat.cooldownSec ?? 10),
+                    Number(heartbeat.cooldownSec ?? 0),
                   )}
                   onCommit={(v) => mark("heartbeat", "cooldownSec", v)}
                   immediate

--- a/ui/src/components/AgentCooldownBadge.tsx
+++ b/ui/src/components/AgentCooldownBadge.tsx
@@ -1,0 +1,45 @@
+import type { AgentRuntimeThrottle } from "@paperclipai/shared";
+import { cn } from "../lib/utils";
+
+function formatCooldownEligibleAt(eligibleAt: string) {
+  const target = new Date(eligibleAt);
+  if (Number.isNaN(target.getTime())) return "soon";
+  const deltaMs = target.getTime() - Date.now();
+  if (deltaMs <= 0) return "now";
+  const totalSec = Math.ceil(deltaMs / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.ceil(totalSec / 60);
+  if (totalMin < 60) return `${totalMin}m`;
+  const hours = Math.floor(totalMin / 60);
+  const minutes = totalMin % 60;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+export function AgentCooldownBadge({
+  throttle,
+  className,
+}: {
+  throttle?: AgentRuntimeThrottle;
+  className?: string;
+}) {
+  if (!throttle?.active) return null;
+  const eligibleLabel = throttle.eligibleAt
+    ? formatCooldownEligibleAt(throttle.eligibleAt)
+    : "soon";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300",
+        className,
+      )}
+      title={
+        throttle.eligibleAt
+          ? `Automatic wakeups resume at ${new Date(throttle.eligibleAt).toLocaleString()}`
+          : "Automatic wakeups are in cooldown"
+      }
+    >
+      Cooling down · {eligibleLabel}
+    </span>
+  );
+}

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -32,6 +32,7 @@ import {
   writeAgentSortMode,
 } from "../lib/agent-order";
 import { AgentIcon } from "./AgentIconPicker";
+import { AgentCooldownBadge } from "./AgentCooldownBadge";
 import { BudgetSidebarMarker } from "./BudgetSidebarMarker";
 import { SidebarSection, type SidebarSectionRadioChoice } from "./SidebarSection";
 import { Button } from "@/components/ui/button";
@@ -133,8 +134,11 @@ function SidebarAgentItem({
       >
         <AgentIcon icon={agent.icon} className="shrink-0 h-3.5 w-3.5 text-muted-foreground" />
         <span className="flex-1 truncate">{agent.name}</span>
-        {(agent.pauseReason === "budget" || runCount > 0) && (
+        {(agent.pauseReason === "budget" || agent.runtimeThrottle?.active || runCount > 0) && (
           <span className="ml-auto flex items-center gap-1.5 shrink-0">
+            {agent.runtimeThrottle?.active ? (
+              <AgentCooldownBadge throttle={agent.runtimeThrottle} />
+            ) : null}
             {agent.pauseReason === "budget" ? (
               <BudgetSidebarMarker title="Agent paused by budget" />
             ) : null}

--- a/ui/src/components/agent-config-primitives.tsx
+++ b/ui/src/components/agent-config-primitives.tsx
@@ -54,7 +54,8 @@ export const help: Record<string, string> = {
   timeoutSec: "Maximum seconds a run can take before being terminated. 0 means no timeout.",
   graceSec: "Seconds to wait after sending interrupt before force-killing the process.",
   wakeOnDemand: "Allow this agent to be woken by assignments, API calls, UI actions, or automated systems.",
-  cooldownSec: "Minimum seconds between consecutive heartbeat runs.",
+  cooldownSec:
+    "Minimum seconds between automatic assignment/automation wakeups (0 disables). Manual Run Heartbeat and timer heartbeats bypass this.",
   maxConcurrentRuns: "Maximum number of heartbeat runs that can execute simultaneously for this agent.",
   maxTurnContinuationEnabled: "Automatically queue bounded continuation runs when an adapter stops because its per-run turn cap was exhausted.",
   maxTurnContinuationMaxAttempts: "Maximum automatic continuations after one max-turn stop. This is separate from max turns per run.",

--- a/ui/src/lib/new-agent-runtime-config.test.ts
+++ b/ui/src/lib/new-agent-runtime-config.test.ts
@@ -10,7 +10,7 @@ describe("buildNewAgentRuntimeConfig", () => {
         enabled: false,
         intervalSec: 300,
         wakeOnDemand: true,
-        cooldownSec: 10,
+        cooldownSec: 0,
         maxConcurrentRuns: AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
       },
     });
@@ -27,7 +27,7 @@ describe("buildNewAgentRuntimeConfig", () => {
         enabled: true,
         intervalSec: 3600,
         wakeOnDemand: true,
-        cooldownSec: 10,
+        cooldownSec: 0,
         maxConcurrentRuns: AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
       },
     });

--- a/ui/src/lib/new-agent-runtime-config.ts
+++ b/ui/src/lib/new-agent-runtime-config.ts
@@ -12,7 +12,7 @@ export function buildNewAgentRuntimeConfig(input?: {
       enabled: input?.heartbeatEnabled ?? defaultCreateValues.heartbeatEnabled,
       intervalSec: input?.intervalSec ?? defaultCreateValues.intervalSec,
       wakeOnDemand: true,
-      cooldownSec: 10,
+      cooldownSec: 0,
       maxConcurrentRuns: AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
     },
   };

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -31,6 +31,7 @@ import { redactCommandText as redactCommandSecretText } from "@paperclipai/adapt
 import { MarkdownEditor } from "../components/MarkdownEditor";
 import { assetsApi } from "../api/assets";
 import { getUIAdapter, buildTranscript, onAdapterChange } from "../adapters";
+import { AgentCooldownBadge } from "../components/AgentCooldownBadge";
 import { StatusBadge } from "../components/StatusBadge";
 import { agentStatusDot, agentStatusDotDefault } from "../lib/status-colors";
 import { MarkdownBody } from "../components/MarkdownBody";
@@ -1103,7 +1104,10 @@ export function AgentDetail() {
             onResume={() => agentAction.mutate("resume")}
             disabled={agentAction.isPending || isPendingApproval}
           />
-          <span className="hidden sm:inline"><StatusBadge status={agent.status} /></span>
+          <span className="hidden sm:inline-flex items-center gap-2">
+            <StatusBadge status={agent.status} />
+            <AgentCooldownBadge throttle={agent.runtimeThrottle} />
+          </span>
           {mobileLiveRun && (
             <Link
               to={`/agents/${canonicalAgentRef}/runs/${mobileLiveRun.id}`}


### PR DESCRIPTION
Fixes #7417

## Thinking Path

> - Paperclip orchestrates AI agents via heartbeat runs triggered by assignments, automation, timers, and manual board invoke
> - Agents already expose `runtime_config.heartbeat.cooldownSec` in the board UI, but the server never enforced it
> - Rapid assignment/automation wakeups can chain expensive runs back-to-back and blow through provider quotas before budget hard-stop kicks in
> - Operators need a simple per-agent pacing knob that defers automatic work without blocking manual intervention
> - This pull request enforces `cooldownSec` in `enqueueWakeup`, defers blocked wakeups as `deferred_cooldown`, promotes them on a schedule, and surfaces `runtimeThrottle` plus a Cooling down badge
> - The benefit is opt-in cost control on automatic churn while preserving timer pacing, manual Run Heartbeat, and critical-issue bypass

## Flow (assignment wakeup)

```mermaid
sequenceDiagram
  participant Board
  participant Issues
  participant Heartbeat
  participant Agent

  Board->>Issues: assign issue to agent
  Issues->>Heartbeat: wakeup(source=assignment)
  alt within cooldown and not critical
    Heartbeat->>Heartbeat: defer wakeup until eligibleAt
    Heartbeat->>Board: activity log + agent shows cooling_down
  else bypass or eligible
    Heartbeat->>Agent: start heartbeat run
    Agent->>Issues: checkout -> in_progress
  end
```

Bypass paths (not shown): timer heartbeat, manual Run Heartbeat (`on_demand` + user), critical priority.

## What Changed

- Add `server/src/services/heartbeat-cooldown.ts` with policy parsing, gate evaluation, deferral promotion, and `runtimeThrottle` computation
- Enforce cooldown in `enqueueWakeup` for `assignment`/`automation` sources; bypass timer, manual `on_demand` (user actor), and critical priority
- Coalesce duplicate deferrals per agent; log `agent.heartbeat_cooldown_deferred`; promote due `deferred_cooldown` requests on startup and periodic scheduler ticks
- Add `deferred_cooldown` to shared wakeup request statuses; include in pending-wakeup status lists used by budget cancel and inbox attention
- Expose `runtimeThrottle` on agent list/detail API responses
- Add `AgentCooldownBadge` in sidebar and agent header; update cooldown field hint; default new agents to `cooldownSec: 0`
- Unit tests for cooldown policy helpers; docs in `doc/spec/agent-runs.md` §8.4.1 and `doc/SPEC-implementation.md` §7.2.1

## Verification

```sh
npx vitest run server/src/__tests__/heartbeat-cooldown.test.ts ui/src/lib/new-agent-runtime-config.test.ts
pnpm --filter @paperclipai/server typecheck
```

Manual:

1. Set an agent `Cooldown (sec)` to e.g. `30` (non-zero).
2. Finish an assignment/automation run, then assign another non-critical issue within 30s — assignee should stay `todo`, activity should show cooldown deferred, sidebar should show **Cooling down**.
3. After the window, deferred wakeup should promote and run starts.
4. **Run Heartbeat** and critical assignment should still start immediately.

## Risks

- Existing agents with persisted `cooldownSec: 10` will start enforcing a 10s gap on automatic wakeups after deploy (field existed but was inert). New agents default to `0` (no change from prior effective behavior).
- No integration test yet for full `enqueueWakeup` defer/promote path (unit tests only).
- Low risk for manual/timer/critical paths due to explicit bypass rules.

## Model Used

Claude (Anthropic) — assisted design, implementation, tests, and documentation in Cursor Agent mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge

