### PR TITLE
docs(skills): document ask_user_questions and suggest_tasks interaction payloads

### DIFF
--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -834,6 +834,7 @@ POST /api/issues/{issueId}/interactions
 Field rules:
 
 - `payload.version` is required and must be `1`.
+- `payload.title` (≤ 240) and `payload.submitLabel` (≤ 120) are optional form-level labels, distinct from the envelope-level `title` (the thread card title).
 - `questions`: 1–10 items, each `id` unique. `options`: 1–10 per question, each `id` unique.
 - `prompt` ≤ 500 chars; option `label` ≤ 120; option `description` ≤ 500; `helpText` ≤ 1000.
 - `selectionMode` is required and is `"single"` or `"multi"`.
@@ -887,6 +888,7 @@ POST /api/issues/{issueId}/interactions
 Field rules:
 
 - `payload.version` is required and must be `1`.
+- `payload.defaultParentId` (optional issue UUID) nests every suggested task under that issue unless a task overrides it with its own `parentId`/`parentClientKey`.
 - `tasks`: 1–50 items; each `clientKey` is required and unique within the interaction; `title` is required (≤ 240).
 - Optional per task: `description`, `priority`, `workMode`, `parentClientKey`/`parentId`, `projectId`, `goalId`, `billingCode`, `labels`, `hiddenInPreview`.
 - A task may set `assigneeAgentId` **or** `assigneeUserId`, never both.
@@ -899,7 +901,7 @@ POST /api/issues/{issueId}/interactions/{interactionId}/accept
 { "selectedClientKeys": ["identify"] }
 ```
 
-Omitting `selectedClientKeys` accepts all suggested tasks.
+Omit `selectedClientKeys` entirely to accept all suggested tasks. Do **not** send an empty array — `selectedClientKeys` requires at least one entry (min 1), so `[]` returns `422`. To accept nothing, reject the interaction instead.
 
 ### Checking approval status
 

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -798,6 +798,109 @@ Best practice:
 - After creating a pending checkbox confirmation, move the source issue to `in_review` with a comment that names exactly what the board must decide. Pending interactions are an explicit waiting path, not a synonym for `done`.
 - When a `superseded_by_comment` or `stale_target` wake fires, address the new comment or rebuild the target, then create a fresh checkbox confirmation with an idempotency key that includes the new revision id.
 
+### Structured questions (`ask_user_questions`)
+
+Use `ask_user_questions` for a short structured form when you need the board/user to answer one or more questions before you proceed (each question is single- or multi-select). For a single multi-select over a long list, prefer `request_checkbox_confirmation`.
+
+All content lives under `payload` with `"version": 1`. Each question requires `selectionMode` — there is **no** `allowMultiple` field.
+
+```json
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "ask_user_questions",
+  "idempotencyKey": "ask:{issueId}:{topic}:r1",
+  "title": "Refactor scope decisions",
+  "continuationPolicy": "wake_assignee",
+  "payload": {
+    "version": 1,
+    "submitLabel": "Submit answers",
+    "questions": [
+      {
+        "id": "scope",
+        "prompt": "How aggressive should the refactor be?",
+        "helpText": "High blast-radius on the money path.",
+        "selectionMode": "single",
+        "required": true,
+        "options": [
+          { "id": "seam", "label": "Repository seam only", "description": "Zero behavior change. Recommended first step." },
+          { "id": "deep", "label": "Deepen the order-execution lifecycle" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Field rules:
+
+- `payload.version` is required and must be `1`.
+- `questions`: 1–10 items, each `id` unique. `options`: 1–10 per question, each `id` unique.
+- `prompt` ≤ 500 chars; option `label` ≤ 120; option `description` ≤ 500; `helpText` ≤ 1000.
+- `selectionMode` is required and is `"single"` or `"multi"`.
+- `continuationPolicy` defaults to `"wake_assignee"` (the assignee is woken when the form is answered).
+
+Respond (board/user action; the creating agent cannot answer its own questions):
+
+```json
+POST /api/issues/{issueId}/interactions/{interactionId}/respond
+{
+  "answers": [{ "questionId": "scope", "optionIds": ["seam"] }],
+  "summaryMarkdown": "Start with the repository seam."
+}
+```
+
+`optionIds` carries one id for `single` questions and one or more for `multi`.
+
+### Suggested tasks (`suggest_tasks`)
+
+Use `suggest_tasks` to propose a batch of child tasks for one-click acceptance, where accepted items become subtasks. (If the items are not concrete tasks to create, use `request_checkbox_confirmation` instead.)
+
+All content lives under `payload` with `"version": 1` and a `tasks` array — there is **no** top-level `body` field.
+
+```json
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "suggest_tasks",
+  "idempotencyKey": "suggest:{issueId}:r1",
+  "title": "Proposed child issues",
+  "continuationPolicy": "wake_assignee",
+  "payload": {
+    "version": 1,
+    "tasks": [
+      {
+        "clientKey": "identify",
+        "title": "Project identification",
+        "description": "Identify all projects routing through the pipeline.",
+        "priority": "high"
+      },
+      {
+        "clientKey": "adapt",
+        "parentClientKey": "identify",
+        "title": "Pipeline adaptations",
+        "description": "Draft project-specific adaptation strategies."
+      }
+    ]
+  }
+}
+```
+
+Field rules:
+
+- `payload.version` is required and must be `1`.
+- `tasks`: 1–50 items; each `clientKey` is required and unique within the interaction; `title` is required (≤ 240).
+- Optional per task: `description`, `priority`, `workMode`, `parentClientKey`/`parentId`, `projectId`, `goalId`, `billingCode`, `labels`, `hiddenInPreview`.
+- A task may set `assigneeAgentId` **or** `assigneeUserId`, never both.
+- `parentClientKey` references another task's `clientKey` in the same batch to nest suggestions.
+
+Accept (board/user action) — optionally accept a subset by `clientKey`:
+
+```json
+POST /api/issues/{issueId}/interactions/{interactionId}/accept
+{ "selectedClientKeys": ["identify"] }
+```
+
+Omitting `selectedClientKeys` accepts all suggested tasks.
+
 ### Checking approval status
 
 ```
@@ -1009,3 +1112,6 @@ Terminal states: `done`, `cancelled`
 | Sit silently on blocked work                | Nobody knows you're stuck; the task rots              | Comment the blocker and escalate immediately            |
 | Leave tasks in ambiguous states             | Others can't tell if work is progressing              | Always update status: `blocked`, `in_review`, or `done` |
 | Block on another task without `blockedByIssueIds` | No automatic wake when blocker resolves; manual follow-up needed | Set `blockedByIssueIds` so Paperclip auto-wakes the assignee when all blockers are done |
+| Flatten interaction fields to the top level | The create-interaction validator is a discriminated union; content must be nested | Put kind-specific fields in `payload` with `"version": 1` (see the interaction sections) |
+| Use `allowMultiple` on an `ask_user_questions` question | Not a field; questions are validated against `selectionMode` | Set `selectionMode: "single"` or `"multi"` per question |
+| Send `suggest_tasks` with a free-text `body` | No `body` field; tasks are structured drafts | Use `payload.tasks: [{ clientKey, title, ... }]` |


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and agents coordinate through the issue-thread interactions API.
> - The agent-facing skill reference (`skills/paperclip/references/api-reference.md`) is where agents learn how to construct those interactions.
> - That reference fully documents `request_confirmation` and `request_checkbox_confirmation`, but `ask_user_questions` and `suggest_tasks` appear only as a passing mention in the endpoint table — there is no payload schema for either.
> - With no documented shape, agents guess and fail validation against `createIssueThreadInteractionSchema`: flattening fields to the top level, using `allowMultiple` instead of `selectionMode`, or sending a free-text `body` for `suggest_tasks`. They retry until a shape passes.
> - Each failed `400` is a wasted heartbeat turn and wasted tokens for every Paperclip user, and an agent that cannot form a valid interaction cannot park on a response — so it falls back to timer wakes.
> - This pull request documents the two missing interaction kinds with their authoritative payload schemas and adds the common shape mistakes to the mistakes table.
> - The benefit is fewer wasted turns/tokens and more reliable demand-driven (wake-on-response) coordination.

## Linked Issues or Issue Description

No existing issue — describing in-PR (documentation gap / bug):

Creating an `ask_user_questions` or `suggest_tasks` issue-thread interaction returns `400` for payloads that the agent guesses, because the skill reference never documents their required shape. The validator (`createIssueThreadInteractionSchema` in `packages/shared/src/validators/issue.ts`) is a discriminated union requiring kind-specific content nested under `payload` with `"version": 1`; common guessed shapes (top-level fields, `allowMultiple`, a free-text `body`) are rejected. Observed in practice as repeated `400`→retry→`201` sequences, each wasting a heartbeat turn and tokens.

## What Changed

- Added a **Structured questions (`ask_user_questions`)** section with the full payload schema (`payload.version`, `questions[1..10]`, per-question `selectionMode`/`options[1..10]`, field bounds) and the `respond` call shape.
- Added a **Suggested tasks (`suggest_tasks`)** section with the full payload schema (`payload.version`, `tasks[1..50]`, `clientKey`/`title` rules, assignee exclusivity, `parentClientKey` nesting) and the `accept` (subset) call shape.
- Extended the **Common Mistakes** table with three interaction-shape errors: flattening fields to the top level, using `allowMultiple` instead of `selectionMode`, and sending a free-text `body` for `suggest_tasks`.
- Documentation only; no code changes.

## Verification

- Schemas were transcribed directly from `packages/shared/src/validators/issue.ts` on `master` (`askUserQuestionsPayloadSchema`, `askUserQuestionsQuestionSchema`, `askUserQuestionsQuestionOptionSchema`, `suggestedTaskDraftSchema`, `suggestTasksPayloadSchema`, and `createIssueThreadInteractionSchema`), so the documented fields, bounds, and defaults match the validator.
- Reviewer check: compare the new sections against those schemas; confirm `selectionMode` is required, `payload.version` is `1`, and the assignee-exclusivity / unique-key rules match the `superRefine` checks.
- Markdown renders cleanly (balanced code fences; sections sit alongside the existing confirmation/checkbox sections).

## Risks

Low risk — documentation-only change to an agent skill reference. No code, schema, or API behavior is modified. Worst case is a doc wording nit.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`, 1M context), with extended reasoning and tool use. Schemas were extracted from the repository's own source files and transcribed; no schema was invented by the model.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass (docs-only; no tests affected)
- [ ] I have added or updated tests where applicable (N/A — documentation only)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after opening)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address on review)
- [x] I will address all Greptile and reviewer comments before requesting merge
