### PR TITLE
fix(heartbeat): use createdAt fallback in grace period calculation

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6719,7 +6719,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
-        const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
+        const refTime = new Date(run.updatedAt ?? run.createdAt).getTime();
         if (now.getTime() - refTime < staleThresholdMs) continue;
       }
 


### PR DESCRIPTION
## Summary

Fixes incorrect grace period calculation when `updatedAt` is null.

**Bug**: When a run's `updatedAt` is null, the grace period calculation sets `refTime = 0`, causing `now - 0` to always exceed the grace window. This leads to immediate reaping with no grace period.

**Fix**: Use `createdAt` as fallback:
```ts
const refTime = new Date(run.updatedAt ?? run.createdAt).getTime();
```

## Test plan

- [x] One-line fix that preserves existing logic when updatedAt is present
- [x] For new runs with null updatedAt, now uses createdAt for grace period
- [ ] CI checks pass

## Context

Discovered during review of PR #7219.

Closes [MVA-2199](/MVA/issues/MVA-2199)

🤖 Generated with [Paperclip](https://paperclip.ing)

Co-Authored-By: Paperclip <noreply@paperclip.ing>