### PR TITLE
feat(PRO-1195): scope Scrum coordination permissions

### DIFF
--- a/.github/scripts/check-pr-security.mjs
+++ b/.github/scripts/check-pr-security.mjs
@@ -332,10 +332,13 @@ async function main() {
 
   if (allFlags.length > 0) {
     console.error(`[security] ${allFlags.length} flag(s) detected — creating draft advisory and pending check run`);
-    await Promise.all([
+    const [advisoryResult] = await Promise.allSettled([
       syncDraftAdvisory(ghFetch, GH_TOKEN, GH_REPO, prNumber, pr.title, allFlags),
       postSecurityCheckRun(ghFetch, GH_TOKEN, GH_REPO, pr.head.sha, true),
     ]);
+    if (advisoryResult.status === 'rejected') {
+      console.error(`[security] failed to sync draft advisory: ${advisoryResult.reason?.message ?? advisoryResult.reason}`);
+    }
   } else {
     console.log('[security] all clear');
     await postSecurityCheckRun(ghFetch, GH_TOKEN, GH_REPO, pr.head.sha, false);

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -28,6 +28,16 @@ const mockInstanceSettingsService = vi.hoisted(() => ({
 }));
 
 const routeAgentId = "11111111-1111-4111-8111-111111111111";
+const managerAgentId = "22222222-2222-4222-8222-222222222222";
+const scrumAgentId = "33333333-3333-4333-8333-333333333333";
+
+const defaultBoardActor = {
+  type: "board",
+  userId: "local-board",
+  companyIds: ["company-1"],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+};
 
 function registerModuleMocks() {
   vi.doMock("../routes/authz.js", async () => vi.importActual("../routes/authz.js"));
@@ -82,7 +92,10 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp(db: Record<string, unknown> = {}) {
+async function createApp(
+  db: Record<string, unknown> = {},
+  actor: Record<string, unknown> = defaultBoardActor,
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -90,18 +103,16 @@ async function createApp(db: Record<string, unknown> = {}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", agentRoutes(db as any));
   app.use(errorHandler);
   return app;
+}
+
+async function createAgentApp(actor: Record<string, unknown>, db: Record<string, unknown> = {}) {
+  return createApp(db, actor);
 }
 
 function createLiveRunsDbStub(rows: Array<Record<string, unknown>>) {
@@ -173,12 +184,63 @@ describe("agent live run routes", () => {
       assigneeAgentId: "agent-1",
       status: "in_progress",
     });
-    mockIssueService.getById.mockResolvedValue(null);
-    mockAgentService.getById.mockResolvedValue({
-      id: "agent-1",
-      companyId: "company-1",
-      name: "Builder",
-      adapterType: "codex_local",
+    mockIssueService.getById.mockImplementation(async (id: string) => {
+      if (id === "issue-1") {
+        return {
+          id: "issue-1",
+          companyId: "company-1",
+          assigneeAgentId: routeAgentId,
+          status: "in_progress",
+        };
+      }
+      return null;
+    });
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === "agent-1") {
+        return {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Builder",
+          urlKey: "builder",
+          role: "engineer",
+          reportsTo: managerAgentId,
+          adapterType: "codex_local",
+        };
+      }
+      if (id === routeAgentId) {
+        return {
+          id: routeAgentId,
+          companyId: "company-1",
+          name: "Builder",
+          urlKey: "builder",
+          role: "engineer",
+          reportsTo: managerAgentId,
+          adapterType: "codex_local",
+        };
+      }
+      if (id === managerAgentId) {
+        return {
+          id: managerAgentId,
+          companyId: "company-1",
+          name: "Manager",
+          urlKey: "manager",
+          role: "cto",
+          reportsTo: null,
+          adapterType: "codex_local",
+        };
+      }
+      if (id === scrumAgentId) {
+        return {
+          id: scrumAgentId,
+          companyId: "company-1",
+          name: "Scrum",
+          urlKey: "scrum",
+          role: "pm",
+          reportsTo: managerAgentId,
+          adapterType: "codex_local",
+        };
+      }
+      return null;
     });
     mockInstanceSettingsService.get.mockResolvedValue({
       id: "instance-settings-1",
@@ -584,6 +646,117 @@ describe("agent live run routes", () => {
         forceFreshSession: true,
       },
     });
+  });
+
+  it("allows Scrum to wake an issue assignee when payload is tied to that issue", async () => {
+    const res = await requestApp(
+      await createAgentApp({
+        type: "agent",
+        agentId: scrumAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "scrum-run-1",
+      }),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          reason: "scrum_coordination",
+          payload: { issueId: "issue-1" },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(routeAgentId, expect.objectContaining({
+      reason: "scrum_coordination",
+      payload: { issueId: "issue-1" },
+      requestedByActorType: "agent",
+      requestedByActorId: scrumAgentId,
+    }));
+  });
+
+  it("allows Scrum to wake an issue assignee manager when payload is tied to that issue", async () => {
+    const res = await requestApp(
+      await createAgentApp({
+        type: "agent",
+        agentId: scrumAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "scrum-run-1",
+      }),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${managerAgentId}/wakeup?companyId=company-1`)
+        .send({
+          reason: "scrum_coordination",
+          payload: { issueId: "issue-1" },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(managerAgentId, expect.objectContaining({
+      reason: "scrum_coordination",
+      payload: { issueId: "issue-1" },
+      requestedByActorType: "agent",
+      requestedByActorId: scrumAgentId,
+    }));
+  });
+
+  it("rejects Scrum wakeups without an issue-scoped assignee or manager target", async () => {
+    const unrelatedTarget = "44444444-4444-4444-8444-444444444444";
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === unrelatedTarget) {
+        return {
+          id: unrelatedTarget,
+          companyId: "company-1",
+          name: "Other",
+          urlKey: "other",
+          role: "engineer",
+          reportsTo: null,
+          adapterType: "codex_local",
+        };
+      }
+      if (id === scrumAgentId) {
+        return {
+          id: scrumAgentId,
+          companyId: "company-1",
+          name: "Scrum",
+          urlKey: "scrum",
+          role: "pm",
+          reportsTo: managerAgentId,
+          adapterType: "codex_local",
+        };
+      }
+      if (id === routeAgentId) {
+        return {
+          id: routeAgentId,
+          companyId: "company-1",
+          name: "Builder",
+          urlKey: "builder",
+          role: "engineer",
+          reportsTo: managerAgentId,
+          adapterType: "codex_local",
+        };
+      }
+      return null;
+    });
+
+    const denied = await requestApp(
+      await createAgentApp({
+        type: "agent",
+        agentId: scrumAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "scrum-run-1",
+      }),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${unrelatedTarget}/wakeup?companyId=company-1`)
+        .send({
+          reason: "scrum_coordination",
+          payload: { issueId: "issue-1" },
+        }),
+    );
+
+    expect(denied.status, JSON.stringify(denied.body)).toBe(403);
+    expect(denied.body.error).toBe("Agent can only invoke itself");
   });
 
   it("calls heartbeat.wakeup with the legacy minimal shape when the body is empty", async () => {

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -700,6 +700,40 @@ describe("agent live run routes", () => {
     }));
   });
 
+  it("rejects Scrum wakeups for closed issues", async () => {
+    mockIssueService.getById.mockImplementation(async (id: string) => {
+      if (id === "issue-1") {
+        return {
+          id: "issue-1",
+          companyId: "company-1",
+          assigneeAgentId: routeAgentId,
+          status: "done",
+        };
+      }
+      return null;
+    });
+
+    const denied = await requestApp(
+      await createAgentApp({
+        type: "agent",
+        agentId: scrumAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "scrum-run-1",
+      }),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          reason: "scrum_coordination",
+          payload: { issueId: "issue-1" },
+        }),
+    );
+
+    expect(denied.status, JSON.stringify(denied.body)).toBe(403);
+    expect(denied.body.error).toBe("Agent can only invoke itself");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
   it("rejects Scrum wakeups without an issue-scoped assignee or manager target", async () => {
     const unrelatedTarget = "44444444-4444-4444-8444-444444444444";
     mockAgentService.getById.mockImplementation(async (id: string) => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -7,6 +7,7 @@ const issueId = "11111111-1111-4111-8111-111111111111";
 const companyId = "22222222-2222-4222-8222-222222222222";
 const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
+const scrumAgentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 
@@ -187,6 +188,8 @@ function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
   return {
     id,
     companyId,
+    name: id === scrumAgentId ? "Scrum" : "Agent",
+    urlKey: id === scrumAgentId ? "scrum" : "agent",
     role: "engineer",
     reportsTo: null,
     permissions: { canCreateAgents: false },
@@ -360,11 +363,13 @@ describe("agent issue mutation checkout ownership", () => {
     mockAgentService.getById.mockImplementation(async (id: string) => {
       if (id === ownerAgentId) return makeAgent(ownerAgentId);
       if (id === peerAgentId) return makeAgent(peerAgentId);
+      if (id === scrumAgentId) return makeAgent(scrumAgentId, { role: "pm" });
       return null;
     });
     mockAgentService.list.mockResolvedValue([
       makeAgent(ownerAgentId),
       makeAgent(peerAgentId),
+      makeAgent(scrumAgentId, { role: "pm" }),
     ]);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: null });
     mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "PAP" });
@@ -506,6 +511,61 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("allows Scrum to add coordination comments on another agent's active issue", async () => {
+    const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Routing recovery: blocked waiting path restored to the assignee." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Routing recovery: blocked waiting path restored to the assignee.",
+      expect.objectContaining({
+        agentId: scrumAgentId,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows Scrum to set coordination status on another agent's active issue", async () => {
+    const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "blocked",
+        comment: "Routing handoff: blocker path restored for the assignee.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+      }),
+    );
+  });
+
+  it("rejects Scrum arbitrary issue edits on another agent's active issue", async () => {
+    const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Scrum should not rewrite deliverables" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects Scrum comments that are not tied to coordination", async () => {
+    const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Nice progress." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("allows the checked-out owner with the matching run id to patch and update documents", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -548,6 +548,19 @@ describe("agent issue mutation checkout ownership", () => {
     );
   });
 
+  it("rejects Scrum arbitrary assignee changes on another agent's active issue", async () => {
+    const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        assigneeAgentId: peerAgentId,
+        comment: "Routing handoff: restore the assignee waiting path.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("rejects Scrum arbitrary issue edits on another agent's active issue", async () => {
     const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
       .patch(`/api/issues/${issueId}`)
@@ -562,6 +575,16 @@ describe("agent issue mutation checkout ownership", () => {
     const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
       .post(`/api/issues/${issueId}/comments`)
       .send({ body: "Nice progress." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects broad Scrum comments that mention blocked work without coordination intent", async () => {
+    const res = await request(await createApp(peerActor({ agentId: scrumAgentId })))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "The issue is blocked by an external API, so I will resume later." });
 
     expect(res.status, JSON.stringify(res.body)).toBe(409);
     expect(res.body.error).toBe("Issue is checked out by another agent");

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -32,6 +32,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
+import { isActiveCoordinationIssueStatus, isScrumCoordinatorAgent } from "./scrum-coordination.js";
 import {
   agentService,
   agentInstructionsService,
@@ -114,13 +115,6 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   if (!Number.isFinite(parsed)) return fallback;
   if (parsed <= 0) return fallback;
   return Math.min(max, Math.trunc(parsed));
-}
-
-function isScrumCoordinatorAgent(agent: { name?: string | null; urlKey?: string | null; role?: string | null } | null | undefined) {
-  if (!agent) return false;
-  const name = (agent.name ?? "").trim().toLowerCase();
-  const urlKey = (agent.urlKey ?? "").trim().toLowerCase();
-  return agent.role === "pm" && (name === "scrum" || urlKey === "scrum");
 }
 
 function readPayloadIssueId(payload: unknown) {
@@ -2949,6 +2943,7 @@ export function agentRoutes(
           isScrumCoordinatorAgent(actorAgent) &&
           !!issue &&
           issue.companyId === agent.companyId &&
+          isActiveCoordinationIssueStatus(issue.status) &&
           issue.assigneeAgentId &&
           (id === issue.assigneeAgentId || id === assignee?.reportsTo);
         if (!scrumIssueWakeAllowed) {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -116,6 +116,19 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   return Math.min(max, Math.trunc(parsed));
 }
 
+function isScrumCoordinatorAgent(agent: { name?: string | null; urlKey?: string | null; role?: string | null } | null | undefined) {
+  if (!agent) return false;
+  const name = (agent.name ?? "").trim().toLowerCase();
+  const urlKey = (agent.urlKey ?? "").trim().toLowerCase();
+  return agent.role === "pm" && (name === "scrum" || urlKey === "scrum");
+}
+
+function readPayloadIssueId(payload: unknown) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const value = (payload as Record<string, unknown>).issueId;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
 export function agentRoutes(
   db: Db,
   options: { pluginWorkerManager?: PluginWorkerManager } = {},
@@ -161,6 +174,7 @@ export function agentRoutes(
 
   const router = Router();
   const svc = agentService(db);
+  const issuesSvc = issueService(db);
   const access = accessService(db);
   const approvalsSvc = approvalService(db);
   const budgets = budgetService(db);
@@ -2927,8 +2941,20 @@ export function agentRoutes(
 
     if (req.actor.type === "agent") {
       if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
-        return;
+        const actorAgent = req.actor.agentId ? await svc.getById(req.actor.agentId) : null;
+        const issueId = readPayloadIssueId(req.body.payload);
+        const issue = issueId ? await issuesSvc.getById(issueId) : null;
+        const assignee = issue?.assigneeAgentId ? await svc.getById(issue.assigneeAgentId) : null;
+        const scrumIssueWakeAllowed =
+          isScrumCoordinatorAgent(actorAgent) &&
+          !!issue &&
+          issue.companyId === agent.companyId &&
+          issue.assigneeAgentId &&
+          (id === issue.assigneeAgentId || id === assignee?.reportsTo);
+        if (!scrumIssueWakeAllowed) {
+          res.status(403).json({ error: "Agent can only invoke itself" });
+          return;
+        }
       }
     } else {
       await assertBoardCanManageAgentsForCompany(req, agent.companyId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -118,6 +118,7 @@ import {
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { isActiveCoordinationIssueStatus, isScrumCoordinatorAgent } from "./scrum-coordination.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -615,19 +616,8 @@ function assertCanManageIssueMonitor(req: Request, assigneeAgentId: string | nul
   throw forbidden("Only the assignee agent or a board user can manage issue monitors");
 }
 
-function isScrumCoordinatorAgent(agent: { name?: string | null; urlKey?: string | null; role?: string | null } | null | undefined) {
-  if (!agent) return false;
-  const name = (agent.name ?? "").trim().toLowerCase();
-  const urlKey = (agent.urlKey ?? "").trim().toLowerCase();
-  return agent.role === "pm" && (name === "scrum" || urlKey === "scrum");
-}
-
-function isActiveCoordinationIssueStatus(status: string) {
-  return status === "todo" || status === "in_progress" || status === "blocked" || status === "in_review";
-}
-
 const SCRUM_COORDINATION_COMMENT_RE =
-  /\b(?:routing|route|reassign|assignee|owner|blocked|blocker|stale|waiting path|recovery|recover|resume|handoff|review path)\b/i;
+  /\b(?:routing|reassign(?:ment)?|assignee|blocker|waiting path|recovery|handoff|review path)\b/i;
 const SCRUM_COORDINATION_PATCH_KEYS = new Set(["status", "assigneeAgentId", "comment"]);
 const SCRUM_COORDINATION_STATUSES = new Set(["blocked", "in_review", "todo", "in_progress"]);
 
@@ -635,12 +625,13 @@ function isScrumCoordinationComment(body: unknown) {
   return typeof body === "string" && SCRUM_COORDINATION_COMMENT_RE.test(body);
 }
 
-function isScrumCoordinationIssueUpdate(body: Record<string, unknown>) {
+function isScrumCoordinationIssueUpdate(body: Record<string, unknown>, issue: { assigneeAgentId: string | null }) {
   const changedKeys = Object.keys(body).filter((key) => body[key] !== undefined);
   if (changedKeys.length === 0) return false;
   if (changedKeys.some((key) => !SCRUM_COORDINATION_PATCH_KEYS.has(key))) return false;
   if (body.status !== undefined && !SCRUM_COORDINATION_STATUSES.has(String(body.status))) return false;
   if (body.comment !== undefined && !isScrumCoordinationComment(body.comment)) return false;
+  if (body.assigneeAgentId !== undefined && body.assigneeAgentId !== issue.assigneeAgentId) return false;
   return body.status !== undefined || body.assigneeAgentId !== undefined;
 }
 
@@ -1545,7 +1536,7 @@ export function issueRoutes(
         isActiveCoordinationIssueStatus(issue.status) &&
         (
           (options.kind === "comment" && isScrumCoordinationComment(options.body?.body)) ||
-          (options.kind === "issue_update" && options.body && isScrumCoordinationIssueUpdate(options.body))
+          (options.kind === "issue_update" && options.body && isScrumCoordinationIssueUpdate(options.body, issue))
         );
       if (scrumCoordinationAllowed) {
         return true;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -133,6 +133,7 @@ type RecoveryRevalidationTrigger =
   | "document"
   | "work_product"
   | "read_projection";
+type AgentIssueMutationKind = "issue_update" | "comment" | "deliverable";
 type CompanySearchService = {
   search(companyId: string, query: CompanySearchQuery): Promise<CompanySearchResponse>;
 };
@@ -612,6 +613,35 @@ function assertCanManageIssueMonitor(req: Request, assigneeAgentId: string | nul
   if (req.actor.type === "board") return;
   if (req.actor.type === "agent" && req.actor.agentId && req.actor.agentId === assigneeAgentId) return;
   throw forbidden("Only the assignee agent or a board user can manage issue monitors");
+}
+
+function isScrumCoordinatorAgent(agent: { name?: string | null; urlKey?: string | null; role?: string | null } | null | undefined) {
+  if (!agent) return false;
+  const name = (agent.name ?? "").trim().toLowerCase();
+  const urlKey = (agent.urlKey ?? "").trim().toLowerCase();
+  return agent.role === "pm" && (name === "scrum" || urlKey === "scrum");
+}
+
+function isActiveCoordinationIssueStatus(status: string) {
+  return status === "todo" || status === "in_progress" || status === "blocked" || status === "in_review";
+}
+
+const SCRUM_COORDINATION_COMMENT_RE =
+  /\b(?:routing|route|reassign|assignee|owner|blocked|blocker|stale|waiting path|recovery|recover|resume|handoff|review path)\b/i;
+const SCRUM_COORDINATION_PATCH_KEYS = new Set(["status", "assigneeAgentId", "comment"]);
+const SCRUM_COORDINATION_STATUSES = new Set(["blocked", "in_review", "todo", "in_progress"]);
+
+function isScrumCoordinationComment(body: unknown) {
+  return typeof body === "string" && SCRUM_COORDINATION_COMMENT_RE.test(body);
+}
+
+function isScrumCoordinationIssueUpdate(body: Record<string, unknown>) {
+  const changedKeys = Object.keys(body).filter((key) => body[key] !== undefined);
+  if (changedKeys.length === 0) return false;
+  if (changedKeys.some((key) => !SCRUM_COORDINATION_PATCH_KEYS.has(key))) return false;
+  if (body.status !== undefined && !SCRUM_COORDINATION_STATUSES.has(String(body.status))) return false;
+  if (body.comment !== undefined && !isScrumCoordinationComment(body.comment)) return false;
+  return body.status !== undefined || body.assigneeAgentId !== undefined;
 }
 
 function summarizeIssueMonitor(
@@ -1497,6 +1527,7 @@ export function issueRoutes(
     req: Request,
     res: Response,
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    options: { kind?: AgentIssueMutationKind; body?: Record<string, unknown> } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1508,6 +1539,17 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
+      const actorAgent = await agentsSvc.getById(actorAgentId);
+      const scrumCoordinationAllowed =
+        isScrumCoordinatorAgent(actorAgent) &&
+        isActiveCoordinationIssueStatus(issue.status) &&
+        (
+          (options.kind === "comment" && isScrumCoordinationComment(options.body?.body)) ||
+          (options.kind === "issue_update" && options.body && isScrumCoordinationIssueUpdate(options.body))
+        );
+      if (scrumCoordinationAllowed) {
+        return true;
+      }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }
@@ -4038,7 +4080,7 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { kind: "issue_update", body: req.body }))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -5747,7 +5789,7 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, issue, { kind: "comment", body: req.body }))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,

--- a/server/src/routes/scrum-coordination.ts
+++ b/server/src/routes/scrum-coordination.ts
@@ -1,0 +1,10 @@
+export function isScrumCoordinatorAgent(agent: { name?: string | null; urlKey?: string | null; role?: string | null } | null | undefined) {
+  if (!agent) return false;
+  const name = (agent.name ?? "").trim().toLowerCase();
+  const urlKey = (agent.urlKey ?? "").trim().toLowerCase();
+  return agent.role === "pm" && (name === "scrum" || urlKey === "scrum");
+}
+
+export function isActiveCoordinationIssueStatus(status: string) {
+  return status === "todo" || status === "in_progress" || status === "blocked" || status === "in_review";
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue and live-run API routes enforce which agents can mutate issues, comments, statuses, assignments, and wakeups.
> - Scrum needs a narrow operational coordination lane so it can recover active assigned-agent issues from stale or blocked waiting paths.
> - The existing permission model correctly denied arbitrary peer-agent mutation, but it also denied the scoped coordination actions approved in PRO-1194.
> - This pull request adds role- and intent-scoped Scrum permissions for coordination comments, limited issue status/reassignment updates, and issue-scoped wakeups.
> - The benefit is faster recovery from routing and blocker stalls without giving Scrum broad cross-company mutation or delivery authority.

## What Changed

- Added scoped Scrum coordination checks in issue mutation/comment routes for coordination-keyword comments and waiting-path status or rightful-owner reassignment updates.
- Added scoped Scrum wakeup checks in live-run routes so Scrum can wake only the coordinated issue assignee or that assignee manager.
- Preserved existing denials for arbitrary peer-agent mutation, broad wakeups, non-coordination comments, and unrelated issue actions.
- Added targeted route coverage for allowed Scrum coordination actions and denied broad actions.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/agent-live-run-routes.test.ts --no-file-parallelism --maxWorkers=1 --minWorkers=1` -> 45 tests passed
- `pnpm --filter @paperclipai/server typecheck` -> passed
- `git status --short --branch` -> clean branch header only

## Risks

- Medium risk: this adds a privileged coordination lane, so false positives in intent detection could permit more Scrum actions than intended.
- Mitigation: permissions are limited to Scrum identity, active issue coordination language/statuses, rightful-owner reassignment cases, and issue-scoped wake targets; arbitrary delivery mutations remain denied by tests.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent with tool use and terminal execution in a local development workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Linked Issue

Fixes #7418