### PR TITLE
fix(interactions): tolerate legacy stale confirmation results

### DIFF
--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -19,6 +19,7 @@ function createSelectChain(rows: SelectRow[]) {
             then(callback: (rows: SelectRow[]) => unknown) {
               return Promise.resolve(callback(rows));
             },
+            orderBy: async () => rows,
           };
         },
       };
@@ -77,6 +78,35 @@ describe("issueThreadInteractionService", () => {
     vi.resetModules();
     vi.clearAllMocks();
   });
+
+  function legacyRequestConfirmationRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "interaction-legacy-expired",
+      companyId: "company-1",
+      issueId: "11111111-1111-4111-8111-111111111111",
+      kind: "request_confirmation",
+      status: "expired",
+      continuationPolicy: "wake_assignee_on_accept",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: null,
+      title: "Confirm plan",
+      summary: null,
+      createdByAgentId: "agent-1",
+      createdByUserId: null,
+      resolvedByAgentId: null,
+      resolvedByUserId: "local-board",
+      payload: {
+        version: 1,
+        prompt: "Proceed?",
+      },
+      result: null,
+      resolvedAt: new Date("2026-06-05T18:00:00.000Z"),
+      createdAt: new Date("2026-06-05T17:00:00.000Z"),
+      updatedAt: new Date("2026-06-05T18:00:00.000Z"),
+      ...overrides,
+    };
+  }
 
   it("create reuses an existing interaction for the same idempotency key", async () => {
     const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
@@ -211,5 +241,65 @@ describe("issueThreadInteractionService", () => {
     });
     expect(state.interactionUpdates).toHaveLength(1);
     expect(state.issueTouches).toHaveLength(1);
+  });
+
+  it("listForIssue normalizes legacy stale request confirmation target results", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const legacyExpiredRow = legacyRequestConfirmationRow({
+      result: {
+        version: 1,
+        outcome: "stale_target",
+        staleTarget: {
+          pr: 911,
+          staleHead: "4a6e4b51a198519ee1358c922c92f8868ba58400",
+          currentHead: "9b310c1952f6c2013dac0e8f5d77f75debaa687c",
+        },
+      },
+    });
+    const db: any = {
+      select: vi.fn(() => createSelectChain([legacyExpiredRow])),
+      update: vi.fn(),
+    };
+    const svc = issueThreadInteractionService(db as never);
+
+    const result = await svc.listForIssue("11111111-1111-4111-8111-111111111111");
+
+    expect(result[0]?.status).toBe("expired");
+    expect(result[0]?.result).toEqual({
+      version: 1,
+      outcome: "stale_target",
+      reason: "Legacy request confirmation stale target normalized for compatibility.",
+    });
+  });
+
+  it("listForIssue normalizes legacy superseded request confirmation results", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const legacyExpiredRow = legacyRequestConfirmationRow({
+      result: {
+        outcome: "accepted",
+        commentId: "22222222-2222-4222-8222-222222222222",
+        reason: "Superseded by a later comment.",
+        staleTarget: {
+          pr: 911,
+        },
+      },
+    });
+    const db: any = {
+      select: vi.fn(() => createSelectChain([legacyExpiredRow])),
+      update: vi.fn(),
+    };
+    const svc = issueThreadInteractionService(db as never);
+
+    const result = await svc.listForIssue("11111111-1111-4111-8111-111111111111");
+
+    expect(result[0]?.status).toBe("expired");
+    expect(result[0]?.result).toEqual({
+      version: 1,
+      outcome: "superseded_by_comment",
+      commentId: "22222222-2222-4222-8222-222222222222",
+      reason: "Superseded by a later comment.",
+    });
   });
 });

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -112,6 +112,62 @@ function isEquivalentCreateRequest(
   );
 }
 
+function normalizeRequestConfirmationLikeResult(
+  row: IssueThreadInteractionRow,
+  schema: typeof requestConfirmationResultSchema | typeof requestCheckboxConfirmationResultSchema,
+) {
+  if (!row.result) return null;
+
+  const parsed = schema.safeParse(row.result);
+  if (parsed.success) return parsed.data;
+
+  const result: unknown = row.result;
+  if (typeof result !== "object" || result === null || !("outcome" in result)) {
+    return schema.parse(row.result);
+  }
+
+  const legacyResult = result as Record<string, unknown>;
+  const withVersion = schema.safeParse({
+    ...legacyResult,
+    version: 1,
+  });
+  if (withVersion.success) return withVersion.data;
+
+  const outcome = legacyResult.outcome;
+  const resultReason = typeof legacyResult.reason === "string" ? legacyResult.reason : "";
+  const legacyReason =
+    resultReason || "Legacy request confirmation stale target normalized for compatibility.";
+
+  const looksSuperseded =
+    outcome === "superseded_by_comment"
+    || typeof legacyResult.commentId === "string";
+  if (row.status === "expired" && looksSuperseded) {
+    const superseded = schema.safeParse({
+      ...legacyResult,
+      version: 1,
+      outcome: "superseded_by_comment",
+      ...(typeof legacyResult.commentId === "string" ? { commentId: legacyResult.commentId } : {}),
+      reason: legacyReason,
+      staleTarget: undefined,
+    });
+    if (superseded.success) return superseded.data;
+  }
+
+  if (outcome === "stale_target") {
+    const staleTarget = requestConfirmationResultSchema.shape.staleTarget.safeParse(legacyResult.staleTarget);
+    const stale = schema.safeParse({
+      ...legacyResult,
+      version: 1,
+      outcome: "stale_target",
+      staleTarget: staleTarget.success ? staleTarget.data : undefined,
+      reason: legacyReason,
+    });
+    if (stale.success) return stale.data;
+  }
+
+  return schema.parse(row.result);
+}
+
 function hydrateInteraction(
   row: IssueThreadInteractionRow,
 ): IssueThreadInteraction {
@@ -142,14 +198,14 @@ function hydrateInteraction(
         ...base,
         kind: "request_confirmation",
         payload: requestConfirmationPayloadSchema.parse(row.payload),
-        result: row.result ? requestConfirmationResultSchema.parse(row.result) : null,
+        result: normalizeRequestConfirmationLikeResult(row, requestConfirmationResultSchema),
       } satisfies RequestConfirmationInteraction;
     case "request_checkbox_confirmation":
       return {
         ...base,
         kind: "request_checkbox_confirmation",
         payload: requestCheckboxConfirmationPayloadSchema.parse(row.payload),
-        result: row.result ? requestCheckboxConfirmationResultSchema.parse(row.result) : null,
+        result: normalizeRequestConfirmationLikeResult(row, requestCheckboxConfirmationResultSchema),
       } satisfies RequestCheckboxConfirmationInteraction;
     default:
       throw unprocessable(`Unknown interaction kind: ${row.kind}`);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue thread interactions API is the control-plane surface that lists pending and completed user/agent interactions for an issue.
> - Expired request confirmations can persist historical `result` payloads that were written before the current result schema.
> - One legacy expired confirmation for VIVA-2058 stored `staleTarget` as PR/head metadata without the current discriminator shape.
> - Listing interactions for the issue failed at response validation, which hid the current pending confirmation from QA and automation.
> - This pull request adds compatibility normalization at hydration time so malformed legacy stale-target metadata cannot break the interaction listing endpoint.
> - The benefit is a narrow, backward-compatible repair that preserves current schemas while keeping historical rows readable.

## Linked Issues or Issue Description

Bug: legacy expired request confirmation results can make `GET /api/issues/:id/interactions` fail validation.

- Internal refs: VIVA-2074, VIVA-2058.
- Related PR: #7614.
- Observed failure: `invalid_union_discriminator` at `staleTarget.type` when a historical expired confirmation stored `staleTarget` as `{ pr, staleHead, currentHead }`.
- Expected behavior: the interactions endpoint should continue listing the issue thread, including the current pending confirmation, even when old expired interaction result rows contain stale metadata.

## What Changed

- Added request-confirmation result normalization when hydrating issue thread interactions.
- Preserved valid current result payloads exactly as-is.
- Backfilled missing legacy `version: 1` where possible.
- Dropped invalid legacy `staleTarget` metadata for stale-target outcomes and returned a schema-valid stale-target result with the existing reason.
- Normalized legacy superseded-by-comment results when the row has a durable superseded signal such as `commentId` or explicit `superseded_by_comment` outcome.
- Applied the same normalization to checkbox request confirmations.
- Added regression coverage for the live VIVA-2058 malformed `staleTarget` shape and for legacy superseded-by-comment rows.

## Verification

- PASS: `pnpm exec vitest run server/src/services/issue-thread-interactions.test.ts`
- PASS: `pnpm exec vitest run server/src/services/issue-thread-interactions.test.ts server/src/__tests__/issue-thread-interactions-service.test.ts`
- PASS: `pnpm --filter @paperclipai/server typecheck`
- PASS: `pnpm -r typecheck`
- PASS: `pnpm build`
- PASS: live control-plane readback after one-row runtime data repair: `GET /api/issues/5fa00b91-5713-4ba3-89d5-cd9afe855100/interactions` returned 4 interactions with `hasCurrentPending: true` for `367d73b1-d9c3-415e-82b8-5fcc6339e3f0` and `hasStaleExpired: true` for `94a784ec-a210-40f7-a081-176c784b6a4a`.
- PASS: GitHub PR matrix on final commit `055c95e8`: policy, review, Typecheck + Release Registry, General tests (server), General tests (workspaces-a), General tests (workspaces-b), Build, Verify serialized server suites (1/4-4/4), Canary Dry Run, e2e, verify, Socket, security-review, and Snyk.
- NOTE: local `pnpm test:run` previously failed in unrelated baseline/environment suites: `cursor-local-adapter-environment.test.ts`, `cursor-local-execute.test.ts`, and `workspace-runtime.test.ts`. The GitHub PR matrix passed these gates on the final commit.

## Risks

Low risk. This only changes deserialization/hydration for request-confirmation-like interaction rows. Current schema-valid results are returned unchanged. Invalid legacy stale-target details are dropped only when needed to keep old stale-target rows readable, and the fallback no longer broadly rewrites every expired unknown result.

## Model Used

OpenAI GPT-5 Codex local coding agent with shell/tool execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
