### PR TITLE
docs(agent): harden checkout readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@ Before making changes, read in this order:
 - `packages/plugins/`: plugin system packages
 - `doc/`: operational and product docs
 
+## 3.1 Checkout Readiness
+
+Before implementation, review, or deploy handoff, complete the source-only readiness checklist in `docs/README.md`.
+
+- Confirm you are in the expected repo root and on the issue branch before editing.
+- Inspect `git status --short --branch` and treat existing dirty files as owned by someone else unless the issue explicitly names them.
+- State the paths you intend to own, and keep edits inside that boundary.
+- Run the smallest relevant local validation before moving work to review or deploy surfaces.
+- Record the validation commands and results in the issue receipt. Do not claim host, runtime, service, or deployment health without evidence from commands you actually ran.
+
 ## 4. Dev Setup (Auto DB)
 
 Use embedded PGlite in dev by leaving `DATABASE_URL` unset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,9 @@ Before making changes, read in this order:
 - `packages/adapter-utils/`: shared adapter utilities
 - `packages/plugins/`: plugin system packages
 - `doc/`: operational and product docs
+- `docs/`: public docs, API references, deploy guides, and agent/operator guides
 
-## 3.1 Checkout Readiness
+Checkout readiness:
 
 Before implementation, review, or deploy handoff, complete the source-only readiness checklist in `docs/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ pnpm db:migrate       # Apply migrations
 
 See [doc/DEVELOPING.md](doc/DEVELOPING.md) for the full development guide.
 
+For agent checkout readiness before implementation, review, or deploy handoff, use the source-only checklist in [docs/README.md](docs/README.md). It covers repo surface checks, owned paths, dirty-worktree handling, local validation, and issue receipt expectations.
+
 <br/>
 
 ## Roadmap

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+---
+title: Docs
+summary: Source-only checkout readiness and documentation entry points
+---
+
+# Documentation
+
+Use this page as the source-only readiness gate before implementation, review, or deploy handoff. These checks describe repository evidence only; they do not prove host, runtime, service, or deployment health unless the named validation command directly checked that surface.
+
+## Checkout Readiness
+
+1. Confirm the repo surface:
+   - `pwd`
+   - `git rev-parse --show-toplevel`
+   - `git status --short --branch`
+
+2. Declare owned paths before editing:
+   - Name the files or directories the issue allows you to change.
+   - Do not edit generated files, runtime config, host services, secrets, or deployment assets unless the issue explicitly includes them.
+   - If a needed path is outside scope, stop and ask for a scoped follow-up instead of broadening the change silently.
+
+3. Handle dirty worktrees conservatively:
+   - Treat pre-existing dirty files as another actor's work.
+   - Do not revert, format, stage, or commit unrelated changes.
+   - If dirty files overlap the paths you need, inspect the diff and either work around it or report the conflict in the issue.
+
+4. Validate locally before handoff:
+   - Run the smallest command that proves the source change, such as a focused test, typecheck, docs lint, or `git diff --check`.
+   - Escalate to broader validation only when the change crosses shared contracts, build surfaces, or user-facing workflows.
+   - Do not move work to review, merge, or deploy readiness without recording what passed and what was intentionally not run.
+
+5. Write the issue receipt:
+   - List the owned paths changed.
+   - Include validation commands and their results.
+   - Include any skipped checks and the reason.
+   - Keep claims source-scoped unless you have direct runtime or deployment evidence.
+
+## Related Guides
+
+- `docs/parallel-agent-workflow.md`: source boundaries for concurrent agents in one checkout.
+- `docs/merge-ready-agent-loop.md`: evidence required before saying a branch is ready for merge or deployment handoff.
+- `docs/guides/agent-developer/task-workflow.md`: Paperclip task checkout, update, blocker, delegation, and confirmation patterns.

--- a/docs/merge-ready-agent-loop.md
+++ b/docs/merge-ready-agent-loop.md
@@ -1,0 +1,35 @@
+---
+title: Merge-Ready Agent Loop
+summary: Evidence required before review, merge, or deploy handoff
+---
+
+# Merge-Ready Agent Loop
+
+A branch is merge-ready when the source change is scoped, locally validated, and documented well enough for the next actor to review without guessing.
+
+## Required Loop
+
+1. Recheck the source surface:
+   - `git status --short --branch`
+   - `git diff --stat`
+   - `git diff --check`
+
+2. Confirm scope:
+   - The diff only touches issue-owned paths.
+   - Any unrelated dirty files are named as untouched.
+   - Generated files are included only when the source change requires them.
+
+3. Validate:
+   - Run the narrowest command that proves the change.
+   - For docs-only changes, `git diff --check` is usually enough unless the edited docs have a dedicated build or lint path.
+   - For contract, schema, API, or UI behavior changes, run focused tests first and broaden only when the blast radius requires it.
+
+4. Record the receipt:
+   - Summary of what changed.
+   - Owned paths.
+   - Validation commands and results.
+   - Explicit note for anything not run.
+
+## Review and Deploy Boundaries
+
+Source-only readiness is not deploy readiness. A source receipt can say that the branch is ready for review or merge consideration. It cannot say a deployment, runtime service, external integration, or customer-visible workflow is healthy unless those surfaces were actually exercised and the evidence is linked.

--- a/docs/parallel-agent-workflow.md
+++ b/docs/parallel-agent-workflow.md
@@ -1,0 +1,38 @@
+---
+title: Parallel Agent Workflow
+summary: Source boundaries for concurrent agent work
+---
+
+# Parallel Agent Workflow
+
+Parallel work is safe only when each agent owns a clear source boundary and leaves receipts that another reviewer can verify.
+
+## Start of Work
+
+Run the repo surface checks before editing:
+
+```sh
+pwd
+git rev-parse --show-toplevel
+git status --short --branch
+```
+
+Then write down the paths you own for the issue. Owned paths should be narrow: specific files when possible, directories only when the issue actually requires them.
+
+## Dirty Worktree Rules
+
+- Pre-existing dirty files are not yours by default.
+- Do not revert, format, stage, or commit unrelated dirty files.
+- If a dirty file overlaps your owned path, inspect it first with `git diff -- <path>` and decide whether the issue can still proceed safely.
+- If the overlap changes behavior you must rely on, report the conflict in the issue and name the owner/action needed.
+
+## Handoff Receipt
+
+Every handoff comment should include:
+
+- Owned paths changed.
+- Validation commands run and whether they passed.
+- Checks not run and why.
+- Any dirty-worktree files intentionally left untouched.
+
+Do not claim that a service, host, runtime, preview URL, or deployment is healthy unless you ran a command that directly checked it.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The affected subsystem is the contributor and agent documentation used at checkout/start.
> - Agents need a clear source-only readiness path before implementation, review, or deploy handoff.
> - The existing docs had checkout and validation guidance, but the requested `docs/` entry points for owned paths, dirty-worktree handling, and receipt expectations were absent.
> - This pull request adds narrow source documentation for those readiness checks and links it from the existing repo entry points.
> - The benefit is safer concurrent agent work with explicit evidence before review/deploy surfaces are claimed.

## Linked Issues or Issue Description

- Refs Paperclip issue IRI-141: Harden checkout readiness docs for source-only flow.

Related search performed:
- Checked open PRs for this fork/user before review.
- No duplicate PR covering the same checkout-readiness docs map and source-only receipt flow was found.

## What Changed

- Added `docs/README.md` with a source-only checkout readiness checklist covering repo surface checks, owned paths, dirty worktree handling, validation, and issue receipts.
- Added `docs/parallel-agent-workflow.md` for concurrent agent ownership boundaries and handoff receipts.
- Added `docs/merge-ready-agent-loop.md` for review/merge/deploy handoff evidence boundaries.
- Linked the readiness checklist from `AGENTS.md` and the root `README.md` development section.
- Added `docs/` to the `AGENTS.md` repo map and kept checkout readiness inside the existing flat top-level heading structure.

## Verification

- `git diff --check -- README.md AGENTS.md docs/README.md docs/parallel-agent-workflow.md docs/merge-ready-agent-loop.md` passed.
- PR CI was green before the latest docs-only follow-up commit; checks have been re-triggered for the pushed update.
- No runtime, host, service, or deployment checks were run; this is docs-only source work.

## Risks

- Low risk. Documentation-only change.
- The upstream repository default branch is `master`; this PR targets `master` rather than `main`.

## Model Used

- OpenAI GPT-5 Codex coding agent via local repository inspection, shell command execution, GitHub CLI usage, and patch editing. Context window/capability details are provided by the Codex environment rather than a standalone model API call.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
