### PR TITLE
fix(recovery): skip spurious in_progress -> blocked transition when no first-class blockers

### DIFF
--- a/server/src/services/recovery/blocked-transition-guard.test.ts
+++ b/server/src/services/recovery/blocked-transition-guard.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { shouldSuppressSpuriousBlockedTransition } from "./blocked-transition-guard.js";
+
+describe("shouldSuppressSpuriousBlockedTransition (BUD-717)", () => {
+  it("suppresses the in_progress -> blocked transition when blockers are empty and the latest run succeeded", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: [],
+        status: "in_progress",
+        latestRunStatus: "succeeded",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress when there are first-class blockers (AC2: real blocked issues still escalate)", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: ["blocker-1"],
+        status: "in_progress",
+        latestRunStatus: "succeeded",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress when the issue is in_review (an in_review consumer owns the next action)", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: [],
+        status: "in_review",
+        latestRunStatus: "succeeded",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress when the latest run is still running (recovery must keep observing)", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: [],
+        status: "in_progress",
+        latestRunStatus: "running",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress when the latest run failed in a retryable way (existing escalation path stays in charge)", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: [],
+        status: "in_progress",
+        latestRunStatus: "failed",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress when there is no latest run (cold-start path is unaffected)", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: [],
+        status: "in_progress",
+        latestRunStatus: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats multiple blockers the same as a single blocker", () => {
+    expect(
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds: ["a", "b", "c"],
+        status: "in_progress",
+        latestRunStatus: "succeeded",
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/recovery/blocked-transition-guard.ts
+++ b/server/src/services/recovery/blocked-transition-guard.ts
@@ -1,0 +1,52 @@
+/**
+ * BUD-717: guard against the source_scoped_recovery_action churn loop.
+ *
+ * The recovery service can transition an issue to `blocked` even when the
+ * source run succeeded, the issue has no first-class blockers, and the
+ * issue is not in review. That flip wakes the assignee, who sees no real
+ * blockers, PATCHes the issue back to `in_progress`, and the loop repeats
+ * on the next heartbeat that observes the source-success state.
+ *
+ * This module isolates the decision so it can be unit-tested without DB
+ * mocks and reasoned about in one place.
+ */
+
+export type SuppressionDecisionInput = {
+  /**
+   * Unresolved `blocks` relations pointing at the issue. Empty means there
+   * is no first-class blocker path to recover.
+   */
+  blockerIds: readonly string[];
+  /**
+   * Current issue status. The guard only suppresses when the issue is
+   * neither in `blocked` (already a blocker path) nor in `in_review`
+   * (a reviewer is the consumer — flipping to blocked would change the
+   * effective unblock work).
+   */
+  status: string;
+  /**
+   * Status of the most recent heartbeat run. The guard is only safe to
+   * apply when the source run actually succeeded; if the run is still
+   * active or failed in a retryable way, the existing escalation path
+   * must keep running.
+   */
+  latestRunStatus: string | null | undefined;
+};
+
+/**
+ * Returns true when the `in_progress -> blocked` transition (and the
+ * recovery wake that follows it) would not change effective unblock work
+ * and is therefore the churn pattern BUD-490 / BUD-710 / BUD-717 observed.
+ *
+ * Equivalent in effect to the issue's "PR armed for auto-merge" check —
+ * the recovery target's blocker graph is empty, so the transition target
+ * would not change the next action a human or agent needs to take.
+ */
+export function shouldSuppressSpuriousBlockedTransition(
+  input: SuppressionDecisionInput,
+): boolean {
+  if (input.blockerIds.length > 0) return false;
+  if (input.status === "blocked" || input.status === "in_review") return false;
+  if (input.latestRunStatus !== "succeeded") return false;
+  return true;
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -28,6 +28,7 @@ import { runningProcesses } from "../../adapters/index.js";
 import { forbidden, notFound } from "../../errors.js";
 import { logger } from "../../middleware/logger.js";
 import { isPidAlive, isProcessGroupAlive, terminateLocalService } from "../local-service-supervisor.js";
+import { shouldSuppressSpuriousBlockedTransition } from "./blocked-transition-guard.js";
 import { redactCurrentUserText } from "../../log-redaction.js";
 import { redactSensitiveText } from "../../redaction.js";
 import { logActivity } from "../activity-log.js";
@@ -2296,6 +2297,51 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+
+    // BUD-717: skip the in_progress -> blocked transition (and the recovery
+    // wake) when there are no first-class blockers, the issue is not
+    // in_review, and the latest run actually succeeded. The transition
+    // target would not change effective unblock work, and the assignee
+    // would just PATCH it back to in_progress on the next heartbeat,
+    // producing a recovery churn loop (BUD-710, BUD-490, BUD-722/724/727).
+    // The recoveryAction above is still created/upserted so manual review
+    // remains possible; we only suppress the spurious status flip + wake.
+    if (
+      shouldSuppressSpuriousBlockedTransition({
+        blockerIds,
+        status: input.issue.status,
+        latestRunStatus: input.latestRun?.status ?? null,
+      })
+    ) {
+      await logActivity(db, {
+        companyId: input.issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.recovery_transition_suppressed",
+        entityType: "issue",
+        entityId: input.issue.id,
+        details: {
+          identifier: input.issue.identifier,
+          status: input.issue.status,
+          previousStatus: input.previousStatus,
+          source:
+            input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
+              ? "recovery.reconcile_successful_run_handoff_missing_state"
+              : "recovery.reconcile_stranded_assigned_issue",
+          recoveryCause: input.recoveryCause ?? "stranded_assigned_issue",
+          reason: "no_first_class_blockers_and_no_in_review_consumer",
+          latestRunId: input.latestRun?.id ?? null,
+          latestRunStatus: input.latestRun?.status ?? null,
+          latestRunErrorCode: input.latestRun?.errorCode ?? null,
+          recoveryActionId: recoveryAction.id,
+          recoveryOwnerAgentId: recoveryAction.ownerAgentId,
+        },
+      });
+      return null;
+    }
+
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The `server/services/recovery` subsystem reconciles stranded assigned issues by calling `escalateStrandedAssignedIssue(...)` from 5 sites inside `reconcileStrandedAssignedIssues()`.
> - That function unconditionally wrote `status: "blocked"` and enqueued a `source_scoped_recovery_action` wake, even when the source run had *succeeded*, the issue's `blockedByIssueIds` was empty, and the issue was not `in_review`.
> - The assignee then woke up, saw no real blockers, PATCHed the issue back to `in_progress`, and the loop repeated on the next heartbeat that observed the source-success state. The pattern has been observed in this repo as BUD-490, BUD-710, and the BUD-722/724/727 cluster — 11 runs / 4 assignee comments per hour driven by the recovery oscillation rather than real work.
> - This pull request isolates the "spurious transition" decision into a pure helper and short-circuits the flip (and the wake) when the helper returns true. The `recoveryAction` upsert still runs, so the manual review / audit trail stays intact.
> - The benefit is that recovery stops waking assignees whose only blocker is the recovery action itself, which was the loop. Real blocked issues (with first-class blockers) still escalate exactly as before.

## What Changed

- New module `server/src/services/recovery/blocked-transition-guard.ts` exporting `shouldSuppressSpuriousBlockedTransition({ blockerIds, status, latestRunStatus })` — pure, no DB, no async, no imports outside the file.
- `server/src/services/recovery/service.ts`: after computing `blockerIds` and upserting the `recoveryAction`, call the helper. If it returns true, emit an `issue.recovery_transition_suppressed` activity log entry (with the suppression reason) and `return null` so the 5 callers correctly count this as a skip rather than an escalation.
- New test file `server/src/services/recovery/blocked-transition-guard.test.ts` with 7 cases covering the three ACs and the boundary conditions (running run, failed run, no run, multiple blockers).

## Verification

Local checks (in `/tmp/bud717-paperclip-wt`, on `fix/bud-717-source-scoped-recovery-blocked-guard` @ `5d590e5`):

- `pnpm --filter @paperclipai/server typecheck` — clean (no TS errors).
- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/` — **24/24 tests pass** across the recovery module (3 files: 7 new + 14 successful-run-handoff + 3 model-profile-hint). No existing test regressed.
- The three ACs map to specific test cases:
  - **AC1** (in_progress + empty blockers + source-success ⇒ no flip): `shouldSuppressSpuriousBlockedTransition({ blockerIds: [], status: "in_progress", latestRunStatus: "succeeded" })` → `true`; the recovery path then logs `issue.recovery_transition_suppressed` and returns `null`, so the wake is never enqueued.
  - **AC2** (real blocked ⇒ still escalates): `shouldSuppressSpuriousBlockedTransition({ blockerIds: ["blocker-1"], ... })` → `false`; the existing `issuesSvc.update(..., { status: "blocked" })` path runs unchanged.
  - **AC3** (BUD-710 repro ⇒ issue stays in_progress, assignee not woken): covered by AC1 at the integration level — the call site returns `null` before `enqueueSourceScopedStrandedRecoveryWake(...)`, so the wake is not enqueued.

To reproduce the AC3 scenario in a live instance, follow the BUD-710 path (assigned issue, in_progress, source run succeeded, empty `blockedByIssueIds`) and confirm:
- `activity_log` gains an `issue.recovery_transition_suppressed` row with `reason: "no_first_class_blockers_and_no_in_review_consumer"`.
- `agent_wakeup_requests` does not gain a new row for the issue.
- Issue status remains `in_progress`.

## Risks

- **Behavioural change in a recovery path.** Previously, an issue that entered the recovery function would always have `status: "blocked"` written. After this change, an issue where the helper returns `true` will *not* be flipped, and the recovery wake is *not* enqueued. The activity log entry is the only side effect, which is by design — the only thing the recovery path was doing in that branch was producing a no-op for the assignee.
- **Operator visibility.** The `escalateStrandedAssignedIssue` call sites report `result.escalated` vs `result.skipped`. A suppressed transition is counted as `skipped` (not `escalated`), which matches the new semantics — recovery ran but decided no action. Operators watching the `escalated` counter may see a drop in volume on instances that had been oscillating; that drop is the loop going away, not a regression in recovery coverage.
- **Equivalent-check disclosure.** The issue's "PR armed for auto-merge" example is not directly expressed in this PR because the `issues` schema has no `pr_url` column. The empty-`blockedByIssueIds` + no-`in_review` check is the equivalent per the issue's "equivalent checks" allowance: when the recovery target's blocker graph is empty, the transition target would not change effective unblock work, so the flip is a no-op. If a future change adds a `pr_url` column or a separate `armed_auto_merge_pr` flag, the helper can be tightened in one place.
- **No DB schema, no migration, no API change.** Pure server-side logic in one existing file plus a new helper + its test. Safe to roll back by reverting the single commit.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.8 (claude-opus-4-8)
- Capabilities used: 1M-token context, structured code editing, vitest authoring
- Operator: CTO (Paperclip) on behalf of `devgoe/Budgetplanung` issue BUD-717

## Checklist

- [x] Tests pass locally (`pnpm typecheck` + `pnpm exec vitest run src/services/recovery/`).
- [x] One logical change in one existing module plus a new pure helper and its test.
- [x] No `pnpm-lock.yaml` changes.
- [x] No new dependencies.
- [x] No DB migration.
- [x] No public API change.
- [x] Diff is small enough to review in one sitting: `git diff master -- 'server/src/services/recovery/**'` is 172 lines across 3 files.
