### PR TITLE
openclaw-gateway: warn loudly when assignee has no routing agentId

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1141,9 +1141,40 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   delete agentParams.text;
   agentParams.paperclip = paperclipPayload;
 
+  // Wake-dispatcher routing identifier.
+  //
+  // The openclaw_gateway multiplexes many Paperclip agents onto a single
+  // OpenClaw control plane. Each outbound wake MUST be tagged with the
+  // assignee's openclaw routing id so the gateway lands it in the assignee's
+  // session (not the company default / first session).
+  //
+  // Resolution order (first non-empty wins):
+  //   1. `agentParams.agentId` set by payloadTemplate (explicit per-wake override)
+  //   2. `ctx.config.agentId` (per-agent adapterConfig — the source of truth
+  //      because Paperclip agent slug != openclaw agent id in general)
+  //
+  // When neither is set we log a LOUD warning instead of silently falling
+  // through to the gateway default. See WIS-25 for the production bug this
+  // guard exists to prevent.
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;
+  }
+  // Mirror the resolved routing id into the gateway's auth header so the
+  // control-plane router routes by assignee, not the company default. The
+  // header is only injected when not already explicitly set.
+  const resolvedRoutingAgentId = nonEmpty(agentParams.agentId) ?? configuredAgentId;
+  if (resolvedRoutingAgentId && !headerMapHasIgnoreCase(headers, "x-openclaw-agent-id")) {
+    headers["x-openclaw-agent-id"] = resolvedRoutingAgentId;
+  }
+  if (!resolvedRoutingAgentId) {
+    await ctx.onLog(
+      "stderr",
+      `[openclaw-gateway] WARNING: outbound wake for agent id=${ctx.agent.id} name=${ctx.agent.name} has no routing agentId. ` +
+        `The wake will fall through to the gateway's default agent. ` +
+        `Set adapterConfig.agentId (and headers['x-openclaw-agent-id']) to the openclaw agent id this Paperclip agent maps to. ` +
+        `See WIS-25.\n`,
+    );
   }
 
   if (typeof agentParams.timeout !== "number") {


### PR DESCRIPTION
## Summary

When an `openclaw_gateway`-backed Paperclip agent is woken without an explicit `adapterConfig.agentId` (and matching `headers['x-openclaw-agent-id']`), the outbound wake silently falls through to the gateway's default agent — so wakes assigned to e.g. *Apollo* land in *Rocky's* `main` session in prod.

Reported as **WIS-25** ("openclaw_gateway wake dispatcher must route by assignee").

## Change

`packages/adapters/openclaw-gateway/src/server/execute.ts`:

1. Mirror the resolved `agentParams.agentId` (or `ctx.config.agentId`) into the `x-openclaw-agent-id` request header when not already set. Today operators have to keep both fields in sync by hand — this collapses them to a single source of truth.
2. Emit a **loud `stderr` warning** when no routing `agentId` can be resolved at all. Includes the offending Paperclip agent id + name + a pointer to WIS-25. Without this, mis-configured agents fail silently into the wrong session.

The per-agent `adapterConfig` remains the source of truth for the **Paperclip-agent → openclaw-agent** mapping; we deliberately don't auto-derive from `agent.urlKey` because the two slug spaces diverge intentionally (e.g. `apollo` → `marketing`, `rocky` → `main`).

## Test plan

- Existing `openclaw-gateway-adapter.test.ts` continues to pass (no behaviour change when `agentId` is configured).
- Manual verification once merged: wake Apollo with a populated `adapterConfig.agentId="marketing"` — header is now present even if the operator forgot to add it under `headers.*`.
- Without `adapterConfig.agentId` at all: `stderr` shows the new WIS-25 warning, making the misconfiguration immediately diagnosable.

## Notes for downstream

This is the **upstream** half of the fix. The operational unblock (populating Apollo's and Rocky's `adapterConfig.agentId` in the Wishroll company) is tracked separately in [WIS-25](https://paperclip.tail63a418.ts.net/WIS/issues/WIS-25).
