### PR TITLE
feat(orchestration): per-issue engine router with decision log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/db/package.json packages/db/
 COPY packages/adapter-utils/package.json packages/adapter-utils/
 COPY packages/mcp-server/package.json packages/mcp-server/
+COPY packages/orchestration/package.json packages/orchestration/
 COPY packages/skills-catalog/package.json packages/skills-catalog/
 COPY packages/teams-catalog/package.json packages/teams-catalog/
 COPY packages/adapters/acpx-local/package.json packages/adapters/acpx-local/

--- a/packages/orchestration/CHANGELOG.md
+++ b/packages/orchestration/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @paperclipai/orchestration
+
+## 0.1.0
+
+- Initial core slice: pure `route()` router, tenant-injected policy
+  (`RouterDependencies.policy`, empty `DEFAULT_POLICY`), model catalog + pricing
+  snapshot, long-context promotion hooks, and the per-call telemetry contract.
+- Ships `EXAMPLE_POLICY` as a reference routing table.

--- a/packages/orchestration/README.md
+++ b/packages/orchestration/README.md
@@ -1,0 +1,57 @@
+# @paperclipai/orchestration
+
+A pure, tenant-agnostic LLM router. Given a `TaskDescriptor` and an injected
+routing policy, it picks `(engine, model)`, scores the decision, and produces a
+telemetry event — with no I/O and no clock dependency.
+
+## Why
+
+Adapter selection is otherwise static — one model pinned per agent. This package
+decides `(engine, model)` *per task*, scaling complexity (simple → critical),
+pivoting role (reasoning / orchestration / document / research / automation),
+and applying blast-radius safety edges (second-pass + sign-off gates).
+
+## Tenant-injected policy
+
+The core ships **no routing rules**. `DEFAULT_POLICY` is empty; the routing grid
+is supplied by the caller at runtime via `RouterDependencies.policy`. Task type
+ids are opaque to the core — define whatever taxonomy fits your domain.
+
+```ts
+import { route, EXAMPLE_POLICY } from '@paperclipai/orchestration';
+
+const decision = route(
+  { task_type: 'strategy_positioning_board', sensitivity: 'outbound', expected_complexity: 'complex' },
+  { policy: EXAMPLE_POLICY },
+);
+// → { engine: 'claude', model: 'claude-opus-4-7', fallback: { engine: 'chatgpt', … }, … }
+```
+
+`EXAMPLE_POLICY` (`./example-policy.ts`) is a reference table only — copy it and
+adapt it to your own task taxonomy.
+
+## What the core owns vs. what the tenant injects
+
+| Concern | Owner |
+|---|---|
+| Routing grid (task_type → engine) | **Tenant** (`deps.policy`) |
+| Sensitivity → complexity floor | Core (domain-neutral default) |
+| Second-pass + human sign-off gates | Core (blast-radius semantics) |
+| Model catalog + pricing snapshot | Core defaults (override via `selectModel` wrap) |
+| Long-context promotion (>200k) | Core, gated by `deps.geminiAvailable` |
+
+## Safety edges
+
+- `sensitivity: outbound|regulatory|critical` floors complexity and forces a
+  cross-vendor second pass; an unresolvable second pass throws
+  `RouterPolicyViolationError`.
+- `sensitivity: regulatory|critical` (or any critical-complexity task) sets
+  `human_sign_off_required`.
+- Tier 2 (`api`) requires `automation: true`, else fail-fast.
+
+## Telemetry
+
+`decisionToTelemetry(decision, descriptor)` lifts a decision into a
+`TelemetryEvent`; emit it via `InMemoryTelemetrySink`, `LoggerTelemetrySink`, or
+your own `TelemetrySink`. Outcome fields (`actual_cost_eur_cents`, `latency_ms`,
+`outcome_signal`) are filled by the caller after the call resolves.

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@paperclipai/orchestration",
+  "version": "0.1.0",
+  "description": "Tenant-agnostic LLM router core: pure (provider, model) routing from a TaskDescriptor + injected policy, with confidence-scored decisions and a telemetry contract.",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/orchestration"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/orchestration/src/errors.ts
+++ b/packages/orchestration/src/errors.ts
@@ -1,0 +1,20 @@
+/** Router error classes. Distinct types so callers can branch on the cause. */
+
+/** Router could not satisfy the active policy (e.g. Tier 2 without the automation
+ *  flag, or outbound sensitivity without a reachable second-pass engine). */
+export class RouterPolicyViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RouterPolicyViolationError';
+  }
+}
+
+/** The router itself is misconfigured — empty/missing policy, model catalog gap,
+ *  unknown task_type, etc. Never raised due to caller input alone; always
+ *  indicates a bug or stale configuration. */
+export class RouterConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RouterConfigError';
+  }
+}

--- a/packages/orchestration/src/example-policy.ts
+++ b/packages/orchestration/src/example-policy.ts
@@ -1,0 +1,138 @@
+/** Reference routing policy.
+ *
+ *  This is an EXAMPLE table demonstrating how a tenant wires task types to
+ *  engines. The core ships no rules of its own (`DEFAULT_POLICY` is empty); a
+ *  tenant supplies a table like this via `RouterDependencies.policy`. Task type
+ *  ids are opaque to the core — define whatever taxonomy fits your domain.
+ *
+ *  Each row maps a task category to a primary engine, an optional cross-vendor
+ *  second-pass engine, a default complexity, and the tier it lives in.
+ */
+
+import type { RoutingRule } from './policy.js';
+
+export const EXAMPLE_POLICY: ReadonlyArray<RoutingRule> = [
+  {
+    task_type: 'strategy_positioning_board',
+    primary: 'claude',
+    secondary: 'chatgpt',
+    role: 'reasoning',
+    default_complexity: 'complex',
+    tier: 1,
+    rationale: 'Strategy / positioning / board materials → reasoning engine, cross-vendor red-team',
+  },
+  {
+    task_type: 'regulated_domain_reasoning',
+    primary: 'claude',
+    secondary: 'chatgpt',
+    role: 'reasoning',
+    default_complexity: 'critical',
+    tier: 1,
+    rationale: 'Regulated-domain reasoning + outbound text → reasoning engine + cross-vendor pass + human sign-off',
+  },
+  {
+    task_type: 'workflow_orchestration',
+    primary: 'chatgpt',
+    secondary: 'claude',
+    role: 'orchestration',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Workflow orchestration / agent coordination → orchestration engine, reasoning on decision nodes',
+  },
+  {
+    task_type: 'multimodal_ux_prototyping',
+    primary: 'chatgpt',
+    secondary: 'gemini',
+    role: 'orchestration',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Multimodal / UX prototyping → orchestration engine, document engine only when document-heavy',
+  },
+  {
+    task_type: 'creative_copy_iteration',
+    primary: 'chatgpt',
+    secondary: 'claude',
+    role: 'orchestration',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Creative / presentations / copy iteration → orchestration engine, reasoning red-team',
+  },
+  {
+    task_type: 'long_context_multidoc_compare',
+    primary: 'gemini',
+    secondary: 'claude',
+    role: 'document',
+    default_complexity: 'complex',
+    tier: 1,
+    rationale: 'Long-context (>200k) / multi-doc compare → document engine, reasoning for outbound',
+  },
+  {
+    task_type: 'sop_kb_ingestion',
+    primary: 'gemini',
+    secondary: 'claude',
+    role: 'document',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'SOPs / knowledge base / manuals / studies → document engine, reasoning for critical outbound',
+  },
+  {
+    task_type: 'workspace_sheets_dataset',
+    primary: 'gemini',
+    role: 'document',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Workspace / spreadsheet dataset analysis → document engine',
+  },
+  {
+    task_type: 'meeting_transcript_action_items',
+    primary: 'gemini',
+    secondary: 'claude',
+    role: 'document',
+    default_complexity: 'simple',
+    tier: 1,
+    rationale: 'Meeting transcript → action items → document engine, reasoning for strategic take',
+  },
+  {
+    task_type: 'web_research_sourcing',
+    primary: 'perplexity',
+    secondary: 'claude',
+    role: 'research',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Web research / market monitoring / study sourcing → research engine, reasoning pass on outbound',
+  },
+  {
+    task_type: 'realtime_news_trend_scouting',
+    primary: 'perplexity',
+    secondary: 'claude',
+    role: 'research',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Realtime news / trend scouting → research engine, reasoning pass before outbound',
+  },
+  {
+    task_type: 'background_automation_bulk',
+    primary: 'api',
+    role: 'automation',
+    default_complexity: 'medium',
+    tier: 2,
+    rationale: 'Background automation / M2M / cron / bulk → Tier 2 API (requires automation=true)',
+  },
+  {
+    task_type: 'simple_classification_format',
+    primary: 'claude',
+    role: 'reasoning',
+    default_complexity: 'simple',
+    tier: 1,
+    rationale: 'Classification / formatting / labeling → cheapest fast model in Tier 1',
+  },
+  {
+    task_type: 'code_review_refactor',
+    primary: 'claude',
+    secondary: 'chatgpt',
+    role: 'reasoning',
+    default_complexity: 'medium',
+    tier: 1,
+    rationale: 'Code review / small refactor → reasoning engine, cross-vendor red-team',
+  },
+];

--- a/packages/orchestration/src/gemini.test.ts
+++ b/packages/orchestration/src/gemini.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeGeminiContextWindow,
+  GEMINI_AVAILABILITY_ENV_KEY,
+  geminiRequiresClaudeReasoningPass,
+  isGeminiAvailable,
+  shouldPromoteToGeminiLongContext,
+} from './index.js';
+
+describe('orchestration.gemini — long-context hooks', () => {
+  it('isGeminiAvailable defaults to false when env var unset', () => {
+    expect(isGeminiAvailable({})).toBe(false);
+  });
+
+  it('isGeminiAvailable accepts truthy variants', () => {
+    expect(isGeminiAvailable({ [GEMINI_AVAILABILITY_ENV_KEY]: 'true' })).toBe(true);
+    expect(isGeminiAvailable({ [GEMINI_AVAILABILITY_ENV_KEY]: '1' })).toBe(true);
+    expect(isGeminiAvailable({ [GEMINI_AVAILABILITY_ENV_KEY]: 'yes' })).toBe(true);
+    expect(isGeminiAvailable({ [GEMINI_AVAILABILITY_ENV_KEY]: 'no' })).toBe(false);
+  });
+
+  it('shouldPromoteToGeminiLongContext fires above 200k', () => {
+    expect(shouldPromoteToGeminiLongContext(199_999)).toBe(false);
+    expect(shouldPromoteToGeminiLongContext(200_001)).toBe(true);
+    expect(shouldPromoteToGeminiLongContext(undefined)).toBe(false);
+  });
+
+  it('describeGeminiContextWindow reports utilization and overflow', () => {
+    const ok = describeGeminiContextWindow(500_000, 1_000_000);
+    expect(ok.utilization).toBeCloseTo(0.5);
+    expect(ok.exceeds_window).toBe(false);
+
+    const overflow = describeGeminiContextWindow(2_500_000, 2_000_000);
+    expect(overflow.utilization).toBe(1);
+    expect(overflow.exceeds_window).toBe(true);
+  });
+
+  it('geminiRequiresClaudeReasoningPass fires for outbound-class sensitivity', () => {
+    expect(geminiRequiresClaudeReasoningPass('internal')).toBe(false);
+    expect(geminiRequiresClaudeReasoningPass('outbound')).toBe(true);
+    expect(geminiRequiresClaudeReasoningPass('regulatory')).toBe(true);
+    expect(geminiRequiresClaudeReasoningPass('critical')).toBe(true);
+  });
+});

--- a/packages/orchestration/src/gemini.ts
+++ b/packages/orchestration/src/gemini.ts
@@ -1,0 +1,65 @@
+/** Long-context / document-engine helpers for the router.
+ *
+ *  - Subscription availability check (env flag, no live ping — that belongs in
+ *    adapter integration, not router decision time).
+ *  - Context window guard: returns whether a long-context task should bias to a
+ *    document engine.
+ *  - Second-pass rule helper: any outbound/regulatory/critical document-engine
+ *    output should be paired with a reasoning-pass marker.
+ */
+
+import { LONG_CONTEXT_THRESHOLD_TOKENS, type Sensitivity } from './types.js';
+
+/** Env var contract. Set to `true|1|yes` once the long-context (Gemini Advanced)
+ *  subscription is reachable for the running agent. Defaults to `false` if unset. */
+const GEMINI_ENV_KEY = 'GEMINI_ADVANCED_AVAILABLE' as const;
+
+type Env = Record<string, string | undefined>;
+
+function readProcessEnv(): Env {
+  const maybeGlobal = globalThis as { process?: { env?: Env } };
+  return maybeGlobal.process?.env ?? {};
+}
+
+export function isGeminiAvailable(env: Env = readProcessEnv()): boolean {
+  const raw = env[GEMINI_ENV_KEY];
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+export function shouldPromoteToGeminiLongContext(estimatedInputTokens?: number): boolean {
+  if (!estimatedInputTokens) return false;
+  return estimatedInputTokens > LONG_CONTEXT_THRESHOLD_TOKENS;
+}
+
+/** True when a document-engine output should not ship without a reasoning pass —
+ *  i.e. anything outbound/regulatory/critical. */
+export function geminiRequiresClaudeReasoningPass(sensitivity: Sensitivity): boolean {
+  return sensitivity === 'outbound' || sensitivity === 'regulatory' || sensitivity === 'critical';
+}
+
+export interface GeminiContextWindowReport {
+  /** Effective context window for the chosen model. */
+  max_input_tokens: number;
+  estimated_input_tokens: number;
+  utilization: number; // 0..1
+  /** True when the request would overflow (caller must chunk or escalate). */
+  exceeds_window: boolean;
+}
+
+export function describeGeminiContextWindow(
+  estimatedInputTokens: number | undefined,
+  maxInputTokens: number,
+): GeminiContextWindowReport {
+  const tokens = estimatedInputTokens ?? 0;
+  const utilization = maxInputTokens > 0 ? Math.min(tokens / maxInputTokens, 1) : 0;
+  return {
+    max_input_tokens: maxInputTokens,
+    estimated_input_tokens: tokens,
+    utilization,
+    exceeds_window: tokens > maxInputTokens,
+  };
+}
+
+export const GEMINI_AVAILABILITY_ENV_KEY = GEMINI_ENV_KEY;

--- a/packages/orchestration/src/index.ts
+++ b/packages/orchestration/src/index.ts
@@ -1,0 +1,68 @@
+/** LLM orchestration core — public surface.
+ *
+ *  A pure, tenant-agnostic router: `(TaskDescriptor, RouterDependencies) →
+ *  RoutingDecision`. The routing grid is injected by the caller via
+ *  `RouterDependencies.policy`; the core ships an empty `DEFAULT_POLICY` plus a
+ *  domain-neutral safety overlay (sensitivity floor, second-pass + sign-off
+ *  gates). See `example-policy.ts` for a reference routing table. */
+
+export {
+  type ComplexityClass,
+  type Engine,
+  type EngineRole,
+  type ModelSelection,
+  type RouterDependencies,
+  type RoutingDecision,
+  type Sensitivity,
+  type TaskDescriptor,
+  type TaskType,
+  type TelemetryEvent,
+  type TelemetrySink,
+  type TierLevel,
+  LONG_CONTEXT_THRESHOLD_TOKENS,
+  TELEMETRY_SCHEMA_VERSION,
+} from './types.js';
+
+export { route } from './router.js';
+export { RouterConfigError, RouterPolicyViolationError } from './errors.js';
+
+export {
+  type AgentPolicy,
+  type AgentPolicyComplexityHint,
+  type RoutingRule,
+  DEFAULT_POLICY,
+  SENSITIVITY_COMPLEXITY_FLOOR,
+  agentPolicyComplexityToClass,
+  buildRuleIndex,
+  getRoutingRule,
+  maxComplexity,
+  requiresHumanSignOff,
+  requiresSecondPass,
+} from './policy.js';
+
+export { MODEL_CATALOG, selectModel } from './models.js';
+export {
+  CATALOG_VERSION as PRICING_CATALOG_VERSION,
+  estimateInputCost,
+  pricePerMillion,
+} from './pricing.js';
+
+export {
+  type GeminiContextWindowReport,
+  GEMINI_AVAILABILITY_ENV_KEY,
+  describeGeminiContextWindow,
+  geminiRequiresClaudeReasoningPass,
+  isGeminiAvailable,
+  shouldPromoteToGeminiLongContext,
+} from './gemini.js';
+
+export {
+  type TelemetryLogger,
+  CompositeTelemetrySink,
+  InMemoryTelemetrySink,
+  LoggerTelemetrySink,
+  decisionToTelemetry,
+  noopTelemetrySink,
+} from './telemetry.js';
+
+export { EXAMPLE_POLICY } from './example-policy.js';

--- a/packages/orchestration/src/models.ts
+++ b/packages/orchestration/src/models.ts
@@ -1,0 +1,174 @@
+/** Default model catalog per engine + complexity tier.
+ *
+ *  Maps `(engine, complexity)` → the model name we actually call. This is the
+ *  shipped default; tenants can supply their own catalog by wrapping
+ *  `selectModel`. Bump in lockstep when vendors release new flagships.
+ */
+
+import { COMPLEXITY_RANK, type ComplexityClass, type Engine, type ModelSelection } from './types.js';
+
+interface ModelEntry {
+  engine: Engine;
+  /** Vendor model identifier as it appears in dashboards. */
+  model: string;
+  tier: 1 | 2 | 3;
+  max_input_tokens: number;
+  multimodal: boolean;
+  /** Lowest complexity this model is the "right size" for. Selector picks the
+   *  cheapest model whose tier ≥ requested complexity. */
+  min_complexity: ComplexityClass;
+}
+
+/** Catalog ordered cheapest → most expensive within each engine. */
+export const MODEL_CATALOG: ReadonlyArray<ModelEntry> = [
+  // Claude — reasoning
+  {
+    engine: 'claude',
+    model: 'claude-haiku-4-5',
+    tier: 1,
+    max_input_tokens: 200_000,
+    multimodal: true,
+    min_complexity: 'simple',
+  },
+  {
+    engine: 'claude',
+    model: 'claude-sonnet-4-6',
+    tier: 1,
+    max_input_tokens: 200_000,
+    multimodal: true,
+    min_complexity: 'medium',
+  },
+  {
+    engine: 'claude',
+    model: 'claude-opus-4-7',
+    tier: 1,
+    max_input_tokens: 200_000,
+    multimodal: true,
+    min_complexity: 'complex',
+  },
+
+  // ChatGPT — orchestration / multimodal
+  {
+    engine: 'chatgpt',
+    model: 'gpt-4o-mini',
+    tier: 1,
+    max_input_tokens: 128_000,
+    multimodal: true,
+    min_complexity: 'simple',
+  },
+  {
+    engine: 'chatgpt',
+    model: 'gpt-4o',
+    tier: 1,
+    max_input_tokens: 128_000,
+    multimodal: true,
+    min_complexity: 'medium',
+  },
+  {
+    engine: 'chatgpt',
+    model: 'gpt-5',
+    tier: 1,
+    max_input_tokens: 256_000,
+    multimodal: true,
+    min_complexity: 'complex',
+  },
+
+  // Gemini — document intelligence / long-context
+  {
+    engine: 'gemini',
+    model: 'gemini-flash',
+    tier: 1,
+    max_input_tokens: 1_000_000,
+    multimodal: true,
+    min_complexity: 'simple',
+  },
+  {
+    engine: 'gemini',
+    model: 'gemini-pro',
+    tier: 1,
+    max_input_tokens: 2_000_000,
+    multimodal: true,
+    min_complexity: 'medium',
+  },
+  {
+    engine: 'gemini',
+    model: 'gemini-ultra-long-context',
+    tier: 1,
+    max_input_tokens: 2_000_000,
+    multimodal: true,
+    min_complexity: 'complex',
+  },
+
+  // Perplexity — research
+  {
+    engine: 'perplexity',
+    model: 'perplexity-sonar',
+    tier: 1,
+    max_input_tokens: 200_000,
+    multimodal: false,
+    min_complexity: 'simple',
+  },
+  {
+    engine: 'perplexity',
+    model: 'perplexity-sonar-pro',
+    tier: 1,
+    max_input_tokens: 200_000,
+    multimodal: false,
+    min_complexity: 'medium',
+  },
+
+  // API (Tier 2) — automation only. Single placeholder model; concrete
+  // selection happens in adapter integration code, not the router.
+  {
+    engine: 'api',
+    model: 'api-automation-default',
+    tier: 2,
+    max_input_tokens: 200_000,
+    multimodal: false,
+    min_complexity: 'simple',
+  },
+];
+
+/** Pick the cheapest model in the engine that meets the requested complexity
+ *  and respects the requested context size + multimodal need. Returns null
+ *  when nothing in the catalog satisfies. */
+export function selectModel(
+  engine: Engine,
+  complexity: ComplexityClass,
+  opts: { estimated_input_tokens?: number; requires_multimodal?: boolean } = {},
+): ModelSelection | null {
+  const wantedRank = COMPLEXITY_RANK[complexity];
+  const candidates = MODEL_CATALOG.filter(
+    (m) =>
+      m.engine === engine &&
+      COMPLEXITY_RANK[m.min_complexity] <= wantedRank &&
+      (opts.estimated_input_tokens === undefined ||
+        m.max_input_tokens >= opts.estimated_input_tokens) &&
+      (!opts.requires_multimodal || m.multimodal),
+  );
+  // The catalog is ordered cheapest-first; pick the model whose min_complexity
+  // is closest to but not above the request — i.e. the highest min_complexity
+  // that is still ≤ wantedRank, or the cheapest meeting threshold otherwise.
+  const eligible = candidates.filter((m) => COMPLEXITY_RANK[m.min_complexity] <= wantedRank);
+  if (eligible.length === 0) return null;
+
+  // Pick the model whose min_complexity rank == wantedRank if present
+  // (avoids "most-expensive model on a Simple task" — cheapest-sufficient bias).
+  const exact = eligible
+    .filter((m) => COMPLEXITY_RANK[m.min_complexity] === wantedRank)
+    .at(-1);
+  const chosen =
+    exact ??
+    eligible
+      .slice()
+      .sort((a, b) => COMPLEXITY_RANK[b.min_complexity] - COMPLEXITY_RANK[a.min_complexity])[0];
+  if (!chosen) return null;
+
+  return {
+    engine: chosen.engine,
+    model: chosen.model,
+    tier: chosen.tier,
+    max_input_tokens: chosen.max_input_tokens,
+    multimodal: chosen.multimodal,
+  };
+}

--- a/packages/orchestration/src/policy.ts
+++ b/packages/orchestration/src/policy.ts
@@ -1,0 +1,155 @@
+/** Routing policy contracts.
+ *
+ *  The routing grid (which task types map to which engines) is *tenant-injected*:
+ *  the core ships an empty `DEFAULT_POLICY` and the caller supplies a
+ *  `RoutingRule[]` via `RouterDependencies.policy`. This keeps the core
+ *  tenant-agnostic — no organisation-specific routing rows live here.
+ *
+ *  The safety edges below (sensitivity → complexity floor, second-pass gate,
+ *  sign-off gate) are domain-neutral and ship as defaults, since they encode
+ *  blast-radius semantics rather than any specific routing preference.
+ */
+
+import { COMPLEXITY_RANK } from './types.js';
+import type {
+  ComplexityClass,
+  Engine,
+  EngineRole,
+  Sensitivity,
+  TaskType,
+  TierLevel,
+} from './types.js';
+
+/** Agent-level routing preferences attached to a `TaskDescriptor`.
+ *
+ *  Soft signals only — the router treats these as tie-breakers. Hard
+ *  constraints (Tier 2 unlock, sensitivity floor, long-context promotion,
+ *  multimodal pivot) always win. See `route()` for the resolution order. */
+export interface AgentPolicy {
+  /** Caller-attached complexity hint. Folded into complexity resolution after
+   *  `descriptor.expected_complexity` if the descriptor itself didn't pin a
+   *  value. Mapped into `ComplexityClass` via `agentPolicyComplexityToClass`. */
+  expectedComplexity?: AgentPolicyComplexityHint;
+  /** Caller-preferred engine. Honored only when it equals the routing rule's
+   *  declared `secondary` for this task type — otherwise silently ignored to
+   *  preserve the routing-grid contract. `null` is treated identically to
+   *  omitting the field; explicit nulling is allowed so config layers can
+   *  unset a previously-configured preference without dropping the key. */
+  preferredEngine?: Engine | null;
+}
+
+/** Coarser complexity vocabulary used in agent config UIs. We translate to
+ *  `ComplexityClass` (the policy-grid-native union) inside the router. */
+export type AgentPolicyComplexityHint = 'low' | 'medium' | 'high';
+
+const AGENT_POLICY_COMPLEXITY_TO_CLASS: Record<AgentPolicyComplexityHint, ComplexityClass> = {
+  low: 'simple',
+  medium: 'medium',
+  high: 'complex',
+};
+
+/** Lift the agent-config complexity hint into the native `ComplexityClass`.
+ *  `critical` cannot be requested from agent config — it is reserved for the
+ *  sensitivity floor in `SENSITIVITY_COMPLEXITY_FLOOR`. */
+export function agentPolicyComplexityToClass(
+  hint: AgentPolicyComplexityHint,
+): ComplexityClass {
+  return AGENT_POLICY_COMPLEXITY_TO_CLASS[hint];
+}
+
+/** A single row of the tenant routing grid. */
+export interface RoutingRule {
+  task_type: TaskType;
+  /** Primary engine choice when this rule matches. */
+  primary: Engine;
+  /** Optional cross-vendor second-pass / red-team for Complex+/outbound flows. */
+  secondary?: Engine;
+  /** Engine role label attached to telemetry. */
+  role: EngineRole;
+  /** Default complexity inferred for this row when caller omits expected_complexity. */
+  default_complexity: ComplexityClass;
+  /** Tier this rule lives in. Tier 2 (API) requires automation=true to unlock. */
+  tier: TierLevel;
+  /** Free-form annotation surfaced as the primary justification line. */
+  rationale: string;
+}
+
+/** Core default policy: empty. Tenants inject their routing grid at runtime via
+ *  `RouterDependencies.policy`. See `example-policy.ts` for a reference table. */
+export const DEFAULT_POLICY: ReadonlyArray<RoutingRule> = [];
+
+const POLICY_INDEX_CACHE = new WeakMap<
+  ReadonlyArray<RoutingRule>,
+  ReadonlyMap<TaskType, RoutingRule>
+>();
+
+/** Build a task_type → rule lookup from a policy table. Later rows win on
+ *  duplicate task_type so tenants can layer overrides. */
+export function buildRuleIndex(
+  policy: ReadonlyArray<RoutingRule>,
+): ReadonlyMap<TaskType, RoutingRule> {
+  const index = new Map<TaskType, RoutingRule>();
+  for (const rule of policy) {
+    index.set(rule.task_type, rule);
+  }
+  return index;
+}
+
+/** Resolve a single routing rule from a policy table. Throws when the task type
+ *  is not present — an empty/missing policy is a configuration error, not a
+ *  caller-input error. */
+export function getRoutingRule(
+  taskType: TaskType,
+  policy: ReadonlyArray<RoutingRule>,
+): RoutingRule {
+  let index = POLICY_INDEX_CACHE.get(policy);
+  if (!index) {
+    index = buildRuleIndex(policy);
+    POLICY_INDEX_CACHE.set(policy, index);
+  }
+  const rule = index.get(taskType);
+  if (!rule) {
+    throw new Error(
+      `No routing rule for task_type=${String(taskType)} in the active policy ` +
+        `(${policy.length} rule(s)). Inject a policy via RouterDependencies.policy.`,
+    );
+  }
+  return rule;
+}
+
+/** Sensitivity → minimum complexity floor.
+ *
+ *  Blast-radius bias: anything leaving the firm or touching regulated/critical
+ *  surfaces defaults to a higher complexity tier + second-pass. */
+export const SENSITIVITY_COMPLEXITY_FLOOR: Record<Sensitivity, ComplexityClass> = {
+  internal: 'simple',
+  outbound: 'complex',
+  regulatory: 'critical',
+  critical: 'critical',
+};
+
+export function maxComplexity(a: ComplexityClass, b: ComplexityClass): ComplexityClass {
+  return COMPLEXITY_RANK[a] >= COMPLEXITY_RANK[b] ? a : b;
+}
+
+/** True when the sensitivity gate fires (outbound/regulatory/critical, or any
+ *  complex/critical task). */
+export function requiresSecondPass(
+  sensitivity: Sensitivity,
+  complexity: ComplexityClass,
+): boolean {
+  if (sensitivity === 'outbound' || sensitivity === 'regulatory' || sensitivity === 'critical') {
+    return true;
+  }
+  return complexity === 'complex' || complexity === 'critical';
+}
+
+/** True when human sign-off is mandatory (regulatory/critical sensitivity, or a
+ *  critical-complexity task). */
+export function requiresHumanSignOff(
+  sensitivity: Sensitivity,
+  complexity: ComplexityClass,
+): boolean {
+  if (sensitivity === 'regulatory' || sensitivity === 'critical') return true;
+  return complexity === 'critical';
+}

--- a/packages/orchestration/src/pricing.ts
+++ b/packages/orchestration/src/pricing.ts
@@ -1,0 +1,58 @@
+/** Per-token price catalog (input tokens, EUR cents per 1M tokens).
+ *
+ *  Hardcoded snapshot: vendors change pricing rarely, a hardcoded table is
+ *  auditable in git, and dashboards import the same constant. Manual update
+ *  workflow:
+ *    1. Bump CATALOG_VERSION + LAST_UPDATED.
+ *    2. Update PRICE_TABLE entries.
+ *    3. Re-run tests — fixtures pin expected estimated_cost values, so a price
+ *       change must propagate explicitly.
+ *
+ *  Output-token pricing is intentionally out of scope: the router only sees the
+ *  input descriptor, not the response. Callers fill `actual_cost_eur_cents`
+ *  with end-to-end totals after the call resolves.
+ */
+
+export const CATALOG_VERSION = 'pricing-2026-05-06' as const;
+export const LAST_UPDATED = '2026-05-06' as const;
+
+/** Input-token price in EUR cents per 1M tokens. EUR conversion baked in to keep
+ *  the router stateless — refresh whenever vendor USD price or FX moves materially. */
+const PRICE_TABLE: Record<string, number> = {
+  // Claude family
+  'claude-haiku-4-5': 80, // ~$0.80/1M
+  'claude-sonnet-4-6': 280, // ~$3.00/1M
+  'claude-opus-4-7': 1400, // ~$15.00/1M
+
+  // ChatGPT family
+  'gpt-4o-mini': 14, // ~$0.15/1M
+  'gpt-4o': 230, // ~$2.50/1M
+  'gpt-5': 1100, // ~$12.00/1M
+
+  // Gemini family — long-context premium kicks in over 128k
+  'gemini-flash': 7, // ~$0.075/1M
+  'gemini-pro': 110, // ~$1.25/1M
+  'gemini-ultra-long-context': 600, // ~$6.50/1M
+
+  // Perplexity family
+  'perplexity-sonar': 90, // bundled in Pro subscription, conservative cents/1M
+  'perplexity-sonar-pro': 280,
+
+  // API placeholder — replaced by adapter at call site
+  'api-automation-default': 230,
+};
+
+/** EUR cents for the planned input pass. Returns 0 if the model is unknown
+ *  (router still routes; cost is best-effort). */
+export function estimateInputCost(model: string, estimatedInputTokens?: number): number {
+  if (!estimatedInputTokens || estimatedInputTokens <= 0) return 0;
+  const pricePerMillion = PRICE_TABLE[model];
+  if (pricePerMillion === undefined) return 0;
+  // Round to nearest cent; never return fractional cents downstream.
+  return Math.round((estimatedInputTokens / 1_000_000) * pricePerMillion);
+}
+
+/** Exposed for tests / dashboard import. */
+export function pricePerMillion(model: string): number | undefined {
+  return PRICE_TABLE[model];
+}

--- a/packages/orchestration/src/router.test.ts
+++ b/packages/orchestration/src/router.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXAMPLE_POLICY,
+  RouterPolicyViolationError,
+  route,
+  type RouterDependencies,
+  type RoutingRule,
+  type TaskDescriptor,
+} from './index.js';
+
+/** Every test injects the reference policy — the core ships no rules of its own. */
+function deps(extra: Omit<RouterDependencies, 'policy'> = {}): RouterDependencies {
+  return { policy: EXAMPLE_POLICY, ...extra };
+}
+
+const PRIMARY_ENGINE_BY_TASK = Object.fromEntries(
+  EXAMPLE_POLICY.map((r): [string, RoutingRule['primary']] => [r.task_type, r.primary]),
+);
+
+describe('orchestration.route — empty default policy', () => {
+  it('throws when no policy is injected (core ships DEFAULT_POLICY = [])', () => {
+    expect(() =>
+      route({ task_type: 'strategy_positioning_board', sensitivity: 'internal' }),
+    ).toThrow(/No routing rule/);
+  });
+});
+
+describe('orchestration.route — policy grid coverage (all rows)', () => {
+  // One assertion per routing-grid row.
+  for (const rule of EXAMPLE_POLICY) {
+    it(`${rule.task_type} → primary engine ${rule.primary}`, () => {
+      const descriptor: TaskDescriptor = {
+        task_type: rule.task_type,
+        sensitivity: 'internal',
+        // Tier 2 rule must opt in to automation; everything else stays Tier 1.
+        ...(rule.tier === 2 ? { automation: true } : {}),
+      };
+      const decision = route(descriptor, deps({ geminiAvailable: true }));
+      expect(decision.engine).toBe(rule.primary);
+      expect(decision.role).toBe(rule.role);
+      expect(decision.tier).toBe(rule.tier);
+      expect(decision.justification[0]).toBe(rule.rationale);
+    });
+  }
+});
+
+describe('orchestration.route — sensitivity gate', () => {
+  it('outbound regulatory text gets a cross-vendor second-pass model', () => {
+    const decision = route(
+      {
+        task_type: 'regulated_domain_reasoning',
+        sensitivity: 'regulatory',
+        estimated_input_tokens: 12_000,
+      },
+      deps({ geminiAvailable: true }),
+    );
+    expect(decision.engine).toBe('claude');
+    expect(decision.fallback).toBeDefined();
+    expect(decision.fallback?.engine).not.toBe(decision.engine);
+    expect(decision.complexity_class).toBe('critical');
+    expect(decision.human_sign_off_required).toBe(true);
+  });
+
+  it('outbound sensitivity with an unsatisfiable context size throws', () => {
+    expect(() =>
+      route(
+        {
+          task_type: 'creative_copy_iteration',
+          sensitivity: 'outbound',
+          estimated_input_tokens: 999_999_999,
+        },
+        deps({ geminiAvailable: false }),
+      ),
+    ).toThrow();
+  });
+
+  it('internal Simple task does not require sign-off or fallback', () => {
+    const decision = route(
+      {
+        task_type: 'simple_classification_format',
+        sensitivity: 'internal',
+        expected_complexity: 'simple',
+      },
+      deps(),
+    );
+    expect(decision.human_sign_off_required).toBe(false);
+    expect(decision.fallback).toBeUndefined();
+  });
+});
+
+describe('orchestration.route — Tier escalation guard', () => {
+  it('background_automation_bulk without automation=true throws RouterPolicyViolationError', () => {
+    expect(() =>
+      route({ task_type: 'background_automation_bulk', sensitivity: 'internal' }, deps()),
+    ).toThrow(RouterPolicyViolationError);
+  });
+
+  it('background_automation_bulk with automation=true routes to API tier 2', () => {
+    const decision = route(
+      {
+        task_type: 'background_automation_bulk',
+        sensitivity: 'internal',
+        automation: true,
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('api');
+    expect(decision.tier).toBe(2);
+  });
+});
+
+describe('orchestration.route — edge cases', () => {
+  it('long-context >200k outbound regulatory text → document-engine ingestion + reasoning pass marker', () => {
+    const decision = route(
+      {
+        task_type: 'regulated_domain_reasoning',
+        sensitivity: 'regulatory',
+        estimated_input_tokens: 350_000,
+      },
+      deps({ geminiAvailable: true }),
+    );
+    // Promotion: long-context kicks engine to the document engine, reasoning becomes the second-pass.
+    expect(decision.engine).toBe('gemini');
+    expect(decision.fallback?.engine).toBe('claude');
+    expect(decision.justification.some((line) => line.includes('Long-context promotion'))).toBe(
+      true,
+    );
+    expect(decision.human_sign_off_required).toBe(true);
+  });
+
+  it('Critical client copy without explicit complexity → reasoning default + cross-vendor red team', () => {
+    const decision = route(
+      {
+        task_type: 'creative_copy_iteration',
+        sensitivity: 'critical',
+      },
+      deps(),
+    );
+    // Critical sensitivity floors complexity → Critical → reasoning red-team selected.
+    expect(decision.complexity_class).toBe('critical');
+    expect(decision.fallback?.engine).toBe('claude');
+    expect(decision.engine).toBe(PRIMARY_ENGINE_BY_TASK['creative_copy_iteration']);
+    expect(decision.human_sign_off_required).toBe(true);
+  });
+
+  it('multimodal UX prototyping → ChatGPT primary; document engine secondary only when document-heavy', () => {
+    const decision = route(
+      {
+        task_type: 'multimodal_ux_prototyping',
+        sensitivity: 'internal',
+        requires_multimodal: true,
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('chatgpt');
+  });
+
+  it('web research / sourcing → Perplexity + reasoning pass marker on outbound', () => {
+    const decision = route(
+      {
+        task_type: 'web_research_sourcing',
+        sensitivity: 'outbound',
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('perplexity');
+    expect(decision.fallback?.engine).toBe('claude');
+  });
+
+  it('bulk parsing / cron without automation flag → fail-fast', () => {
+    expect(() =>
+      route({ task_type: 'background_automation_bulk', sensitivity: 'internal' }, deps()),
+    ).toThrow(RouterPolicyViolationError);
+  });
+});
+
+describe('orchestration.route — model selection cost discipline', () => {
+  it('Simple internal task picks the cheapest tier model (no top-tier model on Simple)', () => {
+    const decision = route(
+      {
+        task_type: 'simple_classification_format',
+        sensitivity: 'internal',
+        expected_complexity: 'simple',
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('claude');
+    expect(decision.model).toBe('claude-haiku-4-5');
+  });
+
+  it('Complex strategy task escalates to the flagship + cross-vendor red-team', () => {
+    const decision = route(
+      {
+        task_type: 'strategy_positioning_board',
+        sensitivity: 'outbound',
+        expected_complexity: 'complex',
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('claude');
+    expect(decision.model).toBe('claude-opus-4-7');
+    expect(decision.fallback?.engine).toBe('chatgpt');
+  });
+
+  it('Estimated cost reflects token count × catalog price', () => {
+    const decision = route(
+      {
+        task_type: 'simple_classification_format',
+        sensitivity: 'internal',
+        expected_complexity: 'simple',
+        estimated_input_tokens: 100_000,
+      },
+      deps(),
+    );
+    // Haiku at 80 cents per 1M tokens; 100k tokens → 8 cents.
+    expect(decision.model).toBe('claude-haiku-4-5');
+    expect(decision.estimated_cost_eur_cents).toBe(8);
+  });
+});
+
+describe('orchestration.route — confidence', () => {
+  it('drops below 1.0 when the descriptor omits estimated_input_tokens and complexity hint', () => {
+    const decision = route(
+      {
+        task_type: 'strategy_positioning_board',
+        sensitivity: 'internal',
+      },
+      deps(),
+    );
+    expect(decision.confidence).toBeLessThan(1);
+  });
+});
+
+describe('orchestration.route — agent policy soft signals', () => {
+  it('preferredEngine matching rule.secondary swaps primary↔secondary', () => {
+    // strategy_positioning_board: primary=claude, secondary=chatgpt.
+    const decision = route(
+      {
+        task_type: 'strategy_positioning_board',
+        sensitivity: 'outbound',
+        expected_complexity: 'complex',
+        agent_policy: { preferredEngine: 'chatgpt' },
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('chatgpt');
+    expect(decision.fallback?.engine).toBe('claude');
+    expect(decision.justification.some((line) => line.includes('preferredEngine=chatgpt'))).toBe(
+      true,
+    );
+  });
+
+  it('preferredEngine=gemini does not re-run long-context promotion after swap', () => {
+    // multimodal_ux_prototyping: primary=chatgpt, secondary=gemini. Once the
+    // preference swaps primary to gemini, long-context promotion must not clobber
+    // the intended chatgpt second pass.
+    const decision = route(
+      {
+        task_type: 'multimodal_ux_prototyping',
+        sensitivity: 'outbound',
+        expected_complexity: 'complex',
+        estimated_input_tokens: 350_000,
+        agent_policy: { preferredEngine: 'gemini' },
+      },
+      deps({ geminiAvailable: true }),
+    );
+    expect(decision.engine).toBe('gemini');
+    expect(decision.fallback?.engine).toBe('chatgpt');
+    expect(decision.justification.some((line) => line.includes('Long-context promotion'))).toBe(
+      false,
+    );
+  });
+
+  it('preferredEngine that is not in {primary, secondary} is silently ignored', () => {
+    // regulated_domain_reasoning: primary=claude, secondary=chatgpt. gemini is
+    // not allowed → preference is dropped, reasoning engine stays primary. This
+    // is also the regulatory-floor guardrail: a regulated task cannot be
+    // downgraded to a document-engine primary via agent config alone.
+    const decision = route(
+      {
+        task_type: 'regulated_domain_reasoning',
+        sensitivity: 'regulatory',
+        estimated_input_tokens: 12_000,
+        agent_policy: { preferredEngine: 'gemini' },
+      },
+      deps({ geminiAvailable: true }),
+    );
+    expect(decision.engine).toBe('claude');
+    expect(decision.justification.some((line) => line.includes('ignored'))).toBe(true);
+  });
+
+  it('preferredEngine equal to current engine is a no-op', () => {
+    const decision = route(
+      {
+        task_type: 'strategy_positioning_board',
+        sensitivity: 'internal',
+        agent_policy: { preferredEngine: 'claude' },
+      },
+      deps(),
+    );
+    expect(decision.engine).toBe('claude');
+    expect(decision.justification.some((line) => line.includes('preferredEngine'))).toBe(false);
+  });
+
+  it('expectedComplexity=high promotes the model tier when the descriptor omits the explicit hint', () => {
+    // simple_classification_format default complexity = simple → haiku.
+    // agent policy bumps to "high" → complex → opus.
+    const decision = route(
+      {
+        task_type: 'simple_classification_format',
+        sensitivity: 'internal',
+        agent_policy: { expectedComplexity: 'high' },
+      },
+      deps(),
+    );
+    expect(decision.complexity_class).toBe('complex');
+    expect(decision.model).toBe('claude-opus-4-7');
+  });
+
+  it('expectedComplexity=low keeps the cheapest model when the rule default is medium', () => {
+    // code_review_refactor default complexity = medium → sonnet.
+    // agent policy hint "low" → simple → haiku (cheaper economy tier).
+    const decision = route(
+      {
+        task_type: 'code_review_refactor',
+        sensitivity: 'internal',
+        agent_policy: { expectedComplexity: 'low' },
+      },
+      deps(),
+    );
+    expect(decision.complexity_class).toBe('simple');
+    expect(decision.model).toBe('claude-haiku-4-5');
+  });
+
+  it('descriptor.expected_complexity wins over agent_policy.expectedComplexity (caller-explicit beats config)', () => {
+    const decision = route(
+      {
+        task_type: 'simple_classification_format',
+        sensitivity: 'internal',
+        expected_complexity: 'simple',
+        agent_policy: { expectedComplexity: 'high' },
+      },
+      deps(),
+    );
+    expect(decision.complexity_class).toBe('simple');
+    expect(decision.model).toBe('claude-haiku-4-5');
+  });
+
+  it('agent_policy.expectedComplexity is still floored by sensitivity (regulatory → critical)', () => {
+    const decision = route(
+      {
+        task_type: 'regulated_domain_reasoning',
+        sensitivity: 'regulatory',
+        agent_policy: { expectedComplexity: 'low' },
+      },
+      deps(),
+    );
+    // Sensitivity floor for regulatory is critical — agent hint cannot lower it.
+    expect(decision.complexity_class).toBe('critical');
+  });
+});

--- a/packages/orchestration/src/router.ts
+++ b/packages/orchestration/src/router.ts
@@ -1,0 +1,274 @@
+/** Pure router: TaskDescriptor → RoutingDecision.
+ *
+ *  Resolves a routing rule from the tenant-injected policy table, applies the
+ *  complexity floor / second-pass / sign-off edges, and selects the cheapest
+ *  model that satisfies complexity + context size + multimodal.
+ *
+ *  Design notes:
+ *    - No I/O, no clock dependency beyond the optional `geminiAvailable`
+ *      injection. Telemetry emit is the caller's choice — the router stays
+ *      synchronous and side-effect-free for testability.
+ *    - The routing grid lives in `deps.policy` (tenant-supplied). Core ships an
+ *      empty `DEFAULT_POLICY`; an unknown task_type is a configuration error.
+ *    - Tier 2 (API) selection requires `automation=true`. Otherwise the router
+ *      fails fast to a policy-violation error.
+ */
+
+import { RouterConfigError, RouterPolicyViolationError } from './errors.js';
+import {
+  describeGeminiContextWindow,
+  geminiRequiresClaudeReasoningPass,
+  isGeminiAvailable,
+  shouldPromoteToGeminiLongContext,
+} from './gemini.js';
+import { selectModel } from './models.js';
+import {
+  agentPolicyComplexityToClass,
+  DEFAULT_POLICY,
+  getRoutingRule,
+  maxComplexity,
+  requiresHumanSignOff,
+  requiresSecondPass,
+  SENSITIVITY_COMPLEXITY_FLOOR,
+} from './policy.js';
+import { estimateInputCost } from './pricing.js';
+import type {
+  ComplexityClass,
+  Engine,
+  ModelSelection,
+  RouterDependencies,
+  RoutingDecision,
+  TaskDescriptor,
+} from './types.js';
+
+/** Engines that carry a Tier 1 reasoning role for second-pass purposes. */
+const REASONING_FALLBACK_ORDER: Engine[] = ['claude', 'chatgpt', 'gemini'];
+
+export function route(
+  descriptor: TaskDescriptor,
+  deps: RouterDependencies = {},
+): RoutingDecision {
+  const rule = getRoutingRule(descriptor.task_type, deps.policy ?? DEFAULT_POLICY);
+
+  // 1. Resolve effective complexity (caller hint vs. sensitivity floor vs. rule default).
+  const complexity = resolveComplexity(descriptor, rule.default_complexity);
+
+  // 2. Tier escalation guard: Tier 2 only with automation=true.
+  if (rule.tier === 2 && !descriptor.automation) {
+    throw new RouterPolicyViolationError(
+      `task_type=${descriptor.task_type} routes to Tier 2 (API) but automation flag is not set. ` +
+        `Set automation=true for cron/webhook/M2M flows, otherwise pick a Tier 1 task_type.`,
+    );
+  }
+
+  // 3. Engine selection.
+  const justification: string[] = [rule.rationale];
+  let engine: Engine = rule.primary;
+  let role = rule.role;
+  let roleMatchScore = 1.0;
+  // After long-context promotion the rule's declared secondary may be wrong, so
+  // track an override for the second-pass engine.
+  let secondPassOverride: Engine | undefined;
+
+  // 3a. Agent policy preferredEngine — soft tie-breaker.
+  // Honored only when it equals the rule's declared secondary (swap
+  // primary↔secondary). Anything else is silently ignored — keeps the policy
+  // grid as the single source of truth for engine eligibility.
+  const preferredEngine = descriptor.agent_policy?.preferredEngine ?? null;
+  if (preferredEngine && preferredEngine !== engine) {
+    if (rule.secondary && preferredEngine === rule.secondary) {
+      justification.push(
+        `Agent policy preferredEngine=${preferredEngine} matches rule secondary → swapping primary↔secondary as soft tie-breaker.`,
+      );
+      engine = preferredEngine;
+      secondPassOverride = rule.primary;
+      roleMatchScore = 0.9;
+    } else {
+      justification.push(
+        `Agent policy preferredEngine=${preferredEngine} ignored — incompatible with task_type=${descriptor.task_type} (allowed engines: ${rule.primary}${rule.secondary ? `/${rule.secondary}` : ''}).`,
+      );
+    }
+  }
+
+  // Long-context promotion to a document engine.
+  if (
+    shouldPromoteToGeminiLongContext(descriptor.estimated_input_tokens) &&
+    engine !== 'gemini' &&
+    rule.tier === 1 &&
+    engine !== 'perplexity' // research engine never gets promoted
+  ) {
+    const geminiOk = deps.geminiAvailable ?? isGeminiAvailable();
+    if (geminiOk) {
+      justification.push(
+        `Long-context promotion: estimated ${descriptor.estimated_input_tokens} tokens > 200k threshold → document-engine ingestion + reasoning pass.`,
+      );
+      engine = 'gemini';
+      role = 'document';
+      roleMatchScore = 0.85; // demoted from 1.0 — promotion is a sensitivity override, not a perfect role match
+      secondPassOverride = 'claude';
+    } else {
+      justification.push(
+        'Long-context task detected but the long-context subscription is unavailable; staying on primary engine and warning caller.',
+      );
+      roleMatchScore = 0.7;
+    }
+  }
+
+  // 4. Multimodal nudge.
+  if (descriptor.requires_multimodal && engine === 'claude') {
+    justification.push(
+      'Multimodal input requested → biased away from Claude towards ChatGPT.',
+    );
+    engine = 'chatgpt';
+    role = 'orchestration';
+    roleMatchScore = 0.8;
+  }
+
+  // 5. Pick the cheapest model that satisfies complexity + context size + multimodal.
+  const primaryModel = selectModel(engine, complexity, {
+    estimated_input_tokens: descriptor.estimated_input_tokens,
+    requires_multimodal: descriptor.requires_multimodal,
+  });
+  if (!primaryModel) {
+    throw new RouterConfigError(
+      `No model in catalog for engine=${engine} complexity=${complexity} ` +
+        `tokens=${descriptor.estimated_input_tokens ?? '?'} multimodal=${Boolean(descriptor.requires_multimodal)}`,
+    );
+  }
+
+  // 6. Second-pass / fallback.
+  let fallback: ModelSelection | undefined;
+  if (requiresSecondPass(descriptor.sensitivity, complexity)) {
+    const secondary = secondPassOverride ?? rule.secondary;
+    fallback = pickSecondPassModel(engine, secondary, complexity, descriptor);
+    if (!fallback) {
+      // For outbound/regulatory/critical we MUST have a configured cross-vendor pass.
+      if (
+        descriptor.sensitivity === 'outbound' ||
+        descriptor.sensitivity === 'regulatory' ||
+        descriptor.sensitivity === 'critical'
+      ) {
+        throw new RouterPolicyViolationError(
+          `Sensitivity=${descriptor.sensitivity} requires a cross-vendor second-pass model but none could be resolved (primary engine=${engine}, secondary=${rule.secondary ?? 'none'}).`,
+        );
+      }
+    } else {
+      justification.push(
+        `Second-pass gate (sensitivity=${descriptor.sensitivity}, complexity=${complexity}) → ${fallback.engine}/${fallback.model}.`,
+      );
+    }
+  }
+
+  // 7. Document-engine reinforcement: Gemini primary + outbound-class sensitivity → reasoning pass.
+  if (engine === 'gemini' && geminiRequiresClaudeReasoningPass(descriptor.sensitivity) && !fallback) {
+    // Reasoning pass operates on the document engine's summary/output, not raw input — no token cap.
+    const claudePass = selectModel('claude', maxComplexity(complexity, 'complex'));
+    if (claudePass) {
+      fallback = claudePass;
+      justification.push(
+        `Document-engine primary + sensitivity=${descriptor.sensitivity} → mandatory reasoning-pass marker.`,
+      );
+    }
+  }
+
+  // 8. Sign-off marker.
+  const humanSignOff = requiresHumanSignOff(descriptor.sensitivity, complexity);
+  if (humanSignOff) {
+    justification.push('Human sign-off required (critical complexity or regulatory/critical sensitivity).');
+  }
+
+  // 9. Confidence: 1.0 base, penalised for missing inputs / long-context fallback / multimodal pivot.
+  const confidence = computeConfidence({
+    descriptor,
+    roleMatchScore,
+    hasFallback: Boolean(fallback),
+  });
+
+  // 10. Estimated cost — primary call only (caller adds fallback cost when invoking second pass).
+  const estimatedCost = estimateInputCost(primaryModel.model, descriptor.estimated_input_tokens);
+
+  // 11. Document-engine context-window report appended to justification when relevant.
+  if (engine === 'gemini' && descriptor.estimated_input_tokens) {
+    const report = describeGeminiContextWindow(
+      descriptor.estimated_input_tokens,
+      primaryModel.max_input_tokens,
+    );
+    justification.push(
+      `Document-engine context window: ${descriptor.estimated_input_tokens}/${report.max_input_tokens} tokens (${(report.utilization * 100).toFixed(1)}% utilization).`,
+    );
+    if (report.exceeds_window) {
+      justification.push(
+        'WARNING: estimated input exceeds the document-engine context window — caller must chunk or escalate.',
+      );
+    }
+  }
+
+  return {
+    engine: primaryModel.engine,
+    model: primaryModel.model,
+    role,
+    complexity_class: complexity,
+    role_match_score: roleMatchScore,
+    estimated_cost_eur_cents: estimatedCost,
+    confidence,
+    justification,
+    fallback,
+    tier: primaryModel.tier,
+    human_sign_off_required: humanSignOff,
+  };
+}
+
+function resolveComplexity(
+  descriptor: TaskDescriptor,
+  ruleDefault: ComplexityClass,
+): ComplexityClass {
+  const floor = SENSITIVITY_COMPLEXITY_FLOOR[descriptor.sensitivity];
+  const agentHint = descriptor.agent_policy?.expectedComplexity;
+  const requested =
+    descriptor.expected_complexity ??
+    (agentHint ? agentPolicyComplexityToClass(agentHint) : undefined) ??
+    ruleDefault;
+  return maxComplexity(requested, floor);
+}
+
+function pickSecondPassModel(
+  primaryEngine: Engine,
+  secondary: Engine | undefined,
+  complexity: ComplexityClass,
+  _descriptor: TaskDescriptor,
+): ModelSelection | undefined {
+  // Second-pass models read a summary / draft from the primary, not the raw
+  // descriptor input — so we deliberately do NOT filter by
+  // `estimated_input_tokens` here. Otherwise long-context promotion (>200k)
+  // would have nowhere to land its cross-vendor pass.
+  if (secondary && secondary !== primaryEngine) {
+    const m = selectModel(secondary, maxComplexity(complexity, 'complex'));
+    if (m) return m;
+  }
+  for (const candidate of REASONING_FALLBACK_ORDER) {
+    if (candidate === primaryEngine) continue;
+    const m = selectModel(candidate, maxComplexity(complexity, 'complex'));
+    if (m) return m;
+  }
+  return undefined;
+}
+
+function computeConfidence(args: {
+  descriptor: TaskDescriptor;
+  roleMatchScore: number;
+  hasFallback: boolean;
+}): number {
+  const { descriptor, roleMatchScore, hasFallback } = args;
+  let conf = roleMatchScore;
+  if (descriptor.estimated_input_tokens === undefined) conf -= 0.05;
+  if (descriptor.expected_complexity === undefined) conf -= 0.05;
+  if (
+    (descriptor.sensitivity === 'outbound' ||
+      descriptor.sensitivity === 'regulatory' ||
+      descriptor.sensitivity === 'critical') &&
+    !hasFallback
+  ) {
+    conf -= 0.2;
+  }
+  return Math.max(0, Math.min(1, Number(conf.toFixed(2))));
+}

--- a/packages/orchestration/src/telemetry.test.ts
+++ b/packages/orchestration/src/telemetry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXAMPLE_POLICY,
+  InMemoryTelemetrySink,
+  decisionToTelemetry,
+  route,
+  type TelemetryEvent,
+} from './index.js';
+
+const deps = { policy: EXAMPLE_POLICY };
+
+describe('orchestration.telemetry — per-call contract', () => {
+  it('lifts a routing decision into a TelemetryEvent with required fields', () => {
+    const descriptor = {
+      task_type: 'strategy_positioning_board',
+      sensitivity: 'outbound' as const,
+      expected_complexity: 'complex' as const,
+      estimated_input_tokens: 5_000,
+      agent_id: 'agent-cto',
+      call_id: 'call-fixture-1',
+    };
+    const decision = route(descriptor, deps);
+    const event: TelemetryEvent = decisionToTelemetry(decision, descriptor, {
+      ts: '2026-05-06T00:00:00.000Z',
+    });
+    expect(event.call_id).toBe('call-fixture-1');
+    expect(event.ts).toBe('2026-05-06T00:00:00.000Z');
+    expect(event.agent_id).toBe('agent-cto');
+    expect(event.task_type).toBe('strategy_positioning_board');
+    expect(event.engine).toBe(decision.engine);
+    expect(event.model).toBe(decision.model);
+    expect(event.role).toBe(decision.role);
+    expect(event.complexity_class).toBe('complex');
+    expect(event.expected_cost_eur_cents).toBe(decision.estimated_cost_eur_cents);
+    expect(event.confidence).toBe(decision.confidence);
+    expect(event.fallback_engine).toBe(decision.fallback?.engine);
+    expect(event.fallback_model).toBe(decision.fallback?.model);
+    // Outcome fields stay undefined until caller populates them post-call.
+    expect(event.actual_cost_eur_cents).toBeUndefined();
+    expect(event.outcome_signal).toBeUndefined();
+    expect(event.failure_class).toBeUndefined();
+  });
+
+  it('InMemoryTelemetrySink retains emitted events in order', () => {
+    const sink = new InMemoryTelemetrySink();
+    const descriptor = {
+      task_type: 'web_research_sourcing',
+      sensitivity: 'internal' as const,
+    };
+    const decision = route(descriptor, deps);
+    sink.emit(decisionToTelemetry(decision, descriptor, { call_id: 'a', ts: 't' }));
+    sink.emit(decisionToTelemetry(decision, descriptor, { call_id: 'b', ts: 't' }));
+    expect(sink.events.map((e) => e.call_id)).toEqual(['a', 'b']);
+  });
+});

--- a/packages/orchestration/src/telemetry.ts
+++ b/packages/orchestration/src/telemetry.ts
@@ -1,0 +1,93 @@
+/** Per-call telemetry contract.
+ *
+ *  Single source of truth that dashboard and self-learning consumers both read.
+ *  Schema is fixed in `types.ts::TelemetryEvent`; this module provides:
+ *    - in-memory sink for tests and dev,
+ *    - logger sink that emits structured events for production tap-in,
+ *    - composite sink so callers can fan out to multiple sinks atomically,
+ *    - a `decisionToTelemetry()` helper that lifts a RoutingDecision into a
+ *      partially-populated TelemetryEvent (caller fills outcome fields after
+ *      the LLM call resolves).
+ */
+
+import {
+  TELEMETRY_SCHEMA_VERSION,
+  type RoutingDecision,
+  type TaskDescriptor,
+  type TelemetryEvent,
+  type TelemetrySink,
+} from './types.js';
+
+/** Minimal structural logger contract for {@link LoggerTelemetrySink}.
+ *
+ *  Kept dependency-free so this package stays vendor-agnostic. Concrete loggers
+ *  (pino, console, custom) match structurally. */
+export interface TelemetryLogger {
+  info: (obj: object, msg?: string) => void;
+}
+
+export class InMemoryTelemetrySink implements TelemetrySink {
+  readonly events: TelemetryEvent[] = [];
+  emit(event: TelemetryEvent): void {
+    this.events.push(event);
+  }
+}
+
+export class LoggerTelemetrySink implements TelemetrySink {
+  constructor(private readonly logger: TelemetryLogger) {}
+  emit(event: TelemetryEvent): void {
+    this.logger.info({ telemetry: event }, 'orchestration.telemetry');
+  }
+}
+
+export class CompositeTelemetrySink implements TelemetrySink {
+  constructor(private readonly sinks: readonly TelemetrySink[]) {}
+  async emit(event: TelemetryEvent): Promise<void> {
+    await Promise.all(this.sinks.map((s) => Promise.resolve(s.emit(event))));
+  }
+}
+
+/** No-op sink used as the default when callers don't supply one. */
+export const noopTelemetrySink: TelemetrySink = {
+  emit() {
+    /* intentional no-op */
+  },
+};
+
+/** Build the immutable portion of a TelemetryEvent from a routing decision +
+ *  the descriptor that produced it. Caller fills `actual_cost_eur_cents`,
+ *  `latency_ms`, `outcome_signal`, `failure_class`, `exit_code`,
+ *  `document_type` after the LLM call. */
+export function decisionToTelemetry(
+  decision: RoutingDecision,
+  descriptor: TaskDescriptor,
+  opts: { call_id?: string; ts?: string } = {},
+): TelemetryEvent {
+  return {
+    call_id: opts.call_id ?? descriptor.call_id ?? generateCallId(),
+    ts: opts.ts ?? new Date().toISOString(),
+    agent_id: descriptor.agent_id,
+    task_type: descriptor.task_type,
+    sensitivity: descriptor.sensitivity,
+    engine: decision.engine,
+    model: decision.model,
+    role: decision.role,
+    tier: decision.tier,
+    complexity_class: decision.complexity_class,
+    estimated_input_tokens: descriptor.estimated_input_tokens,
+    expected_cost_eur_cents: decision.estimated_cost_eur_cents,
+    confidence: decision.confidence,
+    role_match_score: decision.role_match_score,
+    justification: decision.justification,
+    human_sign_off_required: decision.human_sign_off_required,
+    fallback_engine: decision.fallback?.engine,
+    fallback_model: decision.fallback?.model,
+    schema_version: TELEMETRY_SCHEMA_VERSION,
+  };
+}
+
+function generateCallId(): string {
+  // crypto.randomUUID is in Node 22 and the standard runtime. call_id only needs
+  // to be unique within a sink, and most callers will have their own ids.
+  return globalThis.crypto?.randomUUID?.() ?? `call-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/packages/orchestration/src/types.ts
+++ b/packages/orchestration/src/types.ts
@@ -1,0 +1,185 @@
+/** LLM orchestration core — public types.
+ *
+ *  Source of truth for the routing layer. The router is tenant-agnostic: the
+ *  routing grid itself (which task types map to which engines) is supplied by
+ *  the caller via `RouterDependencies.policy`. This module only defines the
+ *  shared vocabulary (engines, complexity, sensitivity) and the decision /
+ *  telemetry shapes.
+ */
+
+import type { AgentPolicy } from './policy.js';
+
+/** Vendor + product tier combination. Tier 1 = subscription, Tier 2 = API automation. */
+export type Engine = 'claude' | 'chatgpt' | 'gemini' | 'perplexity' | 'api';
+
+/** Coarse role label attached to a routing decision for telemetry / dashboards. */
+export type EngineRole =
+  | 'reasoning' // senior strategic reasoning
+  | 'orchestration' // operational + creative + multimodal + agent coordination
+  | 'document' // long-context, knowledge base, multi-doc compare
+  | 'research' // web research, monitoring, sourcing
+  | 'automation'; // Tier 2 — autonomous machine-to-machine
+
+/** Complexity classes, cheapest → most capable. */
+export type ComplexityClass = 'simple' | 'medium' | 'complex' | 'critical';
+
+export const COMPLEXITY_RANK: Record<ComplexityClass, number> = {
+  simple: 0,
+  medium: 1,
+  complex: 2,
+  critical: 3,
+};
+
+/** Sensitivity = blast radius of the output; drives second-pass / sign-off gates. */
+export type Sensitivity = 'internal' | 'outbound' | 'regulatory' | 'critical';
+
+export type TierLevel = 1 | 2 | 3;
+
+/** Task taxonomy is tenant-defined. The core treats task types as opaque ids;
+ *  the supplied `policy` table is the authority on which ids are valid and how
+ *  they route. See `example-policy.ts` for a reference table. */
+export type TaskType = string;
+
+/** Caller-supplied descriptor. Only `task_type` + `sensitivity` are required;
+ *  other fields tighten the routing decision. */
+export interface TaskDescriptor {
+  task_type: TaskType;
+  sensitivity: Sensitivity;
+  /** Override / hint for complexity. If absent, router infers from the policy rule default + sensitivity floor. */
+  expected_complexity?: ComplexityClass;
+  /** Set to `true` ONLY for cron / webhook / M2M automation. Required to unlock Tier 2. */
+  automation?: boolean;
+  /** Best estimate of input tokens. Drives long-context promotion (>200k). */
+  estimated_input_tokens?: number;
+  /** True if input mixes images / audio / video. Biases towards ChatGPT/Gemini. */
+  requires_multimodal?: boolean;
+  /** Free-form context for telemetry only — never used by router logic. */
+  agent_id?: string;
+  call_id?: string;
+  /** Soft routing preferences attached by the calling agent's config layer.
+   *  Router uses these as tie-breakers — hard constraints (Tier, sensitivity,
+   *  long-context, multimodal) always win. See `AgentPolicy` in policy.ts. */
+  agent_policy?: AgentPolicy;
+}
+
+/** Selected model within an engine, with cost/capability metadata. */
+export interface ModelSelection {
+  engine: Engine;
+  model: string;
+  /** Tier 1 = subscription, Tier 2 = API. */
+  tier: TierLevel;
+  /** Maximum input tokens this model accepts (effective context window). */
+  max_input_tokens: number;
+  /** Whether this model accepts non-text inputs. */
+  multimodal: boolean;
+}
+
+/** Outcome of `route(taskDescriptor)`. */
+export interface RoutingDecision {
+  engine: Engine;
+  model: string;
+  role: EngineRole;
+  complexity_class: ComplexityClass;
+  /** 0..1; how well the engine role matches the task. 1.0 = primary engine for that policy row. */
+  role_match_score: number;
+  /** Estimated cost in EUR cents for the planned call (input tokens × price). 0 if unknown. */
+  estimated_cost_eur_cents: number;
+  /** 0..1; aggregate confidence in this routing. Penalised by missing fields, fallbacks, sensitivity. */
+  confidence: number;
+  /** Human-readable reasons. First entry is the primary justification. */
+  justification: string[];
+  /** Required for `outbound|regulatory|critical` — the cross-vendor second-pass model. */
+  fallback?: ModelSelection;
+  /** Tier this routing landed in. */
+  tier: TierLevel;
+  /** True when sign-off is required (e.g. complexity=critical OR sensitivity=critical/regulatory). */
+  human_sign_off_required: boolean;
+}
+
+/** Per-call telemetry contract. Dashboard and self-learning consumers read this schema.
+ *
+ *  Schema versioning: bump TELEMETRY_SCHEMA_VERSION when fields are added or
+ *  semantics change so downstream consumers can detect drift. New fields land
+ *  as optional to preserve back-compat with already-emitted events. */
+export interface TelemetryEvent {
+  call_id: string;
+  /** ISO-8601 timestamp. */
+  ts: string;
+  agent_id?: string;
+  task_type: TaskType;
+  /** Sensitivity tier of the input — drives dashboard filter + second-pass gate. */
+  sensitivity?: Sensitivity;
+  engine: Engine;
+  model: string;
+  role: EngineRole;
+  /** Tier 1 = subscription, Tier 2 = API. Dashboard filter / Tier escalation audit. */
+  tier?: TierLevel;
+  complexity_class: ComplexityClass;
+  /** Caller's best estimate of input tokens — drives context-window utilization analytics. */
+  estimated_input_tokens?: number;
+  /** EUR cents — copied from RoutingDecision at decision time. */
+  expected_cost_eur_cents: number;
+  /** EUR cents — populated by caller after the LLM call resolves. */
+  actual_cost_eur_cents?: number;
+  latency_ms?: number;
+  confidence: number;
+  /** 0..1; how well the engine role matches the task. From RoutingDecision.role_match_score. */
+  role_match_score?: number;
+  /** Human-readable router justification (first entry is primary reason). Drill-down. */
+  justification?: string[];
+  /** True iff sensitivity/complexity required a human sign-off marker. */
+  human_sign_off_required?: boolean;
+  /** Primary call vs cross-vendor second pass (red-team) marker. */
+  pass_role?: 'primary' | 'redteam';
+  /** Links second-pass / sign-off telemetry back to the primary call. */
+  parent_call_id?: string;
+  /** Count of findings produced by the second pass. */
+  red_team_finding_count?: number;
+  /** True when at least one second-pass finding has `severity=block`. */
+  has_blocking_findings?: boolean;
+  /** Why the second pass was skipped in degraded mode. */
+  critical_pass_skipped_reason?: 'tier1_latency_cap';
+  /** Sign-off gate outcome (phase 1 telemetry-only stamp). */
+  sign_off_outcome?: 'requested' | 'skipped';
+  outcome_signal?: 'success' | 'retry' | 'failure';
+  failure_class?: 'model' | 'infra' | 'orchestration';
+  /** Process exit code captured by the runner — `143` = SIGTERM/OOM. */
+  exit_code?: number;
+  /** Free-form sub-class (e.g. `adapter_timeout`, `oom`, `retry_storm`). */
+  failure_subtype?: string;
+  /** Document type for document-engine analytics breakdown. */
+  document_type?:
+    | 'pdf'
+    | 'sheets'
+    | 'docs'
+    | 'workspace'
+    | 'transcript'
+    | 'multi_doc'
+    | 'other';
+  /** Set when sensitivity required a second-pass gate. */
+  fallback_engine?: Engine;
+  fallback_model?: string;
+  /** Schema version stamp — see TELEMETRY_SCHEMA_VERSION. */
+  schema_version?: string;
+}
+
+export interface TelemetrySink {
+  emit(event: TelemetryEvent): void | Promise<void>;
+}
+
+/** Inputs to the router beyond the descriptor — injected for testability and
+ *  tenant configuration. */
+export interface RouterDependencies {
+  /** Tenant-injected routing grid. Core ships an empty default (see
+   *  `DEFAULT_POLICY`); the tenant supplies its own rules at runtime. A
+   *  reference table lives in `example-policy.ts`. */
+  policy?: ReadonlyArray<import('./policy.js').RoutingRule>;
+  /** Signals whether Gemini Advanced subscription is reachable for the current run. */
+  geminiAvailable?: boolean;
+}
+
+/** Telemetry schema stamp — bump on any non-additive change to TelemetryEvent. */
+export const TELEMETRY_SCHEMA_VERSION = '1.1.0' as const;
+
+/** Long-context cutover (>200k tokens biases toward a document/long-context engine). */
+export const LONG_CONTEXT_THRESHOLD_TOKENS = 200_000 as const;

--- a/packages/orchestration/tsconfig.json
+++ b/packages/orchestration/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/orchestration/vitest.config.ts
+++ b/packages/orchestration/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -110,6 +110,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/orchestration",
+    "name": "@paperclipai/orchestration",
+    "publishFromCi": false
+  },
+  {
     "dir": "packages/plugins/create-paperclip-plugin",
     "name": "@paperclipai/create-paperclip-plugin",
     "publishFromCi": true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/skills-catalog",
       "packages/db",
       "packages/adapter-utils",
+      "packages/orchestration",
       "packages/adapters/acpx-local",
       "packages/adapters/claude-local",
       "packages/adapters/codex-local",


### PR DESCRIPTION
### Why
Paperclip dnes vybírá engine staticky (pinned per agent). Tento PR přidává tenant-agnostický router, který před každým runem rozhodne (provider, model) per issue, s rozhodnutím logovaným pro audit.

### What
- route() čistá funkce: (TaskDescriptor, RouterDependencies) → RoutingDecision (bez I/O, testovatelná).
- Core typy + telemetry decision-log kontrakt.
- 43 unit testů (routing grid + red-team invarianty CC1/F1/F2/F5/CC3).
- Nový balík packages/orchestration.

### Co PR NEobsahuje (záměrně)
- Tenant-specifická routing pravidla — injektují se za běhu přes RouterDependencies.policy (core ships prázdný default).
- Compliance gates / dashboard / self-learning — tenant overlay.

### Reference
- RFC_ROUTER v1.1 (canonical) + v1.0
- Board approval a2a909d6-4ca6-44a9-a25d-b2145156d2eb

_Draft PR — telemetry wiring + migrace jdou jako follow-up