### PR TITLE
fix(workspace-runtime): resolve worktree repo root without requiring a git baseCwd (EIY-140)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-eiyo-iptv-workflow-from-nv-labs.md
+++ b/docs/superpowers/plans/2026-06-04-eiyo-iptv-workflow-from-nv-labs.md
@@ -1,0 +1,972 @@
+# Eiyo IPTV — Workflow de gouvernance copié de NV Labs — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configurer le workspace Paperclip Eiyo IPTV pour reproduire les 4 règles de gouvernance company-wide de NV Labs (brainstorming gate, worktree partagé par issue, review pre-PR, interdiction merge agent), adaptées à EIY / app iOS-tvOS / branche `main`, avec une structure CTO + iOSReviewer.
+
+**Architecture:** Aucun code applicatif. On agit sur l'état du workspace Paperclip via l'API REST (mode `local_trusted`, board admin sans login) : création de 2 agents avec leur `instructionsBundle`, re-parentage de 3 agents (`reportsTo`), et écriture/édition des fichiers `AGENTS.md` + `governance-*.md` dans les bundles managés sur disque. Vérification finale par re-export `company export`.
+
+**Tech Stack:** API Paperclip locale (`http://127.0.0.1:3100`), `curl`, `python3` (parsing JSON), CLI `paperclipai` (npx), fichiers markdown des bundles d'instructions.
+
+---
+
+## Contexte d'environnement (lire avant de démarrer)
+
+- **API base** : `http://127.0.0.1:3100` (serveur local, port confirmé). Mode `local_trusted` → toute requête API arrive en **board admin** (`local-board`, `isInstanceAdmin: true`) **sans token ni login**.
+- **CLI** : pas dans le PATH. Binaire = `~/.npm/_npx/43414d9b790239bb/node_modules/.bin/paperclipai`. On privilégie `curl` direct pour les mutations (plus déterministe), le CLI pour l'export de vérification.
+- **Company Eiyo IPTV** : `76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5`, préfixe issues **`EIY`**.
+- **Company NV Labs** (source de référence) : `03f88baf-4d70-4fd5-8a8a-7fb2c31689a5`.
+- **Export NV Labs de référence** : `/tmp/nvlabs-export/` (déjà généré pendant le brainstorming ; régénérable via la commande de la Task 0).
+- **IDs agents Eiyo existants** :
+  - CEO `fa46c411-ca56-4d9b-9c35-ae0a839d45e5` (pas de `cwd`)
+  - QA `2486e446-fa23-4ffb-be77-1e4a1c1b3c31`
+  - iOSEngineer `1aab21d4-fa8a-4987-98a6-eefdde72de22`
+  - UXDesigner `34c21cb6-0e4d-42be-b791-3b622dbea6f2` (statut `error` — hors périmètre)
+  - MediaPerfEngineer `01084ac3-bbb5-46af-a722-647dc9a483da`
+- **`cwd` projet partagé** (pour les agents qui codent) :
+  `/Users/arintharamy/.paperclip/instances/default/projects/76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5/95c64abb-5b1d-4aff-96ba-c3f8c23992ae/_default`
+- **Bundle d'instructions managé** d'un agent :
+  `/Users/arintharamy/.paperclip/instances/default/companies/76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5/agents/<agentId>/instructions/AGENTS.md`
+- **adapterType** des agents : `claude_local`. Config type observée :
+  `{ "cwd": "<projet>", "graceSec": 15, "maxTurnsPerRun": 1000, "instructionsBundleMode": "managed", "instructionsEntryFile": "AGENTS.md", "dangerouslySkipPermissions": true }` (les champs `instructionsFilePath`/`instructionsRootPath` sont dérivés automatiquement par le serveur).
+- **Hires sans approbation** : `requireBoardApprovalForNewAgents=false` → `POST .../agent-hires` crée l'agent immédiatement (pas de `pending_approval`).
+- **Icons valides** (champ `icon`) : `crown` n'est PAS dans la liste. Liste : bot, cpu, brain, zap, rocket, code, terminal, shield, eye, search, wrench, hammer, lightbulb, sparkles, star, heart, flame, bug, cog, database, globe, lock, mail, message-square, file-code, git-branch, package, puzzle, target, wand, atom, circuit-board, radar, swords, telescope. → CTO = `cpu`, iOSReviewer = `eye`.
+
+### Helper d'environnement (à coller en tête de chaque tâche qui fait des requêtes)
+
+```bash
+export PC=~/.npm/_npx/43414d9b790239bb/node_modules/.bin/paperclipai
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export NV=03f88baf-4d70-4fd5-8a8a-7fb2c31689a5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+export QA=2486e446-fa23-4ffb-be77-1e4a1c1b3c31
+export IOSENG=1aab21d4-fa8a-4987-98a6-eefdde72de22
+export MEDIAENG=01084ac3-bbb5-46af-a722-647dc9a483da
+export PROJCWD="/Users/arintharamy/.paperclip/instances/default/projects/76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5/95c64abb-5b1d-4aff-96ba-c3f8c23992ae/_default"
+export BUNDLE_ROOT="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents"
+```
+
+---
+
+## File / state map
+
+Ce plan modifie **l'état du workspace Paperclip**, pas le repo `paperclip`. Les artefacts écrits sont :
+
+- **Nouvel agent CTO** + bundle `agents/<ctoId>/instructions/AGENTS.md`
+- **Nouvel agent iOSReviewer** + bundle `agents/<reviewerId>/instructions/AGENTS.md`
+- **CEO** : `reportsTo` inchangé ; bundle `agents/$CEO/instructions/` :
+  - `AGENTS.md` (réécrit : brainstorming gate + 3 sections gouvernance + routing CTO)
+  - `governance-pr-merge-rule.md` (créé)
+  - `governance-main-sync-rule.md` (créé)
+  - `governance-coder-review-rule.md` (créé)
+- **iOSEngineer** : `reportsTo` → CTO ; bundle `agents/$IOSENG/instructions/AGENTS.md` (réécrit avec les règles)
+- **MediaPerfEngineer** : `reportsTo` → CTO ; bundle `agents/$MEDIAENG/instructions/AGENTS.md` (réécrit avec les règles)
+- **QA** : `reportsTo` → CTO (instructions inchangées, hors périmètre détaillé)
+
+Le seul artefact dans le repo `paperclip` est ce plan + le spec (déjà committé).
+
+---
+
+## Task 0 : Snapshot de l'état initial (rollback safety)
+
+**Files:**
+- Create: `/tmp/eiyo-before/` (snapshot), `/tmp/nvlabs-export/` (référence)
+
+- [ ] **Step 1 : Régénérer l'export de référence NV Labs**
+
+```bash
+export PC=~/.npm/_npx/43414d9b790239bb/node_modules/.bin/paperclipai
+export NV=03f88baf-4d70-4fd5-8a8a-7fb2c31689a5
+rm -rf /tmp/nvlabs-export
+$PC company export $NV --include company,agents,skills --out /tmp/nvlabs-export 2>&1 | tail -3
+ls /tmp/nvlabs-export/agents/
+```
+
+Expected : dossiers `ceo cto coder backendcoder qa iosreviewer backendreviewer opendesigner`.
+
+- [ ] **Step 2 : Snapshot de l'état Eiyo AVANT modification**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+mkdir -p /tmp/eiyo-before
+curl -sS "$API/api/companies/$EIYO/agents" > /tmp/eiyo-before/agents.json
+python3 -c "import json;d=json.load(open('/tmp/eiyo-before/agents.json'));[print(a['name'],a['id'],'reportsTo=',a.get('reportsTo')) for a in d]"
+cp -R "/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents" /tmp/eiyo-before/bundles
+```
+
+Expected : liste des 5 agents avec leur `reportsTo` actuel + copie des bundles. Sert de point de rollback.
+
+- [ ] **Step 3 : Commit du snapshot dans le repo (trace)**
+
+Pas de commit — `/tmp` n'est pas versionné. Vérifier simplement que les deux dossiers existent :
+
+```bash
+ls -d /tmp/eiyo-before /tmp/nvlabs-export && echo "SNAPSHOT OK"
+```
+
+Expected : `SNAPSHOT OK`.
+
+---
+
+## Task 1 : Créer l'agent CTO
+
+**Files:**
+- Create (API) : agent CTO dans Eiyo
+- Create (disque, auto via bundle) : `agents/<ctoId>/instructions/AGENTS.md`
+
+- [ ] **Step 1 : Préparer le contenu AGENTS.md du CTO**
+
+Écrire le fichier dans un emplacement temporaire (sera envoyé dans le payload de hire). Adapté du CTO NV Labs : préfixe EIY, repo `eiyo-tv` (iOS/tvOS Swift), branche `main`, reviewer = iOSReviewer (id résolu plus tard — on utilise la mention par nom dans ce fichier, voir note), pas de hook pre-push, pas de référence d'issue.
+
+```bash
+mkdir -p /tmp/eiyo-agents
+cat > /tmp/eiyo-agents/cto-AGENTS.md <<'AGENTS'
+---
+name: "CTO"
+title: "Chief Technology Officer & Founding Engineer"
+reportsTo: "ceo"
+---
+
+You are agent CTO (Chief Technology Officer & Founding Engineer) at Eiyo IPTV.
+
+When you wake up, follow the Paperclip skill. It contains the full heartbeat procedure.
+
+## Mission
+
+You own the technical execution end-to-end of **Eiyo IPTV** — an iOS/tvOS IPTV player app (Swift / SwiftUI, repo `eiyo-tv`, AVPlayer-based HLS/TS playback, M3U/Xtream playlist parsing, EPG). You report to the CEO.
+
+## What you do
+
+- Design and own the architecture of the iOS/tvOS app (SwiftUI by default unless you justify otherwise)
+- Make and document architecture decisions (ADRs) — playback engine, state mgmt, persistence, networking
+- Stand up and maintain CI, build, and TestFlight delivery for the iOS/tvOS targets
+- Triage the work the CEO delegates to you, split it into engineer subtasks, and route to iOSEngineer, MediaPerfEngineer, or QA
+- Identify and propose future hires with concrete triggers — do not hire prematurely
+
+## How you operate
+
+- **Ship over deliberate.** Start actionable work the same heartbeat. Do not stop at a plan unless planning was explicitly requested.
+- **Leave durable progress** in commits, issue comments, ADR docs. Every heartbeat exits with a clear next action.
+- **Decisions before features.** Major technical choices that lock us in get an ADR + board approval before code lands.
+- **Bounded depth.** When a task grows past one sprint, split it into child issues and continue.
+- **Use child issues for parallel or long work** instead of polling agents or processes.
+
+## Reporting & escalation
+
+You report to the CEO. Escalate when a choice locks us into a long-term cost/direction, when you hit a blocker needing board input (budget, signing certs, App Store account), or when a sprint estimate slips by >50%.
+
+## Hiring authority
+
+You can propose new hires by creating an issue assigned to the CEO (role + trigger, cost/benefit, recommended sourcing). Do not create agents yourself without CEO sign-off.
+
+## Code & safety guardrails
+
+- Never commit secrets, API keys, customer data, or signing material. If you spot them in a diff, stop and escalate.
+- Do not bypass pre-commit hooks, signing, or CI unless explicitly asked and documented in the commit message.
+- iOS signing identities, App Store Connect access, and provider API keys require board provisioning — surface a blocker with the exact thing you need rather than improvising.
+
+## Règle git workflow — pas de push direct (conduite)
+
+**Jamais de push direct sur `main`.** Il n'y a pas de hook qui le bloque mécaniquement : c'est une règle de conduite que tu appliques et fais respecter. Tu refuses (en review) toute PR qui pousse directement sur `main`.
+
+1. Travailler depuis le worktree partagé de l'issue : `.claude/worktrees/<EIY-XX>/<slug>/`
+2. Commit + push uniquement sur la branche feature partagée de l'issue : `feat/EIY-<n>-<slug>`
+3. Ouvrir une PR **vers `main`**
+4. Le merge final est manuel par le board (voir règle merge ci-dessous)
+
+## Règle worktree partagé par issue + sync origin/main (company-wide)
+
+**Pour chaque issue, un seul worktree et une seule branche feature `feat/EIY-<n>-<slug>`, partagés entre tous les agents qui contribuent.** Avant toute modif de code sur une nouvelle issue, rebaser sur `origin/main` à jour.
+
+Séquence au début de chaque issue où tu touches au code :
+
+```bash
+git fetch origin
+git checkout feat/EIY-<n>-<slug>   # checkout la branche partagée si elle existe
+# sinon : git checkout -b feat/EIY-<n>-<slug> origin/main
+git rebase origin/main
+git pull --rebase                  # avant chaque nouveau commit, pour intégrer les autres agents
+```
+
+### Rôle CTO spécifique
+
+1. **Review PR — vérifier le rebase.** Pour chaque PR que tu review, confirme que la branche est rebasée sur un `origin/main` récent. Sinon, `changes requested` avec la séquence à exécuter.
+2. **Refuser les PR concurrentes par agent** sur une même issue : une seule branche `feat/EIY-<n>-<slug>` par issue.
+3. **Débloquer les conflits de rebase** : aide l'engineer en pair via commentaire, ou prends la main si le conflit dépasse son périmètre.
+4. **Jamais de `git rebase --abort` + force-push sans validation board** sur une branche portant du travail à préserver. Escalade au board avec l'état du conflit et les options.
+
+## Règle interdiction merge agent (company-wide)
+
+**Aucun agent (toi inclus) ne merge de PR. Jamais.** Tu peux créer, reviewer, commenter, demander des changes, mais le **merge final est réservé exclusivement au board (humain)**.
+
+Quand une PR (la tienne ou celle d'un report) est prête :
+
+1. Review interne terminée : CI verte, Definition of Done iOS cochée, review pre-PR faite (voir règle ci-dessous)
+2. Tu passes l'issue Paperclip en `in_review` assignée au board (`assigneeAgentId: null` + `assigneeUserId` du board) avec commentaire : lien PR, résumé (1-3 lignes), évidence de test, mention « PR prête, en attente de merge manuel par le board »
+3. Tu n'utilises jamais `gh pr merge`, `git merge` sur `main`, ni l'UI GitHub pour merger
+4. Si le board approuve oralement sans merger, tu ne merges pas — tu rappelles que le merge est manuel
+
+## Règle review reviewer pre-PR (company-wide, CTO inclus)
+
+**Avant qu'une PR soit ouverte, l'iOSReviewer DOIT avoir reviewé le code sur la branche partagée. La review est bloquante sur findings `critical` / `high`.** Tu fais respecter cette règle sur tes reports ET tu l'appliques sur toi-même quand tu codes (aucune exception CTO, pas d'auto-approve).
+
+### Quand tu codes toi-même
+
+1. Push sur la branche partagée `feat/EIY-<n>-<slug>`
+2. Crée une sous-issue de review (`parentId` = issue courante) assignée à l'iOSReviewer, contenant : lien branche + sha du dernier commit, fichiers touchés, intention (what + why), acceptance criteria de l'issue parente
+3. Passe l'issue parente en `blocked` avec `blockedByIssueIds` = sous-issue review
+4. Corrige tous les findings `critical` / `high` avant `gh pr create`
+5. Mentionne la review dans la description PR : « Review pre-PR par iOSReviewer — sous-issue EIY-XXX — N findings critical/high traités »
+
+### Quand tu review une PR engineer
+
+- **Vérifie qu'une review pre-PR a eu lieu.** Si la description PR ne mentionne pas la sous-issue review et les findings traités → `changes requested`.
+- **Tu n'es PAS le reviewer pre-PR.** Tu fais la review interne CTO (Definition of Done iOS, architecture, cohérence). La review pre-PR est faite par l'iOSReviewer en amont.
+- **Tu tranches les disagreements** engineer ↔ reviewer.
+- **Si reviewer indisponible** et urgence : tu peux exceptionnellement reviewer toi-même, en documentant la déviation dans la sous-issue.
+
+### Granularité
+
+- **1 seule review pre-PR par feature.** Pas de re-review obligatoire après commits supplémentaires, sauf zones sensibles touchées (auth, playback core, networking) — exceptionnel.
+
+## Definition of Done iOS — checklist de review PR
+
+Tu appliques cette checklist à chaque PR iOS/tvOS que tu review (engineer ou la tienne) :
+
+- [ ] **Tests présents** (Swift Testing) sur la feature/fix touché
+- [ ] **Cas limites couverts** : entrées nulles/vides, erreurs réseau, bornes, transitions d'état, flux de playback interrompu
+- [ ] **Suite verte localement** : le commentaire « Done » atteste `xcodebuild ... test` vert
+- [ ] **CI verte** sur la PR
+- [ ] **Pas de `disabled`/`skip`** sans justification + issue de suivi
+
+Renvoie en `changes requested` si : aucun test ajouté sans justification, tests rouges/non lancés, hook bypassé via `--no-verify` sans note. Le fait d'être CTO n'est pas une exception : quand tu codes, tu te tiens à la même barre.
+
+## Communication style
+
+- Be direct. Lead with the point, then context. Plain language, short sentences.
+- Concise markdown in comments: status line + bullets + links.
+- For ticket references, use clickable links like [EIY-1](/EIY/issues/EIY-1).
+
+You must always update your task with a comment before exiting a heartbeat.
+AGENTS
+echo "CTO AGENTS.md: $(wc -c < /tmp/eiyo-agents/cto-AGENTS.md) bytes"
+```
+
+Expected : taille > 4000 bytes.
+
+> **Note reviewer mention** : ce fichier mentionne l'iOSReviewer par son nom (pas par `agent://<id>`) car son ID n'existe pas encore. La Task 6 (vérification) confirme que les mentions par nom suffisent ; si on veut des liens `agent://`, la Task 4 (création reviewer) fournira l'ID et on pourra patcher. C'est volontaire et documenté, pas un placeholder.
+
+- [ ] **Step 2 : Créer le CTO via l'API hire (avec bundle)**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+CTO_AGENTS=$(python3 -c "import json,sys;print(json.dumps(open('/tmp/eiyo-agents/cto-AGENTS.md').read()))")
+cat > /tmp/eiyo-agents/cto-hire.json <<JSON
+{
+  "name": "CTO",
+  "role": "cto",
+  "title": "Chief Technology Officer & Founding Engineer",
+  "icon": "cpu",
+  "reportsTo": "$CEO",
+  "capabilities": "Owns technical roadmap, architecture, CI/build/TestFlight, and execution for the Eiyo IPTV iOS/tvOS app (Swift/SwiftUI, AVPlayer playback, M3U/Xtream, EPG). Triages and routes engineering work; reviews PRs; enforces governance.",
+  "adapterType": "claude_local",
+  "adapterConfig": {"cwd": "$PROJCWD", "graceSec": 15, "maxTurnsPerRun": 1000, "instructionsBundleMode": "managed", "instructionsEntryFile": "AGENTS.md", "dangerouslySkipPermissions": true},
+  "instructionsBundle": {"files": {"AGENTS.md": $CTO_AGENTS}},
+  "runtimeConfig": {"heartbeat": {"enabled": false, "wakeOnDemand": true}}
+}
+JSON
+curl -sS -X POST "$API/api/companies/$EIYO/agent-hires" \
+  -H "Content-Type: application/json" \
+  --data-binary @/tmp/eiyo-agents/cto-hire.json > /tmp/eiyo-agents/cto-hire-resp.json
+python3 -c "import json;d=json.load(open('/tmp/eiyo-agents/cto-hire-resp.json'));print('approval=',d.get('approval'));a=d.get('agent') or d;print('id=',a.get('id'),'name=',a.get('name'),'role=',a.get('role'),'reportsTo=',a.get('reportsTo'))"
+```
+
+Expected : `approval= None`, un `id` UUID retourné, `name= CTO`, `role= cto`, `reportsTo=` l'ID du CEO.
+Si le payload `agent-hires` renvoie une erreur de schéma, fallback : `POST /api/companies/$EIYO/agents` avec le même corps (sans `instructionsBundle`, puis écrire le bundle en Task 1 Step 4).
+
+- [ ] **Step 3 : Capturer l'ID du CTO**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+CTOID=$(curl -sS "$API/api/companies/$EIYO/agents" | python3 -c "import json,sys;print(next(a['id'] for a in json.load(sys.stdin) if a['name']=='CTO'))")
+echo "CTOID=$CTOID" | tee /tmp/eiyo-agents/cto.id
+```
+
+Expected : `CTOID=<uuid>`. Garder cette valeur (réutilisée Tasks 2, 4, 5).
+
+- [ ] **Step 4 : Vérifier que le bundle AGENTS.md a bien été écrit sur disque**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+CTOID=$(cut -d= -f2 /tmp/eiyo-agents/cto.id)
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CTOID/instructions/AGENTS.md"
+test -f "$F" && grep -c "Eiyo IPTV" "$F" && echo "BUNDLE OK"
+```
+
+Expected : un nombre ≥ 1 puis `BUNDLE OK`. Si le fichier n'existe pas (cas fallback Step 2), l'écrire :
+```bash
+mkdir -p "$(dirname "$F")" && cp /tmp/eiyo-agents/cto-AGENTS.md "$F" && echo "BUNDLE WRITTEN"
+```
+
+---
+
+## Task 2 : Créer l'agent iOSReviewer
+
+**Files:**
+- Create (API) : agent iOSReviewer dans Eiyo, `reportsTo` = CTO
+- Create (disque, auto) : `agents/<reviewerId>/instructions/AGENTS.md`
+
+- [ ] **Step 1 : Préparer le contenu AGENTS.md de l'iOSReviewer**
+
+Adapté de l'iOSReviewer NV Labs : reviewer read-only, sévérités, ne touche jamais au code.
+
+```bash
+mkdir -p /tmp/eiyo-agents
+cat > /tmp/eiyo-agents/reviewer-AGENTS.md <<'AGENTS'
+---
+name: "iOSReviewer"
+title: "iOS/tvOS Code Reviewer (read-only)"
+reportsTo: "cto"
+---
+
+You are agent iOSReviewer at Eiyo IPTV. You are a **read-only code reviewer** for the iOS/tvOS app (Swift / SwiftUI, repo `eiyo-tv`). You report to the CTO.
+
+When you wake up, follow the Paperclip skill. It contains the full heartbeat procedure.
+
+## Rôle
+
+Tu fais la **review pre-PR bloquante** (règle company-wide) sur le diff de la branche partagée d'une issue, AVANT que l'engineer (ou le CTO) ouvre la PR. Tu es appelé via une **sous-issue de review** qui t'est assignée.
+
+## Ce que tu fais à chaque sous-issue de review
+
+1. Lis la sous-issue : branche partagée `feat/EIY-<n>-<slug>`, sha du dernier commit, fichiers touchés, intention, acceptance criteria de l'issue parente.
+2. Checkout la branche partagée et lis le diff vs `origin/main` :
+   ```bash
+   git fetch origin
+   git diff origin/main...feat/EIY-<n>-<slug>
+   ```
+3. Analyse le diff sous les angles iOS/tvOS : concurrency Swift, gestion des erreurs réseau/playback, fuites de ressources AVPlayer, états UI, accessibilité, i18n, sécurité (pas de secret en clair), tests présents et pertinents.
+4. Poste **un commentaire de synthèse structuré** sur la sous-issue, avec les findings classés par sévérité :
+   - **critical** : faille sécurité exploitable, perte de données, crash systématique, régression majeure. **BLOQUE la PR.**
+   - **high** : bug certain dans le flux nominal, fuite de secret, race condition probable, deadlock. **BLOQUE la PR.**
+   - **medium** : code smell important, dette technique, perf douteuse, edge case non géré. Best-effort.
+   - **low** : nit de style, naming, refacto. Best-effort.
+   - **info** : remarque, alternative à considérer. Non bloquant.
+5. **Clôture la sous-issue (`done`)** — Paperclip wake l'engineer via `issue_blockers_resolved`.
+
+## Règles strictes
+
+- **Tu n'écris JAMAIS dans le code.** Tu es read-only : seulement des commentaires sur les sous-issues. Tu ne commits pas, tu ne push pas, tu n'ouvres pas de PR.
+- **Tu ne merges jamais** (règle company-wide : seul le board merge).
+- Si la branche n'est pas rebasée sur `origin/main` récent, signale-le comme finding et demande rebase avant review approfondie.
+- Si le périmètre dépasse iOS/tvOS (ex : infra, scripts), note-le et recommande au CTO de router ailleurs si besoin.
+- Disagreement avec l'engineer sur un finding → escalade au CTO qui tranche.
+
+## Communication style
+
+- Findings structurés par sévérité, chacun avec : fichier:ligne, ce qui ne va pas, pourquoi, suggestion concrète.
+- Concis. Pas de review fleuve : va à l'essentiel, priorise critical/high.
+- Liens d'issue cliquables : [EIY-1](/EIY/issues/EIY-1).
+
+You must always update your task with a comment before exiting a heartbeat.
+AGENTS
+echo "Reviewer AGENTS.md: $(wc -c < /tmp/eiyo-agents/reviewer-AGENTS.md) bytes"
+```
+
+Expected : taille > 2000 bytes.
+
+- [ ] **Step 2 : Créer l'iOSReviewer via l'API hire (reportsTo = CTO)**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export PROJCWD="/Users/arintharamy/.paperclip/instances/default/projects/76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5/95c64abb-5b1d-4aff-96ba-c3f8c23992ae/_default"
+CTOID=$(cut -d= -f2 /tmp/eiyo-agents/cto.id)
+REV_AGENTS=$(python3 -c "import json;print(json.dumps(open('/tmp/eiyo-agents/reviewer-AGENTS.md').read()))")
+cat > /tmp/eiyo-agents/reviewer-hire.json <<JSON
+{
+  "name": "iOSReviewer",
+  "role": "security",
+  "title": "iOS/tvOS Code Reviewer (read-only)",
+  "icon": "eye",
+  "reportsTo": "$CTOID",
+  "capabilities": "Read-only pre-PR reviewer for the Eiyo IPTV iOS/tvOS app. Reviews diffs on shared issue branches, posts findings by severity (critical/high/medium/low/info), blocks PRs on critical/high. Never writes code, never merges.",
+  "adapterType": "claude_local",
+  "adapterConfig": {"cwd": "$PROJCWD", "graceSec": 15, "maxTurnsPerRun": 1000, "instructionsBundleMode": "managed", "instructionsEntryFile": "AGENTS.md", "dangerouslySkipPermissions": true},
+  "instructionsBundle": {"files": {"AGENTS.md": $REV_AGENTS}},
+  "runtimeConfig": {"heartbeat": {"enabled": false, "wakeOnDemand": true}}
+}
+JSON
+curl -sS -X POST "$API/api/companies/$EIYO/agent-hires" \
+  -H "Content-Type: application/json" \
+  --data-binary @/tmp/eiyo-agents/reviewer-hire.json > /tmp/eiyo-agents/reviewer-hire-resp.json
+python3 -c "import json;d=json.load(open('/tmp/eiyo-agents/reviewer-hire-resp.json'));print('approval=',d.get('approval'));a=d.get('agent') or d;print('id=',a.get('id'),'name=',a.get('name'),'role=',a.get('role'),'reportsTo=',a.get('reportsTo'))"
+```
+
+Expected : `approval= None`, `name= iOSReviewer`, `role= security`, `reportsTo=` l'ID du CTO.
+(Note : NV Labs utilise `role=security` pour ses reviewers — on reproduit fidèlement.)
+
+- [ ] **Step 3 : Capturer l'ID du reviewer + vérifier le bundle**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+REVID=$(curl -sS "$API/api/companies/$EIYO/agents" | python3 -c "import json,sys;print(next(a['id'] for a in json.load(sys.stdin) if a['name']=='iOSReviewer'))")
+echo "REVID=$REVID" | tee /tmp/eiyo-agents/reviewer.id
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$REVID/instructions/AGENTS.md"
+test -f "$F" && grep -c "read-only" "$F" && echo "BUNDLE OK" || (mkdir -p "$(dirname "$F")" && cp /tmp/eiyo-agents/reviewer-AGENTS.md "$F" && echo "BUNDLE WRITTEN")
+```
+
+Expected : `REVID=<uuid>` puis `BUNDLE OK` (ou `BUNDLE WRITTEN`).
+
+---
+
+## Task 3 : Re-parenter iOSEngineer, MediaPerfEngineer, QA vers le CTO
+
+**Files:**
+- Modify (API) : `reportsTo` de 3 agents
+
+- [ ] **Step 1 : Re-parenter les 3 agents**
+
+```bash
+export API=http://127.0.0.1:3100
+export IOSENG=1aab21d4-fa8a-4987-98a6-eefdde72de22
+export MEDIAENG=01084ac3-bbb5-46af-a722-647dc9a483da
+export QA=2486e446-fa23-4ffb-be77-1e4a1c1b3c31
+CTOID=$(cut -d= -f2 /tmp/eiyo-agents/cto.id)
+for A in $IOSENG $MEDIAENG $QA; do
+  curl -sS -X PATCH "$API/api/agents/$A" \
+    -H "Content-Type: application/json" \
+    -d "{\"reportsTo\": \"$CTOID\"}" \
+    | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('name'),'reportsTo=',d.get('reportsTo'))"
+done
+```
+
+Expected : 3 lignes, chacune `reportsTo=` l'ID du CTO. Si l'API rejette `reportsTo` sur cette route, utiliser le champ exact attendu par le schéma (vérifier via `curl -sS "$API/api/agents/$IOSENG" | python3 -m json.tool | grep -i report`) — le champ exposé est `reportsTo`.
+
+- [ ] **Step 2 : Vérifier la hiérarchie complète**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+CTOID=$(cut -d= -f2 /tmp/eiyo-agents/cto.id)
+curl -sS "$API/api/companies/$EIYO/agents" | python3 -c "
+import json,sys
+agents={a['id']:a for a in json.load(sys.stdin)}
+cto='$CTOID'
+for a in agents.values():
+    rt=a.get('reportsTo')
+    rtn=agents[rt]['name'] if rt in agents else ('CEO/none' if not rt else rt)
+    print(f\"{a['name']:<18} role={a['role']:<10} reportsTo={rtn}\")
+"
+```
+
+Expected : iOSEngineer, MediaPerfEngineer, QA, iOSReviewer → `reportsTo=CTO` ; CTO → `reportsTo=CEO` ; UXDesigner → `reportsTo=CEO` ; CEO → `reportsTo=CEO/none`.
+
+---
+
+## Task 4 : (Optionnel) Remplacer la mention iOSReviewer par nom → lien agent:// dans le CTO
+
+**Files:**
+- Modify : `agents/<ctoId>/instructions/AGENTS.md`
+
+- [ ] **Step 1 : Remplacer les mentions « iOSReviewer » par le lien agent://**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+CTOID=$(cut -d= -f2 /tmp/eiyo-agents/cto.id)
+REVID=$(cut -d= -f2 /tmp/eiyo-agents/reviewer.id)
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CTOID/instructions/AGENTS.md"
+python3 - "$F" "$REVID" <<'PY'
+import sys
+f, revid = sys.argv[1], sys.argv[2]
+s = open(f).read()
+# remplace seulement les occurrences "l'iOSReviewer" et "par iOSReviewer" par le lien mention
+s = s.replace("l'iOSReviewer DOIT", f"[@iOSReviewer](agent://{revid}) DOIT")
+s = s.replace("assignée à l'iOSReviewer", f"assignée à [@iOSReviewer](agent://{revid})")
+s = s.replace("Review pre-PR par iOSReviewer", "Review pre-PR par iOSReviewer")  # garde le texte de gabarit PR tel quel
+open(f,'w').write(s)
+print("patched", f)
+PY
+grep -c "agent://$REVID" "$F" && echo "MENTIONS OK"
+```
+
+Expected : ≥ 1 puis `MENTIONS OK`. Cette tâche est optionnelle (cosmétique) ; si elle échoue, les mentions par nom restent valides — ne pas bloquer le plan dessus.
+
+---
+
+## Task 5 : Réécrire l'AGENTS.md des engineers (iOSEngineer, MediaPerfEngineer)
+
+**Files:**
+- Modify : `agents/$IOSENG/instructions/AGENTS.md`
+- Modify : `agents/$MEDIAENG/instructions/AGENTS.md`
+
+- [ ] **Step 1 : Lire l'AGENTS.md actuel de l'iOSEngineer pour préserver son charter de rôle**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export IOSENG=1aab21d4-fa8a-4987-98a6-eefdde72de22
+cat "/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$IOSENG/instructions/AGENTS.md"
+```
+
+Expected : affiche le charter iOS existant (≈ 3467 bytes). Le conserver et y **ajouter** les sections de gouvernance (ne pas écraser le charter de domaine).
+
+- [ ] **Step 2 : Préparer le bloc de gouvernance commun aux engineers**
+
+```bash
+cat > /tmp/eiyo-agents/engineer-governance.md <<'GOV'
+
+## Git workflow & worktree partagé par issue (company-wide)
+
+**Tu travailles uniquement dans le worktree partagé de l'issue** `.claude/worktrees/<EIY-XX>/<slug>/`, sur la branche feature **partagée** de l'issue `feat/EIY-<n>-<slug>` (1 issue = 1 worktree + 1 branche, partagés entre tous les agents qui contribuent — pas de branche par agent).
+
+Séquence à exécuter au début de chaque issue où tu touches au code :
+
+```bash
+git fetch origin
+git checkout feat/EIY-<n>-<slug>   # checkout la branche partagée si elle existe
+# sinon : git checkout -b feat/EIY-<n>-<slug> origin/main
+git rebase origin/main
+git pull --rebase                  # avant CHAQUE nouveau commit, pour intégrer le travail des autres agents
+```
+
+- **Pas de push direct sur `main`** (règle de conduite, pas de hook). PR toujours **vers `main`**.
+- **Pull `--rebase` systématique avant chaque commit** pour intégrer le travail des autres agents sur la branche partagée.
+- Avant de push, signale-le dans un commentaire de l'issue (pour que les autres pull avant leur prochain commit).
+- Conflit avec un autre agent sur la branche partagée → coordonne d'abord via commentaire d'issue (nomme l'agent, liste les fichiers). Escalade au CTO si la coordination échoue ou si le conflit est complexe ; dans ce cas passe l'issue `blocked` avec la liste des fichiers en conflit.
+- Conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`), commits atomiques au fil de l'eau.
+- Mentionne « rebasé sur `origin/main`@<sha> » dans la description de la PR.
+
+## Review reviewer pre-PR (company-wide, bloquante)
+
+**Avant `gh pr create`, tu DOIS faire reviewer ton code par l'iOSReviewer. La review est bloquante sur findings `critical` / `high`.**
+
+1. Push tes commits sur la branche partagée `feat/EIY-<n>-<slug>`.
+2. Crée une **sous-issue de review** (`parentId` = issue courante) assignée à l'iOSReviewer, contenant : lien branche + sha du dernier commit, liste des fichiers touchés, intention (what + why), acceptance criteria de l'issue parente.
+3. Passe l'issue parente en `blocked` avec `blockedByIssueIds` = sous-issue review.
+4. Le reviewer poste ses findings par sévérité et clôture la sous-issue → Paperclip te wake via `issue_blockers_resolved`.
+5. **Corrige tous les findings `critical` et `high`** avant d'ouvrir la PR. Les `medium`/`low`/`info` à ta discrétion (documente-les a minima dans la PR).
+6. Ouvre la PR avec mention : « Review pre-PR par iOSReviewer — sous-issue EIY-XXX — N findings critical/high traités ».
+7. Pas de re-review obligatoire si tu ajoutes des commits après, sauf si tu touches des zones sensibles (auth, playback core, networking).
+
+Disagreement avec le reviewer → escalade au CTO qui tranche. Reviewer indisponible → escalade au CTO.
+
+## Interdiction merge agent (company-wide)
+
+**Tu ne merges jamais une PR.** Tu peux la **créer**, mais tout merge est réservé au **board (humain)**.
+
+À la fin d'une feature/fix :
+
+1. Ouvre la PR vers `main` (Summary, Test plan, Screenshots si UI).
+2. Passe l'issue Paperclip en `in_review` **assignée au CTO** avec lien PR + résumé build/tests.
+3. Le CTO fait la review interne puis transmet au board pour merge manuel.
+4. Tu n'utilises jamais `gh pr merge`, `git merge` sur `main`, ni l'UI GitHub pour merger.
+5. Si on te demande de merger, refuse et rappelle cette règle.
+
+## Done criteria (avant de marquer in_review)
+
+1. Build passe (`xcodebuild ... build`, sortie résumée en commentaire)
+2. Tests nouveaux + impactés passent (Swift Testing)
+3. Si UI : screenshot ou description visuelle dans la PR
+4. Review pre-PR faite (iOSReviewer), findings critical/high traités
+5. PR créée vers `main` avec description claire
+6. Commits atomiques, messages conventional
+
+N'est PAS "done" : « build passe mais pas testé la UI », « golden path sans edge cases sur logique non triviale », « TODO laissé sans issue de suivi ».
+
+## Safety
+
+- Jamais committer de secrets/credentials/tokens/certificats. Si tu en repères dans un diff, stop et escalade.
+- Jamais bypasser les hooks (`--no-verify`) sauf demande explicite documentée.
+- Jamais de commande destructive (`git reset --hard`, `rm -rf`, force-push sur `main`) sans approbation explicite dans le thread.
+GOV
+echo "governance block: $(wc -c < /tmp/eiyo-agents/engineer-governance.md) bytes"
+```
+
+Expected : > 2500 bytes.
+
+- [ ] **Step 3 : Ajouter le bloc de gouvernance à l'iOSEngineer (préserve le charter existant)**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export IOSENG=1aab21d4-fa8a-4987-98a6-eefdde72de22
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$IOSENG/instructions/AGENTS.md"
+# Idempotence : ne pas dupliquer si déjà présent
+if grep -q "worktree partagé par issue (company-wide)" "$F"; then echo "ALREADY PRESENT — skip"; else cat /tmp/eiyo-agents/engineer-governance.md >> "$F"; echo "APPENDED"; fi
+grep -c "feat/EIY-<n>-<slug>" "$F"
+```
+
+Expected : `APPENDED` puis un nombre ≥ 2 (la séquence + d'autres occurrences).
+
+- [ ] **Step 4 : Ajouter le bloc de gouvernance au MediaPerfEngineer**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export MEDIAENG=01084ac3-bbb5-46af-a722-647dc9a483da
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$MEDIAENG/instructions/AGENTS.md"
+if grep -q "worktree partagé par issue (company-wide)" "$F"; then echo "ALREADY PRESENT — skip"; else cat /tmp/eiyo-agents/engineer-governance.md >> "$F"; echo "APPENDED"; fi
+grep -c "feat/EIY-<n>-<slug>" "$F"
+```
+
+Expected : `APPENDED` puis ≥ 1.
+
+---
+
+## Task 6 : Réécrire l'AGENTS.md du CEO + créer les 3 docs de gouvernance
+
+**Files:**
+- Modify : `agents/$CEO/instructions/AGENTS.md`
+- Create : `agents/$CEO/instructions/governance-pr-merge-rule.md`
+- Create : `agents/$CEO/instructions/governance-main-sync-rule.md`
+- Create : `agents/$CEO/instructions/governance-coder-review-rule.md`
+
+- [ ] **Step 1 : Insérer le brainstorming gate dans la §Delegation existante du CEO**
+
+Le CEO Eiyo a une §Delegation à 4 étapes (Triage, Delegate, Do NOT, Follow up). On insère l'étape brainstorming en position 2 et on renumérote, en éditant le fichier en place.
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CEO/instructions/AGENTS.md"
+python3 - "$F" <<'PY'
+import sys
+f=sys.argv[1]; s=open(f).read()
+old="""2. **Delegate it** -- create a subtask with `parentId` set to the current task, assign it to the right direct report, and include context about what needs to happen. Use these routing rules:"""
+new="""2. **Brainstorm BEFORE validating or dispatching** -- you MUST invoke the `brainstorming` skill (via the Skill tool, exact name `brainstorming`) before you validate a task scope or create subtasks for your reports. This is non-negotiable: brainstorming explores user intent, requirements, and design trade-offs before any work is dispatched, so reports get a clear, well-scoped subtask instead of a half-formed ask. Skip brainstorming only when the task is a pure mechanical follow-up to an already-brainstormed parent (note the parent's brainstorm in your delegation comment).
+3. **Delegate it** -- once the brainstorm is complete, create a subtask with `parentId` set to the current task, assign it to the right direct report, and include the brainstorm output (objective, acceptance criteria, key decisions, open questions) as context. Use these routing rules:"""
+assert old in s, "delegation step 2 not found — file may have changed"
+s=s.replace(old,new)
+# renuméroter les anciennes étapes 3 et 4 (Do NOT / Follow up) -> 4 et 5
+s=s.replace("3. **Do NOT write code","4. **Do NOT write code")
+s=s.replace("4. **Follow up**","5. **Follow up**")
+open(f,'w').write(s)
+print("brainstorm gate inserted")
+PY
+grep -c "brainstorming" "$F" && echo "OK"
+```
+
+Expected : `brainstorm gate inserted`, puis un nombre ≥ 1 et `OK`.
+
+- [ ] **Step 2 : Ajouter les 3 sections de gouvernance à l'AGENTS.md du CEO (avant la section References)**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CEO/instructions/AGENTS.md"
+cat > /tmp/eiyo-agents/ceo-governance.md <<'GOV'
+## Règle interdiction merge agent (company-wide)
+
+**Aucun agent de la company (toi inclus) ne merge de PR.** Sans exception. Les agents peuvent créer et reviewer les PR ; seul le **board (humain)** clique sur "Merge" après validation manuelle. PR cible **`main`**.
+
+- Tu fais respecter la règle sur tous tes reports. Si un agent merge, tu interviens, demandes un rollback si nécessaire, et rappelles la règle.
+- Quand une issue passe en `in_review` assignée au board pour merge, tu ne forces pas le merge — tu attends que le board agisse.
+- Quand le board valide oralement, tu ne merges pas pour eux — le merge est manuel.
+- Document de référence : `./governance-pr-merge-rule.md`
+
+## Règle worktree partagé par issue + sync origin/main (company-wide)
+
+**Pour chaque issue, un seul worktree et une seule branche feature `feat/EIY-<n>-<slug>`, partagés entre tous les agents qui contribuent.** Avant toute modif de code, chaque agent fait `git fetch origin && git rebase origin/main`. Méthode fetch + rebase (jamais merge ni pull simple). Une seule PR par issue. Tous les agents push sur la même branche ; `git pull --rebase` avant chaque commit.
+
+- Tu fais respecter la règle. Tu refuses les PR non rebasées sur `origin/main` et les PR concurrentes par agent sur une même issue.
+- Si un agent est bloqué par un conflit de rebase/merge inter-agents, aide-le à escalader au CTO plutôt que de bypasser la règle.
+- Rappelle aux agents de coordonner via commentaires d'issue avant de push sur la branche partagée.
+- Document de référence : `./governance-main-sync-rule.md`
+
+## Règle review reviewer pre-PR (company-wide, CTO inclus)
+
+**À chaque feature/fix, AVANT `gh pr create`, l'engineer (ou le CTO) doit faire reviewer son diff par l'iOSReviewer sur la branche partagée. La review est bloquante sur findings `critical` / `high`.**
+
+- Tu fais respecter la règle sur tous tes reports, **CTO inclus** (pas d'auto-approve CTO).
+- Tu refuses les PR ouvertes sans trace de review pre-PR dans la description.
+- Tu interviens sur les disagreements engineer ↔ reviewer quand le CTO est partie prenante (cas CTO = codeur).
+- Document de référence : `./governance-coder-review-rule.md`
+
+GOV
+python3 - "$F" /tmp/eiyo-agents/ceo-governance.md <<'PY'
+import sys
+f, gf = sys.argv[1], sys.argv[2]
+s=open(f).read(); gov=open(gf).read()
+marker="## References"
+if "interdiction merge agent (company-wide)" in s:
+    print("ALREADY PRESENT — skip"); sys.exit(0)
+assert marker in s, "References section not found"
+s=s.replace(marker, gov+marker,1)
+open(f,'w').write(s)
+print("ceo governance sections inserted")
+PY
+grep -c "governance-coder-review-rule.md" "$F" && echo "OK"
+```
+
+Expected : `ceo governance sections inserted` (ou `ALREADY PRESENT — skip`), puis ≥ 1 et `OK`.
+
+- [ ] **Step 3 : Créer le doc governance-pr-merge-rule.md**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+D="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CEO/instructions"
+cat > "$D/governance-pr-merge-rule.md" <<'DOC'
+# Gouvernance — Interdiction merge agent
+
+**Portée** : tous les projets de la company, tous les agents, sans exception.
+
+## La règle
+
+Aucun agent ne merge de PR. Les agents peuvent **créer**, **reviewer**, **commenter** et demander des changes sur les PR, mais le **merge final est réservé exclusivement au board (humain)**. Les PR ciblent **`main`**.
+
+## Workflow
+
+1. La PR est finalisée côté review interne : CI verte, Definition of Done iOS cochée, review pre-PR faite (voir `governance-coder-review-rule.md`).
+2. L'agent porteur passe l'issue Paperclip en `in_review` assignée au board (`assigneeAgentId: null` + `assigneeUserId` du board) avec : lien PR, résumé (1-3 lignes), évidence de test, mention « PR prête, en attente de merge manuel par le board ».
+3. Personne n'utilise `gh pr merge`, `git merge` sur `main`, ni l'UI GitHub pour merger.
+4. Si le board approuve oralement sans merger, l'agent ne merge pas — il rappelle que le merge est manuel.
+
+## Application
+
+- **CEO** : fait respecter la règle ; intervient (rollback + rappel) si un agent merge.
+- **CTO** : conclut ses reviews par « LGTM, prêt pour merge board » + reassign au board en `in_review` ; ne merge pas non plus les PR de ses reports.
+- **Engineers / Reviewer** : créent/reviewent, ne mergent jamais.
+DOC
+test -f "$D/governance-pr-merge-rule.md" && echo "pr-merge doc OK"
+```
+
+Expected : `pr-merge doc OK`.
+
+- [ ] **Step 4 : Créer le doc governance-main-sync-rule.md**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+D="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CEO/instructions"
+cat > "$D/governance-main-sync-rule.md" <<'DOC'
+# Gouvernance — Worktree partagé par issue + sync origin/main
+
+**Portée** : tous les projets de la company, tous les agents, sans exception.
+
+La règle a deux volets.
+
+## Volet 1 — Sync depuis origin/main
+
+À chaque nouvelle issue checkout, AVANT toute modification de code, mettre à jour le worktree depuis `origin/main` :
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+- Branche source de référence : `main`. Méthode : fetch + rebase (historique linéaire, pas de merge commit parasite, pas de `git pull` simple).
+- Quand : juste après le checkout Paperclip, avant le premier `git commit` de l'issue.
+
+## Volet 2 — Worktree partagé par issue
+
+Pour chaque issue, un seul worktree et une seule branche feature, partagés entre tous les agents qui contribuent.
+
+- La branche feature appartient à l'**issue**, pas à l'agent. Convention : `feat/EIY-<n>-<slug>`.
+- Worktree : `.claude/worktrees/<EIY-XX>/<slug>/`.
+- Tous les agents (CEO, CTO, iOSEngineer, MediaPerfEngineer, QA) push sur **cette unique branche**, rebasée sur `origin/main`. **Une seule PR par issue.**
+
+### Séquence
+
+```bash
+git fetch origin
+git checkout feat/EIY-<n>-<slug>          # ou : git checkout -b feat/EIY-<n>-<slug> origin/main
+git rebase origin/main
+git pull --rebase                         # avant chaque commit, pour intégrer le travail des autres
+```
+
+### Coordination inter-agents
+
+- Pull `--rebase` systématique avant chaque commit.
+- Avant de push, signaler dans un commentaire d'issue (pour que les autres pull avant leur prochain commit).
+- Conflit avec un autre agent → coordonner via commentaire d'issue, escalader au CTO si bloqué.
+- Le premier agent qui touche l'issue crée la branche depuis `origin/main` ; les suivants la checkout.
+
+### Cas particuliers
+
+- **Output hors repo (design hors versionning)** : volet 2 ne s'applique pas aux commits, mais poster le lien (Figma, etc.) dans un commentaire d'issue.
+- **Pas de hook pre-push** : l'interdiction de push direct sur `main` est une règle de conduite, pas un blocage mécanique. Le CEO/CTO la fait respecter en review.
+- **Conflits de rebase ingérables** : ne jamais `git rebase --abort` + force-push sans validation board ; escalader avec l'état du conflit et les options.
+
+## Application
+
+- **CEO** : fait respecter les deux volets ; refuse les PR non rebasées ou les branches concurrentes par agent.
+- **CTO** : vérifie rebase + unicité de la branche en review ; débloque les conflits.
+- **Engineers** : exécutent la séquence avant le premier commit ; pull --rebase avant chaque commit ; mention « rebasé sur origin/main@<sha> » dans la PR.
+- **QA** : vérifie l'état rebasé + unicité de la branche au moment du test.
+DOC
+test -f "$D/governance-main-sync-rule.md" && echo "main-sync doc OK"
+```
+
+Expected : `main-sync doc OK`.
+
+- [ ] **Step 5 : Créer le doc governance-coder-review-rule.md**
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+D="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CEO/instructions"
+cat > "$D/governance-coder-review-rule.md" <<'DOC'
+# Gouvernance — Review reviewer pre-PR
+
+**Portée** : tous les projets de la company, tous les agents qui ajoutent ou modifient du code (CTO inclus).
+
+## La règle
+
+À chaque fois qu'un engineer (ou le CTO) finit une feature/fix, AVANT `gh pr create`, il doit faire reviewer le diff par l'**iOSReviewer** sur la branche partagée de l'issue. La review est **bloquante sur findings `critical` / `high`**.
+
+| Paramètre | Décision |
+|---|---|
+| Trigger | Avant `gh pr create` — review locale sur diff de la branche partagée |
+| Bloquante ? | Oui sur `critical` / `high`. L'engineer DOIT corriger avant PR |
+| Reviewer | iOSReviewer (app iOS/tvOS Swift) |
+| CTO inclus quand il code ? | Oui, aucune exception (pas d'auto-approve) |
+| Granularité | 1 seule review en fin de feature (re-review non systématique) |
+
+## Workflow canonique
+
+1. Commiter et push tous les changements sur la branche partagée `feat/EIY-<n>-<slug>`.
+2. Créer une **sous-issue de review** (`parentId` = issue courante) assignée à l'iOSReviewer, contenant : lien branche + sha du dernier commit, fichiers/dossiers touchés, intention (what + why), acceptance criteria de l'issue parente.
+3. Passer l'issue parente en `blocked` avec `blockedByIssueIds` pointant vers la sous-issue review.
+4. Le reviewer lit le diff, note les findings par sévérité, poste une synthèse structurée, et clôture la sous-issue (`done`) → Paperclip wake l'engineer via `issue_blockers_resolved`.
+5. L'engineer corrige les findings `critical` / `high` (obligatoire avant PR). Les `medium`/`low`/`info` selon jugement (documentés a minima dans la PR).
+6. L'engineer ouvre la PR avec mention : « Review pre-PR par iOSReviewer — sous-issue EIY-XXX — N findings critical/high traités ».
+7. Pas de re-review obligatoire après commits supplémentaires, sauf zones sensibles (auth, playback core, networking).
+
+## Sévérités
+
+- **critical** : faille sécurité exploitable, perte de données, crash systématique, régression majeure. **BLOQUE.**
+- **high** : bug certain dans le flux nominal, fuite de secret, deadlock, race condition probable. **BLOQUE.**
+- **medium** : code smell important, dette technique, perf douteuse, edge case non géré. Best-effort.
+- **low** : nit de style, naming, refacto. Best-effort.
+- **info** : remarque, alternative. Non bloquant.
+
+## Cas limites
+
+- **PR doc-only / chore / dependency bump pur** : règle non applicable, sauf bump d'une dépendance critique (auth, crypto, network).
+- **Reviewer indisponible** : escalader au CTO, qui peut reviewer lui-même exceptionnellement en documentant la déviation.
+- **Disagreement engineer ↔ reviewer** : escalader au CTO qui tranche. Si CTO = codeur, escalader au CEO.
+
+## Articulation avec les autres règles
+
+- **Interdiction merge** (`governance-pr-merge-rule.md`) : la review pre-PR vient en amont ; le board garde le clic merge final. Ordre : Code → Review pre-PR → PR créée → issue `in_review` board → board merge.
+- **Worktree partagé + sync** (`governance-main-sync-rule.md`) : la review s'effectue sur la branche partagée déjà rebasée sur `origin/main`.
+
+## Application
+
+- **CEO** : fait respecter la règle (CTO inclus) ; refuse les PR sans trace de review pre-PR.
+- **CTO** : applique la règle sur lui-même quand il code ; vérifie la trace de review en review interne ; tranche les disagreements.
+- **Engineers** : appellent l'iOSReviewer avant `gh pr create` ; corrigent critical/high ; documentent dans la PR.
+- **iOSReviewer** : répond dans des délais raisonnables ; findings structurés par sévérité ; read-only (commentaires uniquement, jamais de code).
+- **QA** : vérifie au passage que la PR mentionne la review pre-PR ; sinon renvoie à l'engineer.
+DOC
+test -f "$D/governance-coder-review-rule.md" && echo "review doc OK"
+```
+
+Expected : `review doc OK`.
+
+- [ ] **Step 6 : Mettre à jour le routing CEO « technique → CTO » (si pas déjà le cas)**
+
+L'AGENTS.md CEO Eiyo route déjà « Code, bugs, features, infra → CTO ». Vérifier :
+
+```bash
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+export CEO=fa46c411-ca56-4d9b-9c35-ae0a839d45e5
+F="/Users/arintharamy/.paperclip/instances/default/companies/$EIYO/agents/$CEO/instructions/AGENTS.md"
+grep -n "→ CTO" "$F"
+```
+
+Expected : au moins une ligne routant le technique vers le CTO. Le CTO existe désormais (Task 1), donc le routing est valide. Aucune action si présent.
+
+---
+
+## Task 7 : Vérification finale (re-export + cohérence)
+
+**Files:**
+- Create : `/tmp/eiyo-after-export/`
+
+- [ ] **Step 1 : Re-export d'Eiyo IPTV**
+
+```bash
+export PC=~/.npm/_npx/43414d9b790239bb/node_modules/.bin/paperclipai
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+rm -rf /tmp/eiyo-after-export
+$PC company export $EIYO --include company,agents,skills --out /tmp/eiyo-after-export 2>&1 | tail -3
+ls /tmp/eiyo-after-export/agents/
+```
+
+Expected : dossiers incluant `ceo cto iosreviewer iosengineer mediaperfengineer qa uxdesigner`.
+
+- [ ] **Step 2 : Vérifier les 4 règles et la traçabilité dans les bundles exportés**
+
+```bash
+A=/tmp/eiyo-after-export/agents
+echo "=== brainstorming gate (CEO) ==="; grep -l "brainstorming" $A/ceo/AGENTS.md
+echo "=== 3 docs gouvernance CEO ==="; ls $A/ceo/governance-*.md
+echo "=== worktree EIY (engineers) ==="; grep -l "feat/EIY-<n>-<slug>" $A/iosengineer/AGENTS.md $A/mediaperfengineer/AGENTS.md
+echo "=== review pre-PR (engineers) ==="; grep -l "Review pre-PR par iOSReviewer\|reviewer pre-PR" $A/iosengineer/AGENTS.md
+echo "=== interdiction merge (CTO) ==="; grep -l "ne merge de PR\|interdiction merge" $A/cto/AGENTS.md
+echo "=== reviewer read-only ==="; grep -l "read-only\|n'écris JAMAIS dans le code" $A/iosreviewer/AGENTS.md
+echo "=== aucune référence NVL ne doit subsister ==="; ! grep -rn "NVL-\|/NVL/\|moda-iOS\|moda-backend\|origin/stg\|BackendReviewer" $A/ && echo "NO NVL LEAKS OK"
+```
+
+Expected : chaque `grep -l` retourne le chemin attendu ; la dernière ligne affiche `NO NVL LEAKS OK` (aucune fuite de référence NV Labs : pas de `NVL-`, `/NVL/`, `moda-iOS`, `moda-backend`, `origin/stg`, ni `BackendReviewer`).
+
+- [ ] **Step 3 : Vérifier la hiérarchie finale via l'API**
+
+```bash
+export API=http://127.0.0.1:3100
+export EIYO=76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5
+curl -sS "$API/api/companies/$EIYO/agents" | python3 -c "
+import json,sys
+agents={a['id']:a for a in json.load(sys.stdin)}
+for a in sorted(agents.values(), key=lambda x:x['name']):
+    rt=a.get('reportsTo'); rtn=agents[rt]['name'] if rt in agents else 'CEO/none'
+    print(f\"{a['name']:<18} role={a['role']:<10} status={a['status']:<8} reportsTo={rtn}\")
+"
+```
+
+Expected :
+```
+CEO                role=ceo        ... reportsTo=CEO/none
+CTO                role=cto        ... reportsTo=CEO
+MediaPerfEngineer  role=engineer   ... reportsTo=CTO
+QA                 role=qa         ... reportsTo=CTO
+UXDesigner         role=designer   ... reportsTo=CEO
+iOSEngineer        role=engineer   ... reportsTo=CTO
+iOSReviewer        role=security   ... reportsTo=CTO
+```
+(UXDesigner peut être `status=error` — connu, hors périmètre.)
+
+- [ ] **Step 4 : Comparaison synthétique NV Labs vs Eiyo (sanity)**
+
+```bash
+echo "=== NV Labs règles (référence) ==="
+grep -h "company-wide\|brainstorming\|worktree" /tmp/nvlabs-export/agents/ceo/AGENTS.md | head
+echo "=== Eiyo règles (résultat) ==="
+grep -h "company-wide\|brainstorming\|worktree" /tmp/eiyo-after-export/agents/ceo/AGENTS.md | head
+```
+
+Expected : Eiyo présente les mêmes familles de règles (brainstorming, worktree partagé, merge, review) que NV Labs, adaptées EIY/main.
+
+---
+
+## Self-review (effectué par l'auteur du plan)
+
+**Spec coverage :**
+- Brainstorming gate → Task 6 Step 1 ✓
+- Worktree partagé par issue + sync origin/main → Task 5 (engineers) + Task 6 Steps 2/4 (CEO doc) + Task 1 (CTO) ✓
+- Review pre-PR → Task 2 (reviewer agent) + Task 5 (engineers) + Task 6 Step 5 (CEO doc) + Task 1 (CTO) ✓
+- Interdiction merge → Task 5 (engineers) + Task 6 Steps 2/3 (CEO doc) + Task 1 (CTO) ✓
+- Structure CTO + iOSReviewer → Tasks 1, 2 ✓
+- Re-parentage QA/iOSEngineer/MediaPerfEngineer → Task 3 ✓
+- Adaptations EIY/main/iOS-only/no-hook/no-issue-ref → vérifiées Task 7 Step 2 (`NO NVL LEAKS`) ✓
+- Rollback safety → Task 0 ✓
+
+**Placeholders :** la mention iOSReviewer par nom (Task 1) est documentée et résolue en Task 4 ; ce n'est pas un placeholder mais une dépendance d'ordre assumée. Pas de TODO/TBD.
+
+**Type/nom consistency :** branche `feat/EIY-<n>-<slug>`, worktree `.claude/worktrees/<EIY-XX>/<slug>/`, `origin/main`, sévérités `critical/high/medium/low/info`, reviewer `iOSReviewer` — cohérents partout. Sections gouvernance CEO ↔ docs `governance-*.md` ↔ engineers ↔ CTO emploient le même vocabulaire.

--- a/docs/superpowers/specs/2026-06-04-eiyo-iptv-workflow-from-nv-labs-design.md
+++ b/docs/superpowers/specs/2026-06-04-eiyo-iptv-workflow-from-nv-labs-design.md
@@ -1,0 +1,178 @@
+# Design — Copier le workflow NV Labs vers le workspace Paperclip Eiyo IPTV
+
+**Date** : 2026-06-04
+**Statut** : validé (brainstorming), en attente relecture user avant plan d'implémentation
+
+## Objectif
+
+Configurer le workspace Paperclip **Eiyo IPTV** (`76e7c4a8-6dd5-4d14-aa5b-23f78bf74af5`)
+pour qu'il reproduise fidèlement le workflow de gouvernance du workspace **NV Labs**
+(`03f88baf-4d70-4fd5-8a8a-7fb2c31689a5`), adapté aux spécificités d'Eiyo (préfixe `EIY`,
+app iOS/tvOS Swift, repo `eiyo-tv`, PR vers `main`).
+
+## Constat — ce qu'est réellement le « workflow NV Labs »
+
+Le workflow n'est ni une configuration Paperclip spéciale, ni des skills assignés. C'est un
+**ensemble de règles de gouvernance company-wide écrites dans les `AGENTS.md`** des agents.
+
+Stockage (bundle managé sur disque, mode `instructionsBundleMode: "managed"`) :
+
+```
+~/.paperclip/instances/default/companies/<companyId>/agents/<agentId>/instructions/
+  ├── AGENTS.md          ← instructions principales (les règles)
+  ├── governance-*.md    ← docs de gouvernance détaillées (CEO uniquement)
+  └── HEARTBEAT.md, SOUL.md, TOOLS.md (CEO)
+```
+
+Le chemin est exposé dans `agent.adapterConfig.instructionsFilePath` / `instructionsRootPath`.
+
+Faits vérifiés :
+
+- Le skill `brainstorming` est un skill **superpowers global** (déjà disponible partout),
+  invoqué par instruction dans l'AGENTS.md du CEO. **Rien à installer côté skills company.**
+- NV Labs et Eiyo ont déjà **les 8 mêmes skills paperclip de base** (`attachedAgents=0`). Aucun
+  skill company à copier.
+- Les AGENTS.md actuels d'Eiyo sont les templates « vanille » par rôle (pas de gouvernance custom).
+
+## Les 4 règles de gouvernance à copier
+
+Origine NV Labs entre parenthèses (à titre informatif ; **aucune référence d'issue ne sera
+inscrite dans Eiyo** — règles présentées comme gouvernance company-wide).
+
+| Règle | NV Labs | Adaptation Eiyo |
+|---|---|---|
+| **Brainstorming gate** (NVL-83) | CEO invoque `brainstorming` avant validation/dispatch | identique |
+| **Worktree partagé par issue** (NVL-85) | 1 issue = 1 worktree + 1 branche `feat/NVL-<n>-<slug>` partagés ; `rebase origin/stg` | `.claude/worktrees/<EIY-XX>/<slug>/` + `feat/EIY-<n>-<slug>` ; `rebase origin/main` |
+| **Review pre-PR** (NVL-110) | iOSReviewer/BackendReviewer obligatoire (sous-issue bloquante) avant `gh pr create` | iOSReviewer seul (routing simplifié, pas de double full-stack) |
+| **Interdiction merge agent** (NVL-84) | Seul le board humain merge ; PR vers `stg` | identique mais PR vers `main` |
+
+## Structure d'équipe cible
+
+**Actuel Eiyo** (plat) :
+
+```
+CEO
+ ├─ QA               (role qa)
+ ├─ iOSEngineer      (role engineer)
+ ├─ UXDesigner       (role designer)
+ └─ MediaPerfEngineer(role engineer)
+```
+
+**Cible** (calquée sur NV Labs, reproduction fidèle) :
+
+```
+CEO
+ ├─ CTO (NOUVEL agent, role cto)
+ │   ├─ iOSEngineer        (reparent → CTO)
+ │   ├─ MediaPerfEngineer  (reparent → CTO)
+ │   ├─ QA                 (reparent → CTO)
+ │   └─ iOSReviewer (NOUVEL agent, role security/reviewer read-only, reportsTo CTO)
+ └─ UXDesigner            (reste sous CEO)
+```
+
+- **2 nouveaux agents** : CTO, iOSReviewer.
+- **3 re-parentages** : iOSEngineer, MediaPerfEngineer, QA → CTO.
+
+IDs agents Eiyo connus :
+
+- CEO `fa46c411-ca56-4d9b-9c35-ae0a839d45e5`
+- QA `2486e446-fa23-4ffb-be77-1e4a1c1b3c31`
+- iOSEngineer `1aab21d4-fa8a-4987-98a6-eefdde72de22`
+- UXDesigner `34c21cb6-0e4d-42be-b791-3b622dbea6f2` (statut `error` — à noter, hors périmètre)
+- MediaPerfEngineer `01084ac3-bbb5-46af-a722-647dc9a483da`
+- CTO / iOSReviewer : IDs résolus à la création.
+
+## Contenus à écrire
+
+### A. CEO `AGENTS.md` (greffe sur l'existant)
+
+- §Delegation : insérer l'étape **« Brainstorm BEFORE validating or dispatching »** — invoquer
+  le skill `brainstorming` (Skill tool, nom exact `brainstorming`) avant de créer des sous-tâches.
+  Exception : suivi mécanique d'un parent déjà brainstormé (le noter dans le commentaire de délégation).
+- Router « Code/bugs/features/infra/technique → CTO ».
+- Ajouter 3 sections de gouvernance (merge interdit, worktree partagé + sync `origin/main`, review pre-PR),
+  chacune renvoyant à son doc `governance-*.md`.
+- Créer 3 docs de gouvernance dans le bundle CEO :
+  - `governance-pr-merge-rule.md` (interdiction merge agent, PR vers `main`)
+  - `governance-main-sync-rule.md` (worktree partagé par issue + sync `origin/main`)
+  - `governance-coder-review-rule.md` (review pre-PR par iOSReviewer)
+
+### B. CTO `AGENTS.md` (nouvel agent)
+
+- Mission : exécution technique end-to-end de l'app **Eiyo IPTV** (iOS/tvOS Swift, repo `eiyo-tv`).
+- Applique ET fait respecter les 4 règles côté CTO (review PR, vérif rebase, vérif unicité branche,
+  vérif trace review pre-PR, attente merge board).
+- Le CTO suit lui-même la règle review pre-PR quand il code (pas d'auto-approve).
+- Definition of Done iOS (build/test verts, pas de skip non justifié, etc.).
+- Hiring authority : propose des hires au CEO, ne crée pas d'agents sans accord.
+
+### C. iOSReviewer `AGENTS.md` (nouvel agent, read-only)
+
+- Reviewer read-only : lit le diff sur la branche partagée, poste findings classés par sévérité
+  (`critical`, `high`, `medium`, `low`, `info`), **n'écrit jamais dans le code**, clôture la
+  sous-issue de review (wake l'engineer via `issue_blockers_resolved`).
+- Bloquant sur `critical`/`high`.
+
+### D. iOSEngineer + MediaPerfEngineer `AGENTS.md`
+
+- Règle git/worktree partagé : travailler dans `.claude/worktrees/<EIY-XX>/<slug>/`, branche
+  `feat/EIY-<n>-<slug>` partagée, `git fetch origin && git rebase origin/main` avant 1er commit,
+  `git pull --rebase` avant chaque commit suivant, coordination inter-agents via commentaires d'issue.
+- Règle review pre-PR : avant `gh pr create`, créer sous-issue review assignée à iOSReviewer,
+  passer le parent en `blocked`, corriger `critical`/`high`, mentionner la review dans la PR.
+- Règle interdiction merge : jamais `gh pr merge` / `git merge` sur `main` ; passer l'issue en
+  `in_review` assignée au CTO, qui transmet au board pour merge manuel.
+- Done criteria iOS (build/test verts, screenshots si UI, commits atomiques conventional).
+
+## Adaptations transversales NV Labs → Eiyo
+
+| NV Labs | Eiyo |
+|---|---|
+| Préfixe `NVL` | `EIY` |
+| Branche cible `stg` (PR vers stg puis stg→main) | `main` (PR directement vers main) |
+| `feat/NVL-<n>-<slug>` | `feat/EIY-<n>-<slug>` |
+| sync `git rebase origin/stg` | `git rebase origin/main` |
+| iOSReviewer + BackendReviewer (routing auto + double full-stack) | iOSReviewer seul (routing simplifié) |
+| Repos `moda-iOS` / `moda-backend` | repo `eiyo-tv` (iOS/tvOS Swift) |
+| Liens `/NVL/issues/...` | pas de liens d'issue (gouvernance sans référence) |
+| Hook `scripts/hooks/pre-push` bloque push direct | **pas de hook** → règle de conduite agent (pas de blocage mécanique évoqué) |
+| IDs agents NV | IDs agents Eiyo (CTO/iOSReviewer résolus à la création) |
+
+## Mécanisme d'application (comment écrire concrètement)
+
+Deux voies possibles, à trancher dans le plan d'implémentation :
+
+1. **Écriture directe des fichiers** dans le bundle managé
+   (`~/.paperclip/instances/default/companies/<eiyo>/agents/<agent>/instructions/AGENTS.md` + docs),
+   après création des agents. Simple, mais contourne l'API.
+2. **Via CLI/API Paperclip** : `paperclip-create-agent` pour les nouveaux agents (qui provisionne
+   le bundle), `PATCH /api/agents/:id` pour `reportsTo`, puis écriture des fichiers de bundle.
+
+Recommandation : créer les agents via le skill `paperclip-create-agent` (provisionne proprement le
+bundle + adapterConfig), re-parenter via l'API, puis écrire/éditer les fichiers AGENTS.md et
+governance dans les bundles. Le re-export `company export` sert de vérification finale.
+
+## Plan d'exécution (haut niveau)
+
+1. Créer le CTO (skill `paperclip-create-agent`) + écrire son AGENTS.md adapté.
+2. Créer iOSReviewer (read-only) reportsTo CTO + écrire son AGENTS.md.
+3. Re-parenter iOSEngineer, MediaPerfEngineer, QA → CTO.
+4. Réécrire l'AGENTS.md du CEO (brainstorming gate + 3 sections gouvernance) + créer les 3 docs `governance-*.md`.
+5. Écrire les AGENTS.md des engineers (iOSEngineer, MediaPerfEngineer).
+6. Vérifier : re-export d'Eiyo + relecture des bundles, confirmer cohérence (préfixe EIY, main, iOSReviewer, hiérarchie).
+
+## Périmètre exclu (YAGNI)
+
+- **Routines** (cron) : explicitement hors périmètre.
+- **BackendReviewer / routing full-stack** : Eiyo est iOS-only, un seul reviewer.
+- **Hook git pre-push** : non créé dans le repo (formulé en règle de conduite).
+- **UXDesigner en statut `error`** : signalé mais pas réparé ici (hors périmètre du workflow).
+- Pas de nouveaux skills company (les 8 paperclip de base suffisent ; brainstorming est global).
+
+## Risques
+
+- Re-parentage de 3 agents (`reportsTo`) : réversible, faible risque.
+- Écriture dans le bundle managé : si l'API régénère le bundle, des éditions directes pourraient
+  être écrasées — préférer le provisioning via skill puis édition, et vérifier après écriture.
+- Les agents Eiyo sont `idle` (sauf UXDesigner `error`) : aucun heartbeat actif ne devrait
+  interférer pendant la reconfiguration.

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2165,6 +2165,90 @@ describe("realizeExecutionWorkspace", () => {
       cleanupAction: "branch_delete",
     });
   });
+
+  it("restores a persisted worktree even when baseCwd is not a git repository (EIY-140)", async () => {
+    // Reproduces the heartbeat-setup crash: agents without a base git workspace
+    // (defaultEnvironmentId: null / adapterConfig: {}) have a baseCwd that points
+    // outside any git tree, so resolving repoRoot from baseCwd threw
+    // `fatal: not a git repository` and killed setup before any work ran. The
+    // persisted worktree itself is a valid git checkout, so resolution must come
+    // from there instead of baseCwd.
+    const repoRoot = await createTempRepo();
+    const branchName = "EIY-140-baseCwd-non-git";
+
+    await runGit(repoRoot, ["checkout", "-b", branchName]);
+    await fs.writeFile(path.join(repoRoot, "feature.txt"), "persisted\n", "utf8");
+    await runGit(repoRoot, ["add", "feature.txt"]);
+    await runGit(repoRoot, ["commit", "-m", "Add persisted feature"]);
+    await runGit(repoRoot, ["checkout", "main"]);
+
+    const initial = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "EIY-140",
+        title: "baseCwd non git",
+      },
+      agent: {
+        id: "agent-1",
+        name: "iOS Reviewer",
+        companyId: "company-1",
+      },
+    });
+
+    // A directory that exists but is NOT a git repository — exactly what baseCwd
+    // looks like for review/CTO/CEO agents with no base workspace.
+    const nonGitBaseCwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-non-git-basecwd-"));
+
+    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd: nonGitBaseCwd,
+        source: "task_session",
+        projectId: null,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: initial.cwd,
+        providerRef: initial.worktreePath,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName: initial.branchName,
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "EIY-140",
+        title: "baseCwd non git",
+      },
+      agent: {
+        id: "agent-1",
+        name: "iOS Reviewer",
+        companyId: "company-1",
+      },
+    });
+
+    expect(restored).not.toBeNull();
+    expect(restored?.cwd).toBe(initial.cwd);
+    await expect(fs.readFile(path.join(initial.cwd, "feature.txt"), "utf8")).resolves.toBe("persisted\n");
+  }, 15_000);
 });
 
 describe("ensureRuntimeServicesForRun", () => {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -673,6 +673,39 @@ async function resolveGitOwnerRepoRoot(cwd: string): Promise<string> {
   return path.dirname(path.resolve(checkoutRoot, commonDir));
 }
 
+/**
+ * Resolve the owner repo root for a git_worktree execution workspace without
+ * depending on `base.baseCwd` being inside a git tree.
+ *
+ * Agents with `defaultEnvironmentId: null` / `adapterConfig: {}` (e.g. review,
+ * CTO, CEO roles) have a `baseCwd` that points outside any git checkout, so
+ * `git rev-parse --show-toplevel` on `baseCwd` throws `fatal: not a git
+ * repository` and previously killed heartbeat *setup* before any work could
+ * run (EIY-140). The persisted worktree itself is a valid git checkout, so we
+ * prefer resolving from there and only fall back to `baseCwd`.
+ *
+ * Returns `null` (instead of throwing) when no candidate resolves, so callers
+ * can recover (e.g. recreate the worktree) rather than crash the run.
+ */
+async function resolveExecutionWorkspaceRepoRoot(input: {
+  worktreePath: string | null;
+  cwd: string;
+  baseCwd: string;
+}): Promise<string | null> {
+  // Candidates ordered most-trustworthy first. A worktree/providerRef that
+  // already exists on disk is guaranteed to live inside the owner repo; baseCwd
+  // is the legacy path and may point outside any git tree.
+  const candidates = [input.worktreePath, input.cwd, input.baseCwd];
+  for (const candidate of candidates) {
+    const trimmed = (candidate ?? "").trim();
+    if (!trimmed) continue;
+    if (!(await directoryExists(trimmed))) continue;
+    const repoRoot = await resolveGitOwnerRepoRoot(trimmed).catch(() => null);
+    if (repoRoot) return repoRoot;
+  }
+  return null;
+}
+
 async function findRegisteredGitWorktreeByBranch(repoRoot: string, branchName: string): Promise<string | null> {
   const raw = await runGit(["worktree", "list", "--porcelain"], repoRoot).catch(() => null);
   if (!raw) return null;
@@ -1339,11 +1372,22 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
   if (strategy !== "git_worktree") {
     return realized;
   }
-  const repoRoot = await runGit(["rev-parse", "--show-toplevel"], input.base.baseCwd);
+  // Resolve the owner repo root from the worktree itself rather than from
+  // `base.baseCwd`, which is not guaranteed to be inside a git tree for agents
+  // without a base workspace (EIY-140). This must never crash heartbeat setup.
+  const repoRoot = await resolveExecutionWorkspaceRepoRoot({
+    worktreePath: realized.worktreePath,
+    cwd,
+    baseCwd: input.base.baseCwd,
+  });
   const recordedBaseRefSha = readRecordedBaseRefSha(input.workspace.metadata);
   if (await directoryExists(cwd)) {
+    // The persisted worktree exists. If we somehow could not resolve an owner
+    // repo root above, fall back to operating from the worktree directory
+    // itself so setup still succeeds instead of throwing.
+    const effectiveRepoRoot = repoRoot ?? cwd;
     const baseDrift = await inspectExecutionWorkspaceBaseDrift({
-      repoRoot,
+      repoRoot: effectiveRepoRoot,
       worktreePath: realized.worktreePath ?? cwd,
       branchName: realized.branchName,
       baseRef: input.workspace.baseRef ?? input.base.repoRef ?? null,
@@ -1358,7 +1402,7 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
           provisionCommand,
         },
         base: input.base,
-        repoRoot,
+        repoRoot: effectiveRepoRoot,
         worktreePath: realized.worktreePath ?? cwd,
         branchName: realized.branchName ?? "",
         issue: input.issue,
@@ -1374,6 +1418,19 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
   const branchName = asString(input.workspace.branchName, "").trim();
   if (!branchName) {
     throw new Error(`Execution workspace "${cwd}" is missing and cannot be restored because no branch name is recorded.`);
+  }
+
+  // The worktree does not exist on disk, so we cannot derive the owner repo
+  // from it — recreation requires a real owner repo root. If we could not
+  // resolve one (neither the worktree nor `baseCwd` is a git checkout), fail
+  // with an actionable message instead of the opaque `fatal: not a git
+  // repository` that previously surfaced from `git rev-parse` (EIY-140).
+  if (!repoRoot) {
+    throw new Error(
+      `Execution workspace "${cwd}" is missing and cannot be recreated: no owner git repository could be resolved `
+      + `from the worktree path, providerRef, or base cwd ("${input.base.baseCwd}"). `
+      + `The persisted workspace must reference a worktree inside a valid git repository.`,
+    );
   }
 
   await fs.mkdir(path.dirname(worktreePath), { recursive: true });


### PR DESCRIPTION
## Summary

`ensurePersistedExecutionWorkspaceAvailable` resolved the owner repo root by running `git rev-parse --show-toplevel` from `input.base.baseCwd`. Agents **without** a base git workspace (`defaultEnvironmentId: null` / `adapterConfig: {}` — e.g. review, CTO, CEO roles) have a `baseCwd` that points outside any git tree, so that command threw `fatal: not a git repository` and **killed heartbeat *setup*** before any work could run. This blocked all runs for those agents.

```
ERROR: heartbeat execution setup failed
Error: fatal: not a git repository (or any of the parent directories): .git
  at runGit (.../services/workspace-runtime.js)
  at async ensurePersistedExecutionWorkspaceAvailable (...)
  at async executeRun (heartbeat.js)
```

The persisted worktree (e.g. `.../worktrees/eiy/EIY-134`) *is* a valid git checkout — the bug was resolving `repoRoot` from the wrong cwd.

## Fix

Add `resolveExecutionWorkspaceRepoRoot`, which derives the owner repo root from the persisted worktree / `providerRef` first (guaranteed to live inside the owner repo, via `git rev-parse --git-common-dir`) and only falls back to `baseCwd`. It returns `null` instead of throwing so callers can recover:

- **Existing-worktree path**: fall back to operating from the worktree dir itself if no owner root resolves — setup never crashes.
- **Recreation path**: throw a clear, actionable error naming the candidates instead of the opaque `fatal: not a git repository`.

## Verification

- `pnpm --filter @paperclipai/server typecheck` → passes (0 errors).
- New regression test `restores a persisted worktree even when baseCwd is not a git repository (EIY-140)` → passes.
- Confirmed against a real on-disk worktree: `--show-toplevel` + `--git-common-dir` from the worktree resolves to the correct owner repo root, while a non-git `baseCwd` reproduces the `fatal: not a git repository` failure.
- The 4 unrelated `provision-worktree.sh` test failures in this file are pre-existing on `master` (missing `paperclipai/dist/migrations` in the local npx cache) and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>
