### PR TITLE
fix(heartbeat): skip auto-mirror run-summary comment on cross-owner wakes

### DIFF
--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   summarizeHeartbeatRunResultJson,
   buildHeartbeatRunIssueComment,
+  evaluateHeartbeatRunIssueCommentGuard,
   mergeHeartbeatRunResultJson,
 } from "../services/heartbeat-run-summary.js";
 
@@ -62,6 +63,35 @@ describe("buildHeartbeatRunIssueComment", () => {
 
   it("returns null when there is no usable final text", () => {
     expect(buildHeartbeatRunIssueComment({ costUsd: 1.2 })).toBeNull();
+  });
+});
+
+describe("evaluateHeartbeatRunIssueCommentGuard", () => {
+  it("emits the run-summary comment when the issue assignee matches the running agent", () => {
+    expect(
+      evaluateHeartbeatRunIssueCommentGuard({
+        issueAssigneeAgentId: "agent-1",
+        runningAgentId: "agent-1",
+      }),
+    ).toEqual({ emit: true, skipReason: null });
+  });
+
+  it("skips with cross_owner reason when the issue is assigned to a different agent", () => {
+    expect(
+      evaluateHeartbeatRunIssueCommentGuard({
+        issueAssigneeAgentId: "agent-other",
+        runningAgentId: "agent-1",
+      }),
+    ).toEqual({ emit: false, skipReason: "cross_owner" });
+  });
+
+  it("skips with unowned_or_user_assigned reason when the issue has no agent assignee", () => {
+    expect(
+      evaluateHeartbeatRunIssueCommentGuard({
+        issueAssigneeAgentId: null,
+        runningAgentId: "agent-1",
+      }),
+    ).toEqual({ emit: false, skipReason: "unowned_or_user_assigned" });
   });
 });
 

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -106,3 +106,35 @@ export function buildHeartbeatRunIssueComment(
     ?? null
   );
 }
+
+export type HeartbeatRunIssueCommentSkipReason =
+  | "cross_owner"
+  | "unowned_or_user_assigned";
+
+export interface HeartbeatRunIssueCommentGuardInput {
+  issueAssigneeAgentId: string | null;
+  runningAgentId: string;
+}
+
+export interface HeartbeatRunIssueCommentGuardResult {
+  emit: boolean;
+  skipReason: HeartbeatRunIssueCommentSkipReason | null;
+}
+
+// The local-adapter heartbeat-end auto-mirror posts the run summary as a
+// comment under the running agent's authorship on PAPERCLIP_TASK_ID. When the
+// wake source is owned by a different agent (cross-owner wake) the result is a
+// comment authored by the running agent on a peer-owned issue. Skip in that
+// case, and also when the task is user-assigned (assigneeAgentId is null),
+// which is cross-owner from the running agent's perspective.
+export function evaluateHeartbeatRunIssueCommentGuard(
+  input: HeartbeatRunIssueCommentGuardInput,
+): HeartbeatRunIssueCommentGuardResult {
+  if (input.issueAssigneeAgentId === input.runningAgentId) {
+    return { emit: true, skipReason: null };
+  }
+  if (input.issueAssigneeAgentId === null) {
+    return { emit: false, skipReason: "unowned_or_user_assigned" };
+  }
+  return { emit: false, skipReason: "cross_owner" };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -73,6 +73,7 @@ import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import {
   buildHeartbeatRunIssueComment,
+  evaluateHeartbeatRunIssueCommentGuard,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
   HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS,
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
@@ -8283,11 +8284,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const skipRunIssueComment = parseObject(livenessRun.contextSnapshot).skipIssueComment === true;
         if (issueId && outcome === "succeeded" && !skipRunIssueComment) {
           try {
-            const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
-            if (!existingRunComment) {
-              const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
-              if (issueComment) {
-                await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
+            const currentIssueContext = await getIssueExecutionContext(livenessRun.companyId, issueId);
+            const issueAssigneeAgentId = currentIssueContext?.assigneeAgentId ?? null;
+            const guard = evaluateHeartbeatRunIssueCommentGuard({
+              issueAssigneeAgentId,
+              runningAgentId: agent.id,
+            });
+            if (!guard.emit) {
+              const contextSnapshot = parseObject(livenessRun.contextSnapshot);
+              const wakeReason =
+                typeof contextSnapshot.wakeReason === "string" ? contextSnapshot.wakeReason : null;
+              await appendRunEvent(livenessRun, seq++, {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "info",
+                message: "heartbeat_end_auto_mirror_skipped",
+                payload: {
+                  reason: guard.skipReason,
+                  taskId: issueId,
+                  taskAssigneeAgentId: issueAssigneeAgentId,
+                  runningAgentId: agent.id,
+                  wakeReason,
+                },
+              });
+            } else {
+              const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
+              if (!existingRunComment) {
+                const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
+                if (issueComment) {
+                  await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
+                }
               }
             }
           } catch (err) {


### PR DESCRIPTION
Fixes #7509

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - When a heartbeat run ends, the server posts the run's summary text as an issue comment under the running agent's authorship on `PAPERCLIP_TASK_ID`.
> - That auto-mirror assumes the running agent is the issue's owner, but heartbeats also fire on cross-owner wakes (`issue_comment_mentioned` on a peer's issue, dependency-blocked interactions, operator reassignment, user-assigned issues).
> - On those cross-owner wakes the run summary lands authored by the running agent on a peer's issue, which violates one-issue-per-owner authorship discipline downstream consumers rely on.
> - This pull request guards the auto-mirror so it posts only when the wake-source issue's current `assigneeAgentId` matches the running agent.
> - The benefit is the run-summary mirror keeps working for the original case (own-issue wake completion markers) while no longer leaking comments authored by the running agent on peer-owned or user-owned issues.

## What Changed

- Added `evaluateHeartbeatRunIssueCommentGuard` to `server/src/services/heartbeat-run-summary.ts`: a pure helper that returns `{ emit, skipReason }` from the issue's current `assigneeAgentId` and the running agent id. Skip reasons are `cross_owner` (assignee is a different agent) and `unowned_or_user_assigned` (assignee is null, i.e. user-assigned).
- Wired the helper into the heartbeat-end run-summary comment path in `server/src/services/heartbeat.ts`. The path now re-reads the issue's current `assigneeAgentId` via the existing `getIssueExecutionContext`, evaluates the guard, and either proceeds with the existing `addComment` flow or emits a `heartbeat_end_auto_mirror_skipped` lifecycle run-log event with the skip reason, task id, assignee, running agent id, and wake reason. Forensic trail is preserved.
- Added unit tests for the helper in `server/src/__tests__/heartbeat-run-summary.test.ts` covering own-issue emit, cross-agent skip, and user-assigned skip.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-run-summary.test.ts` → 11 tests passed (8 pre-existing + 3 new guard tests).
- `pnpm --filter @paperclipai/server exec tsc --noEmit` → zero new errors in `heartbeat.ts` / `heartbeat-run-summary.ts`. Pre-existing typecheck failures in `plugin-host-services.ts` and `plugin-*` are unrelated to this change (they fail on `main`/`master` without it too).
- No DB schema change. No API surface change. No migration. No removed call sites.

## Risks

Low risk. The guard is additive and read-only on the issue (one extra `getIssueExecutionContext` call per successful run-end). Behavior on own-issue wakes is unchanged. The only behavioral diff on cross-owner wakes is: no run-summary comment is posted, and one lifecycle run-log event records the skip. Existing `skipIssueComment` path is unaffected. Existing fallback-only behavior (when the run already posted a comment of its own) is unaffected.

## Model Used

- Provider: Anthropic. Model: `claude-opus-4-7` (Opus 4.7). Mode: extended thinking, tool use enabled, agentic operation via Paperclip's `claude_local` adapter. Context window: 200K. The model authored the patch end-to-end (fork, locate hook, apply guard, write tests, push, open PR) under operator review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change.
- [x] I have specified the model used (with version and capability details).
- [x] I have checked `ROADMAP.md` and confirmed this PR does not duplicate planned core work. (Bug fix, not a feature.)
- [x] I have run tests locally and they pass.
- [x] I have added or updated tests where applicable.
- [ ] If this change affects the UI, I have included before/after screenshots. (Not a UI change.)
- [x] I have updated relevant documentation to reflect my changes. (No user-facing docs reference the auto-mirror.)
- [x] I have considered and documented any risks above.
- [x] I will address all Greptile and reviewer comments before requesting merge.
