### PR TITLE
fix(ci): guard canary lockfile commit when regen matches HEAD

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -319,8 +319,10 @@ jobs:
           git checkout -B master HEAD
           if [ "$USED_ARTIFACT_LOCKFILE" = "1" ]; then
             git add pnpm-lock.yaml
-            git -c user.email=ci@paperclip.local -c user.name=CI \
-              commit --no-verify -m "ci(canary): stage regenerated lockfile"
+            if ! git diff --cached --quiet; then
+              git -c user.email=ci@paperclip.local -c user.name=CI \
+                commit --no-verify -m "ci(canary): stage regenerated lockfile"
+            fi
           else
             git checkout -- pnpm-lock.yaml
           fi


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The PR pipeline runs a "Canary Dry Run" step that validates dependency PRs against a regenerated `pnpm-lock.yaml` before merge
> - When a dependabot (or other) PR's regenerated lockfile is byte-identical to `HEAD`, `git commit` exits non-zero with "nothing to commit, working tree clean"
> - The surrounding `bash -e` step propagates the non-zero exit, failing the Canary Dry Run for PRs that should be allowed through
> - This pull request guards the commit with `git diff --cached --quiet` so the step only commits when there is a real staged change
> - The benefit is that dependabot PRs (#7571 storybook bump, #7572) and any future PR where regen happens to match HEAD stop getting spuriously blocked by the canary step

## Linked Issues or Issue Description

Refs #7571
Refs #7572

PR #7571 (dependabot: storybook 10.3.5 → 10.4.2) and PR #7572 both fail on the exact same line of the `Canary Dry Run` step:

```
+ git -c user.email=ci@paperclip.local -c user.name=CI commit --no-verify -m 'ci(canary): stage regenerated lockfile'
On branch master
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

The step regenerates `pnpm-lock.yaml`, stages it, and unconditionally commits. When the regenerated lockfile matches `HEAD` exactly (which happens for some dependabot bumps where the lockfile resolution did not actually change), `git commit` exits 1 and `bash -e` fails the entire step.

## What Changed

- `.github/workflows/pr.yml`: Wrap the `git commit` inside the Canary Dry Run step in `if ! git diff --cached --quiet; then ... fi`, so the commit is skipped when there is no staged diff.

## Verification

- Reproduced the failure on PR #7571 and PR #7572 (identical stack trace at the `git commit` line of the Canary Dry Run step).
- Local sanity check: `git diff --cached --quiet` returns 0 (no diff) when the regen is a no-op and non-zero when there is a real change, which matches the intended branching.
- Once merged, dependabot PRs that previously stalled on this step should re-run the Canary Dry Run cleanly.

## Risks

- Low risk: the change only adds a guard before an existing `git commit`. The `else` branch (`git checkout -- pnpm-lock.yaml` when no artifact lockfile was used) is unchanged. No behavior change when there *is* a regen diff.

## Model Used

- Claude (Anthropic) — `claude-opus-4-7`, extended thinking off, tool use enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass (workflow YAML change; verified via shell sanity check of the guard condition)
- [ ] I have added or updated tests where applicable (no test harness for workflow YAML)
- [x] If this change affects the UI, I have included before/after screenshots (n/a — CI workflow only)
- [x] I have updated relevant documentation to reflect my changes (n/a)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge