### PR TITLE
chore(github): add YAML issue forms for bug, feature, and adapter requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter_request.yml
+++ b/.github/ISSUE_TEMPLATE/adapter_request.yml
@@ -1,0 +1,42 @@
+name: New agent adapter
+description: Request or propose support for a new AI agent or model provider
+labels: [adapter]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        New agent adapters are welcome without prior discussion. If you plan to implement, prefer extending Paperclip via the [plugin system](https://github.com/paperclipai/paperclip/blob/master/doc/plugins/PLUGIN_SPEC.md) when possible.
+  - type: input
+    id: agent
+    attributes:
+      label: Agent or provider
+      description: Name of the agent, model, or CLI tool.
+      placeholder: e.g. Gemini CLI, LM Studio, Mistral
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this adapter is useful
+      description: What use cases does this unlock? Who would benefit?
+    validations:
+      required: true
+  - type: textarea
+    id: how-invoked
+    attributes:
+      label: How the agent is invoked
+      description: CLI command, API endpoint, SDK — whatever is relevant. Link docs if available.
+    validations:
+      required: true
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Are you willing to implement it?
+      options:
+        - label: Yes, I plan to open a PR
+        - label: No, requesting for someone else to pick up
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, examples from existing adapters, configuration quirks, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections below so we can reproduce and triage quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps a maintainer can follow to reproduce the bug.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: input
+    id: paperclip-version
+    attributes:
+      label: Paperclip version or commit
+      description: Output of `paperclipai --version` or the commit SHA you are running.
+      placeholder: e.g. 0.42.0 or 78dc3625ac
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment mode
+      options:
+        - Local dev (pnpm dev)
+        - Docker
+        - Self-hosted server
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`.
+      placeholder: e.g. v20.18.0
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 14.5 (Apple Silicon), Ubuntu 22.04
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste error messages, stack traces, or API responses. Will be rendered as a code block.
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord (#dev)
+    url: https://discord.gg/paperclipai
+    about: Design discussions, questions, and feature coordination before opening a PR
+  - name: Roadmap
+    url: https://github.com/paperclipai/paperclip/blob/master/ROADMAP.md
+    about: Check the roadmap before requesting a feature

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose a new capability or improvement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature work on core Paperclip is coordinated against `ROADMAP.md` and Discord `#dev`. Please skim those before filing — see [CONTRIBUTING.md](https://github.com/paperclipai/paperclip/blob/master/CONTRIBUTING.md) for the full guidance.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What are you trying to do that is currently difficult or impossible?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you'd like. How should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you ruled them out.
+  - type: textarea
+    id: roadmap
+    attributes:
+      label: Roadmap alignment
+      description: Does this relate to anything in `ROADMAP.md`? Link the relevant section if so.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, examples from other tools, related issues, etc.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Most of the inbound feedback loop lives in GitHub Issues: bugs, feature ideas, and new-adapter requests
> - Today the "New issue" page is a blank textarea, which means reports arrive without a Paperclip version, without repro steps, and without a clear separation between adapter requests and feature requests
> - That makes triage slow and routes a lot of low-information issues back to the requester for follow-up questions before any work can start
> - This pull request adds `.github/ISSUE_TEMPLATE/` with three YAML issue forms — bug, feature, adapter — plus a `config.yml` that disables blank issues and points contributors at Discord `#dev` and `ROADMAP.md`
> - The benefit is that new issues come in with the fields a maintainer needs to triage on the first read, and feature requests are nudged toward the roadmap/Discord coordination path before they turn into uncoordinated PRs

## What Changed

- Added `.github/ISSUE_TEMPLATE/config.yml` — sets `blank_issues_enabled: false` and adds contact links for Discord `#dev` and the roadmap.
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` — required fields: what happened, expected behavior, repro steps, Paperclip version/commit, and a deployment-mode dropdown. Optional: Node version, OS, logs, additional context.
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` — required fields: problem/motivation, proposed solution. Optional: alternatives, ROADMAP.md alignment, additional context.
- Added `.github/ISSUE_TEMPLATE/adapter_request.yml` — required fields: agent/provider name, why useful, how invoked. Optional: willing-to-implement checkboxes, additional context.

Field structure and labels are lifted from @amitdhanda48's earlier markdown-template proposal (#4260); this PR ports those four files to GitHub's YAML issue-form schema so required fields are enforced at submission time. The bundled `CONTRIBUTING.md` rewrite from that proposal is intentionally out of scope and left for a separate decision.

## Verification

- `node -e "require('js-yaml').load(require('fs').readFileSync(f,'utf8'))"` against each of the four YAML files — all parse.
- Diff against `master` is `.github/ISSUE_TEMPLATE/` only: `git diff --stat master...HEAD` shows 4 files, +162 lines, 0 deletions.
- Reviewer step: after merge, visit the repo's "New issue" page on GitHub and confirm the three forms render in the chooser, blank issues are disabled, and the Discord/roadmap contact links appear.

## Risks

- Low risk. Files are GitHub-config only — they have no runtime effect on the server, UI, CLI, or any package. The only behavioral change is on github.com's "New issue" page.
- If a YAML form has a schema mistake that `js-yaml` accepts but GitHub's form renderer rejects, GitHub silently falls back to a blank issue for that template. The mitigation is the post-merge render check above.

## Model Used

- Claude (Anthropic) — `claude-opus-4-7`, extended-thinking + tool use, running inside the Paperclip Claude Code harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (n/a — no code paths exercised by the test suite; YAML parse-check run instead)
- [ ] I have added or updated tests where applicable (n/a — repo has no test coverage for `.github/` config)
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — only the GitHub.com "New issue" page is affected; render check happens post-merge on github.com)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge