### PR TITLE
feat(server): force Kubernetes sandbox execution via instance executionMode

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -393,6 +393,7 @@ export type {
   AgentSkillEntry,
   AgentSkillSnapshot,
   AgentSkillSyncRequest,
+  InstanceExecutionMode,
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
   InstanceSettings,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   FeedbackTraceBundle,
 } from "./feedback.js";
 export type {
+  InstanceExecutionMode,
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
   InstanceSettings,

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -19,11 +19,29 @@ export const DEFAULT_BACKUP_RETENTION: BackupRetentionPolicy = {
   monthlyMonths: 1,
 };
 
+/**
+ * Instance-wide execution policy.
+ *
+ * - `"any"` (default / absent): unrestricted. Any environment driver (local,
+ *   ssh, sandbox) may run agents. Preserves single-tenant / local-trusted
+ *   behavior.
+ * - `"kubernetes"`: force ALL agent execution onto the Kubernetes
+ *   sandbox-provider environment and REFUSE local/in-process execution. Useful
+ *   for shared/multi-tenant instances so untrusted agents can never run in the
+ *   server process or on an unsandboxed local/ssh adapter.
+ */
+export type InstanceExecutionMode = "kubernetes" | "any";
+
 export interface InstanceGeneralSettings {
   censorUsernameInLogs: boolean;
   keyboardShortcuts: boolean;
   feedbackDataSharingPreference: FeedbackDataSharingPreference;
   backupRetention: BackupRetentionPolicy;
+  /**
+   * Execution policy. Absent/`"any"` = unrestricted; `"kubernetes"` forces the
+   * Kubernetes sandbox provider and denies local/ssh execution.
+   */
+  executionMode?: InstanceExecutionMode;
 }
 
 export interface InstanceExperimentalSettings {

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -31,6 +31,9 @@ export const instanceGeneralSettingsSchema = z.object({
     DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   ),
   backupRetention: backupRetentionPolicySchema.default(DEFAULT_BACKUP_RETENTION),
+  // Execution policy. Absent/"any" = unrestricted; "kubernetes" forces the
+  // Kubernetes sandbox provider and denies local/ssh execution.
+  executionMode: z.enum(["kubernetes", "any"]).optional(),
 }).strict();
 
 export const patchInstanceGeneralSettingsSchema = instanceGeneralSettingsSchema.partial();

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -222,6 +222,74 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(rows[0]?.status).toBe("active");
   });
 
+  it("ensures, refreshes, and finds a managed Kubernetes sandbox environment", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // No managed k8s env yet.
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+
+    const created = await svc.ensureKubernetesEnvironment(companyId, {
+      backend: "job",
+      inCluster: true,
+      runtimeClassName: "gvisor",
+      egressMode: "cilium",
+      egressAllowFqdns: ["api.anthropic.com"],
+    });
+
+    expect(created.driver).toBe("sandbox");
+    expect(created.config.provider).toBe("kubernetes");
+    expect(created.config.backend).toBe("job");
+    expect(created.config.runtimeClassName).toBe("gvisor");
+    expect(created.metadata?.managedKubernetesSandbox).toBe(true);
+
+    // Idempotent: second call refreshes config in place, no new row.
+    const refreshed = await svc.ensureKubernetesEnvironment(companyId, {
+      backend: "job",
+      inCluster: true,
+      egressMode: "cilium",
+      egressAllowFqdns: ["api.anthropic.com", "api.openai.com"],
+    });
+    expect(refreshed.id).toBe(created.id);
+    expect(refreshed.config.egressAllowFqdns).toEqual([
+      "api.anthropic.com",
+      "api.openai.com",
+    ]);
+
+    const found = await svc.findKubernetesEnvironment(companyId);
+    expect(found?.id).toBe(created.id);
+
+    const rows = await db
+      .select()
+      .from(environments)
+      .where(eq(environments.companyId, companyId));
+    expect(rows.filter((row) => row.driver === "sandbox")).toHaveLength(1);
+  });
+
+  it("does not treat a non-kubernetes sandbox environment as the managed k8s env", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await svc.create(companyId, {
+      name: "Fake Sandbox",
+      driver: "sandbox",
+      config: { provider: "fake", image: "busybox", reuseLease: false },
+    });
+
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+  });
+
   it("allows multiple SSH environments for the same company", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -290,6 +290,38 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
   });
 
+  it("ignores a config.provider=kubernetes sandbox env without the managed marker", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // A tenant-created sandbox env with config.provider "kubernetes" but WITHOUT
+    // the managed metadata marker must NOT be treated as the managed k8s env,
+    // otherwise it would bypass the operator gVisor runtimeClass / Cilium egress.
+    await svc.create(companyId, {
+      name: "Tenant K8s Sandbox",
+      driver: "sandbox",
+      config: { provider: "kubernetes", reuseLease: false },
+    });
+
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+
+    // The managed env (created via ensureKubernetesEnvironment) carries the
+    // marker and is the only one found.
+    const managed = await svc.ensureKubernetesEnvironment(companyId, {
+      backend: "job",
+      inCluster: true,
+      runtimeClassName: "gvisor",
+    });
+    const found = await svc.findKubernetesEnvironment(companyId);
+    expect(found?.id).toBe(managed.id);
+  });
+
   it("allows multiple SSH environments for the same company", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -142,6 +142,7 @@ vi.mock("../services/index.js", () => ({
     agentMembershipsInserted: 0,
     humanGrantsInserted: 0,
   })),
+  bootstrapExecutionPolicyFromEnv: vi.fn(async () => null),
   feedbackService: feedbackServiceFactoryMock,
   heartbeatService: vi.fn(() => ({
     reapOrphanedRuns: vi.fn(async () => undefined),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { setupLiveEventsWebSocketServer } from "./realtime/live-events-ws.js";
 import {
   feedbackService,
   backfillPrincipalAccessCompatibility,
+  bootstrapExecutionPolicyFromEnv,
   heartbeatService,
   instanceSettingsService,
   reconcileCloudUpstreamRunsOnStartup,
@@ -716,6 +717,27 @@ export async function startServer(): Promise<StartedServer> {
       logger.error({ err }, "startup reconciliation of cloud upstream runs failed");
     });
   
+  // Force the instance onto the Kubernetes sandbox provider when configured via
+  // env (PAPERCLIP_EXECUTION_MODE=kubernetes). Runs BEFORE the heartbeat resumes
+  // queued runs so the policy + managed k8s environments are in place. A bad
+  // PAPERCLIP_EXECUTION_MODE / PAPERCLIP_K8S_* value throws and fails startup
+  // (fail-loud) rather than silently allowing local execution.
+  try {
+    const policyResult = await bootstrapExecutionPolicyFromEnv(db as any);
+    if (policyResult) {
+      logger.warn(
+        {
+          executionMode: policyResult.executionMode,
+          companiesConfigured: policyResult.companiesConfigured,
+        },
+        "forced execution policy applied at startup",
+      );
+    }
+  } catch (err) {
+    logger.error({ err }, "failed to apply forced execution policy from environment");
+    throw err;
+  }
+
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -15,6 +15,7 @@ import {
   type EnvironmentLeaseStatus,
   type UpdateEnvironment,
 } from "@paperclipai/shared";
+import { KUBERNETES_PROVIDER_KEY } from "./execution-allowlist.js";
 
 type EnvironmentRow = typeof environments.$inferSelect;
 type EnvironmentLeaseRow = typeof environmentLeases.$inferSelect;
@@ -25,8 +26,6 @@ const DEFAULT_LOCAL_ENVIRONMENT_DESCRIPTION =
 const DEFAULT_KUBERNETES_ENVIRONMENT_NAME = "Kubernetes Sandbox";
 const DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION =
   "Managed Kubernetes sandbox environment for hosted tenant execution.";
-/** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
-const KUBERNETES_PROVIDER_KEY = "kubernetes";
 /** Metadata marker for the company's managed-by-config Kubernetes sandbox environment. */
 const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
 

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -206,8 +206,7 @@ export function environmentService(db: Db) {
         .then((rows) =>
           rows.find(
             (row) =>
-              (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true ||
-              (row.config as Record<string, unknown> | null)?.provider === KUBERNETES_PROVIDER_KEY,
+              (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true,
           ) ?? null,
         );
 
@@ -267,8 +266,7 @@ export function environmentService(db: Db) {
         .orderBy(desc(environments.updatedAt));
       const match = rows.find(
         (row) =>
-          (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true ||
-          (row.config as Record<string, unknown> | null)?.provider === KUBERNETES_PROVIDER_KEY,
+          (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true,
       );
       return match ? toEnvironment(match) : null;
     },

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -22,6 +22,34 @@ const DEFAULT_LOCAL_ENVIRONMENT_NAME = "Local";
 const DEFAULT_LOCAL_ENVIRONMENT_DESCRIPTION =
   "Default execution environment for Paperclip runs on this machine.";
 
+const DEFAULT_KUBERNETES_ENVIRONMENT_NAME = "Kubernetes Sandbox";
+const DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION =
+  "Managed Kubernetes sandbox environment for hosted tenant execution.";
+/** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
+const KUBERNETES_PROVIDER_KEY = "kubernetes";
+/** Metadata marker for the company's managed-by-config Kubernetes sandbox environment. */
+const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
+
+/**
+ * Configuration accepted by `ensureKubernetesEnvironment`. Mirrors the keys of
+ * the kubernetes sandbox-provider `configSchema` that an operator typically
+ * pins for a hosted cloud instance. Stored verbatim in `environment.config`
+ * (the plugin validates/defaults it via `kubernetesProviderConfigSchema` at
+ * lease time); `provider` is always forced to "kubernetes".
+ */
+export interface KubernetesEnvironmentConfigInput {
+  backend?: "sandbox-cr" | "job";
+  inCluster?: boolean;
+  runtimeClassName?: string;
+  egressMode?: "cilium" | "standard";
+  egressAllowFqdns?: string[];
+  egressAllowCidrs?: string[];
+  namespacePrefix?: string;
+  imageRegistry?: string;
+  adapterType?: string;
+  [key: string]: unknown;
+}
+
 function cloneRecord(value: unknown, fallback: Record<string, unknown> | null = null): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return fallback;
   return { ...(value as Record<string, unknown>) };
@@ -145,6 +173,104 @@ export function environmentService(db: Db) {
         throw new Error("Failed to ensure local environment");
       }
       return toEnvironment(existing);
+    },
+
+    /**
+     * Idempotently ensure a managed Kubernetes sandbox environment exists for a
+     * company, configured from instance/operator-supplied config. Mirrors
+     * `ensureLocalEnvironment`, but there is no DB unique index for sandbox
+     * drivers, so idempotency is by metadata marker + driver lookup.
+     *
+     * The environment is `driver: "sandbox"` with `config.provider:
+     * "kubernetes"` so it resolves to the first-party Kubernetes sandbox
+     * provider. On subsequent calls the config is refreshed (so operators can
+     * update egress/runtimeClass via gitops without recreating the row).
+     */
+    ensureKubernetesEnvironment: async (
+      companyId: string,
+      config: KubernetesEnvironmentConfigInput,
+    ): Promise<Environment> => {
+      const desiredConfig: Record<string, unknown> = {
+        ...config,
+        provider: KUBERNETES_PROVIDER_KEY,
+      };
+      const desiredMetadata: Record<string, unknown> = {
+        managedByPaperclip: true,
+        [KUBERNETES_MANAGED_MARKER]: true,
+      };
+
+      const existing = await db
+        .select()
+        .from(environments)
+        .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+        .then((rows) =>
+          rows.find(
+            (row) =>
+              (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true ||
+              (row.config as Record<string, unknown> | null)?.provider === KUBERNETES_PROVIDER_KEY,
+          ) ?? null,
+        );
+
+      const now = new Date();
+      if (existing) {
+        const updated = await db
+          .update(environments)
+          .set({
+            config: desiredConfig,
+            metadata: { ...(existing.metadata ?? {}), ...desiredMetadata },
+            status: "active",
+            updatedAt: now,
+          })
+          .where(eq(environments.id, existing.id))
+          .returning()
+          .then((rows) => rows[0] ?? existing);
+        return toEnvironment(updated);
+      }
+
+      const row = await db
+        .insert(environments)
+        .values({
+          companyId,
+          name: DEFAULT_KUBERNETES_ENVIRONMENT_NAME,
+          description: DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION,
+          driver: "sandbox",
+          status: "active",
+          config: desiredConfig,
+          metadata: desiredMetadata,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!row) {
+        throw new Error("Failed to ensure kubernetes environment");
+      }
+      return toEnvironment(row);
+    },
+
+    /**
+     * Find an active Kubernetes sandbox environment for a company, if one
+     * exists. Read-only counterpart to `ensureKubernetesEnvironment` used by the
+     * per-run execution guard (which must not silently create config-less envs).
+     */
+    findKubernetesEnvironment: async (companyId: string): Promise<Environment | null> => {
+      const rows = await db
+        .select()
+        .from(environments)
+        .where(
+          and(
+            eq(environments.companyId, companyId),
+            eq(environments.driver, "sandbox"),
+            eq(environments.status, "active"),
+          ),
+        )
+        .orderBy(desc(environments.updatedAt));
+      const match = rows.find(
+        (row) =>
+          (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true ||
+          (row.config as Record<string, unknown> | null)?.provider === KUBERNETES_PROVIDER_KEY,
+      );
+      return match ? toEnvironment(match) : null;
     },
 
     create: async (companyId: string, input: CreateEnvironment): Promise<Environment> => {

--- a/server/src/services/execution-allowlist.test.ts
+++ b/server/src/services/execution-allowlist.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  KUBERNETES_PROVIDER_KEY,
+  evaluateExecutionAllowlist,
+  type ExecutionEnvironmentCandidate,
+} from "./execution-allowlist.js";
+
+const localEnv: ExecutionEnvironmentCandidate = {
+  driver: "local",
+  provider: null,
+};
+
+const kubernetesEnv: ExecutionEnvironmentCandidate = {
+  driver: "sandbox",
+  provider: KUBERNETES_PROVIDER_KEY,
+};
+
+const fakeSandboxEnv: ExecutionEnvironmentCandidate = {
+  driver: "sandbox",
+  provider: "fake",
+};
+
+const sshEnv: ExecutionEnvironmentCandidate = {
+  driver: "ssh",
+  provider: null,
+};
+
+describe("evaluateExecutionAllowlist", () => {
+  describe('executionMode "any" (unrestricted, default)', () => {
+    it("allows the local environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "any" }, localEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows the kubernetes sandbox environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "any" }, kubernetesEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows a non-kubernetes sandbox environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "any" }, fakeSandboxEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("treats absent executionMode as unrestricted", () => {
+      expect(evaluateExecutionAllowlist({}, localEnv).allowed).toBe(true);
+      expect(evaluateExecutionAllowlist({ executionMode: undefined }, localEnv).allowed).toBe(true);
+    });
+  });
+
+  describe('executionMode "kubernetes" (forced sandbox)', () => {
+    it("allows ONLY a kubernetes sandbox_provider environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, kubernetesEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("DENIES the local environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, localEnv);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/kubernetes/i);
+        expect(result.deniedDriver).toBe("local");
+      }
+    });
+
+    it("DENIES an ssh environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, sshEnv);
+      expect(result.allowed).toBe(false);
+    });
+
+    it("DENIES a non-kubernetes sandbox provider (e.g. fake)", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, fakeSandboxEnv);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.deniedProvider).toBe("fake");
+      }
+    });
+
+    it("DENIES a sandbox driver with no provider", () => {
+      const result = evaluateExecutionAllowlist(
+        { executionMode: "kubernetes" },
+        { driver: "sandbox", provider: null },
+      );
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("isExecutionForcedToKubernetes helper", () => {
+    it("reflects the policy", async () => {
+      const { isExecutionForcedToKubernetes } = await import("./execution-allowlist.js");
+      expect(isExecutionForcedToKubernetes({ executionMode: "kubernetes" })).toBe(true);
+      expect(isExecutionForcedToKubernetes({ executionMode: "any" })).toBe(false);
+      expect(isExecutionForcedToKubernetes({})).toBe(false);
+    });
+  });
+});

--- a/server/src/services/execution-allowlist.ts
+++ b/server/src/services/execution-allowlist.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure execution-allowlist guard.
+ *
+ * Decides whether a candidate execution environment is permitted to run an
+ * agent, given the instance-level execution policy. This is security-critical:
+ * on a shared cloud instance we FORCE all untrusted tenant agents onto the
+ * Kubernetes sandbox-provider and REFUSE local/in-process execution so that a
+ * tenant agent can never run inside the server process or on an unsandboxed
+ * local/ssh adapter.
+ *
+ * The merged tree's environment model represents the Kubernetes sandbox as a
+ * core `driver: "sandbox"` environment whose `config.provider` is the plugin's
+ * `driverKey` ("kubernetes", `kind: "sandbox_provider"`). The local default is
+ * `driver: "local"`. This module knows nothing about the DB or heartbeat — it
+ * just maps (driver, provider, policy) -> allow/deny so it is trivially
+ * unit-testable.
+ */
+
+/** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
+export const KUBERNETES_PROVIDER_KEY = "kubernetes" as const;
+
+/**
+ * Instance execution policy as read from instance general settings.
+ *
+ * - `"any"` / absent: unrestricted — any environment driver is allowed (the
+ *   default, preserves single-tenant / local-trusted behavior).
+ * - `"kubernetes"`: force the Kubernetes sandbox provider; deny local, ssh, and
+ *   any non-kubernetes sandbox provider.
+ */
+export interface ExecutionPolicy {
+  executionMode?: "kubernetes" | "any";
+}
+
+/**
+ * The minimal shape of the selected/candidate environment the guard needs.
+ * `driver` is the core `EnvironmentDriver`; `provider` is the sandbox provider
+ * key (== plugin driverKey) for `driver: "sandbox"` environments, else null.
+ */
+export interface ExecutionEnvironmentCandidate {
+  driver: string;
+  provider: string | null | undefined;
+}
+
+export type ExecutionAllowlistDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: string;
+      deniedDriver: string;
+      deniedProvider: string | null;
+    };
+
+/** True when the policy forces all execution onto the Kubernetes sandbox. */
+export function isExecutionForcedToKubernetes(policy: ExecutionPolicy | null | undefined): boolean {
+  return policy?.executionMode === "kubernetes";
+}
+
+/**
+ * True iff the candidate environment is the Kubernetes sandbox provider, i.e. a
+ * core `sandbox` driver whose provider key is "kubernetes".
+ */
+export function isKubernetesSandboxEnvironment(
+  candidate: ExecutionEnvironmentCandidate,
+): boolean {
+  return candidate.driver === "sandbox" && candidate.provider === KUBERNETES_PROVIDER_KEY;
+}
+
+/**
+ * Decide whether the candidate environment may run under the given policy.
+ *
+ * When `executionMode === "kubernetes"`, ONLY a `sandbox_provider` driver with
+ * provider/driverKey "kubernetes" is allowed; a `local` driver (or any non-k8s
+ * sandbox provider, or ssh, or plugin) is DENIED. Otherwise everything is
+ * allowed.
+ */
+export function evaluateExecutionAllowlist(
+  policy: ExecutionPolicy | null | undefined,
+  candidate: ExecutionEnvironmentCandidate,
+): ExecutionAllowlistDecision {
+  if (!isExecutionForcedToKubernetes(policy)) {
+    return { allowed: true };
+  }
+
+  if (isKubernetesSandboxEnvironment(candidate)) {
+    return { allowed: true };
+  }
+
+  const provider = candidate.provider ?? null;
+  const target =
+    candidate.driver === "sandbox"
+      ? `sandbox provider "${provider ?? "(none)"}"`
+      : `"${candidate.driver}" driver`;
+
+  return {
+    allowed: false,
+    reason:
+      `Instance execution policy requires the Kubernetes sandbox provider ` +
+      `(executionMode=kubernetes), but the resolved environment uses the ${target}. ` +
+      `Untrusted execution on a non-Kubernetes environment is refused.`,
+    deniedDriver: candidate.driver,
+    deniedProvider: provider,
+  };
+}

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -42,10 +42,12 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     expect(parseExecutionPolicyBootstrapEnv(env({}))).toBeNull();
   });
 
-  it("returns null when execution mode is explicitly any", () => {
+  it("returns a cleared-policy bootstrap when execution mode is explicitly any", () => {
+    // Unlike an absent variable, explicit "any" must persist the reset so a
+    // previously bootstrapped kubernetes policy can be rolled back via env.
     expect(
       parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "any" })),
-    ).toBeNull();
+    ).toEqual({ executionMode: "any" });
   });
 
   it("parses the forced kubernetes policy with a job/gvisor/cilium config", () => {
@@ -61,8 +63,8 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
       }),
     );
     expect(parsed).not.toBeNull();
-    expect(parsed?.executionMode).toBe("kubernetes");
-    expect(parsed?.kubernetesConfig).toMatchObject({
+    if (parsed?.executionMode !== "kubernetes") throw new Error("expected a kubernetes bootstrap");
+    expect(parsed.kubernetesConfig).toMatchObject({
       backend: "job",
       inCluster: true,
       runtimeClassName: "gvisor",
@@ -76,9 +78,10 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     const parsed = parseExecutionPolicyBootstrapEnv(
       env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }),
     );
-    expect(parsed?.kubernetesConfig.inCluster).toBe(false);
-    expect(parsed?.kubernetesConfig.runtimeClassName).toBeUndefined();
-    expect(parsed?.kubernetesConfig.egressAllowFqdns).toBeUndefined();
+    if (parsed?.executionMode !== "kubernetes") throw new Error("expected a kubernetes bootstrap");
+    expect(parsed.kubernetesConfig.inCluster).toBe(false);
+    expect(parsed.kubernetesConfig.runtimeClassName).toBeUndefined();
+    expect(parsed.kubernetesConfig.egressAllowFqdns).toBeUndefined();
   });
 
   it("throws on an unknown execution mode", () => {
@@ -118,5 +121,31 @@ describe("applyExecutionPolicyBootstrap", () => {
 
     // It keeps going past the failure (attempts all three companies).
     expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(3);
+    // The enforced policy must NOT be persisted when provisioning failed —
+    // otherwise a failed bootstrap leaves a stale executionMode=kubernetes
+    // that survives an env-var rollback and blocks every run.
+    expect(updateGeneral).not.toHaveBeenCalled();
+  });
+
+  it("persists executionMode only after every company provisioned", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2"]);
+    ensureKubernetesEnvironment.mockResolvedValue({ id: "env" });
+
+    await applyExecutionPolicyBootstrap(fakeDb, bootstrap);
+
+    expect(updateGeneral).toHaveBeenCalledTimes(1);
+    expect(updateGeneral).toHaveBeenCalledWith({ executionMode: "kubernetes" });
+    expect(updateGeneral.mock.invocationCallOrder[0]).toBeGreaterThan(
+      ensureKubernetesEnvironment.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  it("persists the cleared policy for an explicit any bootstrap without touching environments", async () => {
+    const result = await applyExecutionPolicyBootstrap(fakeDb, { executionMode: "any" });
+
+    expect(result).toEqual({ executionMode: "any", companiesConfigured: 0 });
+    expect(updateGeneral).toHaveBeenCalledWith({ executionMode: "any" });
+    expect(listCompanyIds).not.toHaveBeenCalled();
+    expect(ensureKubernetesEnvironment).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -1,12 +1,41 @@
-import { describe, expect, it } from "vitest";
-import {
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateGeneral = vi.fn();
+const listCompanyIds = vi.fn();
+const ensureKubernetesEnvironment = vi.fn();
+
+vi.mock("./instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    updateGeneral,
+    listCompanyIds,
+  }),
+}));
+
+vi.mock("./environments.js", () => ({
+  environmentService: () => ({
+    ensureKubernetesEnvironment,
+  }),
+}));
+
+const {
   parseExecutionPolicyBootstrapEnv,
-  type ExecutionPolicyBootstrapEnv,
-} from "./execution-policy-bootstrap.js";
+  applyExecutionPolicyBootstrap,
+} = await import("./execution-policy-bootstrap.js");
+type ExecutionPolicyBootstrapEnv = import("./execution-policy-bootstrap.js").ExecutionPolicyBootstrapEnv;
+type ExecutionPolicyBootstrap = import("./execution-policy-bootstrap.js").ExecutionPolicyBootstrap;
 
 function env(overrides: Record<string, string | undefined>): ExecutionPolicyBootstrapEnv {
   return overrides;
 }
+
+const bootstrap: ExecutionPolicyBootstrap = {
+  executionMode: "kubernetes",
+  kubernetesConfig: { inCluster: true, backend: "job" },
+};
+
+// `applyExecutionPolicyBootstrap` constructs its services internally from the
+// Db, so we mock the service modules; the Db itself is never touched here.
+const fakeDb = {} as never;
 
 describe("parseExecutionPolicyBootstrapEnv", () => {
   it("returns null when no execution mode is set (default unrestricted)", () => {
@@ -56,5 +85,38 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     expect(() =>
       parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "vm" })),
     ).toThrow(/PAPERCLIP_EXECUTION_MODE/);
+  });
+});
+
+describe("applyExecutionPolicyBootstrap", () => {
+  beforeEach(() => {
+    updateGeneral.mockReset().mockResolvedValue(undefined);
+    listCompanyIds.mockReset();
+    ensureKubernetesEnvironment.mockReset();
+  });
+
+  it("does not throw when every company gets a managed environment", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2", "c3"]);
+    ensureKubernetesEnvironment.mockResolvedValue({ id: "env" });
+
+    const result = await applyExecutionPolicyBootstrap(fakeDb, bootstrap);
+
+    expect(result).toEqual({ executionMode: "kubernetes", companiesConfigured: 3 });
+    expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws when at least one company fails, after attempting every company", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2", "c3"]);
+    ensureKubernetesEnvironment.mockImplementation(async (companyId: string) => {
+      if (companyId === "c2") throw new Error("operator config missing");
+      return { id: `env-${companyId}` };
+    });
+
+    await expect(applyExecutionPolicyBootstrap(fakeDb, bootstrap)).rejects.toThrow(
+      /execution-policy bootstrap: 1 of 3 companies failed.*c2/,
+    );
+
+    // It keeps going past the failure (attempts all three companies).
+    expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(3);
   });
 });

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseExecutionPolicyBootstrapEnv,
+  type ExecutionPolicyBootstrapEnv,
+} from "./execution-policy-bootstrap.js";
+
+function env(overrides: Record<string, string | undefined>): ExecutionPolicyBootstrapEnv {
+  return overrides;
+}
+
+describe("parseExecutionPolicyBootstrapEnv", () => {
+  it("returns null when no execution mode is set (default unrestricted)", () => {
+    expect(parseExecutionPolicyBootstrapEnv(env({}))).toBeNull();
+  });
+
+  it("returns null when execution mode is explicitly any", () => {
+    expect(
+      parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "any" })),
+    ).toBeNull();
+  });
+
+  it("parses the forced kubernetes policy with a job/gvisor/cilium config", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({
+        PAPERCLIP_EXECUTION_MODE: "kubernetes",
+        PAPERCLIP_K8S_BACKEND: "job",
+        PAPERCLIP_K8S_IN_CLUSTER: "true",
+        PAPERCLIP_K8S_RUNTIME_CLASS_NAME: "gvisor",
+        PAPERCLIP_K8S_EGRESS_MODE: "cilium",
+        PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS: "api.anthropic.com, api.openai.com",
+        PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS: "10.0.0.0/8",
+      }),
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed?.executionMode).toBe("kubernetes");
+    expect(parsed?.kubernetesConfig).toMatchObject({
+      backend: "job",
+      inCluster: true,
+      runtimeClassName: "gvisor",
+      egressMode: "cilium",
+      egressAllowFqdns: ["api.anthropic.com", "api.openai.com"],
+      egressAllowCidrs: ["10.0.0.0/8"],
+    });
+  });
+
+  it("defaults inCluster false and omits unset optional fields", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }),
+    );
+    expect(parsed?.kubernetesConfig.inCluster).toBe(false);
+    expect(parsed?.kubernetesConfig.runtimeClassName).toBeUndefined();
+    expect(parsed?.kubernetesConfig.egressAllowFqdns).toBeUndefined();
+  });
+
+  it("throws on an unknown execution mode", () => {
+    expect(() =>
+      parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "vm" })),
+    ).toThrow(/PAPERCLIP_EXECUTION_MODE/);
+  });
+});

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -5,10 +5,11 @@
  * sandbox provider purely via environment variables, with no manual product-API
  * calls. On startup we:
  *   1. Parse `PAPERCLIP_EXECUTION_MODE` (+ `PAPERCLIP_K8S_*`) from the env.
- *   2. Persist `executionMode` into instance general settings (so the per-run
- *      heartbeat guard enforces it).
- *   3. Idempotently ensure a configured Kubernetes sandbox environment for every
+ *   2. Idempotently ensure a configured Kubernetes sandbox environment for every
  *      company (mirrors `ensureLocalEnvironment`).
+ *   3. Persist `executionMode` into instance general settings (so the per-run
+ *      heartbeat guard enforces it) — only after every company provisioned, so
+ *      a failed bootstrap never leaves a stale enforced policy behind.
  *
  * The boot hook is *configuration convenience*; the actual security gate is the
  * per-run guard in the heartbeat (see `execution-allowlist.ts`). Even with no
@@ -25,10 +26,23 @@ import { instanceSettingsService } from "./instance-settings.js";
 
 export type ExecutionPolicyBootstrapEnv = Record<string, string | undefined>;
 
-export interface ExecutionPolicyBootstrap {
+export interface KubernetesExecutionPolicyBootstrap {
   executionMode: Extract<InstanceExecutionMode, "kubernetes">;
   kubernetesConfig: KubernetesEnvironmentConfigInput;
 }
+
+/**
+ * Explicit `PAPERCLIP_EXECUTION_MODE=any` — unlike an absent variable, this
+ * persists the cleared policy so an operator can roll back a previously
+ * bootstrapped `kubernetes` mode purely via env config.
+ */
+export interface ClearedExecutionPolicyBootstrap {
+  executionMode: Extract<InstanceExecutionMode, "any">;
+}
+
+export type ExecutionPolicyBootstrap =
+  | KubernetesExecutionPolicyBootstrap
+  | ClearedExecutionPolicyBootstrap;
 
 function parseBool(value: string | undefined): boolean | undefined {
   if (value === undefined) return undefined;
@@ -48,16 +62,19 @@ function parseList(value: string | undefined): string[] | undefined {
 }
 
 /**
- * Parse the forced-execution-mode env config. Returns null when execution is
- * unrestricted (no env, or `PAPERCLIP_EXECUTION_MODE=any`). Throws on an
- * unrecognized mode so a misconfigured deployment fails loudly instead of
- * silently allowing local execution.
+ * Parse the forced-execution-mode env config. Returns null when the variable
+ * is absent (env config not in use — never touch DB-managed settings). An
+ * explicit `PAPERCLIP_EXECUTION_MODE=any` returns a cleared-policy bootstrap
+ * that persists `executionMode=any`, so removing a forced policy is possible
+ * via env config alone. Throws on an unrecognized mode so a misconfigured
+ * deployment fails loudly instead of silently allowing local execution.
  */
 export function parseExecutionPolicyBootstrapEnv(
   env: ExecutionPolicyBootstrapEnv,
 ): ExecutionPolicyBootstrap | null {
   const raw = env.PAPERCLIP_EXECUTION_MODE?.trim();
-  if (!raw || raw === "any") return null;
+  if (!raw) return null;
+  if (raw === "any") return { executionMode: "any" };
   if (raw !== "kubernetes") {
     throw new Error(
       `PAPERCLIP_EXECUTION_MODE must be "kubernetes" or "any" (got "${raw}").`,
@@ -112,18 +129,30 @@ export function parseExecutionPolicyBootstrapEnv(
 }
 
 /**
- * Apply the parsed bootstrap to the database: persist `executionMode` into
- * instance settings and ensure a configured Kubernetes environment for every
- * company. Idempotent; safe to call on every boot.
+ * Apply the parsed bootstrap to the database. For `kubernetes`, ensure a
+ * configured Kubernetes environment for every company FIRST and persist
+ * `executionMode` only once all companies succeeded — a provisioning failure
+ * therefore aborts startup without leaving a stale enforced policy behind
+ * (which would otherwise survive an env-var rollback and block every run with
+ * "no managed Kubernetes environment is configured"). For an explicit `any`,
+ * persist the cleared policy. Idempotent; safe to call on every boot.
  */
 export async function applyExecutionPolicyBootstrap(
   db: Db,
   bootstrap: ExecutionPolicyBootstrap,
 ): Promise<{ executionMode: InstanceExecutionMode; companiesConfigured: number }> {
   const instanceSettings = instanceSettingsService(db);
-  const environments = environmentService(db);
 
-  await instanceSettings.updateGeneral({ executionMode: bootstrap.executionMode });
+  if (bootstrap.executionMode === "any") {
+    await instanceSettings.updateGeneral({ executionMode: "any" });
+    logger.info(
+      { executionMode: "any" },
+      "cleared forced execution policy (PAPERCLIP_EXECUTION_MODE=any)",
+    );
+    return { executionMode: "any", companiesConfigured: 0 };
+  }
+
+  const environments = environmentService(db);
 
   const companyIds = await instanceSettings.listCompanyIds();
   let configured = 0;
@@ -141,6 +170,14 @@ export async function applyExecutionPolicyBootstrap(
     }
   }
 
+  if (failedCompanyIds.length > 0) {
+    throw new Error(
+      `execution-policy bootstrap: ${failedCompanyIds.length} of ${companyIds.length} companies failed to get a managed Kubernetes environment under executionMode=${bootstrap.executionMode}; refusing to start without persisting the policy (companies: ${failedCompanyIds.join(", ")})`,
+    );
+  }
+
+  await instanceSettings.updateGeneral({ executionMode: bootstrap.executionMode });
+
   logger.info(
     {
       executionMode: bootstrap.executionMode,
@@ -151,12 +188,6 @@ export async function applyExecutionPolicyBootstrap(
     },
     "applied forced Kubernetes execution policy",
   );
-
-  if (failedCompanyIds.length > 0) {
-    throw new Error(
-      `execution-policy bootstrap: ${failedCompanyIds.length} of ${companyIds.length} companies failed to get a managed Kubernetes environment under executionMode=${bootstrap.executionMode}; refusing to start (companies: ${failedCompanyIds.join(", ")})`,
-    );
-  }
 
   return { executionMode: bootstrap.executionMode, companiesConfigured: configured };
 }

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -127,6 +127,7 @@ export async function applyExecutionPolicyBootstrap(
 
   const companyIds = await instanceSettings.listCompanyIds();
   let configured = 0;
+  const failedCompanyIds: string[] = [];
   for (const companyId of companyIds) {
     try {
       await environments.ensureKubernetesEnvironment(companyId, bootstrap.kubernetesConfig);
@@ -136,6 +137,7 @@ export async function applyExecutionPolicyBootstrap(
         { err, companyId },
         "failed to ensure managed Kubernetes environment during execution-policy bootstrap",
       );
+      failedCompanyIds.push(companyId);
     }
   }
 
@@ -149,6 +151,12 @@ export async function applyExecutionPolicyBootstrap(
     },
     "applied forced Kubernetes execution policy",
   );
+
+  if (failedCompanyIds.length > 0) {
+    throw new Error(
+      `execution-policy bootstrap: ${failedCompanyIds.length} of ${companyIds.length} companies failed to get a managed Kubernetes environment under executionMode=${bootstrap.executionMode}; refusing to start (companies: ${failedCompanyIds.join(", ")})`,
+    );
+  }
 
   return { executionMode: bootstrap.executionMode, companiesConfigured: configured };
 }

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -1,0 +1,166 @@
+/**
+ * Cloud execution-policy bootstrap.
+ *
+ * Lets an operator / gitops deployment force the instance onto the Kubernetes
+ * sandbox provider purely via environment variables, with no manual product-API
+ * calls. On startup we:
+ *   1. Parse `PAPERCLIP_EXECUTION_MODE` (+ `PAPERCLIP_K8S_*`) from the env.
+ *   2. Persist `executionMode` into instance general settings (so the per-run
+ *      heartbeat guard enforces it).
+ *   3. Idempotently ensure a configured Kubernetes sandbox environment for every
+ *      company (mirrors `ensureLocalEnvironment`).
+ *
+ * The boot hook is *configuration convenience*; the actual security gate is the
+ * per-run guard in the heartbeat (see `execution-allowlist.ts`). Even with no
+ * boot hook, setting `executionMode=kubernetes` denies local execution.
+ *
+ * The env-var parsing is a pure function so it is trivially unit-testable.
+ */
+
+import type { Db } from "@paperclipai/db";
+import type { InstanceExecutionMode } from "@paperclipai/shared";
+import { logger } from "../middleware/logger.js";
+import { environmentService, type KubernetesEnvironmentConfigInput } from "./environments.js";
+import { instanceSettingsService } from "./instance-settings.js";
+
+export type ExecutionPolicyBootstrapEnv = Record<string, string | undefined>;
+
+export interface ExecutionPolicyBootstrap {
+  executionMode: Extract<InstanceExecutionMode, "kubernetes">;
+  kubernetesConfig: KubernetesEnvironmentConfigInput;
+}
+
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  return undefined;
+}
+
+function parseList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  const items = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
+ * Parse the forced-execution-mode env config. Returns null when execution is
+ * unrestricted (no env, or `PAPERCLIP_EXECUTION_MODE=any`). Throws on an
+ * unrecognized mode so a misconfigured deployment fails loudly instead of
+ * silently allowing local execution.
+ */
+export function parseExecutionPolicyBootstrapEnv(
+  env: ExecutionPolicyBootstrapEnv,
+): ExecutionPolicyBootstrap | null {
+  const raw = env.PAPERCLIP_EXECUTION_MODE?.trim();
+  if (!raw || raw === "any") return null;
+  if (raw !== "kubernetes") {
+    throw new Error(
+      `PAPERCLIP_EXECUTION_MODE must be "kubernetes" or "any" (got "${raw}").`,
+    );
+  }
+
+  const kubernetesConfig: KubernetesEnvironmentConfigInput = {
+    // inCluster defaults to false (matches the plugin schema default); an
+    // in-cluster cloud deployment sets PAPERCLIP_K8S_IN_CLUSTER=true.
+    inCluster: parseBool(env.PAPERCLIP_K8S_IN_CLUSTER) ?? false,
+  };
+
+  const backend = env.PAPERCLIP_K8S_BACKEND?.trim();
+  if (backend) {
+    if (backend !== "job" && backend !== "sandbox-cr") {
+      throw new Error(
+        `PAPERCLIP_K8S_BACKEND must be "job" or "sandbox-cr" (got "${backend}").`,
+      );
+    }
+    kubernetesConfig.backend = backend;
+  }
+
+  const egressMode = env.PAPERCLIP_K8S_EGRESS_MODE?.trim();
+  if (egressMode) {
+    if (egressMode !== "cilium" && egressMode !== "standard") {
+      throw new Error(
+        `PAPERCLIP_K8S_EGRESS_MODE must be "cilium" or "standard" (got "${egressMode}").`,
+      );
+    }
+    kubernetesConfig.egressMode = egressMode;
+  }
+
+  const runtimeClassName = env.PAPERCLIP_K8S_RUNTIME_CLASS_NAME?.trim();
+  if (runtimeClassName) kubernetesConfig.runtimeClassName = runtimeClassName;
+
+  const namespacePrefix = env.PAPERCLIP_K8S_NAMESPACE_PREFIX?.trim();
+  if (namespacePrefix) kubernetesConfig.namespacePrefix = namespacePrefix;
+
+  const imageRegistry = env.PAPERCLIP_K8S_IMAGE_REGISTRY?.trim();
+  if (imageRegistry) kubernetesConfig.imageRegistry = imageRegistry;
+
+  const adapterType = env.PAPERCLIP_K8S_ADAPTER_TYPE?.trim();
+  if (adapterType) kubernetesConfig.adapterType = adapterType;
+
+  const egressAllowFqdns = parseList(env.PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS);
+  if (egressAllowFqdns) kubernetesConfig.egressAllowFqdns = egressAllowFqdns;
+
+  const egressAllowCidrs = parseList(env.PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS);
+  if (egressAllowCidrs) kubernetesConfig.egressAllowCidrs = egressAllowCidrs;
+
+  return { executionMode: "kubernetes", kubernetesConfig };
+}
+
+/**
+ * Apply the parsed bootstrap to the database: persist `executionMode` into
+ * instance settings and ensure a configured Kubernetes environment for every
+ * company. Idempotent; safe to call on every boot.
+ */
+export async function applyExecutionPolicyBootstrap(
+  db: Db,
+  bootstrap: ExecutionPolicyBootstrap,
+): Promise<{ executionMode: InstanceExecutionMode; companiesConfigured: number }> {
+  const instanceSettings = instanceSettingsService(db);
+  const environments = environmentService(db);
+
+  await instanceSettings.updateGeneral({ executionMode: bootstrap.executionMode });
+
+  const companyIds = await instanceSettings.listCompanyIds();
+  let configured = 0;
+  for (const companyId of companyIds) {
+    try {
+      await environments.ensureKubernetesEnvironment(companyId, bootstrap.kubernetesConfig);
+      configured += 1;
+    } catch (err) {
+      logger.error(
+        { err, companyId },
+        "failed to ensure managed Kubernetes environment during execution-policy bootstrap",
+      );
+    }
+  }
+
+  logger.info(
+    {
+      executionMode: bootstrap.executionMode,
+      companiesConfigured: configured,
+      backend: bootstrap.kubernetesConfig.backend,
+      runtimeClassName: bootstrap.kubernetesConfig.runtimeClassName,
+      egressMode: bootstrap.kubernetesConfig.egressMode,
+    },
+    "applied forced Kubernetes execution policy",
+  );
+
+  return { executionMode: bootstrap.executionMode, companiesConfigured: configured };
+}
+
+/**
+ * Convenience: parse + apply from a raw env map. Returns null when unrestricted.
+ */
+export async function bootstrapExecutionPolicyFromEnv(
+  db: Db,
+  env: ExecutionPolicyBootstrapEnv = process.env,
+): Promise<{ executionMode: InstanceExecutionMode; companiesConfigured: number } | null> {
+  const bootstrap = parseExecutionPolicyBootstrapEnv(env);
+  if (!bootstrap) return null;
+  return applyExecutionPolicyBootstrap(db, bootstrap);
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -133,6 +133,10 @@ import {
 } from "./execution-workspace-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import {
+  evaluateExecutionAllowlist,
+  isExecutionForcedToKubernetes,
+} from "./execution-allowlist.js";
+import {
   RECOVERY_ORIGIN_KINDS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
@@ -4374,7 +4378,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const warnings: string[] = [];
     if (sessionCwd && sessionCwdLooksUnsafe) {
       warnings.push(
-        `Saved session workspace "${sessionCwd}" points at a system temp root and was rejected as untrusted. Using fallback workspace "${cwd}" for this run.`,
+        `Saved session workspace "${sessionCwd}" points at a system temp root and was rejected as untrusted (likely persisted from a previous remote-target run). Using fallback workspace "${cwd}" for this run.`,
       );
     } else if (sessionCwd) {
       warnings.push(
@@ -7985,7 +7989,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       persistedExecutionWorkspaceMode === "agent_default"
         ? persistedExecutionWorkspaceMode
         : requestedExecutionWorkspaceMode;
-    const selectedEnvironmentId = environmentResolution.environmentId;
+    // Execution allowlist (security-critical): on a shared cloud instance the
+    // operator sets instance executionMode="kubernetes" to FORCE all agent
+    // execution onto the Kubernetes sandbox provider and REFUSE local/in-process
+    // or ssh execution. When forced, we override the resolved environment to the
+    // company's managed Kubernetes environment (no silent fallback to local).
+    // The default ("any") path is unchanged. This runs before the low-trust
+    // preflight below so the preflight resolves the driver of the forced env.
+    const executionPolicy = { executionMode: (await instanceSettings.getGeneral()).executionMode };
+    let selectedEnvironmentId = environmentResolution.environmentId;
+    if (isExecutionForcedToKubernetes(executionPolicy)) {
+      const kubernetesEnvironment = await environmentsSvc.findKubernetesEnvironment(agent.companyId);
+      if (!kubernetesEnvironment) {
+        throw new Error(
+          "Instance execution policy requires the Kubernetes sandbox provider " +
+            "(executionMode=kubernetes) but no managed Kubernetes environment is " +
+            "configured for this company. Configure one (PAPERCLIP_K8S_* env on the " +
+            "cloud instance) before running agents; refusing to fall back to local execution.",
+        );
+      }
+      if (kubernetesEnvironment.id !== selectedEnvironmentId) {
+        logger.info(
+          {
+            runId: run.id,
+            issueId,
+            agentId: agent.id,
+            resolvedEnvironmentId: selectedEnvironmentId,
+            forcedKubernetesEnvironmentId: kubernetesEnvironment.id,
+          },
+          "Forcing run onto the managed Kubernetes environment (executionMode=kubernetes)",
+        );
+      }
+      selectedEnvironmentId = kubernetesEnvironment.id;
+    }
     const {
       selectedEnvironmentDriver: lowTrustPreflightEnvironmentDriver,
       workspace: resolvedWorkspace,
@@ -8306,7 +8342,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         })
         .where(eq(heartbeatRuns.id, run.id));
     }
-    const persistedEnvironmentId = persistedExecutionWorkspace?.config?.environmentId ?? selectedEnvironmentId;
+    // When execution is forced to Kubernetes, `selectedEnvironmentId` is already
+    // pinned to the managed k8s environment above; ignore any persisted workspace
+    // environmentId (which could point at a stale local/ssh env) so a reused
+    // workspace can never downgrade us off the sandbox.
+    const persistedEnvironmentId = isExecutionForcedToKubernetes(executionPolicy)
+      ? selectedEnvironmentId
+      : persistedExecutionWorkspace?.config?.environmentId ?? selectedEnvironmentId;
     const acquiredEnvironment = await envOrchestrator.acquireForRun({
       companyId: agent.companyId,
       selectedEnvironmentId: persistedEnvironmentId,
@@ -8318,6 +8360,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       persistedExecutionWorkspace,
     });
     const selectedEnvironment = acquiredEnvironment.environment;
+    // Defense-in-depth: re-check the actually-acquired environment against the
+    // execution allowlist. Even if selection were bypassed, a denied (local/ssh/
+    // non-k8s) environment FAILS the run here rather than executing untrusted.
+    const allowlistDecision = evaluateExecutionAllowlist(executionPolicy, {
+      driver: selectedEnvironment.driver,
+      provider:
+        typeof selectedEnvironment.config?.provider === "string"
+          ? selectedEnvironment.config.provider
+          : null,
+    });
+    if (!allowlistDecision.allowed) {
+      logger.error(
+        {
+          runId: run.id,
+          issueId,
+          agentId: agent.id,
+          environmentId: selectedEnvironment.id,
+          deniedDriver: allowlistDecision.deniedDriver,
+          deniedProvider: allowlistDecision.deniedProvider,
+        },
+        "Execution allowlist denied the resolved environment; failing run",
+      );
+      throw new Error(allowlistDecision.reason);
+    }
     let activeEnvironmentLease = {
       environment: acquiredEnvironment.environment,
       lease: acquiredEnvironment.lease,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -62,6 +62,7 @@ export type {
 } from "./authorization.js";
 export { boardAuthService } from "./board-auth.js";
 export { instanceSettingsService } from "./instance-settings.js";
+export { bootstrapExecutionPolicyFromEnv } from "./execution-policy-bootstrap.js";
 export { cloudUpstreamService, reconcileCloudUpstreamRunsOnStartup } from "./cloud-upstreams.js";
 export { companyPortabilityService } from "./company-portability.js";
 export { teamsCatalogService } from "./teams-catalog.js";

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -27,6 +27,8 @@ function normalizeGeneralSettings(raw: unknown): InstanceGeneralSettings {
       feedbackDataSharingPreference:
         parsed.data.feedbackDataSharingPreference ?? DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
       backupRetention: parsed.data.backupRetention ?? DEFAULT_BACKUP_RETENTION,
+      // Absent => unrestricted; only carry through an explicit policy.
+      ...(parsed.data.executionMode ? { executionMode: parsed.data.executionMode } : {}),
     };
   }
   return {


### PR DESCRIPTION
> **TL;DR for reviewers:** this adds **no new Environment type and no new driver.** It is an instance-level *execution policy* layered on top of the existing Kubernetes **sandbox provider** (#5790). When enabled it forces runs onto the managed `driver: "sandbox"` / `config.provider: "kubernetes"` environment and refuses local / in-process / ssh execution. Default behavior is unchanged.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute through the environment/driver model; the Kubernetes sandbox already exists as a **sandbox provider** (#5790): a core `driver: "sandbox"` environment with `config.provider: "kubernetes"` (`kind: sandbox_provider`) — not a new environment type, and the local default stays `driver: "local"`
> - What is missing is an instance-level way to make that sandbox **mandatory**: on shared / multi-tenant deployments, untrusted agents must never run inside the server process or on an unsandboxed local/ssh adapter
> - A tenant must also not be able to opt out simply by selecting a local environment
> - This pull request adds a thin *execution policy* layer over the existing provider rather than a new execution backend: instance-level `executionMode` (`"kubernetes" | "any"`), configured through the existing instance general settings plus generic `PAPERCLIP_EXECUTION_MODE` / `PAPERCLIP_K8S_*` env vars — no cloud/host-specific coupling
> - When enabled it pins runs to the company's managed Kubernetes sandbox environment and refuses local / in-process / ssh execution, failing closed rather than falling back
> - The benefit is an enforceable, fail-closed sandbox guarantee for shared instances while default behavior stays unchanged

## Linked Issues or Issue Description

No single issue tracks this change directly; related issues:

- Refs #248 — proposal for sandboxed agent execution (provider-agnostic interface for secure remote environments). The sandbox provider itself landed via #5790; this PR adds the instance-level policy that can make that sandbox mandatory.
- Refs #966 — managed hosting hooks for SaaS multi-tenant deployment. `executionMode=kubernetes` targets the same shared-instance scenario and is configured the same way (env-driven bootstrap at startup).
- Refs #2554 — security report observing that instances can run with no effective sandbox. This PR gives operators a fail-closed switch that forces all tenant runs onto the Kubernetes sandbox provider.

In-PR problem description (feature-request form): on a shared / multi-tenant Paperclip instance, untrusted tenant agents can run inside the server process or on unsandboxed local/ssh adapters, and a tenant can opt out of sandboxing simply by selecting a local environment. There is no instance-level way to make the existing Kubernetes sandbox provider (#5790) mandatory. This PR adds an `executionMode` instance policy (`"kubernetes" | "any"`, default `"any"` = unchanged behavior): when set to `kubernetes`, runs are pinned to the company's managed Kubernetes sandbox environment and local / in-process / ssh execution is refused, failing closed rather than falling back.

## What Changed

- **shared**: add `InstanceGeneralSettings.executionMode` (`"kubernetes" | "any"`, default/absent = `"any"`) + zod validator + type exports.
- **`execution-allowlist.ts`** (new): a *pure* guard mapping `(driver, provider, policy) -> allow/deny`. With `executionMode=kubernetes` only the kubernetes `sandbox_provider` is allowed; local/ssh/non-k8s-sandbox are denied. Unit-tested.
- **`heartbeat.ts`**: at the environment-selection/dispatch site, when forced to kubernetes, pin the run to the company's managed k8s environment (no silent fallback to local), ignore any persisted-workspace `environmentId`, and re-check the actually-acquired environment against the allowlist as defense-in-depth. Denied -> throw -> run fails via the outer catch.
- **`environments.ts`**: idempotent `ensureKubernetesEnvironment` (mirrors `ensureLocalEnvironment`) + read-only `findKubernetesEnvironment`. These create/find a normal `driver: "sandbox"` environment with the `kubernetes` provider and a `managedKubernetesSandbox` marker; they pre-provision it so tenants do not have to configure one. No new env type is introduced.
- **`execution-policy-bootstrap.ts`** (new): parse `PAPERCLIP_EXECUTION_MODE` + `PAPERCLIP_K8S_*` at startup, persist `executionMode` into instance settings, and ensure a configured k8s environment per company.
- **`index.ts`**: apply the bootstrap before the heartbeat resumes queued runs; fail-loud on bad config.

## Verification

- `execution-allowlist.test.ts` (pure) - 10 tests
- `execution-policy-bootstrap.test.ts` (pure env-parse) - 5 tests
- `environment-service.test.ts` additions (ensure/find the managed k8s env, idempotency, and that a non-k8s sandbox is not mistaken for the managed env) - embedded postgres
- `pnpm --dir server typecheck` passes; all new unit tests pass.

## Risks

- **Backwards compatible by construction.** The default (absent / `"any"`) path is unchanged, so single-tenant self-hosters keep full environment choice. The policy only activates when an operator sets `executionMode=kubernetes`.
- **No new surface to misuse.** It does not add an execution backend, driver, or environment type; it reuses the #5790 sandbox provider, so there is no second code path to keep in sync.
- **Fail-closed.** When forced and the managed k8s environment cannot be acquired, the run throws rather than silently falling back to local execution.

## Model Used

Developed with Claude (Opus 4.x) via Claude Code.

---

Companion UI PR (#7600) hides the local execution picker and defaults to the managed Kubernetes sandbox when `executionMode=kubernetes`. Builds on the sandbox provider in #5790.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge



