### PR TITLE
fix(recovery): reset continuation-attempt budget on assignee change (SAG-3210)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3333,4 +3333,154 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  // SAG-3210: attempt budget resets on assignee change
+  it("dispatches a continuation (not escalates) when exhausted attempts belong to a prior assignee", async () => {
+    // Set up: Agent A exhausted its budget on the issue, then the issue was reassigned to Agent B.
+    const companyId = randomUUID();
+    const agentAId = randomUUID();
+    const agentBId = randomUUID();
+    const issueId = randomUUID();
+    const oldRunId = randomUUID();
+    const oldWakeupId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: agentAId,
+        companyId,
+        name: "AgentA",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentBId,
+        companyId,
+        name: "AgentB",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Agent A's exhausted continuation run (process_lost → default maxAttempts=1).
+    await db.insert(agentWakeupRequests).values({
+      id: oldWakeupId,
+      companyId,
+      agentId: agentAId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_continuation_needed",
+      payload: { issueId },
+      status: "failed",
+      runId: oldRunId,
+      claimedAt: now,
+      finishedAt: now,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: oldRunId,
+      companyId,
+      agentId: agentAId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "failed",
+      wakeupRequestId: oldWakeupId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+        source: "issue.continuation_recovery",
+      },
+      errorCode: "process_lost",
+      error: "process died",
+      startedAt: now,
+      finishedAt: now,
+      updatedAt: now,
+    });
+
+    // Issue is now assigned to Agent B (the new doer) and is still in_progress.
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Work reassigned after prior owner exhausted budget",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentBId,
+      checkoutRunId: oldRunId,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      startedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Agent B gets a fresh budget: the sweep should dispatch a continuation, not escalate.
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    // Verify the new wakeup is for Agent B.
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentBId)));
+    expect(wakeups.length).toBeGreaterThan(0);
+    expect(wakeups[0]?.reason).toBe("issue_continuation_needed");
+
+    const newRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentBId)))
+      .then((rows) => rows[0] ?? null);
+    if (newRun) {
+      await waitForRunToSettle(heartbeat, newRun.id);
+    }
+  });
+
+  it("still escalates when exhausted attempts all belong to the current (unchanged) assignee", async () => {
+    // Negative test: same assignee throughout — the budget must NOT be spuriously reset.
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "issue_continuation_needed",
+    });
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -493,10 +493,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     companyId: string,
     issueId: string,
     errorCodeToMatch: string | null,
+    currentAssigneeAgentId: string,
   ) {
     const rows = await db
       .select({
         id: heartbeatRuns.id,
+        agentId: heartbeatRuns.agentId,
         status: heartbeatRuns.status,
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
@@ -515,6 +517,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     let consecutive = 0;
     let latestFinishedAt: Date | null = null;
     for (const row of rows) {
+      // Stop counting when we encounter a run from a different agent — that signals an
+      // assignee change and the new doer gets a fresh attempt budget (SAG-3210).
+      if (row.agentId !== currentAssigneeAgentId) break;
+
       const ctx = parseObject(row.contextSnapshot);
       const retryReason = readNonEmptyString(ctx.retryReason);
       if (retryReason !== "issue_continuation_needed") break;
@@ -2688,6 +2694,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             issue.companyId,
             issue.id,
             classification.errorCode,
+            agentId,
           );
           if (consecutive >= classification.maxAttempts) {
             const failureSummary = summarizeRunFailureForIssueComment(latestRun);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery sweep (`reconcileStrandedAssignedIssues`) monitors stranded issues and retries continuation runs up to a per-classification attempt budget before escalating to `blocked`
> - Attempt accounting in `summarizeRecentContinuationRetries` queries all `heartbeatRuns` for a given `issueId` regardless of which agent ran them
> - When a stranded issue is reassigned to a new agent, that agent's fresh work inherits the prior owner's exhausted budget — a new doer can be immediately escalated to `blocked` without ever getting a dispatch attempt
> - SAG-3174 made assignee changes durable; now we need the attempt budget to respect that change
> - This PR scopes the consecutive-failure count to the **current `assigneeAgentId`**: the loop breaks as soon as a run with a different `agentId` is encountered, giving the new doer a clean budget
> - The benefit is that reassigned issues get a genuine first retry under the new owner instead of inheriting a poisoned attempt counter

## Linked Issues or Issue Description

- Refs: SAG-3210 (internal; parent SAG-3209)

## What Changed

- `server/src/services/recovery/service.ts` — `summarizeRecentContinuationRetries` now accepts a `currentAssigneeAgentId` parameter; selects `heartbeatRuns.agentId`; breaks the consecutive-run loop on first mismatch (prior-owner runs stop the count)
- Call site (line ~2693) updated to pass `agentId` (the current `issue.assigneeAgentId`)
- `server/src/__tests__/heartbeat-process-recovery.test.ts` — two new regression tests:
  - **Positive:** issue with exhausted attempts under Agent A, reassigned to Agent B → next sweep enqueues a continuation (not escalates)
  - **Negative:** same-owner exhausted attempts → sweep still escalates (existing behaviour preserved)

## Verification

```bash
cd server
npx vitest run "heartbeat-process-recovery"
# → 52 tests pass (2 new)
```

Guardrails confirmed in code review:
- No-op re-assign to same agent: same `agentId` in all rows → loop continues → budget unchanged
- Post-SAG-3174 recovery never overwrites `assigneeAgentId` to a different agent (line 2436 guard enforces same-owner before any write to the source issue)
- Same-owner exhausted budget still escalates (negative regression test)

## Risks

Low risk. Change is scoped to a single counting helper inside the recovery sweep. The new parameter makes the break condition explicit and does not touch escalation logic, schema, or wakeup enqueueing. The only behavioral change: previously cross-agent runs counted toward the new doer's budget; now they don't.

## Model Used

Claude Sonnet 4.6 (Anthropic) — claude-sonnet-4-6, 200k context, tool use + multi-step code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

---

## Inline Issue Description

> Tracked internally as Paperclip SAG-3210 (parent SAG-3209). No public GitHub issue exists, so the underlying issue is described inline below per CONTRIBUTING.md → "Link Issues or Describe Them In-PR".

**Problem or motivation**

In the recovery sweep, dispatch-recovery attempt accounting (`summarizeRecentContinuationRetries`) counts all `heartbeatRuns` for an issue regardless of which agent ran them. When a stranded issue is reassigned to a fresh doer, the prior owner's exhausted attempts still count, so the new doer is escalated straight to `blocked` instead of getting a fresh dispatch/continuation attempt. SAG-3174 made assignee changes durable, so this is exactly the case that should get a clean budget.

**Proposed solution**

Scope the consecutive-failure count to the current `assigneeAgentId`: `summarizeRecentContinuationRetries` now selects `heartbeatRuns.agentId` and breaks the loop on the first run whose `agentId` differs from the current assignee, giving a reassigned doer a clean budget. No schema change (Option 1).

**Alternatives considered**

2a — add `assigneeAgentId` to the attempt record going forward and treat absence/mismatch as a fresh budget; 2b — derive the assignee in effect at the last recorded attempt from run/event history and reset when the current assignee differs. Both rejected in favor of Option 1 because `agentId` is already on the run record, so no migration or backfill is needed.

**Roadmap alignment**

Follows SAG-3174 (durable assignee changes) and completes the recovery-budget correctness work so reassigned stranded issues get a genuine first retry under the new owner instead of inheriting a poisoned attempt counter.
