### PR TITLE
fix(recovery): recognize routine-bound continuous-loop hubs (D1+D2+circuit-breaker)

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -466,7 +466,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       enabled: true,
       cronExpression: "0 9 * * 1",
       timezone: "Europe/Prague",
-      nextRunAt: new Date("2026-03-23T08:00:00.000Z"),
+      nextRunAt: new Date(Date.now() + 60 * 60 * 1000),
     });
 
     const systemWake = await heartbeat.wakeup(agentId, {
@@ -541,6 +541,83 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         .then((rows) => rows[0] ?? null);
       return ["succeeded", "failed", "cancelled", "timed_out"].includes(run?.status ?? "");
     }, 5_000);
+  });
+
+  it("does not park routine hubs when the scheduled next run is stale", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const routineId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Weekly science hub",
+      status: "backlog",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      parentIssueId: issueId,
+      title: "Weekly science loop",
+      status: "active",
+      priority: "medium",
+    });
+    await db.insert(routineTriggers).values({
+      id: randomUUID(),
+      companyId,
+      routineId,
+      kind: "schedule",
+      enabled: true,
+      cronExpression: "0 9 * * 1",
+      timezone: "Europe/Prague",
+      nextRunAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const systemWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: { issueId, wakeReason: "issue_blockers_resolved" },
+    });
+    expect(systemWake).not.toBeNull();
+
+    await waitForCondition(async () => mockAdapterExecute.mock.calls.length >= 1, 5_000);
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+
+    const skippedWake = await db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.reason, "routine_backlog_parked"))
+      .then((rows) => rows[0] ?? null);
+    expect(skippedWake).toBeNull();
   });
 
   it("honors maxConcurrentRuns 1 by leaving a second assignment wake queued", async () => {

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -21,6 +21,8 @@ import {
   issueRelations,
   issueTreeHolds,
   issues,
+  routines,
+  routineTriggers,
   workspaceOperations,
 } from "@paperclipai/db";
 import {
@@ -135,6 +137,8 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     await db.delete(documents);
     await db.delete(issueRelations);
     await db.delete(issueTreeHolds);
+    await db.delete(routineTriggers);
+    await db.delete(routines);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(activityLog);
@@ -397,6 +401,122 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       return rows.every((run) => run.status !== "queued" && run.status !== "running");
     }, 10_000);
     expect(noActiveRuns).toBe(true);
+  });
+
+  it("keeps scheduled routine hubs parked on system dependency wakes but allows user interaction wakes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const routineId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Weekly science hub",
+      status: "backlog",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      parentIssueId: issueId,
+      title: "Weekly science loop",
+      status: "active",
+      priority: "medium",
+    });
+    await db.insert(routineTriggers).values({
+      id: randomUUID(),
+      companyId,
+      routineId,
+      kind: "schedule",
+      enabled: true,
+      cronExpression: "0 9 * * 1",
+      timezone: "Europe/Prague",
+      nextRunAt: new Date("2026-03-23T08:00:00.000Z"),
+    });
+
+    const systemWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: { issueId, wakeReason: "issue_blockers_resolved" },
+    });
+    expect(systemWake).toBeNull();
+
+    const skippedWake = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.reason, "routine_backlog_parked"))
+      .then((rows) => rows[0] ?? null);
+    expect(skippedWake).toMatchObject({ status: "skipped", reason: "routine_backlog_parked" });
+
+    let issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("backlog");
+    expect(issue?.checkoutRunId).toBeNull();
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(0);
+
+    const commentId = randomUUID();
+    await db.insert(issueComments).values({
+      id: commentId,
+      companyId,
+      issueId,
+      authorUserId: "board-user",
+      body: "Please pick this back up now.",
+    });
+
+    const userWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId,
+        commentId,
+        wakeCommentId: commentId,
+        wakeReason: "issue_commented",
+        source: "issue.comment",
+      },
+    });
+    expect(userWake).not.toBeNull();
+
+    await waitForCondition(async () => {
+      const row = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+      return row?.status === "in_progress";
+    }, 5_000);
+    issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.checkoutRunId).toBe(userWake?.id);
   });
 
   it("honors maxConcurrentRuns 1 by leaving a second assignment wake queued", async () => {

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -102,6 +102,33 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
   }, 20_000);
 
   afterEach(async () => {
+    runningProcesses.clear();
+    // Drain to full quiescence BEFORE resetting the adapter spy. A test's runs can
+    // spawn an async bounded-liveness continuation run (enqueueWakeup) that invokes the
+    // adapter after the originating run is already terminal. If we reset the spy first
+    // (as the old order did), that late call increments the fresh count and leaks a
+    // phantom invocation into the next test, corrupting its toHaveBeenCalledTimes(...)
+    // assertions. We therefore wait until no heartbeat run is queued/running AND no
+    // wakeup request is still queued (continuations create a queued run), and only then
+    // reset the spy so the next test starts from a clean, stable count.
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const [runs, wakeups] = await Promise.all([
+        db.select({ status: heartbeatRuns.status }).from(heartbeatRuns),
+        db.select({ status: agentWakeupRequests.status }).from(agentWakeupRequests),
+      ]);
+      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
+      const hasQueuedWakeup = wakeups.some((wakeup) => wakeup.status === "queued");
+      if (!hasActiveRun && !hasQueuedWakeup) {
+        idlePolls += 1;
+        if (idlePolls >= 3) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    runningProcesses.clear();
     mockAdapterExecute.mockReset();
     mockAdapterExecute.mockImplementation(async () => ({
       exitCode: 0,
@@ -112,22 +139,6 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       provider: "test",
       model: "test-model",
     }));
-    runningProcesses.clear();
-    let idlePolls = 0;
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const runs = await db
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns);
-      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
-      if (!hasActiveRun) {
-        idlePolls += 1;
-        if (idlePolls >= 3) break;
-      } else {
-        idlePolls = 0;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50));
     await db.delete(environmentLeases);
     await db.delete(activityLog);
     await db.delete(companySkills);

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -517,6 +517,19 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("in_progress");
     expect(issue?.checkoutRunId).toBe(userWake?.id);
+
+    // Wait for the adapter run to reach a terminal status before the test ends.
+    // Without this, a lingering adapter call can fire after afterEach resets the mock,
+    // causing mock.calls.length to increment unexpectedly in the next test which
+    // asserts calls.length === 1 exactly.
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, userWake!.id))
+        .then((rows) => rows[0] ?? null);
+      return ["succeeded", "failed", "cancelled", "timed_out"].includes(run?.status ?? "");
+    }, 5_000);
   });
 
   it("honors maxConcurrentRuns 1 by leaving a second assignment wake queued", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -731,7 +731,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       enabled: input.enabled ?? true,
       cronExpression: "0 9 * * 1",
       timezone: "Europe/Prague",
-      nextRunAt: input.nextRunAt === undefined ? new Date("2026-03-23T08:00:00.000Z") : input.nextRunAt,
+      nextRunAt: input.nextRunAt === undefined ? new Date(Date.now() + 60 * 60 * 1000) : input.nextRunAt,
     });
   }
 
@@ -2709,6 +2709,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     { name: "archived routine", routine: { status: "archived" as const } },
     { name: "disabled trigger", routine: { enabled: false } },
     { name: "missing next run", routine: { nextRunAt: null } },
+    { name: "stale next run", routine: { nextRunAt: new Date(Date.now() - 60 * 60 * 1000) } },
   ])("still recovers stranded hubs when the scheduled routine is not active: $name", async ({ routine }) => {
     const { companyId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
-import { and, eq, or, inArray } from "drizzle-orm";
+import { and, eq, or, inArray, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -36,6 +36,8 @@ import {
   issues,
   projects,
   projectWorkspaces,
+  routines,
+  routineTriggers,
   workspaceOperations,
 } from "@paperclipai/db";
 import {
@@ -366,6 +368,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(issueRecoveryActions);
     await db.delete(issueTreeHoldMembers);
     await db.delete(issueTreeHolds);
+    await db.delete(routineTriggers);
+    await db.delete(routines);
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(issueComments);
       await db.delete(issueDocuments);
@@ -701,6 +705,34 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
 
     return { companyId, agentId, runId, wakeupRequestId, issueId, rootIssueId };
+  }
+
+  async function seedScheduledRoutineLoop(input: {
+    companyId: string;
+    issueId: string;
+    status?: "active" | "archived" | "disabled";
+    enabled?: boolean;
+    nextRunAt?: Date | null;
+  }) {
+    const routineId = randomUUID();
+    await db.insert(routines).values({
+      id: routineId,
+      companyId: input.companyId,
+      parentIssueId: input.issueId,
+      title: "Weekly science loop",
+      status: input.status ?? "active",
+      priority: "medium",
+    });
+    await db.insert(routineTriggers).values({
+      id: randomUUID(),
+      companyId: input.companyId,
+      routineId,
+      kind: "schedule",
+      enabled: input.enabled ?? true,
+      cronExpression: "0 9 * * 1",
+      timezone: "Europe/Prague",
+      nextRunAt: input.nextRunAt === undefined ? new Date("2026-03-23T08:00:00.000Z") : input.nextRunAt,
+    });
   }
 
   async function seedAssignedTodoNoRunFixture(input?: {
@@ -2649,6 +2681,127 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry failure details were withheld from the issue thread");
     expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction.id}\``);
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
+  });
+
+  it("keeps in-progress scheduled routine hubs out of stranded recovery", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "process_lost",
+    });
+    await seedScheduledRoutineLoop({ companyId, issueId });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    const recoveryActions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(0);
+  });
+
+  it.each([
+    { name: "archived routine", routine: { status: "archived" as const } },
+    { name: "disabled trigger", routine: { enabled: false } },
+    { name: "missing next run", routine: { nextRunAt: null } },
+  ])("still recovers stranded hubs when the scheduled routine is not active: $name", async ({ routine }) => {
+    const { companyId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "agent_not_invokable",
+    });
+    await seedScheduledRoutineLoop({ companyId, issueId, ...routine });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.evidence).toMatchObject({ latestRunId: runId });
+  });
+
+  it("trips the recovery circuit breaker after repeated recovery bounces in the rolling window", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "adapter_failed",
+    });
+    const now = new Date();
+    await db.insert(heartbeatRuns).values(
+      Array.from({ length: 4 }, (_, index) => ({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        errorCode: "adapter_failed",
+        error: "recovery bounced",
+        startedAt: new Date(now.getTime() - (index + 1) * 10 * 60 * 1000),
+        finishedAt: new Date(now.getTime() - (index + 1) * 10 * 60 * 1000 + 60_000),
+        createdAt: new Date(now.getTime() - (index + 1) * 10 * 60 * 1000),
+        updatedAt: new Date(now.getTime() - (index + 1) * 10 * 60 * 1000 + 60_000),
+      })),
+    );
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "issue_continuation_needed",
+    });
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments[0]?.body).toContain("repeated recovery attempts kept bouncing");
+    expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction.id}\``);
+
+    const breakerActivity = await db
+      .select()
+      .from(activityLog)
+      .where(and(eq(activityLog.entityId, issueId), eq(activityLog.action, "recovery.circuit_breaker_tripped")))
+      .then((rows) => rows[0] ?? null);
+    expect(breakerActivity?.details).toMatchObject({
+      retryReason: "issue_continuation_needed",
+      bounceCount: 5,
+      threshold: 5,
+    });
+
+    const retryRuns = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = 'issue_continuation_needed'`,
+        ),
+      )
+      .then((rows) => Number(rows[0]?.count ?? 0));
+    expect(retryRuns).toBe(5);
   });
 
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -50,6 +50,7 @@ import {
   projectWorkspaces,
   routineRevisions,
   routineRuns,
+  routineTriggers,
   routines,
   workspaceOperations,
 } from "@paperclipai/db";
@@ -240,6 +241,14 @@ const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retr
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
 const TIMER_ACTIONABLE_ISSUE_STATUSES = ["todo", "in_progress"] as const;
+const ROUTINE_BACKLOG_PARK_SYSTEM_WAKE_REASONS = new Set([
+  "issue_assigned",
+  "issue_assignment_recovery",
+  "issue_blockers_resolved",
+  "issue_children_completed",
+  "issue_continuation_needed",
+  RUN_LIVENESS_CONTINUATION_REASON,
+]);
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
@@ -2325,6 +2334,14 @@ function shouldAutoCheckoutIssueForWake(input: {
   return true;
 }
 
+function isSystemRoutineBacklogParkWake(contextSnapshot: Record<string, unknown> | null | undefined) {
+  const wakeTriggerDetail = readNonEmptyString(contextSnapshot?.wakeTriggerDetail);
+  if (wakeTriggerDetail !== "system") return false;
+
+  const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
+  return Boolean(wakeReason && ROUTINE_BACKLOG_PARK_SYSTEM_WAKE_REASONS.has(wakeReason));
+}
+
 function shouldQueueFollowupForRunningIssueWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   wakeCommentId: string | null;
@@ -3366,6 +3383,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function hasActiveScheduledRoutineLoop(
+    dbOrTx: Pick<Db, "select">,
+    companyId: string,
+    issueId: string,
+  ) {
+    return dbOrTx
+      .select({ id: routineTriggers.id })
+      .from(routineTriggers)
+      .innerJoin(
+        routines,
+        and(
+          eq(routines.companyId, routineTriggers.companyId),
+          eq(routines.id, routineTriggers.routineId),
+        ),
+      )
+      .where(
+        and(
+          eq(routineTriggers.companyId, companyId),
+          eq(routineTriggers.kind, "schedule"),
+          eq(routineTriggers.enabled, true),
+          sql`${routineTriggers.nextRunAt} is not null`,
+          eq(routines.status, "active"),
+          eq(routines.parentIssueId, issueId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
   }
 
   async function getRoutineEnvForExecutionIssue(
@@ -8120,9 +8166,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
       : null;
+    const shouldKeepRoutineBacklogParked = Boolean(
+      issueId &&
+      issueContext?.status === "backlog" &&
+      isSystemRoutineBacklogParkWake(context) &&
+      await hasActiveScheduledRoutineLoop(db, agent.companyId, issueId),
+    );
     if (
       issueId &&
       issueContext &&
+      !shouldKeepRoutineBacklogParked &&
       shouldAutoCheckoutIssueForWake({
         contextSnapshot: context,
         issueStatus: issueContext.status,
@@ -10802,6 +10855,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             triggerDetail,
             reason: "issue_execution_issue_not_found",
             payload,
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
+        if (
+          issue.status === "backlog" &&
+          isSystemRoutineBacklogParkWake(enrichedContextSnapshot) &&
+          await hasActiveScheduledRoutineLoop(tx, issue.companyId, issue.id)
+        ) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "routine_backlog_parked",
+            payload: {
+              ...(payload ?? {}),
+              issueId,
+            },
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3405,7 +3405,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           eq(routineTriggers.companyId, companyId),
           eq(routineTriggers.kind, "schedule"),
           eq(routineTriggers.enabled, true),
-          sql`${routineTriggers.nextRunAt} is not null`,
+          sql`${routineTriggers.nextRunAt} > now()`,
           eq(routines.status, "active"),
           eq(routines.parentIssueId, issueId),
         ),

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -23,6 +23,8 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  routines,
+  routineTriggers,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -72,6 +74,8 @@ const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+const RECOVERY_CIRCUIT_BREAKER_THRESHOLD = 5;
+const RECOVERY_CIRCUIT_BREAKER_WINDOW_MS = 6 * 60 * 60 * 1000;
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -558,6 +562,73 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { consecutive, latestFinishedAt };
   }
 
+  async function countRecentRecoveryBounces(input: {
+    companyId: string;
+    issueId: string;
+    retryReason: "assignment_recovery" | "issue_continuation_needed";
+    now?: Date;
+  }) {
+    const windowStart = new Date((input.now ?? new Date()).getTime() - RECOVERY_CIRCUIT_BREAKER_WINDOW_MS);
+    return db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, input.companyId),
+          gte(heartbeatRuns.createdAt, windowStart),
+          inArray(heartbeatRuns.status, [...UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES]),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+          sql`${heartbeatRuns.contextSnapshot} ->> 'retryReason' = ${input.retryReason}`,
+        ),
+      )
+      .then((rows) => Number(rows[0]?.count ?? 0));
+  }
+
+  async function tripRecoveryCircuitBreaker(input: {
+    issue: typeof issues.$inferSelect;
+    previousStatus: "todo" | "in_progress";
+    latestRun: LatestIssueRun;
+    retryReason: "assignment_recovery" | "issue_continuation_needed";
+    bounceCount: number;
+  }) {
+    const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
+    const updated = await escalateStrandedAssignedIssue({
+      issue: input.issue,
+      previousStatus: input.previousStatus,
+      latestRun: input.latestRun,
+      comment:
+        "Paperclip stopped automatic recovery for this issue because repeated recovery attempts kept bouncing " +
+        `(${input.bounceCount} attempts in 6 hours, retry reason \`${input.retryReason}\`).${failureSummary ?? ""} ` +
+        "Moving it to `blocked` so the recovery owner can restore a live path or record an intentional manual resolution.",
+    });
+    if (!updated) return null;
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "recovery.circuit_breaker_tripped",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        previousStatus: input.previousStatus,
+        status: "blocked",
+        retryReason: input.retryReason,
+        bounceCount: input.bounceCount,
+        threshold: RECOVERY_CIRCUIT_BREAKER_THRESHOLD,
+        windowMs: RECOVERY_CIRCUIT_BREAKER_WINDOW_MS,
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunStatus: input.latestRun?.status ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+      },
+    });
+
+    return updated;
+  }
+
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
     const [run, deferredWake] = await Promise.all([
       db
@@ -659,6 +730,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .then((rows) => rows[0] ?? null),
     ]);
     return Boolean(comment || attachment);
+  }
+
+  async function hasActiveScheduledRoutineLoop(companyId: string, issueId: string) {
+    return db
+      .select({ id: routineTriggers.id })
+      .from(routineTriggers)
+      .innerJoin(
+        routines,
+        and(
+          eq(routines.companyId, routineTriggers.companyId),
+          eq(routines.id, routineTriggers.routineId),
+        ),
+      )
+      .where(
+        and(
+          eq(routineTriggers.companyId, companyId),
+          eq(routineTriggers.kind, "schedule"),
+          eq(routineTriggers.enabled, true),
+          gt(routineTriggers.nextRunAt, new Date()),
+          eq(routines.status, "active"),
+          eq(routines.parentIssueId, issueId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
   }
 
   async function enqueueStrandedIssueRecovery(input: {
@@ -2765,6 +2861,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      // D1: a routine-bound continuous-loop hub whose recurring routine has an upcoming
+      // scheduled fire is a live continuation between fires, not a stranded issue.
+      if (issue.status === "in_progress" && await hasActiveScheduledRoutineLoop(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({
@@ -2779,6 +2882,35 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           result.skipped += 1;
         }
         continue;
+      }
+
+      const latestRetryReason = readNonEmptyString(parseObject(latestRun?.contextSnapshot).retryReason);
+      if (
+        latestRun &&
+        isUnsuccessfulTerminalIssueRun(latestRun) &&
+        (latestRetryReason === "assignment_recovery" || latestRetryReason === "issue_continuation_needed")
+      ) {
+        const bounceCount = await countRecentRecoveryBounces({
+          companyId: issue.companyId,
+          issueId: issue.id,
+          retryReason: latestRetryReason,
+        });
+        if (bounceCount >= RECOVERY_CIRCUIT_BREAKER_THRESHOLD) {
+          const updated = await tripRecoveryCircuitBreaker({
+            issue,
+            previousStatus: issue.status as "todo" | "in_progress",
+            latestRun,
+            retryReason: latestRetryReason,
+            bounceCount,
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
       }
 
       if (issue.status === "todo") {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -748,7 +748,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(routineTriggers.companyId, companyId),
           eq(routineTriggers.kind, "schedule"),
           eq(routineTriggers.enabled, true),
-          gt(routineTriggers.nextRunAt, new Date()),
+          sql`${routineTriggers.nextRunAt} > now()`,
           eq(routines.status, "active"),
           eq(routines.parentIssueId, issueId),
         ),


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents across multiple companies, with a heartbeat service tracking run health and a recovery service rescuing stranded issues
> - The recovery service scans for issues stuck in `in_progress` that have no live run continuation — and escalates them
> - Some issues are intentional continuous-loop hubs: a scheduled routine fires weekly, the hub runs, finishes, and sits dormant until the next fire. This dormant state is indistinguishable from a genuinely stranded issue.
> - Without this fix, the recovery service treats every dormant routine hub as stranded — posting escalation comments and blocking issues that should just wait for their next scheduled fire.
> - Additionally, if an adapter keeps failing on recovery retries, the current code retries indefinitely, creating a bounce storm.
> - This PR recognises routine-bound hubs (D1), prevents system wakes from re-queuing their backlog state between fires (D2), and adds a circuit breaker (CB) that halts recovery after 5 bounces in 6 hours.
> - The benefit is: routine-based hubs cycle cleanly between fires without false escalations; stuck recovery chains trip a breaker rather than looping forever.

## What Changed

- **D1 (recovery service):** `reconcileStrandedAssignedIssues()` skips `in_progress` issues that have an active scheduled routine. These are live continuations between fires, not stranded issues.
- **D2 (heartbeat service):** System dependency/recovery wakes no longer auto-checkout routine-bound hubs in `backlog`. The skipped wake is recorded as `routine_backlog_parked`. User interaction wakes remain unaffected.
- **Circuit breaker:** Counts unsuccessful runs in a 6-hour rolling window. At 5+ bounces, stops retrying, blocks the issue, and logs `recovery.circuit_breaker_tripped`.
- **Tests:** New coverage for active-routine skip, inactive-routine variants, sticky-backlog system vs. user wake, and circuit-breaker threshold.

## Verification

- `git apply --check` passed on a clean `origin/master` worktree.
- `pnpm --filter @paperclipai/server typecheck` passed after applying the patch.
- All new tests pass in CI (19/19 other checks green; one flaky existing test fixed in commit `f1729b60`).

## Risks

- **D1 skip condition:** Any degraded routine state (archived, disabled trigger, null `nextRunAt`) falls back to normal recovery.
- **Circuit breaker threshold:** 5 bounces / 6 hours is conservative. A genuine adapter outage exceeding both limits would block the issue; oncall would need to manually unblock. Intentional — infinite retries are worse.
- **No schema migration required:** All referenced columns already exist.

## Model Used

- Claude Sonnet 4.6 (`claude-sonnet-4-6`) via Anthropic API, extended context, tool use (bash, code editing, test analysis).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-only)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
- [x] I have searched GitHub for duplicate or related PRs and linked them above

- Fixes #7576
- Duplicate/related PR search: searched GitHub PRs for routine-bound continuous-loop hub recovery circuit breaker D1 D2; no duplicate or related PRs found.
