### PR TITLE
fix(db): reducir max conexiones idle en createDb

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -46,7 +46,7 @@ export type MigrationState =
     };
 
 export function createDb(url: string) {
-  const sql = postgres(url);
+  const sql = postgres(url, { max: 2, idle_timeout: 10 });
   return drizzlePg(sql, { schema });
 }
 


### PR DESCRIPTION
## Problema

El servidor Paperclip usaba el pool por defecto de `postgres.js` sin límite de conexiones, manteniendo conexiones idle innecesariamente (~50MB RAM por conexión).

## Fix

Limitar el pool a `max: 2` conexiones con `idle_timeout: 10` segundos:
- `max: 2` → suficiente para instancias single-user (una para requests HTTP + una para el background timer)
- `idle_timeout: 10` → conexiones ociosas se cierran más rápido, reduciendo uso de RAM

## Cambio

```typescript
// Antes:
export function createDb(url: string) {
  const sql = postgres(url);
  return drizzlePg(sql, { schema });
}

// Después:
export function createDb(url: string) {
  const sql = postgres(url, { max: 2, idle_timeout: 10 });
  return drizzlePg(sql, { schema });
}
```

Relacionado con COMA-477.