### PR TITLE
fix(recovery): terminate orphaned runs on terminal source issues (ING-563)

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -367,9 +367,9 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(event?.message).toContain("Source-resolved watchdog fold");
   });
 
-  it("still escalates terminal source issues without same-run terminal evidence", async () => {
+  it("terminates orphaned runs on terminal source issues without same-run terminal evidence (ING-563)", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
-    const { companyId, runId } = await seedRunningRun({
+    const { companyId, coderId, issueId, runId } = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
       sourceStatus: "done",
@@ -378,15 +378,101 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
 
-    expect(result).toMatchObject({ created: 1, folded: 0 });
+    expect(result).toMatchObject({ created: 0, folded: 0, terminated: 1 });
     const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
-    const [evaluation] = await db
+    expect(run?.status).toBe("succeeded");
+    expect(run?.finishedAt?.toISOString()).toBe(now.toISOString());
+    expect(run?.resultJson).toMatchObject({
+      orphanedRunTerminated: {
+        sourceIssueId: issueId,
+        sourceIssueStatus: "done",
+      },
+    });
+
+    const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluation?.originId).toBe(runId);
-    expect(evaluation?.parentId).toBeNull();
+    expect(evaluations).toHaveLength(0);
+
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.executionRunId).toBeNull();
+    const [agent] = await db.select().from(agents).where(eq(agents.id, coderId));
+    expect(agent?.status).toBe("idle");
+    const [decision] = await db
+      .select()
+      .from(heartbeatRunWatchdogDecisions)
+      .where(eq(heartbeatRunWatchdogDecisions.runId, runId));
+    expect(decision?.decision).toBe("dismissed_false_positive");
+    expect(decision?.reason).toContain("orphan run terminated");
+    const [event] = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(event?.message).toContain("Orphaned active run terminated");
+  });
+
+  it("does not loop with hourly duplicate alerts when source issue is terminal (ING-563 regression)", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      sourceStatus: "done",
+    });
+    const heartbeat = heartbeatService(db);
+
+    // Simulate the hourly scan recurring across many heartbeats — the ING-526
+    // incident produced 34 duplicate review issues this way.
+    for (let i = 0; i < 5; i += 1) {
+      const tickNow = new Date(now.getTime() + i * 60 * 60 * 1000);
+      const tickResult = await heartbeat.scanSilentActiveRuns({ now: tickNow, companyId });
+      if (i === 0) {
+        expect(tickResult).toMatchObject({ created: 0, terminated: 1 });
+      } else {
+        expect(tickResult).toMatchObject({ scanned: 0, created: 0, terminated: 0 });
+      }
+    }
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("succeeded");
+  });
+
+  it("closes any existing silence-review issue when the orphan is terminated (ING-563)", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, managerId, issueId, runId, issuePrefix } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      sourceStatus: "done",
+    });
+    const evaluationIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: evaluationIssueId,
+      companyId,
+      title: "Existing stale evaluation",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "stale_active_run_evaluation",
+      originId: runId,
+      originRunId: runId,
+      originFingerprint: `stale_active_run:${companyId}:${runId}`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ created: 0, terminated: 1 });
+    const [evaluation] = await db.select().from(issues).where(eq(issues.id, evaluationIssueId));
+    expect(evaluation?.status).toBe("done");
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.executionRunId).toBeNull();
   });
 
   it("still escalates when a same-run comment is followed by another actor marking the source done", async () => {
@@ -422,15 +508,18 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
 
-    expect(result).toMatchObject({ created: 1, folded: 0 });
+    // Source is terminal but resolution came from another actor — under ING-563
+    // we still terminate the orphan rather than escalate, because there is no
+    // safe way for the silence detector to know the run had useful state worth
+    // surfacing (a same-run comment alone is not durable terminal evidence).
+    expect(result).toMatchObject({ created: 0, terminated: 1 });
     const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
-    const [evaluation] = await db
+    expect(run?.status).toBe("succeeded");
+    const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluation?.originId).toBe(runId);
-    expect(evaluation?.parentId).toBeNull();
+    expect(evaluations).toHaveLength(0);
   });
 
   it("folds existing evaluation and active watchdog recovery action idempotently", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1218,6 +1218,132 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation?.id ?? null };
   }
 
+  async function terminateOrphanedRunForTerminalSource(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect;
+    existingEvaluation: Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>;
+    silenceStartedAt: Date | null;
+    silenceAgeMs: number | null;
+    now: Date;
+  }) {
+    const cleanup = await cleanupSourceResolvedRunProcess({ run: input.run, runningAgent: input.runningAgent });
+    const finalRunStatus = input.sourceIssue.status === "cancelled" ? "cancelled" : "succeeded";
+    const reason = "Source issue already reached a terminal status; orphan run terminated without alerting.";
+    const resultJson = {
+      ...parseObject(input.run.resultJson),
+      orphanedRunTerminated: {
+        sourceIssueId: input.sourceIssue.id,
+        sourceIssueIdentifier: input.sourceIssue.identifier,
+        sourceIssueStatus: input.sourceIssue.status,
+        silenceStartedAt: input.silenceStartedAt?.toISOString() ?? null,
+        silenceAgeMs: input.silenceAgeMs,
+        existingEvaluationIssueId: input.existingEvaluation?.id ?? null,
+        existingEvaluationIssueIdentifier: input.existingEvaluation?.identifier ?? null,
+        cleanup,
+        reason,
+      },
+    };
+    const finalizedRun = await db.transaction(async (tx) => {
+      const [updatedRun] = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: finalRunStatus,
+          finishedAt: input.now,
+          error: null,
+          errorCode: null,
+          resultJson,
+          updatedAt: input.now,
+        })
+        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.companyId, input.run.companyId), eq(heartbeatRuns.status, "running")))
+        .returning();
+      if (!updatedRun) return null;
+
+      if (input.run.wakeupRequestId) {
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            status: finalRunStatus === "succeeded" ? "completed" : "cancelled",
+            finishedAt: input.now,
+            error: null,
+            updatedAt: input.now,
+          })
+          .where(and(eq(agentWakeupRequests.id, input.run.wakeupRequestId), eq(agentWakeupRequests.companyId, input.run.companyId)));
+      }
+
+      await tx
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: input.now,
+        })
+        .where(
+          and(
+            eq(issues.id, input.sourceIssue.id),
+            eq(issues.companyId, input.run.companyId),
+            eq(issues.executionRunId, input.run.id),
+          ),
+        );
+
+      return updatedRun;
+    });
+    if (!finalizedRun) return { kind: "skipped" as const };
+
+    if (input.existingEvaluation && !isTerminalIssueStatus(input.existingEvaluation.status)) {
+      await issuesSvc.update(input.existingEvaluation.id, { status: "done" });
+      await issuesSvc.addComment(input.existingEvaluation.id, [
+        "Orphaned run terminated.",
+        "",
+        `- Source issue: ${input.sourceIssue.identifier ?? input.sourceIssue.id} is \`${input.sourceIssue.status}\`.`,
+        `- Run: \`${input.run.id}\``,
+        `- Cleanup outcome: ${cleanup.outcome}`,
+        "- No further silence alerts will be raised for this run.",
+      ].join("\n"), { runId: input.run.id });
+    }
+
+    const [decision] = await db
+      .insert(heartbeatRunWatchdogDecisions)
+      .values({
+        companyId: input.run.companyId,
+        runId: input.run.id,
+        evaluationIssueId: input.existingEvaluation?.id ?? null,
+        decision: "dismissed_false_positive",
+        reason,
+        createdByRunId: input.run.id,
+      })
+      .returning();
+
+    await appendRecoveryRunEvent(finalizedRun, {
+      level: cleanup.outcome === "failed" ? "warn" : "info",
+      message: "Orphaned active run terminated because source issue is already terminal",
+      payload: resultJson.orphanedRunTerminated,
+    });
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_orphan_terminated",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        sourceIssueId: input.sourceIssue.id,
+        sourceIssueIdentifier: input.sourceIssue.identifier,
+        sourceIssueStatus: input.sourceIssue.status,
+        existingEvaluationIssueId: input.existingEvaluation?.id ?? null,
+        watchdogDecisionId: decision.id,
+        cleanup,
+        silenceAgeMs: input.silenceAgeMs,
+      },
+    });
+    await finalizeAgentAfterSourceResolvedRun(finalizedRun, finalRunStatus);
+    return { kind: "terminated" as const, evaluationIssueId: input.existingEvaluation?.id ?? null };
+  }
+
   async function resolveStaleRunOwnerAgentId(input: {
     run: typeof heartbeatRuns.$inferSelect;
     runningAgent: typeof agents.$inferSelect;
@@ -1490,6 +1616,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           now: input.now,
         });
       }
+      // Source issue is terminal but we have no same-run evidence that this run drove the resolution
+      // (e.g. another actor closed the issue, or the run never durably attributed its work). The
+      // active run is therefore orphaned — keeping it "running" loops the silence scan forever and
+      // produced 34 duplicate alerts in the ING-526 incident. Terminate the process and finalize
+      // the run instead of escalating yet another review issue.
+      return terminateOrphanedRunForTerminalSource({
+        run: input.run,
+        runningAgent,
+        sourceIssue,
+        existingEvaluation: existing,
+        silenceStartedAt,
+        silenceAgeMs: silenceAgeMsForRun(input.run, input.now),
+        now: input.now,
+      });
     }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
@@ -1635,6 +1775,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       existing: 0,
       escalated: 0,
       folded: 0,
+      terminated: 0,
       snoozed: 0,
       skipped: 0,
       evaluationIssueIds: [] as string[],
@@ -1650,6 +1791,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       else if (outcome.kind === "existing") result.existing += 1;
       else if (outcome.kind === "escalated") result.escalated += 1;
       else if (outcome.kind === "folded") result.folded += 1;
+      else if (outcome.kind === "terminated") result.terminated += 1;
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {
         result.evaluationIssueIds.push(outcome.evaluationIssueId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery service includes a run silence detector that escalates "Review silent active run" issues when a heartbeat run goes quiet
> - In the ING-526 incident the detector escalated 34 duplicate review issues for one stale run because the OS process stayed alive after the source issue was already `done`
> - The existing source-resolved fold only fires when the run itself produced durable terminal evidence — if another actor closed the source issue, the orphan kept generating alerts hourly forever
> - This PR adds an orphan-termination path: when the source issue is terminal but no same-run evidence exists, we cleanup the process, finalize the run, close any open silence-review issue, and log the suppression instead of escalating
> - The benefit is that stale orphan processes no longer create unbounded duplicate alerts, and the suppression/termination is auditable via `heartbeat.output_stale_orphan_terminated` activity and `dismissed_false_positive` watchdog decisions

## What Changed

- Added `terminateOrphanedRunForTerminalSource` in `server/src/services/recovery/service.ts`. When `createOrUpdateStaleRunEvaluation` sees a terminal source issue with no same-run terminal evidence, it cleans up the orphan process, finalizes the run (`succeeded`/`cancelled`), nulls the source issue's `executionRunId`, closes any open silence-review issue with an explanatory comment, inserts a `dismissed_false_positive` watchdog decision, and emits `heartbeat.output_stale_orphan_terminated` activity plus a recovery run event.
- Added a `terminated` counter to `scanSilentActiveRuns` so the new outcome is observable in periodic-recovery logs.
- Replaced the previous "still escalates terminal source issues without same-run terminal evidence" test with three new tests covering: (a) orphan termination on terminal source issues, (b) duplicate-alert loop suppression across multiple hourly ticks (the ING-526 regression), and (c) closing any preexisting silence-review issue when the orphan is terminated. Updated the "another actor marks source done" test to match the new behavior.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` → 15/15 pass, including the three new ING-563 tests.
- Manual reasoning: the regression test runs the scan five times across simulated hourly heartbeats and asserts only the first scan terminates the run; subsequent scans see no `running` candidates and create zero review issues.

## Risks

- Low–medium. The legitimate "source still open" path is unchanged — `findOpenStaleRunEvaluation` and the suspicion/critical escalation paths still fire when the source is `in_progress`. The new path is gated on `isTerminalIssueStatus(sourceIssue.status)`.
- Behavioral shift: previously a terminal source issue closed by another actor would surface a review issue; now the orphan is silently terminated. This is the explicitly requested ING-563 behavior because the prior path produced unbounded duplicates. Auditability is preserved via the new activity event and watchdog decision.
- No schema changes; the new `terminated` counter is additive on the scan result.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), Paperclip CTO heartbeat. Extended thinking via Claude Code, tool use for repo navigation and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only)
- [x] I have updated relevant documentation to reflect my changes (none required; behavior is captured in tests)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge