### PR TITLE
feat: allow manager agents to create and manage routines for subordinates

### DIFF
--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -8,6 +8,9 @@ const routineId = "33333333-3333-4333-8333-333333333333";
 const projectId = "44444444-4444-4444-8444-444444444444";
 const otherAgentId = "55555555-5555-4555-8555-555555555555";
 const revisionId = "77777777-7777-4777-8777-777777777777";
+const managerAgentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const subordinateAgentId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const peerAgentId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 
 const routine = {
   id: routineId,
@@ -119,6 +122,11 @@ const mockAccessService = vi.hoisted(() => ({
   canUser: vi.fn(),
 }));
 
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+}));
+
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockTrackRoutineCreated = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
@@ -149,6 +157,7 @@ function registerModuleMocks() {
 
   vi.doMock("../services/index.js", () => ({
     accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
     logActivity: mockLogActivity,
     routineService: () => mockRoutineService,
   }));
@@ -204,6 +213,7 @@ describe("routine routes", () => {
       status: "issue_created",
     });
     mockAccessService.canUser.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue(null);
     mockLogActivity.mockResolvedValue(undefined);
   });
 
@@ -466,5 +476,142 @@ describe("routine routes", () => {
       runId: null,
     });
     expect(mockTrackRoutineCreated).toHaveBeenCalledWith(expect.anything());
+  });
+
+  describe("manager agent chain-of-command routine access", () => {
+    const subordinateRoutine = {
+      id: routineId,
+      companyId,
+      projectId,
+      goalId: null,
+      parentIssueId: null,
+      title: "Subordinate routine",
+      description: null,
+      assigneeAgentId: subordinateAgentId,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+      variables: [],
+      latestRevisionId: revisionId,
+      latestRevisionNumber: 1,
+      createdByAgentId: null,
+      createdByUserId: null,
+      updatedByAgentId: null,
+      updatedByUserId: null,
+      lastTriggeredAt: null,
+      lastEnqueuedAt: null,
+      createdAt: new Date("2026-03-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-20T00:00:00.000Z"),
+    };
+
+    function setupManagerChain() {
+      // subordinateAgentId.reportsTo = managerAgentId
+      mockAgentService.getById.mockImplementation(async (id: string) => {
+        if (id === subordinateAgentId) return { id: subordinateAgentId, reportsTo: managerAgentId };
+        if (id === managerAgentId) return { id: managerAgentId, reportsTo: null };
+        if (id === peerAgentId) return { id: peerAgentId, reportsTo: null };
+        return null;
+      });
+    }
+
+    it("allows a manager to create a routine for a direct subordinate", async () => {
+      setupManagerChain();
+      const app = await createApp({ type: "agent", agentId: managerAgentId, companyId });
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/routines`)
+        .send({ projectId, title: "Subordinate daily routine", assigneeAgentId: subordinateAgentId });
+
+      expect(res.status).toBe(201);
+      expect(mockRoutineService.create).toHaveBeenCalled();
+    });
+
+    it("blocks a non-manager agent from creating a routine for another agent", async () => {
+      setupManagerChain();
+      const app = await createApp({ type: "agent", agentId: peerAgentId, companyId });
+
+      const res = await request(app)
+        .post(`/api/companies/${companyId}/routines`)
+        .send({ projectId, title: "Peer routine", assigneeAgentId: subordinateAgentId });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/subordinates/);
+      expect(mockRoutineService.create).not.toHaveBeenCalled();
+    });
+
+    it("allows a manager to update a subordinate's routine", async () => {
+      setupManagerChain();
+      mockRoutineService.get.mockResolvedValue(subordinateRoutine);
+      mockRoutineService.update.mockResolvedValue({ ...subordinateRoutine, title: "Updated" });
+      const app = await createApp({ type: "agent", agentId: managerAgentId, companyId });
+
+      const res = await request(app)
+        .patch(`/api/routines/${routineId}`)
+        .send({ title: "Updated" });
+
+      expect(res.status).toBe(200);
+      expect(mockRoutineService.update).toHaveBeenCalled();
+    });
+
+    it("blocks a peer agent from updating another agent's routine", async () => {
+      setupManagerChain();
+      mockRoutineService.get.mockResolvedValue(subordinateRoutine);
+      const app = await createApp({ type: "agent", agentId: peerAgentId, companyId });
+
+      const res = await request(app)
+        .patch(`/api/routines/${routineId}`)
+        .send({ title: "Hijacked" });
+
+      expect(res.status).toBe(403);
+      expect(mockRoutineService.update).not.toHaveBeenCalled();
+    });
+
+    it("allows a manager to reassign a subordinate's routine to another subordinate", async () => {
+      setupManagerChain();
+      mockRoutineService.get.mockResolvedValue(subordinateRoutine);
+      mockAgentService.getById.mockImplementation(async (id: string) => {
+        if (id === subordinateAgentId) return { id: subordinateAgentId, reportsTo: managerAgentId };
+        if (id === otherAgentId) return { id: otherAgentId, reportsTo: managerAgentId };
+        if (id === managerAgentId) return { id: managerAgentId, reportsTo: null };
+        return null;
+      });
+      mockRoutineService.update.mockResolvedValue({ ...subordinateRoutine, assigneeAgentId: otherAgentId });
+      const app = await createApp({ type: "agent", agentId: managerAgentId, companyId });
+
+      const res = await request(app)
+        .patch(`/api/routines/${routineId}`)
+        .send({ assigneeAgentId: otherAgentId });
+
+      expect(res.status).toBe(200);
+      expect(mockRoutineService.update).toHaveBeenCalled();
+    });
+
+    it("blocks a manager from reassigning a subordinate's routine to a non-subordinate", async () => {
+      setupManagerChain();
+      mockRoutineService.get.mockResolvedValue(subordinateRoutine);
+      const app = await createApp({ type: "agent", agentId: managerAgentId, companyId });
+
+      const res = await request(app)
+        .patch(`/api/routines/${routineId}`)
+        .send({ assigneeAgentId: peerAgentId });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/subordinates/);
+      expect(mockRoutineService.update).not.toHaveBeenCalled();
+    });
+
+    it("allows a manager to delete a trigger on a subordinate's routine", async () => {
+      setupManagerChain();
+      mockRoutineService.get.mockResolvedValue(subordinateRoutine);
+      mockRoutineService.getTrigger.mockResolvedValue({ ...trigger, routineId });
+      mockRoutineService.deleteTrigger.mockResolvedValue({ trigger, revision: null });
+      const app = await createApp({ type: "agent", agentId: managerAgentId, companyId });
+
+      const res = await request(app).delete(`/api/routine-triggers/${trigger.id}`);
+
+      expect(res.status).toBe(204);
+      expect(mockRoutineService.deleteTrigger).toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -10,7 +10,7 @@ import {
 } from "@paperclipai/shared";
 import { trackRoutineCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { accessService, logActivity, routineService } from "../services/index.js";
+import { accessService, agentService, logActivity, routineService } from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { forbidden, unauthorized } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
@@ -25,6 +25,21 @@ export function routineRoutes(
     pluginWorkerManager: options.pluginWorkerManager,
   });
   const access = accessService(db);
+  const agentsSvc = agentService(db);
+
+  async function isManagerOf(actorAgentId: string, assigneeAgentId: string): Promise<boolean> {
+    let cursor: string | null = assigneeAgentId;
+    const visited = new Set<string>();
+    for (let depth = 0; cursor && depth < 50; depth++) {
+      if (visited.has(cursor)) break;
+      visited.add(cursor);
+      const agent = await agentsSvc.getById(cursor);
+      if (!agent) break;
+      if (agent.reportsTo === actorAgentId) return true;
+      cursor = agent.reportsTo ?? null;
+    }
+    return false;
+  }
 
   async function assertBoardCanAssignTasks(req: Request, companyId: string) {
     assertCompanyAccess(req, companyId);
@@ -36,13 +51,13 @@ export function routineRoutes(
     }
   }
 
-  function assertCanManageCompanyRoutine(req: Request, companyId: string, assigneeAgentId?: string | null) {
+  async function assertCanManageCompanyRoutine(req: Request, companyId: string, assigneeAgentId?: string | null) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") return;
     if (req.actor.type !== "agent" || !req.actor.agentId) throw unauthorized();
-    if (assigneeAgentId !== req.actor.agentId) {
-      throw forbidden("Agents can only manage routines assigned to themselves");
-    }
+    if (assigneeAgentId === req.actor.agentId) return;
+    if (assigneeAgentId && await isManagerOf(req.actor.agentId, assigneeAgentId)) return;
+    throw forbidden("Agents can only manage routines assigned to themselves or their subordinates");
   }
 
   async function assertCanManageExistingRoutine(req: Request, routineId: string) {
@@ -51,10 +66,9 @@ export function routineRoutes(
     assertCompanyAccess(req, routine.companyId);
     if (req.actor.type === "board") return routine;
     if (req.actor.type !== "agent" || !req.actor.agentId) throw unauthorized();
-    if (routine.assigneeAgentId !== req.actor.agentId) {
-      throw forbidden("Agents can only manage routines assigned to themselves");
-    }
-    return routine;
+    if (routine.assigneeAgentId === req.actor.agentId) return routine;
+    if (routine.assigneeAgentId && await isManagerOf(req.actor.agentId, routine.assigneeAgentId)) return routine;
+    throw forbidden("Agents can only manage routines assigned to themselves or their subordinates");
   }
 
   async function logRoutineRevisionCreated(req: Request, input: {
@@ -96,7 +110,7 @@ export function routineRoutes(
   router.post("/companies/:companyId/routines", validate(createRoutineSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
     await assertBoardCanAssignTasks(req, companyId);
-    assertCanManageCompanyRoutine(req, companyId, req.body.assigneeAgentId);
+    await assertCanManageCompanyRoutine(req, companyId, req.body.assigneeAgentId);
     const created = await svc.create(companyId, req.body, {
       agentId: req.actor.type === "agent" ? req.actor.agentId : null,
       userId: req.actor.type === "board" ? req.actor.userId ?? "board" : null,
@@ -173,7 +187,11 @@ export function routineRoutes(
       req.body.assigneeAgentId !== undefined &&
       req.body.assigneeAgentId !== req.actor.agentId
     ) {
-      throw forbidden("Agents can only assign routines to themselves");
+      const newAssignee = req.body.assigneeAgentId as string | null;
+      const actorAgentId = req.actor.agentId as string;
+      if (!newAssignee || !await isManagerOf(actorAgentId, newAssignee)) {
+        throw forbidden("Agents can only assign routines to themselves or their subordinates");
+      }
     }
     const updated = await svc.update(routine.id, req.body, {
       agentId: req.actor.type === "agent" ? req.actor.agentId : null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, where a hierarchy of manager and subordinate agents collaborate on work
> - The routines subsystem handles recurring automated tasks — agents wake up, process their assignments, and reschedule future runs
> - Routine authorization currently enforces: *"Agents can only manage routines assigned to themselves"*
> - This blocks a manager agent (e.g. `A - Project Manager`) from creating a routine assigned to a subordinate (e.g. `A - DevOps Engineer`) even when the subordinate is in their reporting chain
> - The `chainOfCommand` concept already exists in Paperclip: `hasActiveCheckoutManagementOverride` in `routes/issues.ts` uses the same `reportsTo` chain walk to let managers intervene in subordinates' active issue checkouts
> - This pull request reuses that exact pattern for routine management: if the requesting agent's `agentId` appears in the `reportsTo` chain of the routine's assignee, the request is allowed
> - The benefit is that managers can set up recurring workflows for their team without requiring each subordinate agent to self-bootstrap, unblocking automated onboarding/offboarding flows

## What Changed

- `server/src/routes/routines.ts`:
  - Import `agentService` and instantiate it alongside the existing services
  - Add `isManagerOf(actorAgentId, assigneeAgentId)` helper that walks the `reportsTo` chain from the assignee upward (max 50 hops, cycle-safe) and returns `true` if the actor is found
  - `assertCanManageCompanyRoutine` — converted from `function` to `async function`; now allows when `assigneeAgentId === actorAgentId` OR `isManagerOf` returns true
  - `assertCanManageExistingRoutine` — same manager check added after the self-ownership check
  - `PATCH /routines/:id` inline assignee-change guard — now allows reassignment when the new assignee is also a subordinate of the requesting agent
- `server/src/__tests__/routines-routes.test.ts`:
  - Added `mockAgentService` (with `getById`) to the service mocks
  - Added 6 new tests in a `manager agent chain-of-command routine access` describe block covering: manager create for subordinate (✓), peer create blocked (✗), manager update subordinate (✓), peer update blocked (✗), manager reassign to another subordinate (✓), manager reassign to non-subordinate blocked (✗), manager delete trigger on subordinate routine (✓)

## Verification

```bash
# Run the targeted test suite
cd server
NODE_ENV=test pnpm exec vitest run --project @paperclipai/server \
  "src/__tests__/routines-routes.test.ts" \
  --pool=forks --poolOptions.forks.isolate=true
# Expected: 20 tests passed
```

All 20 tests pass (13 existing + 7 new). Full build and typecheck also pass.

## Risks

- **Low risk** — additive change. The new code path only activates when `assigneeAgentId !== actorAgentId` (which previously always threw); existing self-management behavior is unchanged.
- The `isManagerOf` helper has a 50-hop depth limit and a visited-node cycle guard, matching the pattern in `getChainOfCommand` in `services/agents.ts`.
- No schema or migration changes.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Extended thinking: no
- Tool use: yes (file reads, edits, bash commands for build/test)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge

Closes #7448