### PR TITLE
SAG-2082: skip stalled-issue recovery when assignee agent is in error state

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -560,6 +560,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    agentStatus?: "idle" | "error" | "running";
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -582,7 +583,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       companyId,
       name: "CodexCoder",
       role: "engineer",
-      status: "idle",
+      status: input.agentStatus ?? "idle",
       adapterType: "codex_local",
       adapterConfig: {},
       runtimeConfig: {},
@@ -3238,5 +3239,63 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+
+  it("skips recovery spawn when assignee agent is in persistent error state", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      agentStatus: "error",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)));
+    expect(wakeups).toHaveLength(1);
+  });
+
+  it("escalates normally when assignee agent is not in error state", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      agentStatus: "idle",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(1);
+    expect(recoveryActions[0]?.ownerAgentId).toBe(agentId);
+    expect(recoveryActions[0]?.status).toBe("active");
+    void runId;
   });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2472,6 +2472,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      if (agent.status === "error") {
+        logger.info(
+          { agentId, issueId: issue.id, companyId: issue.companyId },
+          "stalled-issue recovery: skipping spawn — assignee agent is in persistent error state",
+        );
+        result.skipped += 1;
+        continue;
+      }
+
       if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;


### PR DESCRIPTION
## Summary

- In `reconcileStrandedAssignedIssues` (`server/src/services/recovery/service.ts`), adds a peer filter alongside the existing `isAgentInvokable` guard
- Skips recovery spawn when the assignee agent has `status === "error"`, breaking the respawn loop observed with Code-Reviewer canaries
- Logs the skip at INFO level; recovery resumes automatically once the agent's error state is cleared by operator intervention

## Problem

Agent in `error` state → its `in_progress` issues become stalled → recovery handler spawns `Recover stalled issue` task → agent still can't run → loop repeats. Observed concretely in SAG-2057 sweep: SAG-1811/1812/1815 → SAG-1820/1821/1822 (wave 1) → SAG-2070/2071/2072 (wave 2).

## Test plan
- `agent in error state → no recovery action created, issue unchanged` (new)
- `agent in idle state → escalates normally (existing behavior preserved)` (new)
- Run: `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`

## Paperclip issue
SAG-2082

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>