### PR TITLE
Fold heartbeat runs when source issue reaches done

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Eager fold path for terminal heartbeat runs: when an agent updates an issue to `done` or `cancelled`, the recovery service now immediately finalizes the active run instead of waiting up to 1h for the watchdog scan. Adds `foldTerminalIssueRunEager` method with same-run terminal evidence checks, `heartbeat.folded` activity log entries with `source: "eager_terminal_fold"`, and regression tests. Fixes orphaned runs where agents appeared stuck in `running` state with no open assignments.
 - Stable release preparation for 0.3.1
 - Updated dependencies
   - @paperclipai/adapter-utils@0.3.1

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -798,4 +798,185 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  it("eagerly folds run when issue transitions to done with same-run evidence", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: 10 * 60 * 1000, // 10 minutes, well below 1h watchdog threshold
+      withOutput: true,
+      sourceStatus: "in_progress", // Still in progress initially
+    });
+
+    // Verify run is running and issue is in progress
+    const [runBefore] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runBefore?.status).toBe("running");
+    const [issueBefore] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issueBefore?.status).toBe("in_progress");
+    expect(issueBefore?.executionRunId).toBe(runId);
+
+    // Agent updates issue to done with same-run activity evidence
+    const terminalEvidenceAt = new Date(now.getTime() + 1000);
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: coderId,
+      agentId: coderId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        status: "done",
+        _previous: { status: "in_progress" },
+      },
+      createdAt: terminalEvidenceAt,
+    });
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: terminalEvidenceAt, updatedAt: terminalEvidenceAt })
+      .where(eq(issues.id, issueId));
+
+    // Trigger eager fold
+    const recovery = recoveryService(db, {
+      enqueueWakeup: async () => null,
+    });
+    const [issueAfter] = await db.select().from(issues).where(eq(issues.id, issueId));
+    const [runStillRunning] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const foldResult = await recovery.foldTerminalIssueRunEager({
+      run: runStillRunning!,
+      sourceIssue: issueAfter!,
+    });
+
+    // Verify run was folded to succeeded immediately
+    expect(foldResult.kind).toBe("folded");
+    expect(foldResult).toMatchObject({
+      kind: "folded",
+      finalRunStatus: "succeeded",
+    });
+
+    const [runAfter] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runAfter?.status).toBe("succeeded");
+    expect(runAfter?.finishedAt).toBeTruthy();
+    expect(runAfter?.resultJson).toMatchObject({
+      sourceResolvedWatchdogFold: {
+        sourceIssueId: issueId,
+        sourceIssueStatus: "done",
+        sameRunEvidenceKind: "activity",
+      },
+    });
+
+    // Verify issue execution metadata was cleared
+    const [issueFinal] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issueFinal?.executionRunId).toBeNull();
+    expect(issueFinal?.executionAgentNameKey).toBeNull();
+    expect(issueFinal?.executionLockedAt).toBeNull();
+
+    // Verify activity log was created
+    const foldActivity = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.folded"),
+          eq(activityLog.entityId, runId),
+        ),
+      );
+    expect(foldActivity).toHaveLength(1);
+    expect(foldActivity[0]?.details).toMatchObject({
+      source: "eager_terminal_fold",
+      sourceIssueStatus: "done",
+      finalRunStatus: "succeeded",
+    });
+  });
+
+  it("eagerly folds run when issue transitions to cancelled with same-run evidence", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: 5 * 60 * 1000, // 5 minutes
+      withOutput: true,
+      sourceStatus: "in_progress",
+    });
+
+    // Agent updates issue to cancelled with same-run activity evidence
+    const terminalEvidenceAt = new Date(now.getTime() + 1000);
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: coderId,
+      agentId: coderId,
+      runId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        status: "cancelled",
+        _previous: { status: "in_progress" },
+      },
+      createdAt: terminalEvidenceAt,
+    });
+    await db
+      .update(issues)
+      .set({ status: "cancelled", cancelledAt: terminalEvidenceAt, updatedAt: terminalEvidenceAt })
+      .where(eq(issues.id, issueId));
+
+    // Trigger eager fold
+    const recovery = recoveryService(db, {
+      enqueueWakeup: async () => null,
+    });
+    const [issueAfter] = await db.select().from(issues).where(eq(issues.id, issueId));
+    const [runStillRunning] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const foldResult = await recovery.foldTerminalIssueRunEager({
+      run: runStillRunning!,
+      sourceIssue: issueAfter!,
+    });
+
+    // Verify run was folded to cancelled immediately
+    expect(foldResult.kind).toBe("folded");
+    expect(foldResult).toMatchObject({
+      kind: "folded",
+      finalRunStatus: "cancelled",
+    });
+
+    const [runAfter] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runAfter?.status).toBe("cancelled");
+    expect(runAfter?.finishedAt).toBeTruthy();
+  });
+
+  it("skips eager fold when no same-run evidence exists", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: 5 * 60 * 1000,
+      withOutput: true,
+      sourceStatus: "in_progress",
+    });
+
+    // Update issue to done WITHOUT same-run activity evidence
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: now, updatedAt: now })
+      .where(eq(issues.id, issueId));
+
+    // Trigger eager fold attempt
+    const recovery = recoveryService(db, {
+      enqueueWakeup: async () => null,
+    });
+    const [issueAfter] = await db.select().from(issues).where(eq(issues.id, issueId));
+    const [runStillRunning] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const foldResult = await recovery.foldTerminalIssueRunEager({
+      run: runStillRunning!,
+      sourceIssue: issueAfter!,
+    });
+
+    // Verify fold was skipped (no evidence)
+    expect(foldResult.kind).toBe("skipped");
+    expect(foldResult.reason).toBe("no_evidence");
+
+    // Verify run is still running
+    const [runAfter] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runAfter?.status).toBe("running");
+  });
 });

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -42,6 +42,7 @@ vi.mock("../services/index.js", () => ({
   heartbeatService: () => ({
     wakeup: mockWakeup,
     reportRunActivity: vi.fn(async () => undefined),
+    getActiveRunForAgent: vi.fn(async () => null),
   }),
   getIssueContinuationSummaryDocument: vi.fn(async () => null),
   instanceSettingsService: () => ({

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -43,6 +43,7 @@ function registerModuleMocks() {
     heartbeatService: () => ({
       wakeup: vi.fn(async () => undefined),
       reportRunActivity: vi.fn(async () => undefined),
+      getActiveRunForAgent: vi.fn(async () => null),
     }),
     instanceSettingsService: () => ({}),
     issueApprovalService: () => ({}),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -82,6 +82,7 @@ import {
   routineService,
   workProductService,
 } from "../services/index.js";
+import { recoveryService } from "../services/recovery/service.js";
 import { logger } from "../middleware/logger.js";
 import { conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
@@ -917,6 +918,9 @@ export function issueRoutes(
   const goalsSvc = goalService(db);
   const issueApprovalsSvc = issueApprovalService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
+  const recoverySvc = recoveryService(db, {
+    enqueueWakeup: (agentId, opts) => heartbeat.wakeup(agentId, opts),
+  });
   const executionWorkspacesSvc = executionWorkspaceServiceDirect(db);
   const workProductsSvc = workProductService(db);
   const documentsSvc = documentService(db);
@@ -5008,6 +5012,31 @@ export function issueRoutes(
               childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
             },
           });
+        }
+      }
+
+      // Eager fold: when an issue becomes terminal, immediately fold any active run
+      // that has same-run evidence of setting this status, rather than waiting for
+      // the 1h watchdog scan.
+      if (becameTerminal) {
+        const activeRun = await resolveActiveIssueRun(issue);
+        if (activeRun) {
+          const foldResult = await recoverySvc.foldTerminalIssueRunEager({
+            run: activeRun,
+            sourceIssue: issue,
+          }).catch((err) => {
+            logger.warn(
+              { err, issueId: issue.id, runId: activeRun.id },
+              "failed to eagerly fold terminal issue run",
+            );
+            return { kind: "skipped" as const, reason: "error" };
+          });
+          if (foldResult.kind === "folded") {
+            logger.info(
+              { issueId: issue.id, runId: activeRun.id, finalRunStatus: foldResult.finalRunStatus },
+              "eagerly folded terminal issue run",
+            );
+          }
         }
       }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1084,6 +1084,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     silenceStartedAt: Date | null;
     silenceAgeMs: number | null;
     now: Date;
+    source: string;
   }) {
     if (!input.evidence) return { kind: "skipped" as const };
     const cleanup = await cleanupSourceResolvedRunProcess({ run: input.run, runningAgent: input.runningAgent });
@@ -1202,7 +1203,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityType: "heartbeat_run",
       entityId: input.run.id,
       details: {
-        source: "recovery.scan_silent_active_runs",
+        source: input.source,
         sourceIssueId: input.sourceIssue.id,
         sourceIssueIdentifier: input.sourceIssue.identifier,
         sourceIssueStatus: input.sourceIssue.status,
@@ -1488,6 +1489,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           silenceStartedAt,
           silenceAgeMs: silenceAgeMsForRun(input.run, input.now),
           now: input.now,
+          source: "recovery.scan_silent_active_runs",
         });
       }
     }
@@ -3618,6 +3620,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       silenceStartedAt: null,
       silenceAgeMs: null,
       now,
+      source: "eager_terminal_fold",
     });
 
     if (result.kind === "skipped") {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3584,6 +3584,70 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Math.max(1, Math.floor(asNumber(raw, fallback)));
   }
 
+  async function foldTerminalIssueRunEager(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect;
+  }) {
+    if (!isTerminalIssueStatus(input.sourceIssue.status)) {
+      return { kind: "skipped" as const, reason: "not_terminal" };
+    }
+
+    const runningAgent = await getAgent(input.run.agentId);
+    if (!runningAgent) {
+      return { kind: "skipped" as const, reason: "agent_not_found" };
+    }
+
+    const now = new Date();
+    const terminalEvidence = await latestSameRunSourceTerminalEvidence({
+      run: input.run,
+      sourceIssue: input.sourceIssue,
+      evidenceAfter: null,
+    });
+
+    if (!terminalEvidence) {
+      return { kind: "skipped" as const, reason: "no_evidence" };
+    }
+
+    const existingEvaluation = await findOpenStaleRunEvaluation(input.run.companyId, input.sourceIssue.id);
+    const result = await foldSourceResolvedStaleRun({
+      run: input.run,
+      runningAgent,
+      sourceIssue: input.sourceIssue,
+      evidence: terminalEvidence,
+      existingEvaluation,
+      silenceStartedAt: null,
+      silenceAgeMs: null,
+      now,
+    });
+
+    if (result.kind === "skipped") {
+      return result;
+    }
+
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: input.run.id,
+      action: "heartbeat.folded",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "eager_terminal_fold",
+        sourceIssueId: input.sourceIssue.id,
+        sourceIssueIdentifier: input.sourceIssue.identifier,
+        sourceIssueStatus: input.sourceIssue.status,
+        finalRunStatus: input.sourceIssue.status === "cancelled" ? "cancelled" : "succeeded",
+        sameRunEvidenceKind: terminalEvidence.kind,
+        sameRunEvidenceId: terminalEvidence.id,
+        sameRunEvidenceAt: terminalEvidence.createdAt.toISOString(),
+      },
+    });
+
+    return { kind: "folded" as const, finalRunStatus: input.sourceIssue.status === "cancelled" ? "cancelled" : "succeeded" };
+  }
+
   return {
     buildRunOutputSilence,
     escalateStrandedRecoveryIssueInPlace,
@@ -3594,5 +3658,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
+    foldTerminalIssueRunEager,
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents execute work through heartbeat runs that are tracked and managed by the recovery service
> - When agents update issues to terminal status (done/cancelled), the active run should be finalized
> - But currently, only cancelled status triggers immediate run cancellation; done status does not
> - This causes orphaned heartbeat runs where agents stay in running state even after completing work
> - The existing 1h watchdog scan eventually detects these, but is too slow for burst patterns
> - This pull request adds an eager fold path that immediately finalizes runs when issues reach terminal status with same-run evidence
> - The benefit is agents return to idle state immediately after completing work, preventing resource waste and confusion

## Linked Issues or Issue Description

**Bug Report** (no upstream GitHub issue exists):

**Describe the bug:**
After-close council agents PATCH child issues to `done` while adapter processes keep running, leaving agents stuck `running` with no open assignments until manual run cancel.

**To Reproduce:**
1. Agent completes work and updates issue to `done`
2. Run remains in `running` state instead of being finalized
3. Agent appears busy but has no assignments
4. Must wait up to 1h for watchdog scan or manually cancel run

**Expected behavior:**
Run should be immediately finalized when issue transitions to terminal status with same-run evidence.

**Root cause** (confirmed in server code):
1. `PATCH /api/issues/:id` with `status: cancelled` cancels the active run; `status: done` does **not**
2. `scanSilentActiveRuns` only considers runs silent for ≥1h (`ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS`)
3. `foldSourceResolvedStaleRun` exists but is gated behind that silence scan — too slow for burst patterns

**Related:**
- Parent incident: [AIT-196](https://github.com/paperclipai/paperclip/issues/196)
- Refs [PR #7524](https://github.com/paperclipai/paperclip/pull/7524) (different bug: `release()` resetting terminal status to `todo`)

## What Changed

- Added `foldTerminalIssueRunEager` method to recovery service that:
  - Checks for same-run terminal evidence (`latestSameRunSourceTerminalEvidence`)
  - Folds the run immediately if evidence exists
  - Maps issue status to run status: `done` → `succeeded`, `cancelled` → `cancelled`
  - Logs activity with action `heartbeat.folded` and source `eager_terminal_fold`
- Integrated eager fold in `server/src/routes/issues.ts` after the `becameTerminal` check
- Added 3 regression tests in `heartbeat-active-run-output-watchdog.test.ts`:
  - Eagerly folds run when issue transitions to done with same-run evidence
  - Eagerly folds run when issue transitions to cancelled with same-run evidence
  - Skips eager fold when no same-run evidence exists

## Verification

All tests pass (16/16):
```bash
cd /Users/harsh/.paperclip/instances/default/workspaces/3209249b-e380-4fdc-9fb5-3bc875142b82
npx vitest run heartbeat-active-run-output-watchdog
```

Test results:
- ✅ New regression tests verify eager fold with/without evidence
- ✅ Existing `heartbeat-active-run-output-watchdog.test.ts` cases still pass
- ✅ Does **not** change `release()` semantics (PR #7524 remains separate)

**Manual testing**: The eager fold logic is triggered when an issue transitions to terminal status with same-run activity evidence, as verified by the regression tests.

## Risks

**Low risk**. The change is additive and defensive:

- Only affects issues with active runs that transition to terminal status
- Only folds runs when same-run terminal evidence exists (conservative check)
- Falls back gracefully if evidence is missing (skips fold, lets watchdog handle it)
- Error handling wraps the fold call to prevent blocking issue updates
- Existing cancellation path for `cancelled` status remains unchanged

**Rollback**: Revert commit 1068674; behavior returns to 1h watchdog scan (manual cancel remains available).

## Model Used

- **Provider**: Anthropic Claude
- **Model**: Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)
- **Context window**: 200K tokens
- **Reasoning mode**: Interleaved thinking mode
- **Capabilities**: Tool use, code execution, extended context

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass (16/16 tests passing)
- [x] I have added or updated tests where applicable (3 new regression tests)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A - backend only)
- [x] I have updated relevant documentation to reflect my changes (documented in commit message and PR)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending force push)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review after update)
- [ ] I will address all Greptile and reviewer comments before requesting merge

## Files changed

- `server/src/services/recovery/service.ts` (+65 lines): new `foldTerminalIssueRunEager` method
- `server/src/routes/issues.ts` (+29 lines): call eager fold after `becameTerminal`
- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts` (+181 lines): 3 regression tests
