### PR TITLE
fix(cli): default `paperclipai run` to non-interactive migrations

### DIFF
--- a/cli/src/__tests__/run-migration-env.test.ts
+++ b/cli/src/__tests__/run-migration-env.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMigrationEnvUpdates,
+  resolveMigrationEnvUpdates,
+} from "../commands/run-migration-env.js";
+
+describe("resolveMigrationEnvUpdates", () => {
+  describe("default (autoMigrate=true)", () => {
+    it("sets AUTO_APPLY=true when both env vars are unset", () => {
+      const updates = resolveMigrationEnvUpdates({}, { autoMigrate: true });
+      expect(updates).toEqual({ PAPERCLIP_MIGRATION_AUTO_APPLY: "true" });
+    });
+
+    it("treats empty-string env values as unset", () => {
+      const updates = resolveMigrationEnvUpdates(
+        { PAPERCLIP_MIGRATION_AUTO_APPLY: "", PAPERCLIP_MIGRATION_PROMPT: "" },
+        { autoMigrate: true },
+      );
+      expect(updates).toEqual({ PAPERCLIP_MIGRATION_AUTO_APPLY: "true" });
+    });
+
+    it("does not override an explicit PAPERCLIP_MIGRATION_AUTO_APPLY=true", () => {
+      const updates = resolveMigrationEnvUpdates(
+        { PAPERCLIP_MIGRATION_AUTO_APPLY: "true" },
+        { autoMigrate: true },
+      );
+      expect(updates).toEqual({});
+    });
+
+    it("does not override an explicit PAPERCLIP_MIGRATION_AUTO_APPLY=false", () => {
+      // Honor user intent even if their value will be treated as falsy by the server.
+      const updates = resolveMigrationEnvUpdates(
+        { PAPERCLIP_MIGRATION_AUTO_APPLY: "false" },
+        { autoMigrate: true },
+      );
+      expect(updates).toEqual({});
+    });
+
+    it("does not override an explicit PAPERCLIP_MIGRATION_PROMPT=never", () => {
+      const updates = resolveMigrationEnvUpdates(
+        { PAPERCLIP_MIGRATION_PROMPT: "never" },
+        { autoMigrate: true },
+      );
+      expect(updates).toEqual({});
+    });
+
+    it("does not override when both env vars are set", () => {
+      const updates = resolveMigrationEnvUpdates(
+        {
+          PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
+          PAPERCLIP_MIGRATION_PROMPT: "never",
+        },
+        { autoMigrate: true },
+      );
+      expect(updates).toEqual({});
+    });
+  });
+
+  describe("opt-out (autoMigrate=false)", () => {
+    it("sets PROMPT=never even when env is empty", () => {
+      const updates = resolveMigrationEnvUpdates({}, { autoMigrate: false });
+      expect(updates).toEqual({ PAPERCLIP_MIGRATION_PROMPT: "never" });
+    });
+
+    it("forces PROMPT=never overriding existing AUTO_APPLY=true", () => {
+      const updates = resolveMigrationEnvUpdates(
+        { PAPERCLIP_MIGRATION_AUTO_APPLY: "true" },
+        { autoMigrate: false },
+      );
+      // --no-auto-migrate is an explicit CLI signal, so it wins.
+      expect(updates).toEqual({ PAPERCLIP_MIGRATION_PROMPT: "never" });
+    });
+
+    it("forces PROMPT=never overriding existing PROMPT=ask", () => {
+      const updates = resolveMigrationEnvUpdates(
+        { PAPERCLIP_MIGRATION_PROMPT: "ask" },
+        { autoMigrate: false },
+      );
+      expect(updates).toEqual({ PAPERCLIP_MIGRATION_PROMPT: "never" });
+    });
+  });
+});
+
+describe("applyMigrationEnvUpdates", () => {
+  it("mutates env with set keys", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyMigrationEnvUpdates(env, { PAPERCLIP_MIGRATION_AUTO_APPLY: "true" });
+    expect(env.PAPERCLIP_MIGRATION_AUTO_APPLY).toBe("true");
+    expect(env.PAPERCLIP_MIGRATION_PROMPT).toBeUndefined();
+  });
+
+  it("leaves env untouched when updates are empty", () => {
+    const env: NodeJS.ProcessEnv = {
+      PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
+      PAPERCLIP_MIGRATION_PROMPT: "ask",
+    };
+    applyMigrationEnvUpdates(env, {});
+    expect(env.PAPERCLIP_MIGRATION_AUTO_APPLY).toBe("true");
+    expect(env.PAPERCLIP_MIGRATION_PROMPT).toBe("ask");
+  });
+
+  it("overwrites both keys when both are present in updates", () => {
+    const env: NodeJS.ProcessEnv = {
+      PAPERCLIP_MIGRATION_AUTO_APPLY: "old",
+      PAPERCLIP_MIGRATION_PROMPT: "old",
+    };
+    applyMigrationEnvUpdates(env, {
+      PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
+      PAPERCLIP_MIGRATION_PROMPT: "never",
+    });
+    expect(env.PAPERCLIP_MIGRATION_AUTO_APPLY).toBe("true");
+    expect(env.PAPERCLIP_MIGRATION_PROMPT).toBe("never");
+  });
+});
+
+describe("integration: default `paperclipai run` no longer blocks on prompt", () => {
+  // This is the scenario from the bug report: a fresh `npx paperclipai run`
+  // with no explicit env vars should silently auto-apply migrations
+  // instead of dropping into an interactive prompt that hangs the server boot.
+  it("produces an env state where the server's promptApplyMigrations short-circuits to true", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyMigrationEnvUpdates(
+      env,
+      resolveMigrationEnvUpdates(env, { autoMigrate: true }),
+    );
+    // Mirrors server/src/index.ts:119 guard.
+    expect(env.PAPERCLIP_MIGRATION_AUTO_APPLY).toBe("true");
+  });
+
+  it("produces an env state where --no-auto-migrate causes the server to refuse-to-start", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyMigrationEnvUpdates(
+      env,
+      resolveMigrationEnvUpdates(env, { autoMigrate: false }),
+    );
+    // Mirrors server/src/index.ts:120 guard.
+    expect(env.PAPERCLIP_MIGRATION_PROMPT).toBe("never");
+    expect(env.PAPERCLIP_MIGRATION_AUTO_APPLY).toBeUndefined();
+  });
+});

--- a/cli/src/commands/run-migration-env.ts
+++ b/cli/src/commands/run-migration-env.ts
@@ -1,0 +1,54 @@
+export interface MigrationEnvSnapshot {
+  PAPERCLIP_MIGRATION_AUTO_APPLY?: string | undefined;
+  PAPERCLIP_MIGRATION_PROMPT?: string | undefined;
+  [key: string]: string | undefined;
+}
+
+export interface MigrationEnvOptions {
+  autoMigrate: boolean;
+}
+
+export interface MigrationEnvUpdates {
+  PAPERCLIP_MIGRATION_AUTO_APPLY?: string;
+  PAPERCLIP_MIGRATION_PROMPT?: string;
+}
+
+/**
+ * Decide which migration-related env vars `paperclipai run` should set
+ * before importing the server.
+ *
+ * Rules:
+ * - `--no-auto-migrate` (autoMigrate=false): force `PAPERCLIP_MIGRATION_PROMPT=never`
+ *   so the server refuses to start against a stale schema and prints a clear
+ *   "run pnpm db:migrate" error instead of hanging on a stdin prompt.
+ * - Otherwise (autoMigrate=true, the default): set
+ *   `PAPERCLIP_MIGRATION_AUTO_APPLY=true` ONLY when neither env var is already
+ *   set by the caller. This preserves explicit user intent — if a user has
+ *   `PAPERCLIP_MIGRATION_PROMPT=never` exported, we honor it; we never override.
+ */
+export function resolveMigrationEnvUpdates(
+  env: MigrationEnvSnapshot,
+  opts: MigrationEnvOptions,
+): MigrationEnvUpdates {
+  if (!opts.autoMigrate) {
+    return { PAPERCLIP_MIGRATION_PROMPT: "never" };
+  }
+  const autoApplySet = typeof env.PAPERCLIP_MIGRATION_AUTO_APPLY === "string"
+    && env.PAPERCLIP_MIGRATION_AUTO_APPLY.length > 0;
+  const promptSet = typeof env.PAPERCLIP_MIGRATION_PROMPT === "string"
+    && env.PAPERCLIP_MIGRATION_PROMPT.length > 0;
+  if (autoApplySet || promptSet) return {};
+  return { PAPERCLIP_MIGRATION_AUTO_APPLY: "true" };
+}
+
+export function applyMigrationEnvUpdates(
+  env: NodeJS.ProcessEnv,
+  updates: MigrationEnvUpdates,
+): void {
+  if (updates.PAPERCLIP_MIGRATION_AUTO_APPLY !== undefined) {
+    env.PAPERCLIP_MIGRATION_AUTO_APPLY = updates.PAPERCLIP_MIGRATION_AUTO_APPLY;
+  }
+  if (updates.PAPERCLIP_MIGRATION_PROMPT !== undefined) {
+    env.PAPERCLIP_MIGRATION_PROMPT = updates.PAPERCLIP_MIGRATION_PROMPT;
+  }
+}

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -7,6 +7,10 @@ import pc from "picocolors";
 import { bootstrapCeoInvite } from "./auth-bootstrap-ceo.js";
 import { onboard } from "./onboard.js";
 import { doctor } from "./doctor.js";
+import {
+  applyMigrationEnvUpdates,
+  resolveMigrationEnvUpdates,
+} from "./run-migration-env.js";
 import { loadPaperclipEnvFile } from "../config/env.js";
 import { configExists, resolveConfigPath } from "../config/store.js";
 import type { PaperclipConfig } from "../config/schema.js";
@@ -23,6 +27,7 @@ interface RunOptions {
   repair?: boolean;
   yes?: boolean;
   bind?: "loopback" | "lan" | "tailnet";
+  autoMigrate?: boolean;
 }
 
 interface StartedServer {
@@ -79,6 +84,11 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     p.log.error(`No config found at ${configPath}.`);
     process.exit(1);
   }
+
+  applyMigrationEnvUpdates(
+    process.env,
+    resolveMigrationEnvUpdates(process.env, { autoMigrate: opts.autoMigrate ?? true }),
+  );
 
   p.log.step("Starting Paperclip server...");
   const startedServer = await importServerEntry();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -129,6 +129,8 @@ const run = program
   .option("--bind <mode>", "On first run, use onboarding reachability preset (loopback, lan, tailnet)")
   .option("--repair", "Attempt automatic repairs during doctor", true)
   .option("--no-repair", "Disable automatic repairs during doctor")
+  .option("--auto-migrate", "Auto-apply pending DB migrations on start", true)
+  .option("--no-auto-migrate", "Refuse to start when DB migrations are pending")
   .action(runCommand);
 
 registerRunCommands(run);


### PR DESCRIPTION
## Thinking Path

`npx paperclipai run` hung at boot. Tracing it: the server's pending-migration check (`server/src/index.ts:118-132`) drops into a raw `readline` prompt against `process.stdin`. The CLI's existing `--yes` plumbing wires through to `doctor()` only, so the server prompt was never gated. In a non-interactive shell (the npx wrapper, CI, any piped invocation), `readline` either blocks forever or rejects on EOF and the server refuses to start.

Two options considered:

1. **Default `run` to auto-apply (chosen).** `paperclipai run` is a bootstrap command — it already passes `yes: true` to doctor by default. Extending that posture to migrations matches user intent: someone typing `run` wants a running server, not a Y/N prompt about a database they haven't touched. Add `--no-auto-migrate` as the explicit opt-out for users who want a hard refuse-to-start against a stale schema.
2. **Default to refuse-to-start.** Safer in theory, but it just trades a hang for a fatal error on a command that's supposed to "just work." Rejected.

The env-resolution rules are extracted to a pure function so the precedence (explicit user env > CLI flag > new default) is testable without booting a server.

## What Changed

- `cli/src/commands/run-migration-env.ts` *(new)* — pure `resolveMigrationEnvUpdates(env, opts)` + `applyMigrationEnvUpdates(env, updates)`. Default (`autoMigrate: true`) sets `PAPERCLIP_MIGRATION_AUTO_APPLY=true` **only** when neither `PAPERCLIP_MIGRATION_AUTO_APPLY` nor `PAPERCLIP_MIGRATION_PROMPT` is already exported. `autoMigrate: false` forces `PAPERCLIP_MIGRATION_PROMPT=never`.
- `cli/src/commands/run.ts` — calls the resolver before `importServerEntry()`, mutating `process.env` so the server's existing env-var guards (`server/src/index.ts:119-120`) short-circuit the prompt.
- `cli/src/index.ts` — registers `--auto-migrate` / `--no-auto-migrate` flags on the `run` command. Default true.
- `cli/src/__tests__/run-migration-env.test.ts` *(new)* — 14 unit tests: default behavior, empty-string env handling, every explicit-override permutation, and `--no-auto-migrate` opt-out, plus two integration-style assertions that mirror the server's guard clauses.

No changes to the server, no changes to `db:migrate`, no behavior change for users who already export either env var.

## Verification

- `pnpm exec vitest run src/__tests__/run-migration-env.test.ts` — **14/14 pass**
- `pnpm run typecheck` — clean for the changed files. Pre-existing errors in `server/src/services/plugin-*.ts` (cannot resolve `@paperclipai/plugin-sdk`) reproduce on `master` without this diff and are unrelated.
- Manual verification (to run before merge):
  - [ ] `npx paperclipai run` on an instance with pending migrations: applies + starts without prompting
  - [ ] `npx paperclipai run --no-auto-migrate`: refuses to start with the existing "Run pnpm db:migrate or set PAPERCLIP_MIGRATION_AUTO_APPLY=true" error
  - [ ] `PAPERCLIP_MIGRATION_PROMPT=never npx paperclipai run`: still refuses to start (explicit env wins over the new default)
  - [ ] `PAPERCLIP_MIGRATION_AUTO_APPLY=true npx paperclipai run`: still applies (existing behavior unchanged)

## Risks

- **User who relied on the prompt as a manual gate is now silently auto-applied.** Mitigation: documented opt-out via `--no-auto-migrate` or `PAPERCLIP_MIGRATION_PROMPT=never`. The prior behavior in non-TTY shells was already auto-apply (`server/src/index.ts:121`), so this only changes behavior for users running `paperclipai run` from an interactive terminal who were answering N. Narrow blast radius.
- **No change to migration safety itself.** Same `applyPendingMigrations` codepath, same first-run guards, same drift-repair logic. Just gates the prompt.
- **Scope strictly limited to the `run` command.** `pnpm db:migrate`, `worktree` commands, and direct server starts retain prior prompt behavior. If you import `@paperclipai/server` yourself, nothing changes.
- **No env var name collision.** `PAPERCLIP_MIGRATION_AUTO_APPLY` and `PAPERCLIP_MIGRATION_PROMPT` are pre-existing public env vars referenced in the server's "Refusing to start" error message — this PR just opts `run` into them automatically.

## Model Used

Claude Opus 4.7 (1M context).