### PR TITLE
feat(checkout): emit issue.checkout_blocked activity on 409 lock conflict (TON-2088)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2342,6 +2342,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(workspaceOperations);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
@@ -2879,6 +2880,99 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       ],
       childIssueSummaryTruncated: false,
     });
+  });
+
+  it("emits an issue.checkout_blocked activity event on a cross-run 409 conflict (TON-2088)", async () => {
+    const companyId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const blockedAgentId = randomUUID();
+    const ownerRunId = randomUUID();
+    const blockedRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ownerAgentId,
+        companyId,
+        name: "Owner",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: blockedAgentId,
+        companyId,
+        name: "Blocked",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Both runs must exist (issues.checkout_run_id / execution_run_id FK heartbeat_runs.id).
+    await db.insert(heartbeatRuns).values([
+      { id: ownerRunId, companyId, agentId: ownerAgentId, status: "running", invocationSource: "manual" },
+      { id: blockedRunId, companyId, agentId: blockedAgentId, status: "running", invocationSource: "manual" },
+    ]);
+
+    // Issue already locked in_progress by the owner's run.
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Locked issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: ownerAgentId,
+      checkoutRunId: ownerRunId,
+      executionRunId: ownerRunId,
+    });
+
+    // A different agent/run attempts checkout -> genuine cross-run lock conflict (409).
+    await expect(
+      svc.checkout(issueId, blockedAgentId, ["todo", "in_progress", "blocked"], blockedRunId),
+    ).rejects.toMatchObject({ status: 409, details: { code: "issue_checkout_conflict" } });
+
+    const events = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.checkout_blocked"));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      companyId,
+      actorType: "agent",
+      actorId: blockedAgentId,
+      agentId: blockedAgentId,
+      runId: blockedRunId,
+      entityType: "issue",
+      entityId: issueId,
+    });
+    expect(events[0]?.details).toMatchObject({
+      blockedAgentId,
+      blockedRunId,
+      ownerAgentId,
+      ownerRunId,
+      source: "api",
+    });
+
+    // Negative: the owner re-acquiring its OWN issue/run must NOT emit (self-own short-circuit).
+    await svc.checkout(issueId, ownerAgentId, ["todo", "in_progress", "blocked"], ownerRunId);
+    const afterSelfOwn = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.checkout_blocked"));
+    expect(afterSelfOwn).toHaveLength(1);
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7067,7 +7067,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       })
     ) {
       try {
-        await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id);
+        // TON-2088: source:"heartbeat" so the centralized service emission attributes the
+        // highest-volume in-process auto-checkout path distinctly from API/CLI/MCP 409s.
+        await issuesSvc.checkout(issueId, agent.id, ["todo", "backlog", "blocked"], run.id, "heartbeat");
         context[PAPERCLIP_HARNESS_CHECKOUT_KEY] = true;
       } catch (error) {
         if (!isCheckoutConflictError(error)) throw error;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -66,6 +66,8 @@ import {
   parseProjectExecutionWorkspacePolicy,
 } from "./execution-workspace-policy.js";
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
+// TON-2088: leaf import (NOT via "./index.js" barrel — that re-export is the import-cycle risk).
+import { logActivity } from "./activity-log.js";
 import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
@@ -5209,7 +5211,9 @@ export function issueService(db: Db) {
         return enriched;
       }),
 
-    checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+    // TON-2088: `source` defaults to "api" so route/CLI/MCP callers are unchanged; the
+    // in-process heartbeat caller passes "heartbeat" (see heartbeat.ts).
+    checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null, source: "api" | "heartbeat" = "api") => {
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
@@ -5352,7 +5356,41 @@ export function issueService(db: Db) {
         return enriched;
       }
 
+      // TON-2088: counted activity event for EVERY production 409 where the issue is
+      // already locked by another run, at the single choke point all callers traverse
+      // (HTTP route, in-process heartbeat, CLI, MCP). Reuses the existing activity log
+      // (no net-new observability surface, TON-2083). Emission sits AFTER the adopt and
+      // self-own short-circuits above, so a run re-acquiring its own issue never emits —
+      // only genuine cross-run lock conflicts do. Uses logActivity (not a raw insert) so
+      // redaction, the Control Room live-events publish, and plugin dispatch all run.
+      // Isolated in its own try/catch so an audit-write failure can never turn a correct
+      // 409 into a 500.
+      try {
+        await logActivity(db, {
+          companyId: issueCompany.companyId,
+          actorType: "agent",
+          actorId: agentId,
+          agentId,
+          runId: checkoutRunId,
+          action: "issue.checkout_blocked",
+          entityType: "issue",
+          entityId: current.id,
+          details: {
+            blockedAgentId: agentId,
+            blockedRunId: checkoutRunId,
+            ownerAgentId: current.assigneeAgentId ?? null,
+            ownerRunId: current.checkoutRunId ?? null,
+            source,
+          },
+        });
+      } catch (logErr) {
+        logger.warn({ err: logErr, issueId: current.id }, "issue.checkout_blocked audit write failed");
+      }
+
       throw conflict("Issue checkout conflict", {
+        // TON-2088: additive, backward-compatible discriminator for any route-level
+        // consumer; counting itself is centralized in the service emission above.
+        code: "issue_checkout_conflict",
         issueId: current.id,
         status: current.status,
         assigneeAgentId: current.assigneeAgentId,


### PR DESCRIPTION
Fixes #7510

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; agents claim work by checking out issues, and the control plane rejects a checkout with a 409 when the issue is already locked by another run.
> - This sits in the checkout subsystem (`issueService.checkout()`), the single function every caller — HTTP route (CLI + MCP), and the in-process heartbeat auto-checkout — traverses.
> - Control Room MVP (TON-2083/TON-2087) needs to count *every* production 409 ("duplicate work prevented"), but only guarded-path calls emit a durable signal today; route-level and in-process 409s are invisible.
> - A route-only seam would silently miss the highest-volume path (the in-process heartbeat auto-checkout bypasses the route), so emission belongs at the service choke point.
> - This PR emits a first-class `issue.checkout_blocked` activity event at that choke point, immediately before the existing `throw conflict(...)`, reusing the existing activity log (no net-new observability surface).
> - The benefit is a complete, first-class audit signal the Control Room metrics layer can count by `source` (`api` vs `heartbeat`), without a new table or endpoint.

## What Changed

- `server/src/services/issues.ts`: `checkout()` gains an optional 5th `source: "api" | "heartbeat"` arg (defaults to `"api"`, so all existing callers are unchanged). Immediately before the cross-run `throw conflict("Issue checkout conflict", …)`, emit an `issue.checkout_blocked` activity event via `logActivity` with `{ blockedAgentId, blockedRunId, ownerAgentId, ownerRunId, source }`. Emission is placed **after** the adopt + self-own short-circuits, so a run re-acquiring its own issue never emits — only genuine cross-run conflicts do. It is wrapped in its own `try/catch` + `logger.warn` so an audit-write failure can never convert a correct 409 into a 500. A backward-compatible `code: "issue_checkout_conflict"` discriminator is added to the throw details.
- `server/src/services/heartbeat.ts`: the in-process auto-checkout passes `source: "heartbeat"` so the centralized emission attributes that path distinctly. The message-based conflict detector is intentionally left untouched (the throw message is unchanged).
- `server/src/__tests__/issues-service.test.ts`: regression test — a cross-run 409 emits exactly one `issue.checkout_blocked` row with the expected actor/agent/run/entity fields and `details` (incl. `source: "api"`); a self-own re-checkout emits nothing.

## Verification

```bash
pnpm --filter @paperclipai/server exec tsc --noEmit          # 0 errors
npx vitest run server/src/__tests__/issues-service.test.ts   # 63 passed (incl. the new TON-2088 test)
```
- `logActivity` is imported directly from the leaf `./activity-log.js` (not the `./index.js` barrel) so there is no import cycle.
- Using `logActivity` (not a raw `db.insert`) preserves redaction (`sanitizeRecord` + `redactCurrentUserValue`), the Control Room `publishLiveEvent` realtime feed, and plugin dispatch.

## Risks

- Touches the core checkout control-plane path. Mitigated: emission is isolated in its own `try/catch` and never re-throws, so it cannot turn a correct 409 into a 500; the throw message is unchanged so the heartbeat detector still works; the new arg is optional with an `"api"` default so no caller signature breaks. No migration, no schema change — fully reversible by reverting the commit.
- Downstream metrics must dedup by `details.blockedRunId` before counting both this activity row and the TON-2087 guarded JSONL trail (already shipped in TON-2092) — no metric should count `source: "api"` until that dedup is live.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), Anthropic; agentic tool use / code execution, extended reasoning. Authored as the Paperclip CTO agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
