### PR TITLE
Add issues:write permission for cross-agent issue mutation

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -672,6 +672,7 @@ export const PERMISSION_KEYS = [
   "environments:manage",
   "users:invite",
   "users:manage_permissions",
+  "issues:write",
   "tasks:assign",
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1493,6 +1493,11 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  function stripDestructiveIssueFieldsForNonOwner(body: Record<string, unknown>): Record<string, unknown> {
+  const allowed = new Set(["status", "comment", "presentation", "metadata"]);
+  return Object.fromEntries(Object.entries(body).filter(([k]) => allowed.has(k)));
+}
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -1511,6 +1516,12 @@ export function issueRoutes(
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }
+      const grantDecision = await access.decide({
+        actor: { type: "agent", agentId: actorAgentId, companyId: issue.companyId },
+        action: "issue:mutate",
+        resource: { type: "issue", companyId: issue.companyId, issueId: issue.id, assigneeAgentId: issue.assigneeAgentId },
+      });
+      if (grantDecision.allowed) return true;
       if (issue.status === "in_progress") {
         res.status(409).json({
           error: "Issue is checked out by another agent",
@@ -4042,6 +4053,17 @@ export function issueRoutes(
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
+    const isOwnIssue = existing.assigneeAgentId === req.actor.agentId;
+    if (!isOwnIssue && req.actor.type === "agent" && req.actor.agentId) {
+      const grantDecision = await access.decide({
+        actor: { type: "agent", agentId: req.actor.agentId, companyId: existing.companyId },
+        action: "issue:mutate",
+        resource: { type: "issue", companyId: existing.companyId, issueId: existing.id, assigneeAgentId: existing.assigneeAgentId },
+      });
+      if (grantDecision.allowed) {
+        updateFields = stripDestructiveIssueFieldsForNonOwner(updateFields);
+      }
+    }
     const isClosed = isClosedIssueStatus(existing.status);
     const isBlocked = existing.status === "blocked";
     const normalizedAssigneeAgentId = await normalizeIssueAssigneeAgentReference(

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
+  activityLog,
   agents,
   companyMemberships,
   instanceUserRoles,
@@ -9,6 +10,7 @@ import {
 } from "@paperclipai/db";
 import type { PermissionKey, PrincipalType } from "@paperclipai/shared";
 import { conflict } from "../errors.js";
+import { logActivity } from "./activity-log.js";
 import { authorizationService, type AuthorizationActor, type AuthorizationResource } from "./authorization.js";
 import { ensureHumanRoleDefaultGrants } from "./principal-access-compatibility.js";
 
@@ -587,6 +589,19 @@ export function accessService(db: Db) {
     grants: GrantInput[],
     grantedByUserId: string | null,
   ) {
+    const existingRows = await db
+      .select({ permissionKey: principalPermissionGrants.permissionKey, scope: principalPermissionGrants.scope })
+      .from(principalPermissionGrants)
+      .where(
+        and(
+          eq(principalPermissionGrants.companyId, companyId),
+          eq(principalPermissionGrants.principalType, principalType),
+          eq(principalPermissionGrants.principalId, principalId),
+        ),
+      );
+    const existingSet = new Map(existingRows.map((r) => [`${r.permissionKey}::${JSON.stringify(r.scope)}`, r]));
+    const newSet = new Map(grants.map((g) => [`${g.permissionKey}::${JSON.stringify(g.scope ?? null)}`, g]));
+
     await db.transaction(async (tx) => {
       await tx
         .delete(principalPermissionGrants)
@@ -611,6 +626,37 @@ export function accessService(db: Db) {
         })),
       );
     });
+
+    if (principalType === "agent") {
+      for (const [key, grant] of newSet) {
+        if (!existingSet.has(key)) {
+          await logActivity(db, {
+            companyId,
+            actorType: "user",
+            actorId: grantedByUserId ?? "board",
+            agentId: principalId,
+            action: "agent.issues_write_grant_added",
+            entityType: "agent",
+            entityId: principalId,
+            details: { permissionKey: grant.permissionKey, scope: grant.scope },
+          });
+        }
+      }
+      for (const [key, existing] of existingSet) {
+        if (!newSet.has(key)) {
+          await logActivity(db, {
+            companyId,
+            actorType: "user",
+            actorId: grantedByUserId ?? "board",
+            agentId: principalId,
+            action: "agent.issues_write_grant_revoked",
+            entityType: "agent",
+            entityId: principalId,
+            details: { permissionKey: existing.permissionKey, scope: existing.scope },
+          });
+        }
+      }
+    }
   }
 
   async function copyActiveUserMemberships(sourceCompanyId: string, targetCompanyId: string) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -87,7 +87,7 @@ function companyIdForResource(resource: AuthorizationResource) {
 
 function permissionForAction(action: AuthorizationAction): PermissionKey | null {
   if (action === "agent_config:read" || action === "agent_config:update") return "agents:create";
-  if (action === "issue:mutate") return null;
+  if (action === "issue:mutate") return "issues:write";
   return action;
 }
 


### PR DESCRIPTION
## Context

Implements routing A from OVE-215: add scoped `issues:write` grant as an additive change to the existing grant framework.

**Linked issue:** OVE-215

## What this does

Adds the plumbing for agent-to-agent issue mutation via the existing grant framework. No agent receives `issues:write` automatically — it must be explicitly granted via the board API.

## Changes

### 1. permissionForAction (authorization.ts)
Maps `issue:mutate` action → `issues:write` permission key. Previously returned `null`, bypassing the grant system entirely.

### 2. PERMISSION_KEYS (packages/shared/src/constants.ts)
Adds `"issues:write"` to the permitted grant keys enum.

### 3. assertAgentIssueMutationAllowed (issues.ts)
After existing self-allow checks (owner, unassigned, checkout override), calls `access.decide()` with `issue:mutate` action so agents with an `issues:write` grant can mutate non-owned issues.

### 4. Non-owner PATCH whitelist (issues.ts)
`stripDestructiveIssueFieldsForNonOwner()` limits fields that can be modified via PATCH by a non-owner agent with `issues:write` to only `{ status, comment, presentation, metadata }`. Destructive fields (assigneeAgentId, priority, projectId, blockedByIssueIds, billingCode, parentId) are excluded.

### 5. Activity log for agent grants (access.ts)
`setPrincipalGrants` logs `agent.issues_write_grant_added` / `agent.issues_write_grant_revoked` when grants change for agent principals.

## Scope shape (v1)

\`\`\`jsonc
{ "allow": { "projects": ["<project-id>"], "labels": ["label-a"], "statuses": ["blocked", "in_review"] } }
\`\`\`

Company-wide when `allow` is absent/missing.

## Hard locks respected

- OVE-214 workaround stays live
- No CEO auto-grant of `issues:write`
- 2-week C-fallback clock starts at PR filing

## Out of scope

- BlockerResolver charter change (separate issue)
- Auto-grant to any agent
- Per-field granularity beyond the whitelist

---

Co-Authored-By: Paperclip <noreply@paperclip.ing>