### PR TITLE
test(api): cover requester-only approval resubmit route

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -332,13 +332,16 @@ describe("approval routes idempotent retries", () => {
       requestedByUserId: null,
     });
     mockApprovalService.resubmit.mockResolvedValue({
-      id: "approval-9",
-      companyId: "company-1",
-      type: "request_board_approval",
-      status: "pending",
-      payload: { title: "Updated request" },
-      requestedByAgentId: "agent-1",
-      requestedByUserId: null,
+      approval: {
+        id: "approval-9",
+        companyId: "company-1",
+        type: "request_board_approval",
+        status: "pending",
+        payload: { title: "Updated request" },
+        requestedByAgentId: "agent-1",
+        requestedByUserId: null,
+      },
+      applied: true,
     });
 
     const res = await request(await createAgentApp({ agentId: "agent-1" }))
@@ -374,13 +377,16 @@ describe("approval routes idempotent retries", () => {
       requestedByUserId: null,
     });
     mockApprovalService.resubmit.mockResolvedValue({
-      id: "approval-10",
-      companyId: "company-1",
-      type: "request_board_approval",
-      status: "pending",
-      payload: { title: "Board updated request" },
-      requestedByAgentId: "agent-2",
-      requestedByUserId: null,
+      approval: {
+        id: "approval-10",
+        companyId: "company-1",
+        type: "request_board_approval",
+        status: "pending",
+        payload: { title: "Board updated request" },
+        requestedByAgentId: "agent-2",
+        requestedByUserId: null,
+      },
+      applied: true,
     });
 
     const res = await request(await createApp())
@@ -403,6 +409,40 @@ describe("approval routes idempotent retries", () => {
         entityId: "approval-10",
       }),
     );
+  });
+
+  it("does not emit duplicate resubmit logs when already pending", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-11",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Already pending request" },
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+    });
+    mockApprovalService.resubmit.mockResolvedValue({
+      approval: {
+        id: "approval-11",
+        companyId: "company-1",
+        type: "request_board_approval",
+        status: "pending",
+        payload: { title: "Already pending request" },
+        requestedByAgentId: "agent-1",
+        requestedByUserId: null,
+      },
+      applied: false,
+    });
+
+    const res = await request(await createAgentApp({ agentId: "agent-1" }))
+      .post("/api/approvals/approval-11/resubmit")
+      .send({ payload: { title: "Already pending request" } });
+
+    expect(res.status).toBe(200);
+    expect(mockApprovalService.resubmit).toHaveBeenCalledWith("approval-11", {
+      title: "Already pending request",
+    });
+    expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
   it("lets agents create generic issue-linked board approval requests", async () => {

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -66,7 +66,7 @@ async function createApp(actorOverrides: Record<string, unknown> = {}) {
   return app;
 }
 
-async function createAgentApp() {
+async function createAgentApp(actorOverrides: Record<string, unknown> = {}) {
   const [{ errorHandler }, { approvalRoutes }] = await Promise.all([
     import("../middleware/index.js"),
     import("../routes/approvals.js"),
@@ -80,6 +80,7 @@ async function createAgentApp() {
       companyId: "company-1",
       source: "api_key",
       isInstanceAdmin: false,
+      ...actorOverrides,
     };
     next();
   });
@@ -296,6 +297,69 @@ describe("approval routes idempotent retries", () => {
       "approval-6",
       "user-1",
       "Need changes",
+    );
+  });
+
+  it("rejects approval resubmit from a non-requesting agent", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-8",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "revision_requested",
+      payload: {},
+      requestedByAgentId: "agent-2",
+      requestedByUserId: null,
+    });
+
+    const res = await request(await createAgentApp({ agentId: "agent-1" }))
+      .post("/api/approvals/approval-8/resubmit")
+      .send({ payload: { title: "Updated request" } });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Only requesting agent can resubmit this approval" });
+    expect(mockApprovalService.resubmit).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("allows the requesting agent to resubmit an approval revision", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-9",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "revision_requested",
+      payload: { title: "Original request" },
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+    });
+    mockApprovalService.resubmit.mockResolvedValue({
+      id: "approval-9",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Updated request" },
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+    });
+
+    const res = await request(await createAgentApp({ agentId: "agent-1" }))
+      .post("/api/approvals/approval-9/resubmit")
+      .send({ payload: { title: "Updated request" } });
+
+    expect(res.status).toBe(200);
+    expect(mockApprovalService.resubmit).toHaveBeenCalledWith("approval-9", {
+      title: "Updated request",
+    });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId: "company-1",
+        actorType: "agent",
+        actorId: "agent-1",
+        agentId: "agent-1",
+        action: "approval.resubmitted",
+        entityType: "approval",
+        entityId: "approval-9",
+      }),
     );
   });
 

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -363,6 +363,48 @@ describe("approval routes idempotent retries", () => {
     );
   });
 
+  it("allows a board user to resubmit an approval revision requested by an agent", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-10",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "revision_requested",
+      payload: { title: "Original request" },
+      requestedByAgentId: "agent-2",
+      requestedByUserId: null,
+    });
+    mockApprovalService.resubmit.mockResolvedValue({
+      id: "approval-10",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Board updated request" },
+      requestedByAgentId: "agent-2",
+      requestedByUserId: null,
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-10/resubmit")
+      .send({ payload: { title: "Board updated request" } });
+
+    expect(res.status).toBe(200);
+    expect(mockApprovalService.resubmit).toHaveBeenCalledWith("approval-10", {
+      title: "Board updated request",
+    });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId: "company-1",
+        actorType: "user",
+        actorId: "user-1",
+        agentId: null,
+        action: "approval.resubmitted",
+        entityType: "approval",
+        entityId: "approval-10",
+      }),
+    );
+  });
+
   it("lets agents create generic issue-linked board approval requests", async () => {
     mockApprovalService.create.mockResolvedValue({
       id: "approval-1",

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -321,18 +321,20 @@ export function approvalRoutes(
           )
         : req.body.payload
       : undefined;
-    const approval = await svc.resubmit(id, normalizedPayload);
+    const { approval, applied } = await svc.resubmit(id, normalizedPayload);
     const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: approval.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "approval.resubmitted",
-      entityType: "approval",
-      entityId: approval.id,
-      details: { type: approval.type },
-    });
+    if (applied) {
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "approval.resubmitted",
+        entityType: "approval",
+        entityId: approval.id,
+        details: { type: approval.type },
+      });
+    }
     res.json(redactApprovalPayload(approval));
   });
 

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -208,14 +208,17 @@ export function approvalService(db: Db) {
         .then((rows) => rows[0]);
     },
 
-    resubmit: async (id: string, payload?: Record<string, unknown>) => {
+    resubmit: async (id: string, payload?: Record<string, unknown>): Promise<ResolutionResult> => {
       const existing = await getExistingApproval(id);
       if (existing.status !== "revision_requested") {
+        if (existing.status === "pending") {
+          return { approval: existing, applied: false };
+        }
         throw unprocessable("Only revision requested approvals can be resubmitted");
       }
 
       const now = new Date();
-      return db
+      const updated = await db
         .update(approvals)
         .set({
           status: "pending",
@@ -225,9 +228,20 @@ export function approvalService(db: Db) {
           decidedAt: null,
           updatedAt: now,
         })
-        .where(eq(approvals.id, id))
+        .where(and(eq(approvals.id, id), eq(approvals.status, "revision_requested")))
         .returning()
-        .then((rows) => rows[0]);
+        .then((rows) => rows[0] ?? null);
+
+      if (updated) {
+        return { approval: updated, applied: true };
+      }
+
+      const latest = await getExistingApproval(id);
+      if (latest.status === "pending") {
+        return { approval: latest, applied: false };
+      }
+
+      throw unprocessable("Only revision requested approvals can be resubmitted");
     },
 
     listComments: async (approvalId: string) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Approval routes let agents request board decisions and resubmit requests after revision.
> - The resubmit route already restricts mismatched agent actors, while board users intentionally retain operator-level access.
> - The previous test coverage documented authorization but missed the idempotent retry path.
> - A repeated resubmit after the approval is already pending should return the pending approval without re-emitting `approval.resubmitted`.
> - This pull request makes the resubmit service return an `{ approval, applied }` result, matching approve/reject idempotency.
> - The benefit is explicit route coverage for requester-only agents, board-user resubmit behavior, and duplicate-submit side-effect suppression.

## Linked Issues or Issue Description

No linked issue found. This PR addresses a backend idempotency and route-coverage gap found during code review: repeated approval resubmits could duplicate activity logs, and the board/user actor path needed explicit test coverage.

## What Changed

- Extended `approvalService.resubmit` to return `{ approval, applied }` and treat already-pending approvals as idempotent `applied: false` results.
- Updated the resubmit route to emit `approval.resubmitted` only when the service applies a state transition.
- Kept the non-requesting agent 403 coverage.
- Kept the board/user happy-path coverage to document that board users can resubmit agent-requested approvals.
- Added the missing already-pending resubmit test proving no duplicate activity log is emitted.

## Verification

- `pnpm exec vitest run server/src/__tests__/approval-routes-idempotency.test.ts` — 12 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.

## Risks

Low. The behavioral change is scoped to resubmit retries: approvals already in `pending` now behave idempotently instead of throwing, and duplicate `approval.resubmitted` activity logs are suppressed. Non-pending/non-revision statuses still reject.

## Model Used

OpenAI Codex, GPT-5 based coding agent, tool-enabled local repository editing and command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
