### PR TITLE
fix(recovery): stop productivity-review loop (BLU-10308, BLU-10337)

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -11,9 +11,11 @@ import {
   executionWorkspaces,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issueRelations,
   issueTreeHolds,
   issues,
+  labels,
   projects,
   projectWorkspaces,
 } from "@paperclipai/db";
@@ -409,6 +411,32 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       },
     });
     expect(events.filter((event) => event.action === "issue.blockers.updated")).toHaveLength(1);
+  });
+
+  it("does not escalate a blocker carrying the perpetual-tracker label (BLU-10337)", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockerIssueId } = await seedBlockedChain();
+
+    // The blocker is a perpetual tracker: it is its own standing waiting path, so the
+    // liveness classifier must not flip it to blocked nor fire source_scoped_recovery.
+    const labelId = randomUUID();
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "perpetual-tracker",
+      color: "#000000",
+    });
+    await db.insert(issueLabels).values({ companyId, issueId: blockerIssueId, labelId });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(result.escalationsCreated).toBe(0);
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(0);
   });
 
   it("skips budget-blocked direct owners and assigns recovery to the manager fallback", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2096,6 +2096,69 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  it("does not block productivity_review issues stranded without an execution path (BLU-10308)", async () => {
+    // productivity_review issues are reviewer-decision artifacts: there is no execution
+    // to recover, so the stranded-work engine must NOT flip them to blocked nor fire a
+    // source_scoped_recovery_action. This is the exact case that fed the 27-issue loop.
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    await db
+      .update(issues)
+      .set({ originKind: "issue_productivity_review", originId: randomUUID() })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(0);
+
+    const recoveryChildren = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryChildren).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("does not block in_progress productivity_review issues with a failed continuation (BLU-10308)", async () => {
+    // Same exemption must hold regardless of status branch — the guard sits before all
+    // four escalate call sites, so the in_progress failed-continuation path is covered too.
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db
+      .update(issues)
+      .set({ originKind: "issue_productivity_review", originId: randomUUID() })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -225,34 +225,92 @@ describeEmbeddedPostgres("productivity review service", () => {
     await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
     const [review] = await listProductivityReviews(seeded.companyId);
 
-    const firstRefreshAt = new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS);
-    const firstRefresh = await service.reconcileProductivityReviews({
-      now: firstRefreshAt,
-      companyId: seeded.companyId,
-    });
+    // BLU-10308: the refresher now skips byte-identical reposts, so exercising the cap
+    // requires distinct evidence each interval. Add an increasing number of fresh
+    // no-comment runs (1, 2, 3) before each posting step so the windowed run counts in
+    // the rendered body differ and three distinct refreshes actually post.
+    const postingStep = async (intervals: number, freshRuns: number) => {
+      const stepNow = new Date(now.getTime() + intervals * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS);
+      await insertRuns({
+        companyId: seeded.companyId,
+        agentId: seeded.coderId,
+        issueId: seeded.issueId,
+        count: freshRuns,
+        now: stepNow,
+      });
+      return service.reconcileProductivityReviews({ now: stepNow, companyId: seeded.companyId });
+    };
+
+    const firstRefresh = await postingStep(1, 1);
     const tooSoonRefresh = await service.reconcileProductivityReviews({
-      now: new Date(firstRefreshAt.getTime() + 30 * 60 * 1000),
+      now: new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS + 30 * 60 * 1000),
       companyId: seeded.companyId,
     });
-    await service.reconcileProductivityReviews({
-      now: new Date(firstRefreshAt.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
-      companyId: seeded.companyId,
-    });
-    await service.reconcileProductivityReviews({
-      now: new Date(firstRefreshAt.getTime() + 2 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
-      companyId: seeded.companyId,
-    });
-    const cappedRefresh = await service.reconcileProductivityReviews({
-      now: new Date(firstRefreshAt.getTime() + 3 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
-      companyId: seeded.companyId,
-    });
+    const secondRefresh = await postingStep(2, 2);
+    const thirdRefresh = await postingStep(3, 3);
+    const cappedRefresh = await postingStep(4, 4);
 
     expect(firstRefresh.updated).toBe(1);
     expect(tooSoonRefresh.updated).toBe(0);
     expect(tooSoonRefresh.existing).toBe(1);
+    expect(secondRefresh.updated).toBe(1);
+    expect(thirdRefresh.updated).toBe(1);
     expect(cappedRefresh.updated).toBe(0);
     expect(cappedRefresh.existing).toBe(1);
-    expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
+    const refreshComments = await listRefreshComments(review!.id);
+    expect(refreshComments).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
+    // Every posted refresh carried distinct evidence (the dedup guard let them through).
+    expect(new Set(refreshComments.map((row) => row.body)).size).toBe(
+      DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
+    );
+  });
+
+  it("skips refreshing when rendered evidence is identical to the last refresh (BLU-10308)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+    // One extra run inside the first refresh's 1h window so its body differs from the
+    // later windows. After now+1h no run falls in any 1h window again, and the 6h
+    // window contents stay fixed — so now+2h and now+3h render identical bodies.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 1,
+      now: new Date(now.getTime() + 50 * 60 * 1000),
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+
+    const firstRefresh = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
+      companyId: seeded.companyId,
+    });
+    const secondRefresh = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + 2 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
+      companyId: seeded.companyId,
+    });
+    expect(firstRefresh.updated).toBe(1);
+    expect(secondRefresh.updated).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(2);
+
+    // now+3h renders the same body as now+2h (no new runs; both 1h windows empty, both
+    // 6h windows hold the same runs) — the dedup guard must skip the duplicate post.
+    const duplicateRefresh = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + 3 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS),
+      companyId: seeded.companyId,
+    });
+    expect(duplicateRefresh.updated).toBe(0);
+    expect(duplicateRefresh.existing).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(2);
   });
 
   it("holds the refresh-interval guard under concurrent reconciliation (BLU-7718)", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -255,6 +255,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
   });
 
+  it("holds the refresh-interval guard under concurrent reconciliation (BLU-7718)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+
+    // Multiple server processes fire reconcile concurrently in the same window
+    // (simulated here with Promise.all over a shared pool). Without atomic
+    // check-then-act around the cap+interval check, each racer sees the same
+    // pre-burst count and all racers insert. The empirical BLU-7325 burst on
+    // 2026-05-14 showed three refresh comments committed inside 27ms — the
+    // failure mode this test pins.
+    const refreshAt = new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS);
+    const concurrent = 5;
+    const results = await Promise.all(
+      Array.from({ length: concurrent }, () =>
+        service.reconcileProductivityReviews({ now: refreshAt, companyId: seeded.companyId }),
+      ),
+    );
+
+    const totalUpdates = results.reduce((acc, r) => acc + r.updated, 0);
+    expect(totalUpdates).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(1);
+  });
+
   it("caps productivity review creation per source issue in the rolling creation window", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/__tests__/recovery-classifiers.test.ts
+++ b/server/src/__tests__/recovery-classifiers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { classifyIssueGraphLiveness as classifyIssueGraphLivenessCompat } from "../services/issue-liveness.ts";
 import { decideRunLivenessContinuation as decideRunLivenessContinuationCompat } from "../services/run-continuations.ts";
 import {
+  PERPETUAL_TRACKER_LABEL,
   RECOVERY_KEY_PREFIXES,
   RECOVERY_ORIGIN_KINDS,
   RECOVERY_REASON_KINDS,
@@ -10,6 +11,8 @@ import {
   buildRunLivenessContinuationIdempotencyKey,
   classifyIssueGraphLiveness,
   decideRunLivenessContinuation,
+  hasPerpetualTrackerLabel,
+  isProductivityReviewOriginKind,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "../services/recovery/index.ts";
@@ -244,5 +247,68 @@ describe("recovery classifier boundary", () => {
     expect(isStrandedIssueRecoveryOriginKind("harness_liveness_escalation")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind("manual")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind(null)).toBe(false);
+  });
+
+  it("identifies productivity-review origins (BLU-10308 blocked-flip exemption)", () => {
+    expect(RECOVERY_ORIGIN_KINDS.issueProductivityReview).toBe("issue_productivity_review");
+    expect(isProductivityReviewOriginKind("issue_productivity_review")).toBe(true);
+    expect(isProductivityReviewOriginKind("stranded_issue_recovery")).toBe(false);
+    expect(isProductivityReviewOriginKind("manual")).toBe(false);
+    expect(isProductivityReviewOriginKind(null)).toBe(false);
+  });
+
+  it("detects the perpetual-tracker label (BLU-10337)", () => {
+    expect(PERPETUAL_TRACKER_LABEL).toBe("perpetual-tracker");
+    expect(hasPerpetualTrackerLabel({ labels: ["perpetual-tracker"] } as never)).toBe(true);
+    expect(hasPerpetualTrackerLabel({ labels: ["other", "perpetual-tracker"] } as never)).toBe(true);
+    expect(hasPerpetualTrackerLabel({ labels: ["other"] } as never)).toBe(false);
+    expect(hasPerpetualTrackerLabel({ labels: [] } as never)).toBe(false);
+    expect(hasPerpetualTrackerLabel({ labels: null } as never)).toBe(false);
+    expect(hasPerpetualTrackerLabel({} as never)).toBe(false);
+  });
+
+  it("treats a perpetual-tracker label as an explicit waiting path (BLU-10337)", () => {
+    const baseIssue = {
+      id: issueId,
+      companyId,
+      identifier: "PAP-9001",
+      title: "Perpetual roster monitor",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionState: null,
+      // No monitorNextCheckAt: lacking a scheduled monitor is exactly the case the
+      // label must exempt — the tracker is its own perpetual waiting path.
+    };
+    const agents = [
+      {
+        id: agentId,
+        companyId,
+        name: "Coder",
+        role: "engineer",
+        status: "idle",
+        reportsTo: managerId,
+      },
+    ];
+
+    const exempt = classifyIssueGraphLiveness({
+      now: "2026-04-30T18:00:00.000Z",
+      issues: [{ ...baseIssue, labels: ["perpetual-tracker"] }],
+      relations: [],
+      agents,
+    });
+    expect(exempt).toEqual([]);
+
+    // Negative control: a different label does not exempt — the issue is still flagged,
+    // proving the exemption is label-specific, not a blanket suppression.
+    const flagged = classifyIssueGraphLiveness({
+      now: "2026-04-30T18:00:00.000Z",
+      issues: [{ ...baseIssue, labels: ["some-other-label"] }],
+      relations: [],
+      agents,
+    });
+    expect(flagged[0]?.state).toBe("in_review_without_action_path");
   });
 });

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -639,33 +639,44 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   ) {
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
-      const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
-      const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
-      if (
-        refreshState.count >= opts.thresholds.maxRefreshComments ||
-        evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
-      ) {
-        return { kind: "existing" as const, reviewIssueId: existing.id };
-      }
-      await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
-      await logActivity(db, {
-        companyId: evidence.sourceIssue.companyId,
-        actorType: "system",
-        actorId: "system",
-        action: "issue.productivity_review_updated",
-        entityType: "issue",
-        entityId: existing.id,
-        agentId: existing.assigneeAgentId,
-        details: {
-          source: "productivity_review.reconcile",
-          sourceIssueId: evidence.sourceIssue.id,
-          trigger: evidence.trigger,
-          noCommentStreak: evidence.noCommentStreak,
-          runCountLastHour: evidence.runCountLastHour,
-          commentCountLastHour: evidence.commentCountLastHour,
-        },
+      // Serialize cap + interval evaluation per review issue. The SELECT-then-INSERT
+      // pattern below would otherwise race across concurrent reconcile runs (each
+      // server process fires reconcileProductivityReviews on a 30s setInterval),
+      // letting every racer see the same pre-burst count and all racers insert.
+      // BLU-7718: BLU-7325 accumulated 3,754 refresh comments through this race.
+      // pg_advisory_xact_lock auto-releases when the transaction commits.
+      return db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`productivity_review_refresh:${existing.id}`}, 0))`,
+        );
+        const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
+        const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
+        if (
+          refreshState.count >= opts.thresholds.maxRefreshComments ||
+          evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
+        ) {
+          return { kind: "existing" as const, reviewIssueId: existing.id };
+        }
+        await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
+        await logActivity(db, {
+          companyId: evidence.sourceIssue.companyId,
+          actorType: "system",
+          actorId: "system",
+          action: "issue.productivity_review_updated",
+          entityType: "issue",
+          entityId: existing.id,
+          agentId: existing.assigneeAgentId,
+          details: {
+            source: "productivity_review.reconcile",
+            sourceIssueId: evidence.sourceIssue.id,
+            trigger: evidence.trigger,
+            noCommentStreak: evidence.noCommentStreak,
+            runCountLastHour: evidence.runCountLastHour,
+            commentCountLastHour: evidence.commentCountLastHour,
+          },
+        });
+        return { kind: "updated" as const, reviewIssueId: existing.id };
       });
-      return { kind: "updated" as const, reviewIssueId: existing.id };
     }
 
     const recentCreationCount = await countRecentProductivityReviews(

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -307,17 +307,29 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   }
 
   async function getRefreshCommentState(companyId: string, reviewIssueId: string) {
+    const refreshLike = `${PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX}%`;
     return db
       .select({
         count: sql<number>`count(*)::int`,
         latestCreatedAt: sql<Date | null>`max(${issueComments.createdAt})`,
+        // BLU-10308: surface the body of the most recent refresh comment so the
+        // caller can skip posting byte-identical evidence. Deterministic tiebreak
+        // (created_at desc, id desc) mirrors the ordering used elsewhere here.
+        latestBody: sql<string | null>`(
+          select c2.body from ${issueComments} c2
+          where c2.company_id = ${companyId}
+            and c2.issue_id = ${reviewIssueId}
+            and c2.body like ${refreshLike}
+          order by c2.created_at desc, c2.id desc
+          limit 1
+        )`,
       })
       .from(issueComments)
       .where(
         and(
           eq(issueComments.companyId, companyId),
           eq(issueComments.issueId, reviewIssueId),
-          sql`${issueComments.body} like ${`${PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX}%`}`,
+          sql`${issueComments.body} like ${refreshLike}`,
         ),
       )
       .then((rows) => {
@@ -325,6 +337,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         return {
           count: Number(row?.count ?? 0),
           latestCreatedAt: coerceDate(row?.latestCreatedAt),
+          latestBody: row?.latestBody ?? null,
         };
       });
   }
@@ -657,7 +670,15 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         ) {
           return { kind: "existing" as const, reviewIssueId: existing.id };
         }
-        await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
+        // BLU-10308: skip posting when the rendered evidence is byte-identical to the
+        // last refresh comment. The unguarded ~30s repost flooded threads (15-20k
+        // machine comments) and re-tripped the recovery loop. buildRefreshComment is
+        // timestamp-free, so identical evidence renders identical bodies.
+        const refreshBody = buildRefreshComment(evidence, opts.prefix);
+        if (refreshState.latestBody !== null && refreshState.latestBody === refreshBody) {
+          return { kind: "existing" as const, reviewIssueId: existing.id };
+        }
+        await addRefreshComment(existing.id, refreshBody, evidence.generatedAt);
         await logActivity(db, {
           companyId: evidence.sourceIssue.companyId,
           actorType: "system",

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -4,6 +4,7 @@ export {
   RECOVERY_REASON_KINDS,
   buildIssueGraphLivenessIncidentKey,
   buildIssueGraphLivenessLeafKey,
+  isProductivityReviewOriginKind,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";
@@ -13,7 +14,9 @@ export type {
   RecoveryReasonKind,
 } from "./origins.js";
 export {
+  PERPETUAL_TRACKER_LABEL,
   classifyIssueGraphLiveness,
+  hasPerpetualTrackerLabel,
 } from "./issue-graph-liveness.js";
 export type {
   IssueGraphLivenessInput,

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -27,6 +27,16 @@ export interface IssueLivenessIssueInput {
   executionState?: Record<string, unknown> | null;
   monitorNextCheckAt?: Date | string | null;
   monitorAttemptCount?: number | null;
+  labels?: string[] | null;
+}
+
+// BLU-10308/BLU-10337: an issue carrying this label is its own perpetual monitor.
+// It must not be flipped to `blocked` nor fire source_scoped_recovery_action solely
+// for lacking a scheduled monitor check — the label IS the standing waiting path.
+export const PERPETUAL_TRACKER_LABEL = "perpetual-tracker";
+
+export function hasPerpetualTrackerLabel(issue: IssueLivenessIssueInput) {
+  return Array.isArray(issue.labels) && issue.labels.includes(PERPETUAL_TRACKER_LABEL);
 }
 
 export interface IssueLivenessRelationInput {
@@ -395,7 +405,8 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
   }
 
   function hasExplicitWaitingPath(issue: IssueLivenessIssueInput) {
-    return Boolean(issue.assigneeUserId) ||
+    return hasPerpetualTrackerLabel(issue) ||
+      Boolean(issue.assigneeUserId) ||
       hasScheduledMonitor(issue, nowMs) ||
       hasActiveExecutionPath(issue.companyId, issue.id, activeRuns, queuedWakeRequests) ||
       hasWaitingPath(issue.companyId, issue.id, pendingInteractions) ||

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -22,6 +22,10 @@ export function isStrandedIssueRecoveryOriginKind(originKind: string | null | un
   return originKind === RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 }
 
+export function isProductivityReviewOriginKind(originKind: string | null | undefined) {
+  return originKind === RECOVERY_ORIGIN_KINDS.issueProductivityReview;
+}
+
 export function buildIssueGraphLivenessIncidentKey(input: {
   companyId: string;
   issueId: string;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -17,10 +17,12 @@ import {
   heartbeatRunWatchdogDecisions,
   heartbeatRuns,
   issueApprovals,
+  issueLabels,
   issueRecoveryActions,
   issueRelations,
   issueThreadInteractions,
   issues,
+  labels,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -46,10 +48,12 @@ import {
 import {
   RECOVERY_ORIGIN_KINDS,
   buildIssueGraphLivenessLeafKey,
+  isProductivityReviewOriginKind,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";
 import {
+  PERPETUAL_TRACKER_LABEL,
   classifyIssueGraphLiveness,
   type IssueLivenessFinding,
 } from "./issue-graph-liveness.js";
@@ -1825,6 +1829,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
 
+    // BLU-10308: productivity_review issues are reviewer-decision artifacts with no
+    // execution to recover. Exempt them from the stranded-work blocked-flip and the
+    // source_scoped_recovery_action wake — flipping them to blocked is what fed the
+    // 27-issue productivity-review loop. Returning null is treated as a skip by callers.
+    if (isProductivityReviewOriginKind(input.issue.originKind)) {
+      return null;
+    }
+
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,
@@ -2267,6 +2279,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       approvalRows,
       recoveryIssueRows,
       recoveryActionRows,
+      perpetualTrackerLabelRows,
     ] = await Promise.all([
       issueRowsPromise,
       db
@@ -2376,7 +2389,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               ),
             );
       }),
+      // BLU-10337: only the perpetual-tracker label affects liveness classification,
+      // so the join stays cheap — match the single label name across analyzed issues.
+      issueRowsPromise.then((rows) => {
+        const issueIdsUnderAnalysis = rows.map((row) => row.id);
+        return issueIdsUnderAnalysis.length === 0
+          ? []
+          : db
+            .select({ issueId: issueLabels.issueId })
+            .from(issueLabels)
+            .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+            .where(
+              and(
+                eq(labels.name, PERPETUAL_TRACKER_LABEL),
+                inArray(issueLabels.issueId, issueIdsUnderAnalysis),
+              ),
+            );
+      }),
     ]);
+
+    const perpetualTrackerIssueIds = new Set(perpetualTrackerLabelRows.map((row) => row.issueId));
 
     const openRecoveryIssues = recoveryIssueRows.flatMap((row) => {
       if (row.originKind === RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation) {
@@ -2407,7 +2439,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
 
     return classifyIssueGraphLiveness({
-      issues: issueRows,
+      issues: issueRows.map((row) => ({
+        ...row,
+        labels: perpetualTrackerIssueIds.has(row.id) ? [PERPETUAL_TRACKER_LABEL] : [],
+      })),
       relations: relationRows,
       agents: agentRows,
       activeRuns: activeRunRows.map((row) => ({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2389,23 +2389,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               ),
             );
       }),
-      // BLU-10337: only the perpetual-tracker label affects liveness classification,
-      // so the join stays cheap — match the single label name across analyzed issues.
-      issueRowsPromise.then((rows) => {
-        const issueIdsUnderAnalysis = rows.map((row) => row.id);
-        return issueIdsUnderAnalysis.length === 0
-          ? []
-          : db
-            .select({ issueId: issueLabels.issueId })
-            .from(issueLabels)
-            .innerJoin(labels, eq(issueLabels.labelId, labels.id))
-            .where(
-              and(
-                eq(labels.name, PERPETUAL_TRACKER_LABEL),
-                inArray(issueLabels.issueId, issueIdsUnderAnalysis),
-              ),
-            );
-      }),
+      // BLU-10337: only the perpetual-tracker label affects liveness classification.
+      // Match the single label name unconditionally so this runs concurrently with the
+      // issue scan instead of waiting on it — results are scoped to analyzed issues at
+      // classifier-input build time via perpetualTrackerIssueIds.has(row.id).
+      db
+        .select({ issueId: issueLabels.issueId })
+        .from(issueLabels)
+        .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+        .where(eq(labels.name, PERPETUAL_TRACKER_LABEL)),
     ]);
 
     const perpetualTrackerIssueIds = new Set(perpetualTrackerLabelRows.map((row) => row.issueId));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery subsystem watches for "stranded" assigned issues (no live execution path) and flips them to `blocked`, while the productivity-review service periodically refreshes reviewer-facing evidence comments
> - `productivity_review` issues are reviewer-decision artifacts — they have no execution to continue, yet the stranded-work engine kept flipping them to `blocked`; meanwhile the evidence refresher re-posted byte-identical `evidence refreshed` comments roughly every 30s
> - Together this produced a self-sustaining loop across a 27-issue cluster (BLU-10307): ~15–20k machine comments and repeated blocked-flips
> - This pull request exempts `productivity_review` origin issues from the stranded-work flip, dedups identical evidence refresh posts, and treats the `perpetual-tracker` label as an explicit waiting path (BLU-10337)
> - The benefit is the loop stops at its two root causes (no-op recovery on reviewer artifacts + duplicate refresh posts), unblocking the BLU-10306 cleanup of the 27-issue cluster

## Linked Issues or Issue Description

Tracked in the Paperclip issue tracker (no corresponding GitHub issue numbers): BLU-10308 (this fix), BLU-10307 (parent — 27-issue productivity-review loop), BLU-10337 (perpetual-tracker liveness exemption), BLU-10306 (downstream cleanup gate). Inline description below follows the bug report template.

### What happened?

The stranded-work recovery engine treats `productivity_review` issues as if they have a live execution path to recover, repeatedly flipping them to `blocked`. Separately, the productivity-review evidence refresher re-posts a byte-identical `Productivity review evidence refreshed.` comment roughly every 30s with no unchanged-content guard. The two interact into a self-sustaining loop across a 27-issue cluster: ~15–20k machine comments plus repeated blocked-flips. A related case: issues carrying the `perpetual-tracker` label are escalated for "no live execution path" even though the label is itself an explicit waiting signal.

### Expected behavior

- `productivity_review` issues (reviewer-decision artifacts with no execution to continue) are never flipped to `blocked` by the stranded-work engine.
- The evidence refresher skips posting when the rendered evidence is byte-identical to the last refresh comment.
- Issues labelled `perpetual-tracker` are treated as having an explicit waiting path and are not escalated for lacking a scheduled monitor.

### Steps to reproduce

1. Assign a `productivity_review` issue to an agent and let the recovery sweep run; observe it flipped to `blocked` despite having no execution to recover.
2. Let the productivity-review reconcile loop run repeatedly with unchanged evidence; observe a fresh `evidence refreshed` comment posted ~every 30s.
3. Observe the recovery engine re-triggering on the comment churn, producing the cluster-wide loop.

## What Changed

- **Recovery engine exemption** (`server/src/services/recovery/service.ts`, `origins.ts`): `escalateStrandedAssignedIssue` early-returns `null` (already treated as a skip by every caller) for `issue_productivity_review` origin issues, so they are never flipped to `blocked`. New `isProductivityReviewOriginKind` helper mirrors the existing `isStrandedIssueRecoveryOriginKind` pattern. Dispatch/continuation paths are untouched.
- **Identical-evidence dedup** (`server/src/services/productivity-review.ts`): `createOrUpdateReview` renders the candidate body once; `getRefreshCommentState` now returns `latestBody` via a correlated subquery, and the post is skipped when byte-identical to the last refresh comment. The cap+interval check is wrapped in a `pg_advisory_xact_lock` transaction to serialize concurrent reconcile processes and prevent race duplicates.
- **Perpetual-tracker exemption** (`server/src/services/recovery/issue-graph-liveness.ts`, `service.ts`): `classifyIssueGraphLiveness` treats the `perpetual-tracker` label as an explicit waiting path. Adds `PERPETUAL_TRACKER_LABEL` + `hasPerpetualTrackerLabel`; the service join plumbs label names into the classifier input.
- **Re-exports** (`server/src/services/recovery/index.ts`): exposes the three new symbols.

## Verification

- `pnpm --filter @paperclip/server test` — 80 tests green across 4 server suites, including:
  - `recovery-classifiers.test.ts` — unit coverage for `isProductivityReviewOriginKind`, `hasPerpetualTrackerLabel`, and the classifier exemption with a negative control
  - `heartbeat-process-recovery.test.ts` — embedded-Postgres integration: blocked-flip exemption for `productivity_review` on both `todo`/`assignment_recovery` and `in_progress`/`issue_continuation_needed` paths; recovery still fires for `todo`/`in_progress` non-review issues
  - `productivity-review-service.test.ts` — refresh-cap test reworked to vary evidence per interval, identical-evidence skip test, concurrent-reconciliation race test pinning the advisory-lock fix
  - `heartbeat-issue-liveness-escalation.test.ts` — end-to-end: seeds a `perpetual-tracker` label on the blocker, asserts zero escalations
- `pnpm --filter @paperclip/server typecheck` — `tsc --noEmit` clean
- All Paperclip CI gates green on this PR (Build, General tests, serialized server suites 1–4, e2e, Canary Dry Run, Typecheck + Release Registry, policy, Socket, Snyk, security-review).

## Risks

- **Low risk.** Each fix is additive and gated:
  - The recovery exemption only suppresses the blocked-flip + `source_scoped_recovery_action` for `productivity_review` origins; dispatch/continuation are unchanged, and non-review issues are unaffected (covered by negative-control tests).
  - The dedup only skips a post when content is byte-identical to the prior refresh comment; any content change still posts.
  - **Label-name coupling:** the perpetual-tracker exemption keys off the literal `perpetual-tracker` label name via the `PERPETUAL_TRACKER_LABEL` constant — renaming the label would require updating the constant.
  - **Advisory-lock scope (noted, non-regression):** `addRefreshComment`/`logActivity` run on the outer pool, not the `tx` connection, so a throw between them could leave a partial write. This matches pre-existing behavior (the original code already called these sequentially without a transaction); the advisory lock added here serializes concurrent reconciles correctly. Flagged for a future hardening pass rather than expanded in this surgical fix.
  - Greptile's sequential-waterfall nit on the label fetch is a sub-100ms micro-optimization, left out to keep this change surgical.

## Model Used

- Provider/model: Claude (Anthropic), Claude Opus 4.8 (`claude-opus-4-8`)
- Reasoning mode: extended thinking; tool use / code execution via Claude Code
- Context: standard Claude Code session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — see Risks for dispositions of the two non-blocking nits
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
