### PR TITLE
fix(productivity-review): liveness-weighted high-churn counting (BUM-91)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -120,6 +120,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    livenessState?: string;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
     for (let index = 0; index < input.count; index += 1) {
@@ -135,7 +136,7 @@ describeEmbeddedPostgres("productivity review service", () => {
         startedAt: createdAt,
         finishedAt: new Date(createdAt.getTime() + 30_000),
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
-        livenessState: "advanced",
+        livenessState: input.livenessState ?? "advanced",
         nextAction: "Continue processing the next batch.",
         createdAt,
         updatedAt: createdAt,
@@ -360,7 +361,9 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(hold.held).toBe(false);
   });
 
-  it("creates a high-churn review even when every sampled run has a progress comment", async () => {
+  // BUM-91 AC2: a stuck agent (non-advancing runs) STILL triggers a high-churn review,
+  // even when every run leaves a progress comment — comment presence does not suppress churn.
+  it("creates a high-churn review for non-advancing runs even when every sampled run has a progress comment", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();
     await insertRuns({
@@ -370,6 +373,7 @@ describeEmbeddedPostgres("productivity review service", () => {
       count: 10,
       now,
       withRunComments: true,
+      livenessState: "plan_only",
     });
 
     const result = await productivityReviewService(db).reconcileProductivityReviews({
@@ -381,6 +385,31 @@ describeEmbeddedPostgres("productivity review service", () => {
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.description).toContain("Primary trigger: `high_churn`");
     expect(review?.description).toContain("Runs in rolling windows: 10/1h");
+    expect(review?.description).toContain("10 non-advancing of 10 runs");
+  });
+
+  // BUM-91 AC1: an intentional N=5 measurement burst (many advancing runs in 1h) must NOT
+  // trigger a high-churn review. Runs carry progress comments so the no-comment-streak arm
+  // stays silent, isolating the churn arm; all runs are `advanced`, so churn count is 0.
+  it("does not create a high-churn review for an advancing measurement burst", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 15,
+      now,
+      withRunComments: true,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
   });
 
   it("ignores non-assignee comments when evaluating high-churn productivity reviews", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -25,11 +25,25 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS = 10;
 export const DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS = 6;
 export const DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_HOURLY = 10;
 export const DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_SIX_HOURS = 30;
+// BUM-91: Liveness states that represent real progress and must NOT count toward the
+// high-churn window. A deliberate N=5 measurement burst produces many `advanced` runs;
+// counting them made the churn detector fire on intentional work (BUM-88 -> BUM-89). Only
+// non-advancing runs (plan_only / empty_response / needs_followup / failed / still-active)
+// are churn signal.
+export const CHURN_ADVANCING_LIVENESS_STATES = ["advanced"] as const;
 export const DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS = 6 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
+
+// BUM-91: SQL predicate matching runs that did NOT advance (liveness is null or not one
+// of CHURN_ADVANCING_LIVENESS_STATES). These are the only runs that count toward the
+// high-churn window, so a deliberate measurement burst of advancing runs cannot trip it.
+const nonAdvancingChurnLivenessSql = sql`(${heartbeatRuns.livenessState} is null or ${heartbeatRuns.livenessState} not in (${sql.join(
+  CHURN_ADVANCING_LIVENESS_STATES.map((state) => sql`${state}`),
+  sql`, `,
+)}))`;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -361,6 +375,47 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .then((rows) => rows[0]?.count ?? 0);
   }
 
+  // BUM-91: like countIssueRunsSince but excludes runs whose liveness is `advanced`
+  // (real progress). Used for the high-churn signal so deliberate measurement bursts of
+  // advancing runs do not trip the detector, while stuck loops still do.
+  async function countNonAdvancingIssueRunsSince(companyId: string, agentId: string, issueId: string, since: Date) {
+    return db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          issueRunScopeSql(issueId),
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) >= ${since.toISOString()}::timestamptz`,
+          nonAdvancingChurnLivenessSql,
+        ),
+      )
+      .then((rows) => rows[0]?.count ?? 0);
+  }
+
+  // BUM-91: comment-window churn arm, counting only comments authored by non-advancing
+  // runs (a comment from an `advanced` run is progress, not churn).
+  async function countNonAdvancingIssueCommentsSince(companyId: string, issueId: string, agentId: string, since: Date) {
+    return db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issueComments)
+      .innerJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.issueId, issueId),
+          eq(issueComments.authorAgentId, agentId),
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          issueRunScopeSql(issueId),
+          nonAdvancingChurnLivenessSql,
+          sql`${issueComments.createdAt} >= ${since.toISOString()}::timestamptz`,
+        ),
+      )
+      .then((rows) => rows[0]?.count ?? 0);
+  }
+
   async function countIssueCommentsSince(companyId: string, issueId: string, agentId: string, since?: Date) {
     return db
       .select({ count: sql<number>`count(*)::int` })
@@ -435,6 +490,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       assigneeRunCommentCount,
       assigneeRunCommentCountLastHour,
       assigneeRunCommentCountLastSixHours,
+      churnRunCountLastHour,
+      churnRunCountLastSixHours,
+      churnCommentCountLastHour,
+      churnCommentCountLastSixHours,
       latestComments,
       costRow,
     ] = await Promise.all([
@@ -443,6 +502,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       countIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id),
       countIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id, oneHourAgo),
       countIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id, sixHoursAgo),
+      // BUM-91: liveness-weighted churn arms — only non-advancing runs/comments count.
+      countNonAdvancingIssueRunsSince(sourceIssue.companyId, sourceAgent.id, sourceIssue.id, oneHourAgo),
+      countNonAdvancingIssueRunsSince(sourceIssue.companyId, sourceAgent.id, sourceIssue.id, sixHoursAgo),
+      countNonAdvancingIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id, oneHourAgo),
+      countNonAdvancingIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id, sixHoursAgo),
       db
         .select({ comment: issueComments })
         .from(issueComments)
@@ -477,11 +541,15 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
     const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    // BUM-91: churn is measured on NON-ADVANCING runs/comments only, so an intentional
+    // measurement burst (all `advanced`) does not trip the detector while a stuck loop
+    // (plan_only / empty_response / needs_followup / failed) still does. Display totals
+    // (runCountLastHour, assigneeRunCommentCount*) are preserved unchanged.
     const highChurn =
-      runCountLastHour >= thresholds.highChurnHourly ||
-      assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||
-      runCountLastSixHours >= thresholds.highChurnSixHours ||
-      assigneeRunCommentCountLastSixHours >= thresholds.highChurnSixHours;
+      churnRunCountLastHour >= thresholds.highChurnHourly ||
+      churnCommentCountLastHour >= thresholds.highChurnHourly ||
+      churnRunCountLastSixHours >= thresholds.highChurnSixHours ||
+      churnCommentCountLastSixHours >= thresholds.highChurnSixHours;
     const trigger = choosePrimaryTrigger({ noComment, longActive, highChurn });
     if (!trigger) return null;
 
@@ -490,7 +558,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     if (longActive) triggerReasons.push(`current active episode has lasted ${msToHuman(elapsedMs)}`);
     if (highChurn) {
       triggerReasons.push(
-        `${runCountLastHour} runs/${assigneeRunCommentCountLastHour} assignee-run comments in 1h; ${runCountLastSixHours} runs/${assigneeRunCommentCountLastSixHours} assignee-run comments in 6h`,
+        `${churnRunCountLastHour} non-advancing of ${runCountLastHour} runs / ${churnCommentCountLastHour} non-advancing of ${assigneeRunCommentCountLastHour} assignee-run comments in 1h; ${churnRunCountLastSixHours} non-advancing of ${runCountLastSixHours} runs / ${churnCommentCountLastSixHours} non-advancing of ${assigneeRunCommentCountLastSixHours} assignee-run comments in 6h`,
       );
     }
 


### PR DESCRIPTION
## Problem

The `high_churn` arm of the productivity-review detector counts **raw** heartbeat runs/comments in the 1h/6h windows with **no liveness weighting**. A deliberate measurement burst (e.g. 3 fixtures × N=5 = 15 *advancing* agent runs) is therefore indistinguishable from a stuck loop and fires a false-positive churn review. Alert fatigue from these false positives erodes trust in the signal — the next real silent failure may get dismissed as "just another measurement burst".

Every run already carries `liveness_state` (`"advanced"` = real progress); the detector ignored it.

## Change

Count a run/comment toward the high-churn window **only when it did not advance** — `liveness_state` is null or not in the new `CHURN_ADVANCING_LIVENESS_STATES` constant. Display totals (`runCountLastHour`, `assigneeRunCommentCount*`) are preserved unchanged; only the churn boolean and its human-readable reason string are affected.

- 15 advancing measurement runs → churn count 0 → **no review**
- 10 `plan_only`/`failed` runs → churn count 10 → **still triggers**

Implementation:
- `CHURN_ADVANCING_LIVENESS_STATES` constant + a reusable `nonAdvancingChurnLivenessSql` predicate.
- `countNonAdvancingIssueRunsSince` / `countNonAdvancingIssueCommentsSince` mirror the existing counters with the predicate applied.
- `highChurn` and its reason string now read from the liveness-weighted counts.

## Tests

`server/src/__tests__/productivity-review-service.test.ts`:
- Rewrote the existing high-churn test to seed **non-advancing** runs (proves a stuck agent still triggers).
- Added a test that a 15-run **advancing** burst (with progress comments, isolating the churn arm) does **not** trigger a review.

`pnpm exec tsc --noEmit` clean; all 12 tests in the file pass.

## Why this approach

Chosen over (1) per-issue suppression labels — orthogonal to liveness and easy to mis-apply — and (3) raising the threshold — trades one false-positive class for false negatives. Liveness weighting satisfies both invariants by construction: real progress never counts as churn, stuck/non-advancing work always does.