### PR TITLE
feat(tree-hold): exempt productivity-review issues from subtree pause hold (SAG-2127)

### DIFF
--- a/packages/shared/src/constants.test.ts
+++ b/packages/shared/src/constants.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isIssueProductivityReviewOriginKind } from "./constants.js";
+
+describe("isIssueProductivityReviewOriginKind", () => {
+  it("returns true only for the literal 'issue_productivity_review'", () => {
+    expect(isIssueProductivityReviewOriginKind("issue_productivity_review")).toBe(true);
+  });
+
+  it("returns false for other built-in origin kinds", () => {
+    expect(isIssueProductivityReviewOriginKind("manual")).toBe(false);
+    expect(isIssueProductivityReviewOriginKind("routine_execution")).toBe(false);
+    expect(isIssueProductivityReviewOriginKind("stranded_issue_recovery")).toBe(false);
+    expect(isIssueProductivityReviewOriginKind("stale_active_run_evaluation")).toBe(false);
+    expect(isIssueProductivityReviewOriginKind("harness_liveness_escalation")).toBe(false);
+  });
+
+  it("returns false for plugin origin kinds", () => {
+    expect(isIssueProductivityReviewOriginKind("plugin:my-plugin:operation")).toBe(false);
+  });
+
+  it("returns false for null and undefined", () => {
+    expect(isIssueProductivityReviewOriginKind(null)).toBe(false);
+    expect(isIssueProductivityReviewOriginKind(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string and partial matches", () => {
+    expect(isIssueProductivityReviewOriginKind("")).toBe(false);
+    expect(isIssueProductivityReviewOriginKind("productivity_review")).toBe(false);
+    expect(isIssueProductivityReviewOriginKind("issue_productivity")).toBe(false);
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -334,6 +334,10 @@ export function isPluginOperationIssueOriginKind(originKind: string | null | und
   return typeof originKind === "string" && /^plugin:[^:]+:operation(?::|$)/.test(originKind);
 }
 
+export function isIssueProductivityReviewOriginKind(originKind: string | null | undefined): boolean {
+  return originKind === "issue_productivity_review";
+}
+
 export const ISSUE_RELATION_TYPES = ["blocks"] as const;
 export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -147,6 +147,7 @@ export {
   ISSUE_RECOVERY_ACTION_OUTCOMES,
   pluginOperationIssueOriginKind,
   isPluginOperationIssueOriginKind,
+  isIssueProductivityReviewOriginKind,
   ISSUE_RELATION_TYPES,
   ISSUE_TREE_CONTROL_MODES,
   ISSUE_TREE_HOLD_RELEASE_POLICY_STRATEGIES,

--- a/server/src/__tests__/issue-tree-control-service.test.ts
+++ b/server/src/__tests__/issue-tree-control-service.test.ts
@@ -688,4 +688,81 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
       resumeMode: "subtree",
     });
   });
+
+  it("exempts productivity-review child issues from subtree pause hold on checkout", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const parentIssueId = randomUUID();
+    const reviewChildId = randomUUID();
+    const normalChildId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ReviewAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: parentIssueId,
+        companyId,
+        title: "Parent (held)",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: reviewChildId,
+        companyId,
+        parentId: parentIssueId,
+        title: "Productivity review child",
+        status: "todo",
+        priority: "medium",
+        originKind: "issue_productivity_review",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: normalChildId,
+        companyId,
+        parentId: parentIssueId,
+        title: "Normal child",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const treeSvc = issueTreeControlService(db);
+    await treeSvc.createHold(companyId, parentIssueId, {
+      mode: "pause",
+      reason: "test pause hold",
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
+    });
+
+    const issueSvc = issueService(db);
+
+    // Regression: normal child still gets 409
+    await expect(
+      issueSvc.checkout(normalChildId, agentId, ["todo"], null),
+    ).rejects.toMatchObject({
+      status: 409,
+      details: expect.objectContaining({ rootIssueId: parentIssueId, mode: "pause" }),
+    });
+
+    // Fix: productivity-review child can checkout despite the hold
+    const checked = await issueSvc.checkout(reviewChildId, agentId, ["todo"], null);
+    expect(checked.status).toBe("in_progress");
+    expect(checked.id).toBe(reviewChildId);
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -59,6 +59,7 @@ import {
   updateIssueSchema,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
+  isIssueProductivityReviewOriginKind,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
   type CompanySearchQuery,
@@ -3532,7 +3533,7 @@ export function issueRoutes(
   async function assertExplicitResumeIntentAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null; originKind?: string | null },
   ) {
     if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
 
@@ -3555,18 +3556,20 @@ export function issueRoutes(
       return false;
     }
 
-    const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id);
-    if (activePauseHold) {
-      res.status(409).json({
-        error: "Issue follow-up blocked by active subtree pause hold",
-        details: {
-          issueId: issue.id,
-          holdId: activePauseHold.holdId,
-          rootIssueId: activePauseHold.rootIssueId,
-          mode: activePauseHold.mode,
-        },
-      });
-      return false;
+    if (!isIssueProductivityReviewOriginKind(issue.originKind)) {
+      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id);
+      if (activePauseHold) {
+        res.status(409).json({
+          error: "Issue follow-up blocked by active subtree pause hold",
+          details: {
+            issueId: issue.id,
+            holdId: activePauseHold.holdId,
+            rootIssueId: activePauseHold.rootIssueId,
+            mode: activePauseHold.mode,
+          },
+        });
+        return false;
+      }
     }
 
     if (issue.status === "blocked") {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11,6 +11,7 @@ import {
   MODEL_PROFILE_KEYS,
   envBindingSchema,
   isEnvironmentDriverSupportedForAdapter,
+  isIssueProductivityReviewOriginKind,
   type BillingType,
   type EnvironmentLeaseStatus,
   type ExecutionWorkspace,
@@ -6942,6 +6943,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
         projectId: issues.projectId,
+        originKind: issues.originKind,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -7088,7 +7090,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           projectId: issue.projectId,
         })
         : Promise.resolve(null),
-      issue
+      issue && !isIssueProductivityReviewOriginKind(issue.originKind)
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
         : Promise.resolve(null),
       issue
@@ -7802,6 +7804,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        originKind: issues.originKind,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -7891,19 +7894,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
-    if (activePauseHold) {
-      return {
-        allowed: false,
-        reason: "Scheduled retry suppressed because the issue is held by an active subtree pause hold",
-        errorCode: "issue_paused",
-        issueId,
-        details: {
+    if (!isIssueProductivityReviewOriginKind(issue.originKind)) {
+      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
+      if (activePauseHold) {
+        return {
+          allowed: false,
+          reason: "Scheduled retry suppressed because the issue is held by an active subtree pause hold",
+          errorCode: "issue_paused",
           issueId,
-          holdId: activePauseHold.holdId,
-          rootIssueId: activePauseHold.rootIssueId,
-        },
-      };
+          details: {
+            issueId,
+            holdId: activePauseHold.holdId,
+            rootIssueId: activePauseHold.rootIssueId,
+          },
+        };
+      }
     }
 
     const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
@@ -9006,6 +9011,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const issueId = readNonEmptyString(context.issueId);
     if (issueId) {
+      const issueOriginKind = await db
+        .select({ originKind: issues.originKind })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0]?.originKind ?? null);
+      if (!isIssueProductivityReviewOriginKind(issueOriginKind)) {
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
       const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(db, {
         companyId: run.companyId,
@@ -9035,6 +9046,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
         });
         return null;
+      }
       }
 
       const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
@@ -12560,39 +12572,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         const deferredPayload = parseObject(deferred.payload);
         const deferredContextSeed = parseObject(deferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
-        const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id);
-        const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(tx, {
-          companyId: issue.companyId,
-          issueId: issue.id,
-          agentId: deferred.agentId,
-          contextSnapshot: deferredContextSeed,
-          requestedByActorType: deferred.requestedByActorType,
-          requestedByActorId: deferred.requestedByActorId,
-        });
-        if (activePauseHold && !treeHoldInteractionWake) {
-          await tx
-            .update(agentWakeupRequests)
-            .set({
-              status: "cancelled",
-              finishedAt: new Date(),
-              error: "Deferred wake suppressed by active subtree pause hold",
-              updatedAt: new Date(),
-            })
-            .where(eq(agentWakeupRequests.id, deferred.id));
-          continue;
-        }
-
         const promotedContextSeed: Record<string, unknown> = { ...deferredContextSeed };
-        if (activePauseHold) {
-          promotedContextSeed.treeHoldInteraction = true;
-          promotedContextSeed.activeTreeHold = {
-            holdId: activePauseHold.holdId,
-            rootIssueId: activePauseHold.rootIssueId,
-            mode: activePauseHold.mode,
-            reason: activePauseHold.reason,
-            releasePolicy: activePauseHold.releasePolicy,
-            interaction: true,
-          };
+        if (!isIssueProductivityReviewOriginKind(issue.originKind)) {
+          const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id);
+          const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(tx, {
+            companyId: issue.companyId,
+            issueId: issue.id,
+            agentId: deferred.agentId,
+            contextSnapshot: deferredContextSeed,
+            requestedByActorType: deferred.requestedByActorType,
+            requestedByActorId: deferred.requestedByActorId,
+          });
+          if (activePauseHold && !treeHoldInteractionWake) {
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                status: "cancelled",
+                finishedAt: new Date(),
+                error: "Deferred wake suppressed by active subtree pause hold",
+                updatedAt: new Date(),
+              })
+              .where(eq(agentWakeupRequests.id, deferred.id));
+            continue;
+          }
+          if (activePauseHold) {
+            promotedContextSeed.treeHoldInteraction = true;
+            promotedContextSeed.activeTreeHold = {
+              holdId: activePauseHold.holdId,
+              rootIssueId: activePauseHold.rootIssueId,
+              mode: activePauseHold.mode,
+              reason: activePauseHold.reason,
+              releasePolicy: activePauseHold.releasePolicy,
+              interaction: true,
+            };
+          }
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
@@ -12926,7 +12939,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "released" as const };
       }
 
-      if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+      if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc, issue.originKind)) {
         return { kind: "released" as const };
       }
 
@@ -13322,49 +13335,56 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issueId) {
-      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(agent.companyId, issueId);
-      if (activePauseHold) {
-        const treeHoldInteractionWake = await isVerifiedIssueTreeControlInteractionWake(db, {
-          companyId: agent.companyId,
-          issueId,
-          agentId,
-          contextSnapshot: enrichedContextSnapshot,
-          requestedByActorType: opts.requestedByActorType,
-          requestedByActorId: opts.requestedByActorId,
-        });
-
-        if (!treeHoldInteractionWake) {
-          await writeSkippedRequest("issue_tree_hold_active");
-          await logActivity(db, {
+      const issueOriginKind = await db
+        .select({ originKind: issues.originKind })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
+        .then((rows) => rows[0]?.originKind ?? null);
+      if (!isIssueProductivityReviewOriginKind(issueOriginKind)) {
+        const activePauseHold = await treeControlSvc.getActivePauseHoldGate(agent.companyId, issueId);
+        if (activePauseHold) {
+          const treeHoldInteractionWake = await isVerifiedIssueTreeControlInteractionWake(db, {
             companyId: agent.companyId,
-            actorType: "system",
-            actorId: "system",
+            issueId,
             agentId,
-            runId: null,
-            action: "issue.tree_hold_wakeup_deferred",
-            entityType: "issue",
-            entityId: issueId,
-            details: {
-              holdId: activePauseHold.holdId,
-              rootIssueId: activePauseHold.rootIssueId,
-              requestedReason: reason,
-              source,
-              triggerDetail,
-              securityPrinciples: ["Complete Mediation", "Fail Securely", "Secure Defaults"],
-            },
+            contextSnapshot: enrichedContextSnapshot,
+            requestedByActorType: opts.requestedByActorType,
+            requestedByActorId: opts.requestedByActorId,
           });
-          return null;
-        }
 
-        enrichedContextSnapshot.treeHoldInteraction = true;
-        enrichedContextSnapshot.activeTreeHold = {
-          holdId: activePauseHold.holdId,
-          rootIssueId: activePauseHold.rootIssueId,
-          mode: activePauseHold.mode,
-          reason: activePauseHold.reason,
-          releasePolicy: activePauseHold.releasePolicy,
-          interaction: true,
-        };
+          if (!treeHoldInteractionWake) {
+            await writeSkippedRequest("issue_tree_hold_active");
+            await logActivity(db, {
+              companyId: agent.companyId,
+              actorType: "system",
+              actorId: "system",
+              agentId,
+              runId: null,
+              action: "issue.tree_hold_wakeup_deferred",
+              entityType: "issue",
+              entityId: issueId,
+              details: {
+                holdId: activePauseHold.holdId,
+                rootIssueId: activePauseHold.rootIssueId,
+                requestedReason: reason,
+                source,
+                triggerDetail,
+                securityPrinciples: ["Complete Mediation", "Fail Securely", "Secure Defaults"],
+              },
+            });
+            return null;
+          }
+
+          enrichedContextSnapshot.treeHoldInteraction = true;
+          enrichedContextSnapshot.activeTreeHold = {
+            holdId: activePauseHold.holdId,
+            rootIssueId: activePauseHold.rootIssueId,
+            mode: activePauseHold.mode,
+            reason: activePauseHold.reason,
+            releasePolicy: activePauseHold.releasePolicy,
+            interaction: true,
+          };
+        }
       }
     }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -59,6 +59,7 @@ import {
   issueCommentAuthorTypeSchema,
   issueCommentMetadataSchema,
   issueCommentPresentationSchema,
+  isIssueProductivityReviewOriginKind,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
@@ -6412,7 +6413,7 @@ export function issueService(db: Db) {
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
       const issueCompany = await db
-        .select({ companyId: issues.companyId })
+        .select({ companyId: issues.companyId, originKind: issues.originKind })
         .from(issues)
         .where(eq(issues.id, id))
         .then((rows) => rows[0] ?? null);
@@ -6420,18 +6421,20 @@ export function issueService(db: Db) {
       await assertAssignableAgent(db, issueCompany.companyId, agentId, { kind: "work" });
 
       const now = new Date();
-      const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issueCompany.companyId, id);
-      if (
-        activePauseHold &&
-        !(await isTreeHoldInteractionCheckoutAllowed(issueCompany.companyId, checkoutRunId, activePauseHold))
-      ) {
-        throw conflict("Issue checkout blocked by active subtree pause hold", {
-          issueId: id,
-          holdId: activePauseHold.holdId,
-          rootIssueId: activePauseHold.rootIssueId,
-          mode: activePauseHold.mode,
-          securityPrinciples: ["Complete Mediation", "Fail Securely", "Secure Defaults"],
-        });
+      if (!isIssueProductivityReviewOriginKind(issueCompany.originKind)) {
+        const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issueCompany.companyId, id);
+        if (
+          activePauseHold &&
+          !(await isTreeHoldInteractionCheckoutAllowed(issueCompany.companyId, checkoutRunId, activePauseHold))
+        ) {
+          throw conflict("Issue checkout blocked by active subtree pause hold", {
+            issueId: id,
+            holdId: activePauseHold.holdId,
+            rootIssueId: activePauseHold.rootIssueId,
+            mode: activePauseHold.mode,
+            securityPrinciples: ["Complete Mediation", "Fail Securely", "Secure Defaults"],
+          });
+        }
       }
 
       await clearExecutionRunIfTerminal(id);

--- a/server/src/services/recovery/pause-hold-guard.ts
+++ b/server/src/services/recovery/pause-hold-guard.ts
@@ -1,4 +1,5 @@
 import type { Db } from "@paperclipai/db";
+import { isIssueProductivityReviewOriginKind } from "@paperclipai/shared";
 import { issueTreeControlService } from "../issue-tree-control.js";
 
 type IssueTreeControlService = ReturnType<typeof issueTreeControlService>;
@@ -8,7 +9,9 @@ export async function isAutomaticRecoverySuppressedByPauseHold(
   companyId: string,
   issueId: string,
   treeControlSvc: IssueTreeControlService = issueTreeControlService(db),
+  originKind?: string | null,
 ) {
+  if (isIssueProductivityReviewOriginKind(originKind)) return false;
   const activePauseHold = await treeControlSvc.getActivePauseHoldGate(companyId, issueId);
   return Boolean(activePauseHold);
 }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2915,7 +2915,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
-      if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+      if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc, issue.originKind)) {
         result.skipped += 1;
         continue;
       }
@@ -3916,7 +3916,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .where(eq(issues.id, input.finding.issueId))
       .then((rows) => rows[0] ?? null);
     if (!issue || issue.companyId !== input.finding.companyId) return { kind: "skipped" as const };
-    if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+    if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc, issue.originKind)) {
       return { kind: "skipped" as const };
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses `issueTreeHold` records to pause subtrees of work when an operator requests it
> - Agents assigned to issues in a held subtree receive 409 on checkout, cannot be woken, and cannot make progress
> - `issue_productivity_review` issues are meta-reviews of the held subtree itself — they need to run and complete so the reviewer can dispose them
> - When a productivity-review issue lives inside a held subtree, the hold blocks the reviewer from checking it out, causing a deadlock
> - This PR exempts `issue_productivity_review` issues from the pause hold check at every enforcement site
> - The benefit is that productivity reviews always remain disposable, while normal work items under the hold are unaffected

## Linked Issues or Issue Description

Fixes: SAG-2127

## What Changed

- Added `isIssueProductivityReviewOriginKind(originKind)` helper in `@paperclipai/shared/constants.ts` (mirrors shape of `isPluginOperationIssueOriginKind`)
- Exported it from `packages/shared/src/index.ts`
- Applied the exemption (skip `getActivePauseHoldGate` when `true`) at all 8 enforcement sites:
  - `issues.ts` checkout — primary 409 fix; added `originKind` to the select
  - `routes/issues.ts` `assertExplicitResumeIntentAllowed` — PATCH follow-up gate; widened `issue` param type
  - `heartbeat.ts` `handleSuccessfulRunHandoff` — added `originKind` to select; skips hold in `Promise.all`
  - `heartbeat.ts` `evaluateScheduledRetryGate` — added `originKind` to select; wraps hold check
  - `heartbeat.ts` `claimQueuedRun` — no prior issue object; adds targeted `originKind` lookup
  - `heartbeat.ts` `releaseIssueExecutionAndPromote` — issue has full select; wraps deferred-wake hold check
  - `heartbeat.ts` `enqueueWakeup` — no prior issue object; adds targeted `originKind` lookup
  - `recovery/pause-hold-guard.ts` `isAutomaticRecoverySuppressedByPauseHold` — optional `originKind` param; returns `false` early; callers pass `issue.originKind`
- Unit tests: `packages/shared/src/constants.test.ts` — 5 cases for `isIssueProductivityReviewOriginKind`
- Integration test in `issue-tree-control-service.test.ts`: seeds parent + pause hold + review child + normal child; asserts review child succeeds and normal child still 409s

## Verification

```sh
# Unit tests
npx vitest run packages/shared/src/constants.test.ts

# Integration (checkout exemption + regression)
npx vitest run server/src/__tests__/issue-tree-control-service.test.ts

# Typecheck (server)
pnpm --filter server typecheck
# (pre-existing push-fanout.ts errors are unrelated to this PR)
```

All tests pass locally.

## Risks

- **Scope**: The exemption is narrow — only `"issue_productivity_review"` origin kind, not all reviews or meta-issues. A string comparison guards each site.
- **New DB queries**: `claimQueuedRun` and `enqueueWakeup` each add one `SELECT originKind` lookup. Both are indexed by `issues.id` and only fire when `issueId` is present.
- **Behavioral shift**: Productivity-review issues in held subtrees can now be woken and checked out. This is intentional — the hold is meant to pause productive work, not to block oversight reviews.
- Low risk for normal issues: the original 409/suppression behavior is completely unchanged for non-review issues (regression test confirms).

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (claude-sonnet-4-6)
- Mode: Tool-use, direct code execution, no extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above