### PR TITLE
Fix cancelled child blocker attention

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -282,6 +282,40 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("ignores cancelled child-only edges when classifying blocker attention", async () => {
+    const { companyId, agentId } = await createCompany("PBT");
+    const parentId = await insertIssue({ companyId, identifier: "PBT-1", title: "Parent", status: "blocked" });
+    const activeBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBT-2",
+      title: "Running blocker",
+      status: "todo",
+      assigneeAgentId: agentId,
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBT-3",
+      title: "Cancelled child",
+      status: "cancelled",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: activeBlockerId, blockedIssueId: parentId });
+    await activeRun({ companyId, agentId, issueId: activeBlockerId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_dependency",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBT-2",
+    });
+  });
+
   it("does not let another company's active run cover the blocker", async () => {
     const { companyId, agentId } = await createCompany("PBS");
     const other = await createCompany("PBT");

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1566,7 +1566,7 @@ async function listIssueBlockerAttentionMap(
           and(
             eq(issues.companyId, companyId),
             inArray(issues.parentId, chunk),
-            ne(issues.status, "done"),
+            notInArray(issues.status, ["done", "cancelled"]),
           ),
         );
       const [explicitBlockerRows, childRows] = await Promise.all([


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue control-plane surfaces blocker chains so managers can tell whether blocked work has a live path or needs intervention.
> - Blocker attention currently walks both explicit blocker links and child issue edges.
> - Cancelled child-only issues can still be pulled into that traversal, causing cancelled work to appear as the attention sample on an otherwise live blocker chain.
> - WEI-111 shows that failure mode by reporting cancelled WEI-2311 as the sample even though its visible direct blocker is WEI-2841.
> - This pull request excludes cancelled child-only edges from blocker-attention traversal while preserving explicit blocker relations.
> - The benefit is that blocked issue attention points managers at current actionable blockers instead of cancelled historical child work.

## What Changed

- Excluded cancelled child issues from the `listIssueBlockerAttentionMap` child-edge query.
- Added an embedded Postgres regression proving a cancelled child-only edge no longer changes a covered dependency into an attention-needed blocker.

## Verification

- `pnpm vitest run server/src/__tests__/issue-blocker-attention.test.ts`
- Live pre-patch evidence from the local Paperclip API: WEI-111 direct blocker is WEI-2841, while `blockerAttention.sampleBlockerIdentifier` still reports cancelled WEI-2311 before this runtime patch is deployed.

## Risks

- Low risk. This only removes cancelled child-only edges from the blocker-attention graph; explicit blocker relationships to cancelled issues are still queried and can still be surfaced when they are the actual blocker relation.

## Model Used

- OpenAI Codex CLI, GPT-5 coding agent, tool-assisted local code editing and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge