### PR TITLE
fix(ci): handle 422 on advisory PATCH with empty vulnerabilities

### DIFF
--- a/.github/scripts/check-pr-security.mjs
+++ b/.github/scripts/check-pr-security.mjs
@@ -225,11 +225,21 @@ export async function syncDraftAdvisory(fetchImpl, token, repo, prNumber, prTitl
       throw new Error(`Existing advisory for PR #${prNumber} is missing both ghsa_id and id.`);
     }
 
-    return fetchImpl(`/repos/${repo}/security-advisories/${advisoryId}`, token, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
+    // Omit vulnerabilities on PATCH — GitHub 422s if you try to set it to []
+    // on an advisory that already has vulnerabilities recorded.
+    const { vulnerabilities: _v, ...patchPayload } = payload;
+    try {
+      return await fetchImpl(`/repos/${repo}/security-advisories/${advisoryId}`, token, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patchPayload),
+      });
+    } catch (err) {
+      // 422 on advisory update is non-fatal — the advisory already exists and
+      // captures the security flag; swallow so the check-run still gets posted.
+      if (err.message && err.message.includes('422')) return null;
+      throw err;
+    }
   }
 
   return fetchImpl(`/repos/${repo}/security-advisories`, token, {


### PR DESCRIPTION
## Problem

`check-pr-security.mjs` calls `syncDraftAdvisory` which PATCHes an existing draft advisory with `vulnerabilities: []`. GitHub returns 422:

```
GitHub API PATCH /repos/.../security-advisories/GHSA-... → 422: {"message":"Advisory must have at least one vulnerability",...}
```

This causes the `Run security gates` step to exit 1, failing the `commitperclip PR Review` check on every PR that has an existing advisory — including PR #6934.

## Fix

- Omit `vulnerabilities` from the PATCH body so existing entries are preserved
- Catch residual 422s to avoid breaking the CI job (non-fatal — advisory already exists)

## Impact

Unblocks `commitperclip PR Review` for PR #6934 and any other PR with a pre-existing advisory.