### PR TITLE
SAG-3089: Harden heartbeat Step 3 — failed API call must error, not 'no assignments'

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -42,6 +42,35 @@ Follow these steps every time you wake up:
 
 **Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
 
+**Connection failure is an error, not "no work":** You MUST distinguish a successful empty inbox (`200 OK`, `{"items":[]}`) from a connection failure (curl exit 7, HTTP 000, or any non-2xx status). Only `200 OK` with an empty items list means "nothing to do — exit cleanly." Any other result is an error and must be handled as such.
+
+When making control-plane calls via `curl` (applies to all local `opencode_local` / shell-dispatched agents):
+
+1. **Capture both the HTTP status and the curl exit code** — never rely on an empty response body alone to determine success.
+2. **On failure, retry once against the loopback fallback** (`http://127.0.0.1:${PAPERCLIP_LISTEN_PORT:-3100}`) before giving up. Co-located agents always have loopback available, even when the injected `$PAPERCLIP_API_URL` hostname is wrong or temporarily unreachable.
+3. **If the loopback retry also fails, do not exit cleanly.** Emit an error line to stderr and exit non-zero so the failure surfaces in the agent record. Never exit with `reason: stop` or log "no new assignments" when the API was unreachable.
+
+Reference pattern for curl-based callers:
+
+```bash
+LOOPBACK_URL="http://127.0.0.1:${PAPERCLIP_LISTEN_PORT:-3100}"
+for ENDPOINT in "$PAPERCLIP_API_URL" "$LOOPBACK_URL"; do
+  HTTP_STATUS=$(curl -s -o /tmp/pc_inbox.json -w "%{http_code}" \
+    -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+    "$ENDPOINT/api/agents/me/inbox-lite" 2>/dev/null)
+  CURL_EXIT=$?
+  if [ "$CURL_EXIT" -eq 0 ] && [[ "$HTTP_STATUS" == 2* ]]; then
+    break  # success — parse /tmp/pc_inbox.json normally
+  fi
+  echo "[paperclip] WARNING: inbox-lite failed at $ENDPOINT (exit=$CURL_EXIT, http=$HTTP_STATUS); trying fallback..." >&2
+  HTTP_STATUS="000"  # ensure outer check fails if loop exhausted
+done
+if [ "$CURL_EXIT" -ne 0 ] || [[ "$HTTP_STATUS" != 2* ]]; then
+  echo "[paperclip] ERROR: Paperclip API unreachable — tried $PAPERCLIP_API_URL and loopback fallback. exit=$CURL_EXIT http=$HTTP_STATUS" >&2
+  exit 1
+fi
+```
+
 **Step 4 — Pick work.** Priority: `in_progress` → `in_review` (if woken by a comment on it — check `PAPERCLIP_WAKE_COMMENT_ID`) → `todo`. Skip `blocked` unless you can unblock.
 
 Overrides and special cases:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local agents dispatched via the `opencode_local` adapter run their heartbeats by following the `paperclip` skill — specifically the "Step 3 — Get assignments" procedure, which tells them to call `GET /api/agents/me/inbox-lite`
> - When that call fails at the connection level (curl exit 7 / HTTP 000 / empty body), the agent has no instruction telling it the difference between a connection failure and a genuinely empty inbox
> - Without that distinction, agents silently interpret a failed call as "no new assignments" and exit cleanly with `reason: stop` — making an API-unreachability outage invisible in the agent record (root cause of SAG-3084 / Bookkeeper failure)
> - The fix belongs in the skill text, not in adapter code: the skill is the canonical "heartbeat procedure" consumed by all local agents regardless of which local model runs them
> - By adding error-classification rules and a loopback-fallback pattern to Step 3, every local agent that follows the skill will now (a) retry on loopback before giving up, and (b) exit non-zero with a visible error instead of a clean stop when the API is truly unreachable
> - The benefit: future API-reachability outages surface immediately as agent errors rather than appearing as "agent went dark while healthy"

## Linked Issues or Issue Description

Refs: SAG-3089 (internal Paperclip tracker)

Problem: `opencode_local` agents call `curl "$PAPERCLIP_API_URL/api/agents/me/inbox-lite"` in their heartbeat. When curl returns exit 7 (connection refused) or HTTP 000, the response body is empty. Without explicit error classification in the skill text, agents interpret the empty body as "no assignments" and exit cleanly — leaving the agent record showing `status=idle, error=None` during an actual API outage.

## What Changed

- `skills/paperclip/SKILL.md` — added a **Connection failure is an error, not "no work"** block immediately after the Step 3 inbox-lite line that:
  1. Explicitly distinguishes `200 OK + empty items` (genuine "no work") from non-2xx / exit 7 (connection failure)
  2. Instructs curl-based callers to capture HTTP status separately from the response body
  3. Specifies a one-retry loopback fallback (`http://127.0.0.1:${PAPERCLIP_LISTEN_PORT:-3100}`) before giving up — co-located runs always have loopback even when the injected hostname is wrong
  4. Requires a non-zero exit with a visible error line when both primary and fallback fail, instead of a clean `stop`
  5. Includes a reference curl pattern that implements all three steps

## Verification

Manual smoke test procedure:

1. Start a local Paperclip instance and launch a qwen3 / opencode_local agent heartbeat
2. Override `PAPERCLIP_API_URL` to an unreachable host (e.g. `http://does-not-exist.local:3100`)
3. Observe run log — expected: `[paperclip] WARNING: inbox-lite failed at ... trying fallback...` followed by either success on loopback or `[paperclip] ERROR: Paperclip API unreachable ...` + non-zero exit

Regression: run a heartbeat against a live API with an empty inbox — expected: clean exit, no error logged.

## Risks

Low. This is a skill-text (prompt instruction) change only — no TypeScript code paths modified. Existing agents that do not follow the curl pattern (e.g. Claude agents using HTTP tool calls) are unaffected since the block is labeled "applies to all local `opencode_local` / shell-dispatched agents." The worst-case failure mode for an agent that ignores the new instruction is the pre-existing silent clean exit — no regression.

## Model Used

- Provider: Anthropic
- Model ID: claude-sonnet-4-6
- Capabilities: tool use, code execution, file editing, extended context

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge