### PR TITLE
feat(authz): add issues:comment:all and issues:patch:all permission grants

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -737,6 +737,8 @@ export const PERMISSION_KEYS = [
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",
   "joins:approve",
+  "issues:comment:all",
+  "issues:patch:all",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];
 

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1613,6 +1613,50 @@ describe.sequential("agent permission routes", () => {
     expect(mockAccessService.setPrincipalPermission).not.toHaveBeenCalled();
   });
 
+  it("updates explicit agent grants through the dedicated board route", async () => {
+    mockAccessService.listPrincipalGrants.mockResolvedValue([
+      {
+        id: "grant-1",
+        companyId,
+        principalType: "agent",
+        principalId: agentId,
+        permissionKey: "issues:comment:all",
+        scope: null,
+        grantedByUserId: "board-user",
+        createdAt: new Date("2026-03-19T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${agentId}/grants`)
+      .send({ permissionKey: "issues:comment:all", enabled: true }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "issues:comment:all",
+      true,
+      "board-user",
+      null,
+    );
+    expect(res.body.grants).toEqual([
+      expect.objectContaining({
+        permissionKey: "issues:comment:all",
+      }),
+    ]);
+  });
+
   it("exposes a dedicated agent route for the inbox mine view", async () => {
     mockIssueService.list.mockResolvedValue([
       {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1275,6 +1275,42 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("keeps cross-issue grants endpoint-specific for peer agent mutations", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.hasPermission.mockImplementation(async (_companyId, _principalType, _principalId, permissionKey) =>
+      permissionKey === "issues:comment:all"
+    );
+
+    const app = await createApp(peerActor());
+    const patchRes = await request(app).patch(`/api/issues/${issueId}`).send({ title: "Wrong grant" });
+
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(403);
+    expect(patchRes.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+
+    const commentRes = await request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Allowed by grant" });
+
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Allowed by grant",
+      expect.objectContaining({ agentId: peerAgentId }),
+      expect.anything(),
+    );
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      peerAgentId,
+      "issues:patch:all",
+    );
+    expect(mockAccessService.hasPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      peerAgentId,
+      "issues:comment:all",
+    );
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2559,7 +2559,7 @@ export function agentRoutes(
       "agent",
       existing.id,
       permissionKey,
-      enabled !== false,
+      enabled,
       req.actor.type === "board" ? (req.actor.userId ?? null) : null,
       scope ?? null,
     );
@@ -2576,7 +2576,7 @@ export function agentRoutes(
       entityId: existing.id,
       details: {
         permissionKey,
-        enabled: enabled !== false,
+        enabled,
         scope: scope ?? null,
       },
     });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { z } from "zod";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
@@ -14,6 +15,7 @@ import {
   deriveAgentUrlKey,
   isUuidLike,
   normalizeIssueIdentifier,
+  PERMISSION_KEYS,
   resetAgentSessionSchema,
   testAdapterEnvironmentSchema,
   type AgentDesiredSkillEntry,
@@ -2533,6 +2535,54 @@ export function agentRoutes(
     });
 
     res.json(await buildAgentDetail(agent));
+  });
+
+  const upsertAgentGrantSchema = z.object({
+    permissionKey: z.enum(PERMISSION_KEYS),
+    scope: z.record(z.string(), z.unknown()).optional().nullable(),
+    enabled: z.boolean().default(true),
+  });
+
+  router.post("/agents/:id/grants", validate(upsertAgentGrantSchema), async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+    await assertBoardCanManageAgentsForCompany(req, existing.companyId);
+
+    const { permissionKey, scope, enabled } = req.body as z.infer<typeof upsertAgentGrantSchema>;
+    await access.setPrincipalPermission(
+      existing.companyId,
+      "agent",
+      existing.id,
+      permissionKey,
+      enabled !== false,
+      req.actor.type === "board" ? (req.actor.userId ?? null) : null,
+      scope ?? null,
+    );
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: existing.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "agent.grant_updated",
+      entityType: "agent",
+      entityId: existing.id,
+      details: {
+        permissionKey,
+        enabled: enabled !== false,
+        scope: scope ?? null,
+      },
+    });
+
+    const grants = await access.listPrincipalGrants(existing.companyId, "agent", existing.id);
+    res.json({ grants });
   });
 
   router.patch("/agents/:id/instructions-path", validate(updateAgentInstructionsPathSchema), async (req, res) => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -62,6 +62,7 @@ import {
   type ExecutionWorkspace,
   type IssueRelationIssueSummary,
   type IssueWatchdogDiscoveryKind,
+  type PermissionKey,
   type SourceTrustMetadata,
   type SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
@@ -1849,10 +1850,12 @@ export function issueRoutes(
       status: string;
     },
     action: "issue:comment" | "issue:read" | "issue:mutate",
+    options?: { permissionKey?: PermissionKey },
   ) {
     return access.decide({
       actor: req.actor,
       action,
+      permissionKey: options?.permissionKey,
       resource: {
         type: "issue",
         companyId: issue.companyId,
@@ -1892,6 +1895,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    options?: { crossIssueGrantKey?: PermissionKey },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1914,10 +1918,43 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
-    const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
+    const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment", {
+      permissionKey: options?.crossIssueGrantKey,
+    });
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
+    }
+    if (
+      issue.assigneeAgentId &&
+      issue.assigneeAgentId !== actorAgentId &&
+      options?.crossIssueGrantKey &&
+      !isIssueMentionGrantDecision(boundaryDecision)
+    ) {
+      const hasGrant = await access.hasPermission(
+        issue.companyId,
+        "agent",
+        actorAgentId,
+        options.crossIssueGrantKey,
+      );
+      if (hasGrant) {
+        const actor = getActorInfo(req);
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "issue.cross_agent_write",
+          entityType: "issue",
+          entityId: issue.id,
+          details: {
+            grantKey: options.crossIssueGrantKey,
+            actorAgentId,
+            assigneeAgentId: issue.assigneeAgentId,
+          },
+        });
+      }
     }
     return boundaryDecision;
   }
@@ -1973,6 +2010,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    options?: { crossIssueGrantKey?: PermissionKey },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -2003,7 +2041,9 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
-    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
+    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate", {
+      permissionKey: options?.crossIssueGrantKey,
+    });
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
@@ -2014,6 +2054,33 @@ export function issueRoutes(
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
+      }
+      if (options?.crossIssueGrantKey) {
+        const hasGrant = await access.hasPermission(
+          issue.companyId,
+          "agent",
+          actorAgentId,
+          options.crossIssueGrantKey,
+        );
+        if (hasGrant) {
+          const actor = getActorInfo(req);
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "issue.cross_agent_write",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              grantKey: options.crossIssueGrantKey,
+              actorAgentId,
+              assigneeAgentId: issue.assigneeAgentId,
+            },
+          });
+          return true;
+        }
       }
       if (issue.status === "in_progress") {
         res.status(409).json({
@@ -5555,7 +5622,7 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { crossIssueGrantKey: "issues:patch:all" }))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -7391,7 +7458,9 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, issue);
+    const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, issue, {
+      crossIssueGrantKey: "issues:comment:all",
+    });
     if (!commentAccessDecision) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -130,6 +130,7 @@ import {
   remoteSecretImportSchema,
   workspaceFileListQuerySchema,
   workspaceFileResourceQuerySchema,
+  PERMISSION_KEYS,
 } from "@paperclipai/shared";
 
 type JsonSchema = Record<string, unknown>;
@@ -1050,6 +1051,22 @@ registry.registerPath({
     body: jsonBody(updateAgentPermissionsSchema),
   },
   responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/agents/{id}/grants",
+  tags: ["agents"],
+  summary: "Update an agent permission grant",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: jsonBody(z.object({
+      permissionKey: z.enum(PERMISSION_KEYS),
+      scope: z.record(z.string(), z.unknown()).optional().nullable(),
+      enabled: z.boolean().default(true),
+    })),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
 });
 
 registry.registerPath({

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -86,6 +86,7 @@ export function accessService(db: Db) {
   async function decide(input: {
     actor: AuthorizationActor;
     action: Parameters<typeof authorization.decide>[0]["action"];
+    permissionKey?: PermissionKey | null;
     resource: AuthorizationResource;
     scope?: Record<string, unknown> | null;
   }) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -958,10 +958,11 @@ export function authorizationService(db: Db) {
   async function decide(input: {
     actor: AuthorizationActor;
     action: AuthorizationAction;
+    permissionKey?: PermissionKey | null;
     resource: AuthorizationResource;
     scope?: Record<string, unknown> | null;
   }): Promise<AuthorizationDecision> {
-    const permissionKey = permissionForAction(input.action);
+    const permissionKey = input.permissionKey ?? permissionForAction(input.action);
     const companyId = companyIdForResource(input.resource);
 
     async function decideWithTaskAssignmentGrants(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for running AI agents as a supervised company.
> - Cross-agent coordination depends on issue writes staying least-privilege by default, with any exception made explicit and auditable.
> - This PR adds the narrow cross-issue grants that unblock linter-style agents such as COO without changing the default assignee-ownership model.
> - The first draft split the route-level grants correctly, but the shared `issue:mutate` boundary still accepted either cross-issue key, which made the authorization layer more permissive than the endpoint actually intended.
> - The same draft also mounted `POST /api/agents/:id/grants` without documenting it in the OpenAPI route inventory, which broke the serialized OpenAPI test shard.
> - Review also called out one redundant `enabled !== false` expression and the missing required PR template sections.
> - This pull request tightens the authorization boundary to the endpoint-specific permission key, documents the grants route in OpenAPI, adds regression coverage for both, and fills in the required PR metadata.
> - The benefit is that cross-issue grants stay explicit, endpoint-scoped, documented, and test-covered instead of relying on a looser shared boundary.

## Linked Issues or Issue Description

- Refs: #7490
- Refs: #8080
- No upstream GitHub issue exists for this exact PR. The underlying problem is that linter-style agents need a safe, explicit way to comment on or patch issues they do not own. The additive grants introduced here are the escape hatch, but they must remain endpoint-specific (`issues:comment:all` vs `issues:patch:all`) and the new board grants route must be part of the published OpenAPI surface so the server route inventory stays accurate.

## What Changed

- Thread the required `PermissionKey` through `decideIssueAccess` so the `issue:mutate` boundary only approves the endpoint-specific cross-issue grant requested by the caller.
- Keep the route-layer cross-agent audit behavior in place while removing the overly broad "accept either key" fallback from `authorization.ts`.
- Replace `enabled !== false` with `enabled` in `POST /api/agents/:id/grants`.
- Register `POST /api/agents/{id}/grants` in `server/src/routes/openapi.ts`.
- Add regression coverage for the explicit grants route and for keeping comment vs patch grants endpoint-specific.

## Verification

- `pnpm exec vitest run server/src/__tests__/openapi-routes.test.ts server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/authorization-service.test.ts`
- Result: `4 passed`, `144 passed`

## Risks

- Low risk. The main behavioral change is that cross-issue `issue:mutate` approval now depends on the caller passing the correct endpoint-specific permission key into the shared authorization boundary. The patched routes are updated and regression-tested. The OpenAPI registration change is additive.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Follow-up revision in this branch: OpenAI Codex local runtime on `GPT-5.4`, with tool use and code execution through the terminal plus `gh` for GitHub review data.
- Original base commit in this PR: created with Claude Code / Paperclip as recorded in the existing commit metadata and original PR body. The exact Claude model version is not preserved in the repository metadata available from this checkout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
