### PR TITLE
fix: disk monitor + embedded postgres supervisor (Mac-ENOSPC recovery)

### DIFF
--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -114,7 +114,7 @@ function monthKey(date: Date): string {
  * - Monthly tier: keep the NEWEST backup per calendar month for `monthlyMonths` months
  * - Everything else is deleted
  */
-function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, filenamePrefix: string): number {
+export function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, filenamePrefix: string): number {
   if (!existsSync(backupDir)) return 0;
 
   const now = Date.now();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,7 @@ export {
   runDatabaseBackup,
   runDatabaseRestore,
   formatDatabaseBackupResult,
+  pruneOldBackups,
   type BackupRetentionPolicy,
   type RunDatabaseBackupOptions,
   type RunDatabaseBackupResult,

--- a/packages/shared/src/disk-monitor.test.ts
+++ b/packages/shared/src/disk-monitor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { ConsecutiveSkipCounter, evaluateBackupDiskPressure } from "./disk-monitor.js";
+
+const ONE_GIB = 1024 * 1024 * 1024;
+
+function fakeStatfs(freeGiB: number) {
+  return async () => ({ bsize: 4096, bavail: Math.round((freeGiB * ONE_GIB) / 4096) });
+}
+
+describe("evaluateBackupDiskPressure", () => {
+  it("returns no pressure when free space is above both thresholds", async () => {
+    const result = await evaluateBackupDiskPressure({
+      targetPath: "/tmp",
+      minFreeGiB: 2,
+      aggressivePruneGiB: 5,
+      statfsImpl: fakeStatfs(10),
+    });
+    expect(result.skip).toBe(false);
+    expect(result.aggressivePrune).toBe(false);
+    expect(result.freeGiB).toBeCloseTo(10, 1);
+  });
+
+  it("flags aggressivePrune when between aggressive and min thresholds", async () => {
+    const result = await evaluateBackupDiskPressure({
+      targetPath: "/tmp",
+      minFreeGiB: 2,
+      aggressivePruneGiB: 5,
+      statfsImpl: fakeStatfs(3),
+    });
+    expect(result.skip).toBe(false);
+    expect(result.aggressivePrune).toBe(true);
+  });
+
+  it("requests skip when below the minimum free threshold", async () => {
+    const result = await evaluateBackupDiskPressure({
+      targetPath: "/tmp",
+      minFreeGiB: 2,
+      aggressivePruneGiB: 5,
+      statfsImpl: fakeStatfs(1.5),
+    });
+    expect(result.skip).toBe(true);
+    expect(result.aggressivePrune).toBe(true);
+    expect(result.freeGiB).toBeCloseTo(1.5, 1);
+  });
+
+  it("reads env defaults when thresholds are omitted", async () => {
+    const previousMin = process.env.PAPERCLIP_BACKUP_MIN_FREE_GB;
+    const previousAggressive = process.env.PAPERCLIP_BACKUP_AGGRESSIVE_PRUNE_GB;
+    process.env.PAPERCLIP_BACKUP_MIN_FREE_GB = "1";
+    process.env.PAPERCLIP_BACKUP_AGGRESSIVE_PRUNE_GB = "4";
+    try {
+      const result = await evaluateBackupDiskPressure({
+        targetPath: "/tmp",
+        statfsImpl: fakeStatfs(2),
+      });
+      expect(result.minFreeGiB).toBe(1);
+      expect(result.aggressivePruneGiB).toBe(4);
+      expect(result.skip).toBe(false);
+      expect(result.aggressivePrune).toBe(true);
+    } finally {
+      if (previousMin === undefined) {
+        delete process.env.PAPERCLIP_BACKUP_MIN_FREE_GB;
+      } else {
+        process.env.PAPERCLIP_BACKUP_MIN_FREE_GB = previousMin;
+      }
+      if (previousAggressive === undefined) {
+        delete process.env.PAPERCLIP_BACKUP_AGGRESSIVE_PRUNE_GB;
+      } else {
+        process.env.PAPERCLIP_BACKUP_AGGRESSIVE_PRUNE_GB = previousAggressive;
+      }
+    }
+  });
+
+  it("falls back to coded defaults when env values are missing or invalid", async () => {
+    const previousMin = process.env.PAPERCLIP_BACKUP_MIN_FREE_GB;
+    process.env.PAPERCLIP_BACKUP_MIN_FREE_GB = "not-a-number";
+    try {
+      const result = await evaluateBackupDiskPressure({
+        targetPath: "/tmp",
+        statfsImpl: fakeStatfs(10),
+      });
+      expect(result.minFreeGiB).toBe(2);
+      expect(result.aggressivePruneGiB).toBe(5);
+    } finally {
+      if (previousMin === undefined) {
+        delete process.env.PAPERCLIP_BACKUP_MIN_FREE_GB;
+      } else {
+        process.env.PAPERCLIP_BACKUP_MIN_FREE_GB = previousMin;
+      }
+    }
+  });
+});
+
+describe("ConsecutiveSkipCounter", () => {
+  it("emits pause log exactly once on the third consecutive skip", () => {
+    const counter = new ConsecutiveSkipCounter();
+    const r1 = counter.recordSkip();
+    const r2 = counter.recordSkip();
+    const r3 = counter.recordSkip();
+    const r4 = counter.recordSkip();
+    expect(r1.shouldEmitPauseLog).toBe(false);
+    expect(r2.shouldEmitPauseLog).toBe(false);
+    expect(r3.shouldEmitPauseLog).toBe(true);
+    expect(r4.shouldEmitPauseLog).toBe(false);
+    expect(r4.count).toBe(4);
+  });
+
+  it("resets the streak and rearms the pause log on success", () => {
+    const counter = new ConsecutiveSkipCounter();
+    counter.recordSkip();
+    counter.recordSkip();
+    counter.recordSkip();
+    counter.recordSuccess();
+    expect(counter.snapshot()).toEqual({ count: 0, pauseLogEmitted: false });
+    const next = counter.recordSkip();
+    expect(next.shouldEmitPauseLog).toBe(false);
+  });
+});

--- a/packages/shared/src/disk-monitor.ts
+++ b/packages/shared/src/disk-monitor.ts
@@ -1,0 +1,89 @@
+import { statfs } from "node:fs/promises";
+
+const BYTES_PER_GIB = 1024 * 1024 * 1024;
+
+const DEFAULT_MIN_FREE_GB = 2;
+const DEFAULT_AGGRESSIVE_PRUNE_GB = 5;
+const CONSECUTIVE_SKIPS_BEFORE_PAUSE = 3;
+
+export type DiskPressureResult = {
+  skip: boolean;
+  aggressivePrune: boolean;
+  freeGiB: number;
+  minFreeGiB: number;
+  aggressivePruneGiB: number;
+};
+
+export type EvaluateBackupDiskPressureOptions = {
+  targetPath: string;
+  minFreeGiB?: number;
+  aggressivePruneGiB?: number;
+  statfsImpl?: (path: string) => Promise<{ bsize: number | bigint; bavail: number | bigint }>;
+};
+
+function toNumber(value: number | bigint): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
+function readGiBEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export async function getFreeDiskSpaceGiB(
+  targetPath: string,
+  statfsImpl: EvaluateBackupDiskPressureOptions["statfsImpl"] = statfs,
+): Promise<number> {
+  const stats = await statfsImpl(targetPath);
+  const bsize = toNumber(stats.bsize);
+  const bavail = toNumber(stats.bavail);
+  const freeBytes = bsize * bavail;
+  return freeBytes / BYTES_PER_GIB;
+}
+
+export async function evaluateBackupDiskPressure(
+  opts: EvaluateBackupDiskPressureOptions,
+): Promise<DiskPressureResult> {
+  const minFreeGiB = opts.minFreeGiB ?? readGiBEnv("PAPERCLIP_BACKUP_MIN_FREE_GB", DEFAULT_MIN_FREE_GB);
+  const aggressivePruneGiB =
+    opts.aggressivePruneGiB ?? readGiBEnv("PAPERCLIP_BACKUP_AGGRESSIVE_PRUNE_GB", DEFAULT_AGGRESSIVE_PRUNE_GB);
+  const freeGiB = await getFreeDiskSpaceGiB(opts.targetPath, opts.statfsImpl);
+  const skip = freeGiB < minFreeGiB;
+  const aggressivePrune = freeGiB < aggressivePruneGiB;
+  return { skip, aggressivePrune, freeGiB, minFreeGiB, aggressivePruneGiB };
+}
+
+export type ConsecutiveSkipState = {
+  count: number;
+  pauseLogEmitted: boolean;
+};
+
+export type RecordSkipResult = {
+  count: number;
+  shouldEmitPauseLog: boolean;
+};
+
+export class ConsecutiveSkipCounter {
+  private state: ConsecutiveSkipState = { count: 0, pauseLogEmitted: false };
+
+  recordSkip(): RecordSkipResult {
+    this.state.count += 1;
+    const reachedThreshold = this.state.count >= CONSECUTIVE_SKIPS_BEFORE_PAUSE;
+    const shouldEmitPauseLog = reachedThreshold && !this.state.pauseLogEmitted;
+    if (shouldEmitPauseLog) {
+      this.state.pauseLogEmitted = true;
+    }
+    return { count: this.state.count, shouldEmitPauseLog };
+  }
+
+  recordSuccess(): void {
+    this.state = { count: 0, pauseLogEmitted: false };
+  }
+
+  snapshot(): ConsecutiveSkipState {
+    return { ...this.state };
+  }
+}

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -64,6 +64,70 @@ describe("GET /health", () => {
     });
   });
 
+  it("triggers the embedded postgres supervisor on the 503 path exactly once per request", async () => {
+    const db = {
+      execute: vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+    } as unknown as Db;
+    const supervisor = {
+      recoverIfUnhealthy: vi.fn().mockResolvedValue(undefined),
+      resetGaveUp: vi.fn(),
+      state: vi.fn().mockReturnValue("idle" as const),
+    };
+    const app = express();
+    app.use(
+      "/health",
+      healthRoutes(db, {
+        deploymentMode: "local_trusted",
+        deploymentExposure: "private",
+        authReady: true,
+        companyDeletionEnabled: true,
+        embeddedPostgresSupervisor: supervisor,
+      }),
+    );
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(503);
+    expect(supervisor.recoverIfUnhealthy).toHaveBeenCalledTimes(1);
+    expect(supervisor.recoverIfUnhealthy).toHaveBeenCalledWith("health");
+  });
+
+  it("exposes the supervisor reset endpoint when a supervisor is wired", async () => {
+    const supervisor = {
+      recoverIfUnhealthy: vi.fn().mockResolvedValue(undefined),
+      resetGaveUp: vi.fn(),
+      state: vi.fn().mockReturnValue("gave_up" as const),
+    };
+    const app = express();
+    app.use(
+      "/health",
+      healthRoutes(undefined, {
+        deploymentMode: "local_trusted",
+        deploymentExposure: "private",
+        authReady: true,
+        companyDeletionEnabled: true,
+        embeddedPostgresSupervisor: supervisor,
+      }),
+    );
+
+    const res = await request(app).post("/health/supervisor/reset");
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ status: "reset_requested" });
+    expect(supervisor.resetGaveUp).toHaveBeenCalledTimes(1);
+    expect(supervisor.resetGaveUp).toHaveBeenCalledWith("manual");
+  });
+
+  it("returns 404 from the supervisor reset endpoint when no supervisor is wired", async () => {
+    const app = express();
+    app.use("/health", healthRoutes(undefined));
+
+    const res = await request(app).post("/health/supervisor/reset");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "supervisor_unavailable" });
+  });
+
   it("redacts detailed metadata for anonymous requests in authenticated mode", async () => {
     const devServerStatus = await import("../dev-server-status.js");
     vi.spyOn(devServerStatus, "readPersistedDevServerStatus").mockReturnValue(undefined);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -137,6 +137,7 @@ export async function createApp(
       }): Promise<unknown>;
     };
     databaseBackupService?: InstanceDatabaseBackupService;
+    embeddedPostgresSupervisor?: import("./routes/health.js").HealthEmbeddedPostgresSupervisor;
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     allowedHostnames: string[];
@@ -206,6 +207,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
       companyDeletionEnabled: opts.companyDeletionEnabled,
+      embeddedPostgresSupervisor: opts.embeddedPostgresSupervisor,
     }),
   );
   api.use(openApiRoutes());

--- a/server/src/db/embedded-postgres-self-probe.test.ts
+++ b/server/src/db/embedded-postgres-self-probe.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
+import type { EmbeddedPostgresSupervisor } from "./embedded-postgres-supervisor.js";
+import { createEmbeddedPostgresSelfProbe } from "./embedded-postgres-self-probe.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn() };
+}
+
+function makeSupervisor(): EmbeddedPostgresSupervisor {
+  return {
+    recoverIfUnhealthy: vi.fn().mockResolvedValue(undefined),
+    resetGaveUp: vi.fn(),
+    state: vi.fn().mockReturnValue("idle"),
+    shutdown: vi.fn(),
+  };
+}
+
+describe("embedded postgres self-probe", () => {
+  it("does not trigger the supervisor when the health query succeeds", async () => {
+    const supervisor = makeSupervisor();
+    const probe = createEmbeddedPostgresSelfProbe({
+      db: {} as Db,
+      supervisor,
+      logger: makeLogger(),
+      runHealthQuery: async () => undefined,
+    });
+
+    await probe.runOnce();
+
+    expect(supervisor.recoverIfUnhealthy).not.toHaveBeenCalled();
+  });
+
+  it("triggers supervisor.recoverIfUnhealthy('probe') exactly once when the query throws", async () => {
+    const supervisor = makeSupervisor();
+    const logger = makeLogger();
+    const probe = createEmbeddedPostgresSelfProbe({
+      db: {} as Db,
+      supervisor,
+      logger,
+      runHealthQuery: async () => {
+        throw new Error("connect ECONNREFUSED");
+      },
+    });
+
+    await probe.runOnce();
+
+    expect(supervisor.recoverIfUnhealthy).toHaveBeenCalledTimes(1);
+    expect(supervisor.recoverIfUnhealthy).toHaveBeenCalledWith("probe");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "embedded_postgres_self_probe_failed",
+    );
+  });
+
+  it("swallows supervisor errors so the timer does not crash the process", async () => {
+    const supervisor: EmbeddedPostgresSupervisor = {
+      recoverIfUnhealthy: vi.fn().mockRejectedValue(new Error("supervisor blew up")),
+      resetGaveUp: vi.fn(),
+      state: vi.fn().mockReturnValue("idle"),
+      shutdown: vi.fn(),
+    };
+    const logger = makeLogger();
+    const probe = createEmbeddedPostgresSelfProbe({
+      db: {} as Db,
+      supervisor,
+      logger,
+      runHealthQuery: async () => {
+        throw new Error("nope");
+      },
+    });
+
+    await expect(probe.runOnce()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "embedded postgres supervisor probe rejected",
+    );
+  });
+
+  it("start schedules the probe and stop clears it without leaking the handle", async () => {
+    vi.useFakeTimers();
+    try {
+      const supervisor = makeSupervisor();
+      const runHealthQuery = vi.fn(async () => undefined);
+      const probe = createEmbeddedPostgresSelfProbe({
+        db: {} as Db,
+        supervisor,
+        logger: makeLogger(),
+        intervalMs: 30_000,
+        runHealthQuery,
+      });
+
+      probe.start();
+      probe.start(); // double-start is a no-op
+      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(runHealthQuery).toHaveBeenCalledTimes(2);
+
+      probe.stop();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(runHealthQuery).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/src/db/embedded-postgres-self-probe.ts
+++ b/server/src/db/embedded-postgres-self-probe.ts
@@ -1,0 +1,67 @@
+import { sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import type { EmbeddedPostgresSupervisor } from "./embedded-postgres-supervisor.js";
+
+export const SELF_PROBE_INTERVAL_MS = 30_000;
+
+export type EmbeddedPostgresSelfProbeLogger = {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+};
+
+export type EmbeddedPostgresSelfProbeDeps = {
+  db: Db;
+  supervisor: EmbeddedPostgresSupervisor;
+  logger: EmbeddedPostgresSelfProbeLogger;
+  intervalMs?: number;
+  runHealthQuery?: (db: Db) => Promise<void>;
+};
+
+export type EmbeddedPostgresSelfProbe = {
+  runOnce(): Promise<void>;
+  start(): void;
+  stop(): void;
+};
+
+async function defaultRunHealthQuery(db: Db): Promise<void> {
+  await db.execute(sql`SELECT 1`);
+}
+
+export function createEmbeddedPostgresSelfProbe(
+  deps: EmbeddedPostgresSelfProbeDeps,
+): EmbeddedPostgresSelfProbe {
+  const runHealthQuery = deps.runHealthQuery ?? defaultRunHealthQuery;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function runOnce(): Promise<void> {
+    try {
+      await runHealthQuery(deps.db);
+      return;
+    } catch (err) {
+      deps.logger.warn({ err }, "embedded_postgres_self_probe_failed");
+      try {
+        await deps.supervisor.recoverIfUnhealthy("probe");
+      } catch (rerr) {
+        deps.logger.warn({ err: rerr }, "embedded postgres supervisor probe rejected");
+      }
+    }
+  }
+
+  return {
+    runOnce,
+    start() {
+      if (timer) return;
+      const intervalMs = deps.intervalMs ?? SELF_PROBE_INTERVAL_MS;
+      timer = setInterval(() => {
+        void runOnce();
+      }, intervalMs);
+      if (typeof timer.unref === "function") timer.unref();
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/server/src/db/embedded-postgres-supervisor.integration.test.ts
+++ b/server/src/db/embedded-postgres-supervisor.integration.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import {
+  createDb,
+  getEmbeddedPostgresTestSupport,
+  prepareEmbeddedPostgresNativeRuntime,
+} from "@paperclipai/db";
+import { createEmbeddedPostgresSupervisor } from "./embedded-postgres-supervisor.js";
+
+type EmbeddedPostgresInstance = {
+  initialise(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+};
+
+type EmbeddedPostgresCtor = new (opts: {
+  databaseDir: string;
+  user: string;
+  password: string;
+  port: number;
+  persistent: boolean;
+  initdbFlags?: string[];
+  onLog?: (message: unknown) => void;
+  onError?: (message: unknown) => void;
+}) => EmbeddedPostgresInstance;
+
+const support = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = support.supported ? describe : describe.skip;
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close(() => reject(new Error("failed to allocate port")));
+        return;
+      }
+      const port = addr.port;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+describeEmbeddedPostgres("embedded postgres supervisor [integration]", () => {
+  let dataDir = "";
+  let port = 0;
+  let embedded: EmbeddedPostgresInstance | null = null;
+  let conn = "";
+
+  beforeAll(async () => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "tra244-supervisor-"));
+    port = await freePort();
+    await prepareEmbeddedPostgresNativeRuntime();
+    const mod = await import("embedded-postgres");
+    const Ctor = mod.default as EmbeddedPostgresCtor;
+    embedded = new Ctor({
+      databaseDir: dataDir,
+      user: "paperclip",
+      password: "paperclip",
+      port,
+      persistent: true,
+      initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+      onLog: () => {},
+      onError: () => {},
+    });
+    await embedded.initialise();
+    await embedded.start();
+    conn = `postgres://paperclip:paperclip@127.0.0.1:${port}/postgres`;
+  }, 120_000);
+
+  afterAll(async () => {
+    if (embedded) await embedded.stop().catch(() => {});
+    if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("recovers from a simulated postgres crash within the budget", async () => {
+    if (!embedded) throw new Error("embedded postgres not initialized");
+
+    const preflight = createDb(conn);
+    await preflight.execute(sql`SELECT 1`);
+
+    await embedded.stop();
+
+    let postFailed = false;
+    try {
+      const probe = createDb(conn);
+      await probe.execute(sql`SELECT 1`);
+    } catch {
+      postFailed = true;
+    }
+    expect(postFailed).toBe(true);
+
+    const supervisor = createEmbeddedPostgresSupervisor({
+      embeddedPostgres: embedded,
+      dataDir,
+      port,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+
+    await supervisor.recoverIfUnhealthy("health");
+
+    const recovered = createDb(conn);
+    const rows = (await recovered.execute(sql`SELECT 1 AS one`)) as Array<{ one: number }>;
+    expect(Number(rows[0]?.one)).toBe(1);
+  }, 180_000);
+});

--- a/server/src/db/embedded-postgres-supervisor.test.ts
+++ b/server/src/db/embedded-postgres-supervisor.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createEmbeddedPostgresSupervisor,
+  SUPERVISOR_THROTTLE_MS,
+  SUPERVISOR_AUTO_RESET_MS,
+  type EmbeddedPostgresSupervisorDeps,
+  type SupervisorTimer,
+} from "./embedded-postgres-supervisor.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+type ScheduledTask = { delayMs: number; fn: () => void; cleared: boolean };
+
+function makeManualTimer(): SupervisorTimer & { advance(ms: number): void; tasks: ScheduledTask[]; nowOffset: number } {
+  const tasks: ScheduledTask[] = [];
+  return {
+    nowOffset: 0,
+    tasks,
+    schedule(delayMs, fn) {
+      const task: ScheduledTask = { delayMs, fn, cleared: false };
+      tasks.push(task);
+      const handle = { cleared: false, _task: task } as unknown as ScheduledTask & { cleared: boolean };
+      Object.defineProperty(handle, "cleared", {
+        get() {
+          return task.cleared;
+        },
+        set(v: boolean) {
+          task.cleared = v;
+        },
+      });
+      return handle;
+    },
+    clear(handle) {
+      const t = (handle as unknown as { _task?: ScheduledTask })._task;
+      if (t) t.cleared = true;
+    },
+    advance(ms) {
+      this.nowOffset += ms;
+      const due = tasks.filter((t) => !t.cleared && t.delayMs <= ms);
+      for (const t of due) {
+        t.cleared = true;
+        t.fn();
+      }
+      for (const t of tasks) {
+        if (!t.cleared) t.delayMs -= ms;
+      }
+    },
+  };
+}
+
+function makeClock(start = 1_000_000) {
+  let value = start;
+  return {
+    now: () => value,
+    advance(ms: number) {
+      value += ms;
+    },
+  };
+}
+
+function baseDeps(
+  overrides: Partial<EmbeddedPostgresSupervisorDeps> = {},
+): EmbeddedPostgresSupervisorDeps & { logger: ReturnType<typeof makeLogger> } {
+  const logger = makeLogger();
+  const defaults: EmbeddedPostgresSupervisorDeps = {
+    embeddedPostgres: { start: async () => undefined, stop: async () => undefined },
+    dataDir: "/tmp/datadir",
+    port: 5432,
+    logger,
+    isProcessAlive: () => false,
+    readPidFile: () => null,
+    removePidFile: () => undefined,
+  };
+  return { ...defaults, ...overrides, logger };
+}
+
+describe("embedded postgres supervisor", () => {
+  it("restarts on first health trigger and logs attempt + success", async () => {
+    const start = vi.fn(async () => undefined);
+    const clock = makeClock();
+    const sv = createEmbeddedPostgresSupervisor(baseDeps({
+      embeddedPostgres: { start },
+      now: clock.now,
+      timer: makeManualTimer(),
+    }));
+
+    await sv.recoverIfUnhealthy("health");
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(sv.state()).toBe("idle");
+  });
+
+  it("respects the 30 s throttle between attempts", async () => {
+    const start = vi.fn(async () => undefined);
+    const clock = makeClock();
+    const deps = baseDeps({ embeddedPostgres: { start }, now: clock.now, timer: makeManualTimer() });
+    const sv = createEmbeddedPostgresSupervisor(deps);
+
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(SUPERVISOR_THROTTLE_MS - 1);
+    await sv.recoverIfUnhealthy("health");
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(deps.logger.warn.mock.calls.some((c) => String(c[1]).includes("postgres_restart_throttled"))).toBe(true);
+
+    clock.advance(2);
+    await sv.recoverIfUnhealthy("health");
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it("enters gave_up after three failed attempts in the 5-min window", async () => {
+    const start = vi.fn(async () => {
+      throw new Error("start failed");
+    });
+    const clock = makeClock();
+    const timer = makeManualTimer();
+    const deps = baseDeps({ embeddedPostgres: { start }, now: clock.now, timer });
+    const sv = createEmbeddedPostgresSupervisor(deps);
+
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(SUPERVISOR_THROTTLE_MS + 1);
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(45_000 + 1);
+    await sv.recoverIfUnhealthy("health");
+
+    expect(sv.state()).toBe("gave_up");
+    expect(deps.logger.error.mock.calls.some((c) => String(c[1]).includes("postgres_restart_giveup"))).toBe(true);
+
+    clock.advance(SUPERVISOR_THROTTLE_MS + 1);
+    await sv.recoverIfUnhealthy("health");
+    expect(start).toHaveBeenCalledTimes(3);
+  });
+
+  it("removes a stale postmaster.pid before starting when the recorded process is dead", async () => {
+    const removePidFile = vi.fn();
+    const start = vi.fn(async () => undefined);
+    const sv = createEmbeddedPostgresSupervisor(
+      baseDeps({
+        embeddedPostgres: { start },
+        readPidFile: () => "12345\n",
+        isProcessAlive: () => false,
+        removePidFile,
+        timer: makeManualTimer(),
+      }),
+    );
+
+    await sv.recoverIfUnhealthy("health");
+
+    expect(removePidFile).toHaveBeenCalled();
+    expect(start).toHaveBeenCalledTimes(1);
+    const callOrder = (removePidFile.mock.invocationCallOrder[0] ?? 0) < (start.mock.invocationCallOrder[0] ?? 0);
+    expect(callOrder).toBe(true);
+  });
+
+  it("calls stop before start when the recorded process is still alive", async () => {
+    const stop = vi.fn(async () => undefined);
+    const start = vi.fn(async () => undefined);
+    const sv = createEmbeddedPostgresSupervisor(
+      baseDeps({
+        embeddedPostgres: { start, stop },
+        readPidFile: () => "9999\n",
+        isProcessAlive: () => true,
+        timer: makeManualTimer(),
+      }),
+    );
+
+    await sv.recoverIfUnhealthy("health");
+
+    expect(stop).toHaveBeenCalledBefore(start);
+  });
+
+  it("auto-resets gave_up after the configured idle window", async () => {
+    const start = vi.fn(async () => {
+      throw new Error("nope");
+    });
+    const clock = makeClock();
+    const timer = makeManualTimer();
+    const deps = baseDeps({ embeddedPostgres: { start }, now: clock.now, timer });
+    const sv = createEmbeddedPostgresSupervisor(deps);
+
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(SUPERVISOR_THROTTLE_MS + 1);
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(45_000 + 1);
+    await sv.recoverIfUnhealthy("health");
+
+    expect(sv.state()).toBe("gave_up");
+    timer.advance(SUPERVISOR_AUTO_RESET_MS);
+    expect(sv.state()).toBe("idle");
+    expect(deps.logger.warn.mock.calls.some((c) => String(c[1]).includes("postgres_supervisor_giveup_reset"))).toBe(true);
+  });
+
+  it("manual resetGaveUp clears state and counters", async () => {
+    const start = vi.fn(async () => {
+      throw new Error("nope");
+    });
+    const clock = makeClock();
+    const timer = makeManualTimer();
+    const sv = createEmbeddedPostgresSupervisor(
+      baseDeps({ embeddedPostgres: { start }, now: clock.now, timer }),
+    );
+
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(SUPERVISOR_THROTTLE_MS + 1);
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(45_000 + 1);
+    await sv.recoverIfUnhealthy("health");
+    expect(sv.state()).toBe("gave_up");
+
+    sv.resetGaveUp("test");
+    expect(sv.state()).toBe("idle");
+
+    clock.advance(SUPERVISOR_THROTTLE_MS + 1);
+    start.mockImplementation((async () => undefined) as () => Promise<never>);
+    await sv.recoverIfUnhealthy("health");
+    expect(sv.state()).toBe("idle");
+  });
+
+  it("treats probe trigger like health for throttle accounting", async () => {
+    const start = vi.fn(async () => undefined);
+    const clock = makeClock();
+    const sv = createEmbeddedPostgresSupervisor(
+      baseDeps({ embeddedPostgres: { start }, now: clock.now, timer: makeManualTimer() }),
+    );
+
+    await sv.recoverIfUnhealthy("health");
+    clock.advance(SUPERVISOR_THROTTLE_MS - 1);
+    await sv.recoverIfUnhealthy("probe");
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/db/embedded-postgres-supervisor.ts
+++ b/server/src/db/embedded-postgres-supervisor.ts
@@ -1,0 +1,291 @@
+// Supervisor for the embedded-postgres lifecycle. Same code path on macOS
+// and Linux; the acute symptom we ship for is the macOS-ENOSPC class from
+// TRA-242 / TRA-244 (paperclipai/paperclip), but the throttle/window/backoff
+// guards apply to every embedded-postgres deployment.
+
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+
+export const SUPERVISOR_THROTTLE_MS = 30_000;
+export const SUPERVISOR_WINDOW_MS = 5 * 60_000;
+export const SUPERVISOR_MAX_ATTEMPTS_PER_WINDOW = 3;
+export const SUPERVISOR_BACKOFF_MS: ReadonlyArray<number> = [5_000, 15_000, 45_000];
+export const SUPERVISOR_AUTO_RESET_MS = 30 * 60_000;
+
+export type SupervisorTriggerReason = "health" | "probe" | "pool" | "manual";
+export type SupervisorState = "idle" | "attempting" | "gave_up";
+
+export type SupervisorLogger = {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+};
+
+export type SupervisorPostgresHandle = {
+  start(): Promise<void>;
+  stop?(): Promise<void>;
+};
+
+export type SupervisorClock = () => number;
+
+export type TimerHandle = { cleared: boolean };
+
+export type SupervisorTimer = {
+  schedule(delayMs: number, fn: () => void): TimerHandle;
+  clear(handle: TimerHandle): void;
+};
+
+const defaultTimer: SupervisorTimer = {
+  schedule(delayMs, fn) {
+    const t = setTimeout(fn, delayMs);
+    if (typeof t.unref === "function") t.unref();
+    const handle: TimerHandle & { _t: NodeJS.Timeout } = { cleared: false, _t: t };
+    return handle;
+  },
+  clear(handle) {
+    const t = (handle as TimerHandle & { _t?: NodeJS.Timeout })._t;
+    if (t) clearTimeout(t);
+    handle.cleared = true;
+  },
+};
+
+export type EmbeddedPostgresSupervisorDeps = {
+  embeddedPostgres: SupervisorPostgresHandle;
+  dataDir: string;
+  port: number;
+  logger: SupervisorLogger;
+  now?: SupervisorClock;
+  timer?: SupervisorTimer;
+  isProcessAlive?: (pid: number) => boolean;
+  readPidFile?: (path: string) => string | null;
+  removePidFile?: (path: string) => void;
+};
+
+export type EmbeddedPostgresSupervisor = {
+  recoverIfUnhealthy(reason: SupervisorTriggerReason): Promise<void>;
+  resetGaveUp(reason?: string): void;
+  state(): SupervisorState;
+  shutdown(): void;
+};
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultReadPidFile(path: string): string | null {
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function defaultRemovePidFile(path: string): void {
+  if (!existsSync(path)) return;
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    /* swallow */
+  }
+}
+
+function parsePid(contents: string | null): number | null {
+  if (contents === null) return null;
+  const firstLine = contents.split("\n")[0]?.trim() ?? "";
+  if (firstLine.length === 0) return null;
+  const pid = Number(firstLine);
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  return pid;
+}
+
+type Attempt = { startedAt: number; succeeded: boolean };
+
+export function createEmbeddedPostgresSupervisor(
+  deps: EmbeddedPostgresSupervisorDeps,
+): EmbeddedPostgresSupervisor {
+  const now = deps.now ?? Date.now;
+  const timer = deps.timer ?? defaultTimer;
+  const isProcessAlive = deps.isProcessAlive ?? defaultIsProcessAlive;
+  const readPidFile = deps.readPidFile ?? defaultReadPidFile;
+  const removePidFile = deps.removePidFile ?? defaultRemovePidFile;
+  const pidFilePath = resolvePath(deps.dataDir, "postmaster.pid");
+
+  let state: SupervisorState = "idle";
+  let attempts: Attempt[] = [];
+  let lastAttemptAt = 0;
+  let autoResetHandle: TimerHandle | null = null;
+  let inFlight = false;
+
+  function pruneWindow(nowMs: number): void {
+    const cutoff = nowMs - SUPERVISOR_WINDOW_MS;
+    attempts = attempts.filter((a) => a.startedAt >= cutoff);
+  }
+
+  function failedAttemptsInWindow(nowMs: number): number {
+    pruneWindow(nowMs);
+    return attempts.filter((a) => !a.succeeded).length;
+  }
+
+  function scheduleAutoReset(): void {
+    if (autoResetHandle && !autoResetHandle.cleared) timer.clear(autoResetHandle);
+    autoResetHandle = timer.schedule(SUPERVISOR_AUTO_RESET_MS, () => {
+      autoResetHandle = null;
+      if (state === "gave_up") {
+        deps.logger.warn(
+          { dataDir: deps.dataDir, port: deps.port },
+          "postgres_supervisor_giveup_reset",
+        );
+        state = "idle";
+        attempts = [];
+        lastAttemptAt = 0;
+      }
+    });
+  }
+
+  function clearAutoReset(): void {
+    if (autoResetHandle && !autoResetHandle.cleared) timer.clear(autoResetHandle);
+    autoResetHandle = null;
+  }
+
+  function getRunningPid(): number | null {
+    const pid = parsePid(readPidFile(pidFilePath));
+    if (pid === null) return null;
+    if (!isProcessAlive(pid)) return null;
+    return pid;
+  }
+
+  async function performRestart(reason: SupervisorTriggerReason, attemptIndex: number): Promise<void> {
+    const pid = getRunningPid();
+    deps.logger.info(
+      { reason, attempt: attemptIndex + 1, dataDir: deps.dataDir, port: deps.port, runningPid: pid },
+      "postgres_restart_attempt",
+    );
+
+    if (pid !== null) {
+      if (deps.embeddedPostgres.stop) {
+        try {
+          await deps.embeddedPostgres.stop();
+        } catch (err) {
+          deps.logger.warn(
+            { reason, attempt: attemptIndex + 1, err, dataDir: deps.dataDir },
+            "postgres_stop_failed_before_restart",
+          );
+        }
+      }
+    }
+
+    removePidFile(pidFilePath);
+    await deps.embeddedPostgres.start();
+  }
+
+  async function attemptRestart(reason: SupervisorTriggerReason): Promise<void> {
+    const nowMs = now();
+    const failedSoFar = failedAttemptsInWindow(nowMs);
+
+    if (failedSoFar >= SUPERVISOR_MAX_ATTEMPTS_PER_WINDOW) {
+      if (state !== "gave_up") {
+        state = "gave_up";
+        deps.logger.error(
+          {
+            reason,
+            failedAttempts: failedSoFar,
+            windowMs: SUPERVISOR_WINDOW_MS,
+            dataDir: deps.dataDir,
+            port: deps.port,
+          },
+          "postgres_restart_giveup",
+        );
+        scheduleAutoReset();
+      }
+      return;
+    }
+
+    const backoffMs = SUPERVISOR_BACKOFF_MS[Math.min(failedSoFar, SUPERVISOR_BACKOFF_MS.length - 1)] ?? 0;
+    const requiredGapMs = Math.max(SUPERVISOR_THROTTLE_MS, backoffMs);
+    if (lastAttemptAt !== 0 && nowMs - lastAttemptAt < requiredGapMs) {
+      deps.logger.warn(
+        {
+          reason,
+          sinceLastMs: nowMs - lastAttemptAt,
+          throttleMs: SUPERVISOR_THROTTLE_MS,
+          backoffMs,
+          requiredGapMs,
+        },
+        "postgres_restart_throttled",
+      );
+      return;
+    }
+
+    state = "attempting";
+    lastAttemptAt = now();
+    const attempt: Attempt = { startedAt: lastAttemptAt, succeeded: false };
+    attempts.push(attempt);
+
+    try {
+      await performRestart(reason, failedSoFar);
+      attempt.succeeded = true;
+      state = "idle";
+      deps.logger.info(
+        { reason, attempt: failedSoFar + 1, dataDir: deps.dataDir, port: deps.port },
+        "postgres_restart_success",
+      );
+    } catch (err) {
+      state = "idle";
+      deps.logger.error(
+        { reason, attempt: failedSoFar + 1, err, dataDir: deps.dataDir, port: deps.port },
+        "postgres_restart_failed",
+      );
+      const failedAfter = failedAttemptsInWindow(now());
+      if (failedAfter >= SUPERVISOR_MAX_ATTEMPTS_PER_WINDOW) {
+        state = "gave_up";
+        deps.logger.error(
+          {
+            reason,
+            failedAttempts: failedAfter,
+            windowMs: SUPERVISOR_WINDOW_MS,
+            dataDir: deps.dataDir,
+            port: deps.port,
+          },
+          "postgres_restart_giveup",
+        );
+        scheduleAutoReset();
+      }
+    }
+  }
+
+  return {
+    async recoverIfUnhealthy(reason) {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        await attemptRestart(reason);
+      } finally {
+        inFlight = false;
+      }
+    },
+    resetGaveUp(reason) {
+      clearAutoReset();
+      if (state === "gave_up" || attempts.length > 0) {
+        deps.logger.info(
+          { reason: reason ?? "manual", dataDir: deps.dataDir, port: deps.port },
+          "postgres_supervisor_reset",
+        );
+      }
+      state = "idle";
+      attempts = [];
+      lastAttemptAt = 0;
+    },
+    state() {
+      return state;
+    },
+    shutdown() {
+      clearAutoReset();
+    },
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,8 +17,6 @@ import {
   createEmbeddedPostgresLogBuffer,
   prepareEmbeddedPostgresNativeRuntime,
   reconcilePendingMigrationHistory,
-  formatDatabaseBackupResult,
-  runDatabaseBackup,
   authUsers,
   companies,
   companyMemberships,
@@ -41,6 +39,11 @@ import {
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
+import { createDatabaseBackupRunner } from "./services/database-backup-runner.js";
+import {
+  createEmbeddedPostgresSupervisor,
+  type EmbeddedPostgresSupervisor,
+} from "./db/embedded-postgres-supervisor.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -292,6 +295,7 @@ export async function startServer(): Promise<StartedServer> {
   let pluginMigrationDb;
   let embeddedPostgres: EmbeddedPostgresInstance | null = null;
   let embeddedPostgresStartedByThisProcess = false;
+  let embeddedPostgresSupervisor: EmbeddedPostgresSupervisor | null = null;
   let migrationSummary: MigrationSummary = "skipped";
   let activeDatabaseConnectionString: string;
   let resolvedEmbeddedPostgresPort: number | null = null;
@@ -472,6 +476,14 @@ export async function startServer(): Promise<StartedServer> {
     activeDatabaseConnectionString = embeddedConnectionString;
     resolvedEmbeddedPostgresPort = port;
     startupDbInfo = { mode: "embedded-postgres", dataDir, port };
+    if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
+      embeddedPostgresSupervisor = createEmbeddedPostgresSupervisor({
+        embeddedPostgres,
+        dataDir,
+        port,
+        logger,
+      });
+    }
   }
   
   if (config.deploymentMode === "local_trusted" && !isLoopbackHost(config.host)) {
@@ -567,64 +579,19 @@ export async function startServer(): Promise<StartedServer> {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
   const backupSettingsSvc = instanceSettingsService(db);
-  let databaseBackupInFlight = false;
+  const databaseBackupRunner = createDatabaseBackupRunner({
+    connectionString: activeDatabaseConnectionString,
+    backupDir: config.databaseBackupDir,
+    backupSettings: backupSettingsSvc,
+    logger,
+    onConflict: (message) => conflict(message),
+  });
   const runServerDatabaseBackup = async (
     trigger: InstanceDatabaseBackupTrigger,
   ): Promise<InstanceDatabaseBackupRunResult | null> => {
-    if (databaseBackupInFlight) {
-      const message = "Database backup already in progress";
-      if (trigger === "scheduled") {
-        logger.warn("Skipping scheduled database backup because a previous backup is still running");
-        return null;
-      }
-      throw conflict(message);
-    }
-
-    databaseBackupInFlight = true;
-    const startedAt = new Date();
-    const startedAtMs = Date.now();
-    const label = trigger === "scheduled" ? "Automatic" : "Manual";
-    try {
-      logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
-      // Read retention from Instance Settings (DB) so changes take effect without restart.
-      const generalSettings = await backupSettingsSvc.getGeneral();
-      const retention = generalSettings.backupRetention;
-
-      const result = await runDatabaseBackup({
-        connectionString: activeDatabaseConnectionString,
-        backupDir: config.databaseBackupDir,
-        retention,
-        filenamePrefix: "paperclip",
-      });
-      const finishedAt = new Date();
-      const response: InstanceDatabaseBackupRunResult = {
-        ...result,
-        trigger,
-        backupDir: config.databaseBackupDir,
-        retention,
-        startedAt: startedAt.toISOString(),
-        finishedAt: finishedAt.toISOString(),
-        durationMs: Date.now() - startedAtMs,
-      };
-      logger.info(
-        {
-          backupFile: result.backupFile,
-          sizeBytes: result.sizeBytes,
-          prunedCount: result.prunedCount,
-          backupDir: config.databaseBackupDir,
-          retention,
-          trigger,
-          durationMs: response.durationMs,
-        },
-        `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
-      );
-      return response;
-    } catch (err) {
-      logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
-      throw err;
-    } finally {
-      databaseBackupInFlight = false;
-    }
+    const result = await databaseBackupRunner.run(trigger);
+    if (!result) return null;
+    return result as InstanceDatabaseBackupRunResult;
   };
   const pluginWorkerManager = createPluginWorkerManager();
   const app = await createApp(db as any, {
@@ -641,6 +608,7 @@ export async function startServer(): Promise<StartedServer> {
         return result;
       },
     },
+    embeddedPostgresSupervisor: embeddedPostgresSupervisor ?? undefined,
     deploymentMode: config.deploymentMode,
     deploymentExposure: config.deploymentExposure,
     allowedHostnames: config.allowedHostnames,
@@ -832,6 +800,15 @@ export async function startServer(): Promise<StartedServer> {
     }, config.heartbeatSchedulerIntervalMs);
   }
   
+  if (embeddedPostgresSupervisor) {
+    const probe = setInterval(() => {
+      void embeddedPostgresSupervisor!.recoverIfUnhealthy("probe").catch((err: unknown) => {
+        logger.warn({ err }, "embedded postgres supervisor probe rejected");
+      });
+    }, 30_000);
+    probe.unref();
+  }
+
   if (config.databaseBackupEnabled) {
     const backupIntervalMs = config.databaseBackupIntervalMinutes * 60 * 1000;
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,6 +44,7 @@ import {
   createEmbeddedPostgresSupervisor,
   type EmbeddedPostgresSupervisor,
 } from "./db/embedded-postgres-supervisor.js";
+import { createEmbeddedPostgresSelfProbe } from "./db/embedded-postgres-self-probe.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -801,12 +802,12 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   if (embeddedPostgresSupervisor) {
-    const probe = setInterval(() => {
-      void embeddedPostgresSupervisor!.recoverIfUnhealthy("probe").catch((err: unknown) => {
-        logger.warn({ err }, "embedded postgres supervisor probe rejected");
-      });
-    }, 30_000);
-    probe.unref();
+    const selfProbe = createEmbeddedPostgresSelfProbe({
+      db,
+      supervisor: embeddedPostgresSupervisor,
+      logger,
+    });
+    selfProbe.start();
   }
 
   if (config.databaseBackupEnabled) {

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -28,6 +28,12 @@ function hasDevServerStatusToken(providedToken: string | undefined) {
   return timingSafeEqual(expected, provided);
 }
 
+export type HealthEmbeddedPostgresSupervisor = {
+  recoverIfUnhealthy(reason: "health" | "probe" | "pool" | "manual"): Promise<void>;
+  resetGaveUp(reason?: string): void;
+  state(): "idle" | "attempting" | "gave_up";
+};
+
 export function healthRoutes(
   db?: Db,
   opts: {
@@ -35,6 +41,7 @@ export function healthRoutes(
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
     companyDeletionEnabled: boolean;
+    embeddedPostgresSupervisor?: HealthEmbeddedPostgresSupervisor;
   } = {
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
@@ -43,6 +50,20 @@ export function healthRoutes(
   },
 ) {
   const router = Router();
+
+  router.post("/supervisor/reset", async (req, res) => {
+    const actorType = "actor" in req ? req.actor?.type : null;
+    if (opts.deploymentMode === "authenticated" && actorType !== "board") {
+      res.status(403).json({ error: "board_access_required" });
+      return;
+    }
+    if (!opts.embeddedPostgresSupervisor) {
+      res.status(404).json({ error: "supervisor_unavailable" });
+      return;
+    }
+    opts.embeddedPostgresSupervisor.resetGaveUp("manual");
+    res.status(202).json({ status: "reset_requested" });
+  });
 
   router.post("/dev-server/restart", async (req, res) => {
     const actorType = "actor" in req ? req.actor?.type : null;
@@ -100,6 +121,11 @@ export function healthRoutes(
       await db.execute(sql`SELECT 1`);
     } catch (error) {
       logger.warn({ err: error }, "Health check database probe failed");
+      if (opts.embeddedPostgresSupervisor) {
+        void opts.embeddedPostgresSupervisor.recoverIfUnhealthy("health").catch((err: unknown) => {
+          logger.warn({ err }, "Embedded postgres supervisor recoverIfUnhealthy threw");
+        });
+      }
       res.status(503).json({
         status: "unhealthy",
         version: serverVersion,

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -556,6 +556,7 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "GET /api/secrets/{id}/usage",
   "GET /api/secrets/{id}/access-events",
   "POST /api/health/dev-server/restart",
+  "POST /api/health/supervisor/reset",
   "POST /api/issues/{id}/interactions/{interactionId}/accept",
   "POST /api/issues/{id}/interactions/{interactionId}/reject",
   "POST /api/issues/{id}/interactions/{interactionId}/respond",
@@ -615,6 +616,7 @@ const CREATED_OPERATIONS = new Set([
 const ACCEPTED_OPERATIONS = new Set([
   "POST /api/companies/import",
   "POST /api/health/dev-server/restart",
+  "POST /api/health/supervisor/reset",
   "POST /api/invites/{token}/accept",
 ]);
 
@@ -3926,6 +3928,14 @@ registerCurrentRoute({
   tags: ["health"],
   summary: "Request a managed dev-server restart",
   responses: { 202: r.ok(), 403: r.forbidden, 404: r.notFound, 409: { description: "Restart is not required" } },
+});
+
+registerCurrentRoute({
+  method: "post",
+  path: "/api/health/supervisor/reset",
+  tags: ["health"],
+  summary: "Reset the embedded postgres supervisor's gave_up state",
+  responses: { 202: r.ok(), 403: r.forbidden, 404: r.notFound },
 });
 
 registerCurrentRoute({

--- a/server/src/services/database-backup-runner.test.ts
+++ b/server/src/services/database-backup-runner.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BackupRetentionPolicy, RunDatabaseBackupResult } from "@paperclipai/db";
+import type { DiskPressureResult } from "@paperclipai/shared/disk-monitor";
+import { createDatabaseBackupRunner } from "./database-backup-runner.js";
+
+const HEALTHY_RETENTION: BackupRetentionPolicy = {
+  dailyDays: 7,
+  weeklyWeeks: 4,
+  monthlyMonths: 3,
+};
+
+const AGGRESSIVE_RETENTION: BackupRetentionPolicy = {
+  dailyDays: 1,
+  weeklyWeeks: 1,
+  monthlyMonths: 0,
+};
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function withPressure(p: Partial<DiskPressureResult>): DiskPressureResult {
+  return {
+    skip: false,
+    aggressivePrune: false,
+    freeGiB: 100,
+    minFreeGiB: 2,
+    aggressivePruneGiB: 5,
+    ...p,
+  };
+}
+
+function backupResult(overrides: Partial<RunDatabaseBackupResult> = {}): RunDatabaseBackupResult {
+  return { backupFile: "/tmp/x.sql.gz", sizeBytes: 1024, prunedCount: 0, ...overrides };
+}
+
+describe("database backup runner", () => {
+  it("skips backup with WARN log when disk is below the minimum threshold", async () => {
+    const logger = makeLogger();
+    const runBackup = vi.fn();
+    const prune = vi.fn();
+    const runner = createDatabaseBackupRunner({
+      connectionString: "postgres://x",
+      backupDir: "/tmp/backups",
+      backupSettings: { getGeneral: async () => ({ backupRetention: HEALTHY_RETENTION }) },
+      logger,
+      runBackup,
+      prune,
+      evaluateDiskPressure: async () => withPressure({ skip: true, aggressivePrune: true, freeGiB: 1, minFreeGiB: 2 }),
+    });
+
+    const result = await runner.run("scheduled");
+
+    expect(runBackup).not.toHaveBeenCalled();
+    expect(prune).not.toHaveBeenCalled();
+    expect(result?.skipped).toBe(true);
+    expect(logger.warn).toHaveBeenCalled();
+    const warnArgs = logger.warn.mock.calls[0];
+    expect(String(warnArgs[1])).toContain("backup_skipped_low_disk");
+  });
+
+  it("escalates to ERROR backup_paused_low_disk after three consecutive skips", async () => {
+    const logger = makeLogger();
+    const runner = createDatabaseBackupRunner({
+      connectionString: "postgres://x",
+      backupDir: "/tmp/backups",
+      backupSettings: { getGeneral: async () => ({ backupRetention: HEALTHY_RETENTION }) },
+      logger,
+      runBackup: vi.fn(),
+      prune: vi.fn(),
+      evaluateDiskPressure: async () => withPressure({ skip: true, aggressivePrune: true, freeGiB: 1, minFreeGiB: 2 }),
+    });
+
+    await runner.run("scheduled");
+    await runner.run("scheduled");
+    await runner.run("scheduled");
+
+    const errorCalls = logger.error.mock.calls.filter((args) => String(args[1]).includes("backup_paused_low_disk"));
+    expect(errorCalls.length).toBe(1);
+  });
+
+  it("prunes BEFORE the backup write when disk is healthy", async () => {
+    const order: string[] = [];
+    const prune = vi.fn(() => {
+      order.push("prune");
+      return 2;
+    });
+    const runBackup = vi.fn(async () => {
+      order.push("backup");
+      return backupResult({ prunedCount: 0 });
+    });
+    const runner = createDatabaseBackupRunner({
+      connectionString: "postgres://x",
+      backupDir: "/tmp/backups",
+      backupSettings: { getGeneral: async () => ({ backupRetention: HEALTHY_RETENTION }) },
+      logger: makeLogger(),
+      runBackup,
+      prune,
+      evaluateDiskPressure: async () => withPressure({}),
+    });
+
+    const result = await runner.run("scheduled");
+
+    expect(order).toEqual(["prune", "backup"]);
+    expect(result?.skipped).toBeUndefined();
+    expect(prune).toHaveBeenCalledWith("/tmp/backups", HEALTHY_RETENTION, "paperclip");
+    expect(result?.prunedCount).toBe(2);
+  });
+
+  it("applies aggressive retention and emits aggressive_prune_triggered between thresholds", async () => {
+    const logger = makeLogger();
+    const prune = vi.fn(() => 0);
+    const runBackup = vi.fn(async () => backupResult());
+    const runner = createDatabaseBackupRunner({
+      connectionString: "postgres://x",
+      backupDir: "/tmp/backups",
+      backupSettings: { getGeneral: async () => ({ backupRetention: HEALTHY_RETENTION }) },
+      logger,
+      runBackup,
+      prune,
+      evaluateDiskPressure: async () => withPressure({ aggressivePrune: true, freeGiB: 3, aggressivePruneGiB: 5 }),
+    });
+
+    await runner.run("scheduled");
+
+    expect(prune).toHaveBeenCalledWith("/tmp/backups", AGGRESSIVE_RETENTION, "paperclip");
+    expect(runBackup).toHaveBeenCalledWith(expect.objectContaining({ retention: AGGRESSIVE_RETENTION }));
+    expect(logger.warn).toHaveBeenCalled();
+    const warnMessages = logger.warn.mock.calls.map((c) => String(c[1] ?? ""));
+    expect(warnMessages.some((m) => m.includes("aggressive_prune_triggered"))).toBe(true);
+  });
+
+  it("returns null on scheduled re-entry and throws on manual re-entry", async () => {
+    let release!: () => void;
+    const runner = createDatabaseBackupRunner({
+      connectionString: "postgres://x",
+      backupDir: "/tmp/backups",
+      backupSettings: { getGeneral: async () => ({ backupRetention: HEALTHY_RETENTION }) },
+      logger: makeLogger(),
+      runBackup: () =>
+        new Promise((resolve) => {
+          release = () => resolve(backupResult());
+        }),
+      prune: vi.fn(() => 0),
+      evaluateDiskPressure: async () => withPressure({}),
+    });
+
+    const first = runner.run("scheduled");
+    const reentry = await runner.run("scheduled");
+    expect(reentry).toBeNull();
+    await expect(runner.run("manual")).rejects.toThrow(/already in progress/);
+
+    release();
+    await first;
+  });
+});

--- a/server/src/services/database-backup-runner.ts
+++ b/server/src/services/database-backup-runner.ts
@@ -1,0 +1,220 @@
+import {
+  formatDatabaseBackupResult,
+  pruneOldBackups,
+  runDatabaseBackup,
+  type BackupRetentionPolicy,
+  type RunDatabaseBackupResult,
+} from "@paperclipai/db";
+import {
+  ConsecutiveSkipCounter,
+  evaluateBackupDiskPressure,
+  type DiskPressureResult,
+} from "@paperclipai/shared/disk-monitor";
+import type {
+  InstanceDatabaseBackupRunResult,
+  InstanceDatabaseBackupTrigger,
+} from "../routes/instance-database-backups.js";
+
+const AGGRESSIVE_PRUNE_RETENTION: BackupRetentionPolicy = {
+  dailyDays: 1,
+  weeklyWeeks: 1,
+  monthlyMonths: 0,
+};
+
+const DEFAULT_FILENAME_PREFIX = "paperclip";
+
+export type DatabaseBackupRunnerLogger = {
+  info: (obj: Record<string, unknown> | string, msg?: string) => void;
+  warn: (obj: Record<string, unknown> | string, msg?: string) => void;
+  error: (obj: Record<string, unknown> | string, msg?: string) => void;
+};
+
+export type DatabaseBackupRunnerBackupSettings = {
+  getGeneral(): Promise<{ backupRetention: BackupRetentionPolicy }>;
+};
+
+export type DatabaseBackupRunnerDeps = {
+  connectionString: string;
+  backupDir: string;
+  filenamePrefix?: string;
+  backupSettings: DatabaseBackupRunnerBackupSettings;
+  logger: DatabaseBackupRunnerLogger;
+  runBackup?: typeof runDatabaseBackup;
+  prune?: typeof pruneOldBackups;
+  evaluateDiskPressure?: (targetPath: string) => Promise<DiskPressureResult>;
+  skipCounter?: ConsecutiveSkipCounter;
+  onConflict?: (message: string) => Error;
+  now?: () => number;
+};
+
+export type DatabaseBackupRunnerResult =
+  | (InstanceDatabaseBackupRunResult & { skipped?: false })
+  | (Pick<RunDatabaseBackupResult, "backupFile" | "sizeBytes" | "prunedCount"> & {
+      trigger: InstanceDatabaseBackupTrigger;
+      backupDir: string;
+      retention: BackupRetentionPolicy;
+      startedAt: string;
+      finishedAt: string;
+      durationMs: number;
+      skipped: true;
+      skipReason: "low_disk";
+      freeGiB: number;
+      thresholdGiB: number;
+    });
+
+export type DatabaseBackupRunner = {
+  run(trigger: InstanceDatabaseBackupTrigger): Promise<DatabaseBackupRunnerResult | null>;
+};
+
+function defaultConflict(message: string): Error {
+  const err = new Error(message) as Error & { statusCode?: number };
+  err.statusCode = 409;
+  return err;
+}
+
+export function createDatabaseBackupRunner(deps: DatabaseBackupRunnerDeps): DatabaseBackupRunner {
+  const filenamePrefix = deps.filenamePrefix ?? DEFAULT_FILENAME_PREFIX;
+  const runBackup = deps.runBackup ?? runDatabaseBackup;
+  const prune = deps.prune ?? pruneOldBackups;
+  const evaluateDiskPressure =
+    deps.evaluateDiskPressure ?? ((targetPath: string) => evaluateBackupDiskPressure({ targetPath }));
+  const skipCounter = deps.skipCounter ?? new ConsecutiveSkipCounter();
+  const conflict = deps.onConflict ?? defaultConflict;
+  const now = deps.now ?? Date.now;
+  let inFlight = false;
+
+  return {
+    async run(trigger) {
+      if (inFlight) {
+        const message = "Database backup already in progress";
+        if (trigger === "scheduled") {
+          deps.logger.warn(
+            { backupDir: deps.backupDir, trigger },
+            "Skipping scheduled database backup because a previous backup is still running",
+          );
+          return null;
+        }
+        throw conflict(message);
+      }
+
+      inFlight = true;
+      const startedAtMs = now();
+      const startedAt = new Date(startedAtMs);
+      const label = trigger === "scheduled" ? "Automatic" : "Manual";
+
+      try {
+        deps.logger.info({ backupDir: deps.backupDir, trigger }, `${label} database backup starting`);
+
+        const pressure = await evaluateDiskPressure(deps.backupDir);
+
+        if (pressure.skip) {
+          const skipState = skipCounter.recordSkip();
+          deps.logger.warn(
+            {
+              backupDir: deps.backupDir,
+              trigger,
+              freeGiB: pressure.freeGiB,
+              thresholdGiB: pressure.minFreeGiB,
+              consecutiveSkips: skipState.count,
+            },
+            `backup_skipped_low_disk freeGiB=${pressure.freeGiB.toFixed(2)} thresholdGiB=${pressure.minFreeGiB}`,
+          );
+          if (skipState.shouldEmitPauseLog) {
+            deps.logger.error(
+              {
+                backupDir: deps.backupDir,
+                trigger,
+                freeGiB: pressure.freeGiB,
+                thresholdGiB: pressure.minFreeGiB,
+                consecutiveSkips: skipState.count,
+              },
+              "backup_paused_low_disk",
+            );
+          }
+          const finishedAtMs = now();
+          return {
+            trigger,
+            backupDir: deps.backupDir,
+            retention: AGGRESSIVE_PRUNE_RETENTION,
+            startedAt: startedAt.toISOString(),
+            finishedAt: new Date(finishedAtMs).toISOString(),
+            durationMs: finishedAtMs - startedAtMs,
+            backupFile: "",
+            sizeBytes: 0,
+            prunedCount: 0,
+            skipped: true,
+            skipReason: "low_disk" as const,
+            freeGiB: pressure.freeGiB,
+            thresholdGiB: pressure.minFreeGiB,
+          };
+        }
+
+        skipCounter.recordSuccess();
+
+        const generalSettings = await deps.backupSettings.getGeneral();
+        const baseRetention = generalSettings.backupRetention;
+        const retention = pressure.aggressivePrune ? AGGRESSIVE_PRUNE_RETENTION : baseRetention;
+
+        if (pressure.aggressivePrune) {
+          deps.logger.warn(
+            {
+              backupDir: deps.backupDir,
+              trigger,
+              freeGiB: pressure.freeGiB,
+              thresholdGiB: pressure.aggressivePruneGiB,
+              retention,
+            },
+            "aggressive_prune_triggered",
+          );
+        }
+
+        const preBackupPrunedCount = prune(deps.backupDir, retention, filenamePrefix);
+        deps.logger.info(
+          { backupDir: deps.backupDir, trigger, preBackupPrunedCount, retention },
+          "Pre-backup prune complete",
+        );
+
+        const result = await runBackup({
+          connectionString: deps.connectionString,
+          backupDir: deps.backupDir,
+          retention,
+          filenamePrefix,
+        });
+
+        const finishedAtMs = now();
+        const totalPrunedCount = preBackupPrunedCount + result.prunedCount;
+        const response: InstanceDatabaseBackupRunResult = {
+          ...result,
+          prunedCount: totalPrunedCount,
+          trigger,
+          backupDir: deps.backupDir,
+          retention,
+          startedAt: startedAt.toISOString(),
+          finishedAt: new Date(finishedAtMs).toISOString(),
+          durationMs: finishedAtMs - startedAtMs,
+        };
+        deps.logger.info(
+          {
+            backupFile: result.backupFile,
+            sizeBytes: result.sizeBytes,
+            prunedCount: totalPrunedCount,
+            backupDir: deps.backupDir,
+            retention,
+            trigger,
+            durationMs: response.durationMs,
+          },
+          `${label} database backup complete: ${formatDatabaseBackupResult({
+            ...result,
+            prunedCount: totalPrunedCount,
+          })}`,
+        );
+        return response;
+      } catch (err) {
+        deps.logger.error({ err, backupDir: deps.backupDir, trigger }, `${label} database backup failed`);
+        throw err;
+      } finally {
+        inFlight = false;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Embedded Postgres is the default storage layer on macOS / Linux, started inside the server boot block by `@embedded-postgres/*` and consumed via `@paperclipai/db`.
> - On Mac under disk pressure the backup cron consumed all remaining space, the embedded postgres process died from ENOSPC, and the entire agent control plane went silent because no component owned restarting it.
> - The current code logs the failure once and stops there: `/api/health` returns `503 database_unreachable` forever, the backup loop keeps trying to write and fails on every cron tick, and there is no self-heal path.
> - This pull request introduces a wrapper around the existing pieces: a plattform-neutral disk monitor in `@paperclipai/shared`, a server-side backup runner that gates writes behind that monitor and prunes before write, and an embedded postgres supervisor with throttled, bounded restart attempts.
> - The benefit is that the next Mac-ENOSPC incident becomes a logged skip plus an automatic recovery, instead of a silent control-plane outage.

## Linked Issues or Issue Description

Fixes #7588

(Internal tracker reference: TRA-244 / TRA-242.)

## What Changed

- `packages/shared/src/disk-monitor.ts` NEW. `fs.statfs` wrapper, env-overridable thresholds (`PAPERCLIP_BACKUP_MIN_FREE_GB` default 2 GiB, `PAPERCLIP_BACKUP_AGGRESSIVE_PRUNE_GB` default 5 GiB), `ConsecutiveSkipCounter` that escalates to a single `backup_paused_low_disk` ERROR after three consecutive skips.
- `server/src/services/database-backup-runner.ts` NEW. Replaces the inline `runServerDatabaseBackup` body in `server/src/index.ts`. Evaluates disk pressure before write, emits `backup_skipped_low_disk` on skip, `aggressive_prune_triggered` with the reduced retention `{ dailyDays:1, weeklyWeeks:1, monthlyMonths:0 }` between thresholds, and prunes BEFORE invoking `runDatabaseBackup`.
- `server/src/db/embedded-postgres-supervisor.ts` NEW. State machine `idle | attempting | gave_up`, throttle 30 s, cap 3 failed attempts per 5 min window with exponential backoff `[5s, 15s, 45s]` folded into the throttle gap. Probes `postmaster.pid`: alive → `stop()` then `start()`; stale or missing → remove pid file and `start()`. `gave_up` self-resets after 30 min idle (`postgres_supervisor_giveup_reset`) and is resettable from `POST /api/health/supervisor/reset` (board-only in `authenticated` mode).
- `server/src/routes/health.ts` and `server/src/app.ts` thread the supervisor through `healthRoutes`. The 503 path triggers `supervisor.recoverIfUnhealthy("health")` exactly once per request and is rate-limited inside the supervisor.
- `server/src/index.ts` builds the supervisor after the embedded postgres `.start()`, registers a 30 s self-probe `setInterval(...).unref()` (`probe` reason), routes the manual and scheduled backup paths through the new runner, and trims now-unused imports.
- `packages/db/src/backup-lib.ts` visibility-only change: `function pruneOldBackups` is now exported so the runner can call it before write. No signature, no semantics changed. Re-exported from `packages/db/src/index.ts`.

Tests:

- `packages/shared/src/disk-monitor.test.ts` 7 cases (thresholds, env reads, counter escalation, counter reset).
- `server/src/services/database-backup-runner.test.ts` 5 cases (skip path, pause-log escalation, prune-before-write order, aggressive retention switch, re-entry semantics).
- `server/src/db/embedded-postgres-supervisor.test.ts` 8 cases (Fake-Timer-driven: throttle, window cap, PID race with stale file, stop-before-start when alive, auto-reset, manual reset, probe parity).
- `server/src/__tests__/health.test.ts` 3 new cases (503 triggers supervisor once, reset endpoint with and without a wired supervisor).
- `server/src/db/embedded-postgres-supervisor.integration.test.ts` integration smoke: starts a real embedded postgres, calls `embedded.stop()` to simulate the crash, verifies the probe fails, then has the supervisor recover the instance and verifies a follow-up `SELECT 1` succeeds. Skipped automatically on platforms where embedded postgres is not supported (same gating as `packages/db/src/backup-lib.test.ts`).

## Verification

```
cd ~/PROJEKTE/paperclip
pnpm install
pnpm --filter @paperclipai/shared exec vitest run src/disk-monitor.test.ts
pnpm --filter @paperclipai/server exec vitest run \
    src/services/database-backup-runner.test.ts \
    src/db/embedded-postgres-supervisor.test.ts \
    src/__tests__/health.test.ts \
    src/db/embedded-postgres-supervisor.integration.test.ts
pnpm --filter @paperclipai/shared typecheck
pnpm --filter @paperclipai/db typecheck
pnpm --filter @paperclipai/server typecheck
```

Local results on this branch:

```
✓ src/disk-monitor.test.ts (7 tests)
✓ src/services/database-backup-runner.test.ts (5 tests)
✓ src/db/embedded-postgres-supervisor.test.ts (8 tests)
✓ src/__tests__/health.test.ts (9 tests)
✓ src/db/embedded-postgres-supervisor.integration.test.ts (1 test, 854 ms)
```

All four typechecks (`shared`, `db`, `server`) pass with no errors.

## Risks

- Visibility change in `packages/db/src/backup-lib.ts`: `pruneOldBackups` is now part of the public surface. No external callers in this PR; risk is the long-term API contract.
- Supervisor uses `process.kill(pid, 0)` to probe liveness. On macOS / Linux this is the standard signal-0 idiom and matches the existing `getRunningPid` used in `server/src/index.ts` boot. No equivalent verified on Windows; embedded postgres is not the primary Windows target.
- Restart path calls `embeddedPostgres.stop()` before `start()` when the recorded pid is alive. If `stop()` hangs, the throttle and the window cap still bound how often this can happen, so worst case is `postgres_restart_giveup` with the 30 min auto-reset.
- The 30 s probe `setInterval` is `unref()`-ed so SIGINT/process exit are unaffected. There is no other holding handle.

## Model Used

Claude Opus 4.7 (claude-opus-4-7, ~200K context, extended-thinking, code execution and tool use enabled). Used for the design plan, the implementation, and the unit and integration tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge