### PR TITLE
feat(heartbeat): independent wakeOnAutomation gate (decouple from wakeOnDemand)

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -960,4 +960,89 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       },
     });
   });
+
+  it("wakeOnAutomation:false suppresses automation wakes but still allows on_demand wakes", async () => {
+    // Regression for the independent automation-wake gate. Previously wakeOnAutomation was OR-folded
+    // into a single wakeOnDemand boolean, so there was no way to silence server-originated automation
+    // wakes (issue_children_completed / issue_blockers_resolved — the CEO token-burn pattern) without
+    // also killing legitimate on-demand / assignment wakes. The two gates are now independent.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const automationIssueId = randomUUID();
+    const onDemandIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CEO",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          // automation OFF, on_demand ON — the combination only expressible after the gate split.
+          wakeOnDemand: true,
+          wakeOnAutomation: false,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: automationIssueId,
+        companyId,
+        title: "Automation-woken issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: onDemandIssueId,
+        companyId,
+        title: "On-demand-woken issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    // 1. An automation wake is suppressed by the independent wakeOnAutomation:false gate.
+    const automationWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_children_completed",
+      payload: { issueId: automationIssueId },
+      contextSnapshot: { issueId: automationIssueId, wakeReason: "issue_children_completed" },
+    });
+    expect(automationWake).toBeNull();
+    const skippedAutomation = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(sql`${agentWakeupRequests.payload} ->> 'issueId' = ${automationIssueId}`)
+      .then((rows) => rows[0] ?? null);
+    expect(skippedAutomation).toMatchObject({
+      status: "skipped",
+      reason: "heartbeat.wakeOnAutomation.disabled",
+    });
+
+    // 2. An on_demand wake on the SAME agent still fires — wakeOnDemand:true is unaffected.
+    const onDemandWake = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "issue_assigned",
+      payload: { issueId: onDemandIssueId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: { issueId: onDemandIssueId, wakeReason: "issue_assigned" },
+    });
+    expect(onDemandWake).not.toBeNull();
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5973,10 +5973,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
 
+    // `wakeOnDemand` gates the operator-initiated / event sources (on_demand, assignment).
+    // Legacy aliases wakeOnAssignment / wakeOnOnDemand still feed it. NOTE: wakeOnAutomation is
+    // deliberately NOT folded in here anymore — it is now an independent gate (see below) so
+    // operators can suppress server-originated automation wakes (issue_children_completed,
+    // issue_blockers_resolved, recovery sweeps) WITHOUT also killing legitimate on-demand wakes.
+    const wakeOnDemand = asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand, true);
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
-      wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
+      wakeOnDemand,
+      // `wakeOnAutomation` gates source:"automation" wakes only. Default = explicit flag if set,
+      // else inherit wakeOnDemand so prior configs that only set wakeOnDemand:false keep suppressing
+      // automation too (no behavior change for existing agents); defaults to true otherwise.
+      wakeOnAutomation: asBoolean(heartbeat.wakeOnAutomation ?? wakeOnDemand, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };
   }
@@ -9133,7 +9143,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       await writeSkippedRequest("heartbeat.disabled");
       return null;
     }
-    if (source !== "timer" && !policy.wakeOnDemand) {
+    if (source === "automation" && !policy.wakeOnAutomation) {
+      // Independent gate: lets an operator silence server-originated automation wakes
+      // (issue_children_completed, issue_blockers_resolved, recovery) without disabling
+      // on-demand/assignment wakes. Defaults to enabled (true), so no behavior change unless set.
+      await writeSkippedRequest("heartbeat.wakeOnAutomation.disabled");
+      return null;
+    }
+    if (source !== "timer" && source !== "automation" && !policy.wakeOnDemand) {
       await writeSkippedRequest("heartbeat.wakeOnDemand.disabled");
       return null;
     }


### PR DESCRIPTION
Fixes #7730

## Thinking Path
Needed to silence server-originated `source: "automation"` wakes (`issue_children_completed`, `issue_blockers_resolved`, recovery sweeps) WITHOUT also disabling legitimate `on_demand`/`assignment` wakes. Found `parseHeartbeatPolicy` folds everything into one `wakeOnDemand` boolean, and the non-timer gate keys on that single flag — so there is no independent off-switch for automation wakes.

## What Changed
Split the single gate into an independent `wakeOnAutomation` policy field:
- `parseHeartbeatPolicy` parses `wakeOnAutomation` separately (back-compat default preserved).
- The non-timer wake gate checks `source == "automation"` against `wakeOnAutomation`, leaving `on_demand`/`assignment` governed by `wakeOnDemand`.

## Verification
Failing-then-passing test: with `wakeOnAutomation:false`, an `automation`-source wake is skipped while an `on_demand` wake still fires (previously both were gated together). Proven live on a real agent (automation wake skipped, on_demand wake fired).

## Risks
Low + back-compatible: when `wakeOnAutomation` is unset it defaults to the prior behavior, so existing configs are unaffected. Only configs that explicitly set it gain the new independent gate.

## Model Used
Claude Opus 4.x (Claude Code).
