### PR TITLE
revert(ci): remove dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      # Bundle all patch/minor updates of the same dependency type into one
-      # weekly PR. Prevents partial bumps of sibling packages that share
-      # peer dependencies (e.g. lexical + @lexical/*), which otherwise
-      # install two copies of the core package and break type-checking.
-      # Majors stay as individual PRs (and are ignored below anyway).
-      production-dependencies:
-        dependency-type: "production"
-        update-types: ["patch", "minor"]
-      development-dependencies:
-        dependency-type: "development"
-        update-types: ["patch", "minor"]
     ignore:
       # Ignore major version bumps — review those manually
       - dependency-name: "*"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so its automation and CI surfaces need to stay reliable enough for agent-driven maintenance work.
> - Dependabot configuration is part of that maintenance path because it determines how dependency updates reach the repo and CI.
> - PR #7483 changed `.github/dependabot.yml` to group all npm patch/minor updates by dependency type.
> - That immediately produced a 26-package grouped PR that was difficult to merge and contradicted the board's decision to return to one-PR-per-bump.
> - This pull request reverts only the grouping behavior while preserving the rest of the Dependabot schedule, labels, limits, and ignore rules.
> - The benefit is a narrower, more reviewable Dependabot flow that restores the previous operational behavior without changing unrelated CI settings.

## What Changed

- Removed the npm `groups:` block from `.github/dependabot.yml`.
- Left the existing weekly schedule, labels, open PR limit, and major-version ignore rules unchanged.
- Isolated the revert onto a clean branch containing only commit `446453516c` so this PR does not include unrelated local CI work.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `git diff --check origin/master..PAPA-522-revert-dependabot-grouping`
- Inspect the PR diff and confirm only `.github/dependabot.yml` changed.

## Risks

- Low risk. This only removes the grouping stanza and restores previous Dependabot behavior.
- Operationally, this returns to a higher number of smaller Dependabot PRs, which is the intended tradeoff for easier mergeability and triage.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via the local `codex_local` Paperclip adapter, GPT-5-based coding agent backend with tool use and shell execution enabled. The exact backend model ID/context window is not exposed by this adapter run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
