### PR TITLE
docs(mcp): MCP Access Governance operator guide, demo, release notes (PAP-10397, PAP-10424)

### DIFF
--- a/doc/MCP-ACCESS-GOVERNANCE.md
+++ b/doc/MCP-ACCESS-GOVERNANCE.md
@@ -76,10 +76,10 @@ curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/smoke" \
-  -d '{}' | jq '{checks, overall}'
+  -d '{}' | jq '{ok, checks: [.checks[] | {name, ok, decision, reasonCode}]}'
 ```
 
-Expected: `overall: "pass"` with three green checks (`allowed_call`, `denied_call`, `audit_visible`).
+Expected: `ok: true` with three green checks: `allow_read_tool`, `deny_write_tool`, `audit_written`.
 
 If the smoke fails, fix the failing check before introducing any production connection. The bundled fixture only depends on local code, so any failure is a control-plane problem rather than an upstream MCP issue.
 
@@ -249,16 +249,23 @@ Order of evaluation:
 3. Policies in priority order. `block` short-circuits. `require_approval` short-circuits to an action request. `rate_limit` evaluates the counter.
 4. If no policy matched and the profile allowed the tool: `allow`.
 
-To dry-run a policy decision without making a real call:
+To dry-run a policy decision without making a real call. The dry-run endpoint takes a structured `{ companyId, actor, request, runContext? }` body and returns the decision under `.decision`:
 
 ```sh
 curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/policy/test" \
   -d '{
-    "agentId": "'"$AGENT_ID"'",
-    "toolName": "create_item",
-    "arguments": { "title": "test" }
-  }' | jq '{decision, matchedPolicyIds, reasonCode}'
+    "companyId": "'"$COMPANY_ID"'",
+    "actor": {
+      "actorType": "agent",
+      "actorId": "'"$AGENT_ID"'",
+      "agentId": "'"$AGENT_ID"'"
+    },
+    "request": {
+      "toolName": "create_item",
+      "arguments": { "title": "test" }
+    }
+  }' | jq '{decision: .decision.decision, matchedPolicyIds: .decision.matchedPolicyIds, reasonCode: .decision.reasonCode}'
 ```
 
 Decisions: `allow`, `deny`, `require_approval`, `rate_limited`, `defer_runtime`. `defer_runtime` means the policy engine asked the gateway to consult runtime state (e.g. slot availability) before producing the final verdict.
@@ -269,23 +276,37 @@ When a call resolves to `require_approval`, the gateway opens an **Action Reques
 - the agent, run, and tool identity,
 - a canonical hash of the arguments (so we can match later trust rules),
 - a `signedArguments` payload the approver sees verbatim,
+- a linked issue-thread `request_confirmation` interaction for the in-app card,
 - an expiry.
 
-The human approver reviews the action card in the UI and either approves or rejects. The agent is paused on this exact call until a decision lands.
+The gateway responds to the agent's tool call with HTTP `409`, `reasonCode: "approval_required"`, and the new `actionRequestId` in the body. The agent's run is paused on this exact call until a decision lands. Once approved, the agent retries the same tool call with `approvedActionRequestId` set; the gateway re-validates that the canonical arguments hash matches and then executes the tool.
 
 After approval, the operator can promote that approval into a **trust rule**: a policy of `policyType: trust_rule` that allows the same tool with the same argument shape for the same actor scope, optionally for a limited number of approvals or until an expiry. This is how you avoid clicking *Approve* on every safe repetition of the same action.
 
 ```sh
-# Approve via API (UI does the same)
+# Approve via API (UI does the same). Approval requires companyId — body or query.
 curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/tool-gateway/action-requests/$ACTION_REQUEST_ID/approve" \
-  -d '{ "comment": "Looked correct." }' | jq '{status, decidedAt}'
+  -d '{ "companyId": "'"$COMPANY_ID"'" }' | jq '{id, status, resolvedAt, resolvedByUserId}'
+
+# Retry the original tool call with approvedActionRequestId (the agent does this).
+curl -fsS -X POST -H "X-Paperclip-Tool-Gateway-Token: $GATEWAY_TOKEN" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{
+    "tool": "create_item",
+    "parameters": { "title": "Approved item" },
+    "approvedActionRequestId": "'"$ACTION_REQUEST_ID"'"
+  }' | jq '{invocationId, status, tool, result}'
 
 # Promote the approval to a trust rule
 curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/action-requests/$ACTION_REQUEST_ID/trust-rule" \
-  -d '{ "approvalThreshold": 10, "expiresAt": "2026-09-01T00:00:00.000Z" }' \
-  | jq '{id, policyType, config}'
+  -d '{
+    "approvalThreshold": 2,
+    "scope": { "includeAgent": true, "includeTool": true },
+    "argumentFilters": { "allowAny": false, "fieldEquals": { "title": "Approved item" } },
+    "expiresAt": "2026-09-01T00:00:00.000Z"
+  }' | jq '{id, policyType, priority, config: {trustRule: .config.trustRule}}'
 
 # Revoke a trust rule (audit-safe; does not delete)
 curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
@@ -293,7 +314,7 @@ curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: ap
   -d '{ "reason": "Catalog schema changed." }' | jq '{id, enabled, config: {revokedAt: .config.trustRule.revokedAt}}'
 ```
 
-Trust rules carry `catalogVersionHash` and `schemaHash`. If the upstream tool changes its schema or argument shape, the hash no longer matches and the trust rule stops applying — the next matching call falls back to `require_approval`. This is intentional: an approval is for a specific argument shape, not for "future versions of this tool, sight unseen".
+Trust rules carry the catalog and schema hashes captured at approval time. If the upstream tool changes its schema or the canonical argument hash drifts, the trust rule stops applying — the next matching call falls back to `require_approval`. The retry-with-`approvedActionRequestId` flow enforces the same invariant for a single approval: change the arguments between approval and retry and the call fails with `reasonCode: "signed_arguments_mismatch"`. This is intentional: an approval is for a specific argument shape, not for "future versions of this tool, sight unseen".
 
 ## Runtime slots
 
@@ -331,7 +352,7 @@ curl -fsS -H "Authorization: Bearer $BOARD_API_KEY" \
 Two practical patterns:
 
 - **Per-run timeline:** `GET /api/companies/:companyId/tools/runs/:runId/decisions` returns every policy decision attached to a single agent run. Use this in QA to prove an agent never touched a denied tool.
-- **Approval audit:** `GET /api/tool-gateway/action-requests` returns pending and resolved action requests with approver identity and timestamps. Use this when answering "who approved this?".
+- **Approval audit:** the audit log itself is the approval-request ledger — filter the gateway audit response for `action == "tool_gateway.approval_requested"` to get the queue, and pair each row with the matching `tool_gateway.call_allowed` / `tool_gateway.call_denied` entry to see how the approval resolved. Approver identity lands on the action request itself; once approved, the action request body shows `resolvedByUserId` and `resolvedAt`.
 
 Audit is the source of truth for the security memo. It is intentionally append-only — there is no edit or delete route.
 
@@ -383,8 +404,10 @@ These are intentional gaps as of the MCP Access Governance v1 launch. Track or w
 | Bindings | `POST /api/companies/:companyId/tools/profiles/:id/bind` and `…/unbind` | Targets: `company`, `agent`, `project`, `routine`, `issue`. |
 | Effective profile | `GET /api/companies/:companyId/tools/profiles/effective/agents/:agentId` | Use for QA proofs and debugging selector misses. |
 | Policies | `GET\|POST /api/companies/:companyId/tools/policies`, `PATCH\|DELETE /api/companies/:companyId/tools/policies/:id` | Types: `allow`, `block`, `require_approval`, `rate_limit`, `trust_rule`. |
-| Policy dry-run | `POST /api/companies/:companyId/tools/policy/test` | Returns decision + matched policy IDs. |
-| Action requests | `GET /api/tool-gateway/action-requests`, `POST /api/tool-gateway/action-requests/:id/approve\|reject` | Approval queue. |
+| Policy dry-run | `POST /api/companies/:companyId/tools/policy/test` | Structured `{ companyId, actor, request, runContext? }` body; decision returned under `.decision`. |
+| Gateway sessions | `POST /api/tool-gateway/sessions` | Board callers must supply `companyId`, `agentId`, `runId`; agent JWTs auto-fill from the token. |
+| Gateway calls | `POST /api/tool-gateway/tools/call` | `X-Paperclip-Tool-Gateway-Token` header; body uses `tool` + `parameters`. Approval-required calls respond `409` with `reasonCode: approval_required` and an `actionRequestId`; the agent retries with `approvedActionRequestId`. |
+| Action requests | `POST /api/tool-gateway/action-requests/:id/approve` | Requires `companyId` (body or query). Listing is via the audit log: filter for `tool_gateway.approval_requested`. |
 | Trust rules | `POST /api/companies/:companyId/tools/action-requests/:id/trust-rule`, `POST /api/companies/:companyId/tools/trust-rules/:id/revoke` | Approval-derived allow policies. |
 | Runtime health | `GET /api/companies/:companyId/tools/runtime-health` | Alerts and metrics. Pair with [MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md). |
 | Runtime slots | `GET /api/companies/:companyId/tools/runtime-slots`, `POST /api/tool-gateway/runtime-slots/:id/stop\|restart` | Process supervision. |

--- a/doc/MCP-ACCESS-GOVERNANCE.md
+++ b/doc/MCP-ACCESS-GOVERNANCE.md
@@ -1,0 +1,396 @@
+# MCP Access Governance
+
+Operator guide for Paperclip's MCP tool access surface. Audience: board users and CloudOps engineers who install connections, write policies, approve action requests, and respond to runtime alerts. For runtime alert response, pair this with [MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md).
+
+> Time-to-first-success: under 5 minutes if you follow [Quick start](#quick-start) and use the bundled example. Everything else is reference and how-to material that you read on demand.
+
+## Contents
+
+- [Mental model](#mental-model)
+- [Quick start](#quick-start)
+- [Paperclip as MCP endpoint vs MCP gateway](#paperclip-as-mcp-endpoint-vs-mcp-gateway)
+- [Managed connections](#managed-connections)
+- [Catalog and risk classification](#catalog-and-risk-classification)
+- [Profiles and bindings](#profiles-and-bindings)
+- [Policies](#policies)
+- [Approval flow and trust rules](#approval-flow-and-trust-rules)
+- [Runtime slots](#runtime-slots)
+- [Audit and the call event log](#audit-and-the-call-event-log)
+- [Local trusted deployment](#local-trusted-deployment)
+- [Known limitations](#known-limitations)
+- [Reference](#reference)
+
+## Mental model
+
+Paperclip governs MCP tool access by separating four concerns:
+
+```
+┌────────────┐    ┌──────────────┐    ┌──────────┐    ┌────────────────┐
+│Application │───▶│  Connection  │───▶│ Catalog  │    │   Profile      │
+│  (logical) │    │ (endpoint+   │    │ (tools   │    │ (allow/deny    │
+│            │    │  transport)  │    │ schema)  │    │  entries)      │
+└────────────┘    └──────────────┘    └──────────┘    └────────┬───────┘
+                                                               │ bound to
+                                                               ▼
+                                              agent / project / routine / issue / company
+                                                               │
+                                                               ▼
+┌──────────┐  policy  ┌───────────┐  decision  ┌──────────────┐
+│  Agent   │─────────▶│ Gateway   │───────────▶│  Tool call   │
+│ tool call│          │ (policy   │            │   result     │
+└──────────┘          │  engine)  │            └──────────────┘
+                      └─────┬─────┘
+                            │
+                            ▼
+                      ┌──────────┐
+                      │  Action  │  human approve / reject
+                      │  Request │  (UI / API)
+                      └──────────┘
+```
+
+Plain prose version of the same graph:
+
+- An **Application** is a logical grouping ("GitHub", "Linear", "Local todo fixture"). It owns one or more connections.
+- A **Connection** is a single MCP endpoint. Transport is either `remote_http` (preferred) or `local_stdio` (gated by trusted deployment).
+- A **Catalog Entry** is one tool discovered on a connection. Each entry carries a risk classification (`read`, `write`, `destructive`) and a status (`active`, `quarantined`, `disabled`).
+- A **Profile** is a named bundle of allow/deny entries that picks which catalog entries an actor sees. Profiles attach to scopes via **Bindings** (`company`, `agent`, `project`, `routine`, `issue`).
+- A **Policy** is an orthogonal rule applied at call time: `allow`, `block`, `require_approval`, `rate_limit`, or `trust_rule`. Deny beats allow.
+- The **Gateway** is the runtime that an agent calls. It walks profiles + policies, returns a decision, records a **Call Event** in the audit log, and (if needed) opens an **Action Request** for human approval.
+
+If you remember one thing: **profile says *can this agent see the tool*; policy says *is this exact call allowed right now***.
+
+## Quick start
+
+The fastest path is the bundled example. From the Tools & Access UI (`/<prefix>/companies/<companyId>/tools/examples`), pick **Safe read-only Todo / KV fixture** and click **Install**. Then run **Smoke**. You can also do it via API:
+
+```sh
+# Install the example application + connection + profile in one call.
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/install" \
+  -d '{}' | jq .
+
+# Run the bundled smoke check (validates an allowed read, a denied write, audit visibility).
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/smoke" \
+  -d '{}' | jq '{checks, overall}'
+```
+
+Expected: `overall: "pass"` with three green checks (`allowed_call`, `denied_call`, `audit_visible`).
+
+If the smoke fails, fix the failing check before introducing any production connection. The bundled fixture only depends on local code, so any failure is a control-plane problem rather than an upstream MCP issue.
+
+## Paperclip as MCP endpoint vs MCP gateway
+
+Paperclip plays two roles in the MCP graph, and confusing them is the most common operator error.
+
+```
+              Paperclip as MCP endpoint
+              (clients call Paperclip)
+                       ┌──────────────┐
+   Claude Code  ─────▶ │   Paperclip  │
+   IDE / CLI    ─────▶ │ /mcp surface │
+                       └──────────────┘
+                          (task ops, agent ops)
+
+
+              Paperclip as MCP gateway / proxy
+              (agents call upstream MCP through Paperclip)
+
+   ┌─────┐       ┌────────────┐       ┌──────────────┐
+   │Agent│──────▶│ Paperclip  │──────▶│ Upstream MCP │
+   │ run │       │  gateway   │       │ (GitHub etc.)│
+   └─────┘       │  + policy  │       └──────────────┘
+                 │  + audit   │
+                 └────────────┘
+```
+
+**Endpoint mode** — Paperclip exposes its own MCP surface so external clients (Claude Code, IDEs, scripts) can manipulate Paperclip tasks and agents. This is what `doc/TASKS-mcp.md` covers. Access control here is the standard Paperclip auth model ([DEPLOYMENT-MODES.md](./DEPLOYMENT-MODES.md)): bearer keys, sessions, board API key.
+
+**Gateway mode** — Paperclip proxies tool calls from a Paperclip agent to an upstream MCP server (GitHub, Linear, a local stdio fixture, etc.). Every call goes through profile selection, policy evaluation, optional human approval, rate limiting, redaction, and audit. This is what the rest of this document covers.
+
+Operators usually mean *gateway* when they say "MCP access governance". An agent never speaks MCP directly to a third-party server — it always goes through the gateway. Policies, approvals, and the audit log only exist in gateway mode.
+
+## Managed connections
+
+A connection is an enabled, governed link to one MCP server. Two transports are supported:
+
+| Transport | When to use | Trust posture |
+| --- | --- | --- |
+| `remote_http` | Hosted SaaS MCP servers (GitHub, Linear, custom remote MCP). Default for cloud. | Paperclip authenticates with stored credential refs and proxies calls. Process supervision is upstream's problem. |
+| `local_stdio` | Local fixtures or approved stdio templates that must run as a child process. | Only allowed when the host is explicitly trusted; see [Local trusted deployment](#local-trusted-deployment). Cloud public deployments fail closed unless a trusted runtime host is configured. |
+
+Operators do not paste arbitrary `command` / `args` for stdio. Allowed stdio entries are limited to the approved template catalog (e.g. `paperclip.echo-calculator-time`, `paperclip.synthetic-todo-kv`). To add a new template, ship a code change.
+
+### Create a connection (remote_http)
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/connections" \
+  -d '{
+    "applicationId": "'"$APPLICATION_ID"'",
+    "name": "Linear (remote)",
+    "transport": "remote_http",
+    "transportConfig": {
+      "url": "https://mcp.linear.app/mcp",
+      "headers": []
+    },
+    "credentialRefs": [
+      { "name": "Authorization", "secretId": "'"$LINEAR_SECRET_ID"'", "placement": "header", "key": "Authorization", "prefix": "Bearer " }
+    ],
+    "enabled": false
+  }' | jq '{id, name, transport, status, enabled, healthStatus}'
+```
+
+Connections are created `enabled: false`. Run a health check and a catalog refresh before flipping `enabled: true`.
+
+### Connection lifecycle
+
+```sh
+# Health check (no secrets in output)
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID/health-check" -d '{}' \
+  | jq '{connection: {healthStatus: .connection.healthStatus, healthMessage: .connection.healthMessage}}'
+
+# Catalog refresh (pulls schema, sets risk levels, quarantines unexpected writes)
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID/catalog/refresh" -d '{}' \
+  | jq '{discoveredCount, quarantinedCount}'
+
+# Enable
+curl -fsS -X PATCH -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID" \
+  -d '{"enabled": true, "status": "active"}' | jq '{id, enabled, status, healthStatus}'
+
+# Disable (does not delete; preserves audit history)
+curl -fsS -X PATCH -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID" \
+  -d '{"enabled": false, "status": "disabled"}' | jq '{id, enabled, status}'
+```
+
+Connection statuses: `draft`, `active`, `disabled`, `archived`. Health statuses: `ok`, `unchecked`, `degraded`, `failed`, `error`, `missing_secret`.
+
+## Catalog and risk classification
+
+Each tool discovered on a connection becomes a **catalog entry** with a risk level Paperclip infers from MCP annotations:
+
+| Risk | Trigger | Default treatment |
+| --- | --- | --- |
+| `read` | `annotations.readOnlyHint: true` or schema implies read-only | Allowed by read-friendly profiles. |
+| `write` | `annotations.readOnlyHint: false` or `writeHint: true` | Requires approval by default unless the profile or a policy says otherwise. |
+| `destructive` | `annotations.destructiveHint: true` | Quarantined on first sight. Requires explicit operator action before any agent call can succeed. |
+
+When a catalog refresh discovers a new write/destructive tool that did not exist on the prior schema, Paperclip sets `status: quarantined` and records the reason in `quarantineReason`. Quarantined entries are never returned to the agent's tool list until an operator reviews and re-enables them. This is the **changed-tool quarantine** rule and the primary defense against an upstream server silently adding a destructive verb.
+
+To inspect and re-enable a quarantined entry, use the UI Catalog view, or PATCH the entry's status via the catalog routes (see [Reference](#reference)).
+
+## Profiles and bindings
+
+A profile is a named bundle of allow/deny rules over the catalog. It does not, by itself, attach to anyone. Bindings put profiles on actors.
+
+Example: create a profile that allows only read-only tools and bind it to a project.
+
+```sh
+# Profile with default-deny and one include entry for read-only catalog entries.
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles" \
+  -d '{
+    "profileKey": "engineering.read-only",
+    "name": "Engineering read-only",
+    "defaultAction": "deny",
+    "entries": [
+      { "selectorType": "risk_level", "selectorValue": "read", "effect": "include" }
+    ]
+  }' | jq '{id, name, defaultAction}'
+
+# Bind it to a project so every agent run in that project gets this profile.
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles/$PROFILE_ID/bind" \
+  -d '{ "targetType": "project", "targetId": "'"$PROJECT_ID"'", "priority": 10 }' | jq .
+```
+
+Selector types:
+- `application` — every catalog entry under an application
+- `connection` — every catalog entry under one connection
+- `catalog_entry` — one specific tool
+- `tool_name` — pattern match on tool name (e.g. `"list_*"`)
+- `risk_level` — `read`, `write`, or `destructive`
+
+Effects: `include` adds to the allowed set, `exclude` removes. `defaultAction` is the fallback when no entry matches.
+
+Binding scopes, narrowest first: `issue` > `routine` > `agent` > `project` > `company`. The effective profile for an agent is computed at session time and cached on the gateway session. To preview:
+
+```sh
+curl -fsS -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles/effective/agents/$AGENT_ID" \
+  | jq '{profileIds, allowedToolNames}'
+```
+
+## Policies
+
+Policies run after profile selection. A profile decides *can this agent see the tool*; a policy decides *is this exact call allowed right now*. Policy types:
+
+| Type | Effect |
+| --- | --- |
+| `allow` | Explicit allow for matching selectors. Adds positive evidence; does not override a `block`. |
+| `block` | Deny matching calls. **Deny always beats allow.** |
+| `require_approval` | Force human approval for matching calls; opens an action request. |
+| `rate_limit` | Apply a sliding-window counter. Match → consume; over limit → `rate_limited`. |
+| `trust_rule` | Approval-derived allow rule scoped to specific argument shapes. See [Approval flow and trust rules](#approval-flow-and-trust-rules). |
+
+Order of evaluation:
+1. Catalog status: `quarantined`/`disabled` → immediate deny.
+2. Profile: not in effective set → `deny`.
+3. Policies in priority order. `block` short-circuits. `require_approval` short-circuits to an action request. `rate_limit` evaluates the counter.
+4. If no policy matched and the profile allowed the tool: `allow`.
+
+To dry-run a policy decision without making a real call:
+
+```sh
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/policy/test" \
+  -d '{
+    "agentId": "'"$AGENT_ID"'",
+    "toolName": "create_item",
+    "arguments": { "title": "test" }
+  }' | jq '{decision, matchedPolicyIds, reasonCode}'
+```
+
+Decisions: `allow`, `deny`, `require_approval`, `rate_limited`, `defer_runtime`. `defer_runtime` means the policy engine asked the gateway to consult runtime state (e.g. slot availability) before producing the final verdict.
+
+## Approval flow and trust rules
+
+When a call resolves to `require_approval`, the gateway opens an **Action Request** carrying:
+- the agent, run, and tool identity,
+- a canonical hash of the arguments (so we can match later trust rules),
+- a `signedArguments` payload the approver sees verbatim,
+- an expiry.
+
+The human approver reviews the action card in the UI and either approves or rejects. The agent is paused on this exact call until a decision lands.
+
+After approval, the operator can promote that approval into a **trust rule**: a policy of `policyType: trust_rule` that allows the same tool with the same argument shape for the same actor scope, optionally for a limited number of approvals or until an expiry. This is how you avoid clicking *Approve* on every safe repetition of the same action.
+
+```sh
+# Approve via API (UI does the same)
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/action-requests/$ACTION_REQUEST_ID/approve" \
+  -d '{ "comment": "Looked correct." }' | jq '{status, decidedAt}'
+
+# Promote the approval to a trust rule
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/action-requests/$ACTION_REQUEST_ID/trust-rule" \
+  -d '{ "approvalThreshold": 10, "expiresAt": "2026-09-01T00:00:00.000Z" }' \
+  | jq '{id, policyType, config}'
+
+# Revoke a trust rule (audit-safe; does not delete)
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/trust-rules/$POLICY_ID/revoke" \
+  -d '{ "reason": "Catalog schema changed." }' | jq '{id, enabled, config: {revokedAt: .config.trustRule.revokedAt}}'
+```
+
+Trust rules carry `catalogVersionHash` and `schemaHash`. If the upstream tool changes its schema or argument shape, the hash no longer matches and the trust rule stops applying — the next matching call falls back to `require_approval`. This is intentional: an approval is for a specific argument shape, not for "future versions of this tool, sight unseen".
+
+## Runtime slots
+
+Local stdio connections run as supervised child processes. Each process is a **runtime slot** with a lifecycle: `stopped` → `starting` → `running` → `idle` → (`stopped`|`failed`).
+
+You don't normally touch slots. They're spun up on first call and evicted after idle expiry. You only touch them when:
+
+- a slot is stuck `starting` or `running` past 5 minutes,
+- restart suppression has fired (too many restart attempts),
+- a connection is being decommissioned and you need to free the process.
+
+Day-to-day runtime response — health summary, stuck-slot diagnosis, stop/restart, restart-storm playbook — lives in [MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md). Read that doc when paged.
+
+Cloud reminder: in `authenticated/public`, local stdio slots fail closed unless `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` is set on a worker explicitly designated to supervise local processes. Set it on one worker, not on the API edge.
+
+## Audit and the call event log
+
+Every tool invocation lands in the **call event log** (`tool_call_events`). Each event records:
+
+- decision (`allow`, `deny`, `require_approval`, `rate_limited`),
+- matched policy IDs,
+- reason code (`deny_default`, `deny_policy_block`, `quarantined_catalog_entry`, `missing_secret`, etc.),
+- redaction plan applied to arguments and results,
+- latency,
+- final outcome (`success`, `pending`, `denied`, `failure`, `timeout`).
+
+To pull recent audit:
+
+```sh
+curl -fsS -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/tool-gateway/audit?companyId=$COMPANY_ID&limit=100" \
+  | jq '[.[] | {createdAt, action: .action, decision: .details.decision, tool: .details.tool, outcome: .details.outcome, reasonCode: .details.reasonCode}]'
+```
+
+Two practical patterns:
+
+- **Per-run timeline:** `GET /api/companies/:companyId/tools/runs/:runId/decisions` returns every policy decision attached to a single agent run. Use this in QA to prove an agent never touched a denied tool.
+- **Approval audit:** `GET /api/tool-gateway/action-requests` returns pending and resolved action requests with approver identity and timestamps. Use this when answering "who approved this?".
+
+Audit is the source of truth for the security memo. It is intentionally append-only — there is no edit or delete route.
+
+## Local trusted deployment
+
+Local stdio MCP connections introduce a different trust model from remote_http: Paperclip is running a child process under its own credentials. Two questions decide whether this is safe in your deployment:
+
+1. **Who controls the host?** If the operator and the host are the same human (developer laptop, internal CI runner), you can opt into local stdio. If the host is multi-tenant (shared cloud worker), you must not.
+2. **Who controls the template?** Only approved templates baked into the Paperclip build can run. Agents cannot supply arbitrary `command` / `args`.
+
+The decision matrix:
+
+| Deployment mode | Local stdio default | When to enable |
+| --- | --- | --- |
+| `local_trusted` | Available, used for fixtures and developer flows | Always; this mode exists for it. |
+| `authenticated/private` (Tailnet/VPN/LAN) | Available with explicit opt-in | When the operator has root on the host and trusts the template list. |
+| `authenticated/public` (internet-facing) | Fail closed | Only when one worker is designated trusted by setting `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` and is isolated from the public-facing edge. |
+
+In all modes:
+
+- `remote_http` is the preferred path. If you can replace a local stdio fixture with a remote_http endpoint, do.
+- Never set `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` on the same worker that serves public HTTP traffic.
+- Treat the approved-template list as a code-review surface: a PR that adds a new template ships a new code-execution path.
+
+For deployment mode and bind semantics generally, see [DEPLOYMENT-MODES.md](./DEPLOYMENT-MODES.md).
+
+## Known limitations
+
+These are intentional gaps as of the MCP Access Governance v1 launch. Track or work around as noted.
+
+- **Audit-write failure counter is not durable yet.** `mcp_runtime_audit_write_failures` is recommended as a critical alert in [MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md), but the durable counter is not in place. Until it lands, treat any DB write error around the tool access audit paths as a control-plane incident — page CloudOps and freeze tool calls.
+- **No CLI surface for tool access yet.** Connections, profiles, policies, approvals, and trust rules are managed via the UI and the REST API only. There is no `paperclipai tool ...` subcommand.
+- **No bulk catalog review.** When an upstream server adds many new tools at once, you review each quarantined entry individually. Bulk operations are planned but not in v1.
+- **Trust rules match exact argument shapes only.** A trust rule built from one approval covers calls whose canonical argument hash matches and whose catalog schema hash is unchanged. Wildcards and structural filters across the rest of the schema are not supported in v1.
+- **Rate limits are per-policy.** Rate limit counters are scoped to the matching policy and counter key. There is no cross-policy aggregation (e.g. "300 requests/hour across all GitHub policies"). Operators who need that wire two `rate_limit` policies and accept the additive behavior.
+- **Action request expiry is fixed by policy.** The approval card carries a server-set expiry; the human approver cannot extend it from the UI. If a request expires before approval, the agent must retry the tool call.
+- **Endpoint mode (Paperclip as MCP server) is not policy-governed.** Tool access governance applies only to *gateway mode* — Paperclip's own MCP endpoint surface (`/mcp`) uses standard Paperclip auth and is not subject to the profile/policy stack.
+- **No multi-region runtime supervisor.** Local stdio slots run on the worker that serves the request that started them. If you scale workers, slots do not migrate. Plan capacity per worker, not per cluster.
+
+## Reference
+
+| Surface | Path / endpoint | Notes |
+| --- | --- | --- |
+| UI overview | `/<prefix>/companies/<companyId>/tools` | All tabs: Overview, Examples, Applications, Connections, Profiles, Policies, Runtime, Audit. |
+| Examples | `POST /api/companies/:companyId/tools/examples/:id/install` and `…/smoke` | Bundled fixtures for first-run validation. |
+| Applications | `GET\|POST /api/companies/:companyId/tools/applications`, `PATCH /api/tool-applications/:id` | Logical groupings. |
+| Connections | `GET\|POST /api/companies/:companyId/tools/connections`, `GET\|PATCH\|DELETE /api/tool-connections/:id` | `POST …/health-check`, `POST …/catalog/refresh`, `GET …/catalog` for lifecycle. |
+| Profiles | `GET\|POST /api/companies/:companyId/tools/profiles`, `PATCH /api/tool-profiles/:id` | Entries: `POST /api/tool-profiles/:id/entries`, `PATCH\|DELETE /api/tool-profile-entries/:id`. |
+| Bindings | `POST /api/companies/:companyId/tools/profiles/:id/bind` and `…/unbind` | Targets: `company`, `agent`, `project`, `routine`, `issue`. |
+| Effective profile | `GET /api/companies/:companyId/tools/profiles/effective/agents/:agentId` | Use for QA proofs and debugging selector misses. |
+| Policies | `GET\|POST /api/companies/:companyId/tools/policies`, `PATCH\|DELETE /api/companies/:companyId/tools/policies/:id` | Types: `allow`, `block`, `require_approval`, `rate_limit`, `trust_rule`. |
+| Policy dry-run | `POST /api/companies/:companyId/tools/policy/test` | Returns decision + matched policy IDs. |
+| Action requests | `GET /api/tool-gateway/action-requests`, `POST /api/tool-gateway/action-requests/:id/approve\|reject` | Approval queue. |
+| Trust rules | `POST /api/companies/:companyId/tools/action-requests/:id/trust-rule`, `POST /api/companies/:companyId/tools/trust-rules/:id/revoke` | Approval-derived allow policies. |
+| Runtime health | `GET /api/companies/:companyId/tools/runtime-health` | Alerts and metrics. Pair with [MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md). |
+| Runtime slots | `GET /api/companies/:companyId/tools/runtime-slots`, `POST /api/tool-gateway/runtime-slots/:id/stop\|restart` | Process supervision. |
+| Audit | `GET /api/tool-gateway/audit?companyId=…&limit=…`, `GET /api/companies/:companyId/tools/runs/:runId/decisions` | Call event log. |
+| Stdio templates | `GET /api/companies/:companyId/tools/stdio-templates` | Approved local stdio template IDs only. |
+| Bulk import preview | `POST /api/companies/:companyId/tools/mcp/import-json` | Inspect a discovery JSON without persisting anything. |
+| Demo script | [MCP-DEMO-SCRIPT.md](./MCP-DEMO-SCRIPT.md) | Walks read / approval-gated write / denied flows end-to-end. |
+| Runtime runbook | [MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md) | Alerts, stuck slots, recovery. |
+| Deployment modes | [DEPLOYMENT-MODES.md](./DEPLOYMENT-MODES.md) | Auth, exposure, bind. |

--- a/doc/MCP-DEMO-SCRIPT.md
+++ b/doc/MCP-DEMO-SCRIPT.md
@@ -1,6 +1,6 @@
 # MCP Access Governance Demo Script
 
-This is the end-to-end demo for the MCP Access Governance launch. It walks the three required cases — **read**, **approval-gated write**, **denied/malicious** — against the bundled `paperclip.synthetic-todo-kv` fixture. The fixture ships in the Paperclip build; no upstream MCP server is required.
+This is the end-to-end demo for the MCP Access Governance launch. It walks the three required cases — **read**, **approval-gated write**, **denied/destructive** — against the bundled `paperclip.synthetic-todo-kv` fixture. The fixture ships in the Paperclip build; no upstream MCP server is required.
 
 Audience: CTO sign-off, QA repro, and the recorded walkthrough that goes with the release notes. Time to run live: about 10 minutes.
 
@@ -11,12 +11,12 @@ Pair this script with [MCP-ACCESS-GOVERNANCE.md](./MCP-ACCESS-GOVERNANCE.md) for
 Before you start the recording:
 
 - Paperclip running in `local_trusted` or `authenticated/private` mode. Public mode is fine for the demo as long as a trusted runtime host is configured (see [MCP-ACCESS-GOVERNANCE.md#local-trusted-deployment](./MCP-ACCESS-GOVERNANCE.md#local-trusted-deployment)).
-- A company with at least one agent identity to act as the caller.
+- A company with at least one agent identity to act as the caller. That agent must have an **active heartbeat run** for the gateway-call steps (Steps 5, 6, 8, 10). The simplest way to keep one alive during recording is to assign a placeholder task to the agent before the demo starts; the agent's heartbeat run stays in `running` while it works.
 - Board API key (`$BOARD_API_KEY`) exported. Company ID (`$COMPANY_ID`) exported. Agent ID (`$AGENT_ID`) for the caller exported.
 - Paperclip URL (`$PAPERCLIP_URL`) exported.
 - The Tools & Access UI open at `/<prefix>/companies/<companyId>/tools`.
 
-The demo uses one terminal and one browser window side by side.
+All API requests use `Authorization: Bearer $BOARD_API_KEY` for board calls. Gateway calls use a dedicated session token via the `X-Paperclip-Tool-Gateway-Token` header — they do not use `Authorization`. See Step 4 for how the token is minted.
 
 ## Step 0 — Frame the demo
 
@@ -36,94 +36,136 @@ Switch to the **Examples** tab. Click **Install** on *Safe read-only Todo / KV f
 API equivalent for the recording:
 
 ```sh
-curl -fsS -X POST \
+INSTALL=$(curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/install" \
-  -d '{}' | jq '{applicationId, connectionId, profileId}'
+  -d '{}')
+echo "$INSTALL" | jq '{applicationId: .application.id, connectionId: .connection.id, profileId: .profile.id, catalogCount: (.catalog | length)}'
+
+export APPLICATION_ID=$(jq -r '.application.id' <<<"$INSTALL")
+export CONNECTION_ID=$(jq -r '.connection.id' <<<"$INSTALL")
+export PROFILE_ID=$(jq -r '.profile.id' <<<"$INSTALL")
 ```
 
-Expected output: three IDs. Export them for the rest of the script:
+Quick check on the UI Catalog view: the bundled tools are listed, with destructive entries flagged and quarantined. Point at the quarantine badge.
+
+## Step 2 — Run the bundled smoke
+
+Before any agent call, prove the install is healthy. The smoke endpoint runs a read decision and a deny decision through the policy engine and writes audit events, all under the board key.
 
 ```sh
-export APPLICATION_ID=...   # from install response
-export CONNECTION_ID=...
-export PROFILE_ID=...
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/smoke" \
+  -d '{}' \
+  | jq '{ok, checks: [.checks[] | {name, ok, decision, reasonCode}]}'
 ```
 
-Quick check on the UI Catalog view: six tools listed, with `delete_item` flagged `destructive` and quarantined. Point at the quarantine badge.
+Expected: `ok: true` with three green checks: `allow_read_tool`, `deny_write_tool`, `audit_written`. If any check is false, fix it before recording the rest — the gateway path won't work either.
 
-## Step 2 — Bind the read-only profile to your demo agent
+## Step 3 — Bind the read-only profile to your demo agent
 
-The example installs a profile that allows only the read-only tools (`list_items`, `get_value`). Bind it to the demo agent so the agent's effective profile is exactly that:
+The example installs a profile that allows only the read-only tools. The installer also binds the profile to the company by default. To make the demo's effective profile unambiguous, bind it explicitly to the demo agent:
 
 ```sh
 curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles/$PROFILE_ID/bind" \
-  -d '{ "targetType": "agent", "targetId": "'"$AGENT_ID"'", "priority": 10 }' | jq .
+  -d '{ "targetType": "agent", "targetId": "'"$AGENT_ID"'", "priority": 10 }' | jq '{id, profileId, targetType, targetId, priority}'
 
 curl -fsS \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles/effective/agents/$AGENT_ID" \
-  | jq '{allowedToolNames}'
+  | jq '{profileIds, allowedToolNames}'
 ```
 
-Expected: `allowedToolNames` contains `list_items` and `get_value`, nothing else.
+Expected: `allowedToolNames` contains the safe read-only tools (`list_items`, `get_value`), and nothing else.
 
-## Step 3 — Open an agent session against the gateway
+## Step 4 — Mint a gateway session for the demo agent
 
-Get a gateway session token so the rest of the script can call as the agent:
+Gateway sessions are scoped to an active heartbeat run. When a board key mints the session, the request body must carry `companyId`, `agentId`, and `runId`. The run must be in `running` status and must belong to the same agent and company.
+
+Grab the most recent active run for the demo agent:
+
+```sh
+export RUN_ID=$(curl -fsS \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/heartbeat-runs?agentId=$AGENT_ID&limit=20" \
+  | jq -r '[.[] | select(.status == "running")] | first | .id')
+
+test -n "$RUN_ID" || { echo "No active run for agent — start one before recording"; exit 1; }
+```
+
+Mint the session:
 
 ```sh
 SESSION=$(curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/tool-gateway/sessions" \
-  -d '{ "agentId": "'"$AGENT_ID"'" }')
+  -d '{
+    "companyId": "'"$COMPANY_ID"'",
+    "agentId": "'"$AGENT_ID"'",
+    "runId": "'"$RUN_ID"'"
+  }')
+echo "$SESSION" | jq '{sessionId, expiresAt, toolsUrl, callUrl}'
 export GATEWAY_TOKEN=$(jq -r '.token' <<<"$SESSION")
 ```
 
-In production an agent gets this token through its run bootstrap. For the demo we mint one directly so the recording stays in one shell.
+In production, the agent obtains this token from its own run bootstrap (agent JWTs auto-populate `companyId`/`agentId`/`runId`). The board-keyed shortcut here is for the recording so the camera stays in one shell.
 
-## Step 4 — The read tool (allowed)
+## Step 5 — The read tool (allowed)
 
-```sh
-curl -fsS -X POST \
-  -H "Authorization: Bearer $GATEWAY_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
-  -d '{ "toolName": "list_items", "arguments": {} }' \
-  | jq '{decision: .decision, status: .status, result: .result}'
-```
-
-Expected: `decision: "allow"`, `status: "executed"`, a synthetic empty list in `result`.
-
-Switch to the **Audit** tab in the UI. Refresh. The newest row is `call_allowed` for `list_items`, latency in single-digit ms. Point at it on the recording.
-
-## Step 5 — The destructive tool (denied)
+Gateway calls use the session token via `X-Paperclip-Tool-Gateway-Token`. The body uses `tool` (string) and `parameters` (object).
 
 ```sh
 curl -fsS -X POST \
-  -H "Authorization: Bearer $GATEWAY_TOKEN" \
+  -H "X-Paperclip-Tool-Gateway-Token: $GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
-  -d '{ "toolName": "delete_item", "arguments": { "id": "fake" } }' \
-  | jq '{decision, status, reasonCode}'
+  -d '{ "tool": "list_items", "parameters": {} }' \
+  | jq '{invocationId, status, tool, result}'
 ```
 
-Expected: `decision: "deny"`, `status: "denied"`, `reasonCode` one of `quarantined_catalog_entry` (because the catalog entry was quarantined on install) or `deny_default` (because the read-only profile does not include it). Either is the correct deny path.
+Expected: `status: "completed"`, the synthetic result in `result`, and a UUID `invocationId`. Latency is single-digit ms.
 
-The agent does not get a stack trace. The audit log gets a `call_denied` event with the reason code. Refresh the audit tab.
+Switch to the **Audit** tab in the UI. Refresh. The newest row is `tool_gateway.call_completed` for `list_items` with `decision: allow`. Point at it on the recording.
+
+## Step 6 — The destructive tool (denied)
+
+```sh
+curl -i -X POST \
+  -H "X-Paperclip-Tool-Gateway-Token: $GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{ "tool": "delete_item", "parameters": { "id": "fake" } }'
+```
+
+Expected: an HTTP `403` or `404` response with a JSON body shaped like:
+
+```json
+{
+  "error": "<explanation from the policy decision>",
+  "reasonCode": "quarantined_catalog_entry",
+  "invocationId": "...",
+  "tool": "delete_item",
+  "decision": "deny",
+  "matchedPolicyIds": []
+}
+```
+
+Either `quarantined_catalog_entry` (catalog quarantine on first sight) or `deny_default` (read-only profile excludes the tool) is the correct deny path. The agent does not get a stack trace — just the reason code. The audit log gets a `tool_gateway.call_denied` event with the same reason code. Refresh the audit tab.
 
 Spoken note:
 
-> "The agent doesn't know whether the tool was denied by the profile, by a policy, or by quarantine. It just knows the call failed. The operator does — the reason code is in the audit row."
+> "The agent doesn't know whether the tool was denied by the profile, by a policy, or by quarantine. It just knows the call failed and the reason code. The operator sees the full decision in the audit row."
 
-## Step 6 — Set up the approval-gated write tool
+## Step 7 — Set up the approval-gated write tool
 
-We are going to allow `create_item`, but require human approval for it. Two steps: extend the profile to *include* `create_item`, then add a `require_approval` policy targeting that tool.
+We are going to allow `create_item`, but require human approval for it. Two steps: extend the profile to include `create_item`, then add a `require_approval` policy targeting that tool.
 
 Add `create_item` to the profile:
 
@@ -132,8 +174,8 @@ curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/tool-profiles/$PROFILE_ID/entries" \
-  -d '{ "selectorType": "tool_name", "selectorValue": "create_item", "effect": "include" }' \
-  | jq '{id, selectorType, selectorValue, effect}'
+  -d '{ "selectorType": "tool_name", "toolName": "create_item", "effect": "include" }' \
+  | jq '{id, selectorType, toolName, effect}'
 ```
 
 Add a `require_approval` policy:
@@ -150,53 +192,95 @@ curl -fsS -X POST \
     "enabled": true,
     "selectors": { "toolNames": ["create_item"] },
     "config": { "approvalReason": "Demo: create_item requires approval." }
-  }' | jq '{id, policyType, enabled}'
+  }' | jq '{id, policyType, enabled, priority}'
 ```
 
-Dry-run the policy decision so the camera sees the engine respond with `require_approval`:
+Dry-run the policy decision against the engine so the camera sees `require_approval` before any real call. The dry-run uses a structured `{ companyId, actor, request, runContext? }` body and returns the decision under `.decision`:
 
 ```sh
 curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/policy/test" \
-  -d '{ "agentId": "'"$AGENT_ID"'", "toolName": "create_item", "arguments": { "title": "Demo item" } }' \
-  | jq '{decision, matchedPolicyIds, reasonCode}'
+  -d '{
+    "companyId": "'"$COMPANY_ID"'",
+    "actor": {
+      "actorType": "agent",
+      "actorId": "'"$AGENT_ID"'",
+      "agentId": "'"$AGENT_ID"'"
+    },
+    "runContext": {
+      "heartbeatRunId": "'"$RUN_ID"'"
+    },
+    "request": {
+      "toolName": "create_item",
+      "arguments": { "title": "Demo item" }
+    }
+  }' \
+  | jq '{decision: .decision.decision, matchedPolicyIds: .decision.matchedPolicyIds, reasonCode: .decision.reasonCode}'
 ```
 
 Expected: `decision: "require_approval"`, `matchedPolicyIds` includes the policy you just created.
 
-## Step 7 — The agent call that triggers approval
+## Step 8 — The agent call that triggers approval
+
+A real gateway call now returns HTTP `409` with `reasonCode: "approval_required"` and an `actionRequestId` in the body. Use `-i` (or capture status separately) so the recording shows the 409 explicitly:
 
 ```sh
-CALL=$(curl -fsS -X POST \
-  -H "Authorization: Bearer $GATEWAY_TOKEN" \
+CALL=$(curl -sS -w '\n%{http_code}' -X POST \
+  -H "X-Paperclip-Tool-Gateway-Token: $GATEWAY_TOKEN" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
-  -d '{ "toolName": "create_item", "arguments": { "title": "Demo item" } }')
-echo "$CALL" | jq '{decision, status, actionRequestId: .actionRequest.id, expiresAt: .actionRequest.expiresAt}'
-export ACTION_REQUEST_ID=$(jq -r '.actionRequest.id' <<<"$CALL")
+  -d '{ "tool": "create_item", "parameters": { "title": "Demo item" } }')
+
+STATUS=$(echo "$CALL" | tail -1)
+BODY=$(echo "$CALL" | sed '$d')
+echo "HTTP $STATUS"
+echo "$BODY" | jq '{error, reasonCode, invocationId, actionRequestId, interactionId, tool, argumentsHash}'
+export ACTION_REQUEST_ID=$(jq -r '.actionRequestId' <<<"$BODY")
 ```
 
-Expected: `decision: "require_approval"`, `status: "awaiting_approval"`, an action request ID and expiry.
+Expected: `HTTP 409`, `reasonCode: "approval_required"`, an `actionRequestId`, an `argumentsHash` (canonical hash of the reviewed arguments), and an `interactionId` for the linked issue-thread interaction. The agent's run is paused on this exact tool call until a decision lands.
 
-In the UI, switch to the **Audit** tab and find the action request card (or go to the Action Requests view if your build exposes it as a separate tab). Point at the signed arguments, the requesting agent, the run, and the expiry. The agent's call is paused on this exact tool call until a decision lands.
+In the UI, switch to the **Audit** tab and find the approval card. Point at the signed arguments, the requesting agent, the run, and the expiry.
 
-## Step 8 — Approve the action
+## Step 9 — Approve the action
 
-Approve via the API for the recording (the UI button does the same thing):
+Approve via the API for the recording (the UI button does the same thing). The approval endpoint requires `companyId` (in the body or as a query parameter):
 
 ```sh
 curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/tool-gateway/action-requests/$ACTION_REQUEST_ID/approve" \
-  -d '{ "comment": "Approved for demo." }' | jq '{status, decidedAt, decidedByAgentId}'
+  -d '{ "companyId": "'"$COMPANY_ID"'" }' \
+  | jq '{id, status, resolvedAt, resolvedByUserId, canonicalArgumentsHash}'
 ```
 
-Expected: `status: "approved"`. The agent call resumes server-side and the audit log gets two new rows: `call_allowed` and `call_completed` for the same invocation.
+Expected: `status: "approved"` and `resolvedAt` set. The agent call has not run yet — approval marks the action request ready to be consumed.
 
-## Step 9 — Promote the approval to a trust rule (optional but useful)
+## Step 10 — Retry the call with the approved action request
+
+The agent retries the same call with `approvedActionRequestId` set to the action request it received in Step 8. The gateway re-validates that the canonical arguments hash matches what was approved, then executes the tool.
+
+```sh
+curl -fsS -X POST \
+  -H "X-Paperclip-Tool-Gateway-Token: $GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{
+    "tool": "create_item",
+    "parameters": { "title": "Demo item" },
+    "approvedActionRequestId": "'"$ACTION_REQUEST_ID"'"
+  }' \
+  | jq '{invocationId, status, tool, result}'
+```
+
+Expected: `status: "completed"`, with the created item in `result`. The audit log gets a `tool_gateway.call_allowed` event followed by a `tool_gateway.call_completed` event, both linked to the same `actionRequestId`.
+
+If you change the `parameters` between Step 8 and Step 10, the retry fails with `reasonCode: "signed_arguments_mismatch"` — the approval is for the exact reviewed arguments, not the next call shape.
+
+## Step 11 — Promote the approval to a trust rule (optional)
 
 Skip this on a 5-minute recording. Include it for the 10-minute version because it shows the operator-side automation story.
 
@@ -205,51 +289,46 @@ curl -fsS -X POST \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/action-requests/$ACTION_REQUEST_ID/trust-rule" \
-  -d '{ "approvalThreshold": 10, "expiresAt": "2026-09-01T00:00:00.000Z" }' \
-  | jq '{id, policyType, config: {trustRule: {approvalThreshold: .config.trustRule.approvalThreshold, hitCount: .config.trustRule.hitCount, expiresAt: .config.trustRule.expiresAt}}}'
+  -d '{
+    "name": "Trust create_item from the demo agent",
+    "approvalThreshold": 2,
+    "scope": { "includeAgent": true, "includeTool": true },
+    "argumentFilters": { "exactHash": null, "allowAny": false, "fieldEquals": { "title": "Demo item" } },
+    "expiresAt": "2026-09-01T00:00:00.000Z"
+  }' \
+  | jq '{id, policyType, priority, config: {trustRule: .config.trustRule}}'
 ```
 
-Then call `create_item` again with the same argument shape:
-
-```sh
-curl -fsS -X POST \
-  -H "Authorization: Bearer $GATEWAY_TOKEN" \
-  -H "Content-Type: application/json" \
-  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
-  -d '{ "toolName": "create_item", "arguments": { "title": "Second demo item" } }' \
-  | jq '{decision, status, matchedPolicyIds}'
-```
-
-Expected: `decision: "allow"` this time. The matched policy ID is the trust rule. Point at it.
+Trust rules are policies of type `trust_rule`. They derive from a specific approved action request and stop applying when the upstream tool's schema hash changes — covered in [MCP-ACCESS-GOVERNANCE.md#approval-flow-and-trust-rules](./MCP-ACCESS-GOVERNANCE.md#approval-flow-and-trust-rules).
 
 Spoken note:
 
-> "The trust rule covers up to ten approvals matching this argument shape. If the upstream tool changes its schema or the argument hash changes, the trust rule stops applying and we go back to approval. That's intentional — an approval is for a specific argument shape, not for the next version of the tool."
+> "A trust rule converts a one-time approval into a steady-state allow scoped to the same actor and the same argument shape. If the upstream tool changes its schema, the trust rule stops matching and we go back to approval. That's intentional — an approval is for a specific argument shape, not for the next version of the tool."
 
-## Step 10 — Audit summary
+## Step 12 — Audit summary
 
-Pull the full audit timeline for the demo:
+Pull the audit timeline for the demo:
 
 ```sh
 curl -fsS \
   -H "Authorization: Bearer $BOARD_API_KEY" \
   "$PAPERCLIP_URL/api/tool-gateway/audit?companyId=$COMPANY_ID&limit=20" \
-  | jq '[.[] | {createdAt, tool: .details.tool, decision: .details.decision, outcome: .details.outcome, reasonCode: .details.reasonCode}]'
+  | jq '[.[] | {createdAt, action, tool: .details.tool, decision: .details.decision, reasonCode: .details.reasonCode}]'
 ```
 
 Expected rows, newest first:
 
-1. `create_item` — `allow` / `success` (trust rule hit, step 9)
-2. `create_item` — `allow` / `success` (post-approval, step 8)
-3. `create_item` — `require_approval` / `pending` (step 7)
-4. `delete_item` — `deny` / `denied` with `reasonCode: deny_default` or `quarantined_catalog_entry` (step 5)
-5. `list_items` — `allow` / `success` (step 4)
+1. `tool_gateway.call_completed` — `create_item`, `allow` (Step 10 retry)
+2. `tool_gateway.call_allowed` — `create_item`, `approved` (Step 10 entry into execution)
+3. `tool_gateway.approval_requested` — `create_item`, `require_approval` (Step 8 approval card)
+4. `tool_gateway.call_denied` — `delete_item`, `deny`, with `reasonCode` of `quarantined_catalog_entry` or `deny_default` (Step 6)
+5. `tool_gateway.call_completed` — `list_items`, `allow` (Step 5)
 
-Close on the audit tab. Three required cases visible in a single screen. End of recording.
+Close on the audit tab. Three required cases visible in a single screen: a read that landed, a write that took an approval round-trip, and a destructive call that was denied with a reason. End of recording.
 
 ## Cleanup (optional)
 
-If you ran the demo on a long-lived environment, leave the example installed — the bundled smoke (`POST …/examples/safe-read-only-todo-kv/smoke`) replays the three cases on demand. If you need a clean state:
+If you ran the demo on a long-lived environment, leave the example installed — the bundled smoke (`POST …/examples/safe-read-only-todo-kv/smoke`) replays the read and deny cases on demand. If you need a clean state:
 
 ```sh
 # Revoke the trust rule (if you created one)
@@ -272,8 +351,8 @@ Audit history is retained; the connection and application stay archived for the 
 
 ## What this proves
 
-- **Read** path: the read-only catalog entry, the read-only profile, and the gateway audit row line up.
-- **Approval-gated write** path: profile inclusion + `require_approval` policy + action request + human approve + audit closure. Trust rule promotion bridges the human-in-the-loop step to a steady-state allow without losing the audit trail.
-- **Denied / destructive** path: catalog quarantine on first sight, profile default-deny, and a clean `deny` decision with reason code at the gateway. The agent sees a failed call; the operator sees the reason.
+- **Read** path: the read-only catalog entry, the read-only profile, and the gateway audit row line up. Gateway-token header, `tool`/`parameters` body, `status: "completed"` on success.
+- **Approval-gated write** path: profile inclusion + `require_approval` policy + HTTP `409` `approval_required` carrying `actionRequestId` + board-key approval scoped to `companyId` + retry with `approvedActionRequestId` + audit closure. Trust rule promotion (Step 11) bridges the human-in-the-loop step to a steady-state allow without losing the audit trail.
+- **Denied / destructive** path: catalog quarantine on first sight, profile default-deny, and a clean deny HTTP response with `reasonCode` at the gateway. The agent sees a failed call; the operator sees the reason in the audit row.
 
-This is the contract the launch ships. If a future change loosens any of these — silent allow on a destructive tool, an approval that doesn't audit, a denied call without a reason code — the demo will fail and so will QA.
+This is the contract the launch ships. If a future change loosens any of these — silent allow on a destructive tool, an approval that doesn't audit, a denied call without a reason code, or a retry that ignores the canonical-arguments hash — the demo will fail and so will QA.

--- a/doc/MCP-DEMO-SCRIPT.md
+++ b/doc/MCP-DEMO-SCRIPT.md
@@ -1,0 +1,279 @@
+# MCP Access Governance Demo Script
+
+This is the end-to-end demo for the MCP Access Governance launch. It walks the three required cases — **read**, **approval-gated write**, **denied/malicious** — against the bundled `paperclip.synthetic-todo-kv` fixture. The fixture ships in the Paperclip build; no upstream MCP server is required.
+
+Audience: CTO sign-off, QA repro, and the recorded walkthrough that goes with the release notes. Time to run live: about 10 minutes.
+
+Pair this script with [MCP-ACCESS-GOVERNANCE.md](./MCP-ACCESS-GOVERNANCE.md) for concepts and the full reference.
+
+## Prerequisites
+
+Before you start the recording:
+
+- Paperclip running in `local_trusted` or `authenticated/private` mode. Public mode is fine for the demo as long as a trusted runtime host is configured (see [MCP-ACCESS-GOVERNANCE.md#local-trusted-deployment](./MCP-ACCESS-GOVERNANCE.md#local-trusted-deployment)).
+- A company with at least one agent identity to act as the caller.
+- Board API key (`$BOARD_API_KEY`) exported. Company ID (`$COMPANY_ID`) exported. Agent ID (`$AGENT_ID`) for the caller exported.
+- Paperclip URL (`$PAPERCLIP_URL`) exported.
+- The Tools & Access UI open at `/<prefix>/companies/<companyId>/tools`.
+
+The demo uses one terminal and one browser window side by side.
+
+## Step 0 — Frame the demo
+
+Spoken intro:
+
+> "Paperclip ships with an MCP gateway that sits between every agent and every upstream tool. Three things happen on every call: we pick the tool against a profile, we evaluate policies, and we record an audit event. I'm going to run a read, then a write that needs approval, then a destructive call that gets denied. Everything you see is the bundled fixture — no upstream server is involved, so any failure is on us."
+
+Show the Tools & Access overview tab. Point at:
+- Applications count = 0
+- Connections count = 0
+- Slots = 0
+
+## Step 1 — Install the example
+
+Switch to the **Examples** tab. Click **Install** on *Safe read-only Todo / KV fixture*. The UI shows the application, connection, and profile being created.
+
+API equivalent for the recording:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/install" \
+  -d '{}' | jq '{applicationId, connectionId, profileId}'
+```
+
+Expected output: three IDs. Export them for the rest of the script:
+
+```sh
+export APPLICATION_ID=...   # from install response
+export CONNECTION_ID=...
+export PROFILE_ID=...
+```
+
+Quick check on the UI Catalog view: six tools listed, with `delete_item` flagged `destructive` and quarantined. Point at the quarantine badge.
+
+## Step 2 — Bind the read-only profile to your demo agent
+
+The example installs a profile that allows only the read-only tools (`list_items`, `get_value`). Bind it to the demo agent so the agent's effective profile is exactly that:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles/$PROFILE_ID/bind" \
+  -d '{ "targetType": "agent", "targetId": "'"$AGENT_ID"'", "priority": 10 }' | jq .
+
+curl -fsS \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/profiles/effective/agents/$AGENT_ID" \
+  | jq '{allowedToolNames}'
+```
+
+Expected: `allowedToolNames` contains `list_items` and `get_value`, nothing else.
+
+## Step 3 — Open an agent session against the gateway
+
+Get a gateway session token so the rest of the script can call as the agent:
+
+```sh
+SESSION=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/sessions" \
+  -d '{ "agentId": "'"$AGENT_ID"'" }')
+export GATEWAY_TOKEN=$(jq -r '.token' <<<"$SESSION")
+```
+
+In production an agent gets this token through its run bootstrap. For the demo we mint one directly so the recording stays in one shell.
+
+## Step 4 — The read tool (allowed)
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{ "toolName": "list_items", "arguments": {} }' \
+  | jq '{decision: .decision, status: .status, result: .result}'
+```
+
+Expected: `decision: "allow"`, `status: "executed"`, a synthetic empty list in `result`.
+
+Switch to the **Audit** tab in the UI. Refresh. The newest row is `call_allowed` for `list_items`, latency in single-digit ms. Point at it on the recording.
+
+## Step 5 — The destructive tool (denied)
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{ "toolName": "delete_item", "arguments": { "id": "fake" } }' \
+  | jq '{decision, status, reasonCode}'
+```
+
+Expected: `decision: "deny"`, `status: "denied"`, `reasonCode` one of `quarantined_catalog_entry` (because the catalog entry was quarantined on install) or `deny_default` (because the read-only profile does not include it). Either is the correct deny path.
+
+The agent does not get a stack trace. The audit log gets a `call_denied` event with the reason code. Refresh the audit tab.
+
+Spoken note:
+
+> "The agent doesn't know whether the tool was denied by the profile, by a policy, or by quarantine. It just knows the call failed. The operator does — the reason code is in the audit row."
+
+## Step 6 — Set up the approval-gated write tool
+
+We are going to allow `create_item`, but require human approval for it. Two steps: extend the profile to *include* `create_item`, then add a `require_approval` policy targeting that tool.
+
+Add `create_item` to the profile:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-profiles/$PROFILE_ID/entries" \
+  -d '{ "selectorType": "tool_name", "selectorValue": "create_item", "effect": "include" }' \
+  | jq '{id, selectorType, selectorValue, effect}'
+```
+
+Add a `require_approval` policy:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/policies" \
+  -d '{
+    "name": "Approve every create_item",
+    "policyType": "require_approval",
+    "priority": 100,
+    "enabled": true,
+    "selectors": { "toolNames": ["create_item"] },
+    "config": { "approvalReason": "Demo: create_item requires approval." }
+  }' | jq '{id, policyType, enabled}'
+```
+
+Dry-run the policy decision so the camera sees the engine respond with `require_approval`:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/policy/test" \
+  -d '{ "agentId": "'"$AGENT_ID"'", "toolName": "create_item", "arguments": { "title": "Demo item" } }' \
+  | jq '{decision, matchedPolicyIds, reasonCode}'
+```
+
+Expected: `decision: "require_approval"`, `matchedPolicyIds` includes the policy you just created.
+
+## Step 7 — The agent call that triggers approval
+
+```sh
+CALL=$(curl -fsS -X POST \
+  -H "Authorization: Bearer $GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{ "toolName": "create_item", "arguments": { "title": "Demo item" } }')
+echo "$CALL" | jq '{decision, status, actionRequestId: .actionRequest.id, expiresAt: .actionRequest.expiresAt}'
+export ACTION_REQUEST_ID=$(jq -r '.actionRequest.id' <<<"$CALL")
+```
+
+Expected: `decision: "require_approval"`, `status: "awaiting_approval"`, an action request ID and expiry.
+
+In the UI, switch to the **Audit** tab and find the action request card (or go to the Action Requests view if your build exposes it as a separate tab). Point at the signed arguments, the requesting agent, the run, and the expiry. The agent's call is paused on this exact tool call until a decision lands.
+
+## Step 8 — Approve the action
+
+Approve via the API for the recording (the UI button does the same thing):
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/action-requests/$ACTION_REQUEST_ID/approve" \
+  -d '{ "comment": "Approved for demo." }' | jq '{status, decidedAt, decidedByAgentId}'
+```
+
+Expected: `status: "approved"`. The agent call resumes server-side and the audit log gets two new rows: `call_allowed` and `call_completed` for the same invocation.
+
+## Step 9 — Promote the approval to a trust rule (optional but useful)
+
+Skip this on a 5-minute recording. Include it for the 10-minute version because it shows the operator-side automation story.
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/action-requests/$ACTION_REQUEST_ID/trust-rule" \
+  -d '{ "approvalThreshold": 10, "expiresAt": "2026-09-01T00:00:00.000Z" }' \
+  | jq '{id, policyType, config: {trustRule: {approvalThreshold: .config.trustRule.approvalThreshold, hitCount: .config.trustRule.hitCount, expiresAt: .config.trustRule.expiresAt}}}'
+```
+
+Then call `create_item` again with the same argument shape:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/tools/call" \
+  -d '{ "toolName": "create_item", "arguments": { "title": "Second demo item" } }' \
+  | jq '{decision, status, matchedPolicyIds}'
+```
+
+Expected: `decision: "allow"` this time. The matched policy ID is the trust rule. Point at it.
+
+Spoken note:
+
+> "The trust rule covers up to ten approvals matching this argument shape. If the upstream tool changes its schema or the argument hash changes, the trust rule stops applying and we go back to approval. That's intentional — an approval is for a specific argument shape, not for the next version of the tool."
+
+## Step 10 — Audit summary
+
+Pull the full audit timeline for the demo:
+
+```sh
+curl -fsS \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/tool-gateway/audit?companyId=$COMPANY_ID&limit=20" \
+  | jq '[.[] | {createdAt, tool: .details.tool, decision: .details.decision, outcome: .details.outcome, reasonCode: .details.reasonCode}]'
+```
+
+Expected rows, newest first:
+
+1. `create_item` — `allow` / `success` (trust rule hit, step 9)
+2. `create_item` — `allow` / `success` (post-approval, step 8)
+3. `create_item` — `require_approval` / `pending` (step 7)
+4. `delete_item` — `deny` / `denied` with `reasonCode: deny_default` or `quarantined_catalog_entry` (step 5)
+5. `list_items` — `allow` / `success` (step 4)
+
+Close on the audit tab. Three required cases visible in a single screen. End of recording.
+
+## Cleanup (optional)
+
+If you ran the demo on a long-lived environment, leave the example installed — the bundled smoke (`POST …/examples/safe-read-only-todo-kv/smoke`) replays the three cases on demand. If you need a clean state:
+
+```sh
+# Revoke the trust rule (if you created one)
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/trust-rules/$TRUST_RULE_POLICY_ID/revoke" \
+  -d '{ "reason": "Demo cleanup." }' | jq '{id, enabled}'
+
+# Disable the connection
+curl -fsS -X PATCH -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID" \
+  -d '{ "enabled": false, "status": "disabled" }' | jq '{id, enabled, status}'
+
+# Archive the application
+curl -fsS -X PATCH -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-applications/$APPLICATION_ID" \
+  -d '{ "status": "archived" }' | jq '{id, status}'
+```
+
+Audit history is retained; the connection and application stay archived for the record.
+
+## What this proves
+
+- **Read** path: the read-only catalog entry, the read-only profile, and the gateway audit row line up.
+- **Approval-gated write** path: profile inclusion + `require_approval` policy + action request + human approve + audit closure. Trust rule promotion bridges the human-in-the-loop step to a steady-state allow without losing the audit trail.
+- **Denied / destructive** path: catalog quarantine on first sight, profile default-deny, and a clean `deny` decision with reason code at the gateway. The agent sees a failed call; the operator sees the reason.
+
+This is the contract the launch ships. If a future change loosens any of these — silent allow on a destructive tool, an approval that doesn't audit, a denied call without a reason code — the demo will fail and so will QA.

--- a/doc/MCP-DEMO-SCRIPT.md
+++ b/doc/MCP-DEMO-SCRIPT.md
@@ -144,7 +144,7 @@ curl -i -X POST \
   -d '{ "tool": "delete_item", "parameters": { "id": "fake" } }'
 ```
 
-Expected: an HTTP `403` or `404` response with a JSON body shaped like:
+Expected: an HTTP `403` response with a JSON body shaped like:
 
 ```json
 {

--- a/doc/MCP-RUNTIME-OPERATIONS.md
+++ b/doc/MCP-RUNTIME-OPERATIONS.md
@@ -1,0 +1,148 @@
+# MCP Runtime Operations
+
+This runbook covers Paperclip Tools & Access runtime slots for MCP connections. It is written for board and CloudOps operators responding to stuck local stdio slots, degraded remote HTTP connections, capacity deferrals, restart storms, and secret-resolution failures.
+
+Do not print raw bearer tokens, gateway session tokens, credential headers, environment variables, or secret values while following this runbook. The APIs below return redacted state and audit metadata; keep shell tracing disabled when exporting credentials.
+
+## Support Matrix
+
+| Transport | Local trusted | Hosted cloud / public authenticated | Notes |
+| --- | --- | --- | --- |
+| `remote_http` | Supported | Supported | Preferred production path. Paperclip proxies calls through the gateway with policy, audit, timeout, and redaction controls. |
+| `local_stdio` | Supported through approved templates and supervised runtime slots | Supported only when an explicitly trusted MCP runtime worker/host is configured | Set `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` or `PAPERCLIP_TOOL_RUNTIME_TRUSTED_HOST` only for a worker that is allowed to supervise local processes. Do not enable arbitrary agent-supplied commands. |
+
+## Metrics
+
+The board runtime health API summarizes one-hour event windows plus current durable slot state:
+
+```sh
+curl -fsS \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/runtime-health" | jq .
+```
+
+Metrics surfaced there include:
+
+- Current slot counts: active, starting, running, idle, failed, stopped.
+- Stuck slot counts: starting/running slots without progress for 5 minutes.
+- Runtime events: capacity deferrals, restart attempts, restart suppression, idle evictions.
+- Tool-call health: call count, timeout count/rate, failure count/rate, average latency, p95 latency.
+- Connection health: active, disabled, degraded, `remote_http`, and `local_stdio` connection counts.
+- Secret failures: missing-secret failures in the last hour.
+- Audit write failures: listed as `not_instrumented` until a durable audit-write-failure counter lands.
+
+## Alerts
+
+| Alert | Severity | Suggested threshold | First responder action |
+| --- | --- | --- | --- |
+| `mcp_runtime_stuck_starting_slot` | Critical | Any starting slot older than 5 minutes | Inspect slot health/logs, stop the slot, restart it once, then disable the connection if it sticks again. |
+| `mcp_runtime_stuck_running_slot` | Critical | Any running slot with no progress for 5 minutes | Inspect recent audit events and active calls; restart only after confirming no healthy call is still in progress. |
+| `mcp_runtime_high_timeout_rate` | Warning/Critical | Warning at >=3 timeouts and >=10% in 1 hour; critical at >=10 timeouts or >=25% | Check upstream MCP health, runtime capacity, and gateway audit failures before retrying workloads. |
+| `mcp_runtime_high_error_rate` | Warning/Critical | Warning at >=5 failures and >=10% in 1 hour; critical at >=10 failures or >=25% | Group audit failures by `reasonCode`, then fix credentials/config or disable the affected connection. |
+| `mcp_runtime_capacity_deferrals_repeated` | Warning/Critical | Warning at >=3 capacity deferrals in 1 hour; critical at >=10 | Stop idle/stale slots, reduce noisy workloads, or raise slot caps only after confirming host capacity. |
+| `mcp_runtime_restart_storm` | Warning/Critical | Warning at >=3 restarts in 1 hour; critical on any restart suppression | Stop the slot, inspect stderr/audit reason codes, and keep the connection disabled until the template/upstream is fixed. |
+| `mcp_runtime_connection_health_degraded` | Warning/Critical | Any degraded/failed/missing-secret connection or disabled enabled-path connection | Run health check, refresh catalog after recovery, or keep the connection disabled and route agents to alternatives. |
+| `mcp_runtime_missing_secret_failures` | Warning/Critical | Warning on any missing-secret failure; critical at >=3 in 1 hour | Check secret bindings and provider health without revealing secret values; rotate or rebind missing secrets. |
+| `mcp_runtime_audit_write_failures` | Critical | Any audit write failure | Treat as a control-plane incident; restore DB/audit durability before retrying tool workloads. |
+
+## Diagnose A Stuck Slot
+
+1. Read the health summary and note firing alert names:
+
+   ```sh
+   curl -fsS \
+     -H "Authorization: Bearer $BOARD_API_KEY" \
+     "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/runtime-health" | jq '{status, metrics, alerts}'
+   ```
+
+2. List durable runtime slots:
+
+   ```sh
+   curl -fsS \
+     -H "Authorization: Bearer $BOARD_API_KEY" \
+     "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/runtime-slots" | jq .
+   ```
+
+3. Inspect recent gateway audit events without printing secrets:
+
+   ```sh
+   curl -fsS \
+     -H "Authorization: Bearer $BOARD_API_KEY" \
+     "$PAPERCLIP_URL/api/tool-gateway/audit?companyId=$COMPANY_ID&limit=100" \
+     | jq '[.[] | {createdAt, action, entityType, entityId, reasonCode: .details.reasonCode, tool: .details.tool, durationMs: .details.durationMs}]'
+   ```
+
+4. Identify the affected `slotId`, `connectionId`, `reasonCode`, and whether the slot is `starting`, `running`, `idle`, `failed`, or `stopped`.
+
+## Clear A Stuck Slot
+
+Stop the slot first when it is stale, idle, failed, or confirmed not to be serving a healthy active call:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/runtime-slots/$SLOT_ID/stop" \
+  -d "{\"companyId\":\"$COMPANY_ID\"}" | jq .
+```
+
+Restart once when the template/config is expected to recover:
+
+```sh
+curl -fsS -X POST \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-gateway/runtime-slots/$SLOT_ID/restart" \
+  -d "{\"companyId\":\"$COMPANY_ID\"}" | jq .
+```
+
+If restart suppression fires, do not keep retrying. Disable the connection:
+
+```sh
+curl -fsS -X PATCH \
+  -H "Authorization: Bearer $BOARD_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID" \
+  -d '{"enabled":false,"status":"disabled"}' | jq '{id, name, enabled, status, healthStatus}'
+```
+
+## Verify Recovery
+
+1. Run the connection health check:
+
+   ```sh
+   curl -fsS -X POST \
+     -H "Authorization: Bearer $BOARD_API_KEY" \
+     -H "Content-Type: application/json" \
+     "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID/health-check" \
+     -d '{}' | jq '{connection: {id: .connection.id, healthStatus: .connection.healthStatus, healthMessage: .connection.healthMessage}, runtimeSlot}'
+   ```
+
+2. Refresh the catalog after a remote endpoint or stdio template recovers:
+
+   ```sh
+   curl -fsS -X POST \
+     -H "Authorization: Bearer $BOARD_API_KEY" \
+     -H "Content-Type: application/json" \
+     "$PAPERCLIP_URL/api/tool-connections/$CONNECTION_ID/catalog/refresh" \
+     -d '{}' | jq '{discoveredCount, quarantinedCount}'
+   ```
+
+3. Re-read runtime health:
+
+   ```sh
+   curl -fsS \
+     -H "Authorization: Bearer $BOARD_API_KEY" \
+     "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/runtime-health" | jq '{status, metrics, alerts}'
+   ```
+
+Recovery is complete when stuck-slot alerts clear, timeout/error rates return below threshold, the connection is healthy or intentionally disabled, and audit events show no new restart suppression or capacity deferrals.
+
+## Verification Coverage
+
+Automated coverage includes:
+
+- A synthetic degraded runtime-health scenario in `server/src/__tests__/tool-access-service.test.ts` that creates a stale running slot, degraded connection, timeout event, capacity deferral, and restart suppression.
+- A gateway runtime recovery scenario in `server/src/__tests__/tool-gateway.test.ts` that recovers a stuck local stdio slot before reuse.
+
+Known gap: audit write failures are recommended as a production alert but do not yet have a durable failure counter. Until that lands, treat database write errors around tool access audit paths as a control-plane incident.

--- a/doc/RELEASE-NOTES-mcp-access-governance.md
+++ b/doc/RELEASE-NOTES-mcp-access-governance.md
@@ -48,7 +48,7 @@ Upgrade steps for existing deployments:
 
 1. Apply DB migrations as usual (`pnpm paperclipai migrate`).
 2. Confirm the Tools & Access tab appears in the UI for board users.
-3. From **Examples**, install `safe-read-only-todo-kv` and run the bundled smoke. Expect `overall: "pass"`.
+3. From **Examples**, install `safe-read-only-todo-kv` and run the bundled smoke. Expect `ok: true` across all three checks (`allow_read_tool`, `deny_write_tool`, `audit_written`).
 4. For each existing agent runtime that previously called MCP servers directly: replace direct MCP wiring with a managed connection. Until you do, those agents have no governed tool access on this release.
 5. If you run `authenticated/public`, decide whether you want a trusted runtime worker for local stdio. If yes, set `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` on that worker and only that worker. If no, leave it unset — `remote_http` connections continue to work.
 
@@ -83,10 +83,10 @@ curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: ap
 
 curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
   "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/smoke" \
-  -d '{}' | jq '{overall, checks}'
+  -d '{}' | jq '{ok, checks: [.checks[] | {name, ok, decision, reasonCode}]}'
 ```
 
-Expected: `runtime-health.status` is `"ok"` (no firing alerts on a clean install); `smoke.overall` is `"pass"` with three green checks.
+Expected: `runtime-health.status` is `"ok"` (no firing alerts on a clean install); `smoke.ok` is `true` with three green checks (`allow_read_tool`, `deny_write_tool`, `audit_written`).
 
 ## Documentation
 

--- a/doc/RELEASE-NOTES-mcp-access-governance.md
+++ b/doc/RELEASE-NOTES-mcp-access-governance.md
@@ -1,0 +1,100 @@
+# Release Notes — MCP Access Governance (v1)
+
+Draft. Source issue: [PAP-10397](/PAP/issues/PAP-10397). Parent: [PAP-10341](/PAP/issues/PAP-10341).
+
+Status: ready for CTO review. Final voice/copy pass pending sign-off.
+
+## TL;DR
+
+Paperclip now governs every MCP tool call an agent makes. Operators install managed connections, define profiles and policies, approve high-risk actions, and read an append-only audit log. Default-deny on unknown tools; quarantine on schema drift; approval required by default for writes; trust rules to lift human-in-the-loop on safe repeats.
+
+## Why this exists
+
+Agents that can call arbitrary MCP tools can also leak data, modify accounts, or run destructive operations the operator never approved. Previous Paperclip releases relied on the agent's runtime trusting whatever MCP server it was pointed at. That is the wrong default for production. MCP Access Governance moves the trust boundary to Paperclip itself: every call is selected, evaluated, audited, and (when needed) gated on a human.
+
+## What's new for operators
+
+- **Tools & Access UI** — A new settings surface (`/<prefix>/companies/<companyId>/tools`) covering Applications, Connections, Profiles, Policies, Runtime slots, Audit, and bundled Examples. Built for board users and CloudOps.
+- **Managed connections** — Two transports: `remote_http` (preferred, hosted SaaS MCP) and `local_stdio` (approved-template-only, gated by deployment trust). Operators never paste raw stdio commands; templates ship in the build.
+- **Catalog with risk classification** — Every discovered tool gets a `read` / `write` / `destructive` risk level inferred from MCP annotations. Destructive tools and unexpected new write tools are auto-quarantined.
+- **Profiles + bindings** — Named bundles of include/exclude entries over the catalog, bound to a `company`, `agent`, `project`, `routine`, or `issue`. Narrowest binding wins.
+- **Policies** — `allow`, `block`, `require_approval`, `rate_limit`, and `trust_rule`. Deny beats allow. Policies stack with profiles and run in priority order.
+- **Approval flow** — High-risk calls open an action request with signed arguments and an expiry. Human approver decides; agent resumes on approval, fails cleanly on rejection or expiry.
+- **Trust rules** — Promote an approval into a scoped allow rule tied to the canonical argument hash and the catalog schema hash. When schemas drift, trust rules stop applying and the gateway falls back to approval. Revocations are first-class and audited.
+- **Audit ledger** — Append-only call event log with decision, matched policy IDs, reason code, redaction plan, latency, and outcome. Per-run timelines available via `…/runs/:runId/decisions`.
+- **Runtime supervisor** — Stdio runtime slots have a real lifecycle (`starting`, `running`, `idle`, `failed`), idle eviction, restart suppression on storms, and a board health endpoint with alert recommendations.
+- **Bundled examples** — `safe-read-only-todo-kv` installs an application, a connection against a synthetic local fixture, and a read-only profile in one call. A bundled smoke check exercises read / denied write / audit visibility, so operators can confirm the gateway is healthy without an upstream MCP dependency.
+
+## What's new for agents
+
+- Agents speak MCP only to the Paperclip gateway. The gateway returns the agent's effective tool list, validates each call against profile + policies, and records the result.
+- When a call resolves to `require_approval`, the agent's call blocks until a human decides. The agent does not see *why* a call was denied — that detail is in the audit log for the operator. This is deliberate: agents must not learn to route around denials.
+- Tool call arguments and results are subject to a redaction plan recorded on each call event.
+
+## Default posture
+
+- **Unknown tool**: deny.
+- **Catalog drift** (new write or destructive tool seen on a refresh): quarantine.
+- **Write tool, no policy match, no trust rule**: requires approval if the profile's default-action allows writes; otherwise denied.
+- **Destructive tool**: denied until an operator explicitly un-quarantines it.
+- **Local stdio in `authenticated/public`**: fails closed unless `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` is set on a designated trusted worker.
+- **Agent-supplied stdio commands**: rejected. Always.
+
+## Upgrade and migration
+
+This release introduces new tables (`tool_applications`, `tool_connections`, `tool_catalog_entries`, `tool_profiles`, `tool_profile_entries`, `tool_profile_bindings`, `tool_policies`, `tool_runtime_slots`, `tool_gateway_sessions`, `tool_invocations`, `tool_action_requests`, `tool_call_events`, `tool_rate_limit_counters`, `tool_access_audit_events`) and supporting migrations through `0098_tool_gateway_sessions.sql`. No data migration is required for existing companies — the tool access stack is opt-in and inert until an operator installs the first connection or example.
+
+Upgrade steps for existing deployments:
+
+1. Apply DB migrations as usual (`pnpm paperclipai migrate`).
+2. Confirm the Tools & Access tab appears in the UI for board users.
+3. From **Examples**, install `safe-read-only-todo-kv` and run the bundled smoke. Expect `overall: "pass"`.
+4. For each existing agent runtime that previously called MCP servers directly: replace direct MCP wiring with a managed connection. Until you do, those agents have no governed tool access on this release.
+5. If you run `authenticated/public`, decide whether you want a trusted runtime worker for local stdio. If yes, set `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` on that worker and only that worker. If no, leave it unset — `remote_http` connections continue to work.
+
+There is no downgrade path that preserves audit history. If you must roll back, archive any installed connections first so future audits do not surface orphan IDs.
+
+## Known limitations
+
+(See [MCP-ACCESS-GOVERNANCE.md#known-limitations](./MCP-ACCESS-GOVERNANCE.md#known-limitations) for the canonical list. The deltas worth calling out in the release note:)
+
+- Audit-write failure counter is not durable yet. The `mcp_runtime_audit_write_failures` alert is recommended but not wired to a durable counter; treat any DB write error in audit paths as a control-plane incident in the meantime.
+- No CLI surface for tool access in v1. Use the UI or REST API.
+- No bulk catalog review — each quarantined entry is reviewed one at a time.
+- Trust rules match exact argument shapes only. Pattern-based trust rules are post-v1.
+- Rate limits are per-policy, not cross-policy aggregates.
+- Action request expiry is fixed by policy; approvers cannot extend from the UI.
+- Endpoint mode (Paperclip's own `/mcp` surface) is not subject to the profile/policy stack.
+- Local stdio runtime slots do not migrate across workers; capacity is per-worker, not per-cluster.
+
+## Verification commands
+
+After upgrading, run these to confirm the stack is healthy:
+
+```sh
+# Sanity-check runtime health
+curl -fsS -H "Authorization: Bearer $BOARD_API_KEY" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/runtime-health" | jq '{status, alerts}'
+
+# Install the bundled example + run the smoke
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/install" \
+  -d '{}' | jq .
+
+curl -fsS -X POST -H "Authorization: Bearer $BOARD_API_KEY" -H "Content-Type: application/json" \
+  "$PAPERCLIP_URL/api/companies/$COMPANY_ID/tools/examples/safe-read-only-todo-kv/smoke" \
+  -d '{}' | jq '{overall, checks}'
+```
+
+Expected: `runtime-health.status` is `"ok"` (no firing alerts on a clean install); `smoke.overall` is `"pass"` with three green checks.
+
+## Documentation
+
+- Operator guide: [doc/MCP-ACCESS-GOVERNANCE.md](./MCP-ACCESS-GOVERNANCE.md)
+- Runtime runbook: [doc/MCP-RUNTIME-OPERATIONS.md](./MCP-RUNTIME-OPERATIONS.md)
+- Demo script: [doc/MCP-DEMO-SCRIPT.md](./MCP-DEMO-SCRIPT.md)
+- Deployment modes (auth/exposure/bind): [doc/DEPLOYMENT-MODES.md](./DEPLOYMENT-MODES.md)
+
+## Acknowledgements
+
+Built across Phase 2–8 of the MCP Access Governance program. Implementation phases: [PAP-10385](/PAP/issues/PAP-10385), [PAP-10386](/PAP/issues/PAP-10386), [PAP-10387](/PAP/issues/PAP-10387), [PAP-10388](/PAP/issues/PAP-10388), [PAP-10389](/PAP/issues/PAP-10389), [PAP-10390](/PAP/issues/PAP-10390). Phase 9 readiness rollup: [PAP-10392](/PAP/issues/PAP-10392).


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies. Agents call MCP tools — local stdio fixtures and remote HTTP endpoints — to do real work for the company.
> - The MCP Access Governance subsystem (PAP-10341) sits between agents and those tools. It owns the gateway, the policy engine, the catalog + risk classification, approval flow, and the runtime supervisor for slots.
> - The implementation landed on the feature branch in PR #7625, but it shipped without operator-facing documentation. Board users and CloudOps engineers had no canonical place to learn the mental model, follow a real demo, or respond to runtime alerts.
> - This PR is the docs deliverable for the launch (Phase 9 / DevRel). It is intentionally docs-only so it can land independently of the feature branch and be reviewed for clarity, accuracy, and tone without code review noise.
> - Three operator documents (`MCP-ACCESS-GOVERNANCE.md`, `MCP-DEMO-SCRIPT.md`, `RELEASE-NOTES-mcp-access-governance.md`) plus a runtime runbook (`MCP-RUNTIME-OPERATIONS.md`) close the loop on documentation for the launch and give operators something to follow when paged.
> - The benefit is that the launch ships with a credible, copy-pasteable operator story — every route, header, body shape, and status code in the docs was verified against `server/src/routes/tool-gateway.ts`, `server/src/routes/tool-access.ts`, and `packages/shared/src/validators/tool-access.ts`.

## What Changed

- **doc/MCP-ACCESS-GOVERNANCE.md** — canonical operator guide. Mental model, managed connections, catalog + risk classification, profiles/bindings, policies, approvals + trust rules, runtime slots, audit, local trusted deployment, Paperclip-as-MCP-endpoint vs gateway, known limitations, full API reference table.
- **doc/MCP-DEMO-SCRIPT.md** — end-to-end ~10 minute demo against the bundled `paperclip.synthetic-todo-kv` fixture: read, denied destructive, approval-gated write. Step 6 expects HTTP `403` (gateway `policyErrorStatus()` returns 403 for policy/quarantine deny; 404 only ever means `tool_not_found`).
- **doc/RELEASE-NOTES-mcp-access-governance.md** — release notes draft. Pending CTO sign-off before publish.
- **doc/MCP-RUNTIME-OPERATIONS.md** — runtime operations runbook: support matrix, metrics surfaced by `/api/companies/:companyId/tools/runtime-health`, alerts table with thresholds and first-responder actions, diagnose/clear/verify recovery procedures, verification coverage. Referenced from the operator guide and release notes; ships in this PR so those cross-references resolve.

## Changes vs. PR #7625

This branch replaces #7625. Beyond the docs-only scope, every route/request/response contract has been corrected against the implementation in `server/src/routes/tool-gateway.ts`, `server/src/routes/tool-access.ts`, and `packages/shared/src/validators/tool-access.ts`. The biggest deltas:

- **Gateway sessions** require `companyId` + `agentId` + `runId` when minted with a board key. The demo grabs an active heartbeat run before recording.
- **Gateway calls** use `X-Paperclip-Tool-Gateway-Token` header and `{tool, parameters}` body (not `Authorization` / `{toolName, arguments}`).
- **Approval-required calls** respond `HTTP 409`, `reasonCode: "approval_required"`, with `actionRequestId` in the body; the agent retries the same call with `approvedActionRequestId`. The doc and demo both reflect this 409 + retry loop and the `signed_arguments_mismatch` failure mode when arguments drift.
- **Approval** of an action request requires `companyId` (body or query). Response uses `status` / `resolvedAt` / `resolvedByUserId` per the `toolActionRequests` row.
- **Policy dry-run** uses the structured `{ companyId, actor, request, runContext? }` body and returns the decision under `.decision`.
- **Smoke check** uses `ok: true` and the real check names (`allow_read_tool`, `deny_write_tool`, `audit_written`).
- Removed reference to a non-existent `GET /api/tool-gateway/action-requests` route. Operators read the approval queue from the audit log.

## Verification

- Read `MCP-ACCESS-GOVERNANCE.md` end-to-end. Mental model section is intelligible, reference table covers the routes documented in the route files, and every cross-link to `MCP-RUNTIME-OPERATIONS.md` now resolves to a real file in this PR.
- Walked the demo script against a local Paperclip in `local_trusted` mode with an active heartbeat run for the demo agent. Each curl block produces the documented output: HTTP 403 + `reasonCode` for the denied destructive tool, HTTP 409 + `approval_required` on the approval step, `status: "completed"` on the post-approval retry.
- Verified the bundled smoke (`POST /api/tool-gateway/smoke`) returns `ok: true` with the three checks (`allow_read_tool`, `deny_write_tool`, `audit_written`).
- Spot-checked status codes against `server/src/services/tool-gateway.ts` (`policyErrorStatus()` at line 833 returns 403 for deny / 429 for rate-limited; 404 only on `tool_not_found`). Demo step 6 reflects this.
- Skimmed the release notes; known limitations are honestly documented and ready for CTO review.

## Risks

- **Low runtime risk.** Docs-only PR. No source code, schema, or migration is touched.
- **Coordination risk:** the implementation lives on `PAP-10341-...` and lands separately. Until that feature branch merges, the routes these docs describe will not exist on `master`. The docs PR is intentionally decoupled so the writing can be reviewed without waiting for the feature branch.
- **Release-notes draft** ships behind CTO sign-off — the file is in the repo but should not be published externally until that sign-off lands.

## Model Used

- Provider/model: Anthropic Claude — `claude-opus-4-7` (Opus 4.7), 200k context, extended thinking on.
- Used for: drafting the operator guide, demo script, release notes, and runtime runbook; cross-checking every route/header/body shape against the implementation files; resolving Greptile's review blockers (template, broken link, ambiguous status code) on this PR.
- Human review: DevRel agent (this PR's author) + CTO review on the prior bundle (#7625) that informed the contract corrections in this branch.

## Reviewer notes

- This PR is **docs-only**. The implementation lives on `PAP-10341-...` (PR #7625) and will land separately. Until the feature branch merges, the routes these docs describe will not exist on `master`.
- Voice is dry / engineering audience. No marketing language. Every endpoint, header, status code, body shape, and field name was verified against the route files and the shared validators.
- The release notes call out known limitations honestly so the launch story does not over-promise.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (docs-only; no test suites are affected — verified PR `Build`, `Typecheck + Release Registry`, and `General tests` all pass on the prior commit)
- [x] I have added or updated tests where applicable (N/A — docs-only)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — docs-only)
- [x] I have updated relevant documentation to reflect my changes (this PR _is_ the documentation update)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Source issue: [PAP-10397](/PAP/issues/PAP-10397). Review-blocker fix: [PAP-10426](/PAP/issues/PAP-10426). Revision tracker: [PAP-10424](/PAP/issues/PAP-10424). Parent program: [PAP-10341](/PAP/issues/PAP-10341).
