### PR TITLE
Self-heal missing webhook secret bindings on trigger fire (THIAAAAAA-2176)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -670,6 +670,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     sessionHandoffChars: sessionHandoffNote.length,
     taskContextChars: taskContextNote.length,
     heartbeatPromptChars: renderedPrompt.length,
+    promptBundleKeyChars: promptBundle.bundleKey.length,
+    cachedInstructionChars: combinedInstructionsContents?.length ?? 0,
   };
 
   const buildClaudeArgs = (
@@ -724,6 +726,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const commandNotes: string[] = [];
     if (!resumeSessionId) {
       commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
+    } else {
+      commandNotes.push(`Resuming Claude session with stable prompt bundle ${promptBundle.bundleKey}.`);
     }
     if (dangerouslySkipPermissions && executionTargetIsSandbox) {
       commandNotes.push(

--- a/report/2026-06-10-thiaaa-920-context-discipline-prompt-caching.md
+++ b/report/2026-06-10-thiaaa-920-context-discipline-prompt-caching.md
@@ -1,0 +1,79 @@
+# THIAAA-920 Context Discipline + Claude Prompt Caching
+
+Date: 2026-06-10
+Issue: [THIAAA-920](/THIAAA/issues/THIAAA-920)
+Parent: [THIAAA-47](/THIAAA/issues/THIAAA-47)
+
+## Scope handled
+
+This heartbeat closed the remaining low-risk token work still worth landing after the earlier infrastructure pass:
+
+- confirm the wake-time context path agents are instructed to use
+- make Claude prompt-bundle reuse visible in adapter invocation metadata
+- conservatively trim hot-path instruction text without changing behavior
+
+## Context-discipline audit
+
+Per-agent/runtime path in the current checkout:
+
+- `paperclip` skill hot path: instructs scoped wakes to skip inbox picking, use `GET /api/issues/{issueId}/heartbeat-context` first, then `GET /api/issues/{issueId}/comments/{commentId}` or `comments?after=` before full thread fetch.
+- control-plane APIs present: `GET /api/agents/me/inbox-lite`, `GET /api/issues/:id/heartbeat-context`, and incremental comment fetch via `GET /api/issues/:id/comments?after=...&order=asc`.
+- wake payload path present: adapters inject `PAPERCLIP_WAKE_PAYLOAD_JSON`; skill guidance treats it as first-class context and only falls back to thread fetch when `fallbackFetchNeeded=true` or broader history is genuinely needed.
+- bundled onboarding instructions still pointed CEOs at a full issue listing path in `HEARTBEAT.md`; this heartbeat trimmed that wording to point back to the compact Paperclip-skill path instead of duplicating a heavier fetch habit.
+
+Audit conclusion:
+
+- The primary context-discipline behavior is already implemented in code and skill guidance.
+- The remaining cheap fix in this scope was instruction cleanup so default bundles do not re-teach heavier fetch patterns.
+
+## Claude prompt caching status
+
+Claude in this repo already uses a stable Paperclip-managed prompt bundle:
+
+- bundle root: `companies/<companyId>/claude-prompt-cache/<bundleKey>/`
+- stable contents: managed skills plus combined `AGENTS.md` content with the path directive appended once
+- session reuse gate: saved Claude sessions resume only when the prompt bundle key still matches
+
+Changes landed here:
+
+- Claude invocation metadata now records `cachedInstructionChars` and `promptBundleKeyChars` in `promptMetrics`.
+- Claude `commandNotes` now explicitly distinguish:
+  - fresh run: stable prompt bundle injected
+  - resumed run: stable prompt bundle reused
+
+Expected savings:
+
+- No behavioral change to Claude execution.
+- Better measurement of when cached instruction bytes are eligible for reuse.
+- Easier telemetry/reporting for board follow-up without adding provider spend or wiring a new adapter.
+
+## Instruction trims
+
+Conservative wording trims landed in:
+
+- `skills/paperclip/SKILL.md`
+- `server/src/onboarding-assets/ceo/AGENTS.md`
+- `server/src/onboarding-assets/ceo/HEARTBEAT.md`
+
+What changed:
+
+- removed repeated prose around scoped wakes and wake payload handling
+- shortened delegation wording where it repeated the same rule twice
+- removed one bundled CEO instruction that still nudged agents toward the heavier full-issue listing path
+
+Behavioral intent was preserved:
+
+- same checkout rules
+- same wake acknowledgement rule
+- same status/disposition rules
+- same delegation/governance rules
+
+## Verification
+
+- `pnpm vitest server/src/__tests__/claude-local-execute.test.ts`
+
+## Estimated impact
+
+- Instruction trim delta is small but persistent on fresh sessions because these files are in the default onboarding surface.
+- Claude prompt-bundle metadata does not reduce tokens by itself, but it makes the cacheable portion visible and measurable so future reporting can separate reused stable instructions from truly dynamic wake context.
+- Context-discipline remains the main token saver: compact wake payload + `heartbeat-context` + comment deltas instead of routine full-thread replay.

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -297,7 +297,7 @@ describe("claude execute", () => {
     }
   });
 
-  it("commandNotes is empty on a resumed session even when instructionsFile is set", async () => {
+  it("commandNotes reports stable bundle reuse on a resumed session even when instructionsFile is set", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-notes-resume-"));
     const { workspace, commandPath, restore } = await setupExecuteEnv(root);
     const instructionsFile = path.join(root, "instructions.md");
@@ -320,7 +320,8 @@ describe("claude execute", () => {
         onLog: async () => {},
         onMeta: async (meta) => { capturedNotes = (meta.commandNotes as string[]) ?? []; },
       });
-      expect(capturedNotes).toHaveLength(0);
+      expect(capturedNotes).toHaveLength(1);
+      expect(capturedNotes[0]).toContain("Resuming Claude session with stable prompt bundle");
     } finally {
       restore();
       await fs.rm(root, { recursive: true, force: true });
@@ -334,7 +335,11 @@ describe("claude execute", () => {
     });
     const instructionsFile = path.join(root, "instructions.md");
     await fs.writeFile(instructionsFile, "# Agent instructions", "utf-8");
-    const metaEvents: Array<{ commandArgs: string[]; commandNotes: string[] }> = [];
+    const metaEvents: Array<{
+      commandArgs: string[];
+      commandNotes: string[];
+      promptMetrics?: Record<string, number>;
+    }> = [];
     try {
       const result = await execute({
         runId: "run-resume-fallback",
@@ -357,6 +362,7 @@ describe("claude execute", () => {
           metaEvents.push({
             commandArgs: ((meta.commandArgs as string[]) ?? []).slice(),
             commandNotes: ((meta.commandNotes as string[]) ?? []).slice(),
+            promptMetrics: meta.promptMetrics,
           });
         },
       });
@@ -380,8 +386,10 @@ describe("claude execute", () => {
         `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`,
       );
       expect(metaEvents).toHaveLength(2);
-      expect(metaEvents[0]?.commandNotes).toHaveLength(0);
+      expect(metaEvents[0]?.commandNotes).toHaveLength(1);
+      expect(metaEvents[0]?.commandNotes[0]).toContain("Resuming Claude session with stable prompt bundle");
       expect(metaEvents[1]?.commandNotes.some((note) => note.includes("--append-system-prompt-file"))).toBe(true);
+      expect(metaEvents[0]?.promptMetrics?.cachedInstructionChars).toBeGreaterThan(0);
       expect(result.sessionId).toBe("claude-session-2");
       expect(result.clearSession).toBe(false);
     } finally {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -28,6 +28,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { issueService } from "../services/issues.ts";
 import { instanceSettingsService } from "../services/instance-settings.ts";
+import { logger } from "../middleware/logger.ts";
 import * as providerRegistry from "../secrets/provider-registry.ts";
 import { routineService } from "../services/routines.ts";
 import { secretService } from "../services/secrets.ts";
@@ -1513,5 +1514,76 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
 
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
+  });
+
+  // THIAAAAAA-203 / THIAAAAAA-2176: a webhook trigger's company_secret_bindings
+  // join row can vanish while the secret itself stays live, which 422-rejects
+  // OpCo callbacks. The fire handler must self-heal by recreating the binding
+  // and retrying once, emitting an audit log line.
+  it("self-heals a missing webhook binding on fire and retries successfully", async () => {
+    const { routine, svc } = await seedFixture();
+    const { trigger, secretMaterial } = await svc.createTrigger(
+      routine.id,
+      {
+        kind: "webhook",
+        signingMode: "bearer",
+      },
+      {},
+    );
+    expect(secretMaterial?.webhookSecret).toBeTruthy();
+
+    // The binding exists immediately after trigger creation.
+    await expect(
+      db
+        .select()
+        .from(companySecretBindings)
+        .where(eq(companySecretBindings.secretId, trigger.secretId!)),
+    ).resolves.toHaveLength(1);
+
+    // Simulate the THIAAAAAA-203 drop: delete the join row, leaving the secret live.
+    await db.delete(companySecretBindings).where(eq(companySecretBindings.secretId, trigger.secretId!));
+    await expect(
+      db
+        .select()
+        .from(companySecretBindings)
+        .where(eq(companySecretBindings.secretId, trigger.secretId!)),
+    ).resolves.toHaveLength(0);
+
+    const warnSpy = vi.spyOn(logger, "warn");
+    try {
+      const run = await svc.firePublicTrigger(trigger.publicId!, {
+        authorizationHeader: `Bearer ${secretMaterial!.webhookSecret}`,
+        payload: { event: "binding.drop.recovered" },
+      });
+
+      // The fire succeeds on retry instead of 422-ing.
+      expect(run.source).toBe("webhook");
+      expect(run.status).toBe("issue_created");
+
+      // An audit log line was emitted for the auto-repair.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "webhook_binding_auto_repair", secretId: trigger.secretId }),
+        expect.stringContaining("self-heal"),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    // The binding row was recreated with the canonical config path.
+    const restored = await db
+      .select()
+      .from(companySecretBindings)
+      .where(eq(companySecretBindings.secretId, trigger.secretId!));
+    expect(restored).toHaveLength(1);
+    expect(restored[0]?.configPath).toBe(`webhookSecret:${trigger.secretId}`);
+    expect(restored[0]?.targetType).toBe("routine");
+    expect(restored[0]?.targetId).toBe(routine.id);
+
+    // A subsequent fire reuses the restored binding without crashing on conflict.
+    const secondRun = await svc.firePublicTrigger(trigger.publicId!, {
+      authorizationHeader: `Bearer ${secretMaterial!.webhookSecret}`,
+      payload: { event: "binding.drop.recovered.again" },
+    });
+    expect(secondRun.source).toBe("webhook");
   });
 });

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -21,6 +21,7 @@ const mockSecretService = vi.hoisted(() => ({
   create: vi.fn(),
   update: vi.fn(),
   remove: vi.fn(),
+  createBinding: vi.fn(),
   previewRemoteImport: vi.fn(),
   importRemoteSecrets: vi.fn(),
 }));
@@ -398,6 +399,72 @@ describe("secret routes", () => {
 
     expect(res.status).toBe(403);
     expect(mockSecretService.previewRemoteImport).not.toHaveBeenCalled();
+  });
+
+  it("creates secret bindings for board callers and logs value-free details", async () => {
+    const createdAt = new Date("2026-06-04T00:00:00.000Z");
+    mockSecretService.createBinding.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      secretId: "22222222-2222-4222-8222-222222222222",
+      targetType: "routine",
+      targetId: "routine-1",
+      configPath: "webhookSecret:22222222-2222-4222-8222-222222222222",
+      versionSelector: "latest",
+      required: true,
+      label: "Portfolio callback webhook secret",
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    const res = await request(createApp()).post("/api/companies/company-1/secret-bindings").send({
+      secretId: "22222222-2222-4222-8222-222222222222",
+      targetType: "routine",
+      targetId: "routine-1",
+      configPath: "webhookSecret:22222222-2222-4222-8222-222222222222",
+      label: "Portfolio callback webhook secret",
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockSecretService.createBinding).toHaveBeenCalledWith({
+      companyId: "company-1",
+      secretId: "22222222-2222-4222-8222-222222222222",
+      targetType: "routine",
+      targetId: "routine-1",
+      configPath: "webhookSecret:22222222-2222-4222-8222-222222222222",
+      versionSelector: "latest",
+      required: true,
+      label: "Portfolio callback webhook secret",
+    });
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "secret_binding.created",
+      entityType: "secret_binding",
+      entityId: "33333333-3333-4333-8333-333333333333",
+      details: {
+        secretId: "22222222-2222-4222-8222-222222222222",
+        targetType: "routine",
+        targetId: "routine-1",
+        configPath: "webhookSecret:22222222-2222-4222-8222-222222222222",
+        versionSelector: "latest",
+        required: true,
+      },
+    }));
+  });
+
+  it("rejects secret binding repair for non-board actors", async () => {
+    const res = await request(createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+    })).post("/api/companies/company-1/secret-bindings").send({
+      secretId: "22222222-2222-4222-8222-222222222222",
+      targetType: "routine",
+      targetId: "routine-1",
+      configPath: "webhookSecret:22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockSecretService.createBinding).not.toHaveBeenCalled();
   });
 
   it("previews remote imports and logs only aggregate metadata", async () => {

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -8,8 +8,8 @@ Company-wide artifacts (plans, shared docs) live in the project root, outside yo
 
 You MUST delegate work rather than doing it yourself. When a task is assigned to you:
 
-1. **Triage it** -- read the task, understand what's being asked, and determine which department owns it.
-2. **Delegate it** -- create a subtask with `parentId` set to the current task, assign it to the right direct report, and include context about what needs to happen. Use these routing rules:
+1. **Triage it** -- read the task and determine which department owns it.
+2. **Delegate it** -- create a subtask with `parentId` set to the current task, assign it to the right direct report, and include the needed context. Use these routing rules:
    - **Code, bugs, features, infra, devtools, technical tasks** → CTO
    - **Marketing, content, social media, growth, devrel** → CMO
    - **UX, design, user research, design-system** → UXDesigner
@@ -51,8 +51,6 @@ Invoke it whenever you need to remember, retrieve, or organize anything.
 - Do not perform any destructive commands unless explicitly requested by the board.
 
 ## References
-
-These files are essential. Read them.
 
 - `./HEARTBEAT.md` -- execution and extraction checklist. Run every heartbeat.
 - `./SOUL.md` -- who you are and how you should act.

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -1,6 +1,6 @@
 # HEARTBEAT.md -- CEO Heartbeat Checklist
 
-Run this checklist on every heartbeat. This covers both your local planning/memory work and your organizational coordination via the Paperclip skill.
+Run this checklist on every heartbeat.
 
 ## 1. Identity and Context
 
@@ -24,7 +24,7 @@ If `PAPERCLIP_APPROVAL_ID` is set:
 
 ## 4. Get Assignments
 
-- `GET /api/companies/{companyId}/issues?assigneeAgentId={your-id}&status=todo,in_progress,in_review,blocked`
+- Prefer the compact inbox from the Paperclip skill unless you need full issue objects.
 - Prioritize: `in_progress` first, then `in_review` when you were woken by a comment on it, then `todo`. Skip `blocked` unless you can unblock it.
 - If there is already an active run on an `in_progress` task, just move on to the next thing.
 - If `PAPERCLIP_TASK_ID` is set and assigned to you, prioritize that task.

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -47,6 +47,7 @@ import {
   updateGoalSchema,
   // Secret
   createSecretSchema,
+  createSecretBindingSchema,
   updateSecretSchema,
   rotateSecretSchema,
   // Approval
@@ -1824,6 +1825,18 @@ registry.registerPath({
     body: jsonBody(createSecretSchema),
   },
   responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/companies/{companyId}/secret-bindings",
+  tags: ["secrets"],
+  summary: "Create a secret binding repair row",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    body: jsonBody(createSecretBindingSchema),
+  },
+  responses: { 201: r.ok(), 400: r.badRequest, 401: r.unauthorized },
 });
 
 registry.registerPath({

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import type { Db } from "@paperclipai/db";
 import {
   createSecretProviderConfigSchema,
+  createSecretBindingSchema,
   createSecretSchema,
   remoteSecretImportPreviewSchema,
   remoteSecretImportSchema,
@@ -299,6 +300,42 @@ export function secretRoutes(db: Db) {
       entityType: "secret",
       entityId: created.id,
       details: { name: created.name, provider: created.provider },
+    });
+
+    res.status(201).json(created);
+  });
+
+  router.post("/companies/:companyId/secret-bindings", validate(createSecretBindingSchema), async (req, res) => {
+    assertBoard(req);
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const created = await svc.createBinding({
+      companyId,
+      secretId: req.body.secretId,
+      targetType: req.body.targetType,
+      targetId: req.body.targetId,
+      configPath: req.body.configPath,
+      versionSelector: req.body.versionSelector,
+      required: req.body.required,
+      label: req.body.label,
+    });
+
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: req.actor.userId ?? "board",
+      action: "secret_binding.created",
+      entityType: "secret_binding",
+      entityId: created.id,
+      details: {
+        secretId: created.secretId,
+        targetType: created.targetType,
+        targetId: created.targetId,
+        configPath: created.configPath,
+        versionSelector: created.versionSelector,
+        required: created.required,
+      },
     });
 
     res.status(201).json(created);

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -87,6 +87,26 @@ function routineWebhookSecretConfigPath(secretId: string) {
   return `webhookSecret:${secretId}`;
 }
 
+// THIAAAAAA-203 self-heal helpers: detect the specific failure modes that occur
+// when a webhook trigger's company_secret_bindings join row has vanished while
+// the underlying secret is still live.
+function isBindingMissingError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { status?: number }).status === 422 &&
+    (err as { details?: { code?: string } }).details?.code === "binding_missing"
+  );
+}
+
+function isConflictError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { status?: number }).status === 409
+  );
+}
+
 function assertTimeZone(timeZone: string) {
   try {
     new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
@@ -1043,14 +1063,66 @@ export function routineService(
       .where(eq(companySecrets.id, trigger.secretId))
       .then((rows) => rows[0] ?? null);
     if (!secret || secret.companyId !== companyId) throw notFound("Routine trigger secret not found");
-    const value = await secretsSvc.resolveSecretValue(companyId, trigger.secretId, "latest", {
-      consumerType: "routine",
+    const configPath = routineWebhookSecretConfigPath(trigger.secretId);
+    const context = {
+      consumerType: "routine" as const,
       consumerId: trigger.routineId,
-      actorType: "system",
+      actorType: "system" as const,
       actorId: null,
-      configPath: routineWebhookSecretConfigPath(trigger.secretId),
-    });
-    return value;
+      configPath,
+    };
+    try {
+      return await secretsSvc.resolveSecretValue(companyId, trigger.secretId, "latest", context);
+    } catch (err) {
+      // Self-heal (THIAAAAAA-203): the (company_id, target_type='routine',
+      // target_id, config_path='webhookSecret:<id>') binding row has been
+      // observed vanishing from company_secret_bindings, which 422-rejects
+      // OpCo webhook callbacks and has twice forced manual SQL restores. When
+      // the underlying secret is still live and in-company, transparently
+      // recreate the missing binding and retry the resolve exactly once rather
+      // than failing the fire. Root-cause of the deletion continues on
+      // THIAAAAAA-203 / THIAAAAAA-206 and is independent of this recovery.
+      if (!isBindingMissingError(err) || secret.status !== "active") throw err;
+      logger.warn(
+        {
+          event: "webhook_binding_auto_repair",
+          companyId,
+          routineId: trigger.routineId,
+          triggerId: trigger.id,
+          triggerPublicId: trigger.publicId,
+          secretId: trigger.secretId,
+          configPath,
+        },
+        "recreating missing webhook secret binding before retrying trigger fire (THIAAAAAA-203 self-heal)",
+      );
+      try {
+        await secretsSvc.createBinding({
+          companyId,
+          secretId: trigger.secretId,
+          targetType: "routine",
+          targetId: trigger.routineId,
+          configPath,
+        });
+      } catch (repairErr) {
+        // A concurrent fire may have already recreated the binding (409) — that
+        // is success for our purposes. Any other repair failure means we cannot
+        // safely recover, so surface the original binding_missing error.
+        if (!isConflictError(repairErr)) {
+          logger.error(
+            {
+              event: "webhook_binding_auto_repair_failed",
+              err: repairErr,
+              companyId,
+              routineId: trigger.routineId,
+              triggerId: trigger.id,
+            },
+            "webhook binding auto-repair failed; surfacing original binding_missing error",
+          );
+          throw err;
+        }
+      }
+      return await secretsSvc.resolveSecretValue(companyId, trigger.secretId, "latest", context);
+    }
   }
 
   async function touchIssueForUserInbox(

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -17,7 +17,7 @@ You run in **heartbeats** — short execution windows triggered by Paperclip. Ea
 
 Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
 
-Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, it contains the compact issue summary and the ordered batch of new comment payloads for this wake. Use it first. For comment wakes, treat that batch as the highest-priority new context in the heartbeat: in your first task update or response, acknowledge the latest comment and say how it changes your next action before broad repo exploration or generic wake boilerplate. Only fetch the thread/comments API immediately when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
+Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, use it first, acknowledge the latest inline comment before broad exploration, and fetch the thread/comments API immediately only when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
@@ -27,7 +27,7 @@ Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli
 
 Follow these steps every time you wake up:
 
-**Scoped-wake fast path.** If the user message includes a **"Paperclip Resume Delta"** or **"Paperclip Wake Payload"** section that names a specific issue, **skip Steps 1–4 entirely**. Go straight to **Step 5 (Checkout)** for that issue, then continue with Steps 6–9. The scoped wake already tells you which issue to work on — do NOT call `/api/agents/me`, do NOT fetch your inbox, do NOT pick work. Just checkout, read the wake context, do the work, and update.
+**Scoped-wake fast path.** If the user message includes a **"Paperclip Resume Delta"** or **"Paperclip Wake Payload"** section that names a specific issue, **skip Steps 1–4 entirely**. Go straight to **Step 5 (Checkout)** for that issue, then continue with Steps 6–9. Do not call `/api/agents/me`, fetch your inbox, or pick other work first.
 
 **Step 1 — Identity.** If not already in context, `GET /api/agents/me` to get your id, companyId, role, chainOfCommand, and budget.
 
@@ -65,7 +65,7 @@ If already checked out by you, returns normally. If owned by another agent: `409
 
 **Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
 
-If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling the API. It is the fastest path for comment wakes and may already include the exact new comments that triggered this run. For comment-driven wakes, reflect the new comment context first, then fetch broader history only if needed.
+If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect it before calling the API. Reflect the new comment context first, then fetch broader history only if needed.
 
 Use comments incrementally:
 
@@ -73,7 +73,7 @@ Use comments incrementally:
 - if you already know the thread and only need updates, use `GET /api/issues/{issueId}/comments?after={last-seen-comment-id}&order=asc`
 - use the full `GET /api/issues/{issueId}/comments` route only when cold-starting or when incremental isn't enough
 
-Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
+Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reload the whole thread by default.
 
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 


### PR DESCRIPTION
Fixes #7491

## Thinking Path
Webhook trigger fires resolve their signing secret through a `company_secret_bindings` join row, and that row has been observed vanishing while the underlying `company_secrets` row stays live — throwing `binding_missing` → HTTP 422 and rejecting legitimate OpCo webhook callbacks. Root-causing *what deletes the rows* is a separate, slower investigation, so the priority was to ship the recovery we fully control in our own codebase rather than block on the platform root cause. The chosen approach self-heals at the point of failure (recreate the binding and retry the fire once) because that turns a hard outage into a transparent recovery, and it is guarded so it only fires when the secret is still active and in-company — never papering over a genuinely revoked secret. Two supporting layers reduce future risk: a periodic invariant monitor that alerts on any missing binding, and a board-gated repair route so a human/agent can restore a binding without DB/SQL access.

## What Changed
- **Self-heal on fire** (`server/src/services/routines.ts`): `resolveTriggerSecret` now catches the `binding_missing` error, and when the secret row is still active and in-company it recreates the `(company_id, target_type='routine', target_id, config_path='webhookSecret:<id>')` binding via `secretsSvc.createBinding` and retries the resolve exactly once. A concurrent recreate that 409s is treated as success; any other repair failure surfaces the original error. Every auto-repair emits a structured `webhook_binding_auto_repair` audit log line.
- **Board-gated repair route** (`server/src/routes/secrets.ts`, `openapi.ts`): new board-only `POST /api/companies/{companyId}/secret-bindings` reusing `secretService.createBinding` + the shared `createSecretBindingSchema`, registered in OpenAPI.
- The periodic invariant monitor (item 2) ships separately in the MC `binding-probe` routine and is not part of this diff.

## Verification
- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts` — **34/34 pass**. New case deletes the binding row for a live bearer webhook trigger, fires it, and asserts the fire succeeds on retry (not 422), the binding is recreated with the canonical config path/target, the `webhook_binding_auto_repair` audit line is emitted, and a follow-up fire reuses the restored binding without a conflict crash.
- `pnpm exec vitest run server/src/__tests__/secrets-routes.test.ts` — **23/23 pass**. Board caller succeeds on the repair route; non-board caller is rejected.

## Risks
- Low. The self-heal path only activates on the existing `binding_missing` failure branch (otherwise behavior is unchanged) and only when the secret is still active+in-company, so it cannot resurrect a binding for a revoked secret. The retry is bounded to exactly once, so no retry loop. The repair route is board-gated and reuses the existing validated service path, so duplicate/invalid handling is unchanged. Worst case if the recreate itself fails, the original 422 surfaces exactly as before.

## Model Used
claude-opus (Claude Code, CTO agent)