### PR TITLE
fix(watchdog): skip recurring stale-run evals on terminal-source orphans

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -367,26 +367,51 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(event?.message).toContain("Source-resolved watchdog fold");
   });
 
-  it("still escalates terminal source issues without same-run terminal evidence", async () => {
+  it("files one evaluation for a terminal-source orphan and skips subsequent scans after the eval is closed", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
-    const { companyId, runId } = await seedRunningRun({
+    const { companyId, issueId, runId } = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
       sourceStatus: "done",
     });
     const heartbeat = heartbeatService(db);
 
-    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first).toMatchObject({ created: 1, folded: 0, skipped: 0 });
+    const evaluationIssueId = first.evaluationIssueIds[0];
+    expect(evaluationIssueId).toBeTruthy();
 
-    expect(result).toMatchObject({ created: 1, folded: 0 });
-    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
-    const [evaluation] = await db
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, evaluationIssueId!));
+
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const third = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(second).toMatchObject({ created: 0, folded: 0, existing: 0, skipped: 1 });
+    expect(third).toMatchObject({ created: 0, folded: 0, existing: 0, skipped: 1 });
+
+    const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluation?.originId).toBe(runId);
-    expect(evaluation?.parentId).toBeNull();
+    expect(evaluations).toHaveLength(1);
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("running");
+
+    const skipLogs = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.runId, runId),
+          eq(activityLog.action, "heartbeat.output_stale_source_terminal_skipped"),
+        ),
+      );
+    expect(skipLogs).toHaveLength(2);
+    expect(skipLogs[0]?.details).toMatchObject({
+      source: "recovery.scan_silent_active_runs",
+      sourceIssueId: issueId,
+      sourceIssueStatus: "done",
+    });
   });
 
   it("still escalates when a same-run comment is followed by another actor marking the source done", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -840,6 +840,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function hasAnyStaleRunEvaluation(companyId: string, runId: string) {
+    const [row] = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .limit(1);
+    return row != null;
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -1489,6 +1505,34 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           silenceAgeMs: silenceAgeMsForRun(input.run, input.now),
           now: input.now,
         });
+      }
+      // Source-terminal recur guard. The source issue already reached
+      // `done`/`cancelled` without same-run evidence, so foldSourceResolvedStaleRun
+      // cannot safely terminate the process. The first scan still files an eval
+      // for operator visibility, but once that eval is closed the run handle stays
+      // orphaned — the unique-active constraint allows the next scan to file
+      // another, and so on (BASA-28081 saw ~500 such issues from one orphan).
+      // After at least one eval exists (open or closed), skip the recurring file.
+      // Process termination remains foldSourceResolvedStaleRun's responsibility
+      // (it requires same-run evidence to safely terminate).
+      if (!existing && await hasAnyStaleRunEvaluation(input.run.companyId, input.run.id)) {
+        await logActivity(db, {
+          companyId: input.run.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: input.run.agentId,
+          runId: input.run.id,
+          action: "heartbeat.output_stale_source_terminal_skipped",
+          entityType: "heartbeat_run",
+          entityId: input.run.id,
+          details: {
+            source: "recovery.scan_silent_active_runs",
+            sourceIssueId: sourceIssue.id,
+            sourceIssueIdentifier: sourceIssue.identifier ?? null,
+            sourceIssueStatus: sourceIssue.status,
+          },
+        });
+        return { kind: "skipped" as const };
       }
     }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -841,6 +841,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function hasAnyStaleRunEvaluation(companyId: string, runId: string) {
+    // Intentionally not filtered by `hiddenAt` — the recur guard treats an
+    // archived (hidden) eval as "already filed for this orphan" so that
+    // hiding the eval does NOT reset the spam-prevention guard (Greptile P2
+    // on PR #7653).
     const [row] = await db
       .select({ id: issues.id })
       .from(issues)
@@ -849,7 +853,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(issues.companyId, companyId),
           eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
           eq(issues.originId, runId),
-          isNull(issues.hiddenAt),
         ),
       )
       .limit(1);


### PR DESCRIPTION
## Issue

**Bug:** Active-run output watchdog spams `stale_active_run_evaluation` review issues for orphan runs whose source issue is already terminal.

**Subsystem:** `server/src/services/recovery/service.ts` — `createOrUpdateStaleRunEvaluation` + `scanSilentActiveRuns`.

**Reproduction:** A run goes silent. The source issue reaches `done` or `cancelled` via a path that does NOT produce a `runId=run.id` activity-log entry (e.g. board user clicks Close, another run closes it, manual PATCH from a CLI). `foldSourceResolvedStaleRun` returns early because `latestSameRunSourceTerminalEvidence` is null, the code falls through, and a new `stale_active_run_evaluation` issue is filed. Each fired issue is triaged closed (`done`), which frees the unique-active constraint `issues_active_stale_run_evaluation_uq` (filters `status not in ('done','cancelled')`), so the next scan files another. Cycle repeats indefinitely.

**Observed impact (downstream consumer, BASA):** One orphan run (`4826d41c-7c70-42fd-8676-d7f23a96b8c9` against source done since `2026-06-04`) produced ~500 review issues and continues to file ~24 per hour at the time of writing. Each fire wakes the assigned agent (CTO or board) for a triage heartbeat, burning context budget on noise.

**Expected:** After the orphan has been flagged once, the watchdog should not refile every scan cycle just because the prior eval is closed.

**Refs:** No paperclipai/paperclip GitHub issue exists for this; downstream tracker is BASA-28081 in the BASA company tracker.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - One of the safety nets is the active-run output watchdog: it scans `running` heartbeat runs that have gone quiet and files a `stale_active_run_evaluation` review issue so an operator can decide whether to recover or dismiss
> - When the source issue the run was working on is already `done`/`cancelled` AND a same-run activity-log row ties the closure to this run, `foldSourceResolvedStaleRun` reaps the run as a false positive (the work is durable)
> - But when the source is terminal AND there is no same-run evidence (board user, sibling run, or manual close), the current code falls through to filing a fresh evaluation issue
> - The unique-active constraint only suppresses duplicates whose status is not `done`/`cancelled`, so once the prior eval is triaged closed the next scan files another — we have observed a single orphan generate ~500 review issues over a few days, each waking the assignee for a triage heartbeat
> - This pull request adds a recur-guard: the first scan still files an eval (operator visibility for the orphan), but subsequent scans skip the create once any eval already exists for that `(companyId, runId)` and log `heartbeat.output_stale_source_terminal_skipped` instead
> - The benefit is the orphan stays visible exactly once instead of spamming heartbeats indefinitely; process termination remains `foldSourceResolvedStaleRun`'s responsibility (it requires same-run evidence to safely terminate)

## What Changed

- `server/src/services/recovery/service.ts`: added `hasAnyStaleRunEvaluation(companyId, runId)` helper (matches `findOpenStaleRunEvaluation` shape but includes `done`/`cancelled` evals). Added a recur guard in `createOrUpdateStaleRunEvaluation` after the `terminalEvidence` fold branch — when source is terminal, no same-run evidence, and a prior eval already exists for this `(companyId, runId)`, return `{ kind: "skipped" }` and log `heartbeat.output_stale_source_terminal_skipped`.
- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`: rewrote the "still escalates terminal source issues without same-run terminal evidence" test as "files one evaluation for a terminal-source orphan and skips subsequent scans after the eval is closed". The new test scans once (creates), closes the eval, scans twice more (both skip), and asserts only one eval was filed and two skip-log rows exist.

## Verification

```
cd server
pnpm install
pnpm vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts
# Test Files  1 passed (1)
#      Tests  13 passed (13)
```

Manual production-side confirmation (downstream consumer): the BASA company has been logging ~24 spurious review issues per hour from a single orphan run (`4826d41c-...` against source `BASA-25901` which has been `done` since 2026-06-04). Each one auto-closes; the next scan files another. After this fix the first file still arrives so the operator can investigate the orphan, but the recur stream stops as soon as that one is triaged.

## Risks

- **Behavior change.** Pre-existing test "still escalates terminal source issues without same-run terminal evidence" asserted `created: 1` on every scan; the new behavior is `created: 1` on first scan, `skipped: 1` on subsequent scans after the eval closes. Operators who relied on a fresh review issue every cadence period to keep an orphan visible will see only one. The activity-log row `heartbeat.output_stale_source_terminal_skipped` preserves auditability, and the underlying `heartbeatRuns` row stays `running` so a query like "active runs with done source issues" still surfaces these orphans.
- **No process termination.** This PR explicitly does not reap the orphan process. That path stays with `foldSourceResolvedStaleRun`, which requires the same-run activity-log evidence to know which run actually closed the source.
- **No schema change, no migration.** Pure code + test change. Safe to ship in a patch release.
- **Hidden evals (open Greptile P2).** `hasAnyStaleRunEvaluation` currently inherits `isNull(issues.hiddenAt)` from the open-eval helper, so an operator who archives the eval via "hide" instead of `done`/`cancelled` would reset the guard. Follow-up commit will drop the `hiddenAt` filter so the recur guard treats hidden evals as "already filed" too.

## Model Used

- Anthropic Claude Opus 4.7 (claude-opus-4-7), 200K context, extended thinking. Used as part of the BASA agent harness (Paperclip control plane) reviewing the recovery service flow and authoring the fix + test in a single PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched the GitHub PR list for similar PRs and confirmed this is not a duplicate (no other open PR touches `recovery/service.ts` `createOrUpdateStaleRunEvaluation` or the watchdog test file)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [ ] I have updated relevant documentation to reflect my changes — N/A, internal recovery behavior
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
