### PR TITLE
fix(recovery): preserve assigneeAgentId in escalateStrandedAssignedIssue

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2230,6 +2230,155 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  it("escalation preserves assigneeAgentId when recovery owner is an invokable manager (not the doer)", async () => {
+    // Seeds a stranded in_progress issue where doer.reportsTo = manager (idle, invokable).
+    // Dispatch-recovery is exhausted (retryReason: "assignment_recovery").
+    // After escalation the issue should be status=blocked but STILL assigned to the doer —
+    // the recovery owner (manager) gets woken to shepherd but must not inherit ownership.
+    const companyId = randomUUID();
+    const doerId = randomUUID();
+    const managerId = randomUUID();
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const issueId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    // Manager must be seeded before doer due to FK self-reference on agents.reportsTo
+    await db.insert(agents).values([
+      {
+        id: managerId,
+        companyId,
+        name: "EngManager",
+        role: "manager",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: doerId,
+        companyId,
+        name: "Doer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        reportsTo: managerId,
+      },
+    ]);
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId: doerId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_continuation_needed",
+      payload: { issueId },
+      status: "failed",
+      runId,
+      claimedAt: now,
+      finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+      error: "run failed before issue advanced",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: doerId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      wakeupRequestId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+      },
+      startedAt: now,
+      finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:05:00.000Z"),
+      errorCode: "process_lost",
+      error: "run failed before issue advanced",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Work assigned to doer whose manager is invokable",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: doerId,
+      checkoutRunId: runId,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      startedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    // Core assertion — assigneeAgentId must NOT be overwritten with the recovery owner (manager).
+    expect(issue?.assigneeAgentId).toBe(doerId);
+
+    // Recovery action must target the manager as owner (shepherd), doer as return owner.
+    const recoveryAction = await waitForValue(async () =>
+      db
+        .select()
+        .from(issueRecoveryActions)
+        .where(
+          and(
+            eq(issueRecoveryActions.companyId, companyId),
+            eq(issueRecoveryActions.sourceIssueId, issueId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null),
+    );
+    expect(recoveryAction?.ownerAgentId).toBe(managerId);
+    expect(recoveryAction?.previousOwnerAgentId).toBe(doerId);
+    expect(recoveryAction?.returnOwnerAgentId).toBe(doerId);
+
+    // The recovery wake must be queued for the manager, not the doer.
+    const managerWake = await waitForValue(async () => {
+      const wakeups = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.agentId, managerId));
+      return (
+        wakeups.find((w) => {
+          const payload = w.payload as Record<string, unknown> | null;
+          return (
+            payload?.issueId === issueId &&
+            payload?.recoveryActionId === recoveryAction?.id
+          );
+        }) ?? null
+      );
+    });
+    expect(managerWake?.reason).toBe("source_scoped_recovery_action");
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2232,7 +2232,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("escalation preserves assigneeAgentId when recovery owner is an invokable manager (not the doer)", async () => {
     // Seeds a stranded in_progress issue where doer.reportsTo = manager (idle, invokable).
-    // Dispatch-recovery is exhausted (retryReason: "assignment_recovery").
+    // Continuation-recovery is exhausted (retryReason: "issue_continuation_needed").
     // After escalation the issue should be status=blocked but STILL assigned to the doer —
     // the recovery owner (manager) gets woken to shepherd but must not inherit ownership.
     const companyId = randomUUID();

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2313,6 +2313,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
+      // Explicitly preserve the doer; never promote the recovery owner into the assignee slot.
+      assigneeAgentId: input.issue.assigneeAgentId,
     });
     if (!updated) return null;
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2313,7 +2313,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
 
@@ -2426,29 +2425,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       latestRun: input.latestRun,
       recoveryCause,
     });
-
-    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
-      const [currentIssue] = await db
-        .select({
-          status: issues.status,
-          assigneeAgentId: issues.assigneeAgentId,
-        })
-        .from(issues)
-        .where(eq(issues.id, input.issue.id))
-        .limit(1);
-      if (
-        currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
-      ) {
-        const reblocked = await issuesSvc.update(input.issue.id, {
-          status: "blocked",
-          blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
-        });
-        if (reblocked) return reblocked;
-      }
-    }
 
     return updated;
   }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2426,6 +2426,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryCause,
     });
 
+    if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
+      const [currentIssue] = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, input.issue.id))
+        .limit(1);
+      if (currentIssue && currentIssue.status !== "blocked") {
+        const reblocked = await issuesSvc.update(input.issue.id, {
+          status: "blocked",
+          blockedByIssueIds: blockerIds,
+          // assigneeAgentId intentionally omitted — doer stays the assignee
+        });
+        if (reblocked) return reblocked;
+      }
+    }
+
     return updated;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery subsystem (`server/src/services/recovery/service.ts`) detects stranded issues and escalates them by resolving a "recovery owner" (manager via `reportsTo`) to shepherd the work
> - `escalateStrandedAssignedIssue` resolves the recovery owner and wakes them via `enqueueSourceScopedStrandedRecoveryWake`
> - The function was incorrectly writing `assigneeAgentId: recoveryAction.ownerAgentId` in the `issuesSvc.update` call, overwriting the doer's assignment with the manager's ID
> - On the next stranded sweep, a manually-reassigned doer was overwritten back to the manager, creating a revert loop (the DoO → CEO revert observed on SAG-2834)
> - This PR writes `assigneeAgentId: input.issue.assigneeAgentId` (the doer) instead, and restores the re-block branch with only the `status: "blocked"` re-assertion; the recovery wake independently targets the manager via `action.ownerAgentId`
> - The benefit is that doer assignments survive recovery escalation; managers are still woken to shepherd but never inherit ownership of the source issue

## Linked Issues or Issue Description

**What happened?**

`escalateStrandedAssignedIssue` in `server/src/services/recovery/service.ts` permanently overwrites `assigneeAgentId` with the resolved recovery owner (manager or CEO) when it blocks a stranded issue. On the next stranded sweep, any manual reassignment back to the original doer is overwritten again, creating an infinite revert loop.

**Steps to reproduce**

1. Configure a doer agent with `reportsTo` pointing to an idle/invokable manager agent.
2. Let the doer's assigned issue go stranded and exhaust recovery retries.
3. Paperclip escalates: `escalateStrandedAssignedIssue` runs, blocks the issue, and writes `assigneeAgentId = manager.id`.
4. Manually reassign the issue back to the doer.
5. On the next stranded sweep, Paperclip overwrites `assigneeAgentId` back to the manager. The loop repeats indefinitely.

**Expected behavior**

The issue goes `blocked` while remaining assigned to the original doer. The manager (recovery owner) is notified via a `source_scoped_recovery_action` wake but does not become the assignee.

**Paperclip version**

Current `master` (head `a4fa0ea` at time of fix).

**Deployment mode**

Self-hosted.

## What Changed

- `server/src/services/recovery/service.ts`: primary `issuesSvc.update` now writes `assigneeAgentId: input.issue.assigneeAgentId` (the doer) instead of `recoveryAction.ownerAgentId`
- `server/src/services/recovery/service.ts`: re-block branch restored with `status: "blocked"` re-assertion only — `assigneeAgentId` write removed; guards the self-owning synchronous-claim race without overwriting the assignee
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: regression test added — seeds `in_progress` issue with `doer.reportsTo = manager` (idle/invokable), exhausted continuation retry, asserts `escalated=1`, `status=blocked`, `assigneeAgentId=doer`, recovery wake targets manager

## Verification

```bash
npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts
npx vitest run server/src/__tests__/issue-recovery-actions.test.ts
```

72/72 tests pass (51 + 21). CI `General tests (server)` and all `Verify serialized server suites` are green.

## Risks

Low risk. Primary change is a one-field substitution in one update call (write doer instead of owner). The re-block branch change removes only the `assigneeAgentId` write; the `status: "blocked"` re-assertion is preserved to cover the synchronous-claim race. `enqueueSourceScopedStrandedRecoveryWake` is untouched — managers still get woken as shepherds.

Follow-up out of scope: when an assignee changes mid-flight, dispatch-recovery attempt accounting still reflects the prior owner. CTO to scope separately.

## Model Used

Anthropic Claude Sonnet 4.6 (`claude-sonnet-4-6`), 200k context window, tool use / code execution via Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes/Closes/Refs OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge