### PR TITLE
feat(ui): gate the execution picker on instance executionMode (force K8s sandbox)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -393,6 +393,7 @@ export type {
   AgentSkillEntry,
   AgentSkillSnapshot,
   AgentSkillSyncRequest,
+  InstanceExecutionMode,
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
   InstanceSettings,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   FeedbackTraceBundle,
 } from "./feedback.js";
 export type {
+  InstanceExecutionMode,
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
   InstanceSettings,

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -19,11 +19,29 @@ export const DEFAULT_BACKUP_RETENTION: BackupRetentionPolicy = {
   monthlyMonths: 1,
 };
 
+/**
+ * Instance-wide execution policy.
+ *
+ * - `"any"` (default / absent): unrestricted. Any environment driver (local,
+ *   ssh, sandbox) may run agents. Preserves single-tenant / local-trusted
+ *   behavior.
+ * - `"kubernetes"`: force ALL agent execution onto the Kubernetes
+ *   sandbox-provider environment and REFUSE local/in-process execution. Useful
+ *   for shared/multi-tenant instances so untrusted agents can never run in the
+ *   server process or on an unsandboxed local/ssh adapter.
+ */
+export type InstanceExecutionMode = "kubernetes" | "any";
+
 export interface InstanceGeneralSettings {
   censorUsernameInLogs: boolean;
   keyboardShortcuts: boolean;
   feedbackDataSharingPreference: FeedbackDataSharingPreference;
   backupRetention: BackupRetentionPolicy;
+  /**
+   * Execution policy. Absent/`"any"` = unrestricted; `"kubernetes"` forces the
+   * Kubernetes sandbox provider and denies local/ssh execution.
+   */
+  executionMode?: InstanceExecutionMode;
 }
 
 export interface InstanceExperimentalSettings {

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -31,6 +31,9 @@ export const instanceGeneralSettingsSchema = z.object({
     DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   ),
   backupRetention: backupRetentionPolicySchema.default(DEFAULT_BACKUP_RETENTION),
+  // Execution policy. Absent/"any" = unrestricted; "kubernetes" forces the
+  // Kubernetes sandbox provider and denies local/ssh execution.
+  executionMode: z.enum(["kubernetes", "any"]).optional(),
 }).strict();
 
 export const patchInstanceGeneralSettingsSchema = instanceGeneralSettingsSchema.partial();

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -222,6 +222,74 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(rows[0]?.status).toBe("active");
   });
 
+  it("ensures, refreshes, and finds a managed Kubernetes sandbox environment", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // No managed k8s env yet.
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+
+    const created = await svc.ensureKubernetesEnvironment(companyId, {
+      backend: "job",
+      inCluster: true,
+      runtimeClassName: "gvisor",
+      egressMode: "cilium",
+      egressAllowFqdns: ["api.anthropic.com"],
+    });
+
+    expect(created.driver).toBe("sandbox");
+    expect(created.config.provider).toBe("kubernetes");
+    expect(created.config.backend).toBe("job");
+    expect(created.config.runtimeClassName).toBe("gvisor");
+    expect(created.metadata?.managedKubernetesSandbox).toBe(true);
+
+    // Idempotent: second call refreshes config in place, no new row.
+    const refreshed = await svc.ensureKubernetesEnvironment(companyId, {
+      backend: "job",
+      inCluster: true,
+      egressMode: "cilium",
+      egressAllowFqdns: ["api.anthropic.com", "api.openai.com"],
+    });
+    expect(refreshed.id).toBe(created.id);
+    expect(refreshed.config.egressAllowFqdns).toEqual([
+      "api.anthropic.com",
+      "api.openai.com",
+    ]);
+
+    const found = await svc.findKubernetesEnvironment(companyId);
+    expect(found?.id).toBe(created.id);
+
+    const rows = await db
+      .select()
+      .from(environments)
+      .where(eq(environments.companyId, companyId));
+    expect(rows.filter((row) => row.driver === "sandbox")).toHaveLength(1);
+  });
+
+  it("does not treat a non-kubernetes sandbox environment as the managed k8s env", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await svc.create(companyId, {
+      name: "Fake Sandbox",
+      driver: "sandbox",
+      config: { provider: "fake", image: "busybox", reuseLease: false },
+    });
+
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+  });
+
   it("allows multiple SSH environments for the same company", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -142,6 +142,7 @@ vi.mock("../services/index.js", () => ({
     agentMembershipsInserted: 0,
     humanGrantsInserted: 0,
   })),
+  bootstrapExecutionPolicyFromEnv: vi.fn(async () => null),
   feedbackService: feedbackServiceFactoryMock,
   heartbeatService: vi.fn(() => ({
     reapOrphanedRuns: vi.fn(async () => undefined),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { setupLiveEventsWebSocketServer } from "./realtime/live-events-ws.js";
 import {
   feedbackService,
   backfillPrincipalAccessCompatibility,
+  bootstrapExecutionPolicyFromEnv,
   heartbeatService,
   instanceSettingsService,
   reconcileCloudUpstreamRunsOnStartup,
@@ -716,6 +717,27 @@ export async function startServer(): Promise<StartedServer> {
       logger.error({ err }, "startup reconciliation of cloud upstream runs failed");
     });
   
+  // Force the instance onto the Kubernetes sandbox provider when configured via
+  // env (PAPERCLIP_EXECUTION_MODE=kubernetes). Runs BEFORE the heartbeat resumes
+  // queued runs so the policy + managed k8s environments are in place. A bad
+  // PAPERCLIP_EXECUTION_MODE / PAPERCLIP_K8S_* value throws and fails startup
+  // (fail-loud) rather than silently allowing local execution.
+  try {
+    const policyResult = await bootstrapExecutionPolicyFromEnv(db as any);
+    if (policyResult) {
+      logger.warn(
+        {
+          executionMode: policyResult.executionMode,
+          companiesConfigured: policyResult.companiesConfigured,
+        },
+        "forced execution policy applied at startup",
+      );
+    }
+  } catch (err) {
+    logger.error({ err }, "failed to apply forced execution policy from environment");
+    throw err;
+  }
+
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -22,6 +22,34 @@ const DEFAULT_LOCAL_ENVIRONMENT_NAME = "Local";
 const DEFAULT_LOCAL_ENVIRONMENT_DESCRIPTION =
   "Default execution environment for Paperclip runs on this machine.";
 
+const DEFAULT_KUBERNETES_ENVIRONMENT_NAME = "Kubernetes Sandbox";
+const DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION =
+  "Managed Kubernetes sandbox environment for hosted tenant execution.";
+/** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
+const KUBERNETES_PROVIDER_KEY = "kubernetes";
+/** Metadata marker for the company's managed-by-config Kubernetes sandbox environment. */
+const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
+
+/**
+ * Configuration accepted by `ensureKubernetesEnvironment`. Mirrors the keys of
+ * the kubernetes sandbox-provider `configSchema` that an operator typically
+ * pins for a hosted cloud instance. Stored verbatim in `environment.config`
+ * (the plugin validates/defaults it via `kubernetesProviderConfigSchema` at
+ * lease time); `provider` is always forced to "kubernetes".
+ */
+export interface KubernetesEnvironmentConfigInput {
+  backend?: "sandbox-cr" | "job";
+  inCluster?: boolean;
+  runtimeClassName?: string;
+  egressMode?: "cilium" | "standard";
+  egressAllowFqdns?: string[];
+  egressAllowCidrs?: string[];
+  namespacePrefix?: string;
+  imageRegistry?: string;
+  adapterType?: string;
+  [key: string]: unknown;
+}
+
 function cloneRecord(value: unknown, fallback: Record<string, unknown> | null = null): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return fallback;
   return { ...(value as Record<string, unknown>) };
@@ -145,6 +173,104 @@ export function environmentService(db: Db) {
         throw new Error("Failed to ensure local environment");
       }
       return toEnvironment(existing);
+    },
+
+    /**
+     * Idempotently ensure a managed Kubernetes sandbox environment exists for a
+     * company, configured from instance/operator-supplied config. Mirrors
+     * `ensureLocalEnvironment`, but there is no DB unique index for sandbox
+     * drivers, so idempotency is by metadata marker + driver lookup.
+     *
+     * The environment is `driver: "sandbox"` with `config.provider:
+     * "kubernetes"` so it resolves to the first-party Kubernetes sandbox
+     * provider. On subsequent calls the config is refreshed (so operators can
+     * update egress/runtimeClass via gitops without recreating the row).
+     */
+    ensureKubernetesEnvironment: async (
+      companyId: string,
+      config: KubernetesEnvironmentConfigInput,
+    ): Promise<Environment> => {
+      const desiredConfig: Record<string, unknown> = {
+        ...config,
+        provider: KUBERNETES_PROVIDER_KEY,
+      };
+      const desiredMetadata: Record<string, unknown> = {
+        managedByPaperclip: true,
+        [KUBERNETES_MANAGED_MARKER]: true,
+      };
+
+      const existing = await db
+        .select()
+        .from(environments)
+        .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+        .then((rows) =>
+          rows.find(
+            (row) =>
+              (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true ||
+              (row.config as Record<string, unknown> | null)?.provider === KUBERNETES_PROVIDER_KEY,
+          ) ?? null,
+        );
+
+      const now = new Date();
+      if (existing) {
+        const updated = await db
+          .update(environments)
+          .set({
+            config: desiredConfig,
+            metadata: { ...(existing.metadata ?? {}), ...desiredMetadata },
+            status: "active",
+            updatedAt: now,
+          })
+          .where(eq(environments.id, existing.id))
+          .returning()
+          .then((rows) => rows[0] ?? existing);
+        return toEnvironment(updated);
+      }
+
+      const row = await db
+        .insert(environments)
+        .values({
+          companyId,
+          name: DEFAULT_KUBERNETES_ENVIRONMENT_NAME,
+          description: DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION,
+          driver: "sandbox",
+          status: "active",
+          config: desiredConfig,
+          metadata: desiredMetadata,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!row) {
+        throw new Error("Failed to ensure kubernetes environment");
+      }
+      return toEnvironment(row);
+    },
+
+    /**
+     * Find an active Kubernetes sandbox environment for a company, if one
+     * exists. Read-only counterpart to `ensureKubernetesEnvironment` used by the
+     * per-run execution guard (which must not silently create config-less envs).
+     */
+    findKubernetesEnvironment: async (companyId: string): Promise<Environment | null> => {
+      const rows = await db
+        .select()
+        .from(environments)
+        .where(
+          and(
+            eq(environments.companyId, companyId),
+            eq(environments.driver, "sandbox"),
+            eq(environments.status, "active"),
+          ),
+        )
+        .orderBy(desc(environments.updatedAt));
+      const match = rows.find(
+        (row) =>
+          (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true ||
+          (row.config as Record<string, unknown> | null)?.provider === KUBERNETES_PROVIDER_KEY,
+      );
+      return match ? toEnvironment(match) : null;
     },
 
     create: async (companyId: string, input: CreateEnvironment): Promise<Environment> => {

--- a/server/src/services/execution-allowlist.test.ts
+++ b/server/src/services/execution-allowlist.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  KUBERNETES_PROVIDER_KEY,
+  evaluateExecutionAllowlist,
+  type ExecutionEnvironmentCandidate,
+} from "./execution-allowlist.js";
+
+const localEnv: ExecutionEnvironmentCandidate = {
+  driver: "local",
+  provider: null,
+};
+
+const kubernetesEnv: ExecutionEnvironmentCandidate = {
+  driver: "sandbox",
+  provider: KUBERNETES_PROVIDER_KEY,
+};
+
+const fakeSandboxEnv: ExecutionEnvironmentCandidate = {
+  driver: "sandbox",
+  provider: "fake",
+};
+
+const sshEnv: ExecutionEnvironmentCandidate = {
+  driver: "ssh",
+  provider: null,
+};
+
+describe("evaluateExecutionAllowlist", () => {
+  describe('executionMode "any" (unrestricted, default)', () => {
+    it("allows the local environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "any" }, localEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows the kubernetes sandbox environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "any" }, kubernetesEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows a non-kubernetes sandbox environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "any" }, fakeSandboxEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("treats absent executionMode as unrestricted", () => {
+      expect(evaluateExecutionAllowlist({}, localEnv).allowed).toBe(true);
+      expect(evaluateExecutionAllowlist({ executionMode: undefined }, localEnv).allowed).toBe(true);
+    });
+  });
+
+  describe('executionMode "kubernetes" (forced sandbox)', () => {
+    it("allows ONLY a kubernetes sandbox_provider environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, kubernetesEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("DENIES the local environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, localEnv);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/kubernetes/i);
+        expect(result.deniedDriver).toBe("local");
+      }
+    });
+
+    it("DENIES an ssh environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, sshEnv);
+      expect(result.allowed).toBe(false);
+    });
+
+    it("DENIES a non-kubernetes sandbox provider (e.g. fake)", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "kubernetes" }, fakeSandboxEnv);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.deniedProvider).toBe("fake");
+      }
+    });
+
+    it("DENIES a sandbox driver with no provider", () => {
+      const result = evaluateExecutionAllowlist(
+        { executionMode: "kubernetes" },
+        { driver: "sandbox", provider: null },
+      );
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("isExecutionForcedToKubernetes helper", () => {
+    it("reflects the policy", async () => {
+      const { isExecutionForcedToKubernetes } = await import("./execution-allowlist.js");
+      expect(isExecutionForcedToKubernetes({ executionMode: "kubernetes" })).toBe(true);
+      expect(isExecutionForcedToKubernetes({ executionMode: "any" })).toBe(false);
+      expect(isExecutionForcedToKubernetes({})).toBe(false);
+    });
+  });
+});

--- a/server/src/services/execution-allowlist.ts
+++ b/server/src/services/execution-allowlist.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure execution-allowlist guard.
+ *
+ * Decides whether a candidate execution environment is permitted to run an
+ * agent, given the instance-level execution policy. This is security-critical:
+ * on a shared cloud instance we FORCE all untrusted tenant agents onto the
+ * Kubernetes sandbox-provider and REFUSE local/in-process execution so that a
+ * tenant agent can never run inside the server process or on an unsandboxed
+ * local/ssh adapter.
+ *
+ * The merged tree's environment model represents the Kubernetes sandbox as a
+ * core `driver: "sandbox"` environment whose `config.provider` is the plugin's
+ * `driverKey` ("kubernetes", `kind: "sandbox_provider"`). The local default is
+ * `driver: "local"`. This module knows nothing about the DB or heartbeat — it
+ * just maps (driver, provider, policy) -> allow/deny so it is trivially
+ * unit-testable.
+ */
+
+/** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
+export const KUBERNETES_PROVIDER_KEY = "kubernetes" as const;
+
+/**
+ * Instance execution policy as read from instance general settings.
+ *
+ * - `"any"` / absent: unrestricted — any environment driver is allowed (the
+ *   default, preserves single-tenant / local-trusted behavior).
+ * - `"kubernetes"`: force the Kubernetes sandbox provider; deny local, ssh, and
+ *   any non-kubernetes sandbox provider.
+ */
+export interface ExecutionPolicy {
+  executionMode?: "kubernetes" | "any";
+}
+
+/**
+ * The minimal shape of the selected/candidate environment the guard needs.
+ * `driver` is the core `EnvironmentDriver`; `provider` is the sandbox provider
+ * key (== plugin driverKey) for `driver: "sandbox"` environments, else null.
+ */
+export interface ExecutionEnvironmentCandidate {
+  driver: string;
+  provider: string | null | undefined;
+}
+
+export type ExecutionAllowlistDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: string;
+      deniedDriver: string;
+      deniedProvider: string | null;
+    };
+
+/** True when the policy forces all execution onto the Kubernetes sandbox. */
+export function isExecutionForcedToKubernetes(policy: ExecutionPolicy | null | undefined): boolean {
+  return policy?.executionMode === "kubernetes";
+}
+
+/**
+ * True iff the candidate environment is the Kubernetes sandbox provider, i.e. a
+ * core `sandbox` driver whose provider key is "kubernetes".
+ */
+export function isKubernetesSandboxEnvironment(
+  candidate: ExecutionEnvironmentCandidate,
+): boolean {
+  return candidate.driver === "sandbox" && candidate.provider === KUBERNETES_PROVIDER_KEY;
+}
+
+/**
+ * Decide whether the candidate environment may run under the given policy.
+ *
+ * When `executionMode === "kubernetes"`, ONLY a `sandbox_provider` driver with
+ * provider/driverKey "kubernetes" is allowed; a `local` driver (or any non-k8s
+ * sandbox provider, or ssh, or plugin) is DENIED. Otherwise everything is
+ * allowed.
+ */
+export function evaluateExecutionAllowlist(
+  policy: ExecutionPolicy | null | undefined,
+  candidate: ExecutionEnvironmentCandidate,
+): ExecutionAllowlistDecision {
+  if (!isExecutionForcedToKubernetes(policy)) {
+    return { allowed: true };
+  }
+
+  if (isKubernetesSandboxEnvironment(candidate)) {
+    return { allowed: true };
+  }
+
+  const provider = candidate.provider ?? null;
+  const target =
+    candidate.driver === "sandbox"
+      ? `sandbox provider "${provider ?? "(none)"}"`
+      : `"${candidate.driver}" driver`;
+
+  return {
+    allowed: false,
+    reason:
+      `Instance execution policy requires the Kubernetes sandbox provider ` +
+      `(executionMode=kubernetes), but the resolved environment uses the ${target}. ` +
+      `Untrusted execution on a non-Kubernetes environment is refused.`,
+    deniedDriver: candidate.driver,
+    deniedProvider: provider,
+  };
+}

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseExecutionPolicyBootstrapEnv,
+  type ExecutionPolicyBootstrapEnv,
+} from "./execution-policy-bootstrap.js";
+
+function env(overrides: Record<string, string | undefined>): ExecutionPolicyBootstrapEnv {
+  return overrides;
+}
+
+describe("parseExecutionPolicyBootstrapEnv", () => {
+  it("returns null when no execution mode is set (default unrestricted)", () => {
+    expect(parseExecutionPolicyBootstrapEnv(env({}))).toBeNull();
+  });
+
+  it("returns null when execution mode is explicitly any", () => {
+    expect(
+      parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "any" })),
+    ).toBeNull();
+  });
+
+  it("parses the forced kubernetes policy with a job/gvisor/cilium config", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({
+        PAPERCLIP_EXECUTION_MODE: "kubernetes",
+        PAPERCLIP_K8S_BACKEND: "job",
+        PAPERCLIP_K8S_IN_CLUSTER: "true",
+        PAPERCLIP_K8S_RUNTIME_CLASS_NAME: "gvisor",
+        PAPERCLIP_K8S_EGRESS_MODE: "cilium",
+        PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS: "api.anthropic.com, api.openai.com",
+        PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS: "10.0.0.0/8",
+      }),
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed?.executionMode).toBe("kubernetes");
+    expect(parsed?.kubernetesConfig).toMatchObject({
+      backend: "job",
+      inCluster: true,
+      runtimeClassName: "gvisor",
+      egressMode: "cilium",
+      egressAllowFqdns: ["api.anthropic.com", "api.openai.com"],
+      egressAllowCidrs: ["10.0.0.0/8"],
+    });
+  });
+
+  it("defaults inCluster false and omits unset optional fields", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }),
+    );
+    expect(parsed?.kubernetesConfig.inCluster).toBe(false);
+    expect(parsed?.kubernetesConfig.runtimeClassName).toBeUndefined();
+    expect(parsed?.kubernetesConfig.egressAllowFqdns).toBeUndefined();
+  });
+
+  it("throws on an unknown execution mode", () => {
+    expect(() =>
+      parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "vm" })),
+    ).toThrow(/PAPERCLIP_EXECUTION_MODE/);
+  });
+});

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -1,0 +1,166 @@
+/**
+ * Cloud execution-policy bootstrap.
+ *
+ * Lets an operator / gitops deployment force the instance onto the Kubernetes
+ * sandbox provider purely via environment variables, with no manual product-API
+ * calls. On startup we:
+ *   1. Parse `PAPERCLIP_EXECUTION_MODE` (+ `PAPERCLIP_K8S_*`) from the env.
+ *   2. Persist `executionMode` into instance general settings (so the per-run
+ *      heartbeat guard enforces it).
+ *   3. Idempotently ensure a configured Kubernetes sandbox environment for every
+ *      company (mirrors `ensureLocalEnvironment`).
+ *
+ * The boot hook is *configuration convenience*; the actual security gate is the
+ * per-run guard in the heartbeat (see `execution-allowlist.ts`). Even with no
+ * boot hook, setting `executionMode=kubernetes` denies local execution.
+ *
+ * The env-var parsing is a pure function so it is trivially unit-testable.
+ */
+
+import type { Db } from "@paperclipai/db";
+import type { InstanceExecutionMode } from "@paperclipai/shared";
+import { logger } from "../middleware/logger.js";
+import { environmentService, type KubernetesEnvironmentConfigInput } from "./environments.js";
+import { instanceSettingsService } from "./instance-settings.js";
+
+export type ExecutionPolicyBootstrapEnv = Record<string, string | undefined>;
+
+export interface ExecutionPolicyBootstrap {
+  executionMode: Extract<InstanceExecutionMode, "kubernetes">;
+  kubernetesConfig: KubernetesEnvironmentConfigInput;
+}
+
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  return undefined;
+}
+
+function parseList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  const items = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
+ * Parse the forced-execution-mode env config. Returns null when execution is
+ * unrestricted (no env, or `PAPERCLIP_EXECUTION_MODE=any`). Throws on an
+ * unrecognized mode so a misconfigured deployment fails loudly instead of
+ * silently allowing local execution.
+ */
+export function parseExecutionPolicyBootstrapEnv(
+  env: ExecutionPolicyBootstrapEnv,
+): ExecutionPolicyBootstrap | null {
+  const raw = env.PAPERCLIP_EXECUTION_MODE?.trim();
+  if (!raw || raw === "any") return null;
+  if (raw !== "kubernetes") {
+    throw new Error(
+      `PAPERCLIP_EXECUTION_MODE must be "kubernetes" or "any" (got "${raw}").`,
+    );
+  }
+
+  const kubernetesConfig: KubernetesEnvironmentConfigInput = {
+    // inCluster defaults to false (matches the plugin schema default); an
+    // in-cluster cloud deployment sets PAPERCLIP_K8S_IN_CLUSTER=true.
+    inCluster: parseBool(env.PAPERCLIP_K8S_IN_CLUSTER) ?? false,
+  };
+
+  const backend = env.PAPERCLIP_K8S_BACKEND?.trim();
+  if (backend) {
+    if (backend !== "job" && backend !== "sandbox-cr") {
+      throw new Error(
+        `PAPERCLIP_K8S_BACKEND must be "job" or "sandbox-cr" (got "${backend}").`,
+      );
+    }
+    kubernetesConfig.backend = backend;
+  }
+
+  const egressMode = env.PAPERCLIP_K8S_EGRESS_MODE?.trim();
+  if (egressMode) {
+    if (egressMode !== "cilium" && egressMode !== "standard") {
+      throw new Error(
+        `PAPERCLIP_K8S_EGRESS_MODE must be "cilium" or "standard" (got "${egressMode}").`,
+      );
+    }
+    kubernetesConfig.egressMode = egressMode;
+  }
+
+  const runtimeClassName = env.PAPERCLIP_K8S_RUNTIME_CLASS_NAME?.trim();
+  if (runtimeClassName) kubernetesConfig.runtimeClassName = runtimeClassName;
+
+  const namespacePrefix = env.PAPERCLIP_K8S_NAMESPACE_PREFIX?.trim();
+  if (namespacePrefix) kubernetesConfig.namespacePrefix = namespacePrefix;
+
+  const imageRegistry = env.PAPERCLIP_K8S_IMAGE_REGISTRY?.trim();
+  if (imageRegistry) kubernetesConfig.imageRegistry = imageRegistry;
+
+  const adapterType = env.PAPERCLIP_K8S_ADAPTER_TYPE?.trim();
+  if (adapterType) kubernetesConfig.adapterType = adapterType;
+
+  const egressAllowFqdns = parseList(env.PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS);
+  if (egressAllowFqdns) kubernetesConfig.egressAllowFqdns = egressAllowFqdns;
+
+  const egressAllowCidrs = parseList(env.PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS);
+  if (egressAllowCidrs) kubernetesConfig.egressAllowCidrs = egressAllowCidrs;
+
+  return { executionMode: "kubernetes", kubernetesConfig };
+}
+
+/**
+ * Apply the parsed bootstrap to the database: persist `executionMode` into
+ * instance settings and ensure a configured Kubernetes environment for every
+ * company. Idempotent; safe to call on every boot.
+ */
+export async function applyExecutionPolicyBootstrap(
+  db: Db,
+  bootstrap: ExecutionPolicyBootstrap,
+): Promise<{ executionMode: InstanceExecutionMode; companiesConfigured: number }> {
+  const instanceSettings = instanceSettingsService(db);
+  const environments = environmentService(db);
+
+  await instanceSettings.updateGeneral({ executionMode: bootstrap.executionMode });
+
+  const companyIds = await instanceSettings.listCompanyIds();
+  let configured = 0;
+  for (const companyId of companyIds) {
+    try {
+      await environments.ensureKubernetesEnvironment(companyId, bootstrap.kubernetesConfig);
+      configured += 1;
+    } catch (err) {
+      logger.error(
+        { err, companyId },
+        "failed to ensure managed Kubernetes environment during execution-policy bootstrap",
+      );
+    }
+  }
+
+  logger.info(
+    {
+      executionMode: bootstrap.executionMode,
+      companiesConfigured: configured,
+      backend: bootstrap.kubernetesConfig.backend,
+      runtimeClassName: bootstrap.kubernetesConfig.runtimeClassName,
+      egressMode: bootstrap.kubernetesConfig.egressMode,
+    },
+    "applied forced Kubernetes execution policy",
+  );
+
+  return { executionMode: bootstrap.executionMode, companiesConfigured: configured };
+}
+
+/**
+ * Convenience: parse + apply from a raw env map. Returns null when unrestricted.
+ */
+export async function bootstrapExecutionPolicyFromEnv(
+  db: Db,
+  env: ExecutionPolicyBootstrapEnv = process.env,
+): Promise<{ executionMode: InstanceExecutionMode; companiesConfigured: number } | null> {
+  const bootstrap = parseExecutionPolicyBootstrapEnv(env);
+  if (!bootstrap) return null;
+  return applyExecutionPolicyBootstrap(db, bootstrap);
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -133,6 +133,10 @@ import {
 } from "./execution-workspace-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import {
+  evaluateExecutionAllowlist,
+  isExecutionForcedToKubernetes,
+} from "./execution-allowlist.js";
+import {
   RECOVERY_ORIGIN_KINDS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
@@ -4374,7 +4378,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const warnings: string[] = [];
     if (sessionCwd && sessionCwdLooksUnsafe) {
       warnings.push(
-        `Saved session workspace "${sessionCwd}" points at a system temp root and was rejected as untrusted. Using fallback workspace "${cwd}" for this run.`,
+        `Saved session workspace "${sessionCwd}" points at a system temp root and was rejected as untrusted (likely persisted from a previous remote-target run). Using fallback workspace "${cwd}" for this run.`,
       );
     } else if (sessionCwd) {
       warnings.push(
@@ -7985,7 +7989,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       persistedExecutionWorkspaceMode === "agent_default"
         ? persistedExecutionWorkspaceMode
         : requestedExecutionWorkspaceMode;
-    const selectedEnvironmentId = environmentResolution.environmentId;
+    // Execution allowlist (security-critical): on a shared cloud instance the
+    // operator sets instance executionMode="kubernetes" to FORCE all agent
+    // execution onto the Kubernetes sandbox provider and REFUSE local/in-process
+    // or ssh execution. When forced, we override the resolved environment to the
+    // company's managed Kubernetes environment (no silent fallback to local).
+    // The default ("any") path is unchanged. This runs before the low-trust
+    // preflight below so the preflight resolves the driver of the forced env.
+    const executionPolicy = { executionMode: (await instanceSettings.getGeneral()).executionMode };
+    let selectedEnvironmentId = environmentResolution.environmentId;
+    if (isExecutionForcedToKubernetes(executionPolicy)) {
+      const kubernetesEnvironment = await environmentsSvc.findKubernetesEnvironment(agent.companyId);
+      if (!kubernetesEnvironment) {
+        throw new Error(
+          "Instance execution policy requires the Kubernetes sandbox provider " +
+            "(executionMode=kubernetes) but no managed Kubernetes environment is " +
+            "configured for this company. Configure one (PAPERCLIP_K8S_* env on the " +
+            "cloud instance) before running agents; refusing to fall back to local execution.",
+        );
+      }
+      if (kubernetesEnvironment.id !== selectedEnvironmentId) {
+        logger.info(
+          {
+            runId: run.id,
+            issueId,
+            agentId: agent.id,
+            resolvedEnvironmentId: selectedEnvironmentId,
+            forcedKubernetesEnvironmentId: kubernetesEnvironment.id,
+          },
+          "Forcing run onto the managed Kubernetes environment (executionMode=kubernetes)",
+        );
+      }
+      selectedEnvironmentId = kubernetesEnvironment.id;
+    }
     const {
       selectedEnvironmentDriver: lowTrustPreflightEnvironmentDriver,
       workspace: resolvedWorkspace,
@@ -8306,7 +8342,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         })
         .where(eq(heartbeatRuns.id, run.id));
     }
-    const persistedEnvironmentId = persistedExecutionWorkspace?.config?.environmentId ?? selectedEnvironmentId;
+    // When execution is forced to Kubernetes, `selectedEnvironmentId` is already
+    // pinned to the managed k8s environment above; ignore any persisted workspace
+    // environmentId (which could point at a stale local/ssh env) so a reused
+    // workspace can never downgrade us off the sandbox.
+    const persistedEnvironmentId = isExecutionForcedToKubernetes(executionPolicy)
+      ? selectedEnvironmentId
+      : persistedExecutionWorkspace?.config?.environmentId ?? selectedEnvironmentId;
     const acquiredEnvironment = await envOrchestrator.acquireForRun({
       companyId: agent.companyId,
       selectedEnvironmentId: persistedEnvironmentId,
@@ -8318,6 +8360,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       persistedExecutionWorkspace,
     });
     const selectedEnvironment = acquiredEnvironment.environment;
+    // Defense-in-depth: re-check the actually-acquired environment against the
+    // execution allowlist. Even if selection were bypassed, a denied (local/ssh/
+    // non-k8s) environment FAILS the run here rather than executing untrusted.
+    const allowlistDecision = evaluateExecutionAllowlist(executionPolicy, {
+      driver: selectedEnvironment.driver,
+      provider:
+        typeof selectedEnvironment.config?.provider === "string"
+          ? selectedEnvironment.config.provider
+          : null,
+    });
+    if (!allowlistDecision.allowed) {
+      logger.error(
+        {
+          runId: run.id,
+          issueId,
+          agentId: agent.id,
+          environmentId: selectedEnvironment.id,
+          deniedDriver: allowlistDecision.deniedDriver,
+          deniedProvider: allowlistDecision.deniedProvider,
+        },
+        "Execution allowlist denied the resolved environment; failing run",
+      );
+      throw new Error(allowlistDecision.reason);
+    }
     let activeEnvironmentLease = {
       environment: acquiredEnvironment.environment,
       lease: acquiredEnvironment.lease,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -62,6 +62,7 @@ export type {
 } from "./authorization.js";
 export { boardAuthService } from "./board-auth.js";
 export { instanceSettingsService } from "./instance-settings.js";
+export { bootstrapExecutionPolicyFromEnv } from "./execution-policy-bootstrap.js";
 export { cloudUpstreamService, reconcileCloudUpstreamRunsOnStartup } from "./cloud-upstreams.js";
 export { companyPortabilityService } from "./company-portability.js";
 export { teamsCatalogService } from "./teams-catalog.js";

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -27,6 +27,8 @@ function normalizeGeneralSettings(raw: unknown): InstanceGeneralSettings {
       feedbackDataSharingPreference:
         parsed.data.feedbackDataSharingPreference ?? DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
       backupRetention: parsed.data.backupRetention ?? DEFAULT_BACKUP_RETENTION,
+      // Absent => unrestricted; only carry through an explicit policy.
+      ...(parsed.data.executionMode ? { executionMode: parsed.data.executionMode } : {}),
     };
   }
   return {

--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { Environment } from "@paperclipai/shared";
 import { supportsAdapterModelRefresh } from "./AgentConfigForm";
+import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
 
 describe("supportsAdapterModelRefresh", () => {
   it("enables the model refresh action for Claude, Codex, and ACPX adapters", () => {
@@ -11,5 +13,60 @@ describe("supportsAdapterModelRefresh", () => {
   it("keeps the refresh action hidden for adapters without a live refresh hook", () => {
     expect(supportsAdapterModelRefresh("opencode_local")).toBe(false);
     expect(supportsAdapterModelRefresh("process")).toBe(false);
+  });
+});
+
+function makeEnvironment(overrides: Partial<Environment>): Environment {
+  return {
+    id: "env-1",
+    companyId: "co-1",
+    name: "Env",
+    description: null,
+    driver: "local",
+    status: "active",
+    config: {},
+    metadata: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+const localEnv = makeEnvironment({ id: "local-1", name: "Local", driver: "local" });
+const k8sEnv = makeEnvironment({
+  id: "k8s-1",
+  name: "Managed K8s",
+  driver: "sandbox",
+  config: { provider: "kubernetes" },
+});
+
+describe("resolveForcedKubernetesEnvironment", () => {
+  it("does not force when executionMode is 'any' (full picker / unchanged)", () => {
+    const result = resolveForcedKubernetesEnvironment("any", [localEnv, k8sEnv]);
+    expect(result.forced).toBe(false);
+    expect(result.kubernetesEnvironment).toBeNull();
+  });
+
+  it("does not force when executionMode is absent (self-hoster default)", () => {
+    const result = resolveForcedKubernetesEnvironment(undefined, [localEnv, k8sEnv]);
+    expect(result.forced).toBe(false);
+    expect(result.kubernetesEnvironment).toBeNull();
+  });
+
+  it("forces and selects the Kubernetes sandbox when executionMode is 'kubernetes'", () => {
+    const result = resolveForcedKubernetesEnvironment("kubernetes", [localEnv, k8sEnv]);
+    expect(result.forced).toBe(true);
+    expect(result.kubernetesEnvironment?.id).toBe("k8s-1");
+  });
+
+  it("forces but reports no environment when none is the Kubernetes sandbox", () => {
+    const fakeSandbox = makeEnvironment({
+      id: "fake-1",
+      driver: "sandbox",
+      config: { provider: "fake" },
+    });
+    const result = resolveForcedKubernetesEnvironment("kubernetes", [localEnv, fakeSandbox]);
+    expect(result.forced).toBe(true);
+    expect(result.kubernetesEnvironment).toBeNull();
   });
 });

--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Environment } from "@paperclipai/shared";
 import { supportsAdapterModelRefresh } from "./AgentConfigForm";
-import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
+import {
+  resolveExecutionPickerState,
+  resolveForcedKubernetesEnvironment,
+} from "../lib/forced-kubernetes-environment";
 
 describe("supportsAdapterModelRefresh", () => {
   it("enables the model refresh action for Claude, Codex, and ACPX adapters", () => {
@@ -68,5 +71,62 @@ describe("resolveForcedKubernetesEnvironment", () => {
     const result = resolveForcedKubernetesEnvironment("kubernetes", [localEnv, fakeSandbox]);
     expect(result.forced).toBe(true);
     expect(result.kubernetesEnvironment).toBeNull();
+  });
+});
+
+describe("resolveExecutionPickerState", () => {
+  it("renders the forced read-only section when execution is forced", () => {
+    expect(
+      resolveExecutionPickerState({
+        forced: true,
+        environmentsEnabled: false,
+        executionModeLoading: false,
+        executionModeFailed: false,
+      }),
+    ).toEqual({ state: "forced", showPolicyUnknownNotice: false });
+  });
+
+  it("hides the section when the environments picker is disabled", () => {
+    expect(
+      resolveExecutionPickerState({
+        forced: false,
+        environmentsEnabled: false,
+        executionModeLoading: true,
+        executionModeFailed: false,
+      }),
+    ).toEqual({ state: "hidden", showPolicyUnknownNotice: false });
+  });
+
+  it("shows a loading placeholder instead of the picker while the policy loads", () => {
+    expect(
+      resolveExecutionPickerState({
+        forced: false,
+        environmentsEnabled: true,
+        executionModeLoading: true,
+        executionModeFailed: false,
+      }),
+    ).toEqual({ state: "loading", showPolicyUnknownNotice: false });
+  });
+
+  it("shows the full picker without a notice once the policy resolves as not forced", () => {
+    expect(
+      resolveExecutionPickerState({
+        forced: false,
+        environmentsEnabled: true,
+        executionModeLoading: false,
+        executionModeFailed: false,
+      }),
+    ).toEqual({ state: "picker", showPolicyUnknownNotice: false });
+  });
+
+  it("keeps the picker usable but warns when the policy load failed (never forces K8s)", () => {
+    expect(
+      resolveExecutionPickerState({
+        forced: false,
+        environmentsEnabled: true,
+        executionModeLoading: false,
+        executionModeFailed: true,
+      }),
+    ).toEqual({ state: "picker", showPolicyUnknownNotice: true });
   });
 });

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -58,6 +58,7 @@ import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { buildAgentUpdatePatch, type AgentConfigOverlay } from "../lib/agent-config-patch";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { filterAcpxModelsByAgent } from "../lib/acpx-model-filter";
+import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
 
 /* ---- Create mode values ---- */
 
@@ -226,11 +227,33 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   });
   const environmentsEnabled = experimentalSettings?.enableEnvironments === true;
 
+  // Instance execution policy (general settings). When `executionMode` is
+  // "kubernetes" the instance FORCES all execution onto the managed Kubernetes
+  // sandbox; "any"/absent leaves the full environment/adapter choice intact.
+  // Reuses the same general-settings query the rest of the UI uses.
+  const { data: generalSettings } = useQuery({
+    queryKey: queryKeys.instance.generalSettings,
+    queryFn: () => instanceSettingsApi.getGeneral(),
+    retry: false,
+  });
+
   const { data: environments = [] } = useQuery<Environment[]>({
     queryKey: selectedCompanyId ? queryKeys.environments.list(selectedCompanyId) : ["environments", "none"],
     queryFn: () => environmentsApi.list(selectedCompanyId!),
-    enabled: Boolean(selectedCompanyId) && environmentsEnabled,
+    // Load environments when the picker is enabled OR when execution is forced
+    // onto Kubernetes (so we can resolve and default to the managed K8s env even
+    // when the experimental environments picker is otherwise hidden).
+    enabled:
+      Boolean(selectedCompanyId) &&
+      (environmentsEnabled || generalSettings?.executionMode === "kubernetes"),
   });
+
+  // Setting-driven: resolve whether the instance forces Kubernetes execution and
+  // which loaded environment is the managed Kubernetes sandbox.
+  const { forced: forcedKubernetes, kubernetesEnvironment } = useMemo(
+    () => resolveForcedKubernetesEnvironment(generalSettings?.executionMode, environments),
+    [generalSettings?.executionMode, environments],
+  );
   const createSecret = useMutation({
     mutationFn: (input: { name: string; value: string }) => {
       if (!selectedCompanyId) throw new Error("Select a company to create secrets");
@@ -339,6 +362,17 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     () => environments.find((environment) => environment.id === currentDefaultEnvironmentId) ?? null,
     [currentDefaultEnvironmentId, environments],
   );
+
+  // When the instance forces Kubernetes execution, new agents must default to the
+  // managed Kubernetes sandbox environment (never the implicit local default).
+  // Only applies in create mode and only once the K8s environment is loaded; if
+  // none is available the UI surfaces a notice instead of silently selecting it.
+  useEffect(() => {
+    if (!isCreate || !forcedKubernetes || !kubernetesEnvironment) return;
+    if (currentDefaultEnvironmentId === kubernetesEnvironment.id) return;
+    set!({ defaultEnvironmentId: kubernetesEnvironment.id });
+  }, [isCreate, forcedKubernetes, kubernetesEnvironment, currentDefaultEnvironmentId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const runnableEnvironments = useMemo(
     () => environments.filter((environment) => {
       if (!supportedEnvironmentDrivers.has(environment.driver)) return false;
@@ -785,7 +819,35 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       )}
 
       {/* ---- Execution ---- */}
-      {environmentsEnabled ? (
+      {forcedKubernetes ? (
+        // Instance execution policy forces the managed Kubernetes sandbox
+        // (executionMode=kubernetes): never offer local / non-Kubernetes targets.
+        // Render the environment read-only instead of the selectable picker.
+        <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
+          {cards
+            ? <h3 className="text-sm font-medium mb-3">Execution</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Execution</div>
+          }
+          <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
+            <Field
+              label="Default environment"
+              hint="This instance runs all agents in the Kubernetes sandbox. Local execution is disabled."
+            >
+              {kubernetesEnvironment ? (
+                <div className={cn(inputClass, "flex items-center text-muted-foreground")}>
+                  {kubernetesEnvironment.name} · Kubernetes sandbox
+                </div>
+              ) : (
+                <div className="rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  This instance requires the Kubernetes sandbox, but no managed Kubernetes
+                  environment is available for this company yet. Configure one before creating
+                  agents; execution will not fall back to local.
+                </div>
+              )}
+            </Field>
+          </div>
+        </div>
+      ) : environmentsEnabled ? (
         <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
           {cards
             ? <h3 className="text-sm font-medium mb-3">Execution</h3>

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -58,7 +58,10 @@ import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { buildAgentUpdatePatch, type AgentConfigOverlay } from "../lib/agent-config-patch";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { filterAcpxModelsByAgent } from "../lib/acpx-model-filter";
-import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
+import {
+  resolveExecutionPickerState,
+  resolveForcedKubernetesEnvironment,
+} from "../lib/forced-kubernetes-environment";
 
 /* ---- Create mode values ---- */
 
@@ -230,11 +233,19 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   // Instance execution policy (general settings). When `executionMode` is
   // "kubernetes" the instance FORCES all execution onto the managed Kubernetes
   // sandbox; "any"/absent leaves the full environment/adapter choice intact.
-  // Reuses the same general-settings query the rest of the UI uses.
-  const { data: generalSettings } = useQuery({
+  // Reuses the same general-settings query the rest of the UI uses, with the
+  // default retry behavior (like Layout/InstanceGeneralSettings) so a transient
+  // failure does not silently unlock the full picker on a forced-K8s instance.
+  // While the policy loads the Execution section shows a placeholder, and on
+  // persistent failure it shows a notice instead — a failed load never maps to
+  // forced-K8s, which would wrongly restrict non-K8s instances.
+  const {
+    data: generalSettings,
+    isPending: executionPolicyLoading,
+    isError: executionPolicyFailed,
+  } = useQuery({
     queryKey: queryKeys.instance.generalSettings,
     queryFn: () => instanceSettingsApi.getGeneral(),
-    retry: false,
   });
 
   const { data: environments = [] } = useQuery<Environment[]>({
@@ -254,6 +265,16 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     () => resolveForcedKubernetesEnvironment(generalSettings?.executionMode, environments),
     [generalSettings?.executionMode, environments],
   );
+
+  // Which Execution section to render given the policy query status: forced
+  // read-only, loading placeholder, full picker (with a notice when the policy
+  // could not be loaded), or hidden. Pure helper, unit-tested.
+  const { state: executionPickerState, showPolicyUnknownNotice } = resolveExecutionPickerState({
+    forced: forcedKubernetes,
+    environmentsEnabled,
+    executionModeLoading: executionPolicyLoading,
+    executionModeFailed: executionPolicyFailed,
+  });
   const createSecret = useMutation({
     mutationFn: (input: { name: string; value: string }) => {
       if (!selectedCompanyId) throw new Error("Select a company to create secrets");
@@ -819,7 +840,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       )}
 
       {/* ---- Execution ---- */}
-      {forcedKubernetes ? (
+      {executionPickerState === "forced" ? (
         // Instance execution policy forces the managed Kubernetes sandbox
         // (executionMode=kubernetes): never offer local / non-Kubernetes targets.
         // Render the environment read-only instead of the selectable picker.
@@ -847,7 +868,27 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             </Field>
           </div>
         </div>
-      ) : environmentsEnabled ? (
+      ) : executionPickerState === "loading" ? (
+        // Instance execution policy not resolved yet: render a placeholder
+        // instead of the full picker so a forced-K8s instance never briefly
+        // implies unrestricted environment choice while the query is in flight.
+        <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
+          {cards
+            ? <h3 className="text-sm font-medium mb-3">Execution</h3>
+            : <div className="px-4 py-2 text-xs font-medium text-muted-foreground">Execution</div>
+          }
+          <div className={cn(cards ? "border border-border rounded-lg p-4 space-y-3" : "px-4 pb-3 space-y-3")}>
+            <Field
+              label="Default environment"
+              hint="Agent-level default execution target. Project and task settings can still override this."
+            >
+              <div aria-busy="true" className={cn(inputClass, "text-muted-foreground")}>
+                Loading execution policy…
+              </div>
+            </Field>
+          </div>
+        </div>
+      ) : executionPickerState === "picker" ? (
         <div className={cn(!cards && (isCreate ? "border-t border-border" : "border-b border-border"))}>
           {cards
             ? <h3 className="text-sm font-medium mb-3">Execution</h3>
@@ -878,6 +919,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                 ))}
               </select>
             </Field>
+            {showPolicyUnknownNotice && (
+              <p className="text-xs text-amber-400">
+                Couldn&apos;t load the instance execution policy. If this instance restricts
+                execution to the Kubernetes sandbox, runs in other environments will be
+                rejected by the server.
+              </p>
+            )}
           </div>
         </div>
       ) : null}

--- a/ui/src/lib/forced-kubernetes-environment.ts
+++ b/ui/src/lib/forced-kubernetes-environment.ts
@@ -54,3 +54,47 @@ export function resolveForcedKubernetesEnvironment(
     environments.find((environment) => isKubernetesSandboxEnvironment(environment)) ?? null;
   return { forced: true, kubernetesEnvironment };
 }
+
+/**
+ * Which Execution section to render in the agent config form:
+ * - "forced": the instance forces the Kubernetes sandbox — render it read-only.
+ * - "loading": the execution policy is still loading — render a placeholder so
+ *   a forced-K8s instance never briefly implies unrestricted choice.
+ * - "picker": render the full environment picker.
+ * - "hidden": no Execution section (environments picker disabled).
+ */
+export type ExecutionPickerState = "forced" | "loading" | "picker" | "hidden";
+
+export interface ExecutionPickerResolution {
+  state: ExecutionPickerState;
+  /**
+   * True when the execution policy could not be loaded. The picker stays fully
+   * usable (an unreachable settings endpoint must never restrict a non-forced
+   * instance), but a notice warns that a forced-K8s instance would reject
+   * non-Kubernetes environments server-side.
+   */
+  showPolicyUnknownNotice: boolean;
+}
+
+/**
+ * Resolve the Execution section state from the execution-policy query status.
+ * Pure so the loading/error/forced precedence can be unit-tested without
+ * rendering. Deliberately never maps a failed policy load to "forced".
+ */
+export function resolveExecutionPickerState(input: {
+  forced: boolean;
+  environmentsEnabled: boolean;
+  executionModeLoading: boolean;
+  executionModeFailed: boolean;
+}): ExecutionPickerResolution {
+  if (input.forced) {
+    return { state: "forced", showPolicyUnknownNotice: false };
+  }
+  if (!input.environmentsEnabled) {
+    return { state: "hidden", showPolicyUnknownNotice: false };
+  }
+  if (input.executionModeLoading) {
+    return { state: "loading", showPolicyUnknownNotice: false };
+  }
+  return { state: "picker", showPolicyUnknownNotice: input.executionModeFailed };
+}

--- a/ui/src/lib/forced-kubernetes-environment.ts
+++ b/ui/src/lib/forced-kubernetes-environment.ts
@@ -1,0 +1,56 @@
+import type { Environment, InstanceExecutionMode } from "@paperclipai/shared";
+
+/**
+ * Provider key (== plugin driverKey) of the first-party Kubernetes sandbox
+ * provider. Mirrors `KUBERNETES_PROVIDER_KEY` in the server-side execution
+ * allowlist. Kept local to the UI because the allowlist module lives in the
+ * server package and must not be imported by the client bundle.
+ */
+export const KUBERNETES_PROVIDER_KEY = "kubernetes" as const;
+
+/**
+ * True iff the environment is the Kubernetes sandbox provider, i.e. a core
+ * `sandbox` driver whose `config.provider` is "kubernetes". Mirrors the
+ * server-side `isKubernetesSandboxEnvironment` guard so the UI selects exactly
+ * the environment the server forces execution onto.
+ */
+export function isKubernetesSandboxEnvironment(environment: Environment): boolean {
+  if (environment.driver !== "sandbox") return false;
+  const provider = environment.config?.provider;
+  return provider === KUBERNETES_PROVIDER_KEY;
+}
+
+export interface ForcedKubernetesEnvironment {
+  /**
+   * Whether the instance execution policy forces all execution onto the
+   * Kubernetes sandbox. Driven entirely by the `executionMode` instance general
+   * setting: `"kubernetes"` forces; `"any"`/absent does not. A self-hoster who
+   * keeps the default `"any"` retains the full environment/adapter picker.
+   */
+  forced: boolean;
+  /**
+   * The company's managed Kubernetes sandbox environment, if one is present in
+   * the loaded environment list. `null` when forced but no such environment is
+   * available yet (the UI should show a clear notice rather than silently
+   * defaulting to local).
+   */
+  kubernetesEnvironment: Environment | null;
+}
+
+/**
+ * Resolve whether execution is forced onto Kubernetes and, if so, which loaded
+ * environment is the Kubernetes sandbox. Pure so it can be unit-tested without
+ * rendering.
+ */
+export function resolveForcedKubernetesEnvironment(
+  executionMode: InstanceExecutionMode | undefined,
+  environments: readonly Environment[],
+): ForcedKubernetesEnvironment {
+  const forced = executionMode === "kubernetes";
+  if (!forced) {
+    return { forced: false, kubernetesEnvironment: null };
+  }
+  const kubernetesEnvironment =
+    environments.find((environment) => isKubernetesSandboxEnvironment(environment)) ?? null;
+  return { forced: true, kubernetesEnvironment };
+}


### PR DESCRIPTION
> **TL;DR for reviewers:** UI companion to #7599. When the instance general setting `executionMode` is `"kubernetes"`, the agent-create/config UI no longer offers local / non-Kubernetes execution: the environment picker is replaced by a read-only Kubernetes sandbox display and new agents default to the managed K8s environment. When `executionMode` is `"any"` or absent, behavior is unchanged.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute through the environment/driver model; the Kubernetes sandbox already exists as a sandbox provider (#5790), and #7599 adds an instance-level `executionMode` policy that forces all runs onto it on shared / multi-tenant deployments
> - The server-side policy alone leaves a UX gap: the agent config form would still render the full environment picker, letting a user on a forced-K8s instance configure a local environment the server will then refuse at run time
> - The UI must read the same instance setting and mirror the policy — never offering choices the server will reject, and never silently falling back to local
> - It must also handle the moments the policy is *unknown* (settings query loading or failed): briefly showing the unrestricted picker on a forced instance is misleading, while guessing "forced" on error would wrongly restrict ordinary self-hosted instances
> - This pull request gates the execution picker on `executionMode`: forced instances get a read-only Kubernetes sandbox display and K8s-defaulted new agents; while the policy loads the section shows a placeholder; if the policy can't be loaded the picker stays usable with a warning notice
> - The decision logic lives in pure, unit-tested helpers (`resolveForcedKubernetesEnvironment`, `resolveExecutionPickerState`), so the rendering states are testable without mounting the form
> - The benefit is a UI that matches the instance's actual execution policy: tenants on forced-K8s instances can't mis-configure agents the server will refuse, and self-hosters keep full choice

## Linked Issues or Issue Description

No single issue tracks this change directly; related issues (same set as the server-side counterpart):

- Refs #248 — proposal for sandboxed agent execution (provider-agnostic interface for secure remote environments); the sandbox provider landed via #5790
- Refs #966 — managed hosting hooks for SaaS multi-tenant deployment; `executionMode=kubernetes` targets the same shared-instance scenario
- Refs #2554 — security report observing instances can run with no effective sandbox; the forced mode is the operator's fail-closed switch

Related PRs: #7599 is the **server-side counterpart** (adds the `executionMode` instance setting, env-driven bootstrap, and the execution allowlist that refuses non-K8s runs); #5790 is the Kubernetes sandbox-provider plugin this policy forces runs onto.

In-PR problem description (feature-request form): on an instance where `executionMode=kubernetes` forces all execution onto the managed Kubernetes sandbox (#7599), the agent-create/config UI still rendered the full environment picker, including local environments. A user could select a local environment, and only discover at run time that the server refuses it. The UI needs to read the instance setting and (a) render the forced environment read-only, (b) default new agents to the managed K8s environment, (c) avoid implying unrestricted choice while the policy is still loading, and (d) warn — without restricting — when the policy cannot be loaded.

## What Changed

UI (the subject of this PR):

- `ui/src/lib/forced-kubernetes-environment.ts` (new): pure helpers —
  - `resolveForcedKubernetesEnvironment(executionMode, environments)`: whether the instance forces K8s and which loaded environment is the managed Kubernetes sandbox (`driver: "sandbox"`, `config.provider: "kubernetes"`, mirroring the server-side allowlist guard)
  - `resolveExecutionPickerState(...)` (new in this revision): maps policy query status to one of `"forced" | "loading" | "picker" | "hidden"` plus a `showPolicyUnknownNotice` flag; deliberately never maps a failed policy load to `"forced"`
- `ui/src/components/AgentConfigForm.tsx`:
  - reads `executionMode` from the instance general-settings query; when forced, hides the selectable **Default environment** picker and renders the managed Kubernetes sandbox **read-only**, with an inline notice (no silent local fallback) when forced but no managed K8s environment exists yet
  - defaults new agents' `defaultEnvironmentId` to the company's Kubernetes sandbox environment in create mode
  - loads the environment list even when the experimental environments picker is otherwise disabled, so the K8s env can be resolved and selected
  - **(Greptile P2 fix)** drops `retry: false` on the general-settings query (default react-query retries, matching `Layout.tsx` / `InstanceGeneralSettings.tsx` / `AgentDetail.tsx` usages of the same query) so a transient failure doesn't silently unlock the picker; renders a "Loading execution policy…" placeholder instead of the picker while the query is pending; and on persistent failure keeps the picker fully usable but shows a non-blocking amber notice that a forced-K8s instance would reject non-K8s runs server-side
- `ui/src/components/AgentConfigForm.test.ts` (new): unit tests for both helpers, including the loading/error precedence and the "failed load never forces K8s" invariant

When `executionMode` is `"any"` or absent, behavior is unchanged: the full picker and defaults remain, so a self-hoster keeps full choice.

## Stacking

This is **stacked on #7599** (it consumes the `executionMode` shared type added there). Until #7599 merges, this PR's diff also includes #7599's commits (`packages/shared`, `server/`). The UI-only change in this PR is the three `ui/` files listed above.

## Verification

Commands run locally on this branch:

- `pnpm --dir ui vitest run src/components/AgentConfigForm.test.ts` — 11/11 tests pass (6 pre-existing + 5 new `resolveExecutionPickerState` cases)
- `pnpm --dir ui typecheck` (`tsc -b`) — clean

Manual review of the rendering states (this change is conditional rendering of the existing Execution section; no screenshots — the states are described below and the section is otherwise visually unchanged):

- `executionMode=kubernetes` + managed K8s env present → read-only "Default environment" row showing `<name> · Kubernetes sandbox`; create mode pre-selects that env
- `executionMode=kubernetes` + no managed K8s env → amber notice; no local fallback selected
- general-settings query pending (environments picker enabled) → "Loading execution policy…" placeholder instead of the select
- general-settings query failed after retries → full picker (not restricted) plus amber notice that a forced-K8s instance would reject non-K8s runs at the server
- `executionMode=any`/absent → identical to master

## Risks

- Low risk overall: default (`executionMode` unset or `"any"`) behavior is unchanged, and the server-side allowlist in #7599 remains the actual security boundary — this PR only aligns the UX with it.
- The loading placeholder briefly replaces the picker on instances where the environments picker is enabled; with a warm query cache (the same query key is used by `Layout.tsx`) it typically never appears.
- On persistent settings-endpoint failure the UI now *warns* rather than restricts; a user on a forced-K8s instance could still select a local env in that degraded state, but the server refuses the run (deliberate: erring toward restriction would break non-K8s instances).
- Stacked on #7599: merging this before #7599 would break the build (shared `executionMode` type); merge order matters.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Fable 5 (claude-fable-5, 1M context), extended thinking + tool use, via Claude Code — this revision; original PR authored in an earlier Claude Code session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (the "Cloud / Sandbox agents" direction is what #5790/#7599 implement; this PR is UI alignment, not new core scope)
- [x] I have searched GitHub for duplicate or related PRs and linked them above (#7599, #5790)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (states are conditional rendering of the existing Execution section and are described under Verification)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


