### PR TITLE
Fix idle workload counting

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -82,6 +82,11 @@ const mockIssueApprovalService = vi.hoisted(() => ({
 
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
+  listDependencyReadiness: vi.fn(),
+}));
+
+const mockIssueRecoveryActionService = vi.hoisted(() => ({
+  listActiveForIssues: vi.fn(),
 }));
 
 const mockSecretService = vi.hoisted(() => ({
@@ -156,6 +161,10 @@ function registerModuleMocks() {
     issueApprovalService: () => mockIssueApprovalService,
   }));
 
+  vi.doMock("../services/issue-recovery-actions.js", () => ({
+    issueRecoveryActionService: () => mockIssueRecoveryActionService,
+  }));
+
   vi.doMock("../services/issues.js", () => ({
     issueService: () => mockIssueService,
   }));
@@ -195,6 +204,7 @@ function registerModuleMocks() {
     heartbeatService: () => mockHeartbeatService,
     ISSUE_LIST_DEFAULT_LIMIT: 500,
     issueApprovalService: () => mockIssueApprovalService,
+    issueRecoveryActionService: () => mockIssueRecoveryActionService,
     issueService: () => mockIssueService,
     logActivity: mockLogActivity,
     secretService: () => mockSecretService,
@@ -284,6 +294,7 @@ describe.sequential("agent permission routes", () => {
     vi.doUnmock("../services/index.js");
     vi.doUnmock("../services/instance-settings.js");
     vi.doUnmock("../services/issue-approvals.js");
+    vi.doUnmock("../services/issue-recovery-actions.js");
     vi.doUnmock("../services/issues.js");
     vi.doUnmock("../services/secrets.js");
     vi.doUnmock("../services/environments.js");
@@ -319,6 +330,8 @@ describe.sequential("agent permission routes", () => {
     mockHeartbeatService.cancelRun.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
     mockIssueService.list.mockReset();
+    mockIssueService.listDependencyReadiness.mockReset();
+    mockIssueRecoveryActionService.listActiveForIssues.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
     mockSecretService.resolveAdapterConfigForRuntime.mockReset();
     mockAgentInstructionsService.materializeManagedBundle.mockReset();
@@ -370,6 +383,8 @@ describe.sequential("agent permission routes", () => {
     mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
     mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(async (_companyId, requested) => requested);
     mockBudgetService.upsertPolicy.mockResolvedValue(undefined);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map());
+    mockIssueRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map());
     mockAgentInstructionsService.materializeManagedBundle.mockImplementation(
       async (agent: Record<string, unknown>, files: Record<string, string>) => ({
         bundle: null,
@@ -1489,6 +1504,138 @@ describe.sequential("agent permission routes", () => {
       inboxArchivedByUserId: "board-user",
       status: "backlog,todo,in_progress,in_review,blocked,done",
       limit: 500,
+    });
+  });
+
+  it("classifies assigned inbox-lite work as runnable or waiting", async () => {
+    const updatedAt = new Date("2026-06-03T12:00:00.000Z");
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: "issue-todo",
+        identifier: "PAP-1151",
+        title: "Runnable assigned todo",
+        status: "todo",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+      {
+        id: "issue-blocked",
+        identifier: "PAP-1200",
+        title: "Blocked todo",
+        status: "todo",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+      {
+        id: "issue-running",
+        identifier: "PAP-1201",
+        title: "Running todo",
+        status: "todo",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: { id: "run-1", status: "queued" },
+      },
+      {
+        id: "issue-recovery",
+        identifier: "PAP-1202",
+        title: "Recovery todo",
+        status: "todo",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+      {
+        id: "issue-continuation",
+        identifier: "PAP-1205",
+        title: "Continuation work",
+        status: "in_progress",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+      {
+        id: "issue-review",
+        identifier: "PAP-1203",
+        title: "Review wait",
+        status: "in_review",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+      {
+        id: "issue-status-blocked",
+        identifier: "PAP-1204",
+        title: "Blocked status",
+        status: "blocked",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map([
+      ["issue-blocked", {
+        isDependencyReady: false,
+        unresolvedBlockerCount: 1,
+        unresolvedBlockerIssueIds: ["blocker-1"],
+      }],
+    ]));
+    mockIssueRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map([
+      ["issue-recovery", { id: "recovery-1", status: "open" }],
+    ]));
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+      source: "agent_key",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get("/api/agents/me/inbox-lite"));
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(companyId, {
+      assigneeAgentId: agentId,
+      status: "todo,in_progress,in_review,blocked",
+      includeRoutineExecutions: true,
+      limit: 500,
+    });
+    expect(res.body.map((issue: { id: string; runnableWork: unknown }) => [issue.id, issue.runnableWork])).toEqual([
+      ["issue-todo", { runnable: true, reason: "ready" }],
+      ["issue-blocked", { runnable: false, reason: "blocked_dependencies" }],
+      ["issue-running", { runnable: false, reason: "active_run" }],
+      ["issue-recovery", { runnable: false, reason: "active_recovery_action" }],
+      ["issue-continuation", { runnable: true, reason: "continuation_required" }],
+      ["issue-review", { runnable: false, reason: "awaiting_review" }],
+      ["issue-status-blocked", { runnable: false, reason: "issue_blocked" }],
+    ]);
+    expect(res.body[1]).toMatchObject({
+      dependencyReady: false,
+      unresolvedBlockerCount: 1,
+      unresolvedBlockerIssueIds: ["blocker-1"],
     });
   });
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -107,6 +107,31 @@ import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
 
+type AgentInboxLiteIssueStatus = "todo" | "in_progress" | "in_review" | "blocked";
+type AgentInboxRunnableWorkReason =
+  | "ready"
+  | "issue_blocked"
+  | "awaiting_review"
+  | "active_run"
+  | "active_recovery_action"
+  | "blocked_dependencies"
+  | "continuation_required";
+
+function classifyAgentInboxRunnableWork(input: {
+  status: AgentInboxLiteIssueStatus;
+  activeRun: unknown;
+  activeRecoveryAction: unknown;
+  dependencyReady: boolean;
+}): { runnable: boolean; reason: AgentInboxRunnableWorkReason } {
+  if (input.status === "blocked") return { runnable: false, reason: "issue_blocked" };
+  if (input.status === "in_review") return { runnable: false, reason: "awaiting_review" };
+  if (input.activeRun) return { runnable: false, reason: "active_run" };
+  if (input.activeRecoveryAction) return { runnable: false, reason: "active_recovery_action" };
+  if (!input.dependencyReady) return { runnable: false, reason: "blocked_dependencies" };
+  if (input.status === "todo") return { runnable: true, reason: "ready" };
+  return { runnable: true, reason: "continuation_required" };
+}
+
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
   if (!Number.isFinite(parsed)) return RUN_LOG_DEFAULT_LIMIT_BYTES;
@@ -1853,7 +1878,7 @@ export function agentRoutes(
     const recoveryActionsSvc = issueRecoveryActionService(db);
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
-      status: "todo,in_progress,blocked",
+      status: "todo,in_progress,in_review,blocked",
       includeRoutineExecutions: true,
       limit: ISSUE_LIST_DEFAULT_LIMIT,
     });
@@ -1864,22 +1889,34 @@ export function agentRoutes(
     ]);
 
     res.json(
-      rows.map((issue) => ({
-        id: issue.id,
-        identifier: issue.identifier,
-        title: issue.title,
-        status: issue.status,
-        priority: issue.priority,
-        projectId: issue.projectId,
-        goalId: issue.goalId,
-        parentId: issue.parentId,
-        updatedAt: issue.updatedAt,
-        activeRun: issue.activeRun,
-        activeRecoveryAction: recoveryActionByIssue.get(issue.id) ?? null,
-        dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
-        unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
-        unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
-      })),
+      rows.map((issue) => {
+        const readiness = dependencyReadiness.get(issue.id);
+        const activeRecoveryAction = recoveryActionByIssue.get(issue.id) ?? null;
+        const dependencyReady = readiness?.isDependencyReady ?? true;
+
+        return {
+          id: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          status: issue.status,
+          priority: issue.priority,
+          projectId: issue.projectId,
+          goalId: issue.goalId,
+          parentId: issue.parentId,
+          updatedAt: issue.updatedAt,
+          activeRun: issue.activeRun,
+          activeRecoveryAction,
+          dependencyReady,
+          unresolvedBlockerCount: readiness?.unresolvedBlockerCount ?? 0,
+          unresolvedBlockerIssueIds: readiness?.unresolvedBlockerIssueIds ?? [],
+          runnableWork: classifyAgentInboxRunnableWork({
+            status: issue.status as AgentInboxLiteIssueStatus,
+            activeRun: issue.activeRun,
+            activeRecoveryAction,
+            dependencyReady,
+          }),
+        };
+      }),
     );
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that routes work to agents and surfaces their assigned work through lightweight APIs such as `GET /api/agents/me/inbox-lite`.
> - The affected subsystem is the agent inbox / workload-accounting path that downstream automation uses to decide whether an agent is actually busy.
> - The bug was that inbox-lite returned assigned issues without distinguishing runnable work from parked work such as blocked, review, dependency-wait, active-run, or recovery-wait states.
> - That made idle agents with assigned but non-runnable issues look busy, which breaks workload balancing and issue delegation decisions.
> - This needed to be fixed in the route response itself because the incorrect signal was coming from the shape of the API projection, not from a stale execution lock in the reproduced data.
> - This pull request adds explicit runnable/non-runnable classification, expands the projection to include `in_review` explainability, and locks the behavior down with a focused regression test.
> - The benefit is that consumers can count actual runnable work instead of raw assigned rows, so idle agents are no longer misclassified as actively loaded.

## Linked Issues or Issue Description

No matching public GitHub issue was found for this bug, so the issue is described inline following the bug template.

### Pre-submission checklist
- [x] I searched existing open and closed issues and did not find a matching public GitHub issue for this exact bug.
- [x] I reproduced the problem against current `master` behavior before fixing it.
- [x] I confirmed the incorrect workload signal originated in Paperclip's inbox-lite projection rather than a third-party adapter or local config.

### What happened?
When workload-balancing logic used `GET /api/agents/me/inbox-lite`, agents with assigned but non-runnable work could still be counted as busy because the response exposed raw assigned issue rows without saying whether each row represented runnable work.

### Expected behavior
Inbox-lite should let consumers distinguish runnable work from waiting states so blocked, review, active-run, recovery, and dependency-gated issues are not counted as active workload for idle-agent balancing.

### Steps to reproduce
1. Assign an agent a mix of `todo`, `in_progress`, `in_review`, and `blocked` issues.
2. Ensure some of those issues are non-runnable because they are blocked by dependencies, already have an active run, are waiting on recovery, or are in review.
3. Read `GET /api/agents/me/inbox-lite` and use row presence alone as the workload signal.
4. Observe that non-runnable assigned issues are indistinguishable from runnable work, causing idle agents with parked assignments to look busy.

### Paperclip version or commit
- Reproduced on current `master` before the fix.
- Fix branch commit: `923ed74b`.

### Deployment mode
- Built from source (`pnpm build` / local source checkout).

### Installation method
- Built from source.

### Agent adapter(s) involved
- Not adapter-specific (core bug).

### Database mode
- Not database-related.

### Access context
- Agent-authenticated inbox-lite route, with downstream board/agent workload balancing consuming the result.

### Node.js version
- `v22.20.0`

### Additional context
- Related workload / assignment PRs reviewed during dedup search: #5862 and #5867.
- Internal Paperclip tracking existed outside GitHub, but no matching public GitHub issue was found to link here.

## What Changed

- Added `runnableWork` classification to the `GET /api/agents/me/inbox-lite` response so consumers can distinguish runnable work from waiting states.
- Expanded the inbox-lite status query to include `in_review` rows for explainability instead of hiding them from the projection.
- Classified blocked, review, active-run, active-recovery, and dependency-wait states as non-runnable, while preserving runnable `todo` and continuation `in_progress` work.
- Added a focused route test covering blocked dependencies, active runs, recovery actions, review waits, blocked status rows, and in-progress continuations.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts`
- `pnpm --filter @paperclipai/server build`
- Searched for duplicate / related PRs with `gh pr list --state all --search ...` and reviewed relevant matches.

## Risks

- Low risk. The change is additive to the inbox-lite response shape and preserves existing rows while adding runnable classification for consumers that need accurate workload signals.
- Existing consumers that incorrectly count raw row presence will still need to use `runnableWork` to benefit from the fix, but the route now exposes the necessary signal explicitly.

## Model Used

- OpenAI GPT-5.4 via Codex local (`codex_local` adapter in Paperclip).
- Tool-assisted coding with shell, git, GitHub CLI, and local test/build execution.
- Repository-scale context with code search and targeted reasoning over route, test, and PR metadata.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
