### PR TITLE
Reduce Paperclip prompt bootstrap overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,31 +7,36 @@ Guidance for human and AI contributors working in this repository.
 Paperclip is a control plane for AI-agent companies.
 The current implementation target is V1 and is defined in `doc/SPEC-implementation.md`.
 
-## 2. Read This First
+## 2. Read First
 
-Before making changes, read in this order:
+Read these before changing behavior:
 
 1. `doc/GOAL.md`
 2. `doc/PRODUCT.md`
 3. `doc/SPEC-implementation.md`
 4. `doc/DEVELOPING.md`
 5. `doc/DATABASE.md`
+6. `CONTRIBUTING.md`
 
-`doc/SPEC.md` is long-horizon product context.
-`doc/SPEC-implementation.md` is the concrete V1 build contract.
+`doc/SPEC.md` is long-horizon context. `doc/SPEC-implementation.md` is the current build contract.
 
 ## 3. Repo Map
 
-- `server/`: Express REST API and orchestration services
-- `ui/`: React + Vite board UI
-- `packages/db/`: Drizzle schema, migrations, DB clients
-- `packages/shared/`: shared types, constants, validators, API path constants
-- `packages/adapters/`: agent adapter implementations (Claude, Codex, Cursor, etc.)
-- `packages/adapter-utils/`: shared adapter utilities
-- `packages/plugins/`: plugin system packages
-- `doc/`: operational and product docs
+- `server/`: REST API, orchestration, issue/task logic, auth, runtime behavior
+- `ui/`: board UI, routes, components, client behavior
+- `cli/`: CLI commands and operator workflows
+- `packages/db/`: schema, migrations, DB clients
+- `packages/shared/`: shared types, constants, validators, API paths
+- `packages/adapters/`: adapter implementations
+- `packages/adapter-utils/`: shared adapter/runtime utilities
+- `packages/plugins/`: plugin runtime and bundled plugins
+- `packages/skills-catalog/`: bundled skill packaging
+- `tests/e2e/`, `tests/release-smoke/`: browser coverage
+- `doc/`: product, release, and operator docs
 
-## 4. Dev Setup (Auto DB)
+When behavior crosses layers, update every affected contract in the same change.
+
+## 4. Dev Setup
 
 Use embedded PGlite in dev by leaving `DATABASE_URL` unset.
 
@@ -39,11 +44,6 @@ Use embedded PGlite in dev by leaving `DATABASE_URL` unset.
 pnpm install
 pnpm dev
 ```
-
-This starts:
-
-- API: `http://localhost:3100`
-- UI: `http://localhost:3100` (served by API server in dev middleware mode)
 
 Quick checks:
 
@@ -59,40 +59,83 @@ rm -rf data/pglite
 pnpm dev
 ```
 
-## 5. Core Engineering Rules
+## 5. Core Rules
 
 1. Keep changes company-scoped.
-Every domain entity should be scoped to a company and company boundaries must be enforced in routes/services.
+Every domain entity must respect company boundaries.
 
 2. Keep contracts synchronized.
-If you change schema/API behavior, update all impacted layers:
-- `packages/db` schema and exports
-- `packages/shared` types/constants/validators
-- `server` routes/services
-- `ui` API clients and pages
+If schema or API behavior changes, update the impacted `packages/db`, `packages/shared`, `server`, and `ui` layers together.
 
 3. Preserve control-plane invariants.
-- Single-assignee task model
-- Atomic issue checkout semantics
-- Approval gates for governed actions
-- Budget hard-stop auto-pause behavior
-- Activity logging for mutating actions
+- single-assignee task model
+- atomic issue checkout semantics
+- approval gates for governed actions
+- budget hard-stop auto-pause behavior
+- activity logging for mutating actions
 
-4. Do not replace strategic docs wholesale unless asked.
-Prefer additive updates. Keep `doc/SPEC.md` and `doc/SPEC-implementation.md` aligned.
+4. Prefer additive docs changes unless asked otherwise.
+Keep `doc/SPEC.md` and `doc/SPEC-implementation.md` aligned.
 
-5. Keep repo plan docs dated and centralized.
-When you are creating a plan file in the repository itself, new plan documents belong in `doc/plans/` and should use `YYYY-MM-DD-slug.md` filenames. This does not replace Paperclip issue planning: if a Paperclip issue asks for a plan, update the issue `plan` document per the `paperclip` skill instead of creating a repo markdown file.
+5. Keep repo plans in `doc/plans/` with `YYYY-MM-DD-slug.md` filenames.
+If a Paperclip issue asks for a plan, update the issue `plan` document instead of adding a repo markdown file.
 
-6. Attach inspectable generated artifacts.
-When your task produces a user-inspectable file, follow the Paperclip skill's "Generated Artifacts and Work Products" workflow before final disposition. In this repo, prefer the self-contained skill helper at `skills/paperclip/scripts/paperclip-upload-artifact.sh` so the file is available through the Paperclip API, create/update an artifact work product when the file is the deliverable, link the uploaded artifact in the final issue comment, and then set status. Do not rely on local filesystem paths as the only access path. See `doc/AGENT-ARTIFACTS.md` for `.mp4` and `.webm` examples.
+6. Upload inspectable artifacts before final disposition.
+In this repo prefer `skills/paperclip/scripts/paperclip-upload-artifact.sh`, create/update the artifact work product when the file is the deliverable, and link the uploaded artifact in the final issue comment. See `doc/AGENT-ARTIFACTS.md` for examples.
 
-## 6. Database Change Workflow
+## 6. Verification
 
-When changing data model:
+Start with the smallest command that proves the changed surface:
+
+- Docs or instruction-only change: verify links, commands, and references manually.
+- Single Vitest-covered change: run the narrowest relevant test file.
+- Server-only TypeScript change: `pnpm --filter @paperclipai/server typecheck`
+- UI-only TypeScript change: `pnpm --filter @paperclipai/ui typecheck`
+- Single package change: package typecheck plus the narrowest related test
+- Cross-package contract change: `pnpm typecheck` plus targeted Vitest coverage
+
+Broader checks when warranted:
+
+```sh
+pnpm test
+pnpm typecheck
+pnpm build
+```
+
+Repo specifics:
+
+- `pnpm test` is the cheap default and runs Vitest via `scripts/run-vitest-stable.mjs`.
+- Browser suites are opt-in: `pnpm test:e2e`, `pnpm test:release-smoke`.
+- If workspace wiring changes, let the normal commands run `preflight:workspace-links`.
+- For PR-ready handoff or broad refactors, run `pnpm typecheck`, `pnpm test:run`, and `pnpm build`.
+
+If you skip a relevant check, say exactly what was not run and why.
+
+## 7. Git Workflow
+
+- Keep each branch or issue checkout focused on one logical change.
+- Prefer a non-main branch and an isolated workspace or worktree.
+- Push the branch before claiming task completion so reviewers can inspect durable remote state.
+- When implementation is ready, create or update a `pull_request` work product on the issue and move review/merge onto an explicit review path.
+- Repo task work is not done until the PR path is closed and the branch is merged back to base.
+- Prefer linked worktrees or Paperclip-managed execution workspaces for parallel work.
+- Do not commit `pnpm-lock.yaml` in pull requests. GitHub Actions owns lockfile regeneration here.
+- If you touch release, CI, or package publishing, read the matching docs first.
+- Before opening a PR, use [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) exactly as written.
+
+## 8. Ownership Lenses
+
+- API/orchestration: `server/`, issue lifecycle, approvals, auth, workspace/runtime logic
+- UI: `ui/`, user flows, components, visual regressions
+- CLI/operator workflow: `cli/`, plus `doc/CLI.md` and `doc/DEVELOPING.md`
+- Data contracts: `packages/shared/` and `packages/db/`, with follow-through into `server/` and `ui/`
+- Plugin/adapter: `packages/adapters/`, `packages/adapter-utils/`, `packages/plugins/`
+- Docs/process: root docs, repo instructions, release/process docs
+
+## 9. Database Changes
 
 1. Edit `packages/db/src/schema/*.ts`
-2. Ensure new tables are exported from `packages/db/src/schema/index.ts`
+2. Ensure exports from `packages/db/src/schema/index.ts`
 3. Generate migration:
 
 ```sh
@@ -106,29 +149,28 @@ pnpm -r typecheck
 ```
 
 Notes:
+
 - `packages/db/drizzle.config.ts` reads compiled schema from `dist/schema/*.js`
 - `pnpm db:generate` compiles `packages/db` first
 
-## 7. Verification Before Hand-off
+## 10. Hand-off Checks
 
-Default local/agent test path:
+Cheap default:
 
 ```sh
 pnpm test
 ```
 
-This is the cheap default and only runs the Vitest suite. Browser suites stay opt-in:
+Browser suites stay opt-in:
 
 ```sh
 pnpm test:e2e
 pnpm test:release-smoke
 ```
 
-Run the browser suites only when your change touches them or when you are explicitly verifying CI/release flows.
+Run the browser suites only when the change touches them or when explicitly verifying CI/release flows.
 
-For normal issue work, run the smallest relevant verification first. Do not default to repo-wide typecheck/build/test on every heartbeat when a narrower check is enough to prove the change.
-
-Run this full check before claiming repo work done in a PR-ready hand-off, or when the change scope is broad enough that targeted checks are not sufficient:
+Full check before PR-ready handoff or broad changes:
 
 ```sh
 pnpm -r typecheck
@@ -136,86 +178,42 @@ pnpm test:run
 pnpm build
 ```
 
-If anything cannot be run, explicitly report what was not run and why.
+## 11. API and UI Expectations
 
-## 8. API and Auth Expectations
+- Base path is `/api`.
+- Board access is full-control operator context.
+- Agent access uses bearer API keys (`agent_api_keys`), hashed at rest.
+- Agent keys must not access other companies.
+- New endpoints must enforce company access, actor permissions, mutation logging, and consistent HTTP errors.
+- Keep routes and nav aligned with available API surface.
+- Use company selection context on company-scoped pages.
+- Surface failures clearly; do not silently ignore API errors.
 
-- Base path: `/api`
-- Board access is treated as full-control operator context
-- Agent access uses bearer API keys (`agent_api_keys`), hashed at rest
-- Agent keys must not access other companies
+## 12. Pull Request Requirements
 
-When adding endpoints:
+Every PR must follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) exactly, including:
 
-- apply company access checks
-- enforce actor permissions (board vs agent)
-- write activity log entries for mutations
-- return consistent HTTP errors (`400/401/403/404/409/422/500`)
+- `Thinking Path`
+- `What Changed`
+- `Verification`
+- `Risks`
+- `Model Used`
+- `Checklist`
 
-## 9. UI Expectations
+## 13. Definition of Done
 
-- Keep routes and nav aligned with available API surface
-- Use company selection context for company-scoped pages
-- Surface failures clearly; do not silently ignore API errors
+Done means all are true:
 
-## 10. Pull Request Requirements
+1. Behavior matches `doc/SPEC-implementation.md`.
+2. Typecheck, tests, and build pass at the right scope.
+3. Contracts are synced across db/shared/server/ui when relevant.
+4. Docs are updated when behavior or commands change.
+5. The PR description follows the required template.
 
-When creating a pull request (via `gh pr create` or any other method), you **must** read and fill in every section of [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Do not craft ad-hoc PR bodies — use the template as the structure for your PR description. Required sections:
+## 14. Fork-Specific: HenkDz/paperclip
 
-- **Thinking Path** — trace reasoning from project context to this change (see `CONTRIBUTING.md` for examples)
-- **What Changed** — bullet list of concrete changes
-- **Verification** — how a reviewer can confirm it works
-- **Risks** — what could go wrong
-- **Model Used** — the AI model that produced or assisted with the change (provider, exact model ID, context window, capabilities). Write "None — human-authored" if no AI was used.
-- **Checklist** — all items checked
+This fork externalizes the Hermes adapter on branch `feat/externalize-hermes-adapter`.
 
-## 11. Definition of Done
-
-A change is done when all are true:
-
-1. Behavior matches `doc/SPEC-implementation.md`
-2. Typecheck, tests, and build pass
-3. Contracts are synced across db/shared/server/ui
-4. Docs updated when behavior or commands change
-5. PR description follows the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with all sections filled in (including Model Used)
-
-## 11. Fork-Specific: HenkDz/paperclip
-
-This is a fork of `paperclipai/paperclip` with QoL patches and an **external-only** Hermes adapter story on branch `feat/externalize-hermes-adapter` ([tree](https://github.com/HenkDz/paperclip/tree/feat/externalize-hermes-adapter)).
-
-### Branch Strategy
-
-- `feat/externalize-hermes-adapter` → core has **no** `hermes-paperclip-adapter` dependency and **no** built-in `hermes_local` registration. Install Hermes via the Adapter Plugin manager (`@henkey/hermes-paperclip-adapter` or a `file:` path).
-- Older fork branches may still document built-in Hermes; treat this file as authoritative for the externalize branch.
-
-### Hermes (plugin only)
-
-- Register through **Board → Adapter manager** (same as Droid). Type remains `hermes_local` once the package is loaded.
-- UI uses generic **config-schema** + **ui-parser.js** from the package — no Hermes imports in `server/` or `ui/` source.
-- Optional: `file:` entry in `~/.paperclip/adapter-plugins.json` for local dev of the adapter repo.
-
-### Local Dev
-
-- Fork runs on port 3101+ (auto-detects if 3100 is taken by upstream instance)
-- `npx vite build` hangs on NTFS — use `node node_modules/vite/bin/vite.js build` instead
-- Server startup from NTFS takes 30-60s — don't assume failure immediately
-- Kill ALL paperclip processes before starting: `pkill -f "paperclip"; pkill -f "tsx.*index.ts"`
-- Vite cache survives `rm -rf dist` — delete both: `rm -rf ui/dist ui/node_modules/.vite`
-
-### Fork QoL Patches (not in upstream)
-
-These are local modifications in the fork's UI. If re-copying source, these must be re-applied:
-
-1. **stderr_group** — amber accordion for MCP init noise in `RunTranscriptView.tsx`
-2. **tool_group** — accordion for consecutive non-terminal tools (write, read, search, browser)
-3. **Dashboard excerpt** — `LatestRunCard` strips markdown, shows first 3 lines/280 chars
-
-### Plugin System
-
-PR #2218 (`feat/external-adapter-phase1`) adds external adapter support. See root `AGENTS.md` for full details.
-
-- Adapters can be loaded as external plugins via `~/.paperclip/adapter-plugins.json`
-- The plugin-loader should have ZERO hardcoded adapter imports — pure dynamic loading
-- `createServerAdapter()` must include ALL optional fields (especially `detectModel`)
-- Built-in UI adapters can shadow external plugin parsers — remove built-in when fully externalizing
-- Reference external adapters: Hermes (`@henkey/hermes-paperclip-adapter` or `file:`) and Droid (npm)
+- Core should not depend on `hermes-paperclip-adapter`.
+- Register Hermes through the Adapter Plugin manager.
+- UI should use the package's config-schema and `ui-parser.js`, not source imports from `server/` or `ui/`.

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -639,10 +639,52 @@ describe("renderPaperclipWakePrompt", () => {
 
     expect(prompt).toContain("## Paperclip Wake Payload");
     expect(prompt).toContain("Execution contract: take concrete action in this heartbeat");
-    expect(prompt).toContain("clear final disposition");
-    expect(prompt).toContain("evidence, not valid liveness paths by themselves");
-    expect(prompt).toContain("Use child issues for long or parallel delegated work instead of polling");
-    expect(prompt).toContain("named unblock owner/action");
+    expect(prompt).toContain("finish in `done`, `in_review`, or `blocked`");
+    expect(prompt).toContain("keep `in_progress` only with a real continuation path");
+    expect(prompt).toContain("evidence, not liveness");
+    expect(prompt).toContain("Use child issues instead of polling");
+  });
+
+  it("only requires comment acknowledgement when wake comments are bundled", () => {
+    const assignmentPrompt = renderPaperclipWakePrompt({
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1580",
+        title: "Update prompts",
+        status: "in_progress",
+      },
+      commentWindow: {
+        requestedCount: 0,
+        includedCount: 0,
+        missingCount: 0,
+      },
+      comments: [],
+      fallbackFetchNeeded: false,
+    });
+
+    expect(assignmentPrompt).not.toContain("acknowledge the latest comment");
+
+    const commentPrompt = renderPaperclipWakePrompt({
+      reason: "issue_commented",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1580",
+        title: "Update prompts",
+        status: "in_progress",
+      },
+      commentIds: ["comment-1"],
+      latestCommentId: "comment-1",
+      commentWindow: {
+        requestedCount: 1,
+        includedCount: 1,
+        missingCount: 0,
+      },
+      comments: [{ id: "comment-1", body: "Please revise the prompt." }],
+      fallbackFetchNeeded: false,
+    });
+
+    expect(commentPrompt).toContain("acknowledge the latest comment");
   });
 
   it("preserves Chinese, Japanese, and Hindi issue and comment text in scoped wake prompts", () => {
@@ -724,6 +766,30 @@ describe("renderPaperclipWakePrompt", () => {
     });
 
     expect(commentPrompt).toContain("Update the plan only. Do not write code or perform implementation work.");
+  });
+
+  it("renders the proactive execution standard for assignment and resumed wakes", () => {
+    const payload = {
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1221",
+        title: "Clarify ambiguous bug",
+        status: "in_progress",
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+    };
+
+    const assignmentPrompt = renderPaperclipWakePrompt(payload);
+    expect(assignmentPrompt).toContain("Proactive execution standard:");
+    expect(assignmentPrompt).toContain("record the missing assumption or success condition in your first issue comment");
+    expect(assignmentPrompt).toContain("create the child issue or issue-thread interaction before you exit");
+
+    const resumedPrompt = renderPaperclipWakePrompt(payload, { resumedSession: true });
+    expect(resumedPrompt).toContain("## Paperclip Resume Delta");
+    expect(resumedPrompt).toContain("Proactive execution standard:");
   });
 
   it("does not render stale accepted-plan continuation guidance for later planning comment wakes", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -115,19 +115,20 @@ export const DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE = [
   "",
   "Execution contract:",
   "- Start actionable work in this heartbeat; do not stop at a plan unless the issue asks for planning.",
-  "- Leave durable progress in comments, documents, or work products, then update the issue to a clear final disposition before ending the heartbeat.",
   "- Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
-  "- Final disposition checklist: mark `done` when complete; use `in_review` only with a real reviewer, approval, interaction, or monitor path; use `blocked` only with first-class blockers or a named unblock owner/action; create delegated follow-up issues with blockers when another agent owns the next step; keep `in_progress` only when a live continuation path exists.",
+  "- Leave durable progress and end the heartbeat in a clear final disposition: `done` when complete, `in_review` only with a real reviewer or waiting path, `blocked` only with a named unblock owner/action, and keep `in_progress` only when a live continuation path exists.",
   "- Prefer the smallest verification that proves the change; do not default to full workspace typecheck/build/test on every heartbeat unless the task scope warrants it.",
   "- Use child issues for parallel or long delegated work instead of polling agents, sessions, or processes.",
   "- If woken by a human comment on a dependency-blocked issue, respond or triage the comment without treating the blocked deliverable work as unblocked.",
-  "- Create child issues directly when you know what needs to be done; use issue-thread interactions when the board/user must choose suggested tasks, answer structured questions, or confirm a proposal.",
-  "- To ask for that input, create an interaction on the current issue with POST /api/issues/{issueId}/interactions using kind suggest_tasks, ask_user_questions, or request_confirmation. Use continuationPolicy wake_assignee when you need to resume after a response; for request_confirmation this resumes only after acceptance.",
-  "- When you intentionally restart follow-up work on a completed assigned issue, include structured `resume: true` with the POST /api/issues/{issueId}/comments or PATCH /api/issues/{issueId} comment payload. Generic agent comments on closed issues are inert by default.",
-  "- For plan approval, update the plan document first, then create request_confirmation targeting the latest plan revision with idempotencyKey confirmation:{issueId}:plan:{revisionId}. Wait for acceptance before creating implementation subtasks, and create a fresh confirmation after superseding board/user comments if approval is still needed.",
+  "- Create child issues directly when you know what needs to be done. Otherwise use POST /api/issues/{issueId}/interactions with kind suggest_tasks, ask_user_questions, or request_confirmation; use continuationPolicy wake_assignee when you need to resume after a response.",
+  "- When you intentionally restart follow-up work on a completed assigned issue, include structured `resume: true` with the POST /api/issues/{issueId}/comments or PATCH /api/issues/{issueId} comment payload.",
+  "- For plan approval, update the plan document first, then create request_confirmation targeting the latest plan revision with idempotencyKey confirmation:{issueId}:plan:{revisionId}. Wait for acceptance before creating implementation subtasks.",
   "- If blocked, mark the issue blocked and name the unblock owner and action.",
   "- Respect budget, pause/cancel, approval gates, and company boundaries.",
 ].join("\n");
+
+const SCOPED_WAKE_EXECUTION_CONTRACT =
+  "Execution contract: take concrete action in this heartbeat when the issue is actionable; leave durable progress; finish in `done`, `in_review`, or `blocked`, and keep `in_progress` only with a real continuation path. Use child issues instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not liveness.";
 
 export interface PaperclipSkillEntry {
   key: string;
@@ -678,6 +679,7 @@ export function renderPaperclipWakePrompt(
   if (!normalized) return "";
   const resumedSession = options.resumedSession === true;
   const executionStage = normalized.executionStage;
+  const hasWakeComments = normalized.comments.length > 0;
   const principalLabel = (principal: PaperclipWakeExecutionPrincipal | null) => {
     if (!principal || !principal.type) return "unknown";
     if (principal.type === "agent") return principal.agentId ? `agent ${principal.agentId}` : "agent";
@@ -692,8 +694,9 @@ export function renderPaperclipWakePrompt(
         "This heartbeat is scoped to the issue below. Do not switch to another issue until you have handled this wake.",
         "Focus on the new wake delta below and continue the current task without restating the full heartbeat boilerplate.",
         "Fetch the API thread only when `fallbackFetchNeeded` is true or you need broader history than this batch.",
+        "Proactive execution standard: if the task is underspecified, record the missing assumption or success condition in your first issue comment and take the safest concrete next step. If you discover follow-up work outside the current scope, create the child issue or issue-thread interaction before you exit instead of leaving only a passive note.",
         "",
-        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists. Use child issues for long or parallel delegated work instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
+        SCOPED_WAKE_EXECUTION_CONTRACT,
         "",
         `- reason: ${normalized.reason ?? "unknown"}`,
         `- issue: ${normalized.issue?.identifier ?? normalized.issue?.id ?? "unknown"}${normalized.issue?.title ? ` ${normalized.issue.title}` : ""}`,
@@ -705,12 +708,11 @@ export function renderPaperclipWakePrompt(
         "## Paperclip Wake Payload",
         "",
         "Treat this wake payload as the highest-priority change for the current heartbeat.",
-        "This heartbeat is scoped to the issue below. Do not switch to another issue until you have handled this wake.",
-        "Before generic repo exploration or boilerplate heartbeat updates, acknowledge the latest comment and explain how it changes your next action.",
-        "Use this inline wake data first before refetching the issue thread.",
+        "This heartbeat is scoped to the issue below. Use this inline wake data first and do not switch issues until you have handled it.",
         "Only fetch the API thread when `fallbackFetchNeeded` is true or you need broader history than this batch.",
+        "Proactive execution standard: if the task is underspecified, record the missing assumption or success condition in your first issue comment and take the safest concrete next step. If you discover follow-up work outside the current scope, create the child issue or issue-thread interaction before you exit instead of leaving only a passive note.",
         "",
-        "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists. Use child issues for long or parallel delegated work instead of polling. Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
+        SCOPED_WAKE_EXECUTION_CONTRACT,
         "",
         `- reason: ${normalized.reason ?? "unknown"}`,
         `- issue: ${normalized.issue?.identifier ?? normalized.issue?.id ?? "unknown"}${normalized.issue?.title ? ` ${normalized.issue.title}` : ""}`,
@@ -718,6 +720,14 @@ export function renderPaperclipWakePrompt(
         `- latest comment id: ${normalized.latestCommentId ?? "unknown"}`,
         `- fallback fetch needed: ${normalized.fallbackFetchNeeded ? "yes" : "no"}`,
       ];
+
+  if (!resumedSession && hasWakeComments) {
+    lines.splice(
+      4,
+      0,
+      "Before generic repo exploration or boilerplate heartbeat updates, acknowledge the latest comment and explain how it changes your next action.",
+    );
+  }
 
   if (normalized.issue?.status) {
     lines.push(`- issue status: ${normalized.issue.status}`);
@@ -729,7 +739,6 @@ export function renderPaperclipWakePrompt(
     lines.push(`- issue priority: ${normalized.issue.priority}`);
   }
   if (normalized.issue?.workMode === "planning") {
-    const hasWakeComments = normalized.comments.length > 0;
     const acceptedPlanContinuation =
       !hasWakeComments &&
       normalized.interactionKind === "request_confirmation" && normalized.interactionStatus === "accepted";

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -681,7 +681,7 @@ describe.sequential("agent skill routes", () => {
           adapterType: "claude_local",
         }),
         expect.objectContaining({
-          "AGENTS.md": expect.stringMatching(/Start actionable work in the same heartbeat\.[\s\S]*Keep the work moving until it is done\./),
+          "AGENTS.md": expect.stringMatching(/## Wake Checklist[\s\S]*Start actionable work in the same heartbeat\.[\s\S]*Keep the work moving until it is done\./),
         }),
         { entryFile: "AGENTS.md", replaceExisting: false },
       );
@@ -696,6 +696,20 @@ describe.sequential("agent skill routes", () => {
         expect.any(Object),
         expect.objectContaining({
           "AGENTS.md": expect.stringContaining("confirmation:{issueId}:plan:{revisionId}"),
+        }),
+        expect.any(Object),
+      );
+      expect(mockAgentInstructionsService.materializeManagedBundle).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          "AGENTS.md": expect.stringContaining("para-memory-files"),
+        }),
+        expect.any(Object),
+      );
+      expect(mockAgentInstructionsService.materializeManagedBundle).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          "AGENTS.md": expect.stringContaining("turning ambiguous requests into the next concrete owned action"),
         }),
         expect.any(Object),
       );

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -1,17 +1,33 @@
 You are an agent at Paperclip company.
 
+## Wake Checklist
+
+- If the wake payload or latest comment names a specific issue, treat that issue as the top priority before broader inbox scans.
+- Read the latest wake reason, comment, or interaction context first, and say how it changes your next action in your first task update.
+- Confirm the issue has a real path before you exit: active execution, explicit review, named blocker, pending interaction, or another continuation that will wake the assignee later.
+- State the current success condition and next concrete action in your first task comment if the issue does not already make them explicit.
+- For API mechanics, follow the installed Paperclip skill. For durable notes, plans, or memory, use `para-memory-files` instead of inventing side workflows.
+
+## Proactive Standard
+
+- Proactive execution means turning ambiguous requests into the next concrete owned action instead of waiting for another wake.
+- If the task is underspecified, state the missing assumption or success condition in your first task comment and proceed with the safest concrete step.
+- If you discover adjacent work that does not fit in the current issue, create the child issue or issue-thread interaction before you exit instead of leaving only a passive note.
+- Request QA, review, or approval as soon as the work reaches that boundary; do not wait for another heartbeat just to ask.
+
 ## Execution Contract
 
 - Start actionable work in the same heartbeat. Do not stop at a plan unless the issue explicitly asks for planning.
 - Keep the work moving until it is done. If you need QA to review it, ask them. If you need your boss to review it, ask them.
+- If you changed behavior that another specialist should verify, route to that reviewer before marking the issue `done`. For user-visible code changes, prefer an independent QA pass when a QA path exists.
 - Leave durable progress in task comments, documents, or work products, then update the issue to a clear final disposition before you exit.
-- When your work produces a user-inspectable file, follow the Paperclip skill's "Generated Artifacts and Work Products" workflow before final disposition. Use `skills/paperclip/scripts/paperclip-upload-artifact.sh` when working in this repo, create/update an artifact work product when the file is the deliverable, and link the uploaded attachment in the final comment. Do not rely on local filesystem paths as the only access path.
+- When your work produces a user-inspectable file, follow the Paperclip artifact workflow before final disposition. In this repo use `skills/paperclip/scripts/paperclip-upload-artifact.sh`, create/update the artifact work product when the file is the deliverable, and link the uploaded attachment in the final comment.
 - Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.
 - Final disposition checklist: mark `done` when complete and verified; use `in_review` only with a real reviewer, approval, interaction, or monitor path; use `blocked` only with first-class blockers or a named unblock owner/action; create delegated follow-up issues with blockers when another agent owns the next step; keep `in_progress` only when a live continuation path exists.
 - Use child issues for parallel or long delegated work instead of polling agents, sessions, or processes.
 - Create child issues directly when you know what needs to be done. If the board/user needs to choose suggested tasks, answer structured questions, or confirm a proposal first, create an issue-thread interaction on the current issue with `POST /api/issues/{issueId}/interactions` using `kind: "suggest_tasks"`, `kind: "ask_user_questions"`, or `kind: "request_confirmation"`.
-- Use `request_confirmation` instead of asking for yes/no decisions in markdown. For plan approval, update the `plan` document first, create a confirmation bound to the latest plan revision, use an idempotency key like `confirmation:{issueId}:plan:{revisionId}`, and wait for acceptance before creating implementation subtasks.
-- Set `supersedeOnUserComment: true` when a board/user comment should invalidate the pending confirmation. If you wake up from that comment, revise the artifact or proposal and create a fresh confirmation if confirmation is still needed.
+- Use `request_confirmation` instead of asking for yes/no decisions in markdown. For plan approval, update the `plan` document first, create the confirmation with `confirmation:{issueId}:plan:{revisionId}`, and wait for acceptance before creating implementation subtasks.
+- If a new board/user comment should invalidate a pending confirmation, set `supersedeOnUserComment: true` and create a fresh confirmation after revising the proposal.
 - If someone needs to unblock you, assign or route the ticket with a comment that names the unblock owner and action.
 - Respect budget, pause/cancel, approval gates, and company boundaries.
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane used to run AI-agent companies through repeated heartbeat-style execution.
> - The most repeated cost in that model is instruction/bootstrap text that gets re-sent on every run before any task-specific work begins.
> - The prompt/bootstrap layer for local agents lives in the repo-level `AGENTS.md`, the adapter-level fallback prompt, the scoped wake preamble, and the default managed agent bundle.
> - API-72 exists because those repeated instruction surfaces were materially inflating token usage without adding equivalent execution value.
> - The lowest-risk way to reduce spend here is to compress repeated wording while preserving the same execution invariants around ownership, blockers, review paths, and verification.
> - This pull request trims those repeated prompt surfaces and updates the focused tests that assert the wake contract and default agent bundle content.
> - The benefit is lower recurring token overhead on Paperclip heartbeats, especially in the Paperclip repo itself where Codex auto-applies the repo `AGENTS.md` on every run.

## Linked Issues or Issue Description

- No public GitHub issue was linked for this internal Paperclip task.
- Problem: repeated bootstrap and wake boilerplate in Paperclip agent instruction surfaces was consuming avoidable tokens on every heartbeat.
- Scope: tightly scoped prompt and test compaction only; no workflow ownership, approval, blocker, or verification semantics were intentionally removed.

## What Changed

- Compressed the repo-level `AGENTS.md` so Codex picks up a materially smaller repo bootstrap in the Paperclip codebase.
- Compressed `DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE` in `packages/adapter-utils/src/server-utils.ts` while preserving the required execution contract and planning/interaction rules.
- Reused a shared scoped wake execution-contract string inside `renderPaperclipWakePrompt()` to remove repeated wake boilerplate.
- Trimmed `server/src/onboarding-assets/default/AGENTS.md` while preserving the explicit `para-memory-files` and review/confirmation guidance expected by the hire flow.
- Updated focused tests for the new wake-contract wording and the default bundled-agent instruction content.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts`
- `pnpm exec vitest run server/src/__tests__/agent-skills-routes.test.ts`

## Risks

- Low risk. The main risk is prompt wording drift changing agent behavior subtly despite preserved semantics.
- The focused tests were updated and rerun to reduce that risk, but broader behavior still depends on model interpretation of the compressed wording.

> I checked `ROADMAP.md`; this is scoped prompt-cost and instruction polish work, not overlapping roadmap-level core feature delivery.

## Model Used

- OpenAI Codex via Paperclip `codex_local`
- Model family used in the surrounding execution context: GPT-5 class Codex runtime with tool use and code execution
- Mode: local coding agent with shell, patching, and HTTP/API tool access

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
