### PR TITLE
feat/sag 2699 loopback api url

### DIFF
--- a/cli/src/__tests__/http.test.ts
+++ b/cli/src/__tests__/http.test.ts
@@ -82,6 +82,33 @@ describe("PaperclipApiClient", () => {
     );
   });
 
+  it("falls back to localhost when the configured host is unreachable", async () => {
+    const fetchMock = vi.fn((input: unknown) => {
+      const url = String(input);
+      if (url.includes("localhost")) {
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      }
+      return Promise.reject(new TypeError("fetch failed"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PaperclipApiClient({ apiBase: "http://remote-host.example:3100" });
+    const result = await client.get<{ ok: boolean }>("/api/health");
+
+    expect(result).toMatchObject({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("remote-host.example");
+    expect(String(fetchMock.mock.calls[1][0])).toContain("localhost");
+  });
+
+  it("does not double-fetch when the configured host is already loopback", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new PaperclipApiClient({ apiBase: "http://localhost:3100" });
+    await expect(client.get("/api/health")).rejects.toBeInstanceOf(ApiConnectionError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("retries once after interactive auth recovery", async () => {
     const fetchMock = vi
       .fn()

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -55,12 +55,14 @@ export class PaperclipApiClient {
   apiKey?: string;
   readonly runId?: string;
   readonly recoverAuth?: (input: RecoverAuthInput) => Promise<string | null>;
+  readonly loopbackFallbackBase?: string;
 
   constructor(opts: ApiClientOptions) {
     this.apiBase = opts.apiBase.replace(/\/+$/, "");
     this.apiKey = opts.apiKey?.trim() || undefined;
     this.runId = opts.runId?.trim() || undefined;
     this.recoverAuth = opts.recoverAuth;
+    this.loopbackFallbackBase = computeLoopbackFallbackBase(this.apiBase);
   }
 
   get<T>(path: string, opts?: RequestOptions): Promise<T | null> {
@@ -101,8 +103,10 @@ export class PaperclipApiClient {
     init: RequestInit,
     opts?: RequestOptions,
     hasRetriedAuth = false,
+    usedLoopbackFallback = false,
   ): Promise<T | null> {
-    const url = buildUrl(this.apiBase, path);
+    const base = usedLoopbackFallback && this.loopbackFallbackBase ? this.loopbackFallbackBase : this.apiBase;
+    const url = buildUrl(base, path);
     const method = String(init.method ?? "GET").toUpperCase();
 
     const headers: Record<string, string> = {
@@ -129,6 +133,9 @@ export class PaperclipApiClient {
         headers,
       });
     } catch (error) {
+      if (this.loopbackFallbackBase && !usedLoopbackFallback) {
+        return this.request<T>(path, init, opts, hasRetriedAuth, true);
+      }
       throw new ApiConnectionError({
         apiBase: this.apiBase,
         path,
@@ -246,6 +253,21 @@ function formatConnectionCause(error: unknown): string | undefined {
   }
   const message = String(error).trim();
   return message || undefined;
+}
+
+function computeLoopbackFallbackBase(apiBase: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(apiBase);
+  } catch {
+    return undefined;
+  }
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1") {
+    return undefined; // already loopback; nothing to fall back to
+  }
+  parsed.hostname = "localhost";
+  return parsed.toString().replace(/\/+$/, "");
 }
 
 function toStringRecord(headers: HeadersInit | undefined): Record<string, string> {

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -21,6 +21,7 @@ import {
 import { createSshCommandManagedRuntimeRunner, parseSshRemoteExecutionSpec, runSshCommand, shellQuote } from "./ssh.js";
 import {
   ensureCommandResolvable,
+  preferLoopbackApiUrl,
   resolveCommandForLogs,
   runChildProcess,
   type RunProcessResult,
@@ -1088,7 +1089,7 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
   const hostApiUrl =
     input.hostApiUrl?.trim() ||
     process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ||
-    process.env.PAPERCLIP_API_URL?.trim() ||
+    preferLoopbackApiUrl(process.env.PAPERCLIP_API_URL?.trim()) ||
     resolveDefaultPaperclipApiUrl();
   const shellCommand = adapterExecutionTargetShellCommand(target);
   const runner = adapterExecutionTargetCommandRunner(target);

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -928,6 +928,31 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
+/**
+ * Returns a loopback-preferring API URL for co-located agents/runners.
+ * Co-located callers share the host, so loopback is reachable and fastest; a
+ * non-loopback configured host (e.g. a Tailscale MagicDNS name) is only
+ * meaningful to off-box callers and is unreachable from inside the sandbox.
+ * The port is preserved; only the host is rewritten. Returns undefined for
+ * empty input so it composes in `??` chains.
+ */
+export function preferLoopbackApiUrl(rawUrl: string | undefined): string | undefined {
+  const value = rawUrl?.trim();
+  if (!value) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return value; // not a parseable URL; leave untouched
+  }
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const isLoopback =
+    host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1";
+  if (isLoopback) return value;
+  parsed.hostname = "localhost";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
 export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
@@ -945,7 +970,7 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
   const apiUrl =
     process.env.PAPERCLIP_RUNTIME_API_URL ??
-    process.env.PAPERCLIP_API_URL ??
+    preferLoopbackApiUrl(process.env.PAPERCLIP_API_URL) ??
     `http://${runtimeHost}:${runtimePort}`;
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -63,6 +63,17 @@ describe("buildPaperclipEnv", () => {
     expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3101");
   });
 
+  it("rewrites a non-loopback PAPERCLIP_API_URL to localhost for co-located agents", () => {
+    delete process.env.PAPERCLIP_RUNTIME_API_URL;
+    process.env.PAPERCLIP_API_URL = "http://gus-pinsoneault-framework.tail302fee.ts.net:3100";
+    delete process.env.PAPERCLIP_LISTEN_HOST;
+    delete process.env.PAPERCLIP_LISTEN_PORT;
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:3100");
+  });
+
   it("formats IPv6 hosts safely in fallback URL generation", () => {
     delete process.env.PAPERCLIP_RUNTIME_API_URL;
     delete process.env.PAPERCLIP_API_URL;


### PR DESCRIPTION
- **feat(SAG-2699): loopback-normalize PAPERCLIP_API_URL for co-located agents**
- **fix(opencode-local): replace stale gpt-5.1-codex-mini with ollama/qwen3:30b-a3b in cheap modelProfile**
- **SAG-2867: exempt in_progress issues with active routine liveness path from recovery scanner**
- **feat(skills): expose lastInvocationAt in Skills API (TRA-211)**
- **feat: add skills:manage permission scope (TRA-216)**
