### PR TITLE
fix: handle parentId and goalId foreign key violations as 400

### DIFF
--- a/server/src/__tests__/issues-fk-errors.test.ts
+++ b/server/src/__tests__/issues-fk-errors.test.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import type { StorageService } from "../storage/types.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres FK issue route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue foreign key constraint error routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let app!: ReturnType<typeof createApp>;
+  let companyId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-fk-errors-");
+    db = createDb(tempDb.connectionString);
+    companyId = randomUUID();
+    app = createApp(companyId);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "FK Error Test tenant",
+      issuePrefix: "FK",
+      requireBoardApprovalForNewAgents: false,
+    });
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createStorage(): StorageService {
+    return {
+      provider: "local_disk",
+      putFile: vi.fn(async () => {
+        throw new Error("Unexpected storage.putFile call in fk error issue route test");
+      }),
+      getObject: vi.fn(async () => {
+        throw new Error("Unexpected storage.getObject call in fk error issue route test");
+      }),
+      headObject: vi.fn(async () => ({ exists: false })),
+      deleteObject: vi.fn(async () => undefined),
+    };
+  }
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: true,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, createStorage()));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("returns 400 when setting a parentId that does not exist", async () => {
+    // 1. Create an initial issue
+    const res = await request(app)
+      .post("/api")
+      .send({ title: "Issue to patch", description: "This will have a fake parent" })
+      .expect(200);
+
+    const issueId = res.body.id;
+    const fakeParentId = randomUUID();
+
+    // 2. Patch with an invalid parentId
+    const patchRes = await request(app)
+      .patch(`/api/${issueId}`)
+      .send({ parentId: fakeParentId });
+
+    expect(patchRes.status).toBe(400);
+    expect(patchRes.body).toMatchObject({
+      error: expect.stringContaining("parent issue not found"),
+    });
+  });
+
+  it("returns 400 when setting a goalId that does not exist", async () => {
+    // 1. Create an initial issue
+    const res = await request(app)
+      .post("/api")
+      .send({ title: "Issue to patch", description: "This will have a fake goal" })
+      .expect(200);
+
+    const issueId = res.body.id;
+    const fakeGoalId = randomUUID();
+
+    // 2. Patch with an invalid goalId
+    const patchRes = await request(app)
+      .patch(`/api/${issueId}`)
+      .send({ goalId: fakeGoalId });
+
+    expect(patchRes.status).toBe(400);
+    expect(patchRes.body).toMatchObject({
+      error: expect.stringContaining("goal not found"),
+    });
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5033,6 +5033,12 @@ export function issueRoutes(
           },
           "issue update rejected with 422",
         );
+      } else if (err instanceof Error && err.message.includes("issues_parent_id_issues_id_fk")) {
+        res.status(400).json({ error: "parent issue not found" });
+        return;
+      } else if (err instanceof Error && err.message.includes("issues_goal_id_goals_id_fk")) {
+        res.status(400).json({ error: "goal not found" });
+        return;
       }
       throw err;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5033,12 +5033,29 @@ export function issueRoutes(
           },
           "issue update rejected with 422",
         );
-      } else if (err instanceof Error && err.message.includes("issues_parent_id_issues_id_fk")) {
-        res.status(400).json({ error: "parent issue not found" });
-        return;
-      } else if (err instanceof Error && err.message.includes("issues_goal_id_goals_id_fk")) {
-        res.status(400).json({ error: "goal not found" });
-        return;
+      } else {
+        const candidate = err as any;
+        const constraintName =
+          candidate?.constraint ??
+          candidate?.constraint_name ??
+          candidate?.cause?.constraint ??
+          candidate?.cause?.constraint_name;
+
+        if (constraintName === "issues_parent_id_issues_id_fk") {
+          logger.warn(
+            { issueId: id, companyId: existing.companyId, error: err },
+            "issue update rejected due to stale parentId",
+          );
+          res.status(400).json({ error: "parent issue not found" });
+          return;
+        } else if (constraintName === "issues_goal_id_goals_id_fk") {
+          logger.warn(
+            { issueId: id, companyId: existing.companyId, error: err },
+            "issue update rejected due to stale goalId",
+          );
+          res.status(400).json({ error: "goal not found" });
+          return;
+        }
       }
       throw err;
     }


### PR DESCRIPTION
## Thinking Path
The issue identified was that assigning stale `parentId` or `goalId` UUIDs caused raw 500 server errors because the Postgres driver threw FK constraint violations. This prevented agents from receiving actionable error messages. To solve this, I mapped the `issues_parent_id_issues_id_fk` and `issues_goal_id_goals_id_fk` violations to a 400 Bad Request error. Following code review, the detection logic was updated to use structured constraint names (`err.constraint` / `err.cause.constraint`) instead of brittle string matching, and missing `logger.warn` statements were added.

## What Changed
- Added catch block paths in `server/src/routes/issues.ts` for `PATCH /issues/:id`.
- Safely extract constraint names from the database error or its underlying `.cause`.
- Respond with 400 when parentId or goalId FKs are violated, and emit structured logs.

## Verification
- Sent a PATCH request with a non-existent parentId to trigger the FK error.
- Verified that a 400 is returned instead of 500, and a log entry is created.

## Risks
- Low risk. The change is narrowly scoped to handling specific FK constraint errors.

## Model Used
- Claude 3.5 Sonnet / Antigravity

- [x] I searched the GitHub PR list for similar PRs before creating this one.

Fixes #7656
