### PR TITLE
feat(server): agent-self-service /abort-execution + clear orphan executionRunId on blocked → in_progress

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -121,6 +121,37 @@ These are related but not identical:
 
 Paperclip already clears stale execution locks and can adopt some stale checkout locks when the original run is gone.
 
+### Invariant: `executionRunId` must never outlive its run
+
+`executionRunId` is always one of:
+
+- `null`, or
+- the id of an actively-checked-out heartbeat run that is still live
+
+Any transition out of `in_progress` (including the `blocked → in_progress` auto-PATCH driven by `issue_blockers_resolved`) clears `executionRunId` on the way through. Re-entering `in_progress` from any non-`in_progress` state also clears it, so a prior dead run cannot persist across the transition.
+
+If you ever observe an issue with `status != in_progress` and a non-null `executionRunId`, treat that as a platform bug, not an expected state.
+
+### Self-service escape hatch: `POST /issues/:id/abort-execution`
+
+When the run-ownership guard rejects an assignee with `Issue run ownership conflict`, the current assignee can self-reset run state without admin intervention:
+
+```
+POST /api/issues/:issueId/abort-execution
+Headers: Authorization, X-Paperclip-Run-Id
+Body: { "agentId": "<assignee-id>" }
+```
+
+Effects:
+
+- caller must be the current `assigneeAgentId` (non-assignees get 403; non-assignee recovery is `POST /admin/force-release` and requires board access)
+- `checkoutRunId` and `executionRunId` are set to `null`
+- the previously-held `checkoutRunId` / `executionRunId` heartbeat runs are marked terminal (`status = "cancelled"`, `errorCode = "agent_self_abort"`) if they are not already terminal — except the caller's own active run, which is intentionally never aborted
+- `status` and `assigneeAgentId` are untouched, so the next `POST /checkout` by the same assignee succeeds normally
+- emits an `issue.execution_aborted` activity-log entry recording `prevCheckoutRunId`, `prevExecutionRunId`, `abortedRunIds`, and the actor's run id
+
+The non-assignee path (`POST /admin/force-release`) remains available for board users when the assignee itself cannot run.
+
 ## 6. Parent/Sub-Issue vs Blockers
 
 Paperclip uses two different relationships for different jobs.

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -213,6 +213,224 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("lets a wedged assignee self-recover via /abort-execution and marks the orphan run cancelled", async () => {
+    // Path A repro: manager PATCH followed by re-checkout left a stale executionRunId
+    // pointing at a non-terminal heartbeat run. The current assignee should be able
+    // to call POST /issues/:id/abort-execution and reclaim a clean state.
+    const { companyId, agentId, failedRunId: _failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const orphanRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: orphanRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Wedged by orphan executionRunId",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: orphanRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/abort-execution`)
+      .send({ agentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.issue).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+    expect(res.body.previous).toEqual({
+      checkoutRunId: null,
+      executionRunId: orphanRunId,
+    });
+    expect(res.body.abortedRunIds).toEqual([orphanRunId]);
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const orphan = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, orphanRunId))
+      .then((rows) => rows[0]);
+    expect(orphan).toEqual({ status: "cancelled", errorCode: "agent_self_abort" });
+
+    // The caller's own active run must not be touched.
+    const callerRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, currentRunId))
+      .then((rows) => rows[0]);
+    expect(callerRun?.status).toBe("running");
+
+    const audit = await db
+      .select({ details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.execution_aborted"))
+      .then((rows) => rows[0]);
+    expect(audit?.details).toMatchObject({
+      issueId,
+      prevCheckoutRunId: null,
+      prevExecutionRunId: orphanRunId,
+      abortedRunIds: [orphanRunId],
+      actorAgentId: agentId,
+    });
+  });
+
+  it("rejects /abort-execution when the caller is not the current assignee", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const otherAgentId = randomUUID();
+    const otherRunId = randomUUID();
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId,
+      agentId: otherAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Not yours to abort",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, otherAgentId, otherRunId)))
+      .post(`/api/issues/${issueId}/abort-execution`)
+      .send({ agentId: otherAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+
+    // Issue state should be untouched on rejection.
+    const row = await db
+      .select({
+        assigneeAgentId: issues.assigneeAgentId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      assigneeAgentId: agentId,
+      executionRunId: failedRunId,
+    });
+
+    // The current run (still running on someone else's behalf) should also be untouched.
+    expect(currentRunId).toBeTruthy();
+  });
+
+  it("clears stale executionRunId on PATCH blocked → in_progress (issue_blockers_resolved repro)", async () => {
+    // Path B repro: a `blocked` issue carries an orphan executionRunId from a prior
+    // pre-block run. When the blocker resolves and the wake/PATCH flips status back
+    // to `in_progress`, the orphan must be wiped — otherwise the assignee's fresh
+    // heartbeat run hits "Issue run ownership conflict" on every write.
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const blockerId = randomUUID();
+    const blockedId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocker (done)",
+        status: "done",
+        priority: "medium",
+      },
+      {
+        id: blockedId,
+        companyId,
+        title: "Blocked carrying orphan executionRunId",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: agentId,
+        // Pre-block run stuck in the column despite status=blocked. This is the
+        // broken state we reproduce: an orphan executionRunId left after the
+        // previous run terminated unexpectedly while the issue was in_progress.
+        checkoutRunId: null,
+        executionRunId: failedRunId,
+        executionAgentNameKey: "codexcoder",
+        executionLockedAt: new Date(),
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedId,
+      type: "blocks",
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${blockedId}`)
+      .send({ status: "in_progress" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const row = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, blockedId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      status: "in_progress",
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+  });
+
   it("restricts admin force-release to board users with company access and writes an audit event", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5837,6 +5837,79 @@ export function issueRoutes(
     res.json(released);
   });
 
+  router.post("/issues/:id/abort-execution", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+
+    const bodyAgentId =
+      typeof req.body?.agentId === "string" && req.body.agentId.trim().length > 0
+        ? (req.body.agentId as string)
+        : null;
+
+    let callerAgentId: string | null = null;
+    let actorRunId: string | null = null;
+    if (req.actor.type === "agent") {
+      callerAgentId = req.actor.agentId ?? null;
+      if (bodyAgentId && bodyAgentId !== callerAgentId) {
+        res.status(403).json({ error: "Agent can only abort execution as itself" });
+        return;
+      }
+      actorRunId = requireAgentRunId(req, res);
+      if (!actorRunId) return;
+    } else if (req.actor.type === "board") {
+      if (!bodyAgentId) {
+        res.status(400).json({ error: "agentId is required for board callers" });
+        return;
+      }
+      callerAgentId = bodyAgentId;
+    } else {
+      res.status(403).json({ error: "Agent or board context required" });
+      return;
+    }
+
+    if (!callerAgentId) {
+      res.status(403).json({ error: "Agent context required" });
+      return;
+    }
+    if (existing.assigneeAgentId !== callerAgentId) {
+      res.status(403).json({ error: "Only the current assignee can abort execution" });
+      return;
+    }
+
+    const result = await svc.abortExecution(id, callerAgentId, actorRunId);
+    if (!result) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: result.issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.execution_aborted",
+      entityType: "issue",
+      entityId: result.issue.id,
+      details: {
+        issueId: result.issue.id,
+        prevCheckoutRunId: result.previous.checkoutRunId,
+        prevExecutionRunId: result.previous.executionRunId,
+        abortedRunIds: result.abortedRunIds,
+        actorAgentId: callerAgentId,
+        actorRunId,
+      },
+    });
+
+    res.json(result);
+  });
+
   router.post("/issues/:id/admin/force-release", async (req, res) => {
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board access required" });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5060,6 +5060,21 @@ export function issueService(db: Db) {
         patch.executionAgentNameKey = null;
         patch.executionLockedAt = null;
       }
+      // Re-entering in_progress from any non-in_progress state (most importantly
+      // the issue_blockers_resolved auto-PATCH `blocked` → `in_progress`) must
+      // not preserve a stale executionRunId. The prior run cannot still legitimately
+      // own the lock because the issue was not in_progress; without this clear, a
+      // wedged executionRunId persists and every subsequent checkout/comment hits
+      // the run-ownership guard.
+      if (
+        issueData.status === "in_progress" &&
+        existing.status !== "in_progress"
+      ) {
+        patch.checkoutRunId = null;
+        patch.executionRunId = null;
+        patch.executionAgentNameKey = null;
+        patch.executionLockedAt = null;
+      }
       if (
         (issueData.assigneeAgentId !== undefined && issueData.assigneeAgentId !== existing.assigneeAgentId) ||
         (issueData.assigneeUserId !== undefined && issueData.assigneeUserId !== existing.assigneeUserId)
@@ -5642,6 +5657,99 @@ export function issueService(db: Db) {
             checkoutRunId: existing.checkoutRunId,
             executionRunId: existing.executionRunId,
           },
+        };
+      }),
+
+    abortExecution: async (
+      id: string,
+      actorAgentId: string,
+      actorRunId: string | null,
+    ) =>
+      db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select ${issues.id} from ${issues} where ${issues.id} = ${id} for update`,
+        );
+        const existing = await tx
+          .select({
+            id: issues.id,
+            companyId: issues.companyId,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) return null;
+        if (existing.assigneeAgentId !== actorAgentId) {
+          // The guard at assertCheckoutOwner already throws "Issue run ownership conflict";
+          // this is the deliberate self-service escape hatch, so only the current
+          // assignee can use it. Non-assignees use POST /admin/force-release.
+          throw conflict("Only assignee can abort issue execution", {
+            issueId: existing.id,
+            status: existing.status,
+            assigneeAgentId: existing.assigneeAgentId,
+            actorAgentId,
+          });
+        }
+
+        const candidateRunIds = new Set<string>();
+        if (existing.checkoutRunId) candidateRunIds.add(existing.checkoutRunId);
+        if (existing.executionRunId) candidateRunIds.add(existing.executionRunId);
+        // Never abort the caller's own active heartbeat run — that would terminate the
+        // very run trying to recover. The caller's run will simply own a fresh checkout
+        // after this returns.
+        if (actorRunId) candidateRunIds.delete(actorRunId);
+
+        const abortedRunIds: string[] = [];
+        const now = new Date();
+        for (const runId of candidateRunIds) {
+          await tx.execute(
+            sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${runId} for update`,
+          );
+          const run = await tx
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, runId))
+            .then((rows) => rows[0] ?? null);
+          if (!run) continue;
+          if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) continue;
+          await tx
+            .update(heartbeatRuns)
+            .set({
+              status: "cancelled",
+              errorCode: "agent_self_abort",
+              error: "Aborted by issue assignee via /abort-execution",
+              finishedAt: now,
+              updatedAt: now,
+            })
+            .where(eq(heartbeatRuns.id, runId));
+          abortedRunIds.push(runId);
+        }
+
+        const updated = await tx
+          .update(issues)
+          .set({
+            checkoutRunId: null,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: now,
+          })
+          .where(eq(issues.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+
+        const [enriched] = await withIssueLabels(tx, [updated]);
+        return {
+          issue: enriched,
+          previous: {
+            checkoutRunId: existing.checkoutRunId,
+            executionRunId: existing.executionRunId,
+          },
+          abortedRunIds,
         };
       }),
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -67,6 +67,16 @@ Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLI
 
 If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**
 
+**Stuck on `Issue run ownership conflict`?** If you are the current `assigneeAgentId` and every write to the issue is rejected with `{"error":"Issue run ownership conflict",...}` (because `executionRunId` points at a heartbeat run that is no longer alive), you can self-recover without escalating:
+
+```
+POST /api/issues/{issueId}/abort-execution
+Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+{ "agentId": "{your-agent-id}" }
+```
+
+This clears `checkoutRunId` / `executionRunId`, cancels the orphan heartbeat run if it is still non-terminal, and leaves `status` and `assigneeAgentId` untouched. Then re-`POST /checkout` and continue. The route only works when the caller IS the current assignee — if you are not, escalate via your chain of command.
+
 **Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
 
 If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling the API. It is the fastest path for comment wakes and may already include the exact new comments that triggered this run. For comment-driven wakes, reflect the new comment context first, then fetch broader history only if needed.

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -900,6 +900,7 @@ Terminal states: `done`, `cancelled`
 | PATCH  | `/api/issues/:issueId`             | Update issue (optional `comment` field; `blockedByIssueIds` replaces blocker set)        |
 | POST   | `/api/issues/:issueId/checkout`    | Atomic checkout (claim + start). Idempotent if you already own it.                       |
 | POST   | `/api/issues/:issueId/release`     | Release task ownership                                                                   |
+| POST   | `/api/issues/:issueId/abort-execution` | Assignee self-recovery from `Issue run ownership conflict`: clears `checkoutRunId`/`executionRunId` and cancels the orphan heartbeat run. Body: `{ "agentId": "<your-id>" }`. Auth: caller must be the current assignee. |
 | GET    | `/api/issues/:issueId/comments`    | List comments                                                                            |
 | GET    | `/api/issues/:issueId/comments/:commentId` | Get a specific comment by ID                                                     |
 | POST   | `/api/issues/:issueId/comments`    | Add comment (@-mentions trigger wakeups)                                                 |


### PR DESCRIPTION
## Summary

Adds an assignee self-service escape hatch for "Issue run ownership conflict" wedges and fixes the proximate cause where stale `executionRunId` survives the `blocked → in_progress` flip.

- **New route `POST /api/issues/:id/abort-execution`** — the current assignee can clear `checkoutRunId` / `executionRunId` and cancel an orphan heartbeat run without CEO/admin DB intervention. Board callers may pass an explicit `agentId`; agent callers must call as themselves and supply `X-Paperclip-Run-Id`. Writes an `issue.execution_aborted` activity entry recording prev/aborted run ids. `status` and `assigneeAgentId` are untouched.
- **`update()` clears the lock on re-entering `in_progress`** — any PATCH that flips a non-`in_progress` row into `in_progress` (most importantly the `issue_blockers_resolved` auto-flip from `blocked`) now also nulls `executionRunId` / `checkoutRunId` / `executionAgentNameKey` / `executionLockedAt`. Without this, a wedged `executionRunId` persists indefinitely and every subsequent checkout/comment hits the run-ownership guard.
- **Docs** — `doc/execution-semantics.md` documents the `executionRunId` invariant and the escape hatch. `skills/paperclip/SKILL.md` + `references/api-reference.md` tell agents how to self-recover from "Issue run ownership conflict" without escalating.

## Motivation

We hit this in production twice in our private Paperclip instance:

1. A heartbeat run terminated unexpectedly while the issue was `in_progress`, leaving a non-terminal `executionRunId` pointing at a dead run. All subsequent agent writes (`PATCH`, `POST /comments`, `POST /checkout`) returned `{"error":"Issue run ownership conflict",...}` and the only fix was a CEO/admin DB UPDATE.
2. An issue went `in_progress → blocked → in_progress` (via `issue_blockers_resolved`) without clearing the prior `executionRunId`, producing the same wedge.

The two changes are paired because they cover both directions: the route lets a stuck assignee recover when the wedge already exists, and the PATCH clear prevents the most common path to the wedge from recurring.

## Acceptance criteria

- Assignee can call `POST /api/issues/:id/abort-execution` and reclaim a clean state without external help.
- Non-assignees calling the route get `403` and leave the row untouched.
- A PATCH that flips `blocked → in_progress` on a row carrying an orphan `executionRunId` clears the lock and lets the same caller take ownership in the same request.

## Test plan

New test file `server/src/__tests__/issue-stale-execution-lock-routes.test.ts` (6 cases, embedded Postgres) covers:

- Assigned agent PATCH recovers a terminal stale `executionRunId`.
- Rightful assignee can release after the owning run failed.
- Wedged assignee self-recovers via `/abort-execution`; orphan heartbeat run becomes `cancelled`/`agent_self_abort`, the caller's own run is untouched.
- Non-assignee `/abort-execution` returns `403` and leaves state intact.
- PATCH `blocked → in_progress` on a row with an orphan `executionRunId` clears the lock.
- Board callers must pass explicit `agentId`; agent callers may not target another agent.

Verification on the rebased branch:

```
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/issue-stale-execution-lock-routes.test.ts \
  src/__tests__/issue-agent-mutation-ownership-routes.test.ts \
  src/__tests__/authorization-service.test.ts
# Test Files  3 passed (3) — Tests 60 passed (60)

pnpm --filter @paperclipai/server typecheck
# clean
```

## Notes for reviewers

- The route deliberately accepts a board caller with `agentId` (no `X-Paperclip-Run-Id` required) so an operator/board user can rescue a stuck agent. Agent callers must always call as themselves and supply the run header.
- The cancellation update on the orphan heartbeat run uses `status='cancelled'` with `finishReason='agent_self_abort'` and skips any run id that matches the caller's active run, so the caller's own heartbeat is never collateral-cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)