### PR TITLE
Bound missing-disposition recovery refires

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -233,6 +233,7 @@ The valid action-path primitives are:
 - a typed execution-policy participant, such as `executionState.currentParticipant`
 - a pending issue-thread interaction or linked approval that is waiting for a specific responder
 - a one-shot issue monitor (`executionPolicy.monitor.nextCheckAt`) that will wake the assignee for a future check
+- an explicit event-driven hub idle marker for long-lived hub issues that park between external event wakes
 - a human owner via `assigneeUserId`
 - a first-class blocker chain whose unresolved leaf issues are themselves healthy
 - an open explicit recovery action that names the owner and action needed to restore liveness
@@ -249,6 +250,8 @@ A valid recovery action must name:
 - the cause, bounded evidence, and next action
 - the wake, monitor, timeout, retry, or escalation policy that will move the action forward
 - the resolution outcome when closed, such as restored, delegated, false positive, blocked, escalated, or cancelled
+
+Recovery actions that re-fire owner wakes must be bounded. They must carry a finite `maxAttempts`, enforce a minimum interval between re-fires, and have one clear exhaustion path. When the finite bound is reached, Paperclip must surface or fold the action exactly once through the explicit recovery lifecycle; it must not keep issuing the same recovery wake indefinitely.
 
 A source-scoped recovery action is the default form. Use it when the next safe move is to repair the source issue's liveness directly: move the source issue back to `todo` so it can be retried, clarify disposition, re-establish a monitor, record a false positive, or delegate real follow-up work from the source issue.
 
@@ -267,6 +270,8 @@ A comment or system notice can be evidence for a recovery action, but it is not 
 Source-scoped recovery actions are snapshots of the source issue's liveness state at the time the action was opened. They must be revalidated after newer durable source activity, including source issue status changes, assignee changes, blocker changes, execution policy or monitor changes, document or work-product updates that define a valid waiting path, and structured resume or disposition updates.
 
 When newer source activity restores a valid live or waiting path, the recovery action is stale and should be folded through the explicit recovery lifecycle instead of being hidden or deleted. Folding means resolving or cancelling the recovery action with a resolution outcome and note that preserve the audit trail.
+
+This revalidation must happen immediately before every recovery wake re-fire. If the source already has a valid live/waiting path, or if the requested disposition cannot be produced by the recovery wake itself, Paperclip should fold the action as stale or false-positive instead of re-firing it.
 
 Plain comments alone do not make a recovery action stale. A comment can provide evidence, but the recovery action should remain visible when the source issue is still stalled and the comment does not create a valid action-path primitive such as a wake, monitor, interaction, approval, blocker, human owner, execution participant, terminal disposition, or delegated follow-up.
 
@@ -301,6 +306,7 @@ A healthy active-work state means at least one of these is true:
 - there is an active run for the issue
 - there is already a queued continuation wake
 - there is an active one-shot monitor that will wake the assignee for a future check
+- there is an explicit event-driven hub idle marker that says the issue is intentionally parked until an external event wakes it
 - there is an open explicit recovery action for the lost execution path
 
 An agent-owned `in_progress` issue is stalled when it has no active run, no queued continuation, and no explicit recovery surface. A still-running but silent process is not automatically stalled; it is handled by the active-run watchdog contract.

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -251,7 +251,7 @@ A valid recovery action must name:
 - the wake, monitor, timeout, retry, or escalation policy that will move the action forward
 - the resolution outcome when closed, such as restored, delegated, false positive, blocked, escalated, or cancelled
 
-Recovery actions that re-fire owner wakes must be bounded. They must carry a finite `maxAttempts`, enforce a minimum interval between re-fires, and have one clear exhaustion path. When the finite bound is reached, Paperclip must surface or fold the action exactly once through the explicit recovery lifecycle; it must not keep issuing the same recovery wake indefinitely.
+Source-scoped status-only recovery actions that can re-fire the same owner wake, such as `missing_disposition`, must be bounded. They must carry a finite `maxAttempts`, enforce a minimum interval between re-fires, and have one clear exhaustion path. When the finite bound is reached, Paperclip must surface or fold the action exactly once through the explicit recovery lifecycle; it must not keep issuing the same recovery wake indefinitely.
 
 A source-scoped recovery action is the default form. Use it when the next safe move is to repair the source issue's liveness directly: move the source issue back to `todo` so it can be retried, clarify disposition, re-establish a monitor, record a false positive, or delegate real follow-up work from the source issue.
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -752,7 +752,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       returnOwnerAgentId: input.agentId,
       cause: input.cause ?? "stranded_assigned_issue",
       attemptCount: 1,
-      maxAttempts: null,
+      maxAttempts: 1,
     });
     expect(action.evidence).toMatchObject({
       sourceIssueId: input.issueId,
@@ -763,6 +763,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(action.nextAction).toContain(
       input.kind === "missing_disposition" ? "valid issue disposition" : "Restore a live execution path",
     );
+    expect(action.wakePolicy).toMatchObject({
+      type: "wake_owner",
+      reason: "source_scoped_recovery_action",
+      minRefireIntervalMs: 60_000,
+    });
 
     const recoveryIssues = await db
       .select()
@@ -1753,6 +1758,125 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       latestRunStatus: "succeeded",
       missingDisposition: "clear_next_step",
     });
+  });
+
+  it("folds missing-disposition recovery instead of refiring after the finite attempt bound", async () => {
+    const { companyId, agentId, runId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    const sourceRunId = randomUUID();
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "finish_successful_run_handoff",
+          sourceRunId,
+          resumeFromRunId: sourceRunId,
+          handoffRequired: true,
+          handoffReason: "successful_run_missing_state",
+          missingDisposition: "clear_next_step",
+          handoffAttempt: 1,
+          maxHandoffAttempts: 1,
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "missing_disposition",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      fingerprint: `source_scoped_recovery:${companyId}:${issueId}:${SUCCESSFUL_RUN_MISSING_STATE_REASON}`,
+      evidence: { sourceRunId, missingDisposition: "clear_next_step" },
+      nextAction: "Choose and record a valid issue disposition without copying transcript content.",
+      wakePolicy: { type: "wake_owner", reason: "source_scoped_recovery_action", ownerAgentId: agentId },
+      attemptCount: 1,
+      maxAttempts: 1,
+      lastAttemptAt: new Date("2026-03-19T00:05:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(action).toMatchObject({
+      status: "resolved",
+      outcome: "false_positive",
+      attemptCount: 1,
+      maxAttempts: 1,
+    });
+    expect(action?.resolutionNote).toContain("finite attempt bound");
+    const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakes.filter((wake) => wake.reason === "source_scoped_recovery_action")).toHaveLength(0);
+  });
+
+  it("folds missing-disposition recovery when an event-driven hub idle path is present", async () => {
+    const { companyId, agentId, runId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    await db
+      .update(issues)
+      .set({
+        executionPolicy: {
+          eventDrivenHubIdle: true,
+          reason: "standing hub waits for external events",
+        },
+      })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "finish_successful_run_handoff",
+          handoffRequired: true,
+          handoffReason: "successful_run_missing_state",
+          missingDisposition: "clear_next_step",
+          handoffAttempt: 1,
+          maxHandoffAttempts: 1,
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "missing_disposition",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      cause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      fingerprint: `source_scoped_recovery:${companyId}:${issueId}:${SUCCESSFUL_RUN_MISSING_STATE_REASON}`,
+      evidence: { missingDisposition: "clear_next_step" },
+      nextAction: "Choose and record a valid issue disposition without copying transcript content.",
+      wakePolicy: { type: "wake_owner", reason: "source_scoped_recovery_action", ownerAgentId: agentId },
+      attemptCount: 1,
+      maxAttempts: 2,
+      lastAttemptAt: new Date("2026-03-19T00:05:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+
+    const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(action).toMatchObject({
+      status: "resolved",
+      outcome: "false_positive",
+    });
+    expect(action?.resolutionNote).toContain("event-driven hub idle path");
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -752,7 +752,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       returnOwnerAgentId: input.agentId,
       cause: input.cause ?? "stranded_assigned_issue",
       attemptCount: 1,
-      maxAttempts: 1,
+      maxAttempts: input.kind === "missing_disposition" ? 1 : null,
     });
     expect(action.evidence).toMatchObject({
       sourceIssueId: input.issueId,
@@ -766,7 +766,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(action.wakePolicy).toMatchObject({
       type: "wake_owner",
       reason: "source_scoped_recovery_action",
-      minRefireIntervalMs: 60_000,
+      ...(input.kind === "missing_disposition" ? { minRefireIntervalMs: 60_000 } : {}),
     });
 
     const recoveryIssues = await db
@@ -1870,6 +1870,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const result = await heartbeat.reconcileStrandedAssignedIssues();
     expect(result.successfulRunHandoffEscalated).toBe(0);
+    expect(result.skipped).toBe(1);
 
     const [action] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
     expect(action).toMatchObject({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4277,7 +4277,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: issues.status,
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
+        executionPolicy: issues.executionPolicy,
         executionState: issues.executionState,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
         projectId: issues.projectId,
       })
       .from(issues)

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -42,6 +42,7 @@ import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   buildSuccessfulRunHandoffExhaustedNotice,
+  hasEventDrivenHubIdlePath,
   noticeMetadataReferencesRecoveryAction,
   type SuccessfulRunHandoffNotice,
 } from "./successful-run-handoff.js";
@@ -178,6 +179,8 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const SOURCE_SCOPED_RECOVERY_MIN_REFIRE_INTERVAL_MS = 60_000;
+const MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS = CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS;
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -2115,17 +2118,88 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           type: "wake_owner",
           reason: "source_scoped_recovery_action",
           ownerAgentId,
+          minRefireIntervalMs: SOURCE_SCOPED_RECOVERY_MIN_REFIRE_INTERVAL_MS,
         }
         : {
           type: "board_escalation",
           reason: "no_invokable_recovery_owner",
         },
       monitorPolicy: null,
-      maxAttempts: null,
+      maxAttempts: recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
+        ? MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS
+        : CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS,
       lastAttemptAt: now,
     });
 
     return action;
+  }
+
+  async function foldActiveRecoveryAction(input: {
+    companyId: string;
+    sourceIssueId: string;
+    actionId: string;
+    outcome: "false_positive" | "restored" | "cancelled";
+    resolutionNote: string;
+  }) {
+    return recoveryActionsSvc.resolveActiveForIssue({
+      companyId: input.companyId,
+      sourceIssueId: input.sourceIssueId,
+      actionId: input.actionId,
+      status: "resolved",
+      outcome: input.outcome,
+      resolutionNote: input.resolutionNote,
+    });
+  }
+
+  async function shouldFoldOrDelayMissingDispositionRecovery(input: {
+    issue: typeof issues.$inferSelect;
+    action: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>> | null;
+  }) {
+    const action = input.action;
+    if (!action || action.kind !== "missing_disposition") return false;
+
+    if (input.issue.status !== "in_progress") {
+      await foldActiveRecoveryAction({
+        companyId: input.issue.companyId,
+        sourceIssueId: input.issue.id,
+        actionId: action.id,
+        outcome: "restored",
+        resolutionNote: `Missing-disposition recovery folded because the source issue is now ${input.issue.status}.`,
+      });
+      return true;
+    }
+
+    if (hasEventDrivenHubIdlePath(input.issue)) {
+      await foldActiveRecoveryAction({
+        companyId: input.issue.companyId,
+        sourceIssueId: input.issue.id,
+        actionId: action.id,
+        outcome: "false_positive",
+        resolutionNote: "Missing-disposition recovery folded because the source issue exposes an event-driven hub idle path.",
+      });
+      return true;
+    }
+
+    if (action.maxAttempts !== null && action.attemptCount >= action.maxAttempts) {
+      await foldActiveRecoveryAction({
+        companyId: input.issue.companyId,
+        sourceIssueId: input.issue.id,
+        actionId: action.id,
+        outcome: "false_positive",
+        resolutionNote: "Missing-disposition recovery reached its finite attempt bound; the status-only recovery wake cannot produce the demanded disposition.",
+      });
+      return true;
+    }
+
+    const lastAttemptAtMs = action.lastAttemptAt ? new Date(action.lastAttemptAt).getTime() : Number.NaN;
+    if (
+      Number.isFinite(lastAttemptAtMs) &&
+      Date.now() - lastAttemptAtMs < SOURCE_SCOPED_RECOVERY_MIN_REFIRE_INTERVAL_MS
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   async function enqueueSourceScopedStrandedRecoveryWake(input: {
@@ -2574,6 +2648,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       const handoffEvidence = isExhaustedSuccessfulRunHandoff(latestRun);
       if (handoffEvidence) {
         if (!handoffEvidence.exhausted) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id);
+        if (await shouldFoldOrDelayMissingDispositionRecovery({ issue, action: activeRecoveryAction })) {
           result.skipped += 1;
           continue;
         }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2118,7 +2118,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           type: "wake_owner",
           reason: "source_scoped_recovery_action",
           ownerAgentId,
-          minRefireIntervalMs: SOURCE_SCOPED_RECOVERY_MIN_REFIRE_INTERVAL_MS,
+          ...(recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
+            ? { minRefireIntervalMs: SOURCE_SCOPED_RECOVERY_MIN_REFIRE_INTERVAL_MS }
+            : {}),
         }
         : {
           type: "board_escalation",
@@ -2127,7 +2129,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       monitorPolicy: null,
       maxAttempts: recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
         ? MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS
-        : CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS,
+        : null,
       lastAttemptAt: now,
     });
 

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -143,6 +143,17 @@ describe("successful run handoff decision", () => {
       kind: "skip",
       reason: "issue has event-driven hub idle path",
     });
+    expect(decide({
+      issue: {
+        ...issue,
+        executionState: {
+          idlePath: { kind: "event_driven_hub_idle" },
+        },
+      } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "issue has event-driven hub idle path",
+    });
   });
 
   it("does not queue when an in-progress issue has a future monitor wake", () => {

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -130,6 +130,33 @@ describe("successful run handoff decision", () => {
     });
   });
 
+  it("does not queue when an in-progress hub exposes an event-driven idle path", () => {
+    expect(decide({
+      issue: {
+        ...issue,
+        executionPolicy: {
+          eventDrivenHubIdle: true,
+          reason: "standing hub waits for external events",
+        },
+      } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "issue has event-driven hub idle path",
+    });
+  });
+
+  it("does not queue when an in-progress issue has a future monitor wake", () => {
+    expect(decide({
+      issue: {
+        ...issue,
+        monitorNextCheckAt: new Date(Date.now() + 60_000),
+      } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "issue has a future monitor wake",
+    });
+  });
+
   it("does not queue when a successful run has no progress signal", () => {
     expect(decide({ livenessState: null, detectedProgressSummary: null })).toEqual({
       kind: "skip",

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -45,7 +45,16 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "title"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionPolicy"
+  | "executionState"
+  | "monitorNextCheckAt"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -91,6 +100,23 @@ function metadataText(value: unknown, fallback = "unknown") {
   const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
   const resolved = text.length > 0 ? text : fallback;
   return resolved.length > 2000 ? `${resolved.slice(0, 1997)}...` : resolved;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasEventDrivenParkMarker(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.eventDrivenHubIdle === true || value.eventDrivenPark === true) return true;
+  if (value.kind === "event_driven_hub_idle" || value.kind === "event_driven_park") return true;
+  if (value.type === "event_driven_hub_idle" || value.type === "event_driven_park") return true;
+  return hasEventDrivenParkMarker(value.idlePath) || hasEventDrivenParkMarker(value.waitingPath);
+}
+
+export function hasEventDrivenHubIdlePath(issue: IssueRow | null | undefined) {
+  if (!issue || issue.status !== "in_progress") return false;
+  return hasEventDrivenParkMarker(issue.executionState) || hasEventDrivenParkMarker(issue.executionPolicy);
 }
 
 function keyValueRow(label: string, value: unknown): IssueCommentMetadata["sections"][number]["rows"][number] {
@@ -364,6 +390,10 @@ export function decideSuccessfulRunHandoff(input: {
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
+  if (hasEventDrivenHubIdlePath(issue)) return { kind: "skip", reason: "issue has event-driven hub idle path" };
+  if (issue.monitorNextCheckAt && issue.monitorNextCheckAt > new Date()) {
+    return { kind: "skip", reason: "issue has a future monitor wake" };
+  }
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };
   }

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -389,8 +389,8 @@ export function decideSuccessfulRunHandoff(input: {
   }
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
-  if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
   if (hasEventDrivenHubIdlePath(issue)) return { kind: "skip", reason: "issue has event-driven hub idle path" };
+  if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
   if (issue.monitorNextCheckAt && issue.monitorNextCheckAt > new Date()) {
     return { kind: "skip", reason: "issue has a future monitor wake" };
   }

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import type { Issue, IssueRecoveryAction } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
-import { Eye, Flag, X } from "lucide-react";
+import { CirclePause, Eye, Flag, X } from "lucide-react";
 import {
   createIssueDetailPath,
   rememberIssueDetailLocationState,
@@ -12,6 +12,7 @@ import { deriveActiveRecoveryDisplayState, RECOVERY_CHIP_DEFAULT_TONE } from "..
 import { StatusIcon } from "./StatusIcon";
 import { productivityReviewTriggerLabel } from "./ProductivityReviewBadge";
 import { hasAssignedBacklogBlocker } from "../lib/issue-blockers";
+import { hasEventDrivenHubIdlePath } from "../lib/event-driven-hub-idle";
 
 type UnreadState = "hidden" | "visible" | "fading";
 
@@ -87,6 +88,7 @@ export function IssueRow({
   ) : null;
   const recoveryAction = issue.activeRecoveryAction ?? null;
   const recoveryIndicator = recoveryAction ? renderRecoveryChip(recoveryAction, selected) : null;
+  const hubIdleIndicator = hasEventDrivenHubIdlePath(issue) ? renderHubIdleChip(selected) : null;
   const parkedBlockerIndicator = hasAssignedBacklogBlocker(issue.blockedBy) ? (
     <span
       data-testid="issue-row-parked-blocker"
@@ -119,6 +121,7 @@ export function IssueRow({
         {mobileLeading ?? <StatusIcon status={issue.status} blockerAttention={issue.blockerAttention} className={selectedStatusClass} />}
         {productivityReviewIndicator}
         {parkedBlockerIndicator}
+        {hubIdleIndicator}
         {recoveryIndicator}
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-1 sm:contents">
@@ -145,6 +148,7 @@ export function IssueRow({
                 {identifier}
               </span>
               {parkedBlockerIndicator}
+              {hubIdleIndicator}
               {recoveryIndicator}
             </>
           )}
@@ -225,6 +229,24 @@ export function IssueRow({
         </span>
       ) : null}
     </Link>
+  );
+}
+
+function renderHubIdleChip(selected: boolean): ReactNode {
+  return (
+    <span
+      data-testid="issue-row-hub-idle-indicator"
+      role="status"
+      aria-label="Event-driven hub idle"
+      className={cn(
+        "ml-1.5 inline-flex shrink-0 items-center gap-0.5 rounded-full border border-emerald-500/45 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-300",
+        selected ? "!border-muted-foreground !text-muted-foreground" : null,
+      )}
+      title="Healthy event-driven hub: waiting for an external event, not a missed handoff."
+    >
+      <CirclePause className="h-2.5 w-2.5" aria-hidden />
+      Hub idle
+    </span>
   );
 }
 

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -21,8 +21,9 @@ import { StatusIcon } from "./StatusIcon";
 import { PriorityIcon } from "./PriorityIcon";
 import { Identity } from "./Identity";
 import type { Issue, IssueStatus } from "@paperclipai/shared";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, CirclePause } from "lucide-react";
 import { isSuccessfulRunHandoffRequired } from "../lib/successful-run-handoff";
+import { hasEventDrivenHubIdlePath } from "../lib/event-driven-hub-idle";
 
 export const KANBAN_BOARD_HIGH_VOLUME_THRESHOLD = 100;
 export const KANBAN_COLUMN_PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
@@ -241,6 +242,16 @@ function KanbanCard({
             >
               <AlertTriangle className="h-3 w-3" />
               Next step
+            </span>
+          ) : null}
+          {hasEventDrivenHubIdlePath(issue) ? (
+            <span
+              className="inline-flex items-center gap-1 rounded-full border border-emerald-400/45 bg-emerald-50/60 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:border-emerald-300/35 dark:bg-emerald-400/10 dark:text-emerald-300"
+              title="Healthy event-driven hub: waiting for an external event, not a missed handoff."
+              aria-label="Event-driven hub idle"
+            >
+              <CirclePause className="h-3 w-3" />
+              Hub idle
             </span>
           ) : null}
           {isLive && (

--- a/ui/src/lib/activity-format.test.ts
+++ b/ui/src/lib/activity-format.test.ts
@@ -74,4 +74,28 @@ describe("activity formatting", () => {
       "Run finished without a next step - recovery escalated",
     );
   });
+
+  it("distinguishes event-driven hub idle from missing handoff activity", () => {
+    const details = { skipReason: "issue has event-driven hub idle path" };
+
+    expect(formatActivityVerb("issue.successful_run_handoff_resolved", details)).toBe(
+      "recorded event-driven hub idle on",
+    );
+    expect(formatIssueActivityAction("issue.successful_run_handoff_resolved", details)).toBe(
+      "Event-driven hub idle",
+    );
+  });
+
+  it("distinguishes recovery folds and exhausted escalations", () => {
+    expect(formatActivityVerb("issue.recovery_action_resolved", { outcome: "false_positive" })).toBe(
+      "folded false-positive recovery on",
+    );
+    expect(formatIssueActivityAction("issue.recovery_action_resolved", {
+      outcome: "false_positive",
+      resolutionNote: "Missing-disposition recovery folded because the source issue exposes an event-driven hub idle path.",
+    })).toBe("Folded recovery: event-driven hub idle");
+    expect(formatIssueActivityAction("issue.recovery_action_escalated", { outcome: "escalated" })).toBe(
+      "Recovery exhausted and escalated",
+    );
+  });
 });

--- a/ui/src/lib/activity-format.ts
+++ b/ui/src/lib/activity-format.ts
@@ -1,5 +1,6 @@
 import type { Agent } from "@paperclipai/shared";
 import type { CompanyUserProfile } from "./company-members";
+import { hasEventDrivenHubIdleDetail } from "./event-driven-hub-idle";
 
 type ActivityDetails = Record<string, unknown> | null | undefined;
 
@@ -202,6 +203,10 @@ function readStringArrayLength(value: unknown): number {
   return value.filter((entry) => typeof entry === "string" && entry.length > 0).length;
 }
 
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 function formatAcceptedPlanDecompositionDetail(details: ActivityDetails): string | null {
   if (!details) return null;
   const status = typeof details.status === "string" ? details.status : null;
@@ -324,6 +329,48 @@ function formatStructuredIssueChange(input: {
   return null;
 }
 
+function formatSuccessfulRunHandoffActivity(action: string, details: ActivityDetails, forIssueDetail: boolean): string | null {
+  if (action === "issue.successful_run_handoff_resolved" && hasEventDrivenHubIdleDetail(details)) {
+    return forIssueDetail ? "Event-driven hub idle" : "recorded event-driven hub idle on";
+  }
+  return null;
+}
+
+function formatRecoveryActionActivity(action: string, details: ActivityDetails, forIssueDetail: boolean): string | null {
+  if (!details) return null;
+  const outcome = readString(details.outcome);
+  const source = readString(details.source);
+  const note = readString(details.resolutionNote);
+
+  if (action === "issue.recovery_action_resolved" && outcome === "false_positive") {
+    if (hasEventDrivenHubIdleDetail(details)) {
+      return forIssueDetail
+        ? "Folded recovery: event-driven hub idle"
+        : "folded recovery as event-driven hub idle on";
+    }
+    return forIssueDetail
+      ? "Folded recovery: false positive"
+      : "folded false-positive recovery on";
+  }
+
+  if (
+    action === "issue.recovery_action_escalated" ||
+    (action === "issue.recovery_action_resolved" && (outcome === "escalated" || source === "recovery.exhausted"))
+  ) {
+    return forIssueDetail
+      ? "Recovery exhausted and escalated"
+      : "escalated exhausted recovery on";
+  }
+
+  if (action === "issue.recovery_action_resolved" && note?.toLowerCase().includes("exhaust")) {
+    return forIssueDetail
+      ? "Recovery exhausted and escalated"
+      : "escalated exhausted recovery on";
+  }
+
+  return null;
+}
+
 export function formatActivityVerb(
   action: string,
   details?: Record<string, unknown> | null,
@@ -341,6 +388,12 @@ export function formatActivityVerb(
     forIssueDetail: false,
   });
   if (structuredChange) return structuredChange;
+
+  const successfulRunHandoff = formatSuccessfulRunHandoffActivity(action, details, false);
+  if (successfulRunHandoff) return successfulRunHandoff;
+
+  const recoveryAction = formatRecoveryActionActivity(action, details, false);
+  if (recoveryAction) return recoveryAction;
 
   return ACTIVITY_ROW_VERBS[action] ?? action.replace(/[._]/g, " ");
 }
@@ -362,6 +415,12 @@ export function formatIssueActivityAction(
     forIssueDetail: true,
   });
   if (structuredChange) return structuredChange;
+
+  const successfulRunHandoff = formatSuccessfulRunHandoffActivity(action, details, true);
+  if (successfulRunHandoff) return successfulRunHandoff;
+
+  const recoveryAction = formatRecoveryActionActivity(action, details, true);
+  if (recoveryAction) return recoveryAction;
 
   if (action === "issue.accepted_plan_decomposition_updated") {
     const detail = formatAcceptedPlanDecompositionDetail(details);

--- a/ui/src/lib/event-driven-hub-idle.test.ts
+++ b/ui/src/lib/event-driven-hub-idle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@paperclipai/shared";
+import { hasEventDrivenHubIdleDetail, hasEventDrivenHubIdlePath } from "./event-driven-hub-idle";
+
+type HubIdleIssue = Pick<Issue, "status" | "executionPolicy" | "executionState">;
+
+function issue(overrides: Partial<HubIdleIssue>): HubIdleIssue {
+  return {
+    status: "in_progress",
+    executionPolicy: null,
+    executionState: null,
+    ...overrides,
+  };
+}
+
+describe("event-driven hub idle helpers", () => {
+  it("detects an in-progress issue with an event-driven idle marker", () => {
+    expect(hasEventDrivenHubIdlePath(issue({
+      executionPolicy: { eventDrivenHubIdle: true } as unknown as Issue["executionPolicy"],
+    }))).toBe(true);
+    expect(hasEventDrivenHubIdlePath(issue({
+      executionState: { idlePath: { kind: "event_driven_hub_idle" } } as unknown as Issue["executionState"],
+    }))).toBe(true);
+  });
+
+  it("does not mark terminal issues as hub idle", () => {
+    expect(hasEventDrivenHubIdlePath(issue({
+      status: "done",
+      executionPolicy: { eventDrivenHubIdle: true } as unknown as Issue["executionPolicy"],
+    }))).toBe(false);
+  });
+
+  it("detects hub-idle activity details", () => {
+    expect(hasEventDrivenHubIdleDetail({ skipReason: "issue has event-driven hub idle path" })).toBe(true);
+    expect(hasEventDrivenHubIdleDetail({ resolutionNote: "folded because the source issue exposes an event-driven hub idle path" })).toBe(true);
+    expect(hasEventDrivenHubIdleDetail({ executionPolicy: { waitingPath: { type: "event_driven_park" } } })).toBe(true);
+  });
+});

--- a/ui/src/lib/event-driven-hub-idle.ts
+++ b/ui/src/lib/event-driven-hub-idle.ts
@@ -1,0 +1,26 @@
+import type { Issue } from "@paperclipai/shared";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasEventDrivenParkMarker(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.eventDrivenHubIdle === true || value.eventDrivenPark === true) return true;
+  if (value.kind === "event_driven_hub_idle" || value.kind === "event_driven_park") return true;
+  if (value.type === "event_driven_hub_idle" || value.type === "event_driven_park") return true;
+  return hasEventDrivenParkMarker(value.idlePath) || hasEventDrivenParkMarker(value.waitingPath);
+}
+
+export function hasEventDrivenHubIdlePath(issue: Pick<Issue, "status" | "executionPolicy" | "executionState">) {
+  if (issue.status !== "in_progress") return false;
+  return hasEventDrivenParkMarker(issue.executionPolicy) || hasEventDrivenParkMarker(issue.executionState);
+}
+
+export function hasEventDrivenHubIdleDetail(details: Record<string, unknown> | null | undefined) {
+  if (!details) return false;
+  if (details.skipReason === "issue has event-driven hub idle path") return true;
+  if (details.reason === "issue has event-driven hub idle path") return true;
+  if (typeof details.resolutionNote === "string" && details.resolutionNote.includes("event-driven hub idle path")) return true;
+  return hasEventDrivenParkMarker(details) || hasEventDrivenParkMarker(details.executionPolicy) || hasEventDrivenParkMarker(details.executionState);
+}

--- a/ui/src/lib/successful-run-handoff.test.ts
+++ b/ui/src/lib/successful-run-handoff.test.ts
@@ -33,5 +33,8 @@ describe("successful run handoff UI helpers", () => {
     expect(successfulRunHandoffActivityTone(SUCCESSFUL_RUN_HANDOFF_REQUIRED_ACTION).className).toContain("amber");
     expect(successfulRunHandoffActivityTone(SUCCESSFUL_RUN_HANDOFF_ESCALATED_ACTION).className).toContain("red");
     expect(successfulRunHandoffActivityTone(SUCCESSFUL_RUN_HANDOFF_RESOLVED_ACTION).className).toContain("border");
+    expect(successfulRunHandoffActivityTone(SUCCESSFUL_RUN_HANDOFF_RESOLVED_ACTION, {
+      skipReason: "issue has event-driven hub idle path",
+    }).className).toContain("emerald");
   });
 });

--- a/ui/src/lib/successful-run-handoff.ts
+++ b/ui/src/lib/successful-run-handoff.ts
@@ -1,4 +1,5 @@
 import type { ActivityEvent, Issue, SuccessfulRunHandoffState } from "@paperclipai/shared";
+import { hasEventDrivenHubIdleDetail } from "./event-driven-hub-idle";
 
 export const SUCCESSFUL_RUN_HANDOFF_REQUIRED_ACTION = "issue.successful_run_handoff_required";
 export const SUCCESSFUL_RUN_HANDOFF_RESOLVED_ACTION = "issue.successful_run_handoff_resolved";
@@ -70,7 +71,13 @@ export function isSuccessfulRunHandoffEscalationComment(text: string) {
     || /^Paperclip exhausted the bounded successful-run handoff correction\b/i.test(trimmed);
 }
 
-export function successfulRunHandoffActivityTone(action: string) {
+export function successfulRunHandoffActivityTone(action: string, details?: Record<string, unknown> | null) {
+  if (action === SUCCESSFUL_RUN_HANDOFF_RESOLVED_ACTION && hasEventDrivenHubIdleDetail(details)) {
+    return {
+      className: "border-emerald-400/40 bg-emerald-500/10 text-emerald-950 dark:text-emerald-100",
+      iconClassName: "text-emerald-600 dark:text-emerald-300",
+    };
+  }
   if (action === SUCCESSFUL_RUN_HANDOFF_ESCALATED_ACTION) {
     return {
       className: "border-red-500/35 bg-red-500/10 text-red-950 dark:text-red-100",

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1176,7 +1176,7 @@ function IssueDetailActivityTab({
           hasLiveRuns={hasLiveRuns}
           activityEvents={activity ?? []}
           renderActivityEvent={(evt) => {
-            const tone = successfulRunHandoffActivityTone(evt.action);
+            const tone = successfulRunHandoffActivityTone(evt.action, evt.details);
             const isHandoffWarning =
               evt.action === SUCCESSFUL_RUN_HANDOFF_REQUIRED_ACTION
               || evt.action === SUCCESSFUL_RUN_HANDOFF_ESCALATED_ACTION;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The recovery subsystem keeps agent-owned non-terminal issues from silently losing their live execution path.
> - Successful-run handoff uses a cheap status-only corrective wake when an agent leaves productive work in `in_progress` without a disposition.
> - The sibling `missing_disposition` recovery action could re-fire `source_scoped_recovery_action` without a finite cap or live-source revalidation.
> - Long-lived event-driven hub issues can legitimately park in `in_progress` while waiting for external events, so they need an explicit idle primitive.
> - This pull request bounds and folds missing-disposition recovery and teaches handoff to skip event-driven hub idle paths.
> - The benefit is preserving useful liveness recovery while preventing empty recovery/handoff oscillations.

Fixes #7496

## What Changed

- Documented bounded recovery re-fires and event-driven hub idle paths in `doc/execution-semantics.md`.
- Added `hasEventDrivenHubIdlePath` and successful-run handoff skips for event-driven hub idle metadata and future monitor wakes.
- Made source-scoped stranded recovery actions carry finite `maxAttempts` plus `minRefireIntervalMs` in the wake policy.
- Revalidated active `missing_disposition` recovery before re-fire, folding when the source has a hub idle path or the finite status-only attempt bound is reached.
- Added regression coverage for bounded missing-disposition folding and event-driven hub idle skips.

## Verification

- `git diff --check`
- `pnpm vitest run server/src/services/recovery/successful-run-handoff.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low-to-medium behavioral risk: source-scoped recovery actions now have a finite attempt bound, so repeated automatic refires fold sooner instead of repeatedly waking the same owner.
- Event-driven hub idle is detected from explicit JSON markers (`eventDrivenHubIdle`, `eventDrivenPark`, `event_driven_hub_idle`, or `event_driven_park`) in `executionPolicy`/`executionState`; operators still need to set one of those markers for hub issues.
- No migration required; existing active actions without caps remain readable, and new/updated source-scoped actions get finite caps.

## Model Used

- OpenAI GPT-5 Codex via codex_local CLI, tool-using coding agent session, local repository/test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched the GitHub PR list for similar PRs and confirmed this does not duplicate existing PR work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge