### PR TITLE
fix(adapter): kill process group on close; add 2h default timeout for claude_local

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2264,6 +2264,12 @@ export async function runChildProcess(
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
+          // Kill any surviving descendants in the process group (e.g. claude --tools
+          // subagents still executing a tool call when the main agent exited). Without
+          // this, they are reparented to init and accumulate indefinitely.
+          if (process.platform !== "win32" && processGroupId && processGroupId > 0) {
+            try { process.kill(-processGroupId, "SIGKILL"); } catch { /* group already gone */ }
+          }
           void logChain.finally(() => {
             void Promise.resolve()
               .then(() => target.cleanup?.())

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -276,7 +276,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   );
   const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
     executionTarget,
-    asNumber(config.timeoutSec, 0),
+    asNumber(config.timeoutSec, 7200), // default 2h; configurable via timeoutSec in adapter config
   );
   const graceSec = asNumber(config.graceSec, 20);
   await ensureAdapterExecutionTargetRuntimeCommandInstalled({


### PR DESCRIPTION
## Root Cause

When the main claude agent process exits naturally, orphaned subagents (`claude --tools`) spawned for tool calls were reparented to init and accumulated indefinitely — each consuming ~300MB. Over several hours with many concurrent agents this exhausted all available RAM and caused an OOM kill.

**Evidence:**
- `runChildProcess` close handler (server-utils.ts) had no `signalRunningProcess` call on natural exit — only the timeout and `terminalResultCleanup` paths kill the process group
- `claude_local` had `timeoutSec` defaulting to 0 (no timeout), so the timeout path never fired either
- Within 9 minutes of a fresh WSL boot, two orphaned `claude --tools` processes (PPID=1) were already visible

## Fixes

**1. Kill process group on close** (`packages/adapter-utils/src/server-utils.ts`)

In the `close` handler, after the main child exits, send SIGKILL to the process group. This reaps any surviving descendants (tool-use subagents, shell commands, etc.) immediately — whether the run succeeded, failed, or hit max_turns.

**2. Default 2-hour timeout for claude_local** (`packages/adapters/claude-local/src/server/execute.ts`)

Change the `timeoutSec` default from 0 (unbounded) to 7200s (2 hours) as a backstop for stuck/hung agent processes that never exit naturally. Configurable per-agent via `timeoutSec` in the adapter config.

## Test Plan

- [ ] Start a heartbeat run; confirm that after it completes, no orphaned `claude --tools` processes remain (`ps -u $USER -o pid,ppid,cmd | grep 'claude --tools'`)
- [ ] Confirm normal run completion still resolves correctly (no regression from the SIGKILL — the group should already be gone)
- [ ] Run `pnpm test` in `packages/adapter-utils`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)