### PR TITLE
feat(recovery): Contract B — sweep active recoveries with out-of-band dispositions

### DIFF
--- a/server/src/__tests__/heartbeat-oob-disposition-sweep.test.ts
+++ b/server/src/__tests__/heartbeat-oob-disposition-sweep.test.ts
@@ -1,0 +1,305 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  approvals,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueApprovals,
+  issueRecoveryActions,
+  issueRelations,
+  issueThreadInteractions,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
+import { recoveryService } from "../services/recovery/service.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("sweepOutOfBandDispositions", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-oob-sweep-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(issueApprovals);
+    await db.delete(approvals);
+    await db.delete(issueThreadInteractions);
+    await db.delete(issueRecoveryActions);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedBase() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const prefix = `OB${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "OOB Co",
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId, prefix };
+  }
+
+  async function seedIssue(
+    companyId: string,
+    prefix: string,
+    num: number,
+    overrides: Partial<typeof issues.$inferInsert> = {},
+  ) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: `Issue ${num}`,
+      status: "in_progress",
+      priority: "medium",
+      issueNumber: num,
+      identifier: `${prefix}-${num}`,
+      ...overrides,
+    });
+    return issueId;
+  }
+
+  async function seedActiveRecovery(companyId: string, sourceIssueId: string, agentId: string) {
+    const svc = issueRecoveryActionService(db);
+    return svc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      cause: "successful_run_missing_issue_disposition",
+      fingerprint: `oob-test:${sourceIssueId}`,
+      evidence: {},
+      nextAction: "Choose a valid issue disposition.",
+    });
+  }
+
+  function recovery() {
+    return recoveryService(db, {
+      enqueueWakeup: async () => {},
+    });
+  }
+
+  it("resolves a recovery when the source issue reaches done out-of-band", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_progress", assigneeAgentId: agentId });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    // Simulate out-of-band state change: issue moves to done without going through route handler
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, issueId));
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({ status: "cancelled", outcome: "cancelled" });
+    expect(actionRow?.resolutionNote).toMatch(/reached done/);
+    expect(actionRow?.resolvedAt).toBeTruthy();
+  });
+
+  it("resolves a recovery when the source issue is blocked with unresolved first-class blockers out-of-band", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_progress", assigneeAgentId: agentId });
+    const blockerId = await seedIssue(companyId, prefix, 2, { status: "in_progress", assigneeAgentId: agentId });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    // Out-of-band: mark issue as blocked and add a blocker relation
+    await db.update(issues).set({ status: "blocked", assigneeAgentId: null }).where(eq(issues.id, issueId));
+    // blockerId blocks issueId: blockerId.type="blocks" with relatedIssueId=issueId
+    await db.insert(issueRelations).values({
+      id: randomUUID(),
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({ status: "cancelled", outcome: "cancelled" });
+    expect(actionRow?.resolutionNote).toMatch(/unresolved first-class blockers/);
+  });
+
+  it("keeps a recovery active when the source issue is blocked with no unresolved blockers", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_progress", assigneeAgentId: agentId });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    // Out-of-band: mark issue as blocked but add no blocker relations
+    await db.update(issues).set({ status: "blocked", assigneeAgentId: null }).where(eq(issues.id, issueId));
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow?.status).toBe("active");
+  });
+
+  it("resolves a recovery when the source issue is in_progress with an agent owner out-of-band", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    // Start with no assignee (so recovery was valid), then out-of-band assign agent
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_progress", assigneeAgentId: null });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    await db.update(issues).set({ assigneeAgentId: agentId }).where(eq(issues.id, issueId));
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(1);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({ status: "cancelled", outcome: "cancelled" });
+    expect(actionRow?.resolutionNote).toMatch(/in_progress with an agent owner/);
+  });
+
+  it("resolves a recovery when the source issue gains a human owner out-of-band", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_progress", assigneeAgentId: null });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    await db.update(issues).set({ assigneeUserId: "board-user-1" }).where(eq(issues.id, issueId));
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(1);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow?.resolutionNote).toMatch(/human owner/);
+  });
+
+  it("resolves a recovery when the source issue has a scheduled monitor out-of-band", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_review", assigneeAgentId: null });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000); // 1 hour from now
+    await db.update(issues).set({ monitorNextCheckAt: futureDate }).where(eq(issues.id, issueId));
+
+    const result = await recovery().sweepOutOfBandDispositions({ now: new Date() });
+
+    expect(result.resolved).toBe(1);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow?.resolutionNote).toMatch(/scheduled monitor/);
+  });
+
+  it("keeps a recovery active when the source issue has no valid resting disposition", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    // Issue in_review with no participant, no interactions, no approvals, no monitor
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "in_review", assigneeAgentId: null });
+    const action = await seedActiveRecovery(companyId, issueId, agentId);
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow?.status).toBe("active");
+  });
+
+  it("logs activity for each resolved recovery action", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const issueId = await seedIssue(companyId, prefix, 1, { status: "done", assigneeAgentId: null });
+    await seedActiveRecovery(companyId, issueId, agentId);
+
+    await recovery().sweepOutOfBandDispositions();
+
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(and(eq(activityLog.entityId, issueId), eq(activityLog.action, "issue.recovery_action_resolved")));
+    expect(activityRows).toHaveLength(1);
+    expect(activityRows[0]?.details).toMatchObject({
+      source: "out_of_band_disposition_sweep",
+      outcome: "cancelled",
+    });
+  });
+
+  it("handles multiple active recoveries across different issues in one sweep", async () => {
+    const { companyId, agentId, prefix } = await seedBase();
+    const doneIssueId = await seedIssue(companyId, prefix, 1, { status: "done" });
+    const activeIssueId = await seedIssue(companyId, prefix, 2, { status: "in_progress", assigneeAgentId: null });
+    const agentOwnedIssueId = await seedIssue(companyId, prefix, 3, { status: "in_progress", assigneeAgentId: agentId });
+
+    await seedActiveRecovery(companyId, doneIssueId, agentId);
+    const activeAction = await seedActiveRecovery(companyId, activeIssueId, agentId);
+    await seedActiveRecovery(companyId, agentOwnedIssueId, agentId);
+
+    const result = await recovery().sweepOutOfBandDispositions();
+
+    expect(result.resolved).toBe(2); // done + agentOwned
+    expect(result.skipped).toBe(1); // activeIssue with no valid resting disposition
+
+    // The active one (no agent, in_progress) should still be active
+    const [activeRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, activeAction.id));
+    expect(activeRow?.status).toBe("active");
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -760,6 +760,12 @@ export async function startServer(): Promise<StartedServer> {
           logger.warn({ ...reviewed }, "startup productivity reconciliation created or updated review work");
         }
       })
+      .then(async () => {
+        const swept = await heartbeat.sweepOutOfBandDispositions();
+        if (swept.resolved > 0) {
+          logger.warn({ ...swept }, "startup out-of-band disposition sweep resolved stale recovery actions");
+        }
+      })
       .catch((err) => {
         logger.error({ err }, "startup heartbeat recovery failed");
       });
@@ -824,6 +830,12 @@ export async function startServer(): Promise<StartedServer> {
           const reviewed = await heartbeat.reconcileProductivityReviews();
           if (reviewed.created > 0 || reviewed.updated > 0 || reviewed.failed > 0) {
             logger.warn({ ...reviewed }, "periodic productivity reconciliation created or updated review work");
+          }
+        })
+        .then(async () => {
+          const swept = await heartbeat.sweepOutOfBandDispositions();
+          if (swept.resolved > 0) {
+            logger.warn({ ...swept }, "periodic out-of-band disposition sweep resolved stale recovery actions");
           }
         })
         .catch((err) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7171,6 +7171,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileIssueGraphLiveness(opts);
   }
 
+  async function sweepOutOfBandDispositions(opts?: { now?: Date }) {
+    return recovery.sweepOutOfBandDispositions(opts);
+  }
+
   async function updateRuntimeState(
     agent: typeof agents.$inferSelect,
     run: typeof heartbeatRuns.$inferSelect,
@@ -10605,6 +10609,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     scanSilentActiveRuns,
 
     reconcileProductivityReviews,
+
+    sweepOutOfBandDispositions,
 
     buildRunOutputSilence,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -60,6 +60,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { parseIssueExecutionState } from "../issue-execution-policy.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -3584,6 +3585,165 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Math.max(1, Math.floor(asNumber(raw, fallback)));
   }
 
+  // Contract B: classify whether a source issue has a valid resting disposition that makes
+  // an active recovery action stale. Mirrors classifySourceRecoveryRevalidation in routes/issues.ts
+  // but is evaluated unconditionally (no durableSourceChange guard) so it can be called from
+  // a periodic sweep that catches out-of-band status changes.
+  async function classifyOutOfBandDispositionResolution(
+    issue: {
+      id: string;
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+      executionState: unknown;
+      monitorNextCheckAt: Date | null;
+    },
+    now: Date,
+  ): Promise<string | null> {
+    if (issue.status === "done" || issue.status === "cancelled") {
+      return `Recovery action became stale because the source issue reached ${issue.status}.`;
+    }
+
+    if (issue.status === "blocked") {
+      const readiness = await issuesSvc.getDependencyReadiness(issue.id);
+      if (readiness.unresolvedBlockerCount > 0) {
+        return "Recovery action became stale because the source issue now has unresolved first-class blockers.";
+      }
+      return null;
+    }
+
+    if (issue.assigneeUserId) {
+      return "Recovery action became stale because the source issue now has a human owner.";
+    }
+
+    if ((issue.status === "todo" || issue.status === "in_progress") && issue.assigneeAgentId) {
+      return `Recovery action became stale because the source issue is ${issue.status} with an agent owner.`;
+    }
+
+    if (issue.status === "in_review") {
+      const executionState = parseIssueExecutionState(issue.executionState);
+      const participant = executionState?.status === "pending" ? executionState.currentParticipant : null;
+      if (
+        (participant?.type === "agent" && readNonEmptyString(participant.agentId)) ||
+        (participant?.type === "user" && readNonEmptyString(participant.userId))
+      ) {
+        return "Recovery action became stale because the source issue now has a typed review participant.";
+      }
+
+      const pendingInteraction = await db
+        .select({ id: issueThreadInteractions.id })
+        .from(issueThreadInteractions)
+        .where(and(eq(issueThreadInteractions.issueId, issue.id), eq(issueThreadInteractions.status, "pending")))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (pendingInteraction) {
+        return "Recovery action became stale because the source issue now has a pending issue interaction.";
+      }
+
+      const pendingApproval = await db
+        .select({ id: approvals.id })
+        .from(issueApprovals)
+        .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+        .where(and(eq(issueApprovals.issueId, issue.id), inArray(approvals.status, ["pending", "revision_requested"])))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (pendingApproval) {
+        return "Recovery action became stale because the source issue now has a pending approval.";
+      }
+    }
+
+    if (issue.monitorNextCheckAt && issue.monitorNextCheckAt.getTime() > now.getTime()) {
+      return "Recovery action became stale because the source issue now has a scheduled monitor.";
+    }
+
+    return null;
+  }
+
+  // Periodic sweep: for every active recovery action, check if the source issue has
+  // a valid resting disposition that was recorded out-of-band (i.e., without going
+  // through a mutation path that calls revalidateActiveSourceRecovery). If so, cancel
+  // the recovery action.
+  async function sweepOutOfBandDispositions(opts?: { now?: Date }) {
+    const now = opts?.now ?? new Date();
+
+    const candidates = await db
+      .select({
+        recoveryId: issueRecoveryActions.id,
+        companyId: issueRecoveryActions.companyId,
+        sourceIssueId: issueRecoveryActions.sourceIssueId,
+        issueId: issues.id,
+        issueIdentifier: issues.identifier,
+        issueStatus: issues.status,
+        issueAssigneeAgentId: issues.assigneeAgentId,
+        issueAssigneeUserId: issues.assigneeUserId,
+        issueExecutionState: issues.executionState,
+        issueMonitorNextCheckAt: issues.monitorNextCheckAt,
+      })
+      .from(issueRecoveryActions)
+      .innerJoin(issues, eq(issueRecoveryActions.sourceIssueId, issues.id))
+      .where(inArray(issueRecoveryActions.status, ["active", "escalated"]));
+
+    const result = { resolved: 0, skipped: 0, issueIds: [] as string[] };
+
+    for (const candidate of candidates) {
+      const resolutionNote = await classifyOutOfBandDispositionResolution(
+        {
+          id: candidate.sourceIssueId,
+          status: candidate.issueStatus,
+          assigneeAgentId: candidate.issueAssigneeAgentId,
+          assigneeUserId: candidate.issueAssigneeUserId,
+          executionState: candidate.issueExecutionState,
+          monitorNextCheckAt: candidate.issueMonitorNextCheckAt,
+        },
+        now,
+      );
+
+      if (!resolutionNote) {
+        result.skipped++;
+        continue;
+      }
+
+      const resolved = await recoveryActionsSvc.resolveActiveForIssue({
+        companyId: candidate.companyId,
+        sourceIssueId: candidate.sourceIssueId,
+        actionId: candidate.recoveryId,
+        status: "cancelled",
+        outcome: "cancelled",
+        resolutionNote,
+      });
+
+      if (!resolved) {
+        result.skipped++;
+        continue;
+      }
+
+      await logActivity(db, {
+        companyId: candidate.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.recovery_action_resolved",
+        entityType: "issue",
+        entityId: candidate.sourceIssueId,
+        details: {
+          identifier: candidate.issueIdentifier,
+          recoveryActionId: resolved.id,
+          recoveryActionStatus: resolved.status,
+          outcome: resolved.outcome,
+          sourceIssueStatus: candidate.issueStatus,
+          resolutionNote: resolved.resolutionNote,
+          source: "out_of_band_disposition_sweep",
+        },
+      });
+
+      result.resolved++;
+      result.issueIds.push(candidate.sourceIssueId);
+    }
+
+    return result;
+  }
+
   return {
     buildRunOutputSilence,
     escalateStrandedRecoveryIssueInPlace,
@@ -3594,5 +3754,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
+    sweepOutOfBandDispositions,
   };
 }


### PR DESCRIPTION
## Summary
Contract B implementation from SAG-3139 (parent SAG-3134 missing_disposition routine-loop). Sweeps active recoveries that carry out-of-band dispositions so they resolve cleanly instead of looping.

Commit: 406b7a2e

## Context
- Part of the missing_disposition routine-loop fix (SAG-3134, CEO-approved A+B+C).
- This PR opens for **Phase 3 QA criterion #2 / Phase 4 review** — no merge requested.

## Test plan
- Phase 3 QA (SAG-3138) to validate sweep behavior against active-recovery fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)