### PR TITLE
feat(adapter): add getConfigSchema to hermes_local adapter

### DIFF
--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -131,6 +131,7 @@ import {
   listSkills as hermesListSkills,
   syncSkills as hermesSyncSkills,
   detectModel as detectModelFromHermes,
+  getConfigSchema as getHermesConfigSchema,
 } from "hermes-paperclip-adapter/server";
 import {
   agentConfigurationDoc as hermesAgentConfigurationDoc,
@@ -495,6 +496,7 @@ const hermesLocalAdapter: ServerAdapterModule = {
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: hermesAgentConfigurationDoc,
   detectModel: () => detectModelFromHermes(),
+  getConfigSchema: getHermesConfigSchema,
 };
 
 const adaptersByType = new Map<string, ServerAdapterModule>();


### PR DESCRIPTION
## Summary

Wire up `getConfigSchema` from the `hermes-paperclip-adapter/server` module to the `hermesLocalAdapter` definition in the adapter registry.

This enables the hermes_local adapter to provide its configuration schema to the Paperclip UI, allowing dynamic configuration forms for provider/model selection.

## Changes

- Import `getConfigSchema as getHermesConfigSchema` from `hermes-paperclip-adapter/server`
- Add `getConfigSchema: getHermesConfigSchema` to the `hermesLocalAdapter` module definition

## Testing

- Type-safe import — no runtime behavior change
- Verified that the export exists in the hermes-paperclip-adapter package