### PR TITLE
feat(security): SH-12 Layer 1 credential scanner — prefix-match redaction at P0 boundaries

### DIFF
--- a/packages/shared/src/telemetry/types.ts
+++ b/packages/shared/src/telemetry/types.ts
@@ -41,4 +41,5 @@ export type TelemetryEventName =
   | "agent.first_heartbeat"
   | "agent.task_completed"
   | "error.handler_crash"
+  | "sh12.credential_redacted"
   | `plugin.${string}`;

--- a/server/src/__tests__/credential-scanner.test.ts
+++ b/server/src/__tests__/credential-scanner.test.ts
@@ -246,4 +246,61 @@ describe("credential-scanner: env-driven extra rules (SH12_EXTRA_RULES)", () => 
       resetScannerRuleCache();
     }
   });
+
+  // P1 regression: invalid regex in SH12_EXTRA_RULES must not break the scanner
+  it("skips invalid-regex extra rule and continues scanning with remaining rules", () => {
+    const badExtra = JSON.stringify([
+      { kind: "regex", typeHint: "BAD_RULE", pattern: "[invalid(regex" },
+    ]);
+    const original = process.env["SH12_EXTRA_RULES"];
+    process.env["SH12_EXTRA_RULES"] = badExtra;
+    resetScannerRuleCache();
+    try {
+      const token = "ghp_" + "V".repeat(36);
+      // Must not throw; base rules still fire
+      const { text, matches } = scanAndRedact(token);
+      expect(text).toContain("[REDACTED:SH-12:GH_PAT]");
+      expect(matches[0].typeHint).toBe("GH_PAT");
+    } finally {
+      if (original === undefined) {
+        delete process.env["SH12_EXTRA_RULES"];
+      } else {
+        process.env["SH12_EXTRA_RULES"] = original;
+      }
+      resetScannerRuleCache();
+    }
+  });
+});
+
+describe("credential-scanner: characterOffset accuracy across multiple rules", () => {
+  // P2 regression: characterOffset must reflect the original input position even
+  // when a prior rule has already mutated the text (replacement length ≠ match length)
+  it("reports correct characterOffset for second-rule match after first rule fires", () => {
+    const gh = "ghp_" + "W".repeat(36);   // 40 chars, matched by GH_PAT rule
+    const aws = "AKIA" + "X".repeat(16);  // 20 chars, matched by AWS_ACCESS_KEY rule
+    const sep = " | ";
+    const input = gh + sep + aws;
+    const ghOffset = 0;
+    const awsOffset = gh.length + sep.length;
+    const { matches } = scanAndRedact(input);
+    expect(matches).toHaveLength(2);
+    const ghMatch = matches.find((m) => m.typeHint === "GH_PAT");
+    const awsMatch = matches.find((m) => m.typeHint === "AWS_ACCESS_KEY");
+    expect(ghMatch?.characterOffset).toBe(ghOffset);
+    expect(awsMatch?.characterOffset).toBe(awsOffset);
+  });
+
+  // P2 regression: within a single rule, second match offset must also be original-relative
+  it("reports correct characterOffset for second match within same rule", () => {
+    const token = "ghp_" + "Y".repeat(36);  // 40 chars
+    const sep = " middle ";
+    const input = token + sep + token;
+    const firstOffset = 0;
+    const secondOffset = token.length + sep.length;
+    const { matches } = scanAndRedact(input);
+    const ghMatches = matches.filter((m) => m.typeHint === "GH_PAT");
+    expect(ghMatches).toHaveLength(2);
+    expect(ghMatches[0].characterOffset).toBe(firstOffset);
+    expect(ghMatches[1].characterOffset).toBe(secondOffset);
+  });
 });

--- a/server/src/__tests__/credential-scanner.test.ts
+++ b/server/src/__tests__/credential-scanner.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { scanAndRedact, resetScannerRuleCache } from "../credential-scanner.js";
+
+// All credential-shaped strings below are SYNTHETIC: correct prefix + random suffix.
+// No real credentials are used anywhere in this file.
+
+beforeEach(() => {
+  resetScannerRuleCache();
+});
+
+describe("credential-scanner: GitHub tokens", () => {
+  it("redacts ghp_ PAT and preserves surrounding text", () => {
+    const token = "ghp_" + "A".repeat(36);
+    const input = `See token: ${token} and continue.`;
+    const { text, matches } = scanAndRedact(input);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:GH_PAT]");
+    expect(text).toContain("See token:");
+    expect(text).toContain("and continue.");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].typeHint).toBe("GH_PAT");
+    expect(matches[0].inputLength).toBe(token.length);
+  });
+
+  it("redacts ghs_ app secret", () => {
+    const token = "ghs_" + "B".repeat(36);
+    const { text, matches } = scanAndRedact(`secret=${token}`);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:GH_APP_SECRET]");
+    expect(matches[0].typeHint).toBe("GH_APP_SECRET");
+  });
+
+  it("redacts gho_ OAuth token", () => {
+    const token = "gho_" + "C".repeat(36);
+    const { text } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:GH_OAUTH]");
+  });
+
+  it("redacts ghr_ refresh token", () => {
+    const token = "ghr_" + "D".repeat(36);
+    const { text } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:GH_REFRESH]");
+  });
+
+  it("does not redact ghp_ with too-short suffix", () => {
+    const shortToken = "ghp_" + "X".repeat(10);
+    const { text, matches } = scanAndRedact(shortToken);
+    expect(text).toBe(shortToken);
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("credential-scanner: OpenAI / API keys", () => {
+  it("redacts sk- key", () => {
+    const token = "sk-" + "E".repeat(24);
+    const input = `api_key = ${token}`;
+    const { text, matches } = scanAndRedact(input);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:OPENAI_SK]");
+    expect(matches[0].typeHint).toBe("OPENAI_SK");
+  });
+});
+
+describe("credential-scanner: AWS keys", () => {
+  it("redacts AKIA access key", () => {
+    const token = "AKIA" + "F".repeat(16);
+    const { text, matches } = scanAndRedact(`AWS_ACCESS_KEY=${token}`);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:AWS_ACCESS_KEY]");
+    expect(matches[0].typeHint).toBe("AWS_ACCESS_KEY");
+    expect(matches[0].inputLength).toBe(20);
+  });
+
+  it("redacts ASIA temporary credential", () => {
+    const token = "ASIA" + "G".repeat(16);
+    const { text, matches } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:AWS_TEMP_CRED]");
+    expect(matches[0].typeHint).toBe("AWS_TEMP_CRED");
+  });
+});
+
+describe("credential-scanner: Slack tokens", () => {
+  it("redacts xoxb- bot token", () => {
+    const token = "xoxb-" + "1234567890" + "-" + "H".repeat(30);
+    const { text, matches } = scanAndRedact(`SLACK_TOKEN=${token}`);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:SLACK_BOT_TOKEN]");
+    expect(matches[0].typeHint).toBe("SLACK_BOT_TOKEN");
+  });
+
+  it("redacts xoxp- user token", () => {
+    const token = "xoxp-" + "I".repeat(20);
+    const { text } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:SLACK_USER_TOKEN]");
+  });
+});
+
+describe("credential-scanner: Stripe live keys", () => {
+  it("redacts sk_live_ secret key", () => {
+    const token = "sk_live_" + "J".repeat(24);
+    const { text, matches } = scanAndRedact(`STRIPE_SK=${token}`);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:STRIPE_LIVE_KEY]");
+    expect(matches[0].typeHint).toBe("STRIPE_LIVE_KEY");
+  });
+
+  it("redacts pk_live_ publishable key", () => {
+    const token = "pk_live_" + "K".repeat(24);
+    const { text } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:STRIPE_LIVE_KEY]");
+  });
+
+  it("redacts rk_live_ restricted key", () => {
+    const token = "rk_live_" + "L".repeat(24);
+    const { text } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:STRIPE_LIVE_KEY]");
+  });
+});
+
+describe("credential-scanner: Google OAuth / npm", () => {
+  it("redacts ya29. Google OAuth token", () => {
+    const token = "ya29." + "M".repeat(24);
+    const { text, matches } = scanAndRedact(token);
+    expect(text).toBe("[REDACTED:SH-12:GOOGLE_OAUTH]");
+    expect(matches[0].typeHint).toBe("GOOGLE_OAUTH");
+  });
+
+  it("redacts npm_ token", () => {
+    const token = "npm_" + "N".repeat(36);
+    const { text, matches } = scanAndRedact(`//registry.npmjs.org/:_authToken=${token}`);
+    expect(text).not.toContain(token);
+    expect(text).toContain("[REDACTED:SH-12:NPM_TOKEN]");
+    expect(matches[0].typeHint).toBe("NPM_TOKEN");
+  });
+});
+
+describe("credential-scanner: Bearer / JWT tokens", () => {
+  it("redacts Authorization: Bearer header value", () => {
+    const tokenValue = "O".repeat(40);
+    const input = `Authorization: Bearer ${tokenValue}`;
+    const { text, matches } = scanAndRedact(input);
+    expect(text).not.toContain(tokenValue);
+    expect(text).toContain("[REDACTED:SH-12:BEARER_TOKEN]");
+    expect(text).toContain("Authorization:");
+    expect(matches[0].typeHint).toBe("BEARER_TOKEN");
+  });
+
+  it("redacts JWT-shaped token (eyJ header)", () => {
+    const header = "eyJhbGciOiJIUzI1NiJ9";
+    const payload = "eyJzdWIiOiJzeW50aGV0aWMtdXNlci1pZCJ9";
+    const sig = "P".repeat(43);
+    const jwt = `${header}.${payload}.${sig}`;
+    const input = `token: ${jwt} end`;
+    const { text, matches } = scanAndRedact(input);
+    expect(text).not.toContain(jwt);
+    expect(text).toContain("[REDACTED:SH-12:JWT_TOKEN]");
+    expect(text).toContain("token:");
+    expect(text).toContain("end");
+    expect(matches[0].typeHint).toBe("JWT_TOKEN");
+  });
+});
+
+describe("credential-scanner: safe text not redacted", () => {
+  it("does not redact plain prose", () => {
+    const safe = "This is a normal message about fixing a bug in the auth module.";
+    const { text, matches } = scanAndRedact(safe);
+    expect(text).toBe(safe);
+    expect(matches).toHaveLength(0);
+  });
+
+  it("does not redact short strings that look like partial tokens", () => {
+    const partials = ["ghp_short", "sk-", "AKIA123", "Bearer x"];
+    for (const p of partials) {
+      const { matches } = scanAndRedact(p);
+      expect(matches, `expected no match for: ${p}`).toHaveLength(0);
+    }
+  });
+
+  it("returns empty text unchanged", () => {
+    const { text, matches } = scanAndRedact("");
+    expect(text).toBe("");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("credential-scanner: multi-token and surrounding-text preservation", () => {
+  it("redacts multiple tokens in one string", () => {
+    const gh = "ghp_" + "Q".repeat(36);
+    const aws = "AKIA" + "R".repeat(16);
+    const input = `github=${gh} aws=${aws} done`;
+    const { text, matches } = scanAndRedact(input);
+    expect(text).not.toContain(gh);
+    expect(text).not.toContain(aws);
+    expect(text).toContain("github=");
+    expect(text).toContain("aws=");
+    expect(text).toContain("done");
+    expect(matches).toHaveLength(2);
+  });
+
+  it("characterOffset in match reflects position in original string", () => {
+    const prefix = "prefix:";
+    const token = "ghp_" + "S".repeat(36);
+    const input = prefix + token;
+    const { matches } = scanAndRedact(input);
+    expect(matches[0].characterOffset).toBe(prefix.length);
+    expect(matches[0].inputLength).toBe(token.length);
+  });
+
+  it("match record never contains the credential value", () => {
+    const token = "sk-" + "T".repeat(24);
+    const { matches } = scanAndRedact(token);
+    expect(matches).toHaveLength(1);
+    // ScanMatch only has typeHint, characterOffset, inputLength
+    const keys = Object.keys(matches[0]);
+    expect(keys).toEqual(expect.arrayContaining(["typeHint", "characterOffset", "inputLength"]));
+    expect(keys).not.toContain("value");
+    expect(keys).not.toContain("match");
+    expect(keys).not.toContain("raw");
+  });
+});
+
+describe("credential-scanner: env-driven extra rules (SH12_EXTRA_RULES)", () => {
+  it("applies extra rules from SH12_EXTRA_RULES env var", () => {
+    const extraRule = JSON.stringify([
+      {
+        kind: "prefix",
+        prefix: "XTEST_",
+        typeHint: "CUSTOM_TEST_TOKEN",
+        suffixPattern: "[A-Z]{10,}",
+      },
+    ]);
+    const original = process.env["SH12_EXTRA_RULES"];
+    process.env["SH12_EXTRA_RULES"] = extraRule;
+    resetScannerRuleCache();
+    try {
+      const token = "XTEST_" + "U".repeat(12);
+      const { text, matches } = scanAndRedact(token);
+      expect(text).toBe("[REDACTED:SH-12:CUSTOM_TEST_TOKEN]");
+      expect(matches[0].typeHint).toBe("CUSTOM_TEST_TOKEN");
+    } finally {
+      if (original === undefined) {
+        delete process.env["SH12_EXTRA_RULES"];
+      } else {
+        process.env["SH12_EXTRA_RULES"] = original;
+      }
+      resetScannerRuleCache();
+    }
+  });
+});

--- a/server/src/credential-scanner-config.json
+++ b/server/src/credential-scanner-config.json
@@ -1,0 +1,32 @@
+{
+  "rules": [
+    { "kind": "prefix", "prefix": "ghp_", "typeHint": "GH_PAT", "suffixPattern": "[A-Za-z0-9]{36,}" },
+    { "kind": "prefix", "prefix": "ghs_", "typeHint": "GH_APP_SECRET", "suffixPattern": "[A-Za-z0-9]{36,}" },
+    { "kind": "prefix", "prefix": "gho_", "typeHint": "GH_OAUTH", "suffixPattern": "[A-Za-z0-9]{36,}" },
+    { "kind": "prefix", "prefix": "ghr_", "typeHint": "GH_REFRESH", "suffixPattern": "[A-Za-z0-9]{36,}" },
+    { "kind": "prefix", "prefix": "sk-", "typeHint": "OPENAI_SK", "suffixPattern": "[A-Za-z0-9_-]{20,}" },
+    { "kind": "prefix", "prefix": "AKIA", "typeHint": "AWS_ACCESS_KEY", "suffixPattern": "[A-Z0-9]{16}" },
+    { "kind": "prefix", "prefix": "ASIA", "typeHint": "AWS_TEMP_CRED", "suffixPattern": "[A-Z0-9]{16}" },
+    { "kind": "prefix", "prefix": "xoxb-", "typeHint": "SLACK_BOT_TOKEN", "suffixPattern": "[A-Za-z0-9-]{10,}" },
+    { "kind": "prefix", "prefix": "xoxp-", "typeHint": "SLACK_USER_TOKEN", "suffixPattern": "[A-Za-z0-9-]{10,}" },
+    { "kind": "prefix", "prefix": "xoxr-", "typeHint": "SLACK_REFRESH_TOKEN", "suffixPattern": "[A-Za-z0-9-]{10,}" },
+    { "kind": "prefix", "prefix": "xoxs-", "typeHint": "SLACK_SESSION_TOKEN", "suffixPattern": "[A-Za-z0-9-]{10,}" },
+    { "kind": "prefix", "prefix": "ya29.", "typeHint": "GOOGLE_OAUTH", "suffixPattern": "[A-Za-z0-9._-]{20,}" },
+    { "kind": "prefix", "prefix": "npm_", "typeHint": "NPM_TOKEN", "suffixPattern": "[A-Za-z0-9]{36,}" },
+    {
+      "kind": "regex",
+      "typeHint": "STRIPE_LIVE_KEY",
+      "pattern": "(?:sk|pk|rk)_live_[A-Za-z0-9]{20,}"
+    },
+    {
+      "kind": "regex",
+      "typeHint": "BEARER_TOKEN",
+      "pattern": "Bearer [A-Za-z0-9._/+=~-]{20,}"
+    },
+    {
+      "kind": "regex",
+      "typeHint": "JWT_TOKEN",
+      "pattern": "eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"
+    }
+  ]
+}

--- a/server/src/credential-scanner.ts
+++ b/server/src/credential-scanner.ts
@@ -1,0 +1,148 @@
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(__dirname, "credential-scanner-config.json");
+
+interface PrefixRule {
+  kind: "prefix";
+  prefix: string;
+  typeHint: string;
+  /** Suffix pattern (regex string) to match after the prefix */
+  suffixPattern: string;
+}
+
+interface RegexRule {
+  kind: "regex";
+  typeHint: string;
+  /** Full regex pattern (no flags; always global) */
+  pattern: string;
+}
+
+type CredentialRule = PrefixRule | RegexRule;
+
+interface ScannerConfig {
+  rules: CredentialRule[];
+}
+
+export interface ScanMatch {
+  typeHint: string;
+  characterOffset: number;
+  inputLength: number;
+}
+
+export interface ScanResult {
+  text: string;
+  matches: ScanMatch[];
+}
+
+function loadConfig(): ScannerConfig {
+  let config: ScannerConfig = { rules: [] };
+
+  if (existsSync(CONFIG_PATH)) {
+    try {
+      config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) as ScannerConfig;
+    } catch {
+      // malformed config — fall through to empty rule set
+    }
+  }
+
+  // Env-driven extra rules: SH12_EXTRA_RULES=JSON array of CredentialRule
+  const envExtra = process.env["SH12_EXTRA_RULES"];
+  if (envExtra) {
+    try {
+      const extra = JSON.parse(envExtra) as CredentialRule[];
+      if (Array.isArray(extra)) {
+        config = { rules: [...config.rules, ...extra] };
+      }
+    } catch {
+      // ignore malformed env override
+    }
+  }
+
+  return config;
+}
+
+interface CompiledRule {
+  typeHint: string;
+  regex: RegExp;
+}
+
+function compileRule(rule: CredentialRule): CompiledRule {
+  if (rule.kind === "prefix") {
+    const escapedPrefix = rule.prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return {
+      typeHint: rule.typeHint,
+      regex: new RegExp(`${escapedPrefix}${rule.suffixPattern}`, "g"),
+    };
+  }
+  return {
+    typeHint: rule.typeHint,
+    regex: new RegExp(rule.pattern, "g"),
+  };
+}
+
+let _compiledRules: CompiledRule[] | null = null;
+
+function getCompiledRules(): CompiledRule[] {
+  if (_compiledRules) return _compiledRules;
+  const config = loadConfig();
+  _compiledRules = config.rules.map(compileRule);
+  return _compiledRules;
+}
+
+/** Reset compiled rule cache — used in tests to apply a fresh config */
+export function resetScannerRuleCache(): void {
+  _compiledRules = null;
+}
+
+/**
+ * Scan `input` for credential-shaped tokens and redact each match.
+ *
+ * Stateless and side-effect-free. Never stores, logs, or forwards matched values.
+ * Telemetry payloads contain only `{typeHint, characterOffset, inputLength}`.
+ */
+export function scanAndRedact(input: string): ScanResult {
+  if (!input) return { text: input, matches: [] };
+
+  const rules = getCompiledRules();
+  const matches: ScanMatch[] = [];
+  let text = input;
+
+  for (const rule of rules) {
+    const replacement = `[REDACTED:SH-12:${rule.typeHint}]`;
+    const rawMatches: Array<{ index: number; matchLength: number }> = [];
+
+    rule.regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = rule.regex.exec(text)) !== null) {
+      rawMatches.push({ index: m.index, matchLength: m[0].length });
+      // Guard against zero-length match infinite loops
+      if (m[0].length === 0) { rule.regex.lastIndex++; }
+    }
+
+    if (rawMatches.length === 0) continue;
+
+    // Rebuild text with replacements and record offset metadata (NO values)
+    let result = "";
+    let cursor = 0;
+    let offsetDelta = 0;
+
+    for (const raw of rawMatches) {
+      result += text.slice(cursor, raw.index);
+      matches.push({
+        typeHint: rule.typeHint,
+        characterOffset: raw.index + offsetDelta,
+        inputLength: raw.matchLength,
+      });
+      result += replacement;
+      cursor = raw.index + raw.matchLength;
+      offsetDelta += replacement.length - raw.matchLength;
+    }
+    result += text.slice(cursor);
+    text = result;
+  }
+
+  return { text, matches };
+}

--- a/server/src/credential-scanner.ts
+++ b/server/src/credential-scanner.ts
@@ -88,7 +88,17 @@ let _compiledRules: CompiledRule[] | null = null;
 function getCompiledRules(): CompiledRule[] {
   if (_compiledRules) return _compiledRules;
   const config = loadConfig();
-  _compiledRules = config.rules.map(compileRule);
+  const compiled: CompiledRule[] = [];
+  for (const rule of config.rules) {
+    try {
+      compiled.push(compileRule(rule));
+    } catch {
+      // Invalid regex in rule — skip and continue with remaining rules.
+      // Never log the pattern value; only the typeHint is safe to surface.
+      console.error(`[SH-12] Skipping invalid rule (typeHint=${rule.typeHint ?? "unknown"})`);
+    }
+  }
+  _compiledRules = compiled;
   return _compiledRules;
 }
 
@@ -109,6 +119,9 @@ export function scanAndRedact(input: string): ScanResult {
   const rules = getCompiledRules();
   const matches: ScanMatch[] = [];
   let text = input;
+  // Tracks the cumulative length delta across all previous rules so that
+  // characterOffset always reflects the match position in the original input.
+  let cumulativeOffsetDelta = 0;
 
   for (const rule of rules) {
     const replacement = `[REDACTED:SH-12:${rule.typeHint}]`;
@@ -127,21 +140,25 @@ export function scanAndRedact(input: string): ScanResult {
     // Rebuild text with replacements and record offset metadata (NO values)
     let result = "";
     let cursor = 0;
-    let offsetDelta = 0;
+    let ruleOffsetDelta = 0;
 
     for (const raw of rawMatches) {
       result += text.slice(cursor, raw.index);
       matches.push({
         typeHint: rule.typeHint,
-        characterOffset: raw.index + offsetDelta,
+        // raw.index is relative to the current (already-mutated) text.
+        // Subtract the cumulative delta from all prior rules to recover the
+        // position in the original input string.
+        characterOffset: raw.index - cumulativeOffsetDelta,
         inputLength: raw.matchLength,
       });
       result += replacement;
       cursor = raw.index + raw.matchLength;
-      offsetDelta += replacement.length - raw.matchLength;
+      ruleOffsetDelta += replacement.length - raw.matchLength;
     }
     result += text.slice(cursor);
     text = result;
+    cumulativeOffsetDelta += ruleOffsetDelta;
   }
 
   return { text, matches };

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -105,6 +105,7 @@ import { instanceSettingsService } from "../services/instance-settings.js";
 import { readAcceptedPlanConfirmationTarget } from "../services/issues.js";
 import { environmentService } from "../services/environments.js";
 import { redactSensitiveText } from "../redaction.js";
+import { scanAndRedact } from "../credential-scanner.js";
 import {
   createCompanySearchRateLimiter,
   type CompanySearchRateLimiter,
@@ -2881,12 +2882,29 @@ export function issueRoutes(
 
     const actor = getActorInfo(req);
     const referenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
+
+    // P0: SH-12 credential scan — redact before persisting document body
+    const docScanResult = scanAndRedact(req.body.body ?? "");
+    if (docScanResult.matches.length > 0) {
+      const tc = getTelemetryClient();
+      if (tc) {
+        for (const m of docScanResult.matches) {
+          tc.track("sh12.credential_redacted", {
+            boundary: "document",
+            type_hint: m.typeHint,
+            character_offset: m.characterOffset,
+            input_length: m.inputLength,
+          });
+        }
+      }
+    }
+
     const result = await documentsSvc.upsertIssueDocument({
       issueId: issue.id,
       key: keyParsed.data,
       title: req.body.title ?? null,
       format: req.body.format,
-      body: req.body.body,
+      body: docScanResult.text,
       changeSummary: req.body.changeSummary ?? null,
       baseRevisionId: req.body.baseRevisionId ?? null,
       createdByAgentId: actor.agentId ?? null,
@@ -5879,7 +5897,23 @@ export function issueRoutes(
       }
     }
 
-    const comment = await svc.addComment(id, req.body.body, {
+    // P0: SH-12 credential scan — redact before persisting comment body
+    const commentScanResult = scanAndRedact(req.body.body ?? "");
+    if (commentScanResult.matches.length > 0) {
+      const tc = getTelemetryClient();
+      if (tc) {
+        for (const m of commentScanResult.matches) {
+          tc.track("sh12.credential_redacted", {
+            boundary: "comment",
+            type_hint: m.typeHint,
+            character_offset: m.characterOffset,
+            input_length: m.inputLength,
+          });
+        }
+      }
+    }
+
+    const comment = await svc.addComment(id, commentScanResult.text, {
       agentId: actor.agentId ?? undefined,
       userId: actor.actorType === "user" ? actor.actorId : undefined,
       runId: actor.runId,


### PR DESCRIPTION
## Summary

- Implements SH-12 Layer 1 MVP credential scanner per approved design (FUL-7105, FUL-7067, FUL-7017)
- `credential-scanner.ts`: stateless, regex-based prefix-match scanner; redacts to `[REDACTED:SH-12:<type-hint>]`; never stores/logs matched values
- `credential-scanner-config.json`: config-driven rule list (ghp_, ghs_, gho_, ghr_, sk-, AKIA/ASIA, xox*, Stripe live keys, ya29., npm_, Bearer, JWT); updatable at runtime via `SH12_EXTRA_RULES` env var
- P0 integration: credential scan applied before `POST /api/issues/:id/comments` and `PUT /api/issues/:id/documents/:key` persist content
- Telemetry: emits `sh12.credential_redacted` with `{boundary, type_hint, character_offset, input_length}` — no values, SH-1/2/3 compliant
- 27 unit tests using synthetic fixtures only (no real credentials)
- Zero new TypeScript errors introduced (8 pre-existing errors on this branch unrelated to this change)
- **FUL-7237 fixes (commit f00f022a):** P1 invalid-regex crash guard + P2 characterOffset drift across rules

## Thinking Path

> - Paperclip orchestrates AI agents across company workflows; issue comments and documents are the primary data surfaces
> - The SH-12 policy requires credential-shaped tokens to be redacted before they reach persistent storage
> - Layer 1 targets well-known prefixes (ghp_, sk-, AKIA, Bearer, etc.) which are safe to match without false-positive risk
> - The scanner runs synchronously at P0 boundaries (comment POST, document PUT) before the database write
> - Runtime-configurable rules via `SH12_EXTRA_RULES` allow operators to extend coverage without a deploy
> - P1 fix: an invalid regex in `SH12_EXTRA_RULES` previously left `_compiledRules` null permanently, breaking all writes — now each rule is compiled independently with try/catch; bad rules are skipped
> - P2 fix: `characterOffset` was computed relative to the already-mutated text when multiple rules fired — now a cumulative delta across all rule passes correctly maps each match back to the original input position
> - This pull request delivers the Layer 1 scanner with both correctness bugs resolved and regression tests for each

## What Changed

- `server/src/credential-scanner.ts` — new stateless scanner module (+ P1/P2 bug fixes in commit f00f022a)
- `server/src/credential-scanner-config.json` — prefix rule list
- `server/src/routes/issues.ts` — P0 integration at comment POST and document PUT
- `server/src/services/issues.ts` — service-layer wiring
- `packages/shared/src/telemetry/types.ts` — adds `sh12.credential_redacted` to TelemetryEventName
- `server/src/__tests__/credential-scanner.test.ts` — 27 synthetic-fixture unit tests (24 original + 3 P1/P2 regression tests)

## Verification

- 27/27 credential-scanner tests pass
- 7/7 redaction regression tests pass
- TypeScript error count unchanged vs baseline (0 errors in credential-scanner.ts)
- Security Lead code review: APPROVED (all 11 hard conditions) — FUL-7096
- CTO pre-merge sign-off: ACCEPTED — interaction 7a01e319
- Greptile: pending re-review after P1/P2 fixes (prior score 3/5 — FUL-7237)

## Risks

- Low: Scanner runs synchronously on comment POST and document PUT — minimal latency impact
- None: No database schema changes or migrations in this PR
- Mitigated: Layer 2 entropy-based detection deferred per FUL-7067
- Mitigated: P1 crash on invalid regex now guarded; bad extra rules are skipped with console.error (typeHint only, no value)

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) — extended context, tool use, code execution

## Test plan

- [x] 27/27 credential-scanner tests pass
- [x] 7/7 redaction regression tests pass
- [x] P1 regression: invalid regex in SH12_EXTRA_RULES skipped, base rules still fire
- [x] P2 regression: characterOffset correct across multiple rules and within-rule multi-match
- [x] Security Lead APPROVED (FUL-7096)
- [x] CTO sign-off ACCEPTED (interaction 7a01e319)
- [ ] Greptile re-review >= 4/5 (pending push of commit f00f022a)

## Related issues

- Parent: FUL-7096
- Design: FUL-7067
- ADR: FUL-7017
- P1/P2 fixes: FUL-7237

Generated with Claude Code