### PR TITLE
Fix instruction bundle file revision recording

### DIFF
--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -289,6 +289,51 @@ describe("agent instructions bundle routes", () => {
     );
   });
 
+  it("records config revision proof for a file-only bundle write", async () => {
+    await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .put("/api/agents/11111111-1111-4111-8111-111111111111/instructions-bundle/file?companyId=company-1")
+      .send({
+        path: "AGENTS.md",
+        content: "# Updated Agent\n",
+      }));
+
+    expect(mockAgentInstructionsService.readFile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "11111111-1111-4111-8111-111111111111" }),
+      "AGENTS.md",
+    );
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          instructionsBundleMode: "managed",
+          instructionsRootPath: "/tmp/agent-1",
+          instructionsEntryFile: "AGENTS.md",
+          instructionsFilePath: "/tmp/agent-1/AGENTS.md",
+        }),
+      }),
+      {
+        recordRevision: expect.objectContaining({
+          source: "instructions_bundle_file_put",
+          forceChangedKeys: ["instructionsBundle.files.AGENTS.md"],
+          beforeConfigExtras: {
+            instructionsBundleFile: {
+              path: "AGENTS.md",
+              size: 12,
+              sha256: "2cfdfc8ea8448c4cbfef13a84358d87f328933938e8e1b06fbb8f21ba7a05be8",
+            },
+          },
+          afterConfigExtras: {
+            instructionsBundleFile: {
+              path: "AGENTS.md",
+              size: 18,
+              sha256: "6ebc1436091156200ac6d5f8212205e57f80d34e2c74c5ce6bb6f83038bf29d1",
+            },
+          },
+        }),
+      },
+    );
+  });
+
   it("preserves managed instructions config when switching adapters", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from "express";
-import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { createHash, generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
@@ -106,6 +106,17 @@ import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
+
+function buildInstructionFileRevisionProof(file: { path: string; size: number; content?: string } | null) {
+  if (!file || typeof file.content !== "string") {
+    return null;
+  }
+  return {
+    path: file.path,
+    size: file.size,
+    sha256: createHash("sha256").update(file.content, "utf8").digest("hex"),
+  };
+}
 
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
@@ -2595,6 +2606,7 @@ export function agentRoutes(
     await assertCanManageInstructionsPath(req, existing);
 
     const actor = getActorInfo(req);
+    const beforeFile = await instructions.readFile(existing, req.body.path).catch(() => null);
     const result = await instructions.writeFile(existing, req.body.path, req.body.content, {
       clearLegacyPromptTemplate: req.body.clearLegacyPromptTemplate,
     });
@@ -2603,6 +2615,7 @@ export function agentRoutes(
       result.adapterConfig,
       { strictMode: strictSecretsMode },
     );
+    const revisionKey = `instructionsBundle.files.${result.file.path}`;
     await svc.update(
       id,
       { adapterConfig: normalizedAdapterConfig },
@@ -2611,6 +2624,13 @@ export function agentRoutes(
           createdByAgentId: actor.agentId,
           createdByUserId: actor.actorType === "user" ? actor.actorId : null,
           source: "instructions_bundle_file_put",
+          forceChangedKeys: [revisionKey],
+          beforeConfigExtras: {
+            instructionsBundleFile: buildInstructionFileRevisionProof(beforeFile),
+          },
+          afterConfigExtras: {
+            instructionsBundleFile: buildInstructionFileRevisionProof(result.file),
+          },
         },
       },
     );

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -57,6 +57,9 @@ interface RevisionMetadata {
   createdByUserId?: string | null;
   source?: string;
   rolledBackFromRevisionId?: string | null;
+  forceChangedKeys?: string[];
+  beforeConfigExtras?: Record<string, unknown>;
+  afterConfigExtras?: Record<string, unknown>;
 }
 
 interface UpdateAgentOptions {
@@ -141,11 +144,22 @@ function normalizeRuntimeConfigForNewAgent(runtimeConfig: unknown): Record<strin
   return normalizedRuntimeConfig;
 }
 
-function diffConfigSnapshot(
+export function diffConfigSnapshot(
   before: AgentConfigSnapshot,
   after: AgentConfigSnapshot,
 ): string[] {
   return CONFIG_REVISION_FIELDS.filter((field) => !jsonEqual(before[field], after[field]));
+}
+
+export function mergeRevisionChangedKeys(
+  beforeConfig: AgentConfigSnapshot,
+  afterConfig: AgentConfigSnapshot,
+  forcedChangedKeys: string[] = [],
+): string[] {
+  return [
+    ...diffConfigSnapshot(beforeConfig, afterConfig),
+    ...forcedChangedKeys.filter((key) => typeof key === "string" && key.trim().length > 0),
+  ].filter((key, index, keys) => keys.indexOf(key) === index);
 }
 
 function configPatchFromSnapshot(snapshot: unknown): Partial<typeof agents.$inferInsert> {
@@ -412,8 +426,12 @@ export function agentService(db: Db) {
       normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
     }
 
-    const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
-    const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
+    const forcedChangedKeys = options?.recordRevision?.forceChangedKeys ?? [];
+    const shouldRecordRevision =
+      Boolean(options?.recordRevision) && (hasConfigPatchFields(normalizedPatch) || forcedChangedKeys.length > 0);
+    const beforeConfig = shouldRecordRevision
+      ? { ...buildConfigSnapshot(existing), ...options?.recordRevision?.beforeConfigExtras }
+      : null;
 
     const updated = await db
       .update(agents)
@@ -424,8 +442,8 @@ export function agentService(db: Db) {
     const normalizedUpdated = updated ? await getById(updated.id) : null;
 
     if (normalizedUpdated && shouldRecordRevision && beforeConfig) {
-      const afterConfig = buildConfigSnapshot(normalizedUpdated);
-      const changedKeys = diffConfigSnapshot(beforeConfig, afterConfig);
+      const afterConfig = { ...buildConfigSnapshot(normalizedUpdated), ...options?.recordRevision?.afterConfigExtras };
+      const changedKeys = mergeRevisionChangedKeys(beforeConfig, afterConfig, forcedChangedKeys);
       if (changedKeys.length > 0) {
         await db.insert(agentConfigRevisions).values({
           companyId: normalizedUpdated.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent instruction bundles are part of the agent configuration surface because they define how a managed agent behaves.
> - The config revision API is the durable audit path operators use to prove approved agent configuration changes were applied.
> - `PUT /api/agents/:id/instructions-bundle/file` already requested a revision, but the service skipped it when only file contents changed and `adapterConfig` stayed the same.
> - This pull request lets revision callers provide explicit changed keys and sanitized snapshot proof for file-backed changes.
> - The benefit is that board-authenticated instruction file applies now leave visible revision proof without storing raw instruction text in the revision row.

## Linked Issues or Issue Description

Bug fix: board-authenticated `PUT /api/agents/:id/instructions-bundle/file` could successfully write an instruction bundle file without creating an agent config revision when the compatibility `adapterConfig` was unchanged.

- Expected behavior: instruction bundle file writes requested with `source: "instructions_bundle_file_put"` create durable revision proof visible through `GET /api/agents/:id/config-revisions`.
- Actual behavior: the service only inserted a revision when `diffConfigSnapshot(beforeConfig, afterConfig)` found changed config keys, so file-only content writes produced no revision row.
- Steps to reproduce: write a managed `AGENTS.md` file through the board-authenticated file PUT route for an agent whose managed instructions `adapterConfig` is already current, then list config revisions.
- Paperclip version/commit: observed against local package version `2026.529.0`; fixed against current `master`.
- Deployment mode: local trusted board-auth path.

## What Changed

- Added forced revision changed keys and before/after snapshot extras to agent config revision recording.
- Recorded `instructionsBundle.files.<path>` for instruction bundle file PUT operations.
- Added sanitized file proof (`path`, `size`, `sha256`) to revision snapshots instead of storing raw instruction content.
- Added route regression coverage for file-only instruction bundle writes.

## Verification

- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-instructions-routes.test.ts --no-file-parallelism --maxWorkers=1`
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && corepack pnpm --filter @paperclipai/server exec tsc --noEmit`
- Manual local replay against Freya's `AGENTS.md` through the patched route created revision `172054db-9a1a-4f69-b894-56f2e26563ea` with `source: "instructions_bundle_file_put"` and `changedKeys: ["instructionsBundle.files.AGENTS.md"]`.

## Risks

Low risk. This preserves the existing revision behavior for normal config patches and only adds an explicit revision path for callers that opt into forced changed keys. The route stores hashes and sizes, not raw instruction text.

## Model Used

OpenAI GPT-5 Codex via local Codex CLI/API, with tool use for repository inspection, editing, tests, GitHub CLI, and local Paperclip API verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
