### PR TITLE
ci(dependabot): bundle npm patch/minor updates by dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      # Bundle all patch/minor updates of the same dependency type into one
+      # weekly PR. Prevents partial bumps of sibling packages that share
+      # peer dependencies (e.g. lexical + @lexical/*), which otherwise
+      # install two copies of the core package and break type-checking.
+      # Majors stay as individual PRs (and are ignored below anyway).
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["patch", "minor"]
+      development-dependencies:
+        dependency-type: "development"
+        update-types: ["patch", "minor"]
     ignore:
       # Ignore major version bumps — review those manually
       - dependency-name: "*"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Dependabot keeps the JS/TS dependency tree up to date so the agents and UI run on supported package versions
> - When a sibling package family shares peer dependencies (lexical core + `@lexical/*`, `@codemirror/*`, `@radix-ui/*`, `@assistant-ui/*`, etc.), bumping one without the others leaves the lockfile with two installed copies of the core package
> - That trips TypeScript: nodes from one version are not assignable to types from the other, and the UI build fails — observed concretely on PR #7330 (lexical 0.35 → 0.45) once PAPA-490 stopped masking it
> - The first cut (per-scope `groups` for each sibling-package family) works but requires maintenance whenever a new scope is added
> - This pull request goes broader: it groups *all* npm patch/minor updates by dependency type (production vs development), so any sibling-package family is bundled regardless of scope
> - The benefit is a single weekly PR per dep type, no per-scope maintenance, and no more partial peer bumps

## What Changed

- Replaced the lexical-specific `groups` entry with two type-based groups in `.github/dependabot.yml`:
  - `production-dependencies`: bundles all patch/minor `dependencies` updates into one PR
  - `development-dependencies`: bundles all patch/minor `devDependencies` updates into one PR
- Majors continue to land as individual PRs (and are already ignored by the existing `version-update:semver-major` rule).

## Verification

- After merge, the next Dependabot run (Monday 06:00 weekly, or on `@dependabot recreate`) should open at most two new npm PRs — `chore(deps): bump the production-dependencies group` and `chore(deps-dev): bump the development-dependencies group` — each combining many bumps. The existing per-package PRs (#7318–#7331) will be closed and superseded by the grouped PRs.
- Sanity-check by inspecting the resulting lockfile diff: `lexical` and `@lexical/link` should always move together to the same version.

## Risks

- Low risk for CI config itself. The trade-off is larger weekly PRs that are harder to bisect when one bump breaks the batch — but Dependabot also publishes per-package failure reports inside the grouped PR, so triage stays tractable.
- If a future package genuinely needs to stay ungrouped (e.g. a noisy one that breaks often), it can be moved out via `exclude-patterns` on the group.

## Model Used

- Claude (Anthropic), claude-opus-4-7, tool-use enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — N/A, YAML-only CI config change
- [ ] I have added or updated tests where applicable — N/A
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge