### PR TITLE
fix(issues): resolve identifier to UUID for parentId/descendantOf filters

### DIFF
--- a/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
+++ b/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
@@ -120,7 +120,11 @@ describe("GET /api/companies/:companyId/issues — parentId / descendantOf resol
   });
 
   it("resolves an identifier parentId to a UUID before calling the service", async () => {
-    mockIssueService.getByIdentifier.mockResolvedValueOnce({ id: parentUuid, identifier: parentIdentifier } as never);
+    mockIssueService.getByIdentifier.mockResolvedValueOnce(
+      { id: parentUuid, identifier: parentIdentifier } as unknown as Awaited<
+        ReturnType<(typeof mockIssueService)["getByIdentifier"]>
+      >,
+    );
 
     const app = await createApp();
     const res = await request(app)
@@ -161,7 +165,11 @@ describe("GET /api/companies/:companyId/issues — parentId / descendantOf resol
   });
 
   it("resolves an identifier descendantOf to a UUID before calling the service", async () => {
-    mockIssueService.getByIdentifier.mockResolvedValueOnce({ id: parentUuid, identifier: parentIdentifier } as never);
+    mockIssueService.getByIdentifier.mockResolvedValueOnce(
+      { id: parentUuid, identifier: parentIdentifier } as unknown as Awaited<
+        ReturnType<(typeof mockIssueService)["getByIdentifier"]>
+      >,
+    );
 
     const app = await createApp();
     const res = await request(app)
@@ -201,7 +209,11 @@ describe("GET /api/companies/:companyId/issues — parentId / descendantOf resol
   });
 
   it("applies the same resolution to GET /issues/count", async () => {
-    mockIssueService.getByIdentifier.mockResolvedValueOnce({ id: parentUuid, identifier: parentIdentifier } as never);
+    mockIssueService.getByIdentifier.mockResolvedValueOnce(
+      { id: parentUuid, identifier: parentIdentifier } as unknown as Awaited<
+        ReturnType<(typeof mockIssueService)["getByIdentifier"]>
+      >,
+    );
 
     const app = await createApp();
     const res = await request(app)

--- a/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
+++ b/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
@@ -1,0 +1,219 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const parentUuid = "11111111-1111-4111-8111-111111111111";
+const parentIdentifier = "PAP-4382";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(async () => [] as unknown[]),
+  count: vi.fn(async () => 0),
+  getByIdentifier: vi.fn(async () => null),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(async () => true),
+    decide: vi.fn(async () => ({ allowed: true })),
+    hasPermission: vi.fn(async () => true),
+  }),
+  agentService: () => ({ getById: vi.fn(async () => null) }),
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+  documentService: () => ({ getIssueDocumentPayload: vi.fn(async () => ({})) }),
+  executionWorkspaceService: () => ({ getById: vi.fn(async () => null) }),
+  feedbackService: () => ({ listIssueVotesForUser: vi.fn(async () => []) }),
+  goalService: () => ({
+    getById: vi.fn(async () => null),
+    getDefaultCompanyGoal: vi.fn(async () => null),
+  }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  getIssueContinuationSummaryDocument: vi.fn(async () => null),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => ({
+    getActiveForIssue: vi.fn(async () => null),
+    listActiveForIssues: vi.fn(async () => new Map()),
+  }),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueThreadInteractionService: () => ({
+    listForIssue: vi.fn(async () => []),
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(async () => null),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+  workProductService: () => ({ listForIssue: vi.fn(async () => []) }),
+  ISSUE_LIST_DEFAULT_LIMIT: 50,
+  ISSUE_LIST_MAX_LIMIT: 200,
+  clampIssueListLimit: (n: number) => Math.min(Math.max(n, 1), 200),
+}));
+
+async function createApp() {
+  const { issueRoutes } = await vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js");
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { actor: Record<string, unknown> }).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.use("/api", issueRoutes({} as any, {} as any));
+  return app;
+}
+
+describe("GET /api/companies/:companyId/issues — parentId / descendantOf resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.list.mockResolvedValue([]);
+    mockIssueService.count.mockResolvedValue(0);
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+  });
+
+  it("passes a UUID parentId straight to the service without consulting getByIdentifier", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ parentId: parentUuid });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ parentId: parentUuid }),
+    );
+  });
+
+  it("resolves an identifier parentId to a UUID before calling the service", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValueOnce({ id: parentUuid, identifier: parentIdentifier } as never);
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ parentId: parentIdentifier });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(mockIssueService.getByIdentifier).toHaveBeenCalledWith(parentIdentifier);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ parentId: parentUuid }),
+    );
+  });
+
+  it("returns 404 with parent_not_found when an identifier parentId does not resolve", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValueOnce(null);
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ parentId: "PAP-99999999" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "parent_not_found", identifier: "PAP-99999999" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with invalid_parent_id (echoing the trimmed value) for garbage parentId", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ parentId: "  not-a-uuid-or-identifier  " });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "invalid_parent_id", value: "not-a-uuid-or-identifier" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("resolves an identifier descendantOf to a UUID before calling the service", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValueOnce({ id: parentUuid, identifier: parentIdentifier } as never);
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ descendantOf: parentIdentifier });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getByIdentifier).toHaveBeenCalledWith(parentIdentifier);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ descendantOf: parentUuid }),
+    );
+  });
+
+  it("returns 404 with descendant_not_found when an identifier descendantOf does not resolve", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValueOnce(null);
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ descendantOf: "PAP-99999999" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "descendant_not_found", identifier: "PAP-99999999" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with invalid_descendant_of for garbage descendantOf", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query({ descendantOf: "lower-case-words" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "invalid_descendant_of", value: "lower-case-words" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("applies the same resolution to GET /issues/count", async () => {
+    mockIssueService.getByIdentifier.mockResolvedValueOnce({ id: parentUuid, identifier: parentIdentifier } as never);
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues/count")
+      .query({ attention: "blocked", parentId: parentIdentifier });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ count: 0 });
+    expect(mockIssueService.getByIdentifier).toHaveBeenCalledWith(parentIdentifier);
+    expect(mockIssueService.count).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ parentId: parentUuid }),
+    );
+  });
+});

--- a/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
+++ b/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
@@ -21,6 +21,10 @@ vi.mock("../services/index.js", () => ({
   companyService: () => ({
     getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
   }),
+  companySkillService: () => ({
+    completeTestRunForIssue: vi.fn(async () => null),
+    markTestRunRunning: vi.fn(async () => undefined),
+  }),
   documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
   documentService: () => ({ getIssueDocumentPayload: vi.fn(async () => ({})) }),
   executionWorkspaceService: () => ({ getById: vi.fn(async () => null) }),

--- a/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
+++ b/server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts
@@ -232,4 +232,86 @@ describe("GET /api/companies/:companyId/issues — parentId / descendantOf resol
       expect.objectContaining({ parentId: parentUuid }),
     );
   });
+
+  // Regression: with Express' default query parser, repeated query params
+  // (e.g. `?parentId=a&parentId=b`) arrive as arrays at runtime. The pre-fix
+  // code cast them to `string` and then called `.trim()`, which threw a 500.
+  // These tests lock in the explicit 400 for both filters, on both endpoints.
+  //
+  // Note on object shapes: `?parentId[eq]=x` would produce an object under
+  // `req.query.parentId` only if the app opts into Express' "extended" query
+  // parser (qs). The current server keeps the default "simple" parser, so
+  // that bracket form arrives as a literal `parentId[eq]` key and never hits
+  // this validator; the runtime-type guard remains as a defence-in-depth for
+  // a possible future parser switch.
+  it("returns 400 (not 500) when parentId is repeated in the query", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query(`parentId=${parentUuid}&parentId=other-value`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_parent_id",
+      reason: "expected a single string value, received a repeated or structured query parameter",
+    });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+    expect(mockIssueService.getByIdentifier).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 (not 500) when descendantOf is repeated in the query", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query(`descendantOf=${parentUuid}&descendantOf=${parentIdentifier}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_descendant_of",
+      reason: "expected a single string value, received a repeated or structured query parameter",
+    });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 (not 500) when parentId is repeated on GET /issues/count", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues/count")
+      .query(`attention=blocked&parentId=${parentUuid}&parentId=other`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_parent_id",
+      reason: "expected a single string value, received a repeated or structured query parameter",
+    });
+    expect(mockIssueService.count).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 (not 500) when descendantOf is repeated on GET /issues/count", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues/count")
+      .query(`attention=blocked&descendantOf=${parentUuid}&descendantOf=x`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_descendant_of",
+      reason: "expected a single string value, received a repeated or structured query parameter",
+    });
+    expect(mockIssueService.count).not.toHaveBeenCalled();
+  });
+
+  it("falls back to parentIssueId only when parentId is absent, and still validates its type", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/issues")
+      .query(`parentIssueId=${parentUuid}&parentIssueId=other`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_parent_id",
+      reason: "expected a single string value, received a repeated or structured query parameter",
+    });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5658,6 +5658,34 @@ export function issueRoutes(
     return rawId;
   }
 
+  // Resolves a query parameter that points at an issue. Accepts either a UUID
+  // or a human identifier (e.g. "NUB-4382"); resolves the identifier to a UUID
+  // before it reaches Drizzle/Postgres so that uuid-typed columns don't blow up
+  // with a 500.
+  async function resolveIssueIdQueryParam(
+    raw: string,
+    paramName: "parentId" | "descendantOf",
+  ): Promise<
+    | { ok: true; uuid: string }
+    | { ok: false; status: 400 | 404; body: Record<string, unknown> }
+  > {
+    const trimmed = raw.trim();
+    if (isUuidLike(trimmed)) {
+      return { ok: true, uuid: trimmed };
+    }
+    const identifier = normalizeIssueReferenceIdentifier(trimmed);
+    if (identifier) {
+      const issue = await svc.getByIdentifier(identifier);
+      if (!issue) {
+        const errorKey = paramName === "parentId" ? "parent_not_found" : "descendant_not_found";
+        return { ok: false, status: 404, body: { error: errorKey, identifier } };
+      }
+      return { ok: true, uuid: issue.id };
+    }
+    const errorKey = paramName === "parentId" ? "invalid_parent_id" : "invalid_descendant_of";
+    return { ok: false, status: 400, body: { error: errorKey, value: raw } };
+  }
+
   async function resolveIssueProjectAndGoal(issue: {
     companyId: string;
     projectId: string | null;
@@ -6043,6 +6071,28 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
+    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
+    let parentId: string | undefined;
+    if (parentIdRaw !== undefined && parentIdRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      parentId = resolved.uuid;
+    }
+
+    const descendantOfRaw = req.query.descendantOf as string | undefined;
+    let descendantOf: string | undefined;
+    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      descendantOf = resolved.uuid;
+    }
+
     const listFilters: IssueFilters = {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | string[] | undefined,
@@ -6055,8 +6105,8 @@ export function issueRoutes(
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId: (req.query.parentId ?? req.query.parentIssueId) as string | undefined,
-      descendantOf: req.query.descendantOf as string | undefined,
+      parentId,
+      descendantOf,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
@@ -6239,6 +6289,28 @@ export function issueRoutes(
       return;
     }
 
+    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
+    let parentId: string | undefined;
+    if (parentIdRaw !== undefined && parentIdRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      parentId = resolved.uuid;
+    }
+
+    const descendantOfRaw = req.query.descendantOf as string | undefined;
+    let descendantOf: string | undefined;
+    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      descendantOf = resolved.uuid;
+    }
+
     const blockedCountFilters = {
       attention: "blocked",
       status: req.query.status as string | string[] | undefined,
@@ -6248,8 +6320,8 @@ export function issueRoutes(
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId: (req.query.parentId ?? req.query.parentIssueId) as string | undefined,
-      descendantOf: req.query.descendantOf as string | undefined,
+      parentId,
+      descendantOf,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5683,7 +5683,32 @@ export function issueRoutes(
       return { ok: true, uuid: issue.id };
     }
     const errorKey = paramName === "parentId" ? "invalid_parent_id" : "invalid_descendant_of";
-    return { ok: false, status: 400, body: { error: errorKey, value: raw } };
+    return { ok: false, status: 400, body: { error: errorKey, value: trimmed } };
+  }
+
+  // Pulls the two issue-pointing query params (`parentId`, `descendantOf`) off
+  // a request, resolves them via {@link resolveIssueIdQueryParam}, and writes
+  // the validation error to `res` itself when one fails. Returns `null` after
+  // writing the error so the handler can simply `return`.
+  async function resolveIssueIdListFilters(
+    req: Request,
+    res: Response,
+  ): Promise<{ parentId?: string; descendantOf?: string } | null> {
+    const out: { parentId?: string; descendantOf?: string } = {};
+    for (const paramName of ["parentId", "descendantOf"] as const) {
+      const raw =
+        paramName === "parentId"
+          ? ((req.query.parentId ?? req.query.parentIssueId) as string | undefined)
+          : (req.query[paramName] as string | undefined);
+      if (raw === undefined || raw === "") continue;
+      const resolved = await resolveIssueIdQueryParam(raw, paramName);
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return null;
+      }
+      out[paramName] = resolved.uuid;
+    }
+    return out;
   }
 
   async function resolveIssueProjectAndGoal(issue: {
@@ -6071,27 +6096,8 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
-    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
-    let parentId: string | undefined;
-    if (parentIdRaw !== undefined && parentIdRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      parentId = resolved.uuid;
-    }
-
-    const descendantOfRaw = req.query.descendantOf as string | undefined;
-    let descendantOf: string | undefined;
-    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      descendantOf = resolved.uuid;
-    }
+    const issueIdFilters = await resolveIssueIdListFilters(req, res);
+    if (!issueIdFilters) return;
 
     const listFilters: IssueFilters = {
       attention: attention === "blocked" ? "blocked" : undefined,
@@ -6105,8 +6111,8 @@ export function issueRoutes(
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId,
-      descendantOf,
+      parentId: issueIdFilters.parentId,
+      descendantOf: issueIdFilters.descendantOf,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
@@ -6289,27 +6295,8 @@ export function issueRoutes(
       return;
     }
 
-    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
-    let parentId: string | undefined;
-    if (parentIdRaw !== undefined && parentIdRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      parentId = resolved.uuid;
-    }
-
-    const descendantOfRaw = req.query.descendantOf as string | undefined;
-    let descendantOf: string | undefined;
-    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      descendantOf = resolved.uuid;
-    }
+    const issueIdFilters = await resolveIssueIdListFilters(req, res);
+    if (!issueIdFilters) return;
 
     const blockedCountFilters = {
       attention: "blocked",
@@ -6320,8 +6307,8 @@ export function issueRoutes(
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId,
-      descendantOf,
+      parentId: issueIdFilters.parentId,
+      descendantOf: issueIdFilters.descendantOf,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7420,6 +7420,34 @@ export function issueRoutes(
     return rawId;
   }
 
+  // Resolves a query parameter that points at an issue. Accepts either a UUID
+  // or a human identifier (e.g. "NUB-4382"); resolves the identifier to a UUID
+  // before it reaches Drizzle/Postgres so that uuid-typed columns don't blow up
+  // with a 500.
+  async function resolveIssueIdQueryParam(
+    raw: string,
+    paramName: "parentId" | "descendantOf",
+  ): Promise<
+    | { ok: true; uuid: string }
+    | { ok: false; status: 400 | 404; body: Record<string, unknown> }
+  > {
+    const trimmed = raw.trim();
+    if (isUuidLike(trimmed)) {
+      return { ok: true, uuid: trimmed };
+    }
+    const identifier = normalizeIssueReferenceIdentifier(trimmed);
+    if (identifier) {
+      const issue = await svc.getByIdentifier(identifier);
+      if (!issue) {
+        const errorKey = paramName === "parentId" ? "parent_not_found" : "descendant_not_found";
+        return { ok: false, status: 404, body: { error: errorKey, identifier } };
+      }
+      return { ok: true, uuid: issue.id };
+    }
+    const errorKey = paramName === "parentId" ? "invalid_parent_id" : "invalid_descendant_of";
+    return { ok: false, status: 400, body: { error: errorKey, value: raw } };
+  }
+
   async function resolveIssueProjectAndGoal(issue: {
     companyId: string;
     projectId: string | null;
@@ -7905,6 +7933,28 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
+    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
+    let parentId: string | undefined;
+    if (parentIdRaw !== undefined && parentIdRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      parentId = resolved.uuid;
+    }
+
+    const descendantOfRaw = req.query.descendantOf as string | undefined;
+    let descendantOf: string | undefined;
+    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      descendantOf = resolved.uuid;
+    }
+
     const listFilters: IssueFilters = {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | string[] | undefined,
@@ -7916,11 +7966,9 @@ export function issueRoutes(
       unreadForUserId,
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
-      executionWorkspaceId: req.query.executionWorkspaceId as
-        string | undefined,
-      parentId: (req.query.parentId ?? req.query.parentIssueId) as
-        string | undefined,
-      descendantOf: req.query.descendantOf as string | undefined,
+      executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
+      parentId,
+      descendantOf,
       createdFromIssueId: req.query.createdFromIssueId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
@@ -8133,6 +8181,28 @@ export function issueRoutes(
       return;
     }
 
+    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
+    let parentId: string | undefined;
+    if (parentIdRaw !== undefined && parentIdRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      parentId = resolved.uuid;
+    }
+
+    const descendantOfRaw = req.query.descendantOf as string | undefined;
+    let descendantOf: string | undefined;
+    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
+      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return;
+      }
+      descendantOf = resolved.uuid;
+    }
+
     const blockedCountFilters = {
       attention: "blocked",
       status: req.query.status as string | string[] | undefined,
@@ -8141,11 +8211,9 @@ export function issueRoutes(
       assigneeUserId: req.query.assigneeUserId as string | undefined,
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
-      executionWorkspaceId: req.query.executionWorkspaceId as
-        string | undefined,
-      parentId: (req.query.parentId ?? req.query.parentIssueId) as
-        string | undefined,
-      descendantOf: req.query.descendantOf as string | undefined,
+      executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
+      parentId,
+      descendantOf,
       createdFromIssueId: req.query.createdFromIssueId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7445,7 +7445,32 @@ export function issueRoutes(
       return { ok: true, uuid: issue.id };
     }
     const errorKey = paramName === "parentId" ? "invalid_parent_id" : "invalid_descendant_of";
-    return { ok: false, status: 400, body: { error: errorKey, value: raw } };
+    return { ok: false, status: 400, body: { error: errorKey, value: trimmed } };
+  }
+
+  // Pulls the two issue-pointing query params (`parentId`, `descendantOf`) off
+  // a request, resolves them via {@link resolveIssueIdQueryParam}, and writes
+  // the validation error to `res` itself when one fails. Returns `null` after
+  // writing the error so the handler can simply `return`.
+  async function resolveIssueIdListFilters(
+    req: Request,
+    res: Response,
+  ): Promise<{ parentId?: string; descendantOf?: string } | null> {
+    const out: { parentId?: string; descendantOf?: string } = {};
+    for (const paramName of ["parentId", "descendantOf"] as const) {
+      const raw =
+        paramName === "parentId"
+          ? ((req.query.parentId ?? req.query.parentIssueId) as string | undefined)
+          : (req.query[paramName] as string | undefined);
+      if (raw === undefined || raw === "") continue;
+      const resolved = await resolveIssueIdQueryParam(raw, paramName);
+      if (!resolved.ok) {
+        res.status(resolved.status).json(resolved.body);
+        return null;
+      }
+      out[paramName] = resolved.uuid;
+    }
+    return out;
   }
 
   async function resolveIssueProjectAndGoal(issue: {
@@ -7933,27 +7958,8 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
-    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
-    let parentId: string | undefined;
-    if (parentIdRaw !== undefined && parentIdRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      parentId = resolved.uuid;
-    }
-
-    const descendantOfRaw = req.query.descendantOf as string | undefined;
-    let descendantOf: string | undefined;
-    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      descendantOf = resolved.uuid;
-    }
+    const issueIdFilters = await resolveIssueIdListFilters(req, res);
+    if (!issueIdFilters) return;
 
     const listFilters: IssueFilters = {
       attention: attention === "blocked" ? "blocked" : undefined,
@@ -7967,8 +7973,8 @@ export function issueRoutes(
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId,
-      descendantOf,
+      parentId: issueIdFilters.parentId,
+      descendantOf: issueIdFilters.descendantOf,
       createdFromIssueId: req.query.createdFromIssueId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,
@@ -8181,27 +8187,8 @@ export function issueRoutes(
       return;
     }
 
-    const parentIdRaw = (req.query.parentId ?? req.query.parentIssueId) as string | undefined;
-    let parentId: string | undefined;
-    if (parentIdRaw !== undefined && parentIdRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(parentIdRaw, "parentId");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      parentId = resolved.uuid;
-    }
-
-    const descendantOfRaw = req.query.descendantOf as string | undefined;
-    let descendantOf: string | undefined;
-    if (descendantOfRaw !== undefined && descendantOfRaw !== "") {
-      const resolved = await resolveIssueIdQueryParam(descendantOfRaw, "descendantOf");
-      if (!resolved.ok) {
-        res.status(resolved.status).json(resolved.body);
-        return;
-      }
-      descendantOf = resolved.uuid;
-    }
+    const issueIdFilters = await resolveIssueIdListFilters(req, res);
+    if (!issueIdFilters) return;
 
     const blockedCountFilters = {
       attention: "blocked",
@@ -8212,8 +8199,8 @@ export function issueRoutes(
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId,
-      descendantOf,
+      parentId: issueIdFilters.parentId,
+      descendantOf: issueIdFilters.descendantOf,
       createdFromIssueId: req.query.createdFromIssueId as string | undefined,
       labelId: req.query.labelId as string | undefined,
       originKind: req.query.originKind as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7452,18 +7452,34 @@ export function issueRoutes(
   // a request, resolves them via {@link resolveIssueIdQueryParam}, and writes
   // the validation error to `res` itself when one fails. Returns `null` after
   // writing the error so the handler can simply `return`.
+  //
+  // Repeated query params (e.g. `?parentId=a&parentId=b`) arrive as arrays
+  // from Express' default query parser; opting into the `extended` (qs)
+  // parser would also produce objects for bracketed keys. The TypeScript
+  // cast is a compile-time no-op, so we validate the runtime type here and
+  // 400 explicitly instead of letting `raw.trim()` throw a 500 downstream.
   async function resolveIssueIdListFilters(
     req: Request,
     res: Response,
   ): Promise<{ parentId?: string; descendantOf?: string } | null> {
     const out: { parentId?: string; descendantOf?: string } = {};
     for (const paramName of ["parentId", "descendantOf"] as const) {
-      const raw =
+      const rawUnknown: unknown =
         paramName === "parentId"
-          ? ((req.query.parentId ?? req.query.parentIssueId) as string | undefined)
-          : (req.query[paramName] as string | undefined);
-      if (raw === undefined || raw === "") continue;
-      const resolved = await resolveIssueIdQueryParam(raw, paramName);
+          ? req.query.parentId ?? req.query.parentIssueId
+          : req.query[paramName];
+      if (rawUnknown === undefined) continue;
+      if (typeof rawUnknown !== "string") {
+        const errorKey =
+          paramName === "parentId" ? "invalid_parent_id" : "invalid_descendant_of";
+        res.status(400).json({
+          error: errorKey,
+          reason: "expected a single string value, received a repeated or structured query parameter",
+        });
+        return null;
+      }
+      if (rawUnknown === "") continue;
+      const resolved = await resolveIssueIdQueryParam(rawUnknown, paramName);
       if (!resolved.ok) {
         res.status(resolved.status).json(resolved.body);
         return null;


### PR DESCRIPTION
Fixes #7489

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents (and the harness) routinely call `GET /api/companies/:companyId/issues` with filters to find related work
> - The `parentId` and `descendantOf` filters are uuid-typed in Postgres, but agents naturally hand each other human identifiers (`NUB-4382`) when composing queries (issue references in comments, mentions, etc.)
> - When an identifier slipped through it crashed the request with a 500 (`PostgresError: invalid input syntax for type uuid`) instead of either resolving it or returning a clean validation error — and the parent issue stayed `blocked` waiting on a child it could not list
> - This PR teaches both list-style handlers to accept either a UUID or an identifier, and to fail loudly (`400` / `404`) instead of crashing
> - The benefit is two-fold: existing clients keep working unchanged, and any new caller that hands in a `NUB-XXXX`-style id Just Works without a server crash

## What Changed

- `server/src/routes/issues.ts`
  - New `resolveIssueIdQueryParam(raw, paramName)` helper: returns the trimmed UUID on success; on miss returns `404 { error: "parent_not_found"|"descendant_not_found", identifier }`; on a value matching neither UUID nor identifier returns `400 { error: "invalid_parent_id"|"invalid_descendant_of", value: <trimmed> }`.
  - New `resolveIssueIdListFilters(req, res)` helper: reads `parentId` + `descendantOf` off the query, runs them through `resolveIssueIdQueryParam`, writes the validation error to `res` itself on failure, and returns either `{ parentId, descendantOf }` or `null`.
  - `GET /api/companies/:companyId/issues` and `GET /api/companies/:companyId/issues/count` both delegate to the new helper (no more copy-pasted resolution block).
- `server/src/__tests__/issue-list-parent-id-resolution-routes.test.ts` (new): 8 tests covering UUID pass-through (no `getByIdentifier` call), identifier resolution, `404` for unknown identifier, `400` for garbage (asserting the **trimmed** echo), descendantOf parity, and the same matrix applied to `/issues/count`.

## Verification

- `cd server && pnpm vitest run src/__tests__/issue-list-parent-id-resolution-routes.test.ts` — all 8 tests pass locally (`vitest 3.2.4`, node 24.16.0).
- Manual matrix (against a local server):
  - `?parentId=<uuid>` → 200, results for that UUID parent.
  - `?parentId=NUB-<n>` → 200, results for the resolved UUID parent.
  - `?parentId=NUB-99999999` → 404 `{ error: "parent_not_found", identifier: "NUB-99999999" }`.
  - `?parentId=not-a-uuid` → 400 `{ error: "invalid_parent_id", value: "not-a-uuid" }`.
  - Same matrix repeated for `descendantOf` and against `/issues/count`.
- `isUuidLike` is the same helper already used by `router.param("id")` and `services/issues.ts#getById`, so behaviour is consistent with other identifier-tolerant routes.

## Risks

- **Low.** No schema changes, no breaking changes to the response shape on the success path (UUID input still returns the same payload). New error responses (`400` / `404`) are strictly more informative than the previous `500`. Service signatures are unchanged. The resolver runs an extra `getByIdentifier` lookup only when the caller passes an identifier — the UUID-only hot path adds a single regex check.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`) via Claude Code, no extended thinking, regular tool use. Agent harness applied the edit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — server-only change)
- [x] I have updated relevant documentation to reflect my changes (no docs reference these filters)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

### Greptile review responses (commit 5c9dea40)

- ✅ **Duplicated resolution blocks** — extracted to `resolveIssueIdListFilters(req, res)`, called from both list and count handlers.
- ✅ **400 echoes raw vs trimmed** — now echoes `trimmed`.
- ✅ **PR template sections** — added above.
- ✅ **Missing test files** — `issue-list-parent-id-resolution-routes.test.ts` covers the matrix.
- [x] I searched the GitHub PR list (open and recently closed) for similar PRs and confirmed this is not a duplicate
