### PR TITLE
fix(adapter-utils): strip RC-2 T1 vars from agent child env

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -15,6 +15,7 @@ import {
   renderPaperclipWakePrompt,
   runningProcesses,
   runChildProcess,
+  sanitizeInheritedPaperclipEnv,
   sanitizeSshRemoteEnv,
   shapePaperclipWorkspaceEnvForExecution,
   rewriteWorkspaceCwdEnvVarsForExecution,
@@ -144,6 +145,23 @@ describe("sanitizeSshRemoteEnv", () => {
         },
       ),
     ).toEqual({ PATH: "/explicit/remote/bin" });
+  });
+});
+
+describe("sanitizeInheritedPaperclipEnv", () => {
+  it("drops RC-2 T1 vars inherited from the Paperclip server process", () => {
+    expect(
+      sanitizeInheritedPaperclipEnv({
+        DATABASE_URL: "test-only-db-url",
+        GEMINI_API_KEY: "test-only-gemini-key",
+        HELP2DAY_QA_BYPASS_TOKEN: "test-only-bypass-token",
+        PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+        SAFE_VALUE: "visible",
+      }),
+    ).toEqual({
+      PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+      SAFE_VALUE: "visible",
+    });
   });
 });
 
@@ -388,6 +406,53 @@ describe("adapter skill snapshots", () => {
 });
 
 describe("runChildProcess", () => {
+  it("does not pass RC-2 T1 vars from the parent env to child processes", async () => {
+    const previous = {
+      DATABASE_URL: process.env.DATABASE_URL,
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+      HELP2DAY_QA_BYPASS_TOKEN: process.env.HELP2DAY_QA_BYPASS_TOKEN,
+    };
+    process.env.DATABASE_URL = "test-only-db-url";
+    process.env.GEMINI_API_KEY = "test-only-gemini-key";
+    process.env.HELP2DAY_QA_BYPASS_TOKEN = "test-only-bypass-token";
+
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "const keys=['DATABASE_URL','GEMINI_API_KEY','HELP2DAY_QA_BYPASS_TOKEN'];",
+            "process.stdout.write(JSON.stringify(Object.fromEntries(keys.map((key)=>[key,process.env[key]!=null]))));",
+          ].join(""),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        DATABASE_URL: false,
+        GEMINI_API_KEY: false,
+        HELP2DAY_QA_BYPASS_TOKEN: false,
+      });
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
   it("does not arm a timeout when timeoutSec is 0", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1157,15 +1157,16 @@ export function refreshPaperclipWorkspaceEnvForExecution(input: {
   return shapedWorkspaceEnv;
 }
 
+const RC2_AGENT_ENV_DENYLIST = new Set([
+  "DATABASE_URL",
+  "GEMINI_API_KEY",
+  "HELP2DAY_QA_BYPASS_TOKEN",
+]);
+
 export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
-  const rc2AgentEnvDenylist = new Set([
-    "DATABASE_URL",
-    "GEMINI_API_KEY",
-    "HELP2DAY_QA_BYPASS_TOKEN",
-  ]);
   for (const key of Object.keys(env)) {
-    if (rc2AgentEnvDenylist.has(key)) {
+    if (RC2_AGENT_ENV_DENYLIST.has(key)) {
       delete env[key];
       continue;
     }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1159,7 +1159,16 @@ export function refreshPaperclipWorkspaceEnvForExecution(input: {
 
 export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
+  const rc2AgentEnvDenylist = new Set([
+    "DATABASE_URL",
+    "GEMINI_API_KEY",
+    "HELP2DAY_QA_BYPASS_TOKEN",
+  ]);
   for (const key of Object.keys(env)) {
+    if (rc2AgentEnvDenylist.has(key)) {
+      delete env[key];
+      continue;
+    }
     if (!key.startsWith("PAPERCLIP_")) continue;
     if (key === "PAPERCLIP_RUNTIME_API_URL") continue;
     if (key === "PAPERCLIP_LISTEN_HOST") continue;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Agent subprocess execution inherits environment from the Paperclip server process before adapter-specific shaping.
> - RC-2 T1 credentials can still be present in that inherited server process environment even after per-agent config cleanup.
> - Those values must not cross into agent child processes where command output or env serialization can expose them.
> - This pull request adds a narrow inherited-env denylist for the known RC-2 T1 variables.
> - The benefit is a bounded runtime sanitizer with regression coverage, without changing unrelated agent environment behavior.

## Linked Issues or Issue Description

No upstream GitHub issue exists for this Help2day board ticket. Internal Paperclip issue: FUL-6463 / FUL-7052.

## Problem or motivation

RC-2 runtime activation requires preventing sensitive top-level environment variables from being inherited by agent child processes. If the server process carries T1 credentials, inherited environment propagation can expose those values to agent commands or serialized runtime output.

## Proposed solution

Filter the known RC-2 inherited environment variable names in `sanitizeInheritedPaperclipEnv` before launching child processes, and keep the sanitizer scoped to the specific names required by this release.

## Alternatives considered

A broader `PAPERCLIP_*` sanitizer already exists, but these RC-2 variables are not all `PAPERCLIP_*` names. Full environment isolation was considered too broad for this release because it could break adapters that intentionally inherit normal process variables.

## Roadmap alignment

This supports the RC-2 environment sanitizer release path tracked by Help2day FUL-6463 / FUL-7052 and does not duplicate planned roadmap feature work.

## What Changed

- Added RC-2 inherited environment filtering for `DATABASE_URL`, `GEMINI_API_KEY`, and `HELP2DAY_QA_BYPASS_TOKEN` in `sanitizeInheritedPaperclipEnv`.
- Hoisted the denylist to `RC2_AGENT_ENV_DENYLIST` so it is allocated once and easier to audit.
- Added unit coverage for the sanitizer.
- Added child-process integration coverage proving those names are absent from spawned child environments.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts`

Machine-verifiable evidence is tied to head commit `b4f7fdb0d20d40091904b85a5c2f6b2977754ab1`.

## Risks

- Low-to-medium risk: this intentionally removes three environment names from all agent child processes inherited from the server process. If an agent still depended on one of these top-level variables, that dependency should move to scoped secret injection instead of inherited process env.

## Model Used

- OpenAI GPT-5 Codex local supervisor with repository access, shell/tool execution, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub PRs for similar PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] For merge, deploy, or runtime activation approval, I have included current machine-verifiable evidence tied to the exact commit/config being approved
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
