### PR TITLE
Handle legacy expired request confirmations

### DIFF
--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -19,6 +19,7 @@ function createSelectChain(rows: SelectRow[]) {
             then(callback: (rows: SelectRow[]) => unknown) {
               return Promise.resolve(callback(rows));
             },
+            orderBy: async () => rows,
           };
         },
       };
@@ -77,6 +78,35 @@ describe("issueThreadInteractionService", () => {
     vi.resetModules();
     vi.clearAllMocks();
   });
+
+  function legacyRequestConfirmationRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "interaction-legacy-expired",
+      companyId: "company-1",
+      issueId: "11111111-1111-4111-8111-111111111111",
+      kind: "request_confirmation",
+      status: "expired",
+      continuationPolicy: "wake_assignee_on_accept",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: null,
+      title: "Confirm plan",
+      summary: null,
+      createdByAgentId: "agent-1",
+      createdByUserId: null,
+      resolvedByAgentId: null,
+      resolvedByUserId: "local-board",
+      payload: {
+        version: 1,
+        prompt: "Proceed?",
+      },
+      result: null,
+      resolvedAt: new Date("2026-06-05T18:00:00.000Z"),
+      createdAt: new Date("2026-06-05T17:00:00.000Z"),
+      updatedAt: new Date("2026-06-05T18:00:00.000Z"),
+      ...overrides,
+    };
+  }
 
   it("create reuses an existing interaction for the same idempotency key", async () => {
     const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
@@ -211,5 +241,84 @@ describe("issueThreadInteractionService", () => {
     });
     expect(state.interactionUpdates).toHaveLength(1);
     expect(state.issueTouches).toHaveLength(1);
+  });
+
+  it("listForIssue normalizes legacy expired request_confirmation results", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const legacyExpiredRow = legacyRequestConfirmationRow({
+      result: {
+        outcome: "expired",
+      },
+    });
+    const db: any = {
+      select: vi.fn(() => createSelectChain([legacyExpiredRow])),
+      update: vi.fn(),
+    };
+    const svc = issueThreadInteractionService(db as never);
+
+    const result = await svc.listForIssue("11111111-1111-4111-8111-111111111111");
+
+    expect(result[0]?.status).toBe("expired");
+    expect(result[0]?.result).toEqual({
+      version: 1,
+      outcome: "stale_target",
+      staleTarget: undefined,
+      reason: "Legacy request confirmation result normalized for compatibility.",
+    });
+  });
+
+  it("listForIssue maps legacy superseded expired request_confirmation results", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const legacyExpiredRow = legacyRequestConfirmationRow({
+      result: {
+        outcome: "expired",
+        commentId: "33333333-3333-4333-8333-333333333333",
+        reason: "Superseded by a later comment.",
+      },
+    });
+    const db: any = {
+      select: vi.fn(() => createSelectChain([legacyExpiredRow])),
+      update: vi.fn(),
+    };
+    const svc = issueThreadInteractionService(db as never);
+
+    const result = await svc.listForIssue("11111111-1111-4111-8111-111111111111");
+
+    expect(result[0]?.status).toBe("expired");
+    expect(result[0]?.result).toEqual({
+      version: 1,
+      outcome: "superseded_by_comment",
+      commentId: "33333333-3333-4333-8333-333333333333",
+      reason: "Superseded by a later comment.",
+    });
+  });
+
+  it("listForIssue backfills a missing version on otherwise valid request_confirmation results", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const legacyAcceptedRow = legacyRequestConfirmationRow({
+      status: "accepted",
+      resolvedByUserId: "local-board",
+      result: {
+        outcome: "accepted",
+        commentId: "44444444-4444-4444-8444-444444444444",
+      },
+    });
+    const db: any = {
+      select: vi.fn(() => createSelectChain([legacyAcceptedRow])),
+      update: vi.fn(),
+    };
+    const svc = issueThreadInteractionService(db as never);
+
+    const result = await svc.listForIssue("11111111-1111-4111-8111-111111111111");
+
+    expect(result[0]?.status).toBe("accepted");
+    expect(result[0]?.result).toEqual({
+      version: 1,
+      outcome: "accepted",
+      commentId: "44444444-4444-4444-8444-444444444444",
+    });
   });
 });

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -112,6 +112,64 @@ function isEquivalentCreateRequest(
   );
 }
 
+function normalizeRequestConfirmationResult(
+  row: IssueThreadInteractionRow,
+): RequestConfirmationInteraction["result"] {
+  if (!row.result) return null;
+
+  const parsed = requestConfirmationResultSchema.safeParse(row.result);
+  if (parsed.success) return parsed.data;
+
+  const result: unknown = row.result;
+  if (typeof result === "object" && result !== null && "outcome" in result) {
+    const legacyResult = result as Record<string, unknown>;
+    const outcome = legacyResult.outcome;
+    const resultReason = typeof legacyResult.reason === "string" ? legacyResult.reason : "";
+    const legacyReason =
+      resultReason || "Legacy request confirmation result normalized for compatibility.";
+    const withVersion = requestConfirmationResultSchema.safeParse({
+      ...legacyResult,
+      version: 1,
+    });
+    if (withVersion.success) return withVersion.data;
+
+    if (row.status !== "expired") {
+      return requestConfirmationResultSchema.parse(row.result);
+    }
+
+    const looksSuperseded =
+      outcome === "superseded_by_comment"
+      || typeof legacyResult.commentId === "string"
+      || /superseded/i.test(resultReason);
+
+    if (looksSuperseded) {
+      const superseded = requestConfirmationResultSchema.safeParse({
+        version: 1,
+        outcome: "superseded_by_comment",
+        ...(typeof legacyResult.commentId === "string" ? { commentId: legacyResult.commentId } : {}),
+        reason: legacyReason,
+      });
+      if (superseded.success) return superseded.data;
+    }
+
+    const stale = requestConfirmationResultSchema.safeParse({
+      version: 1,
+      outcome: "stale_target",
+      staleTarget: legacyResult.staleTarget,
+      reason: legacyReason,
+    });
+    if (stale.success) return stale.data;
+
+    return {
+      version: 1,
+      outcome: "stale_target",
+      reason: legacyReason,
+    };
+  }
+
+  return requestConfirmationResultSchema.parse(row.result);
+}
+
 function hydrateInteraction(
   row: IssueThreadInteractionRow,
 ): IssueThreadInteraction {
@@ -142,7 +200,7 @@ function hydrateInteraction(
         ...base,
         kind: "request_confirmation",
         payload: requestConfirmationPayloadSchema.parse(row.payload),
-        result: row.result ? requestConfirmationResultSchema.parse(row.result) : null,
+        result: normalizeRequestConfirmationResult(row),
       } satisfies RequestConfirmationInteraction;
     case "request_checkbox_confirmation":
       return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected subsystem is issue-thread interactions, specifically `request_confirmation` hydration for issue reads and status-update validation.
> - A live instance had an expired `request_confirmation` row with legacy result JSON: `{ "outcome": "expired" }`.
> - Current code validates every persisted request-confirmation result against the newer schema, which requires `version: 1` and a narrower outcome enum.
> - That made `GET /api/issues/:id/interactions` fail before agents could inspect or repair the issue, and it also blocked issue update flows that list interactions for disposition validation.
> - This pull request fixes the read-model boundary by normalizing legacy request-confirmation result shapes into schema-valid current results while preserving valid rows unchanged.
> - The benefit is that historical interaction data can be read safely without broad data migration or hiding unrelated malformed data.

## Linked Issues or Issue Description

Fixes #7615
Refs #6135
Refs #6579
Refs #6788

Duplicate/related PR search performed on 2026-06-06:
- `request_confirmation interactions validation`
- `legacy expired request confirmation`

No duplicate PR was found for this legacy expired request-confirmation hydration fix. Related interaction PRs are linked above for reviewer context.

## What Changed

- Added `normalizeRequestConfirmationResult()` in `issue-thread-interactions` hydration.
- Preserved valid current request-confirmation results unchanged.
- Backfilled missing `version: 1` for otherwise valid legacy request-confirmation results.
- Normalized legacy expired rows into schema-valid results:
  - `superseded_by_comment` when the legacy record has `commentId` or a superseded-style reason.
  - `stale_target` as the conservative fallback.
- Added focused service regression coverage for:
  - legacy expired rows without `version: 1`
  - legacy superseded expired rows
  - otherwise valid unversioned accepted results

## Verification

- Red check first: focused service test failed with the original Zod validation error before the fix.
- `NODE_ENV=test pnpm --filter @paperclipai/server exec vitest run src/services/issue-thread-interactions.test.ts`
- `NODE_ENV=test pnpm --filter @paperclipai/server typecheck`
- Rebase verification on 2026-06-06 after syncing to latest `origin/master`:
  - `NODE_ENV=test pnpm --filter @paperclipai/server exec vitest run src/services/issue-thread-interactions.test.ts`
  - `NODE_ENV=test pnpm --filter @paperclipai/server typecheck`
- Live API repro after data repair: `GET /api/issues/2429389a-8a05-45c1-ba5d-c79504ae2146/interactions` returned HTTP 200.

## Risks

- This is intentionally read-model compatibility, not a broad data migration. Historical rows remain as stored unless a later write updates them.
- A legacy row with ambiguous `{ "outcome": "expired" }` is surfaced as `stale_target` by default. That is conservative: it avoids implying acceptance/rejection and keeps the interaction terminal.
- Unsupported malformed non-expired result objects still fail hard, so unrelated data corruption is not silently hidden.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

GPT-5 Codex local agent with shell, GitHub CLI, and focused test/typecheck execution.

## Live Repair Notes

For VIVA-2005 on the affected local instance, one malformed row was normalized directly so the running server could recover without a control-plane restart:

- `issue_thread_interactions.id = 5dcb38d7-cc36-4790-8127-74cd3600653e`
- old result: `{ "outcome": "expired", ... }`
- normalized result: `{ "version": 1, "outcome": "superseded_by_comment", ... }`

After that data repair, `GET /api/issues/2429389a-8a05-45c1-ba5d-c79504ae2146/interactions` returned HTTP 200.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
