### PR TITLE
feat(opencode-local): map maxTurnsPerRun to OpenCode steps via OPENCODE_CONFIG_CONTENT

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -294,6 +294,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   // selection is already handled via the --model CLI flag.  Set after the
   // envConfig loop so user overrides cannot disable this guard.
   env.OPENCODE_DISABLE_PROJECT_CONFIG = "true";
+  // Map Paperclip's maxTurnsPerRun to OpenCode's per-agent steps config
+  // via inline runtime config.  OpenCode's "opencode run" CLI does not
+  // expose a --max-steps flag, so we inject it as a JSON env var that
+  // takes effect at the agent config level (higher precedence than local
+  // opencode.json files).  When unset or zero, OpenCode's default applies
+  // (unlimited steps, with doom_loop permission as a secondary guard).
+  const maxSteps = asNumber(config.maxTurnsPerRun, 0);
+  if (maxSteps > 0) {
+    env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+      agent: { build: { steps: maxSteps } },
+    });
+  }
   if (!hasExplicitApiKey && authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents have a maxTurnsPerRun config to cap token burn on runaway tasks
> - claude_local implements this via --max-turns CLI flag
> - opencode_local received the config field but had no way to enforce it — OpenCode's "opencode run" CLI does not expose a --max-steps flag
> - OpenCode supports per-agent step limits via its JSON config (steps field in agent definitions)
> - OpenCode also supports OPENCODE_CONFIG_CONTENT — an env var that acts as inline JSON config at runtime
> - This pull request maps maxTurnsPerRun to OpenCode's native steps mechanism via OPENCODE_CONFIG_CONTENT
> - The benefit is cost protection parity between claude_local and opencode_local agents

## What Changed

- When config.maxTurnsPerRun > 0, inject OPENCODE_CONFIG_CONTENT env var with {"agent":{"build":{"steps":<value>}}}
- When unset or 0, OpenCode's default applies (unlimited steps, with native doom_loop permission as a secondary guard)
- Minimal change — 12 lines in execute.ts

## Verification

```bash
# Verify the env var takes effect: OPENCODE_CONFIG_CONTENT={agent:{build:{steps:3}}} opencode run --format json --model "opencode-go/deepseek-v4-flash" "Write a complex script"
# Should stop after 3 tool call steps and produce a summary

# Run tests
cd packages/adapters/opencode-local && pnpm vitest run
```

## Risks

Low risk. The env var approach is non-invasive — it doesn't modify any opencode.json files on disk. OPENCODE_CONFIG_CONTENT has higher precedence than local config files per OpenCode's documented precedence order. If the env var is not supported on older OpenCode versions, it is silently ignored.

## Model Used

- Provider: DeepSeek (via OpenCode/deepseek-v4-flash)
- Exact model: deepseek-v4-flash
- 1M context window
- Tool use

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
