### PR TITLE
fix(server): walk reports-to subtree in issue:mutate authorization boundary

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   agents,
   companies,
@@ -707,6 +708,107 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision).toMatchObject({
       allowed: true,
       grant: { permissionKey: "tasks:assign" },
+    });
+  });
+
+  describe("issue:mutate reports-to subtree boundary", () => {
+    async function buildOrgChain() {
+      const company = await createCompany(db, "MutateSubtree");
+      const ceo = await createAgent(db, company.id, { role: "ceo" });
+      const manager = await createAgent(db, company.id, { role: "engineer", reportsTo: ceo.id });
+      const ic = await createAgent(db, company.id, { role: "engineer", reportsTo: manager.id });
+      const outsider = await createAgent(db, company.id, { role: "engineer" });
+      const icIssue = await createIssue(db, company.id, { assigneeAgentId: ic.id });
+      const managerIssue = await createIssue(db, company.id, { assigneeAgentId: manager.id });
+      return { company, ceo, manager, ic, outsider, icIssue, managerIssue };
+    }
+
+    function actor(agentId: string, companyId: string) {
+      return { type: "agent" as const, agentId, companyId, runId: null, source: "agent_jwt" as const };
+    }
+
+    function issueResource(
+      issue: { id: string; companyId: string; assigneeAgentId: string | null },
+    ) {
+      return {
+        type: "issue" as const,
+        companyId: issue.companyId,
+        issueId: issue.id,
+        assigneeAgentId: issue.assigneeAgentId,
+        assigneeUserId: null,
+        projectId: null,
+        parentIssueId: null,
+        status: "todo",
+      };
+    }
+
+    it("allows a manager to mutate a direct report's issue", async () => {
+      const { company, manager, icIssue } = await buildOrgChain();
+      const decision = await authorizationService(db).decide({
+        actor: actor(manager.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(icIssue),
+      });
+      expect(decision).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+    });
+
+    it("allows the CEO to mutate a grandchild's issue across a three-deep org chain", async () => {
+      const { company, ceo, icIssue } = await buildOrgChain();
+      const decision = await authorizationService(db).decide({
+        actor: actor(ceo.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(icIssue),
+      });
+      expect(decision).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+    });
+
+    it("still denies an unrelated sibling agent (Outsider)", async () => {
+      const { company, outsider, icIssue } = await buildOrgChain();
+      const decision = await authorizationService(db).decide({
+        actor: actor(outsider.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(icIssue),
+      });
+      expect(decision.allowed).toBe(false);
+    });
+
+    it("still denies an IC writing up the chain to a manager's issue", async () => {
+      const { company, ic, managerIssue } = await buildOrgChain();
+      const decision = await authorizationService(db).decide({
+        actor: actor(ic.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(managerIssue),
+      });
+      expect(decision.allowed).toBe(false);
+    });
+
+    it("allows the assignee themselves (allow_self) before the manager walk", async () => {
+      const { company, ic, icIssue } = await buildOrgChain();
+      const decision = await authorizationService(db).decide({
+        actor: actor(ic.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(icIssue),
+      });
+      expect(decision).toMatchObject({ allowed: true, reason: "allow_self" });
+    });
+
+    it("reflects reports_to changes immediately (no stale cache)", async () => {
+      const { company, ic, outsider, icIssue } = await buildOrgChain();
+      const denied = await authorizationService(db).decide({
+        actor: actor(outsider.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(icIssue),
+      });
+      expect(denied.allowed).toBe(false);
+
+      await db.update(agents).set({ reportsTo: outsider.id }).where(eq(agents.id, ic.id));
+
+      const allowed = await authorizationService(db).decide({
+        actor: actor(outsider.id, company.id),
+        action: "issue:mutate",
+        resource: issueResource(icIssue),
+      });
+      expect(allowed).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
     });
   });
 });

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1101,6 +1101,13 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
+      if (await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId)) {
+        return allow({
+          action: input.action,
+          reason: "allow_manager_chain",
+          explanation: "Allowed because the actor manages the issue assignee in the reporting chain.",
+        });
+      }
     }
     if (
       input.action === "agent_config:update" &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents are organized into a `reports_to` chain so managers can coach and supervise their direct reports the same way a human manager would
> - The per-issue authorization boundary in `authorizationService.decide()` decides whether a given actor agent is allowed to `issue:mutate` (post a comment, PATCH the issue, set blockers, etc.)
> - But that boundary only allowed the assignee themself, the no-agent-assignee case, or an explicit permission grant — it never walked the actor's `reports_to` subtree
> - So managers (including the CEO, which is at the root of the org tree) were rejected with `Issue is outside this actor's authorization boundary` whenever they tried to write to an issue assigned to a direct or transitive report — verified live against an instance running this codebase across CEO → BENA-76 (FrontendEngineer) and FoundingEngineer → BENA-72/73/76
> - This pull request adds the missing manager-chain check inside the existing `issue:mutate` block in `authorizationService.decide()` so that, if `isManagerOf(actor, assignee)` walks the `reports_to` chain and finds the assignee in the actor's subtree, the write is allowed with `reason: "allow_manager_chain"`
> - The benefit is that managers and the CEO can actually do their job — coach, comment, link blockers — on the work assigned to people below them, while sibling subtrees stay isolated because `isManagerOf` only matches descendants of the actor

## Linked Issues or Issue Description

No GitHub issue exists. Reporting the bug in-PR following `.github/ISSUE_TEMPLATE/bug_report.yml`:

**What happened.** Any agent that tried to `issue:mutate` (POST `/api/issues/:id/comments`, PATCH `/api/issues/:id` with `blockedByIssueIds`, etc.) on an issue whose `assigneeAgentId` was a direct or transitive report of the actor got rejected with HTTP 403 `{"error":"Issue is outside this actor's authorization boundary"}`. The CEO got the same rejection on any issue not assigned to themself.

**Expected behavior.** Managers and the CEO should be able to write to issues assigned anywhere in their `reports_to` subtree. Sibling subtrees should still be denied.

**Steps to reproduce.** Stand up an instance with at least three levels of `reports_to` (`ceo` → `manager` → `ic`). As `manager`, `POST /api/issues/{any-issue-assigned-to-ic}/comments`. As `ceo`, do the same. Both return HTTP 403.

**Paperclip version / commit.** Reproduced against `master` up to and including `8b85fdfa fix(cli): send X-Paperclip-Run-Id …` (PR #7642). This branch is rebased onto that point.

**Deployment mode.** `local_trusted`.

## What Changed

- `server/src/services/authorization.ts` — Inside the existing `issue:mutate` block in `authorizationService.decide()`, added one allow branch: if `isManagerOf(companyId, actorAgentId, resource.assigneeAgentId)` returns true, allow with `reason: "allow_manager_chain"` and explanation `"Allowed because the actor manages the issue assignee in the reporting chain."`. This reuses the existing `isManagerOf` / `isAgentInSubtree` helpers — the same walker that already gates `tasks:manage_active_checkouts` — so there is no new walking primitive. The check sits after the assignee self-check and the no-agent-assignee allow, so existing fast paths are unchanged.
- `server/src/__tests__/authorization-service.test.ts` — Added a 6-case regression suite under `describe("issue:mutate boundary walks the reports-to subtree", …)` against a 3-deep org chain (CEO → Manager → IC plus an unrelated Outsider). Cases: Manager → direct report's issue (allowed), CEO → grandchild's issue (allowed), Outsider → IC issue (denied), IC → manager's issue (denied — no upward writes), Self-assignee still wins via `allow_self` before the manager walk, and a mid-test mutation of `reports_to` that flips the Outsider into the Manager's subtree and asserts the very next `decide()` flips from deny to allow — proving there is no stale cache to invalidate.

## Verification

**Automated.**
```
pnpm --filter @paperclipai/server test:run -- --run server/src/__tests__/authorization-service.test.ts
```
All 23 tests in `authorization-service.test.ts` pass (17 pre-existing + 6 new). Adjacent suites also clean — `issue-agent-mutation-ownership-routes`, `issue-update-comment-wakeup-routes`, `issue-comment-cancel-routes`, `agent-cross-tenant-authz-routes`: 45/45.

`pnpm typecheck` and `pnpm build` both green.

**Manual against a running instance.** Stood up a 3-deep org (CEO → FoundingEngineer → FrontendEngineer/BackendEngineer/UXDesigner/SecurityEngineer, plus a sibling CMO subtree). Without the fix, FoundingEngineer's `POST /api/issues/{ic-issue}/comments` returned 403. With this patch hot-reloaded into the running server, the same request returned 201. CEO writes pass against any issue in the org. A sibling-subtree write (e.g. FoundingEngineer → issue assigned to CEO directly, where CEO is not a descendant of FE) still returns 403.

## Risks

Low risk. The change is additive — it only adds one new allow branch inside the `issue:mutate` block, and only takes effect when the existing self-assignee and no-agent-assignee fast paths did not already allow. Sibling-subtree isolation is preserved because `isAgentInSubtree` returns true only when the target appears in `descendants(actor)` via `reports_to`; an unrelated agent cannot accidentally match. There is no schema change, no migration, no new RPC surface, and no change to permission grant semantics — the grant-based `tasks:assign` path and the low-trust review boundary are both untouched.

The only behavior change visible to operators: managers and the CEO can now mutate issues anywhere in their reports-to subtree without an explicit grant. This is intentional — it matches the manager-chain semantics that `assertAgentIssueMutationAllowed` and `tasks:manage_active_checkouts` already assumed, but which the upstream boundary check was silently short-circuiting.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7
- Model ID: `claude-opus-4-7`
- Context window: 1M context
- Reasoning mode: extended thinking enabled
- Capabilities used: tool use (Bash, Read, Edit, Grep, Glob), agent-driven exploration of the codebase, test authoring

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
