### PR TITLE
fix(telegram): safe background polling invocation scope

### DIFF
--- a/server/src/__tests__/fixtures/plugin-worker-invocation-scope.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-invocation-scope.cjs
@@ -15,7 +15,7 @@ function sendNestedHostRequest(originalRequest, invocationId) {
   const nestedRequest = {
     jsonrpc: "2.0",
     id: nestedId,
-    method: "companies.get",
+    method: mode === "http.fetch" ? "http.fetch" : "companies.get",
     params: {
       companyId: requestedCompanyId,
     },
@@ -25,6 +25,8 @@ function sendNestedHostRequest(originalRequest, invocationId) {
     nestedRequest.paperclipInvocationId = invocationId;
   } else if (mode === "unknown") {
     nestedRequest.paperclipInvocationId = "unknown-invocation";
+  } else if (mode === "http.fetch") {
+    // Explicitly omit paperclipInvocationId
   }
 
   pendingNested.set(nestedId, originalRequest.id);

--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -417,4 +417,47 @@ describe("plugin-worker-manager stderr failure context", () => {
       await handle.stop().catch(() => undefined);
     }
   });
+
+  it("allows whitelisted methods (like http.fetch) without an invocation id even while a company invocation is active", async () => {
+    const httpFetch = vi.fn(async () => ({ status: 200 }));
+    const hostHandlers = createHostClientHandlers({
+      pluginId: "test.plugin",
+      capabilities: ["http.outbound"],
+      services: {
+        http: {
+          fetch: httpFetch,
+        },
+      } as unknown as HostServices,
+    });
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: {
+        instanceId: "instance-1",
+        hostVersion: "1.0.0",
+      },
+      apiVersion: 1,
+      hostHandlers,
+    });
+
+    try {
+      await handle.start();
+
+      // This will call getData, which triggers a nested host request using mode: "http.fetch".
+      // The fixture omits paperclipInvocationId, but it should succeed because it's whitelisted.
+      await expect(handle.call("getData", {
+        key: "probe",
+        companyId: "company-1",
+        params: {
+          mode: "http.fetch",
+          requestedCompanyId: "company-2",
+        },
+      } as HostToWorkerMethods["getData"][0])).resolves.toEqual({ status: 200 });
+
+      expect(httpFetch).toHaveBeenCalled();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
 });

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -559,9 +559,15 @@ export function createPluginWorkerHandle(
       (message as { paperclipInvocationId?: unknown }).paperclipInvocationId,
     );
     if (!invocationId) {
-      const hasActiveInvocation = activeInvocations.size > 0 ||
-        Array.from(pendingRequests.values()).some((pending) => pending.invocationId);
-      return hasActiveInvocation ? { invalidInvocationScope: true } : {};
+      const safeBackgroundMethods = ["http.fetch", "companies.list", "log"];
+      const isSafeBackgroundMethod = typeof message.method === "string" && safeBackgroundMethods.includes(message.method);
+
+      if (!isSafeBackgroundMethod) {
+        const hasActiveInvocation = activeInvocations.size > 0 ||
+          Array.from(pendingRequests.values()).some((pending) => pending.invocationId);
+        return hasActiveInvocation ? { invalidInvocationScope: true } : {};
+      }
+      return {};
     }
     const entry = activeInvocations.get(invocationId);
     if (!entry) return { invalidInvocationScope: true };

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -559,8 +559,11 @@ export function createPluginWorkerHandle(
       (message as { paperclipInvocationId?: unknown }).paperclipInvocationId,
     );
     if (!invocationId) {
-      const safeBackgroundMethods = ["http.fetch", "companies.list", "log"];
-      const isSafeBackgroundMethod = typeof message.method === "string" && safeBackgroundMethods.includes(message.method);
+      // These methods are globally whitelisted for background execution without an
+      // invocation ID. This allows plugins (like the Telegram adapter's polling loop)
+      // to fetch data and update state even when another company's invocation is active.
+      const safeBackgroundMethods: WorkerToHostMethodName[] = ["http.fetch", "companies.list", "log"];
+      const isSafeBackgroundMethod = typeof message.method === "string" && safeBackgroundMethods.includes(message.method as WorkerToHostMethodName);
 
       if (!isSafeBackgroundMethod) {
         const hasActiveInvocation = activeInvocations.size > 0 ||


### PR DESCRIPTION
Fixes #1912

## Thinking Path
- The `plugin-worker-manager.ts` strictly blocks requests without an invocation ID if there's any active invocation.
- The Telegram polling loop sends `http.fetch` and `companies.list` without an invocation ID.
- Rather than removing the guard entirely (which caused security regressions), we whitelist these harmless polling methods to allow the loop to function while keeping strict isolation intact.

## What Changed
- Restored strict `invalidInvocationScope` checks in `contextForWorkerMessage`.
- Whitelisted `http.fetch`, `companies.list`, and `log` for background execution.

## Verification
- Local `pnpm test:run server/src/__tests__/plugin-worker-manager.test.ts` passes successfully with the strict rejection remaining for `getData` and `performAction`.

## Risks
- Very low.

## Model Used
None — human-authored

## Checklist
- [x] Behavior matches specs
- [x] Typecheck, tests, and build pass