### PR TITLE
Make session-compaction maxRawInputTokens cache-aware (count cached input tokens)

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -6,6 +6,7 @@ import {
   applyPersistedExecutionWorkspaceConfig,
   buildRealizedExecutionWorkspaceFromPersisted,
   buildExplicitResumeSessionOverride,
+  computeSessionCompactionReason,
   deriveTaskKeyWithHeartbeatFallback,
   extractWakeCommentIds,
   formatRuntimeWorkspaceWarningLog,
@@ -540,6 +541,92 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
     expect(
       prioritizeProjectWorkspaceCandidatesForRun(rows, "workspace-9").map((row) => row.id),
     ).toEqual(["workspace-1", "workspace-2"]);
+  });
+});
+
+describe("computeSessionCompactionReason", () => {
+  const policy = {
+    enabled: true,
+    maxSessionRuns: 0,
+    maxRawInputTokens: 150_000,
+    maxSessionAgeHours: 0,
+  };
+
+  it("rotates on a cache-heavy run where non-cached input alone is tiny", () => {
+    // Models the MC v2 (THIAAAAAA-1103) signature: real context ~352K is almost
+    // entirely cache_read tokens while non-cached input never exceeds ~7.5K.
+    const reason = computeSessionCompactionReason({
+      policy,
+      runCount: 1,
+      latestRawUsage: {
+        inputTokens: 7_500,
+        cachedInputTokens: 344_500,
+        outputTokens: 2_000,
+      },
+      sessionAgeHours: 0,
+    });
+
+    expect(reason).toBe("session raw input reached 352,000 tokens (threshold 150,000)");
+  });
+
+  it("does not rotate when total context (input + cached) stays under the ceiling", () => {
+    expect(
+      computeSessionCompactionReason({
+        policy,
+        runCount: 1,
+        latestRawUsage: {
+          inputTokens: 7_500,
+          cachedInputTokens: 100_000,
+          outputTokens: 2_000,
+        },
+        sessionAgeHours: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("would never fire on the cache-heavy run if only non-cached input were counted", () => {
+    // Regression guard for the pre-fix behaviour: non-cached inputTokens (7.5K)
+    // is far below the 150K ceiling, so the old check stayed silent.
+    expect(7_500 >= policy.maxRawInputTokens).toBe(false);
+    expect(
+      computeSessionCompactionReason({
+        policy,
+        runCount: 1,
+        latestRawUsage: { inputTokens: 7_500, cachedInputTokens: 344_500, outputTokens: 0 },
+        sessionAgeHours: 0,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("still rotates on run-count and age thresholds", () => {
+    expect(
+      computeSessionCompactionReason({
+        policy: { enabled: true, maxSessionRuns: 25, maxRawInputTokens: 0, maxSessionAgeHours: 0 },
+        runCount: 26,
+        latestRawUsage: null,
+        sessionAgeHours: 0,
+      }),
+    ).toBe("session exceeded 25 runs");
+
+    expect(
+      computeSessionCompactionReason({
+        policy: { enabled: true, maxSessionRuns: 0, maxRawInputTokens: 0, maxSessionAgeHours: 72 },
+        runCount: 1,
+        latestRawUsage: null,
+        sessionAgeHours: 80,
+      }),
+    ).toBe("session age reached 80 hours");
+  });
+
+  it("returns null when no thresholds are configured", () => {
+    expect(
+      computeSessionCompactionReason({
+        policy: { enabled: true, maxSessionRuns: 0, maxRawInputTokens: 0, maxSessionAgeHours: 0 },
+        runCount: 100,
+        latestRawUsage: { inputTokens: 1_000_000, cachedInputTokens: 1_000_000, outputTokens: 0 },
+        sessionAgeHours: 1_000,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1524,6 +1524,43 @@ export function parseSessionCompactionPolicy(agent: typeof agents.$inferSelect):
   return resolveSessionCompactionPolicy(agent.adapterType, agent.runtimeConfig).policy;
 }
 
+/**
+ * Decide whether a session should rotate, returning a human-readable reason or
+ * null. Pure helper so the threshold logic can be unit-tested independently of
+ * the DB-backed {@link evaluateSessionCompaction} closure.
+ *
+ * The raw-input-token check counts BOTH non-cached input and cache_read input
+ * (`inputTokens + cachedInputTokens`) because that sum is the true size of the
+ * context re-fed to the model each run. For prompt-caching adapters (e.g.
+ * claude_local) a resumed bloated context is almost entirely cache_read tokens,
+ * so comparing `inputTokens` alone is structurally blind and never fires
+ * (THIAAAAAA-1743).
+ */
+export function computeSessionCompactionReason(input: {
+  policy: SessionCompactionPolicy;
+  runCount: number;
+  latestRawUsage: UsageTotals | null;
+  sessionAgeHours: number;
+}): string | null {
+  const { policy, runCount, latestRawUsage, sessionAgeHours } = input;
+  if (policy.maxSessionRuns > 0 && runCount > policy.maxSessionRuns) {
+    return `session exceeded ${policy.maxSessionRuns} runs`;
+  }
+  if (policy.maxRawInputTokens > 0 && latestRawUsage) {
+    const totalContextTokens = latestRawUsage.inputTokens + latestRawUsage.cachedInputTokens;
+    if (totalContextTokens >= policy.maxRawInputTokens) {
+      return (
+        `session raw input reached ${formatCount(totalContextTokens)} tokens ` +
+        `(threshold ${formatCount(policy.maxRawInputTokens)})`
+      );
+    }
+  }
+  if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
+    return `session age reached ${Math.floor(sessionAgeHours)} hours`;
+  }
+  return null;
+}
+
 export function resolveRuntimeSessionParamsForWorkspace(input: {
   agentId: string;
   previousSessionParams: Record<string, unknown> | null;
@@ -3524,20 +3561,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           )
         : 0;
 
-    let reason: string | null = null;
-    if (policy.maxSessionRuns > 0 && runs.length > policy.maxSessionRuns) {
-      reason = `session exceeded ${policy.maxSessionRuns} runs`;
-    } else if (
-      policy.maxRawInputTokens > 0 &&
-      latestRawUsage &&
-      latestRawUsage.inputTokens >= policy.maxRawInputTokens
-    ) {
-      reason =
-        `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
-        `(threshold ${formatCount(policy.maxRawInputTokens)})`;
-    } else if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
-      reason = `session age reached ${Math.floor(sessionAgeHours)} hours`;
-    }
+    const reason = computeSessionCompactionReason({
+      policy,
+      runCount: runs.length,
+      latestRawUsage,
+      sessionAgeHours,
+    });
 
     if (!reason || !latestRun) {
       return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, waking each agent in short heartbeats that resume a persistent session.
> - Long-lived sessions are kept healthy by `evaluateSessionCompaction` in `server/src/services/heartbeat.ts`, which rotates (compacts) a session once its re-fed context grows too large, via three levers: `maxRawInputTokens`, `maxSessionRuns`, and `maxSessionAgeHours`.
> - The token lever compared only the **non-cached** `latestRawUsage.inputTokens` against `policy.maxRawInputTokens`.
> - For prompt-caching adapters (e.g. `claude_local`) a resumed bloated context is almost entirely `cache_read_input_tokens`, so the non-cached `inputTokens` stays tiny while the *real* re-fed context is huge — the token check is structurally blind and never fires.
> - Measured on a real cache-heavy session, true context peaked at ~352K tokens while non-cached `input_tokens` never exceeded ~7.5K, so operators had to lean on `maxSessionRuns` as a coarse run-count proxy instead of a true token ceiling.
> - This pull request makes the token check count `inputTokens + cachedInputTokens` (the true re-fed context size), so `maxRawInputTokens` becomes a precise ceiling that fires on cache-heavy sessions.
> - The benefit is that the token lever works as designed on all adapters, including prompt-caching ones, instead of silently never firing.

## What Changed

- `server/src/services/heartbeat.ts`: `evaluateSessionCompaction` now compares `inputTokens + cachedInputTokens` against `policy.maxRawInputTokens` (previously only the non-cached `inputTokens`). Run-count and age checks are unchanged.
- Extracted the threshold decision into a pure, exported `computeSessionCompactionReason()` helper so the rotation logic is unit-testable without the DB-backed closure.
- `server/src/__tests__/heartbeat-workspace-session.test.ts`: added tests covering the cache-heavy signature (~352K real context, ~7.5K non-cached input → now rotates) plus a regression guard proving the old non-cached-only check would have stayed silent.

## Verification

- `pnpm --filter server test heartbeat-workspace-session` → all pass (44/44 locally), including the new cache-heavy rotation tests.
- `tsc -p server/tsconfig.json --noEmit` → clean.
- The change is a single isolated commit touching only `heartbeat.ts` and its test; it does not modify any config defaults, so existing `maxRawInputTokens` values simply become accurate (cache-inclusive) ceilings.

## Risks

- Low risk, but it touches a core path (`evaluateSessionCompaction` runs for every agent's session rotation). Because the new sum is always ≥ the old value, the only behavioral change is that sessions which *should* have rotated on the token ceiling but didn't (cache-heavy ones) now do. Sessions already under the ceiling are unaffected.
- No schema or migration changes. Fully revertable as a standalone commit, independent of any operator config lever.

## Model Used

- Claude (Anthropic), model ID `claude-opus-4-8`, extended-thinking + tool-use enabled, operating as an autonomous Paperclip agent. Local test/typecheck verification run via tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

<sub>Note: no UI changes — screenshots N/A. This is a small, focused bug/robustness fix per CONTRIBUTING Path 1 (one logical change, two files).</sub>
