### PR TITLE
fix(adapters): import external adapter plugins via file:// URL on Windows

### DIFF
--- a/server/src/__tests__/plugin-loader-local-path.test.ts
+++ b/server/src/__tests__/plugin-loader-local-path.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadExternalAdapterPackage } from "../adapters/plugin-loader.js";
+
+// Regression test for the Windows ESM import bug: loadExternalAdapterPackage /
+// reloadExternalAdapter must import from a proper file:// URL. On Windows an
+// absolute module path is a drive-letter path (C:\...\index.js); passing it
+// straight to import() throws "Received protocol 'c:'". pathToFileURL fixes it,
+// and this test exercises that path with a real absolute local-path package.
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeLocalAdapter(type: string): Promise<{ dir: string; packageName: string }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "pc-adapter-"));
+  tmpDirs.push(dir);
+  const packageName = `test-${type}-adapter`;
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify(
+      { name: packageName, version: "1.0.0", type: "module", main: "index.js", exports: { ".": "./index.js" } },
+      null,
+      2,
+    ),
+  );
+  await writeFile(
+    path.join(dir, "index.js"),
+    `export function createServerAdapter() {
+  return {
+    type: ${JSON.stringify(type)},
+    async execute() { return { exitCode: 0, signal: null, timedOut: false }; },
+    async testEnvironment() {
+      return { adapterType: ${JSON.stringify(type)}, status: "pass", checks: [], testedAt: new Date().toISOString() };
+    },
+  };
+}
+`,
+  );
+  return { dir, packageName };
+}
+
+describe("loadExternalAdapterPackage (local path)", () => {
+  it("loads an ESM adapter from an absolute local path via a file:// URL", async () => {
+    const { dir, packageName } = await makeLocalAdapter("localpathfixture");
+    // dir is an absolute path; on Windows this is a drive-letter path that would
+    // crash import() without the pathToFileURL conversion this test guards.
+    expect(path.isAbsolute(dir)).toBe(true);
+
+    const mod = await loadExternalAdapterPackage(packageName, dir);
+
+    expect(mod.type).toBe("localpathfixture");
+    expect(typeof mod.execute).toBe("function");
+    expect(typeof mod.testEnvironment).toBe("function");
+  });
+});

--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -11,6 +11,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ServerAdapterModule } from "./types.js";
 import { logger } from "../middleware/logger.js";
 
@@ -177,7 +178,9 @@ export async function loadExternalAdapterPackage(
 
   logger.info({ packageName, packageDir, entryPoint, modulePath, hasUiParser: !!uiParserSource }, "Loading external adapter package");
 
-  const mod = await import(modulePath);
+  // On Windows a bare drive path (C:\...) is not a valid ESM specifier; Node's
+  // dynamic import requires a file:// URL.
+  const mod = await import(pathToFileURL(modulePath).href);
   const adapterModule = validateAdapterModule(mod, packageName);
 
   if (uiParserSource) {

--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -215,7 +215,9 @@ export async function reloadExternalAdapter(
   const packageDir = resolvePackageDir(record);
   const entryPoint = resolvePackageEntryPoint(packageDir);
   const modulePath = path.resolve(packageDir, entryPoint);
-  const fileUrl = `file://${modulePath}`;
+  // Use a proper file:// URL (string interpolation breaks on Windows drive paths,
+  // e.g. file://C:\... -> "Received protocol 'c:'"). Matches loadExternalAdapterPackage.
+  const fileUrl = pathToFileURL(modulePath).href;
 
   // Bust ESM module cache so re-import loads fresh code from disk.
   // Query-string trick (?t=...) works in Node; Bun may need the file:// URL


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents are pluggable via external **adapters**, loaded at runtime by `server/src/adapters/plugin-loader.ts`.
> - That loader resolves an adapter package's entry point to an absolute path and calls dynamic `import()` on it.
> - On Windows that absolute path is a drive-letter path (`C:\Users\...\index.js`), which Node's ESM loader rejects with `Received protocol 'c:'` — it requires a `file://` URL.
> - As a result no external adapter can be installed or loaded on Windows: `POST /api/adapters/install` 500s, and startup `buildExternalAdapters()` skips stored plugins.
> - This PR converts the resolved path with `pathToFileURL().href` before `import()` in both `loadExternalAdapterPackage` and `reloadExternalAdapter`.
> - The benefit: external adapter plugins work on Windows, with POSIX behavior unchanged.

## Linked Issues or Issue Description

Fixes #7602

## What Changed

- `loadExternalAdapterPackage`: import via `pathToFileURL(modulePath).href` instead of a bare path.
- `reloadExternalAdapter`: build the `file://` URL via `pathToFileURL` instead of string interpolation (`file://${modulePath}`), which was broken on Windows in the same way (addresses review feedback).
- Add `server/src/__tests__/plugin-loader-local-path.test.ts` — loads a real ESM adapter from an absolute local path, exercising the `file://` conversion (would throw on Windows before this fix). Cross-platform.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-loader-local-path.test.ts` → 1 passed.
- Manual, Windows 11 / Node 24 / pnpm 9.15.4: `POST /api/adapters/install { packageName: "C:\...\adapter", isLocalPath: true }` now returns 201; the adapter appears in `GET /api/adapters` (`source: external`, `loaded: true`), and startup logs `Loaded external adapters from plugin store`. Before the fix: 500 `Received protocol 'c:'`.

## Risks

Low risk — pure path-to-URL normalisation. `pathToFileURL()` yields an equivalent `file://` URL on POSIX, so behaviour there is unchanged; the only behavioural change is that Windows drive-letter paths now produce a valid URL.

## Model Used

Anthropic **Claude Opus 4.8**, used agentically via Claude Code (tool use + code execution; read the repo, wrote the fix and test, ran vitest locally to confirm).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (small cross-platform bugfix, not core feature work)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [ ] I have updated relevant documentation to reflect my changes (N/A — no doc change)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green (re-running after this push)
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (reload-path P1 + template P2 addressed)
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)