### PR TITLE
Fix persisted worktree reuse with unavailable base cwd

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1785,6 +1785,74 @@ describe("realizeExecutionWorkspace", () => {
     expect(actualHead).toBe(expectedHead);
   }, 15_000);
 
+  it("reuses an existing persisted git worktree when the base workspace cwd is unavailable", async () => {
+    const repoRoot = await createTempRepo();
+    const initial = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-453",
+        title: "Reuse persisted worktree",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+    const unavailableBaseCwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-non-git-base-"));
+
+    const reused = await ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd: unavailableBaseCwd,
+        source: "task_session",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: initial.cwd,
+        providerRef: initial.worktreePath,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName: initial.branchName,
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-453",
+        title: "Reuse persisted worktree",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(reused).not.toBeNull();
+    expect(reused?.cwd).toBe(initial.cwd);
+    expect(reused?.worktreePath).toBe(initial.worktreePath);
+    await expect(readGit(initial.cwd, ["rev-parse", "--show-toplevel"])).resolves.toBe(initial.cwd);
+  }, 15_000);
+
   it("reprovisions an existing persisted git worktree before manual control starts it", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -673,6 +673,12 @@ async function resolveGitOwnerRepoRoot(cwd: string): Promise<string> {
   return path.dirname(path.resolve(checkoutRoot, commonDir));
 }
 
+async function resolveGitOwnerRepoRootOrNull(cwd: string | null | undefined): Promise<string | null> {
+  const trimmed = asString(cwd, "").trim();
+  if (!trimmed) return null;
+  return await resolveGitOwnerRepoRoot(trimmed).catch(() => null);
+}
+
 async function findRegisteredGitWorktreeByBranch(repoRoot: string, branchName: string): Promise<string | null> {
   const raw = await runGit(["worktree", "list", "--porcelain"], repoRoot).catch(() => null);
   if (!raw) return null;
@@ -1339,7 +1345,14 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
   if (strategy !== "git_worktree") {
     return realized;
   }
-  const repoRoot = await runGit(["rev-parse", "--show-toplevel"], input.base.baseCwd);
+  const repoRoot =
+    await resolveGitOwnerRepoRootOrNull(input.base.baseCwd)
+    ?? await resolveGitOwnerRepoRootOrNull(realized.worktreePath ?? cwd);
+  if (!repoRoot) {
+    throw new Error(
+      `Execution workspace "${cwd}" cannot be reused because neither base workspace "${input.base.baseCwd}" nor the persisted worktree path is a git repository.`,
+    );
+  }
   const recordedBaseRefSha = readRecordedBaseRefSha(input.workspace.metadata);
   if (await directoryExists(cwd)) {
     const baseDrift = await inspectExecutionWorkspaceBaseDrift({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent runs need a usable workspace before a local adapter can start.
> - The `git_worktree` strategy saves task worktrees for later runs.
> - A saved worktree can still be valid after the base workspace path becomes missing or stops being a Git checkout.
> - The old reuse path resolved the owner repository only from that base path.
> - The provision command also received the unusable base path after fallback.
> - This pull request resolves the owner repository from the saved worktree when needed and gives provision commands a usable base checkout.
> - The benefit is reliable workspace reuse without hiding unrelated Git or file-system failures.

## Linked Issues or Issue Description

Fixes: #7507

## What Changed

- Resolve a saved worktree owner repository from the configured base checkout first and from the saved worktree second.
- Return `null` only for an absent path or a path that is not a Git checkout. Keep other Git and file-system errors visible.
- Set `PAPERCLIP_WORKSPACE_BASE_CWD` to the resolved owner repository when the configured base path is unusable.
- Add focused coverage for non-Git and missing base paths, provision-command use of the fallback value, and temporary-directory cleanup.

## Verification

- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t "reuses and provisions a persisted git worktree when the base cwd is unavailable or non-git"`
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t "(reuses and provisions a persisted git worktree|reprovisions an existing persisted git worktree|base checkout path)"`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk. The new path runs only when Paperclip reuses a saved Git worktree.
- A provision command now receives the owner repository root as `PAPERCLIP_WORKSPACE_BASE_CWD` when the configured base path is unusable.
- If neither path is a Git checkout, setup still fails with a message that names both paths.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5-family reasoning, repository inspection, shell tool use, code editing, and local test and type-check execution. The run did not expose a more specific model ID or context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
