### PR TITLE
fix(server): isolate projectless issue heartbeats

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildExecutionWorkspaceAdapterConfig,
+  defaultProjectlessIssueExecutionWorkspacePolicy,
   defaultIssueExecutionWorkspaceSettingsForProject,
   gateProjectExecutionWorkspacePolicy,
   issueExecutionWorkspaceModeForPersistedWorkspace,
@@ -365,5 +366,61 @@ describe("execution workspace policy helpers", () => {
         true,
       ),
     ).toEqual({ enabled: true, defaultMode: "isolated_workspace" });
+  });
+
+  it("defaults projectless issue-backed runs to isolated git worktrees", () => {
+    expect(
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: "issue-1",
+        projectId: null,
+        isolatedWorkspacesEnabled: true,
+        projectPolicy: null,
+        issueSettings: null,
+      }),
+    ).toEqual({
+      enabled: true,
+      defaultMode: "isolated_workspace",
+      workspaceStrategy: { type: "git_worktree" },
+    });
+
+    expect(
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: "issue-1",
+        projectId: null,
+        isolatedWorkspacesEnabled: true,
+        projectPolicy: { enabled: true, defaultMode: "shared_workspace" },
+        issueSettings: null,
+      }),
+    ).toBeNull();
+
+    expect(
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: "issue-1",
+        projectId: null,
+        isolatedWorkspacesEnabled: true,
+        projectPolicy: null,
+        issueSettings: { mode: "shared_workspace" },
+      }),
+    ).toBeNull();
+
+    expect(
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: null,
+        projectId: null,
+        isolatedWorkspacesEnabled: true,
+        projectPolicy: null,
+        issueSettings: null,
+      }),
+    ).toBeNull();
+
+    expect(
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: "issue-1",
+        projectId: "project-1",
+        isolatedWorkspacesEnabled: true,
+        projectPolicy: null,
+        issueSettings: null,
+      }),
+    ).toBeNull();
   });
 });

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -416,6 +416,16 @@ describe("execution workspace policy helpers", () => {
     expect(
       defaultProjectlessIssueExecutionWorkspacePolicy({
         issueId: "issue-1",
+        projectId: null,
+        isolatedWorkspacesEnabled: false,
+        projectPolicy: null,
+        issueSettings: null,
+      }),
+    ).toBeNull();
+
+    expect(
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: "issue-1",
         projectId: "project-1",
         isolatedWorkspacesEnabled: true,
         projectPolicy: null,

--- a/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
+++ b/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
@@ -358,6 +358,106 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
     expect(isolatedRows[0]?.cwd).not.toBe(repoRoot);
   }, 20_000);
 
+  it("realizes an isolated worktree for projectless issue runs from the agent configured cwd", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const repoRoot = await createGitRepo();
+    tempRoots.push(repoRoot);
+
+    await instanceSettingsService(db).updateExperimental({
+      enableIsolatedWorkspaces: true,
+    });
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: { cwd: repoRoot },
+      runtimeConfig: {},
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId: null,
+      title: "Projectless CTO task",
+      status: "in_progress",
+      workMode: "standard",
+      priority: "high",
+      assigneeAgentId: agentId,
+      identifier: "VIVA-1729",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    adapterExecute.mockImplementationOnce(async () => {
+      await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, issueId));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        sessionParams: { sessionId: "fresh-session" },
+        sessionDisplayId: "fresh-session",
+        summary: "Projectless worktree isolation test run.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+    const adapterInput = adapterExecute.mock.calls[0]?.[0] as {
+      context: Record<string, unknown>;
+    };
+    expect(adapterInput.context.paperclipWorkspace).toEqual(expect.objectContaining({
+      mode: "isolated_workspace",
+      strategy: "git_worktree",
+    }));
+    const workspace = adapterInput.context.paperclipWorkspace as { cwd: string; worktreePath: string };
+    expect(workspace.cwd).not.toBe(repoRoot);
+    expect(workspace.worktreePath).toContain("VIVA-1729");
+    expect(workspace.worktreePath).toContain(".paperclip");
+
+    const refreshedIssue = await db
+      .select({ executionWorkspaceId: issues.executionWorkspaceId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(refreshedIssue?.executionWorkspaceId).toBeNull();
+
+    const persistedRows = await db.select().from(executionWorkspaces);
+    expect(persistedRows).toHaveLength(0);
+  }, 20_000);
+
   it("forces a fresh session and suppresses accepted-plan continuation when another issue owns the in-flight claim", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { eq, sql } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agentRuntimeState,
+  agentTaskSessions,
   agentWakeupRequests,
   agents,
   companies,
@@ -26,6 +27,27 @@ import {
 import { heartbeatService } from "../services/heartbeat.ts";
 import { normalizeIssueExecutionPolicy, parseIssueExecutionState } from "../services/issue-execution-policy.ts";
 
+const adapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  sessionParams: { sessionId: "issue-monitor-test-session" },
+  sessionDisplayId: "issue-monitor-test-session",
+  summary: "Issue monitor scheduler test run.",
+  provider: "test",
+  model: "test-model",
+})));
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({
+    type: "process",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  listAdapterModelProfiles: async () => [],
+  runningProcesses: new Map(),
+}));
+
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -44,6 +66,10 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-monitor-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
+
+  afterEach(() => {
+    adapterExecute.mockClear();
+  });
 
   async function waitForHeartbeatIdle(timeoutMs = 3_000) {
     const deadline = Date.now() + timeoutMs;
@@ -108,6 +134,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
     await db.delete(environmentLeases);
     await db.delete(workspaceRuntimeServices);
     await db.delete(issues);
+    await db.delete(agentTaskSessions);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
@@ -129,7 +156,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
       }
     }
     throw lastError;
-  });
+  }, 20_000);
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -87,6 +87,26 @@ export function gateProjectExecutionWorkspacePolicy(
   return projectPolicy;
 }
 
+export function defaultProjectlessIssueExecutionWorkspacePolicy(input: {
+  issueId: string | null | undefined;
+  projectId: string | null | undefined;
+  isolatedWorkspacesEnabled: boolean;
+  projectPolicy: ProjectExecutionWorkspacePolicy | null;
+  issueSettings: IssueExecutionWorkspaceSettings | null;
+}): ProjectExecutionWorkspacePolicy | null {
+  if (!input.isolatedWorkspacesEnabled) return null;
+  if (!input.issueId) return null;
+  if (input.projectId) return null;
+  if (input.projectPolicy?.enabled) return null;
+  const issueMode = input.issueSettings?.mode;
+  if (issueMode && issueMode !== "inherit") return null;
+  return {
+    enabled: true,
+    defaultMode: "isolated_workspace",
+    workspaceStrategy: { type: "git_worktree" },
+  };
+}
+
 export function parseIssueExecutionWorkspaceSettings(raw: unknown): IssueExecutionWorkspaceSettings | null {
   const parsed = parseObject(raw);
   if (Object.keys(parsed).length === 0) return null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3667,7 +3667,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null },
+    opts?: { useProjectWorkspace?: boolean | null; allowConfiguredCwd?: boolean | null },
   ): Promise<ResolvedWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
     const contextProjectId = readNonEmptyString(context.projectId);
@@ -3839,7 +3839,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const configuredCwd = issueId ? readNonEmptyString(parseObject(agent.adapterConfig).cwd) : null;
+    const configuredCwd = issueId && opts?.allowConfiguredCwd === true
+      ? readNonEmptyString(parseObject(agent.adapterConfig).cwd)
+      : null;
     const configuredCwdLooksUnsafe = isUnsafeSessionWorkspaceCwd(configuredCwd);
     if (configuredCwd && !configuredCwdLooksUnsafe) {
       const configuredCwdExists = await fs
@@ -7177,15 +7179,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       parseProjectExecutionWorkspacePolicy(projectContext?.executionWorkspacePolicy),
       isolatedWorkspacesEnabled,
     );
+    const projectlessIssueExecutionWorkspacePolicy = defaultProjectlessIssueExecutionWorkspacePolicy({
+      issueId: issueContext?.id ?? null,
+      projectId: executionProjectId ?? null,
+      isolatedWorkspacesEnabled,
+      projectPolicy: configuredProjectExecutionWorkspacePolicy,
+      issueSettings: issueExecutionWorkspaceSettings,
+    });
     const projectExecutionWorkspacePolicy =
-      configuredProjectExecutionWorkspacePolicy ??
-      defaultProjectlessIssueExecutionWorkspacePolicy({
-        issueId: issueContext?.id ?? null,
-        projectId: executionProjectId ?? null,
-        isolatedWorkspacesEnabled,
-        projectPolicy: configuredProjectExecutionWorkspacePolicy,
-        issueSettings: issueExecutionWorkspaceSettings,
-      });
+      configuredProjectExecutionWorkspacePolicy ?? projectlessIssueExecutionWorkspacePolicy;
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;
@@ -7214,7 +7216,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agent,
       context,
       previousSessionParams,
-      { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
+      {
+        useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default",
+        allowConfiguredCwd:
+          requestedExecutionWorkspaceMode === "isolated_workspace" &&
+          projectExecutionWorkspacePolicy?.workspaceStrategy?.type === "git_worktree",
+      },
     );
     const issueRef = issueContext
       ? {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -121,6 +121,7 @@ import { workspaceOperationService } from "./workspace-operations.js";
 import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
 import {
   buildExecutionWorkspaceAdapterConfig,
+  defaultProjectlessIssueExecutionWorkspacePolicy,
   gateProjectExecutionWorkspacePolicy,
   issueExecutionWorkspaceModeForPersistedWorkspace,
   parseIssueExecutionWorkspaceSettings,
@@ -3838,6 +3839,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
+    const configuredCwd = issueId ? readNonEmptyString(parseObject(agent.adapterConfig).cwd) : null;
+    const configuredCwdLooksUnsafe = isUnsafeSessionWorkspaceCwd(configuredCwd);
+    if (configuredCwd && !configuredCwdLooksUnsafe) {
+      const configuredCwdExists = await fs
+        .stat(configuredCwd)
+        .then((stats) => stats.isDirectory())
+        .catch(() => false);
+      if (configuredCwdExists) {
+        return {
+          cwd: configuredCwd,
+          source: "task_session" as const,
+          projectId: resolvedProjectId,
+          workspaceId: null,
+          repoUrl: null,
+          repoRef: null,
+          workspaceHints,
+          warnings: [],
+        };
+      }
+    }
+
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
@@ -7151,10 +7173,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       delete context.acceptedPlanWakeRouting;
     }
     const routineEnvContext = await getRoutineEnvForExecutionIssue(agent.companyId, issueContext);
-    const projectExecutionWorkspacePolicy = gateProjectExecutionWorkspacePolicy(
+    const configuredProjectExecutionWorkspacePolicy = gateProjectExecutionWorkspacePolicy(
       parseProjectExecutionWorkspacePolicy(projectContext?.executionWorkspacePolicy),
       isolatedWorkspacesEnabled,
     );
+    const projectExecutionWorkspacePolicy =
+      configuredProjectExecutionWorkspacePolicy ??
+      defaultProjectlessIssueExecutionWorkspacePolicy({
+        issueId: issueContext?.id ?? null,
+        projectId: executionProjectId ?? null,
+        isolatedWorkspacesEnabled,
+        projectPolicy: configuredProjectExecutionWorkspacePolicy,
+        issueSettings: issueExecutionWorkspaceSettings,
+      });
     const taskSession = taskKey
       ? await getTaskSession(agent.companyId, agent.id, agent.adapterType, taskKey)
       : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Heartbeat execution chooses a workspace before handing a task to an adapter.
> - Project-scoped tasks can already use execution workspace policies to create isolated git worktrees.
> - Projectless issue-backed CTO tasks were falling through to shared agent checkout behavior, so concurrent tasks could fail preflight or collide on unrelated work.
> - The fix should preserve explicit project and issue workspace settings while giving projectless issue runs a safe default.
> - This pull request defaults projectless issue-backed runs to isolated git worktrees when isolated workspaces are enabled and derives the source repo from the agent configured cwd only for isolated git-worktree runs.
> - It also stabilizes the existing issue monitor scheduler test harness after CI exposed a background heartbeat cleanup race.
> - The benefit is that routine issue heartbeats no longer contend on one shared checkout while existing project-level policy remains authoritative.

## What Changed

- Added `defaultProjectlessIssueExecutionWorkspacePolicy` so issue-backed runs without a project get an isolated `git_worktree` policy only when isolated workspaces are enabled and no explicit setting overrides it.
- Updated heartbeat workspace resolution to honor a safe existing agent `adapterConfig.cwd` only when the resolved execution mode is `isolated_workspace` with a `git_worktree` strategy, allowing projectless issue worktrees to be realized from the intended repo without changing non-isolated issue runs.
- Added unit coverage for the projectless fallback policy, including the disabled-isolation branch, and integration coverage proving a projectless issue run receives an isolated worktree rooted under `.paperclip`.
- Stabilized the existing issue monitor scheduler test harness by mocking adapter execution, cleaning up generated task-session rows, and giving the bounded cleanup retry loop enough hook time.

## Verification

- `pnpm exec vitest run server/src/__tests__/execution-workspace-policy.test.ts`
- `pnpm exec vitest run server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts`
- `pnpm exec vitest run server/src/__tests__/issue-monitor-scheduler.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`

## Risks

- Low-to-moderate behavior risk: issue-backed runs with an existing safe `adapterConfig.cwd` now use that configured repo as the source only when the run is creating an isolated git worktree.
- The projectless fallback does not persist an `execution_workspaces` row because the current schema requires `project_id`; the runtime still passes the realized isolated worktree to the adapter for the run.
- Existing project execution workspace policies and explicit issue `shared_workspace` settings remain authoritative.
- Test-only risk: the issue monitor scheduler suite now mocks adapter execution, so it remains focused on scheduler/recovery DB behavior rather than process-adapter integration.

## Model Used

- OpenAI Codex, GPT-5, with command execution and code editing tool use in local development worktrees.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
