### PR TITLE
Prefer public base URL for generated invite links

### DIFF
--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -47,6 +47,7 @@ const additionalSerializedServerTests = new Set([
   "server/src/__tests__/invite-expiry.test.ts",
   "server/src/__tests__/invite-join-manager.test.ts",
   "server/src/__tests__/invite-onboarding-text.test.ts",
+  "server/src/__tests__/invite-url-public-base-url.test.ts",
   "server/src/__tests__/issues-checkout-wakeup.test.ts",
   "server/src/__tests__/issues-service.test.ts",
   "server/src/__tests__/opencode-local-adapter-environment.test.ts",

--- a/server/src/__tests__/invite-url-public-base-url.test.ts
+++ b/server/src/__tests__/invite-url-public-base-url.test.ts
@@ -1,0 +1,174 @@
+/**
+ * TDD: authPublicBaseUrl takes precedence over request-derived host when building invite URLs.
+ * These tests are written first (will fail until the implementation lands).
+ */
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logActivityMock = vi.fn();
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({
+      isInstanceAdmin: vi.fn(),
+      canUser: vi.fn(),
+      hasPermission: vi.fn(),
+    }),
+    agentService: () => ({
+      getById: vi.fn(),
+    }),
+    boardAuthService: () => ({
+      createChallenge: vi.fn(),
+      resolveBoardAccess: vi.fn(),
+      assertCurrentBoardKey: vi.fn(),
+      revokeBoardApiKey: vi.fn(),
+    }),
+    deduplicateAgentName: vi.fn(),
+    logActivity: (...args: unknown[]) => logActivityMock(...args),
+    notifyHireApproved: vi.fn(),
+  }));
+}
+
+function createDbStub() {
+  const createdInvite = {
+    id: "invite-1",
+    companyId: "company-1",
+    inviteType: "company_join",
+    allowedJoinTypes: "human",
+    tokenHash: "hash",
+    defaultsPayload: { humanRole: "viewer" },
+    expiresAt: new Date("2027-03-10T00:00:00.000Z"),
+    invitedByUserId: null,
+    revokedAt: null,
+    acceptedAt: null,
+    createdAt: new Date("2026-03-07T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-07T00:00:00.000Z"),
+  };
+
+  return {
+    insert() {
+      return {
+        values() {
+          return {
+            returning() {
+              return Promise.resolve([createdInvite]);
+            },
+          };
+        },
+      };
+    },
+    select(_shape?: unknown) {
+      return {
+        from() {
+          const query = {
+            leftJoin() {
+              return query;
+            },
+            where() {
+              return Promise.resolve([{
+                name: "Acme Robotics",
+                brandColor: "#114488",
+                logoAssetId: null,
+              }]);
+            },
+          };
+          return query;
+        },
+      };
+    },
+  };
+}
+
+async function createApp(authPublicBaseUrl?: string) {
+  const [{ accessRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/access.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source: "local_implicit",
+      userId: null,
+      companyIds: ["company-1"],
+    };
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes(createDbStub() as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+      authPublicBaseUrl,
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("invite URL: authPublicBaseUrl precedence", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/access.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    logActivityMock.mockReset();
+  });
+
+  it("uses authPublicBaseUrl for inviteUrl when configured, ignoring request host", async () => {
+    const app = await createApp(
+      "http://gus-pinsoneault-framework.tail302fee.ts.net:3100",
+    );
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .set("host", "127.0.0.1:3100")
+      .set("x-forwarded-proto", "http")
+      .send({ allowedJoinTypes: "human", humanRole: "viewer" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.inviteUrl).toMatch(
+      /^http:\/\/gus-pinsoneault-framework\.tail302fee\.ts\.net:3100\/invite\/pcp_invite_/,
+    );
+    expect(res.body.inviteUrl).not.toContain("127.0.0.1");
+  });
+
+  it("falls back to request-derived host when authPublicBaseUrl is not configured", async () => {
+    const app = await createApp(undefined);
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .set("host", "paperclip.example")
+      .set("x-forwarded-proto", "https")
+      .send({ allowedJoinTypes: "human", humanRole: "viewer" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.inviteUrl).toMatch(
+      /^https:\/\/paperclip\.example\/invite\/pcp_invite_/,
+    );
+  });
+
+  it("strips trailing slash from authPublicBaseUrl before joining with invite path", async () => {
+    const app = await createApp(
+      "http://gus-pinsoneault-framework.tail302fee.ts.net:3100/",
+    );
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .set("host", "127.0.0.1:3100")
+      .send({ allowedJoinTypes: "human", humanRole: "viewer" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.inviteUrl).not.toContain("//invite/");
+    expect(res.body.inviteUrl).toMatch(
+      /^http:\/\/gus-pinsoneault-framework\.tail302fee\.ts\.net:3100\/invite\/pcp_invite_/,
+    );
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -252,6 +252,7 @@ export async function createApp(
     deploymentExposure: DeploymentExposure;
     allowedHostnames: string[];
     bindHost: string;
+    authPublicBaseUrl?: string;
     authReady: boolean;
     companyDeletionEnabled: boolean;
     instanceId?: string;
@@ -525,6 +526,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       bindHost: opts.bindHost,
       allowedHostnames: opts.allowedHostnames,
+      authPublicBaseUrl: opts.authPublicBaseUrl,
     }),
   );
   app.use("/api", api);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -759,6 +759,7 @@ export async function startServer(): Promise<StartedServer> {
     deploymentExposure: config.deploymentExposure,
     allowedHostnames: config.allowedHostnames,
     bindHost: config.host,
+    authPublicBaseUrl: config.authPublicBaseUrl,
     authReady,
     companyDeletionEnabled: config.companyDeletionEnabled,
     pluginMigrationDb: pluginMigrationDb as any,

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -141,6 +141,11 @@ function requestBaseUrl(req: Request) {
   return `${proto}://${host}`;
 }
 
+function resolveBaseUrl(req: Request, authPublicBaseUrl?: string): string {
+  if (authPublicBaseUrl) return authPublicBaseUrl.replace(/\/+$/, "");
+  return requestBaseUrl(req);
+}
+
 function buildCliAuthApprovalPath(challengeId: string, token: string) {
   return `/cli-auth/${challengeId}?token=${encodeURIComponent(token)}`;
 }
@@ -1078,12 +1083,13 @@ function toInviteSummaryResponse(
       brandColor: string | null;
       logoUrl: string | null;
     }
-    | null = null
+    | null = null,
+  authPublicBaseUrl?: string
 ) {
   const companyInfo = typeof company === "string"
     ? { name: company, brandColor: null, logoUrl: null }
     : company;
-  const baseUrl = requestBaseUrl(req);
+  const baseUrl = resolveBaseUrl(req, authPublicBaseUrl);
   const invitePath = `/invite/${token}`;
   const onboardingPath = `/api/invites/${token}/onboarding`;
   const onboardingTextPath = `/api/invites/${token}/onboarding.txt`;
@@ -1698,9 +1704,10 @@ function buildInviteOnboardingManifest(
     deploymentExposure: DeploymentExposure;
     bindHost: string;
     allowedHostnames: string[];
+    authPublicBaseUrl?: string;
   }
 ) {
-  const baseUrl = requestBaseUrl(req);
+  const baseUrl = resolveBaseUrl(req, opts.authPublicBaseUrl);
   const skillPath = `/api/invites/${token}/skills/paperclip`;
   const skillUrl = baseUrl ? `${baseUrl}${skillPath}` : skillPath;
   const registrationEndpointPath = `/api/invites/${token}/accept`;
@@ -1729,7 +1736,8 @@ function buildInviteOnboardingManifest(
       req,
       token,
       invite,
-      opts.companyName ?? null
+      opts.companyName ?? null,
+      opts.authPublicBaseUrl
     ),
     onboarding: {
       instructions:
@@ -1796,6 +1804,7 @@ export function buildInviteOnboardingTextDocument(
     deploymentExposure: DeploymentExposure;
     bindHost: string;
     allowedHostnames: string[];
+    authPublicBaseUrl?: string;
   }
 ) {
   const manifest = buildInviteOnboardingManifest(req, token, invite, opts);
@@ -2604,6 +2613,7 @@ export function accessRoutes(
     allowedHostnames: string[];
     inviteResolutionNetwork?: Partial<InviteResolutionNetwork>;
     inviteRateLimiter?: InviteRateLimiter;
+    authPublicBaseUrl?: string;
   }
 ) {
   const router = Router();
@@ -3318,7 +3328,8 @@ export function accessRoutes(
         req,
         token,
         created,
-        companyBranding
+        companyBranding,
+        opts.authPublicBaseUrl
       );
       res.status(201).json({
         ...created,
@@ -3372,7 +3383,8 @@ export function accessRoutes(
         req,
         token,
         created,
-        companyBranding
+        companyBranding,
+        opts.authPublicBaseUrl
       );
       res.status(201).json({
         ...created,
@@ -3412,7 +3424,7 @@ export function accessRoutes(
         )
       : null;
     res.json({
-      ...toInviteSummaryResponse(req, token, invite, companyBranding),
+      ...toInviteSummaryResponse(req, token, invite, companyBranding, opts.authPublicBaseUrl),
       invitedByUserName: inviterName,
       joinRequestStatus: inviteJoinRequest?.status ?? null,
       joinRequestType: inviteJoinRequest?.requestType ?? null,


### PR DESCRIPTION
Fixes #7623

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Company invites are part of the access subsystem and must produce URLs that recipients can open from outside the host machine.
> - Paperclip already has public/auth base URL configuration for deployments behind a public hostname, Tailscale, or a reverse proxy.
> - Invite URL composition was still deriving its origin from the incoming request host, so loopback-bound servers emitted `http://127.0.0.1:3100/invite/...`.
> - A loopback invite URL is not shareable with a remote human or agent, even when the token itself is valid.
> - This pull request makes invite URL builders prefer the configured public base URL and keep the existing request-host fallback when it is unset.
> - The benefit is that copied invite links use the reachable deployment origin without changing local-only behavior.

## Linked Issues or Issue Description

Fixes #7623

No duplicate or related PRs/issues were found in a GitHub search for invite URL, loopback, public base URL, and `authPublicBaseUrl` terms.

## What Changed

- Added base URL resolution in `server/src/routes/access.ts` that strips trailing slashes and prefers configured `authPublicBaseUrl` over the request-derived host.
- Threaded `authPublicBaseUrl` through invite summary, invite onboarding manifest, onboarding text, access routes, `createApp`, and server startup wiring.
- Added `server/src/__tests__/invite-url-public-base-url.test.ts` covering configured public-base precedence, unset fallback behavior, and trailing-slash normalization.
- Registered the invite public-base URL test in the serialized Vitest server runner.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm exec vitest run server/src/__tests__/invite-url-public-base-url.test.ts
pnpm run test:run:serialized
```

Local results from the rebased PR branch:

- `pnpm install --frozen-lockfile` exited 0.
- Targeted invite URL test exited 0: 1 file, 3 tests passed.
- Serialized server suite exited 0: 106 serialized suites completed; the new invite URL test passed inside that runner.

Manual check after deployment: set `PAPERCLIP_AUTH_PUBLIC_BASE_URL` or equivalent public base URL config, create a company invite, and confirm the returned/copied invite URL uses that public origin instead of `127.0.0.1`.

## Risks

Low risk. The new public base URL parameter is optional and falls back to existing request-derived behavior when unset. The main operational risk is misconfigured public base URL input; the implementation only trims trailing slashes and otherwise trusts the configured origin.

## Model Used

- Original implementation: Anthropic `claude-sonnet-4-6`, 200k context, tool use and test execution.
- Conflict repair and verification: OpenAI Codex GPT-5.5, coding agent with shell, git, GitHub CLI, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
