### PR TITLE
fix(ui): stop company-prefix accumulation on plugin routes

### DIFF
--- a/ui/src/hooks/useCompanyPageMemory.test.ts
+++ b/ui/src/hooks/useCompanyPageMemory.test.ts
@@ -88,3 +88,24 @@ describe("sanitizeRememberedPathForCompany", () => {
     ).toBe("/skills/skill-123/files/SKILL.md");
   });
 });
+
+describe("sanitizeRememberedPathForCompany — known-prefix self-heal", () => {
+  it("fully self-heals mixed-prefix corruption in one pass when given all known prefixes", () => {
+    expect(
+      sanitizeRememberedPathForCompany({
+        path: "/BETA/ACME/my-plugin",
+        companyPrefix: "ACME",
+        knownCompanyPrefixes: ["ACME", "BETA"],
+      }),
+    ).toBe("/my-plugin");
+  });
+
+  it("falls back to the target prefix alone when known prefixes are not provided", () => {
+    expect(
+      sanitizeRememberedPathForCompany({
+        path: "/ACME/my-plugin",
+        companyPrefix: "ACME",
+      }),
+    ).toBe("/my-plugin");
+  });
+});

--- a/ui/src/hooks/useCompanyPageMemory.ts
+++ b/ui/src/hooks/useCompanyPageMemory.ts
@@ -49,13 +49,20 @@ export function useCompanyPageMemory() {
   // Uses prevCompanyId ref so we save under the correct company even
   // during the render where selectedCompanyId has already changed.
   const fullPath = location.pathname + location.search;
+  const knownPrefixes = useMemo(
+    () => companies.map((company) => company.issuePrefix),
+    [companies],
+  );
   useEffect(() => {
     const companyId = rememberedPathOwnerCompanyId;
-    const relativePath = toCompanyRelativePath(fullPath);
+    // Pass the known prefixes so plugin-contributed routes (not in the
+    // board-root allowlist) still get their company prefix stripped before
+    // being remembered — otherwise the prefix accumulates on every switch.
+    const relativePath = toCompanyRelativePath(fullPath, knownPrefixes);
     if (companyId && isRememberableCompanyPath(relativePath)) {
       saveCompanyPath(companyId, relativePath);
     }
-  }, [fullPath, rememberedPathOwnerCompanyId]);
+  }, [fullPath, rememberedPathOwnerCompanyId, knownPrefixes]);
 
   // Navigate to saved path when company changes
   useEffect(() => {

--- a/ui/src/hooks/useCompanyPageMemory.ts
+++ b/ui/src/hooks/useCompanyPageMemory.ts
@@ -77,10 +77,11 @@ export function useCompanyPageMemory() {
         const targetPath = sanitizeRememberedPathForCompany({
           path: paths[selectedCompanyId],
           companyPrefix: selectedCompany.issuePrefix,
+          knownCompanyPrefixes: knownPrefixes,
         });
         navigate(`/${selectedCompany.issuePrefix}${targetPath}`, { replace: true });
       }
     }
     prevCompanyId.current = selectedCompanyId;
-  }, [selectedCompany, selectedCompanyId, selectionSource, navigate]);
+  }, [selectedCompany, selectedCompanyId, selectionSource, navigate, knownPrefixes]);
 }

--- a/ui/src/lib/company-page-memory.ts
+++ b/ui/src/lib/company-page-memory.ts
@@ -43,7 +43,9 @@ export function sanitizeRememberedPathForCompany(params: {
   path: string | null | undefined;
   companyPrefix: string;
 }): string {
-  const relativePath = params.path ? toCompanyRelativePath(params.path) : "/dashboard";
+  const relativePath = params.path
+    ? toCompanyRelativePath(params.path, [params.companyPrefix])
+    : "/dashboard";
   if (!isRememberableCompanyPath(relativePath)) {
     return "/dashboard";
   }

--- a/ui/src/lib/company-page-memory.ts
+++ b/ui/src/lib/company-page-memory.ts
@@ -42,9 +42,17 @@ export function getRememberedPathOwnerCompanyId<T extends { id: string; issuePre
 export function sanitizeRememberedPathForCompany(params: {
   path: string | null | undefined;
   companyPrefix: string;
+  /** All companies' prefixes — lets restore fully self-heal paths corrupted
+   *  with a mix of different companies' prefixes in a single pass. Falls
+   *  back to the target prefix alone when not provided. */
+  knownCompanyPrefixes?: readonly string[];
 }): string {
+  const prefixes =
+    params.knownCompanyPrefixes && params.knownCompanyPrefixes.length > 0
+      ? params.knownCompanyPrefixes
+      : [params.companyPrefix];
   const relativePath = params.path
-    ? toCompanyRelativePath(params.path, [params.companyPrefix])
+    ? toCompanyRelativePath(params.path, prefixes)
     : "/dashboard";
   if (!isRememberableCompanyPath(relativePath)) {
     return "/dashboard";

--- a/ui/src/lib/company-routes.test.ts
+++ b/ui/src/lib/company-routes.test.ts
@@ -28,6 +28,33 @@ describe("company routes", () => {
     );
   });
 
+  it("strips known company prefixes from plugin-contributed routes", () => {
+    // Plugin pages are not in BOARD_ROUTE_ROOTS — the second-segment check
+    // left the prefix in place, so remembered paths accumulated a new prefix
+    // on every company switch.
+    const known = ["ACME", "BETA"];
+    expect(toCompanyRelativePath("/ACME/my-plugin", known)).toBe("/my-plugin");
+    expect(toCompanyRelativePath("/ACME/my-plugin/sub?tab=x", known)).toBe("/my-plugin/sub?tab=x");
+  });
+
+  it("self-heals remembered paths corrupted by prefix accumulation", () => {
+    const known = ["ACME", "BETA"];
+    expect(toCompanyRelativePath("/BETA/ACME/my-plugin", known)).toBe("/my-plugin");
+    expect(toCompanyRelativePath("/ACME/BETA/ACME/my-plugin", known)).toBe("/my-plugin");
+  });
+
+  it("never strips plugin roots that are not known prefixes", () => {
+    expect(toCompanyRelativePath("/ACME/my-plugin/sub", ["ACME"])).toBe("/my-plugin/sub");
+    expect(toCompanyRelativePath("/my-plugin/sub", ["ACME"])).toBe("/my-plugin/sub");
+  });
+
+  it("leaves global and unprefixed board paths untouched (with and without known prefixes)", () => {
+    expect(toCompanyRelativePath("/docs/getting-started", ["ACME"])).toBe("/docs/getting-started");
+    expect(toCompanyRelativePath("/issues/ABC-1", ["ACME"])).toBe("/issues/ABC-1");
+    expect(toCompanyRelativePath("/dashboard", ["ACME"])).toBe("/dashboard");
+    expect(toCompanyRelativePath("/PAP/issues/PAP-1")).toBe("/issues/PAP-1");
+  });
+
   it("treats /search as a board route that needs a company prefix", () => {
     expect(isBoardPathWithoutPrefix("/search")).toBe(true);
     expect(extractCompanyPrefixFromPath("/search")).toBeNull();

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -77,9 +77,33 @@ export function applyCompanyPrefix(path: string, companyPrefix: string | null | 
   return `/${prefix}${pathname}${search}${hash}`;
 }
 
-export function toCompanyRelativePath(path: string): string {
+export function toCompanyRelativePath(
+  path: string,
+  knownCompanyPrefixes?: readonly string[],
+): string {
   const { pathname, search, hash } = splitPath(path);
   const segments = pathname.split("/").filter(Boolean);
+
+  // When the caller can supply the known company prefixes, strip ALL leading
+  // company prefixes. The legacy heuristic below only recognises built-in
+  // board roots as "the segment after a prefix", so plugin-contributed pages
+  // (e.g. /ACME/my-plugin) were stored prefix-and-all and accumulated another
+  // prefix on every company switch (/BETA/ACME/my-plugin → … → 404).
+  // Stripping in a loop also self-heals paths already corrupted in
+  // localStorage. Only known prefixes are stripped, so a plugin route that
+  // happens to share a prefix-like shape is never eaten.
+  if (knownCompanyPrefixes && knownCompanyPrefixes.length > 0) {
+    const known = new Set(knownCompanyPrefixes.map((prefix) => normalizeCompanyPrefix(prefix)));
+    let stripped = false;
+    while (segments.length >= 2 && known.has(normalizeCompanyPrefix(segments[0]!))) {
+      segments.shift();
+      stripped = true;
+    }
+    if (stripped) {
+      return `/${segments.join("/")}${search}${hash}`;
+    }
+    return `${pathname}${search}${hash}`;
+  }
 
   if (segments.length >= 2) {
     const second = segments[1]!.toLowerCase();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The board UI remembers the last visited page per company and restores it on company switch (`useCompanyPageMemory` + `toCompanyRelativePath`)
> - Plugins can contribute their own UI pages, whose route roots the host cannot know at build time
> - The remembered-path normalizer only strips the company prefix when the *second* URL segment is a built-in board root, so plugin pages are remembered prefix-and-all
> - On every company switch the restore logic glues a new prefix onto the stored one: `/ACME/my-plugin` → `/BETA/ACME/my-plugin` → … → 404, persisted in localStorage
> - This pull request makes prefix-stripping aware of the *known company prefixes* instead of guessing from a route allowlist
> - The benefit is that plugin pages survive company switching, and already-corrupted stored paths self-heal in one pass

## Linked Issues or Issue Description

Fixes #7533

## What Changed

- `toCompanyRelativePath` accepts an optional `knownCompanyPrefixes` list; when provided, it strips leading segments matching a known prefix in a loop (self-healing corrupted paths) and never strips a plugin root that merely looks prefix-shaped. Single-argument behaviour is byte-identical for existing callers.
- `useCompanyPageMemory` passes the companies' prefixes (memoized) when saving, and on restore.
- `sanitizeRememberedPathForCompany` accepts `knownCompanyPrefixes` so mixed-prefix corruption heals in one pass (review feedback), falling back to the target prefix alone.
- 6 new unit tests across `company-routes.test.ts` and `useCompanyPageMemory.test.ts`.

## Verification

- `cd ui && npx vitest run src/lib/company-routes.test.ts src/hooks/useCompanyPageMemory.test.ts` — all pass (incl. plugin-route stripping, multi-prefix self-heal, prefix-lookalike protection, restore-side one-pass heal)
- `npx tsc -p ui/tsconfig.json --noEmit` — clean
- Full `ui/src/lib` + `ui/src/hooks` sweep: 450+ tests pass
- Reproduced the original failure on a live 2026.428.0 install with a plugin page; field report and minified-bundle workaround in #7533

## Risks

- Low. The new behaviour only activates when a caller passes `knownCompanyPrefixes`; all existing single-argument call sites (`LiveUpdatesProvider`) keep the legacy heuristic unchanged.
- Theoretical edge: a plugin route root that exactly equals an existing company's issue prefix would be stripped — but such a route was already unreachable under the prefixed router, so no behaviour regresses.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`, 1M context, extended thinking, tool use) via Claude Code, supervised — human-directed root-cause analysis on a live install preceded the patch.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)