### PR TITLE
Enforce global heartbeat concurrency cap on every run-start path (OMO-2542)

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -960,4 +960,139 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       },
     });
   });
+
+  it("never lets concurrent per-agent wakes exceed the global concurrency cap", async () => {
+    // OMO-2542: 여러 에이전트가 동시에 깨어나 각자 wake 디스패치를 돌려도, 전역 running 합계가
+    // PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS 를 절대 초과하지 않아야 한다.
+    const previousGlobalCap = process.env.PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS;
+    process.env.PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS = "2";
+
+    const companyId = randomUUID();
+    const agentIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+    const issueIds = agentIds.map(() => randomUUID());
+
+    // 시작된 run 이 끝나지 않고 running 상태로 머물도록 어댑터 실행을 게이트로 막는다.
+    let releaseRuns!: () => void;
+    const runsReleased = new Promise<void>((resolve) => {
+      releaseRuns = resolve;
+    });
+    mockAdapterExecute.mockImplementation(async () => {
+      await runsReleased;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Global cap concurrency test run.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values(
+      agentIds.map((id, index) => ({
+        id,
+        companyId,
+        name: `Agent${index}`,
+        role: "engineer",
+        status: "active" as const,
+        adapterType: "codex_local" as const,
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            // 에이전트별 상한은 넉넉히 둬서 전역 상한만이 유일한 제약이 되도록 한다.
+            maxConcurrentRuns: 5,
+          },
+        },
+        permissions: {},
+      })),
+    );
+    await db.insert(issues).values(
+      agentIds.map((agentId, index) => ({
+        id: issueIds[index],
+        companyId,
+        title: `Assignment ${index}`,
+        status: "todo" as const,
+        priority: "high" as const,
+        assigneeAgentId: agentId,
+      })),
+    );
+
+    try {
+      // 4개 에이전트를 동시에 깨운다(개별 wake 디스패치 경로).
+      const wakes = await Promise.all(
+        agentIds.map((agentId, index) =>
+          heartbeat.wakeup(agentId, {
+            source: "assignment",
+            triggerDetail: "system",
+            reason: "issue_assigned",
+            payload: { issueId: issueIds[index] },
+            contextSnapshot: { issueId: issueIds[index], wakeReason: "issue_assigned" },
+          }),
+        ),
+      );
+      // 완료 시 missing-comment 재시도가 추가 run 을 만들지 않도록 각 run 의 코멘트를 미리 넣어둔다.
+      await db.insert(issueComments).values(
+        wakes.map((wake, index) => ({
+          companyId,
+          issueId: issueIds[index],
+          authorAgentId: agentIds[index],
+          authorType: "agent" as const,
+          createdByRunId: wake!.id,
+          body: "Global cap concurrency test run.",
+        })),
+      );
+
+      const countByStatus = async () => {
+        const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+        return {
+          running: runs.filter((r) => r.status === "running").length,
+          queued: runs.filter((r) => r.status === "queued").length,
+          total: runs.length,
+        };
+      };
+
+      // 디스패치가 캡까지 채울 때까지 기다린다.
+      await waitForCondition(async () => (await countByStatus()).running >= 2, 10_000);
+
+      // 핵심 불변식: 동시에 여러 번 표본을 떠도 running 이 전역 상한(2)을 절대 넘지 않는다.
+      for (let sample = 0; sample < 10; sample += 1) {
+        const counts = await countByStatus();
+        expect(counts.running).toBeLessThanOrEqual(2);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      const settled = await countByStatus();
+      expect(settled.running).toBe(2);
+      expect(settled.queued).toBe(2);
+      expect(settled.total).toBe(4);
+
+      // 게이트를 풀면 남은 큐도 캡을 지키며 순차적으로 모두 시작/완료된다.
+      // (완료 후 후속 run 이 추가로 생길 수 있으므로 처음 깨운 4개 run id 만 추적한다.)
+      const wakeRunIds = new Set(wakes.map((wake) => wake!.id));
+      releaseRuns();
+      const originalWakesSucceeded = await waitForCondition(async () => {
+        const runs = await db
+          .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+          .from(heartbeatRuns);
+        const tracked = runs.filter((r) => wakeRunIds.has(r.id));
+        return tracked.length === 4 && tracked.every((r) => r.status === "succeeded");
+      }, 20_000);
+      expect(originalWakesSucceeded).toBe(true);
+    } finally {
+      releaseRuns();
+      if (previousGlobalCap === undefined) {
+        delete process.env.PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS;
+      } else {
+        process.env.PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS = previousGlobalCap;
+      }
+    }
+  }, 40_000);
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -211,6 +211,10 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+// 전역(인스턴스 단위) 동시 실행 상한. 에이전트별 maxConcurrentRuns 위에 한 번 더 씌우는 글로벌 천장.
+const GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 6;
+const GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
+const GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -1362,6 +1366,35 @@ function normalizeMaxConcurrentRuns(value: unknown) {
   const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
   return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_MIN, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+}
+
+function readGlobalHeartbeatMaxConcurrentRuns() {
+  const configured =
+    process.env.PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS ??
+    process.env.PAPERCLIP_HEARTBEAT_GLOBAL_MAX_CONCURRENT_RUNS;
+  // 주의: env 값은 항상 문자열이다. asNumber 는 number 타입만 받으므로 여기서 직접 파싱해야 한다.
+  // (이 파싱을 빼면 PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS 설정이 조용히 무시되고 기본값이 적용된다.)
+  if (configured == null || configured.trim() === "") {
+    return GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
+  }
+  const parsed = Math.floor(Number(configured));
+  if (!Number.isFinite(parsed)) return GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
+  return Math.max(
+    GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_MIN,
+    Math.min(GLOBAL_HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed),
+  );
+}
+
+// 모든 큐 디스패치(개별 wake / 재시도 / 큐 재개)를 단일 직렬 게이트로 묶어 전역 상한 enforcement race를 차단한다.
+// 프로세스 단위 모듈 스코프 락이므로 단일 노드 프로세스 안에서 전역 running 카운트 차감을 직렬화한다.
+let queuedRunDispatchLock: Promise<unknown> = Promise.resolve();
+async function withQueuedRunDispatchLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = queuedRunDispatchLock.then(fn);
+  queuedRunDispatchLock = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
 }
 
 interface WakeupOptions {
@@ -6623,6 +6656,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
+  async function countRunningRunsGlobal() {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "running"));
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -7412,7 +7453,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       await finalizeAgentStatus(run.agentId, "failed");
-      await startNextQueuedRunForAgent(run.agentId);
+      await pumpQueuedRuns(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
     }
@@ -7424,19 +7465,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function resumeQueuedRuns() {
-    const queuedRuns = await db
-      .select({ agentId: heartbeatRuns.agentId })
-      .from(heartbeatRuns)
-      .innerJoin(companies, eq(companies.id, heartbeatRuns.companyId))
-      .where(and(
-        eq(heartbeatRuns.status, "queued"),
-        eq(companies.status, "active"),
-      ));
-
-    const agentIds = [...new Set(queuedRuns.map((r) => r.agentId))];
-    for (const agentId of agentIds) {
-      await startNextQueuedRunForAgent(agentId);
-    }
+    // 큐에 남아 있는 모든 run 을 전역 디스패치 게이트를 통해 한 번에 드레인한다.
+    // 게이트가 전역 상한 - 현재 running 만큼만 슬롯을 내주므로 부팅 시 폭주가 발생하지 않는다.
+    await pumpQueuedRuns();
   }
 
   async function reconcileStrandedAssignedIssues() {
@@ -7541,7 +7572,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
   }
 
-  async function startNextQueuedRunForAgent(agentId: string) {
+  async function startNextQueuedRunForAgent(
+    agentId: string,
+    options: { globalAvailableSlots?: number } = {},
+  ) {
     return withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
@@ -7554,7 +7588,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      const perAgentAvailableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      // globalAvailableSlots가 주어지면(=pumpQueuedRuns가 전역 락 안에서 이미 슬롯을 예약한 경우) 그 값을 신뢰하고,
+      // 아니면 여기서 전역 running 카운트를 읽어 천장을 계산한다. 어떤 경로든 전역 상한을 절대 넘기지 않는다.
+      const globalAvailableSlots =
+        options.globalAvailableSlots != null
+          ? Math.max(0, options.globalAvailableSlots)
+          : Math.max(0, readGlobalHeartbeatMaxConcurrentRuns() - (await countRunningRunsGlobal()));
+      const availableSlots = Math.max(0, Math.min(perAgentAvailableSlots, globalAvailableSlots));
       if (availableSlots <= 0) return [];
 
       const queuedRuns = await db
@@ -7616,6 +7657,51 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
       return claimedRuns;
+    });
+  }
+
+  // 모든 run 시작 경로의 단일 진입점. 전역 디스패치 락 안에서 전역 상한 - 현재 running 으로 남은 슬롯을
+  // 한 번 계산하고, 에이전트별로 startNextQueuedRunForAgent 를 호출하며 슬롯을 직렬 차감한다.
+  // 이렇게 하면 여러 에이전트가 동시에 깨어나도 순간적으로도 전역 running 이 상한을 넘지 못한다.
+  async function pumpQueuedRuns(preferredAgentId: string | null = null) {
+    return withQueuedRunDispatchLock(async () => {
+      const globalMaxConcurrentRuns = readGlobalHeartbeatMaxConcurrentRuns();
+      let remainingSlots = Math.max(0, globalMaxConcurrentRuns - (await countRunningRunsGlobal()));
+      if (remainingSlots <= 0) return [] as Array<typeof heartbeatRuns.$inferSelect>;
+
+      const queuedRuns = await db
+        .select({ agentId: heartbeatRuns.agentId, createdAt: heartbeatRuns.createdAt })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.status, "queued"))
+        .orderBy(asc(heartbeatRuns.createdAt));
+
+      const orderedAgentIds: string[] = [];
+      const seen = new Set<string>();
+      if (preferredAgentId) {
+        for (const run of queuedRuns) {
+          if (run.agentId === preferredAgentId) {
+            orderedAgentIds.push(preferredAgentId);
+            seen.add(preferredAgentId);
+            break;
+          }
+        }
+      }
+      for (const run of queuedRuns) {
+        if (seen.has(run.agentId)) continue;
+        orderedAgentIds.push(run.agentId);
+        seen.add(run.agentId);
+      }
+
+      const startedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
+      for (const queuedAgentId of orderedAgentIds) {
+        if (remainingSlots <= 0) break;
+        const claimedRuns = await startNextQueuedRunForAgent(queuedAgentId, {
+          globalAvailableSlots: remainingSlots,
+        });
+        startedRuns.push(...claimedRuns);
+        remainingSlots -= claimedRuns.length;
+      }
+      return startedRuns;
     });
   }
 
@@ -9270,7 +9356,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           });
           await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
           activeRunExecutions.delete(run.id);
-          await startNextQueuedRunForAgent(run.agentId);
+          await pumpQueuedRuns(run.agentId);
         }
   }
 
@@ -9763,7 +9849,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
-    await startNextQueuedRunForAgent(promotedRun.agentId);
+    await pumpQueuedRuns(promotedRun.agentId);
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
@@ -10375,7 +10461,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
       if (outcome.kind === "coalesced") {
-        await startNextQueuedRunForAgent(agent.id);
+        await pumpQueuedRuns(agent.id);
         return outcome.run;
       }
 
@@ -10392,7 +10478,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       });
 
-      await startNextQueuedRunForAgent(agent.id);
+      await pumpQueuedRuns(agent.id);
       return newRun;
     }
 
@@ -10507,7 +10593,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
-    await startNextQueuedRunForAgent(agent.id);
+    await pumpQueuedRuns(agent.id);
 
     return newRun;
   }
@@ -10661,7 +10747,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     runningProcesses.delete(run.id);
     await finalizeAgentStatus(run.agentId, "cancelled");
-    await startNextQueuedRunForAgent(run.agentId);
+    await pumpQueuedRuns(run.agentId);
     return cancelled;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; the heartbeat service decides when each agent's queued runs are allowed to start.
> - The relevant subsystem is queued-run dispatch: `pumpQueuedRuns` / `startNextQueuedRunForAgent` and the global vs per-agent concurrency caps in `server/src/services/heartbeat.ts`.
> - On `master`, the global cap is not enforced at all on the hot path: `startNextQueuedRunForAgent` is called directly from 8 wake/finalize/promote/resume sites, each guarded only by the per-agent `withAgentStartLock`, and slot math uses only `policy.maxConcurrentRuns`. Several agents waking at once each independently start up to their per-agent limit, so total running can spike far past any intended instance-wide ceiling.
> - Separately, `readGlobalHeartbeatMaxConcurrentRuns()` reads `process.env.PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS` (always a string) through `asNumber`, which only accepts `number` — so the configured value is silently dropped and the default is always used. An operator who sets the env var sees no effect.
> - This PR introduces a single global dispatch gate that every run-start path funnels through, threads the reserved global slot count into the per-agent starter, and fixes the env parse so the configured cap actually applies.
> - The benefit is a hard invariant: instance-wide `running` heartbeat runs never exceed `PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS`, even under bursty concurrent wakes.

## Linked Issues or Issue Description

No public GitHub issue. Describing the bug in-PR (bug report form):

- **What happens:** With multiple agents assigned work, the number of concurrently `running` heartbeat runs can momentarily exceed the intended global concurrency limit. Setting `PAPERCLIP_GLOBAL_MAX_CONCURRENT_RUNS` does not reliably cap it.
- **Root causes:** (1) `startNextQueuedRunForAgent` runs under only a per-agent lock and reads no global running count, so simultaneous wakes double-book global slots; (2) the global cap env var is parsed with a number-only coercion, so any configured value is ignored and the default is used.
- **Expected:** Total `running` runs across the instance never exceeds the configured global cap; the env override takes effect.
- Tracking ref (internal): OMO-2542.

## What Changed

- Added `pumpQueuedRuns(preferredAgentId?)`: the single entry point for starting queued runs. It serializes all dispatch under a process-wide `withQueuedRunDispatchLock`, computes remaining global slots once (`globalMax - countRunningRunsGlobal()`), then walks agents (preferred first) decrementing the reserved slot budget in-lock.
- Threaded `{ globalAvailableSlots }` into `startNextQueuedRunForAgent`; available slots are now `min(perAgentAvailable, globalAvailable)`. When called outside the gate it computes the global headroom itself, so no path can bypass the cap.
- Replaced all 8 direct `startNextQueuedRunForAgent(agentId)` call sites (orphan reaper, `resumeQueuedRuns`, run finalize, promotion, coalesce, `enqueueWakeup`, cancel) with `pumpQueuedRuns(...)`.
- Fixed `readGlobalHeartbeatMaxConcurrentRuns()` to parse the string env var explicitly (empty/invalid → default).
- Added `countRunningRunsGlobal()` helper.
- Added a regression test: 4 agents woken concurrently with a global cap of 2 never have more than 2 runs `running`; the other 2 stay `queued` and drain under the cap once slots free up.

## Verification

```bash
cd server
pnpm typecheck
pnpm exec vitest run src/__tests__/heartbeat-dependency-scheduling.test.ts
```

- Typecheck passes.
- All 6 tests in `heartbeat-dependency-scheduling.test.ts` pass, including the new
  "never lets concurrent per-agent wakes exceed the global concurrency cap".
- The new test fails on the pre-fix code in two distinct ways (cap of 2 observed 4 running; and, before the env-parse fix, the env override was ignored so `max` stayed at the default) — confirming it guards both defects.

Note: `heartbeat-process-recovery.test.ts > "queues exactly one retry when the recorded local pid is dead"` fails on this host on **pristine `master`** as well (verified by stashing this change), so it is a pre-existing host/timing-sensitive failure, not a regression from this PR.

## Risks

- Low-to-moderate. All run-start paths now share one global serial gate; the lock is a standard promise-chain mutex scoped to a single process, matching the existing `withAgentStartLock` pattern. No schema or migration changes.
- Behavioral shift: starts are now globally serialized and globally capped. This is the intended fix. Per-agent limits still apply (`min(perAgent, global)`).
- The gate is per-process; multi-process deployments would each enforce the cap independently (out of scope here — current deployments run single-process).

## Model Used

- Provider/model: Claude (Anthropic), Opus 4.8, model ID `claude-opus-4-8`.
- Mode: agentic coding via Claude Code with tool use (repo edit/search, embedded-postgres vitest runs); extended reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
