### PR TITLE
feat(adapter): add amplifier-local for the Amplifier engine

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@clack/prompts": "^0.10.0",
     "@paperclipai/adapter-acpx-local": "workspace:*",
+    "@paperclipai/adapter-amplifier-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -1,6 +1,7 @@
 import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
 import { printAcpxStreamEvent } from "@paperclipai/adapter-acpx-local/cli";
 import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
+import { printAmplifierLocalStreamEvent } from "@paperclipai/adapter-amplifier-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printCursorCloudEvent } from "@paperclipai/adapter-cursor-cloud/cli";
@@ -20,6 +21,11 @@ const claudeLocalCLIAdapter: CLIAdapterModule = {
 const acpxLocalCLIAdapter: CLIAdapterModule = {
   type: "acpx_local",
   formatStdoutEvent: printAcpxStreamEvent,
+};
+
+const amplifierLocalCLIAdapter: CLIAdapterModule = {
+  type: "amplifier_local",
+  formatStdoutEvent: printAmplifierLocalStreamEvent,
 };
 
 const codexLocalCLIAdapter: CLIAdapterModule = {
@@ -66,6 +72,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     acpxLocalCLIAdapter,
     claudeLocalCLIAdapter,
+    amplifierLocalCLIAdapter,
     codexLocalCLIAdapter,
     openCodeLocalCLIAdapter,
     piLocalCLIAdapter,

--- a/packages/adapters/amplifier-local/package.json
+++ b/packages/adapters/amplifier-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-amplifier-local",
+  "version": "0.0.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/amplifier-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "amplifier-agent-ts": "^0.6.1",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/amplifier-local/src/__tests__/build-config.test.ts
+++ b/packages/adapters/amplifier-local/src/__tests__/build-config.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the UI form → adapterConfig builder.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { buildAmplifierLocalConfig } from "../ui/build-config.js";
+import { DEFAULT_AMPLIFIER_LOCAL_MODEL } from "../index.js";
+
+function vals(over: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    name: "test agent",
+    role: "ic",
+    description: "",
+    instructionsFilePath: "",
+    cwd: "",
+    model: "",
+    envBindings: {},
+    envVars: "",
+    promptTemplate: "",
+    command: "",
+    extraArgs: "",
+    ...over,
+  } as unknown as CreateConfigValues;
+}
+
+describe("buildAmplifierLocalConfig", () => {
+  it("supplies sensible defaults", () => {
+    const cfg = buildAmplifierLocalConfig(vals());
+    expect(cfg.model).toBe(DEFAULT_AMPLIFIER_LOCAL_MODEL);
+    expect(cfg.timeoutSec).toBe(0);
+    expect(cfg.graceSec).toBe(15);
+    expect(cfg.cwd).toBeUndefined();
+    expect(cfg.instructionsFilePath).toBeUndefined();
+  });
+
+  it("preserves the operator's model selection", () => {
+    const cfg = buildAmplifierLocalConfig(vals({ model: "claude-sonnet-4-5" }));
+    expect(cfg.model).toBe("claude-sonnet-4-5");
+  });
+
+  it("emits env bindings only when set", () => {
+    const cfgEmpty = buildAmplifierLocalConfig(vals());
+    expect(cfgEmpty.env).toBeUndefined();
+
+    const cfg = buildAmplifierLocalConfig(
+      vals({
+        envBindings: {
+          ANTHROPIC_API_KEY: { type: "plain", value: "sk-xyz" },
+        } as unknown as Record<string, unknown>,
+      }),
+    );
+    expect(cfg.env).toEqual({
+      ANTHROPIC_API_KEY: { type: "plain", value: "sk-xyz" },
+    });
+  });
+
+  it("merges legacy KEY=VALUE env-vars text without overwriting structured bindings", () => {
+    const cfg = buildAmplifierLocalConfig(
+      vals({
+        envBindings: {
+          ANTHROPIC_API_KEY: { type: "secret_ref", value: "secret://ant" },
+        } as unknown as Record<string, unknown>,
+        envVars: "ANTHROPIC_API_KEY=overridden\nOPENAI_API_KEY=sk-legacy" as unknown as string,
+      }),
+    );
+    const env = cfg.env as Record<string, { type: string; value: string }>;
+    // Structured binding wins; legacy fills only the missing key.
+    expect(env.ANTHROPIC_API_KEY).toEqual({ type: "secret_ref", value: "secret://ant" });
+    expect(env.OPENAI_API_KEY).toEqual({ type: "plain", value: "sk-legacy" });
+  });
+
+  it("parses extraArgs as a comma-separated list", () => {
+    const cfg = buildAmplifierLocalConfig(
+      vals({ extraArgs: "--verbose, --foo=bar" as unknown as string }),
+    );
+    expect(cfg.extraArgs).toEqual(["--verbose", "--foo=bar"]);
+  });
+
+  it("emits workspaceStrategy when git_worktree is selected", () => {
+    const cfg = buildAmplifierLocalConfig(
+      vals({
+        workspaceStrategyType: "git_worktree",
+        workspaceBaseRef: "main",
+        workspaceBranchTemplate: "agent/{{slug}}",
+      } as unknown as Partial<CreateConfigValues>),
+    );
+    expect(cfg.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      baseRef: "main",
+      branchTemplate: "agent/{{slug}}",
+    });
+  });
+});

--- a/packages/adapters/amplifier-local/src/__tests__/parse-stdout.test.ts
+++ b/packages/adapters/amplifier-local/src/__tests__/parse-stdout.test.ts
@@ -1,0 +1,174 @@
+/**
+ * UI transcript-parser tests.
+ *
+ * Verifies that:
+ *   - The §4.1 envelope (final stdout line) yields init + result entries.
+ *   - The 9 wire notifications on stderr map to the right TranscriptEntry kinds.
+ *   - Non-JSON / malformed lines fall through to a stdout entry.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseAmplifierLocalStdoutLine } from "../ui/parse-stdout.js";
+
+const TS = "2026-06-03T17:00:00.000Z";
+
+describe("parseAmplifierLocalStdoutLine — envelope path", () => {
+  it("yields init + result entries for a successful envelope", () => {
+    const envelope = {
+      protocolVersion: "0.3.0",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      reply: "Hello from Amplifier",
+      error: null,
+      metadata: {
+        tokensIn: 100,
+        tokensOut: 200,
+        durationMs: 1500,
+        bundleDigest: "abc123",
+        engineVersion: "0.4.1",
+      },
+    };
+    const entries = parseAmplifierLocalStdoutLine(JSON.stringify(envelope), TS);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ kind: "init", sessionId: "sess-1" });
+    expect(entries[1]).toMatchObject({
+      kind: "result",
+      text: "Hello from Amplifier",
+      inputTokens: 100,
+      outputTokens: 200,
+      isError: false,
+    });
+  });
+
+  it("marks the result as error when the envelope has an error block", () => {
+    const envelope = {
+      protocolVersion: "0.3.0",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      reply: "",
+      error: {
+        code: "provider_init_failed",
+        message: "OpenAI 401",
+        classification: "transport",
+      },
+      metadata: {},
+    };
+    const entries = parseAmplifierLocalStdoutLine(JSON.stringify(envelope), TS);
+    const result = entries.find((e) => e.kind === "result");
+    expect(result).toMatchObject({
+      isError: true,
+      subtype: "transport",
+      errors: ["OpenAI 401"],
+    });
+  });
+});
+
+describe("parseAmplifierLocalStdoutLine — wire notifications", () => {
+  function notif(method: string, params: Record<string, unknown>): string {
+    return JSON.stringify({ method, params });
+  }
+
+  it("maps result/delta to assistant entry", () => {
+    const entries = parseAmplifierLocalStdoutLine(
+      notif("result/delta", { sessionId: "s", turnId: "t", text: "partial reply" }),
+      TS,
+    );
+    expect(entries).toEqual([{ kind: "assistant", ts: TS, text: "partial reply" }]);
+  });
+
+  it("maps tool/started to tool_call entry", () => {
+    const entries = parseAmplifierLocalStdoutLine(
+      notif("tool/started", {
+        sessionId: "s",
+        turnId: "t",
+        toolCallId: "tc-1",
+        name: "bash",
+        args: { command: "ls" },
+      }),
+      TS,
+    );
+    expect(entries).toEqual([
+      {
+        kind: "tool_call",
+        ts: TS,
+        name: "bash",
+        input: { command: "ls" },
+        toolUseId: "tc-1",
+      },
+    ]);
+  });
+
+  it("maps tool/completed to tool_result with stringified result", () => {
+    const entries = parseAmplifierLocalStdoutLine(
+      notif("tool/completed", {
+        sessionId: "s",
+        turnId: "t",
+        toolCallId: "tc-1",
+        name: "bash",
+        result: { stdout: "ok\n" },
+        durationMs: 42,
+      }),
+      TS,
+    );
+    expect(entries[0]).toMatchObject({
+      kind: "tool_result",
+      toolUseId: "tc-1",
+      isError: false,
+    });
+    expect((entries[0] as { content: string }).content).toContain("ok");
+  });
+
+  it("maps thinking/delta and thinking/final to thinking entries", () => {
+    const a = parseAmplifierLocalStdoutLine(
+      notif("thinking/delta", { sessionId: "s", turnId: "t", text: "I should..." }),
+      TS,
+    );
+    const b = parseAmplifierLocalStdoutLine(
+      notif("thinking/final", { sessionId: "s", turnId: "t", text: "done thinking" }),
+      TS,
+    );
+    expect(a).toEqual([{ kind: "thinking", ts: TS, text: "I should..." }]);
+    expect(b).toEqual([{ kind: "thinking", ts: TS, text: "done thinking" }]);
+  });
+
+  it("maps progress to system entry with percentage", () => {
+    const entries = parseAmplifierLocalStdoutLine(
+      notif("progress", {
+        sessionId: "s",
+        turnId: "t",
+        message: "Loading bundle",
+        percent: 42,
+      }),
+      TS,
+    );
+    expect(entries).toEqual([
+      { kind: "system", ts: TS, text: "Loading bundle (42%)" },
+    ]);
+  });
+
+  it("maps error notification to stderr entry", () => {
+    const entries = parseAmplifierLocalStdoutLine(
+      notif("error", {
+        sessionId: "s",
+        turnId: "t",
+        code: "tool_execution_failed",
+        message: "bash: command not found",
+        recoverable: true,
+      }),
+      TS,
+    );
+    expect(entries).toEqual([
+      { kind: "stderr", ts: TS, text: "bash: command not found" },
+    ]);
+  });
+
+  it("falls back to stdout entry for non-JSON lines", () => {
+    const entries = parseAmplifierLocalStdoutLine("not even json", TS);
+    expect(entries).toEqual([{ kind: "stdout", ts: TS, text: "not even json" }]);
+  });
+
+  it("returns nothing for blank lines", () => {
+    expect(parseAmplifierLocalStdoutLine("", TS)).toEqual([]);
+    expect(parseAmplifierLocalStdoutLine("   \t  ", TS)).toEqual([]);
+  });
+});

--- a/packages/adapters/amplifier-local/src/__tests__/parse.test.ts
+++ b/packages/adapters/amplifier-local/src/__tests__/parse.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the error classification helpers in src/server/parse.ts.
+ *
+ * These run via vitest at the monorepo level (`pnpm test`).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  asAmplifierErrorView,
+  describeAmplifierError,
+  isAmplifierApprovalUnconfiguredError,
+  isAmplifierBundleLoadFailedError,
+  isAmplifierProtocolMismatchError,
+  isAmplifierUnknownSessionError,
+} from "../server/parse.js";
+
+describe("asAmplifierErrorView", () => {
+  it("normalises loose fields and trims whitespace", () => {
+    const view = asAmplifierErrorView({
+      code: "  session_not_found  ",
+      classification: "  engine ",
+      message: " Session abc is missing ",
+      stderrTail: "blah",
+    });
+    expect(view).toEqual({
+      code: "session_not_found",
+      classification: "engine",
+      message: "Session abc is missing",
+      stderrTail: "blah",
+    });
+  });
+
+  it("returns empty strings on null/undefined inputs", () => {
+    expect(asAmplifierErrorView({})).toEqual({
+      code: "",
+      classification: "",
+      message: "",
+      stderrTail: "",
+    });
+  });
+});
+
+describe("isAmplifierUnknownSessionError", () => {
+  it("matches structured engine codes", () => {
+    for (const code of ["session_not_found", "invalid_session", "stale_session"]) {
+      const view = asAmplifierErrorView({ code });
+      expect(isAmplifierUnknownSessionError(view, "")).toBe(true);
+    }
+  });
+
+  it("matches engine messages without structured codes (regex fallback)", () => {
+    const view = asAmplifierErrorView({
+      code: "engine_error",
+      message: "Session 7d3e is not found",
+    });
+    expect(isAmplifierUnknownSessionError(view, "")).toBe(true);
+  });
+
+  it("matches via the stderr buffer when message is empty", () => {
+    const view = asAmplifierErrorView({ code: "engine_error" });
+    expect(
+      isAmplifierUnknownSessionError(view, "no session directory at path/to/sess"),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    const view = asAmplifierErrorView({
+      code: "provider_init_failed",
+      message: "OpenAI API returned 401",
+    });
+    expect(isAmplifierUnknownSessionError(view, "")).toBe(false);
+  });
+});
+
+describe("isAmplifierProtocolMismatchError", () => {
+  it("matches the canonical protocol_version_mismatch code", () => {
+    expect(
+      isAmplifierProtocolMismatchError(
+        asAmplifierErrorView({ code: "protocol_version_mismatch" }),
+      ),
+    ).toBe(true);
+  });
+  it("does not match other protocol-class errors", () => {
+    expect(
+      isAmplifierProtocolMismatchError(
+        asAmplifierErrorView({ code: "wire_protocol_violation" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isAmplifierApprovalUnconfiguredError", () => {
+  it("matches the G3 approval_unconfigured code", () => {
+    expect(
+      isAmplifierApprovalUnconfiguredError(
+        asAmplifierErrorView({ code: "approval_unconfigured" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isAmplifierBundleLoadFailedError", () => {
+  it("matches bundle_load_failed", () => {
+    expect(
+      isAmplifierBundleLoadFailedError(
+        asAmplifierErrorView({ code: "bundle_load_failed" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("describeAmplifierError", () => {
+  it("prefers the structured message", () => {
+    const view = asAmplifierErrorView({
+      code: "engine_error",
+      message: "Provider call failed: 401",
+    });
+    expect(describeAmplifierError(view, "noise on stderr\n", 1)).toBe(
+      "Provider call failed: 401",
+    );
+  });
+
+  it("falls back to the first non-empty stderr line", () => {
+    const view = asAmplifierErrorView({ code: "engine_error" });
+    expect(describeAmplifierError(view, "\n   \nFatal: bundle prep failed\n", 1)).toBe(
+      "Fatal: bundle prep failed",
+    );
+  });
+
+  it("falls back to the generic exit code message", () => {
+    const view = asAmplifierErrorView({});
+    expect(describeAmplifierError(view, "", 137)).toBe(
+      "amplifier-agent exited with code 137",
+    );
+    expect(describeAmplifierError(view, "", null)).toBe(
+      "amplifier-agent exited with code -1",
+    );
+  });
+});

--- a/packages/adapters/amplifier-local/src/__tests__/session-codec.test.ts
+++ b/packages/adapters/amplifier-local/src/__tests__/session-codec.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Round-trip tests for the sessionCodec exported from src/server/index.ts.
+ *
+ * Paperclip stores `sessionParams` as opaque JSON; the codec validates the
+ * shape on read and ensures the round-trip is lossless for the canonical
+ * field set.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sessionCodec } from "../server/index.js";
+
+describe("sessionCodec.deserialize", () => {
+  it("requires sessionId", () => {
+    expect(sessionCodec.deserialize({})).toBeNull();
+    expect(sessionCodec.deserialize({ cwd: "/x" })).toBeNull();
+  });
+
+  it("returns null for non-object inputs", () => {
+    expect(sessionCodec.deserialize(null)).toBeNull();
+    expect(sessionCodec.deserialize("string")).toBeNull();
+    expect(sessionCodec.deserialize([1, 2, 3])).toBeNull();
+  });
+
+  it("extracts the canonical field set", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "amp-sess-123",
+      cwd: "/Users/me/proj",
+      workspaceId: "ws-99",
+      repoUrl: "git@github.com:me/proj.git",
+      repoRef: "main",
+    });
+    expect(result).toEqual({
+      sessionId: "amp-sess-123",
+      cwd: "/Users/me/proj",
+      workspaceId: "ws-99",
+      repoUrl: "git@github.com:me/proj.git",
+      repoRef: "main",
+    });
+  });
+
+  it("accepts snake_case aliases (forward-compat)", () => {
+    const result = sessionCodec.deserialize({
+      session_id: "amp-sess-123",
+      workdir: "/Users/me/proj",
+      workspace_id: "ws-99",
+      repo_url: "git@github.com:me/proj.git",
+      repo_ref: "main",
+    });
+    expect(result).toEqual({
+      sessionId: "amp-sess-123",
+      cwd: "/Users/me/proj",
+      workspaceId: "ws-99",
+      repoUrl: "git@github.com:me/proj.git",
+      repoRef: "main",
+    });
+  });
+
+  it("omits empty optional fields rather than persisting empty strings", () => {
+    const result = sessionCodec.deserialize({
+      sessionId: "amp-sess-123",
+      cwd: "",
+      workspaceId: "",
+    });
+    expect(result).toEqual({ sessionId: "amp-sess-123" });
+  });
+});
+
+describe("sessionCodec.serialize", () => {
+  it("returns null when input is null or has no sessionId", () => {
+    expect(sessionCodec.serialize(null)).toBeNull();
+    expect(sessionCodec.serialize({})).toBeNull();
+  });
+
+  it("round-trips with deserialize", () => {
+    const original = {
+      sessionId: "amp-sess-rt",
+      cwd: "/proj",
+      workspaceId: "ws-1",
+    };
+    const serialized = sessionCodec.serialize(original);
+    const deserialized = sessionCodec.deserialize(serialized);
+    expect(deserialized).toEqual(original);
+  });
+});
+
+describe("sessionCodec.getDisplayId", () => {
+  it("returns the sessionId", () => {
+    expect(sessionCodec.getDisplayId!({ sessionId: "amp-sess-display" })).toBe(
+      "amp-sess-display",
+    );
+  });
+
+  it("returns null for null input", () => {
+    expect(sessionCodec.getDisplayId!(null)).toBeNull();
+  });
+});

--- a/packages/adapters/amplifier-local/src/cli/format-event.ts
+++ b/packages/adapters/amplifier-local/src/cli/format-event.ts
@@ -1,0 +1,166 @@
+/**
+ * Terminal formatter for `paperclipai run --watch` output.
+ *
+ * Receives raw stdout/stderr lines from the subprocess (forwarded by the
+ * server's ChildProcessFactory via paperclip's onLog). Detects whether the
+ * line is:
+ *   - the §4.1 envelope (one JSON object at end of stdout)
+ *   - a wire-protocol notification (NDJSON event on stderr)
+ *   - non-JSON noise (printed through dim)
+ *
+ * Color scheme is consistent with codex-local's printer:
+ *   blue   — init / structural events
+ *   green  — assistant text (final reply)
+ *   gray   — thinking / reasoning
+ *   yellow — tool calls (in-flight)
+ *   cyan   — tool results
+ *   red    — errors / failures
+ */
+
+import pc from "picocolors";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function looksLikeEnvelope(obj: Record<string, unknown>): boolean {
+  return (
+    typeof obj.protocolVersion === "string" &&
+    typeof obj.sessionId === "string" &&
+    typeof obj.turnId === "string" &&
+    "reply" in obj &&
+    "metadata" in obj
+  );
+}
+
+function printEnvelope(obj: Record<string, unknown>): void {
+  const errorBlock = asRecord(obj.error);
+  const metadata = asRecord(obj.metadata) ?? {};
+  if (errorBlock) {
+    console.log(
+      pc.red(
+        `[envelope] error: ${asString(errorBlock.code, "(no code)")} — ${asString(errorBlock.message, "")}`,
+      ),
+    );
+  } else {
+    const reply = asString(obj.reply, "");
+    console.log(pc.green(`[final] ${reply}`));
+  }
+  const tokensIn = asNumber(metadata.tokensIn);
+  const tokensOut = asNumber(metadata.tokensOut);
+  const durationMs = asNumber(metadata.durationMs);
+  console.log(
+    pc.blue(
+      `[metadata] tokens=${tokensIn}/${tokensOut} duration=${durationMs}ms engine=${asString(metadata.engineVersion)}`,
+    ),
+  );
+}
+
+function printNotification(method: string, params: Record<string, unknown>): void {
+  switch (method) {
+    case "result/delta":
+      process.stdout.write(pc.green(asString(params.text, "")));
+      break;
+    case "result/final":
+      console.log(pc.green(`[result/final] ${asString(params.text, "")}`));
+      break;
+    case "tool/started":
+      console.log(
+        pc.yellow(
+          `[tool/started] ${asString(params.name, "<tool>")} ${
+            params.args ? JSON.stringify(params.args) : ""
+          }`,
+        ),
+      );
+      break;
+    case "tool/completed": {
+      const result = params.result;
+      const out =
+        typeof result === "string"
+          ? result
+          : result != null
+            ? JSON.stringify(result)
+            : "";
+      console.log(
+        pc.cyan(
+          `[tool/completed] ${asString(params.name, "<tool>")} → ${out.slice(0, 200)}`,
+        ),
+      );
+      break;
+    }
+    case "thinking/delta":
+      process.stdout.write(pc.gray(asString(params.text, "")));
+      break;
+    case "thinking/final":
+      console.log(pc.gray(`[thinking] ${asString(params.text, "")}`));
+      break;
+    case "progress": {
+      const percent = typeof params.percent === "number" ? params.percent : null;
+      console.log(
+        pc.blue(
+          `[progress] ${asString(params.message, "")}${percent !== null ? ` (${percent.toFixed(0)}%)` : ""}`,
+        ),
+      );
+      break;
+    }
+    case "usage":
+      console.log(
+        pc.blue(
+          `[usage] in=${asNumber(params.inputTokens)} out=${asNumber(params.outputTokens)}`,
+        ),
+      );
+      break;
+    case "error":
+      console.log(
+        pc.red(
+          `[error] ${asString(params.code, "")}: ${asString(params.message, "")}`,
+        ),
+      );
+      break;
+    default:
+      console.log(
+        pc.gray(`[${method}] ${JSON.stringify(params).slice(0, 200)}`),
+      );
+  }
+}
+
+export function printAmplifierLocalStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+  const parsed = safeJsonParse(line);
+  const obj = asRecord(parsed);
+  if (!obj) {
+    // Non-JSON noise — engine startup/shutdown messages. Dim to stay out of the way.
+    console.log(pc.dim(line));
+    return;
+  }
+  if (looksLikeEnvelope(obj)) {
+    printEnvelope(obj);
+    return;
+  }
+  const method = asString(obj.method) || asString(obj.type);
+  if (method) {
+    const params = asRecord(obj.params) ?? {};
+    printNotification(method, params);
+    return;
+  }
+  // Unknown JSON shape — show raw.
+  console.log(pc.dim(line));
+}

--- a/packages/adapters/amplifier-local/src/cli/index.ts
+++ b/packages/adapters/amplifier-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAmplifierLocalStreamEvent } from "./format-event.js";

--- a/packages/adapters/amplifier-local/src/index.ts
+++ b/packages/adapters/amplifier-local/src/index.ts
@@ -1,0 +1,112 @@
+/**
+ * @paperclipai/adapter-amplifier-local — shared metadata.
+ *
+ * This file is imported by all three consumers (server, UI, CLI). Keep it
+ * dependency-free (no Node APIs, no React) so the UI bundle stays browser-safe.
+ */
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+export const type = "amplifier_local";
+export const label = "Amplifier (local)";
+
+/**
+ * Canonical install command surfaced in `agentConfigurationDoc` and used by
+ * the platform's sandbox install path. amplifier-agent v0.4+ declares `mcp`
+ * as a transitive dependency, so the previous `--with mcp` workaround is no
+ * longer required.
+ */
+export const SANDBOX_INSTALL_COMMAND =
+  "uv tool install git+https://github.com/microsoft/amplifier-agent";
+
+/**
+ * Default model used when none is explicitly configured. Matches the
+ * provider-anthropic module's default in amplifier-agent's bundle.md.
+ */
+export const DEFAULT_AMPLIFIER_LOCAL_MODEL = "claude-opus-4-5";
+
+/**
+ * The four provider modules amplifier-agent ships in its default bundle.
+ * The adapter derives the provider from the model id (see deriveProvider
+ * in src/server/amplifier-args.ts); the user never picks a provider in the
+ * UI, only a model.
+ */
+export const AMPLIFIER_LOCAL_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "azure-openai",
+  "ollama",
+] as const;
+export type AmplifierLocalProvider = (typeof AMPLIFIER_LOCAL_PROVIDERS)[number];
+
+/**
+ * Models advertised to the agent creation form. Provider is derived from the
+ * model id by the adapter (claude-* to anthropic, gpt-* / o3-* / o4-* to
+ * openai, llama* to ollama). amplifier-agent v0.4+'s host_config layer
+ * accepts model overrides via provider.config.model, so any string here
+ * gets honored.
+ */
+export const models = [
+  // Anthropic
+  { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
+  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  { id: "claude-3-5-sonnet-20241022", label: "Claude 3.5 Sonnet (2024-10-22)" },
+  // OpenAI
+  { id: "gpt-5.5", label: "GPT-5.5" },
+  { id: "gpt-5", label: "GPT-5" },
+  { id: "gpt-5-mini", label: "GPT-5 mini" },
+  { id: "o3", label: "o3" },
+  { id: "o3-mini", label: "o3-mini" },
+  { id: "o4-mini", label: "o4-mini" },
+  // Ollama (local)
+  { id: "llama3.2", label: "Llama 3.2 (Ollama)" },
+];
+
+// ---------------------------------------------------------------------------
+// agentConfigurationDoc — routing logic for LLM-driven agent configuration
+// ---------------------------------------------------------------------------
+
+export const agentConfigurationDoc = `# amplifier_local agent configuration
+
+Adapter: amplifier_local
+
+Use when:
+- The agent should run the Amplifier engine (amplifier-agent Python CLI) locally on the host machine
+- You want the agent to use the four-specialist orchestration pattern (parent agent + explorer/planner/coder/tester sub-agents) for multi-step work
+- You need MCP tool integration via the engine's tool-mcp module
+- You need session continuity across heartbeats (amplifier-agent supports session resumption via --resume)
+
+Don't use when:
+- The agent only needs a simple one-shot LLM call (use the "process" adapter or a thinner adapter instead)
+- amplifier-agent is not installed on the host (run \`uv tool install git+https://github.com/microsoft/amplifier-agent\` first)
+- You need fine-grained per-tool approval prompts during agent execution (this adapter always passes --yes to satisfy amplifier-agent's G3 fail-fast on headless runs; configure host_config.approval.mode explicitly if you need different policy)
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible). Paperclip workspaces override this when an active workspace is present.
+- model (string, optional): amplifier-agent model id. Provider is derived from the prefix (claude-* → anthropic, gpt-*/o3-*/o4-* → openai, llama* → ollama). Defaults to "${DEFAULT_AMPLIFIER_LOCAL_MODEL}".
+- promptTemplate (string, optional): heartbeat prompt template (uses {{variable}} substitution). Defaults to the shared DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE.
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the prompt at runtime.
+- command (string, optional): defaults to "amplifier-agent" (resolved via PATH).
+- extraArgs (string[], optional): additional CLI args appended verbatim to the amplifier-agent invocation.
+- env (object, optional): KEY=VALUE environment variables. Use this to inject provider API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, AZURE_OPENAI_API_KEY, OLLAMA_HOST) and any AMPLIFIER_* overrides.
+- workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
+- workspaceRuntime (object, optional): reserved for workspace runtime metadata; runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds. 0 = no timeout (platform default applies).
+- graceSec (number, optional): SIGTERM grace period in seconds. Default 15.
+
+Notes:
+- amplifier-agent emits a single JSON envelope on stdout at end-of-turn (the §4.1 wire envelope) and structured wire-protocol events on stderr (result/delta, tool/started, tool/completed, usage, error, etc.). The adapter parses both.
+- The adapter always passes \`-y\` (auto-approve all tool calls) to satisfy amplifier-agent's G3 fail-fast rule for non-TTY invocations. To deny tool calls explicitly, set host_config.approval.mode = "no" via env config.
+- The adapter writes a per-turn host_config.json containing provider selection, approval mode, MCP config path, and skill source dirs. It is passed to amplifier-agent via \`--config <path>\`.
+- MCP server config (when configured) is spilled to a 0600 tmpfile and forwarded to amplifier-agent via AMPLIFIER_MCP_CONFIG environment variable (the engine's tool-mcp module reads it natively).
+- Paperclip skills are injected into a per-instance managed directory (under ~/.paperclip/instances/<id>/companies/<companyId>/amplifier-skills/) and made discoverable to amplifier-agent's tool-skills module via host_config.skills.skills.
+- amplifier-agent stores per-session state at $XDG_STATE_HOME/amplifier-agent/sessions/<id>/. Sessions resume via --resume; the adapter gates resume on cwd match (sessions saved in a different cwd are not resumed).
+- The adapter pins --protocol-version 0.2.0. Engine protocol bumps require coordinated wrapper + adapter updates.
+- When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
+- Provider API keys must be configured via the \`env\` field (e.g. {"env": {"ANTHROPIC_API_KEY": "sk-..."}}); the adapter does not read keys from the host environment.
+`;

--- a/packages/adapters/amplifier-local/src/server/amplifier-host-config.ts
+++ b/packages/adapters/amplifier-local/src/server/amplifier-host-config.ts
@@ -1,0 +1,133 @@
+/**
+ * Per-instance managed home + per-turn host_config.json writer + skills
+ * directory for amplifier-local.
+ *
+ * Mirrors the codex-home.ts pattern from codex-local: each (instance,
+ * company) gets a stable managed directory under the Paperclip instance
+ * root, and per-turn artefacts (host_config.json, skills/) are written
+ * atomically inside it.
+ *
+ * Why managed-dir-per-company:
+ *   - Same isolation guarantee as codex-local's CODEX_HOME isolation
+ *   - Skills symlinks survive across turns (don't leak between companies)
+ *   - host_config.json is rewritten per turn but kept at a stable path so a
+ *     resumed session sees a fresh config
+ *
+ * MCP server config is NOT handled here — the amplifier-agent-ts wrapper
+ * (≥0.6.1) owns the MCP spill via its `resolveMcpConfigPath` / `cleanupSpillFile`
+ * helpers. The adapter passes `mcpServers` directly to `spawnAgent({ mcpServers })`
+ * and the wrapper writes a 0600 tmpfile under `$XDG_RUNTIME_DIR/amplifier-agent/<sessionId>/`
+ * and injects `AMPLIFIER_MCP_CONFIG` into the subprocess env.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-utils/server-utils";
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the per-company managed root for amplifier-local artefacts:
+ *
+ *   $PAPERCLIP_HOME/instances/<instanceId>/companies/<companyId>/amplifier-local/
+ *
+ * `resolvePaperclipInstanceRootForAdapter` falls back to
+ * ~/.paperclip/instances/<id>/ when PAPERCLIP_HOME is not set.
+ */
+export function resolveAmplifierLocalManagedDir(
+  env: NodeJS.ProcessEnv = process.env,
+  companyId?: string,
+): string {
+  const instanceRoot = resolvePaperclipInstanceRootForAdapter({
+    homeDir: nonEmpty(env.PAPERCLIP_HOME) ?? undefined,
+    instanceId: nonEmpty(env.PAPERCLIP_INSTANCE_ID) ?? undefined,
+  });
+  return companyId
+    ? path.resolve(instanceRoot, "companies", companyId, "amplifier-local")
+    : path.resolve(instanceRoot, "amplifier-local");
+}
+
+/**
+ * The host_config.json path within the managed dir. Stable across turns so
+ * resumed sessions re-read the same file.
+ */
+export function resolveHostConfigPath(managedDir: string): string {
+  return path.join(managedDir, "host_config.json");
+}
+
+/**
+ * The skills directory the engine's tool-skills module will scan. Symlinks
+ * to paperclip skills are placed here, then surfaced to the engine via
+ * `host_config.skills.skills = [<skillsDir>]`.
+ */
+export function resolveSkillsDir(managedDir: string): string {
+  return path.join(managedDir, "skills");
+}
+
+// ---------------------------------------------------------------------------
+// host_config.json types and writer
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of host_config.json that amplifier-agent's loader accepts.
+ * The loader closes the top-level schema to these five keys (anything else
+ * raises `config_unknown_key` at parse time):
+ *   - mcp:        passes through to tool-mcp module config (rarely set by
+ *                 this adapter — wrapper handles MCP via env var)
+ *   - approval:   mode in {"yes","no","prompt"} + optional patterns[]
+ *   - provider:   module + config (config overlays onto provider module's
+ *                 mount config — `model` goes here)
+ *   - allowProtocolSkew: bypasses protocol version check (UNSAFE)
+ *   - skills:    skills[] (list-concatenated with bundle defaults) +
+ *                visibility{} (dict-overlay onto bundle defaults)
+ */
+export interface AmplifierAgentHostConfig {
+  approval?: {
+    mode?: "yes" | "no" | "prompt";
+    patterns?: string[];
+  };
+  provider?: {
+    module?: string;
+    config?: Record<string, unknown>;
+  };
+  mcp?: {
+    configPath?: string;
+    [k: string]: unknown;
+  };
+  allowProtocolSkew?: boolean;
+  skills?: {
+    skills?: string[];
+    visibility?: Record<string, unknown>;
+  };
+}
+
+/**
+ * Atomically write host_config.json (write-to-tmp then rename) so a partially
+ * written file is never observed by a concurrent engine read on session
+ * resume.
+ */
+export async function writeHostConfigAtomic(
+  hostConfigPath: string,
+  config: AmplifierAgentHostConfig,
+): Promise<void> {
+  const dir = path.dirname(hostConfigPath);
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  const tmpPath = `${hostConfigPath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(config, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fs.rename(tmpPath, hostConfigPath);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nonEmpty(value: string | undefined | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/packages/adapters/amplifier-local/src/server/execute.ts
+++ b/packages/adapters/amplifier-local/src/server/execute.ts
@@ -1,0 +1,824 @@
+/**
+ * Core execution for amplifier-local — wraps the amplifier-agent CLI via the
+ * amplifier-agent-ts wrapper (≥0.6.1).
+ *
+ * Flow:
+ *   1. Extract config (model, provider, env, timeout, instructions, cwd)
+ *   2. Resolve effective cwd (paperclip workspace > config.cwd > process.cwd)
+ *   3. Resolve managed dir, host_config path, skills dir
+ *   4. Symlink paperclip skills into the managed skills dir (NEVER into cwd)
+ *   5. Build subprocess env (PAPERCLIP_* + wake context + user env + api keys)
+ *   6. Resolve session resume gate (cwd match)
+ *   7. Render prompt (instructions prefix + wake delta + handoff + template)
+ *   8. Write host_config.json (provider, approval mode "yes", skills dirs)
+ *   9. Spawn via wrapper, providing a ChildProcessFactory that feeds onLog
+ *      raw stream chunks and calls onSpawn with the PID
+ *  10. Iterate DisplayEvents — collect result text, usage, session id, errors
+ *  11. On unknown-session error during resume, retry once with --fresh and
+ *      set clearSession=true on the result
+ *  12. Return AdapterExecutionResult
+ *
+ * All MCP, argv, envelope parsing, NDJSON event parsing, SIGTERM/SIGKILL,
+ * timeout enforcement, and protocol version checks are owned by the wrapper.
+ * The adapter owns paperclip-side concerns: workspace, env, skills delivery,
+ * host_config writing, prompt rendering, session-resume gating, paperclip
+ * error classification.
+ */
+
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
+import {
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  buildInvocationEnvForLogs,
+  buildPaperclipEnv,
+  ensurePaperclipSkillSymlink,
+  joinPromptSections,
+  parseObject,
+  readPaperclipRuntimeSkillEntries,
+  refreshPaperclipWorkspaceEnvForExecution,
+  renderPaperclipWakePrompt,
+  renderTemplate,
+  resolvePaperclipDesiredSkillNames,
+  stringifyPaperclipWakePayload,
+} from "@paperclipai/adapter-utils/server-utils";
+
+import {
+  AaaError,
+  type DisplayEvent,
+  type McpServerConfig,
+  spawnAgent,
+} from "amplifier-agent-ts";
+
+import {
+  AMPLIFIER_LOCAL_PROVIDERS,
+  DEFAULT_AMPLIFIER_LOCAL_MODEL,
+  type AmplifierLocalProvider,
+} from "../index.js";
+import {
+  type AmplifierAgentHostConfig,
+  resolveAmplifierLocalManagedDir,
+  resolveHostConfigPath,
+  resolveSkillsDir,
+  writeHostConfigAtomic,
+} from "./amplifier-host-config.js";
+import {
+  asAmplifierErrorView,
+  describeAmplifierError,
+  isAmplifierApprovalUnconfiguredError,
+  isAmplifierBundleLoadFailedError,
+  isAmplifierProtocolMismatchError,
+  isAmplifierUnknownSessionError,
+} from "./parse.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Internal result shapes
+// ---------------------------------------------------------------------------
+
+interface RunAttemptOk {
+  kind: "ok";
+  sessionId: string;
+  resultText: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number | null;
+  terminalError: ReturnType<typeof asAmplifierErrorView> | null;
+  /** Tail of stderr surfaced by the wrapper on the error event. */
+  stderrBuffer: string;
+}
+
+interface RunAttemptSpawnError {
+  kind: "spawn_error";
+  result: AdapterExecutionResult;
+}
+
+type RunAttemptResult = RunAttemptOk | RunAttemptSpawnError;
+
+// ---------------------------------------------------------------------------
+// Provider inference
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a model id prefix to one of the four provider modules amplifier-agent
+ * ships. The user picks a model in the paperclip UI; the adapter derives the
+ * provider automatically. If the user wants `azure-openai` specifically (same
+ * model names as `openai`), they pass `config.provider = "azure-openai"`.
+ *
+ *   claude-*                          → anthropic
+ *   gpt-*, o1-*, o3-*, o4-*           → openai
+ *   llama*, mistral*, qwen*, deepseek*, phi* → ollama
+ */
+function deriveAmplifierProvider(model: string): AmplifierLocalProvider {
+  const trimmed = model.trim().toLowerCase();
+  if (!trimmed) return "anthropic";
+  if (trimmed.startsWith("claude-")) return "anthropic";
+  if (
+    trimmed.startsWith("gpt-") ||
+    /^o[1-9]/i.test(trimmed) ||
+    trimmed.startsWith("text-davinci-")
+  ) {
+    return "openai";
+  }
+  if (
+    trimmed.startsWith("llama") ||
+    trimmed.startsWith("mistral") ||
+    trimmed.startsWith("qwen") ||
+    trimmed.startsWith("deepseek") ||
+    trimmed.startsWith("phi")
+  ) {
+    return "ollama";
+  }
+  // Default to anthropic for unrecognised prefixes — the bundle's
+  // default_provider is "anthropic" anyway, and operators wanting a different
+  // provider can set it explicitly via config.provider.
+  return "anthropic";
+}
+
+function resolveProvider(
+  configProvider: string,
+  model: string,
+): AmplifierLocalProvider {
+  const explicit = configProvider.trim().toLowerCase();
+  if (explicit && (AMPLIFIER_LOCAL_PROVIDERS as readonly string[]).includes(explicit)) {
+    return explicit as AmplifierLocalProvider;
+  }
+  return deriveAmplifierProvider(model);
+}
+
+// ---------------------------------------------------------------------------
+// Skills injection — symlink paperclip skills into the managed skills dir
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure each desired paperclip skill is symlinked into the adapter's managed
+ * skills dir. The engine's tool-skills module discovers skills by scanning
+ * directories listed in `host_config.skills.skills`. We point it at this
+ * managed dir (NOT the user's cwd) so the project checkout stays clean.
+ *
+ * Mirrors `ensureCodexSkillsInjected` from codex-local but lives under
+ * paperclip's per-company managed dir instead of `$CODEX_HOME/skills/`.
+ */
+async function ensureAmplifierSkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  skillsDir: string,
+  skillsEntries: Array<{ key: string; runtimeName: string; source: string }>,
+  desiredSkillNames: string[],
+): Promise<void> {
+  const desiredSet = new Set(desiredSkillNames);
+  const filtered = skillsEntries.filter((e) => desiredSet.has(e.key));
+  if (filtered.length === 0) return;
+  await fs.mkdir(skillsDir, { recursive: true, mode: 0o700 });
+  for (const entry of filtered) {
+    const target = path.join(skillsDir, entry.runtimeName);
+    try {
+      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      if (result === "skipped") continue;
+      await onLog(
+        "stdout",
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Injected"} ` +
+          `amplifier-local skill "${entry.runtimeName}" into ${skillsDir}\n`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to inject amplifier-local skill "${entry.key}" into ${skillsDir}: ${msg}\n`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session resume gate
+// ---------------------------------------------------------------------------
+
+interface RuntimeSessionParamsView {
+  sessionId: string;
+  cwd: string;
+  workspaceId: string;
+  repoUrl: string;
+  repoRef: string;
+}
+
+function parseRuntimeSessionParams(raw: unknown): RuntimeSessionParamsView {
+  const obj = parseObject(raw);
+  return {
+    sessionId: asString(obj.sessionId, ""),
+    cwd: asString(obj.cwd, ""),
+    workspaceId: asString(obj.workspaceId, ""),
+    repoUrl: asString(obj.repoUrl, ""),
+    repoRef: asString(obj.repoRef, ""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// User env layering (config.env + provider API keys)
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider env vars that amplifier-agent looks up when the host_config /
+ * argv don't override. Listed here so we can warn / pass through the
+ * operator's `config.env` values without enforcing a specific shape.
+ */
+const PROVIDER_ENV_VARS = new Set([
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "AZURE_OPENAI_ENDPOINT",
+  "OLLAMA_HOST",
+]);
+
+function layerUserEnv(
+  env: Record<string, string>,
+  userEnv: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(userEnv)) {
+    if (typeof value === "string" && value.length > 0) {
+      env[key] = value;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error translation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a wrapper DisplayEvent of type "error" or a thrown AaaError into
+ * the paperclip-side AmplifierErrorView used by the classifier helpers in
+ * parse.ts.
+ */
+function errorEventToView(
+  event: Extract<DisplayEvent, { type: "error" }>,
+): ReturnType<typeof asAmplifierErrorView> {
+  return asAmplifierErrorView({
+    code: event.code,
+    classification: event.classification,
+    message: event.message,
+    stderrTail: event.stderrTail ?? "",
+  });
+}
+
+function aaaErrorToView(
+  err: AaaError,
+): ReturnType<typeof asAmplifierErrorView> {
+  return asAmplifierErrorView({
+    code: err.code,
+    classification: err.classification ?? "unknown",
+    message: err.message,
+    stderrTail: err.stderrTail ?? "",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ChildProcessFactory — splits the subprocess output between the wrapper
+// (NDJSON parsing) and paperclip's onLog (run viewer raw text)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a child-process factory that the wrapper substitutes for
+ * `child_process.spawn`. We use this hook to:
+ *
+ *   1. Forward raw stdout/stderr chunks to paperclip's `onLog` so the run
+ *      viewer shows real-time output. The wrapper attaches its own listeners
+ *      to the same streams for NDJSON parsing — Node EventEmitters allow
+ *      multiple listeners, so both consumers see the data.
+ *   2. Call paperclip's `onSpawn` with the subprocess PID so paperclip can
+ *      track the live process (for cancellation, accounting, the run UI).
+ *
+ * Note that we still let the wrapper do the actual `child_process.spawn` —
+ * the wrapper's process-group leadership (`detached: true`), SIGTERM grace
+ * window, and SIGKILL escalation continue to work as before.
+ */
+function buildChildProcessFactory(
+  onLog: AdapterExecutionContext["onLog"],
+  onSpawn: AdapterExecutionContext["onSpawn"] | undefined,
+) {
+  return (
+    command: string,
+    args: readonly string[],
+    spawnOptions: SpawnOptions,
+  ): ChildProcess => {
+    const child = spawn(command, args as string[], spawnOptions);
+    if (child.pid !== undefined && onSpawn !== undefined) {
+      void onSpawn({
+        pid: child.pid,
+        processGroupId: spawnOptions.detached === true ? child.pid : null,
+        startedAt: new Date().toISOString(),
+      });
+    }
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+      void onLog("stdout", text);
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+      void onLog("stderr", text);
+    });
+    return child;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The execute() entrypoint
+// ---------------------------------------------------------------------------
+
+export async function execute(
+  ctx: AdapterExecutionContext,
+): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } =
+    ctx;
+
+  // ---- 1. Config extraction ----
+  const promptTemplate = asString(
+    config.promptTemplate,
+    DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  );
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const command = asString(config.command, "amplifier-agent");
+  const model = asString(config.model, DEFAULT_AMPLIFIER_LOCAL_MODEL);
+  const explicitProvider = asString(config.provider, "");
+  const provider = resolveProvider(explicitProvider, model);
+  const configuredCwd = asString(config.cwd, "");
+  const instructionsFilePath = asString(config.instructionsFilePath, "");
+  const timeoutSec = asNumber(config.timeoutSec, 0); // 0 = no timeout
+  const allowProtocolSkew = asBoolean(config.allowProtocolSkew, false);
+  const extraArgs = asStringArray(config.extraArgs);
+  const envConfig = parseObject(config.env);
+  const mcpServersConfig = parseObject(config.mcpServers);
+
+  // ---- 2. Workspace + cwd resolution ----
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+
+  // If the workspace source is "agent_home" but the operator explicitly set
+  // config.cwd, honour the config. Otherwise the workspace cwd wins.
+  const useConfiguredInsteadOfAgentHome =
+    workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+
+  // ---- 3. Managed dir + paths ----
+  const managedDir = resolveAmplifierLocalManagedDir(process.env, agent.companyId);
+  await fs.mkdir(managedDir, { recursive: true, mode: 0o700 });
+  const hostConfigPath = resolveHostConfigPath(managedDir);
+  const skillsDir = resolveSkillsDir(managedDir);
+
+  // ---- 4. Skills injection ----
+  // Read paperclip skills entries (from config or filesystem discovery) and
+  // resolve the desired subset, then symlink each into the managed skills
+  // dir. NEVER write into the user's cwd.
+  const skillsEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkillNames = resolvePaperclipDesiredSkillNames(config, skillsEntries);
+  await ensureAmplifierSkillsInjected(onLog, skillsDir, skillsEntries, desiredSkillNames);
+
+  // ---- 5. Env assembly ----
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  // Wake / context vars (only set when present — don't pollute env with empty
+  // strings).
+  const wakeTaskId = asString(context.taskId, asString(context.issueId, ""));
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  const wakeReason = asString(context.wakeReason, "");
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  const wakeCommentId = asString(context.wakeCommentId, asString(context.commentId, ""));
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  const approvalId = asString(context.approvalId, "");
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  const approvalStatus = asString(context.approvalStatus, "");
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  const linkedIssueIds = asStringArray(context.issueIds);
+  if (linkedIssueIds.length > 0) {
+    env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  }
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+
+  // Workspace env (PAPERCLIP_WORKSPACE_*).
+  refreshPaperclipWorkspaceEnvForExecution({
+    env,
+    envConfig,
+    workspaceCwd: effectiveWorkspaceCwd,
+    workspaceSource,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+  });
+
+  // Auth token (server-issued JWT for paperclip API). The agent's tools can
+  // read PAPERCLIP_API_KEY to call paperclip endpoints.
+  const hasExplicitApiKey = "PAPERCLIP_API_KEY" in envConfig;
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  // User-supplied env overrides last. This is where provider API keys come
+  // from (ANTHROPIC_API_KEY etc.).
+  layerUserEnv(env, envConfig);
+
+  // ---- 6. Session resume gate ----
+  const runtimeSessionParams = parseRuntimeSessionParams(runtime.sessionParams);
+  const runtimeSessionId =
+    runtimeSessionParams.sessionId || asString(runtime.sessionId, "");
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionParams.cwd.length === 0 ||
+      path.resolve(runtimeSessionParams.cwd) === path.resolve(cwd));
+
+  // If we have a saved session but the cwd doesn't match, log it so the
+  // operator can see why we're starting fresh.
+  if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] amplifier-agent session "${runtimeSessionId}" was saved for cwd ` +
+        `"${runtimeSessionParams.cwd}" and will not be resumed in "${cwd}".\n`,
+    );
+  }
+
+  // ---- 7. Prompt rendering ----
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt =
+    !canResumeSession && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, {
+    resumedSession: canResumeSession,
+  });
+  const shouldUseResumeDeltaPrompt = canResumeSession && wakePrompt.length > 0;
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+
+  // Instructions prefix is suppressed on the resume-delta path so we don't
+  // re-inject project instructions into an already-warm session.
+  const instructionsPrefix = await readInstructionsPrefix(
+    instructionsFilePath,
+    shouldUseResumeDeltaPrompt,
+  );
+  const renderedPrompt = shouldUseResumeDeltaPrompt
+    ? ""
+    : renderTemplate(promptTemplate, templateData);
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    sessionHandoffNote,
+    renderedPrompt,
+  ]);
+
+  // ---- 8. host_config.json ----
+  // Provider config carries model. Approval mode "yes" matches the wrapper's
+  // approval: { mode: "yes" } so the engine's G3 fail-fast is satisfied
+  // either way (argv beats host_config, but both agree). Skills dir is the
+  // managed one we just symlinked into.
+  const hostConfig: AmplifierAgentHostConfig = {
+    approval: { mode: "yes" },
+    provider: {
+      module: provider,
+      config: { model },
+    },
+    skills: {
+      skills: [skillsDir],
+    },
+    ...(allowProtocolSkew ? { allowProtocolSkew: true } : {}),
+  };
+  await writeHostConfigAtomic(hostConfigPath, hostConfig);
+
+  // ---- 9. onMeta — record invocation before spawning ----
+  const loggedEnv = buildInvocationEnvForLogs(env, {
+    runtimeEnv: process.env as Record<string, string>,
+    includeRuntimeKeys: ["HOME", "USER", "PATH"],
+  });
+  if (onMeta) {
+    await onMeta({
+      adapterType: "amplifier_local",
+      command,
+      cwd,
+      commandNotes: [
+        `provider=${provider}`,
+        `model=${model}`,
+        `session=${canResumeSession ? "resume" : "fresh"}`,
+        `protocol=0.3.0`,
+      ],
+      commandArgs: [
+        "run",
+        "--session-id",
+        canResumeSession ? runtimeSessionId : "<fresh>",
+        canResumeSession ? "--resume" : "--fresh",
+        "--cwd",
+        cwd,
+        "--config",
+        hostConfigPath,
+        "--protocol-version",
+        "0.3.0",
+        "-y",
+        `<prompt ${prompt.length} chars>`,
+      ],
+      env: loggedEnv,
+      prompt,
+      promptMetrics: {
+        promptChars: prompt.length,
+        instructionsChars: instructionsPrefix.length,
+        bootstrapPromptChars: renderedBootstrapPrompt.length,
+        wakePromptChars: wakePrompt.length,
+        sessionHandoffChars: sessionHandoffNote.length,
+        heartbeatPromptChars: renderedPrompt.length,
+      },
+      context,
+    });
+  }
+
+  // ---- 10. Spawn + iterate events ----
+  const mcpServers = toMcpServersMap(mcpServersConfig);
+  const runAttempt = async (
+    resumeSessionIdArg: string | null,
+  ): Promise<RunAttemptResult> => {
+    const sessionIdForRun = resumeSessionIdArg ?? createFreshSessionId(agent.id);
+    let handle;
+    try {
+      handle = await spawnAgent({
+        lifecycle: "one-shot",
+        sessionId: sessionIdForRun,
+        resume: resumeSessionIdArg !== null,
+        cwd,
+        env: {
+          allowlist: Object.keys(env),
+          extra: env,
+        },
+        providerOverride: provider,
+        approval: { mode: "yes" },
+        configPath: hostConfigPath,
+        allowProtocolSkew,
+        timeoutMs: timeoutSec > 0 ? timeoutSec * 1000 : undefined,
+        ...(mcpServers ? { mcpServers } : {}),
+        runChildProcess: buildChildProcessFactory(onLog, onSpawn),
+      });
+    } catch (err) {
+      if (err instanceof AaaError) {
+        return spawnAaaErrorToResult(err, command);
+      }
+      throw err;
+    }
+
+    let resolvedSessionId: string = sessionIdForRun;
+    let resultText = "";
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cost: number | null = null;
+    let terminalError: ReturnType<typeof asAmplifierErrorView> | null = null;
+    let stderrBuffer = ""; // accumulates only what we can see via the error event's stderrTail
+
+    for await (const event of handle.submit(prompt)) {
+      switch (event.type) {
+        case "init":
+          resolvedSessionId = event.sessionId || resolvedSessionId;
+          break;
+        case "activity":
+          // 2-second keep-alive ticks — paperclip doesn't need to see them.
+          break;
+        case "result":
+          resultText = event.text;
+          break;
+        case "error":
+          terminalError = errorEventToView(event);
+          stderrBuffer = event.stderrTail ?? "";
+          break;
+        case "notification": {
+          // Update structured state from the 9 stderr wire events.
+          // We don't need to forward these as additional onLog calls — the
+          // ChildProcessFactory already feeds raw stderr to onLog, and the
+          // UI's parseStdoutLine maps the lines to TranscriptEntries.
+          const method = event.method;
+          const params = (event.params ?? {}) as Record<string, unknown>;
+          if (method === "usage") {
+            inputTokens = asNumber(params.inputTokens, inputTokens);
+            outputTokens = asNumber(params.outputTokens, outputTokens);
+            const c = params.cost;
+            if (typeof c === "number") cost = c;
+          } else if (method === "result/final") {
+            const text = asString(params.text, "");
+            if (text) resultText = text;
+          }
+          break;
+        }
+      }
+    }
+
+    const ok: RunAttemptOk = {
+      kind: "ok",
+      sessionId: resolvedSessionId,
+      resultText,
+      inputTokens,
+      outputTokens,
+      cost,
+      terminalError,
+      stderrBuffer,
+    };
+    return ok;
+  };
+
+  // First attempt: with resume if we have a valid session, else fresh.
+  let attempt: RunAttemptResult = await runAttempt(
+    canResumeSession ? runtimeSessionId : null,
+  );
+
+  // Unknown-session retry path: if resume failed with a session-not-found
+  // error, retry with --fresh and set clearSession=true on the result.
+  let clearSession = false;
+  if (
+    canResumeSession &&
+    attempt.kind === "ok" &&
+    attempt.terminalError &&
+    isAmplifierUnknownSessionError(attempt.terminalError, attempt.stderrBuffer)
+  ) {
+    await onLog(
+      "stdout",
+      `[paperclip] amplifier-agent resume session "${runtimeSessionId}" is unavailable; ` +
+        `retrying with a fresh session.\n`,
+    );
+    attempt = await runAttempt(null);
+    clearSession = true;
+  }
+
+  // ---- 11. Build the AdapterExecutionResult ----
+  if (attempt.kind === "spawn_error") {
+    return attempt.result;
+  }
+  return buildResult({
+    attempt,
+    cwd,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    model,
+    provider,
+    clearSession,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers used by execute()
+// ---------------------------------------------------------------------------
+
+async function readInstructionsPrefix(
+  instructionsFilePath: string,
+  shouldSuppressOnResume: boolean,
+): Promise<string> {
+  if (shouldSuppressOnResume) return "";
+  if (!instructionsFilePath) return "";
+  try {
+    const contents = await fs.readFile(instructionsFilePath, "utf-8");
+    return contents.trim().length > 0
+      ? `${contents.trim()}\n\n(instructions sourced from: ${instructionsFilePath})`
+      : "";
+  } catch {
+    // Silently skip — instructions file is optional; missing file shouldn't
+    // block the run. The agent will run with bundle + skill content only.
+    return "";
+  }
+}
+
+function toMcpServersMap(
+  raw: Record<string, unknown>,
+): Record<string, McpServerConfig> | null {
+  const entries = Object.entries(raw);
+  if (entries.length === 0) return null;
+  const out: Record<string, McpServerConfig> = {};
+  for (const [name, value] of entries) {
+    if (value && typeof value === "object") {
+      out[name] = value as McpServerConfig;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function createFreshSessionId(agentId: string): string {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `pc-${agentId.slice(0, 8)}-${ts}-${rand}`;
+}
+
+function spawnAaaErrorToResult(
+  err: AaaError,
+  command: string,
+): { kind: "spawn_error"; result: AdapterExecutionResult } {
+  const view = aaaErrorToView(err);
+  const errorMessage = describeAmplifierError(view, "", null);
+  // Map common wrapper-side codes to paperclip-style adapter result fields.
+  const isProtocol = isAmplifierProtocolMismatchError(view) || err.code === "protocol_version_mismatch";
+  const isBinaryMissing = err.code === "binary_not_found";
+  return {
+    kind: "spawn_error",
+    result: {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorMessage:
+        isBinaryMissing
+          ? `${errorMessage} (install: uv tool install git+https://github.com/microsoft/amplifier-agent)`
+          : errorMessage,
+      errorCode: isProtocol
+        ? "amplifier_protocol_mismatch"
+        : isBinaryMissing
+          ? "amplifier_binary_not_found"
+          : err.code || "amplifier_spawn_failed",
+      resultJson: {
+        command,
+        wrapperError: {
+          code: err.code,
+          classification: err.classification ?? "unknown",
+          message: err.message,
+          remediation: err.remediation ?? "",
+        },
+      },
+    },
+  };
+}
+
+function buildResult(input: {
+  attempt: RunAttemptOk;
+  cwd: string;
+  workspaceId: string;
+  workspaceRepoUrl: string;
+  workspaceRepoRef: string;
+  model: string;
+  provider: string;
+  clearSession: boolean;
+}): AdapterExecutionResult {
+  const { attempt, cwd, workspaceId, workspaceRepoUrl, workspaceRepoRef, model, provider, clearSession } =
+    input;
+  const errorMessage = attempt.terminalError
+    ? describeAmplifierError(attempt.terminalError, attempt.stderrBuffer, null)
+    : null;
+
+  // Map engine error codes to adapter error codes for paperclip.
+  let errorCode: string | null = null;
+  if (attempt.terminalError) {
+    if (isAmplifierUnknownSessionError(attempt.terminalError, attempt.stderrBuffer)) {
+      errorCode = "amplifier_session_unknown";
+    } else if (isAmplifierProtocolMismatchError(attempt.terminalError)) {
+      errorCode = "amplifier_protocol_mismatch";
+    } else if (isAmplifierApprovalUnconfiguredError(attempt.terminalError)) {
+      errorCode = "amplifier_approval_unconfigured";
+    } else if (isAmplifierBundleLoadFailedError(attempt.terminalError)) {
+      errorCode = "amplifier_bundle_load_failed";
+    } else {
+      errorCode = `amplifier_${attempt.terminalError.classification || "engine"}`;
+    }
+  }
+
+  const sessionParams = attempt.sessionId
+    ? {
+        sessionId: attempt.sessionId,
+        cwd,
+        ...(workspaceId ? { workspaceId } : {}),
+        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+      }
+    : null;
+
+  return {
+    exitCode: attempt.terminalError ? 1 : 0,
+    signal: null,
+    timedOut: false,
+    errorMessage,
+    errorCode,
+    usage: {
+      inputTokens: attempt.inputTokens,
+      outputTokens: attempt.outputTokens,
+    },
+    sessionId: attempt.sessionId,
+    sessionParams,
+    sessionDisplayId: attempt.sessionId,
+    provider,
+    model,
+    costUsd: attempt.cost,
+    summary: attempt.resultText,
+    clearSession: clearSession && !attempt.sessionId,
+  };
+}
+
+

--- a/packages/adapters/amplifier-local/src/server/index.ts
+++ b/packages/adapters/amplifier-local/src/server/index.ts
@@ -1,0 +1,101 @@
+/**
+ * Server-side public exports for @paperclipai/adapter-amplifier-local.
+ *
+ * Imported by paperclip's server/src/adapters/registry.ts.
+ */
+
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export {
+  asAmplifierErrorView,
+  describeAmplifierError,
+  isAmplifierApprovalUnconfiguredError,
+  isAmplifierBundleLoadFailedError,
+  isAmplifierProtocolMismatchError,
+  isAmplifierUnknownSessionError,
+} from "./parse.js";
+export type { AmplifierErrorView } from "./parse.js";
+export {
+  resolveAmplifierLocalManagedDir,
+  resolveHostConfigPath,
+  resolveSkillsDir,
+  writeHostConfigAtomic,
+} from "./amplifier-host-config.js";
+export type { AmplifierAgentHostConfig } from "./amplifier-host-config.js";
+
+// ---------------------------------------------------------------------------
+// sessionCodec
+// ---------------------------------------------------------------------------
+
+/**
+ * Paperclip persists `sessionParams` opaquely per task. The codec validates
+ * the shape and extracts a human-readable display id.
+ *
+ * Fields the adapter writes (see execute.ts buildResult):
+ *   sessionId    — the amplifier-agent session id (REQUIRED)
+ *   cwd          — effective execution cwd at time of session creation
+ *   workspaceId  — paperclip workspace id (when an active workspace)
+ *   repoUrl      — workspace repo URL (when applicable)
+ *   repoRef      — workspace repo ref (when applicable)
+ *
+ * Deserialize tolerates both camelCase and snake_case aliases (defensive
+ * forward-compat with engine versions that might emit snake_case in JSON
+ * envelope metadata).
+ */
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId =
+      readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl =
+      readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef =
+      readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd);
+    const workspaceId = readNonEmptyString(params.workspaceId);
+    const repoUrl = readNonEmptyString(params.repoUrl);
+    const repoRef = readNonEmptyString(params.repoRef);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString((params as Record<string, unknown>).session_id)
+    );
+  },
+};

--- a/packages/adapters/amplifier-local/src/server/parse.ts
+++ b/packages/adapters/amplifier-local/src/server/parse.ts
@@ -1,0 +1,193 @@
+/**
+ * amplifier-agent error classification helpers.
+ *
+ * After the wrapper's 0.6.1 hardening release, envelope parsing and NDJSON
+ * stream parsing are owned by `amplifier-agent-ts`:
+ *   - The wrapper's `parseRunOutput()` decodes the §4.1 envelope.
+ *   - The wrapper's `parseNdjsonStream()` parses the 9 stderr wire events.
+ *   - The wrapper's `SessionHandle` surfaces both as typed `DisplayEvent`s.
+ *
+ * This module is the adapter's classifier layer: given a structured error
+ * (from the wrapper's `DisplayEvent` of type `error`) plus accumulated
+ * stderr, it answers paperclip-specific questions:
+ *   - Was this an "unknown session" failure that warrants a fresh retry?
+ *   - Was it a protocol skew (user-actionable)?
+ *   - Was it G3's approval_unconfigured (indicates an argv assembly bug)?
+ *   - What's the best human-readable message for the result?
+ *
+ * The classifier inputs are intentionally primitive (string / string / string)
+ * so this file has no dependency on the wrapper's `DisplayEvent` type. The
+ * caller (execute.ts) extracts the relevant fields from whatever shape it
+ * has and passes them in.
+ *
+ * Engine error codes are from `src/amplifier_agent_lib/protocol/errors.py`
+ * in `microsoft/amplifier-agent`.
+ */
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal classifier input — paperclip-side equivalent of the engine's §4.1
+ * envelope error. Constructed by execute.ts from either the wrapper's
+ * `{type: "error", ...}` DisplayEvent or a thrown `AaaError`.
+ */
+export interface AmplifierErrorView {
+  /** Engine error code (e.g. "session_not_found"). Empty when unknown. */
+  code: string;
+  /** Engine classification ("transport" | "protocol" | "engine" | "approval" | "unknown"). */
+  classification: string;
+  /** Human-readable message from the engine. */
+  message: string;
+  /** Last 4096 bytes of subprocess stderr, if surfaced by the wrapper. */
+  stderrTail: string;
+}
+
+/**
+ * Build an `AmplifierErrorView` from loose fields. Useful when the caller
+ * has an `AaaError` or wrapper `DisplayEvent` and just wants a uniform shape.
+ */
+export function asAmplifierErrorView(input: {
+  code?: string | null;
+  classification?: string | null;
+  message?: string | null;
+  stderrTail?: string | null;
+}): AmplifierErrorView {
+  return {
+    code: (input.code ?? "").trim(),
+    classification: (input.classification ?? "").trim(),
+    message: (input.message ?? "").trim(),
+    stderrTail: input.stderrTail ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unknown session detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Engine error codes that mean "the session id you asked to resume does not
+ * exist on disk". When this fires on a resume attempt, execute.ts retries
+ * with `--fresh` and sets `clearSession: true` on the result so paperclip
+ * discards the stale runtimeSessionParams.
+ *
+ * Codes from `amplifier_agent_lib/protocol/errors.py`:
+ *   - session_not_found    (canonical)
+ *   - invalid_session      (legacy alias kept by engine for backward compat)
+ *   - stale_session        (engine emits when transcript exists but has
+ *                           been invalidated by a foundation upgrade)
+ */
+const AMPLIFIER_UNKNOWN_SESSION_CODES = new Set([
+  "session_not_found",
+  "invalid_session",
+  "stale_session",
+]);
+
+/**
+ * Human-readable patterns for engines that predate structured error codes
+ * (defensive forward-compat). The adapter should never see these in
+ * practice with engine ≥0.4.0; kept so older engines degrade gracefully.
+ */
+const AMPLIFIER_UNKNOWN_SESSION_RE =
+  /session\b[^\n]*\b(?:not\s+found|does\s+not\s+exist|is\s+unavailable|is\s+invalid)|no\s+session\s+(?:found|directory)|missing\s+transcript|session\s+id\s+invalid/i;
+
+/**
+ * True when the failure indicates "the session id we tried to resume does
+ * not exist". Causes execute.ts to retry with `--fresh` and clear paperclip's
+ * stored sessionParams.
+ *
+ * Mirrors the codex-local `isCodexUnknownSessionError` pattern: checks the
+ * structured error code first, then falls back to message/stderr regex
+ * matching for resilience.
+ */
+export function isAmplifierUnknownSessionError(
+  error: AmplifierErrorView,
+  stderr: string,
+): boolean {
+  if (error.code && AMPLIFIER_UNKNOWN_SESSION_CODES.has(error.code)) {
+    return true;
+  }
+  const haystack = [error.message, error.stderrTail, stderr]
+    .filter((s) => s && s.length > 0)
+    .join("\n");
+  return AMPLIFIER_UNKNOWN_SESSION_RE.test(haystack);
+}
+
+// ---------------------------------------------------------------------------
+// Other engine-specific error code matchers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrapper-pinned protocol version diverged from the engine's. The wrapper
+ * (≥0.6.1) catches this at `spawnAgent()` time via `checkProtocolVersion()`
+ * and throws `AaaError(code: "protocol_version_mismatch")` before any
+ * subprocess spawn — so the adapter should rarely observe this from the
+ * engine directly. Kept as a check for the fallback path where the wrapper's
+ * pre-flight is bypassed (e.g. `allowProtocolSkew: true`).
+ *
+ * The error surfaces a structured `remediation` field; execute.ts should
+ * include it in the AdapterExecutionResult's errorMessage.
+ */
+export function isAmplifierProtocolMismatchError(
+  error: AmplifierErrorView,
+): boolean {
+  return error.code === "protocol_version_mismatch";
+}
+
+/**
+ * Engine G3 fail-fast: non-TTY run without an explicit approval policy.
+ * The adapter always passes `approval: { mode: "yes" }` (which emits `-y`),
+ * so this should NEVER fire. If it does, it indicates an argv-assembly bug
+ * or a stale wrapper version — surface it loudly in monitoring.
+ */
+export function isAmplifierApprovalUnconfiguredError(
+  error: AmplifierErrorView,
+): boolean {
+  return error.code === "approval_unconfigured";
+}
+
+/**
+ * Bundle failed to mount — typically a stale `$XDG_CACHE_HOME/amplifier-agent`
+ * after a foundation/engine version bump. The remediation is to run
+ * `amplifier-agent prepare` (or `amplifier-agent cache clear`) on the host.
+ * execute.ts surfaces this as `errorCode: "amplifier_bundle_load_failed"` so
+ * paperclip can show the actionable hint in the run viewer.
+ */
+export function isAmplifierBundleLoadFailedError(
+  error: AmplifierErrorView,
+): boolean {
+  return error.code === "bundle_load_failed";
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable error summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the best human-readable error string from the structured error and
+ * surrounding stderr. Preference order:
+ *   1. error.message (from the engine's envelope)
+ *   2. first non-empty stderr line
+ *   3. generic "amplifier-agent exited with code N"
+ *
+ * Used by execute.ts to populate `AdapterExecutionResult.errorMessage`.
+ */
+export function describeAmplifierError(
+  error: AmplifierErrorView,
+  stderr: string,
+  exitCode: number | null,
+): string {
+  if (error.message && error.message.length > 0) return error.message;
+  const firstStderr = firstNonEmptyLine(stderr);
+  if (firstStderr) return firstStderr;
+  return `amplifier-agent exited with code ${exitCode ?? -1}`;
+}
+
+function firstNonEmptyLine(text: string): string {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length > 0) return line;
+  }
+  return "";
+}

--- a/packages/adapters/amplifier-local/src/server/test.ts
+++ b/packages/adapters/amplifier-local/src/server/test.ts
@@ -1,0 +1,259 @@
+/**
+ * testEnvironment — preflight checks for amplifier-local.
+ *
+ * Runs in the paperclip UI when an operator clicks "Test environment" on an
+ * agent. Validates:
+ *   1. cwd exists and is a directory
+ *   2. The configured command (default "amplifier-agent") is resolvable on PATH
+ *   3. `amplifier-agent doctor` runs cleanly (and includes the G4 mcp-importable check)
+ *   4. The configured provider env var (e.g. ANTHROPIC_API_KEY) is present
+ *
+ * Status mapping:
+ *   - any `error` check  → "fail" (blocks the agent from running)
+ *   - any `warn` check   → "warn" (visible in UI, doesn't block)
+ *   - all `info`         → "pass"
+ */
+
+import { promisify } from "node:util";
+import { execFile as _execFile } from "node:child_process";
+
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  ensureAbsoluteDirectory,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+
+import { DEFAULT_AMPLIFIER_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
+
+const execFile = promisify(_execFile);
+
+const DOCTOR_TIMEOUT_MS = 30_000;
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): "pass" | "warn" | "fail" {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+function info(code: string, message: string, hint?: string): AdapterEnvironmentCheck {
+  return { code, level: "info", message, ...(hint ? { hint } : {}) };
+}
+function warn(code: string, message: string, hint?: string): AdapterEnvironmentCheck {
+  return { code, level: "warn", message, ...(hint ? { hint } : {}) };
+}
+function error(code: string, message: string, hint?: string): AdapterEnvironmentCheck {
+  return { code, level: "error", message, ...(hint ? { hint } : {}) };
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+async function checkCwd(cwd: string): Promise<AdapterEnvironmentCheck> {
+  if (!cwd) {
+    return info("amplifier_cwd_default", "cwd: <process default> (none configured)");
+  }
+  try {
+    await ensureAbsoluteDirectory(cwd);
+    return info("amplifier_cwd_valid", `cwd: ${cwd} (exists)`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return error("amplifier_cwd_invalid", `cwd invalid: ${msg}`, `Create ${cwd} or update the agent's cwd setting.`);
+  }
+}
+
+async function checkCommand(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+): Promise<AdapterEnvironmentCheck> {
+  // Resolve via `command -v` (POSIX) or the equivalent. Avoids a dependency
+  // on platform-specific tooling.
+  try {
+    const probe = await execFile(
+      "/bin/sh",
+      ["-c", `command -v "${command.replace(/"/g, '\\"')}"`],
+      { cwd: cwd || process.cwd(), env, timeout: 5_000, maxBuffer: 64 * 1024 },
+    );
+    const resolved = probe.stdout.trim();
+    if (resolved) {
+      return info("amplifier_command_resolvable", `command: ${resolved}`);
+    }
+    return error(
+      "amplifier_command_unresolvable",
+      `"${command}" not found in PATH`,
+      `Install amplifier-agent: ${SANDBOX_INSTALL_COMMAND}`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return error(
+      "amplifier_command_unresolvable",
+      `Cannot resolve "${command}" in PATH: ${msg}`,
+      `Install amplifier-agent: ${SANDBOX_INSTALL_COMMAND}`,
+    );
+  }
+}
+
+async function checkDoctor(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+): Promise<AdapterEnvironmentCheck[]> {
+  if (command !== "amplifier-agent") {
+    return [
+      info(
+        "amplifier_doctor_skipped_custom_command",
+        `doctor probe skipped (custom command: ${command})`,
+        "Set command to 'amplifier-agent' to run the built-in doctor.",
+      ),
+    ];
+  }
+  try {
+    const { stdout, stderr } = await execFile(command, ["doctor"], {
+      cwd: cwd || process.cwd(),
+      env,
+      timeout: DOCTOR_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024,
+    });
+    const output = `${stdout}\n${stderr}`;
+    const checks: AdapterEnvironmentCheck[] = [];
+    checks.push(info("amplifier_doctor_passed", "amplifier-agent doctor: all checks passed"));
+
+    // Surface the mcp-importable check status separately so the UI shows the
+    // G4 result explicitly (engine PR #34 added this check).
+    if (/\[\s*OK\s*\]\s*mcp module:/.test(output)) {
+      checks.push(info("amplifier_mcp_importable", "mcp Python package: importable"));
+    } else if (/mcp module/.test(output)) {
+      // The doctor reported on tool-mcp but not with OK — surface as warn.
+      checks.push(
+        warn(
+          "amplifier_mcp_check_indeterminate",
+          "amplifier-agent doctor mentioned the mcp module but didn't report [OK]",
+          "Run `amplifier-agent doctor` manually to see the full report.",
+        ),
+      );
+    }
+    return checks;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; signal?: string };
+    if (e.code === "ETIMEDOUT" || e.signal === "SIGTERM") {
+      return [
+        warn(
+          "amplifier_doctor_timed_out",
+          `amplifier-agent doctor did not return within ${DOCTOR_TIMEOUT_MS / 1000}s`,
+          "The doctor probe may be slow on first run (bundle preparation). Try again or run it manually.",
+        ),
+      ];
+    }
+    const stderr = (e.stderr ?? "").toString().trim();
+    const stdout = (e.stdout ?? "").toString().trim();
+    const detail = [stderr, stdout].filter(Boolean).join("\n") || e.message;
+    return [
+      error(
+        "amplifier_doctor_failed",
+        `amplifier-agent doctor reported a failure: ${detail.split("\n")[0]}`,
+        "Run `amplifier-agent doctor` manually for the full report. If the bundle cache is stale, try `amplifier-agent cache clear` and re-run.",
+      ),
+    ];
+  }
+}
+
+function checkProviderApiKey(
+  envConfig: Record<string, unknown>,
+  hostEnv: NodeJS.ProcessEnv,
+  model: string,
+): AdapterEnvironmentCheck {
+  const expectedEnvVar = providerEnvVarForModel(model);
+  const fromConfig = asString(envConfig[expectedEnvVar], "");
+  const fromHost = asString(hostEnv[expectedEnvVar], "");
+  if (fromConfig.length > 0) {
+    return info(
+      "amplifier_provider_key_present_config",
+      `${expectedEnvVar}: present in adapter env config`,
+    );
+  }
+  if (fromHost.length > 0) {
+    return info(
+      "amplifier_provider_key_present_host",
+      `${expectedEnvVar}: present in host environment`,
+    );
+  }
+  return warn(
+    "amplifier_provider_key_missing",
+    `${expectedEnvVar} is not set in adapter env or host environment`,
+    `Set ${expectedEnvVar} in the agent's env config to allow amplifier-agent to call the provider.`,
+  );
+}
+
+function providerEnvVarForModel(model: string): string {
+  const m = model.trim().toLowerCase();
+  if (m.startsWith("claude-")) return "ANTHROPIC_API_KEY";
+  if (
+    m.startsWith("gpt-") ||
+    /^o[1-9]/i.test(m) ||
+    m.startsWith("text-davinci-")
+  ) {
+    return "OPENAI_API_KEY";
+  }
+  if (
+    m.startsWith("llama") ||
+    m.startsWith("mistral") ||
+    m.startsWith("qwen") ||
+    m.startsWith("deepseek") ||
+    m.startsWith("phi")
+  ) {
+    return "OLLAMA_HOST";
+  }
+  return "ANTHROPIC_API_KEY";
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "amplifier-agent");
+  const cwd = asString(config.cwd, "");
+  const model = asString(config.model, DEFAULT_AMPLIFIER_LOCAL_MODEL);
+  const envConfig = parseObject(config.env);
+
+  // Build the env for command resolution. Use the host env as the base (so
+  // PATH is present) and let user env override.
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (typeof v === "string") env[k] = v;
+  }
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
+
+  const checks: AdapterEnvironmentCheck[] = [];
+  checks.push(await checkCwd(cwd));
+  checks.push(await checkCommand(command, cwd, env));
+
+  // Only run doctor if the command was resolvable — otherwise it'll just
+  // produce a redundant failure.
+  const commandResolvable = checks.some(
+    (c) => c.code === "amplifier_command_resolvable",
+  );
+  if (commandResolvable) {
+    checks.push(...(await checkDoctor(command, cwd, env)));
+  }
+
+  checks.push(checkProviderApiKey(envConfig, process.env, model));
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/amplifier-local/src/ui/build-config.ts
+++ b/packages/adapters/amplifier-local/src/ui/build-config.ts
@@ -1,0 +1,105 @@
+/**
+ * Convert the agent-creation UI's `CreateConfigValues` form into the
+ * `adapterConfig` JSON blob persisted on the agent record.
+ *
+ * Mirrors codex-local's `buildCodexLocalConfig`: required fields get sensible
+ * defaults, optional fields are only emitted when set. The result is what
+ * the server's `execute.ts` parses on every run.
+ */
+
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+import { DEFAULT_AMPLIFIER_LOCAL_MODEL } from "../index.js";
+
+interface EnvBinding {
+  type: "plain" | "secret_ref";
+  value: string;
+}
+
+function parseEnvBindings(
+  raw: Record<string, { type?: string; value?: string }> | undefined,
+): Record<string, EnvBinding> {
+  if (!raw) return {};
+  const out: Record<string, EnvBinding> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (v && typeof v === "object" && typeof v.value === "string") {
+      out[k] = {
+        type: v.type === "secret_ref" ? "secret_ref" : "plain",
+        value: v.value,
+      };
+    }
+  }
+  return out;
+}
+
+function parseEnvVarsText(text: string | undefined): Record<string, string> {
+  if (!text) return {};
+  const out: Record<string, string> = {};
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const idx = line.indexOf("=");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+function parseCommaArgs(text: string | undefined): string[] {
+  if (!text) return [];
+  return text
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function buildAmplifierLocalConfig(
+  v: CreateConfigValues,
+): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  ac.model = v.model || DEFAULT_AMPLIFIER_LOCAL_MODEL;
+
+  // Operational defaults — match codex-local conventions.
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+
+  // env bindings (structured secret_ref aware) + legacy text-block env vars
+  const envBindings = parseEnvBindings(
+    v.envBindings as Record<string, { type?: string; value?: string }> | undefined,
+  );
+  const legacyEnv = parseEnvVarsText(v.envVars as string | undefined);
+  for (const [k, plainValue] of Object.entries(legacyEnv)) {
+    if (!Object.prototype.hasOwnProperty.call(envBindings, k)) {
+      envBindings[k] = { type: "plain", value: plainValue };
+    }
+  }
+  if (Object.keys(envBindings).length > 0) {
+    ac.env = envBindings;
+  }
+
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs as string);
+
+  // workspace strategy (matches codex-local's git_worktree handling)
+  const vRec = v as unknown as Record<string, unknown>;
+  if (vRec.workspaceStrategyType === "git_worktree") {
+    const baseRef = typeof vRec.workspaceBaseRef === "string" ? vRec.workspaceBaseRef : "";
+    const branchTemplate =
+      typeof vRec.workspaceBranchTemplate === "string" ? vRec.workspaceBranchTemplate : "";
+    const worktreeParentDir =
+      typeof vRec.worktreeParentDir === "string" ? vRec.worktreeParentDir : "";
+    ac.workspaceStrategy = {
+      type: "git_worktree",
+      ...(baseRef ? { baseRef } : {}),
+      ...(branchTemplate ? { branchTemplate } : {}),
+      ...(worktreeParentDir ? { worktreeParentDir } : {}),
+    };
+  }
+
+  return ac;
+}

--- a/packages/adapters/amplifier-local/src/ui/index.ts
+++ b/packages/adapters/amplifier-local/src/ui/index.ts
@@ -1,0 +1,10 @@
+/**
+ * UI-side public exports for @paperclipai/adapter-amplifier-local.
+ *
+ * Imported by paperclip's ui/src/adapters/amplifier-local/index.ts. The
+ * React config-fields component lives in paperclip's main UI tree (alongside
+ * the other adapters) because it depends on paperclip-internal primitives.
+ */
+
+export { parseAmplifierLocalStdoutLine } from "./parse-stdout.js";
+export { buildAmplifierLocalConfig } from "./build-config.js";

--- a/packages/adapters/amplifier-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/amplifier-local/src/ui/parse-stdout.ts
@@ -1,0 +1,249 @@
+/**
+ * Maps amplifier-agent output lines into paperclip `TranscriptEntry[]` for
+ * the run viewer.
+ *
+ * The server's ChildProcessFactory (see server/execute.ts) feeds raw stream
+ * chunks into paperclip's `onLog(stream, chunk)`. Paperclip splits those by
+ * newline and calls this parser per line. We see two stream types:
+ *
+ *   - stdout: amplifier-agent emits exactly ONE §4.1 envelope JSON object at
+ *     end-of-turn:
+ *       { protocolVersion, sessionId, turnId, reply, error, metadata }
+ *
+ *   - stderr: NDJSON stream of typed notifications (the 9 wire events:
+ *     result/delta, result/final, tool/started, tool/completed, progress,
+ *     thinking/delta, thinking/final, usage, error) plus arbitrary
+ *     non-JSON lines from the engine's startup / shutdown.
+ *
+ * The parser auto-discriminates by inspecting the JSON shape — we don't
+ * need a `stream` parameter because envelope and notification have
+ * distinguishable keys (`protocolVersion+reply+metadata` vs `method+params`
+ * or `type+sessionId+...`).
+ *
+ * Defensive parsing: any line we can't parse becomes a `stdout` fallback
+ * entry so it still shows up in the viewer.
+ */
+
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Envelope detection + parsing
+// ---------------------------------------------------------------------------
+
+function looksLikeEnvelope(obj: Record<string, unknown>): boolean {
+  return (
+    typeof obj.protocolVersion === "string" &&
+    typeof obj.sessionId === "string" &&
+    typeof obj.turnId === "string" &&
+    "reply" in obj &&
+    "metadata" in obj
+  );
+}
+
+function parseEnvelope(obj: Record<string, unknown>, ts: string): TranscriptEntry[] {
+  const entries: TranscriptEntry[] = [];
+  const sessionId = asString(obj.sessionId);
+  const metadata = asRecord(obj.metadata) ?? {};
+  const engineVersion = asString(metadata.engineVersion);
+  if (sessionId) {
+    entries.push({
+      kind: "init",
+      ts,
+      model: engineVersion ? `amplifier-agent ${engineVersion}` : "amplifier-agent",
+      sessionId,
+    });
+  }
+  const errorBlock = asRecord(obj.error);
+  if (errorBlock) {
+    // Terminal error envelope.
+    const message = asString(errorBlock.message) || asString(errorBlock.code) || "amplifier-agent error";
+    entries.push({
+      kind: "result",
+      ts,
+      text: asString(obj.reply, ""),
+      inputTokens: asNumber(metadata.tokensIn),
+      outputTokens: asNumber(metadata.tokensOut),
+      cachedTokens: asNumber(metadata.cachedTokens),
+      costUsd: typeof metadata.costUsd === "number" ? (metadata.costUsd as number) : 0,
+      subtype: asString(errorBlock.classification, "error"),
+      isError: true,
+      errors: [message],
+    });
+    return entries;
+  }
+  // Successful turn envelope.
+  entries.push({
+    kind: "result",
+    ts,
+    text: asString(obj.reply, ""),
+    inputTokens: asNumber(metadata.tokensIn),
+    outputTokens: asNumber(metadata.tokensOut),
+    cachedTokens: asNumber(metadata.cachedTokens),
+    costUsd: typeof metadata.costUsd === "number" ? (metadata.costUsd as number) : 0,
+    subtype: "completed",
+    isError: false,
+    errors: [],
+  });
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Wire notification mapping
+// ---------------------------------------------------------------------------
+
+function notificationMethod(obj: Record<string, unknown>): string | null {
+  const method = asString(obj.method);
+  if (method) return method;
+  const type = asString(obj.type);
+  if (type) return type;
+  return null;
+}
+
+function notificationParams(obj: Record<string, unknown>): Record<string, unknown> {
+  return asRecord(obj.params) ?? {};
+}
+
+function parseNotification(
+  obj: Record<string, unknown>,
+  ts: string,
+): TranscriptEntry[] {
+  const method = notificationMethod(obj);
+  if (!method) return [];
+  const params = notificationParams(obj);
+
+  switch (method) {
+    case "result/delta":
+      return [
+        {
+          kind: "assistant",
+          ts,
+          text: asString(params.text),
+        },
+      ];
+    case "result/final":
+      return [
+        {
+          kind: "assistant",
+          ts,
+          text: asString(params.text),
+        },
+      ];
+    case "tool/started":
+      return [
+        {
+          kind: "tool_call",
+          ts,
+          name: asString(params.name, "<tool>"),
+          input: (params.args ?? null) as Record<string, unknown>,
+          toolUseId: asString(params.toolCallId),
+        },
+      ];
+    case "tool/completed": {
+      const resultValue = params.result;
+      const content =
+        typeof resultValue === "string"
+          ? resultValue
+          : resultValue != null
+            ? JSON.stringify(resultValue)
+            : "";
+      return [
+        {
+          kind: "tool_result",
+          ts,
+          toolUseId: asString(params.toolCallId),
+          content,
+          isError: false,
+        },
+      ];
+    }
+    case "thinking/delta":
+    case "thinking/final":
+      return [
+        {
+          kind: "thinking",
+          ts,
+          text: asString(params.text),
+        },
+      ];
+    case "progress": {
+      const message = asString(params.message);
+      const percent = typeof params.percent === "number" ? params.percent : null;
+      return [
+        {
+          kind: "system",
+          ts,
+          text: percent !== null ? `${message} (${percent.toFixed(0)}%)` : message,
+        },
+      ];
+    }
+    case "usage":
+      // Usage events are aggregated into the result entry; nothing to display
+      // in-line. Could surface as system metadata in a future iteration.
+      return [];
+    case "error":
+      return [
+        {
+          kind: "stderr",
+          ts,
+          text: asString(params.message) || asString(params.code) || "amplifier-agent error",
+        },
+      ];
+    default:
+      // Unknown notification — surface as system message so we don't lose
+      // forward-compatible events.
+      return [
+        {
+          kind: "system",
+          ts,
+          text: `[${method}] ${JSON.stringify(params).slice(0, 200)}`,
+        },
+      ];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entrypoint
+// ---------------------------------------------------------------------------
+
+export function parseAmplifierLocalStdoutLine(
+  line: string,
+  ts: string,
+): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+  const parsed = safeJsonParse(trimmed);
+  const obj = asRecord(parsed);
+  if (!obj) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+  if (looksLikeEnvelope(obj)) {
+    return parseEnvelope(obj, ts);
+  }
+  // Notification or unknown — try the notification parser first.
+  if (notificationMethod(obj)) {
+    return parseNotification(obj, ts);
+  }
+  // Unknown JSON object — fallback to stdout entry.
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/amplifier-local/tsconfig.json
+++ b/packages/adapters/amplifier-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/amplifier-local/vitest.config.ts
+++ b/packages/adapters/amplifier-local/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
+      '@paperclipai/adapter-amplifier-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/amplifier-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -126,6 +129,25 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       acpx:
+        specifier: ^0.6.1
+        version: 0.6.1
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/amplifier-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      amplifier-agent-ts:
         specifier: ^0.6.1
         version: 0.6.1
       picocolors:
@@ -622,6 +644,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':
@@ -630,6 +654,9 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
+      '@paperclipai/adapter-amplifier-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/amplifier-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -796,6 +823,9 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
+      '@paperclipai/adapter-amplifier-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/amplifier-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -4219,6 +4249,10 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  amplifier-agent-ts@0.6.1:
+    resolution: {integrity: sha512-Csj2sZ7T3YXftTJ6cT3fWtLhxBJBgv0JOsaDgTXJuFHBdnrb6YHzbDYhDRuIahdXeDkR0/LgNujoySq/1hLg8w==}
+    engines: {node: '>=20'}
 
   anser@2.3.5:
     resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
@@ -11319,6 +11353,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  amplifier-agent-ts@0.6.1: {}
 
   anser@2.3.5: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",
     "@paperclipai/adapter-acpx-local": "workspace:*",
+    "@paperclipai/adapter-amplifier-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -36,6 +36,15 @@ import {
   modelProfiles as claudeModelProfiles,
 } from "@paperclipai/adapter-claude-local";
 import {
+  execute as amplifierExecute,
+  testEnvironment as amplifierTestEnvironment,
+  sessionCodec as amplifierSessionCodec,
+} from "@paperclipai/adapter-amplifier-local/server";
+import {
+  agentConfigurationDoc as amplifierAgentConfigurationDoc,
+  models as amplifierModels,
+} from "@paperclipai/adapter-amplifier-local";
+import {
   execute as codexExecute,
   listCodexSkills,
   syncCodexSkills,
@@ -288,6 +297,19 @@ const acpxLocalAdapter: ServerAdapterModule = {
   getConfigSchema: getAcpxConfigSchema,
 };
 
+const amplifierLocalAdapter: ServerAdapterModule = {
+  type: "amplifier_local",
+  execute: amplifierExecute,
+  testEnvironment: amplifierTestEnvironment,
+  sessionCodec: amplifierSessionCodec,
+  models: amplifierModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: amplifierAgentConfigurationDoc,
+};
+
 const codexLocalAdapter: ServerAdapterModule = {
   type: "codex_local",
   execute: codexExecute,
@@ -514,6 +536,7 @@ function registerBuiltInAdapters() {
   for (const adapter of [
     acpxLocalAdapter,
     claudeLocalAdapter,
+    amplifierLocalAdapter,
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "@lexical/link": "0.35.0",
     "@mdxeditor/editor": "^3.52.4",
     "@paperclipai/adapter-acpx-local": "workspace:*",
+    "@paperclipai/adapter-amplifier-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/ui/src/adapters/amplifier-local/config-fields.tsx
+++ b/ui/src/adapters/amplifier-local/config-fields.tsx
@@ -1,0 +1,101 @@
+/**
+ * Agent-creation/edit form fields for amplifier-local. Renders only the
+ * adapter-specific fields — model, cwd, env, command, timeout, etc. are
+ * rendered by the shared parent form.
+ *
+ * Fields:
+ *   - Agent instructions file (markdown file prepended to the system prompt)
+ *   - Allow protocol skew (advanced — bypass the wrapper's pre-flight
+ *     protocol-version check; UNSAFE outside dev)
+ *   - LocalWorkspaceRuntimeFields (workspace strategy + runtime services)
+ */
+
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  ToggleField,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) prepended to the amplifier-agent prompt at runtime. The engine's tool-skills module also surfaces team skills automatically — use this for agent-specific instructions that don't belong in shared skills.";
+const allowSkewHint =
+  "Bypass the wrapper's protocol-version pre-flight check. UNSAFE — only use when intentionally pairing a wrapper and engine across a known-incompatible protocol gap during development.";
+
+export function AmplifierLocalConfigFields({
+  mode,
+  isCreate,
+  adapterType,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  // CreateConfigValues is a closed type; cast through unknown to reach
+  // adapter-specific fields (allowProtocolSkew, instructionsFilePath).
+  const valuesAny = (values ?? {}) as unknown as Record<string, unknown>;
+  const allowSkewEnabled = isCreate
+    ? Boolean(valuesAny.allowProtocolSkew)
+    : eff("adapterConfig", "allowProtocolSkew", Boolean(config.allowProtocolSkew));
+
+  return (
+    <>
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? (typeof valuesAny.instructionsFilePath === "string"
+                      ? valuesAny.instructionsFilePath
+                      : "")
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(v: string) =>
+                isCreate
+                  ? set!({ instructionsFilePath: v })
+                  : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+      <ToggleField
+        label="Allow protocol skew (advanced)"
+        hint={allowSkewHint}
+        checked={allowSkewEnabled}
+        onChange={(v: boolean) =>
+          isCreate
+            ? set!({ allowProtocolSkew: v } as Record<string, unknown>)
+            : mark("adapterConfig", "allowProtocolSkew", v)
+        }
+      />
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/amplifier-local/index.ts
+++ b/ui/src/adapters/amplifier-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseAmplifierLocalStdoutLine } from "@paperclipai/adapter-amplifier-local/ui";
+import { AmplifierLocalConfigFields } from "./config-fields";
+import { buildAmplifierLocalConfig } from "@paperclipai/adapter-amplifier-local/ui";
+
+export const amplifierLocalUIAdapter: UIAdapterModule = {
+  type: "amplifier_local",
+  label: "Amplifier (local)",
+  parseStdoutLine: parseAmplifierLocalStdoutLine,
+  ConfigFields: AmplifierLocalConfigFields,
+  buildAdapterConfig: buildAmplifierLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -1,6 +1,7 @@
 import type { UIAdapterModule } from "./types";
 import { acpxLocalUIAdapter } from "./acpx-local";
 import { claudeLocalUIAdapter } from "./claude-local";
+import { amplifierLocalUIAdapter } from "./amplifier-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorCloudUIAdapter } from "./cursor-cloud";
 import { cursorLocalUIAdapter } from "./cursor";
@@ -54,6 +55,7 @@ function registerBuiltInUIAdapters() {
   for (const adapter of [
     acpxLocalUIAdapter,
     claudeLocalUIAdapter,
+    amplifierLocalUIAdapter,
     codexLocalUIAdapter,
     cursorCloudUIAdapter,
     geminiLocalUIAdapter,


### PR DESCRIPTION
## Summary

First-class paperclip adapter for the **Amplifier engine** (amplifier-agent Python CLI), matching the integration depth of `claude-local` and `codex-local`.

## Engine prerequisites

| Component | Required | Why |
|---|---|---|
| `amplifier-agent` (Python) | `>= 0.4.0` | G3 fail-fast + G4 mcp-importable doctor check landed in [microsoft/amplifier-agent#34](https://github.com/microsoft/amplifier-agent/pull/34) |
| `amplifier-agent-ts` (npm) | `^0.6.1` | Closes 9 of 10 audited wrapper gaps in [microsoft/amplifier-agent#36](https://github.com/microsoft/amplifier-agent/pull/36); the 10th was clarified as a non-bug |
| Wire protocol | `0.3.0` | Engine + wrapper synchronized |

## What the adapter does end-to-end

1. Resolves config (model, provider, env, cwd, instructions, timeout)
2. Derives provider from model id: `claude-*` → `anthropic`, `gpt-* / o3-* / o4-*` → `openai`, `llama* / mistral*` → `ollama`. Operators can force a provider via `config.provider` (e.g. `azure-openai`).
3. Sets up per-company managed dir (`$PAPERCLIP_HOME/instances/<id>/companies/<companyId>/amplifier-local/`) for `host_config.json` and skill symlinks; never writes to agent's cwd
4. Injects paperclip skills by symlink into the managed dir
5. Writes `host_config.json` atomically (provider/model, approval mode `yes`, skills dir, optional `allowProtocolSkew`)
6. Builds subprocess env (PAPERCLIP_* + wake context + workspace vars + provider API keys)
7. Spawns via `spawnAgent({ configPath, runChildProcess, approval: { mode: "yes" }, display: { onEvent } })`. Wrapper owns argv assembly, MCP spill, NDJSON event parsing, envelope parsing, protocol pre-flight.
8. Iterates wrapper DisplayEvents (init / activity / result / error / notification)
9. Retries unknown-session errors with `--fresh` and `clearSession: true`
10. Returns `AdapterExecutionResult` with paperclip-mapped error codes (`amplifier_session_unknown`, `amplifier_protocol_mismatch`, `amplifier_approval_unconfigured`, `amplifier_bundle_load_failed`)

## Session-resume semantics

- Resume gate: stored `sessionId` + stored `cwd` matches current `cwd` (resolved). Otherwise starts fresh and logs why.
- Unknown-session retry: codex-local pattern — if resume errors with `session_not_found` / `invalid_session` / `stale_session`, retries with `--fresh` and clears paperclip's stored session.

## Capability flags

- `supportsLocalAgentJwt: true`
- `supportsInstructionsBundle: true`
- `instructionsPathKey: "instructionsFilePath"`
- `requiresMaterializedRuntimeSkills: false` (skills symlinked, not copied)

## Testing & quality

- **38/38 unit tests pass**: parse (13), parse-stdout (10), session-codec (9), build-config (6)
- **Typecheck clean** on `@paperclipai/adapter-amplifier-local`, `@paperclipai/server`, `@paperclipai/ui`
- **No-remote-git contract honored** — adapter executes locally only; no `git push` from runtime code

## Design rationale

- **Built-in adapter, not external plugin** — matches `codex-local` and `claude-local` integration depth. Discoverable in paperclip's adapter UI without an extra install step. Reversibility ~3 days if needed (mostly UI parser rewrite for browser sandbox).
- **Depends on `amplifier-agent-ts@^0.6.1`** — wrapper owns argv assembly, MCP spill, NDJSON event parsing, envelope parsing, protocol pre-flight, child-process injection. Engine protocol bumps → wrapper bumps → adapter bumps the dep version. No duplicated engine-side logic.
- **Wrapper PR #36 closed 9 of 10 gaps** that this adapter would otherwise have had to bypass. Net adapter LoC: ~1500 (vs ~1900 bypass-style, with bypass eventually becoming dead code).

## Commit structure

- `c761edf3` — `feat(adapter): add amplifier-local adapter package` (18 files under `packages/adapters/amplifier-local/`)
- `096a3060` — `feat(server,ui,cli): register amplifier-local adapter` (3 registry edits + 3 workspace deps + UI integration + lockfile)
