### PR TITLE
feat(issues): auto-inherit projectId from ancestor chain on child issue create

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4535,3 +4535,121 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     expect(record?.childIssues.every((child) => typeof child.title === "string")).toBe(true);
   });
 });
+
+describeEmbeddedPostgres("projectId inheritance via parentId", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-projectid-inherit-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndProject() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Inherit Test Co",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Inherit Project",
+      status: "in_progress",
+    });
+    return { companyId, projectId };
+  }
+
+  it("inherits projectId from direct parent when child omits it", async () => {
+    const { companyId, projectId } = await seedCompanyAndProject();
+    const parent = await svc.create(companyId, {
+      title: "Parent issue",
+      status: "todo",
+      priority: "medium",
+      projectId,
+    });
+
+    const child = await svc.create(companyId, {
+      title: "Child issue",
+      status: "todo",
+      priority: "medium",
+      parentId: parent.id,
+      // projectId intentionally omitted
+    });
+
+    expect(child.projectId).toBe(projectId);
+  });
+
+  it("inherits projectId from grandparent when parent has no projectId", async () => {
+    const { companyId, projectId } = await seedCompanyAndProject();
+    const grandparent = await svc.create(companyId, {
+      title: "Grandparent issue",
+      status: "todo",
+      priority: "medium",
+      projectId,
+    });
+    // Create parent without projectId by inserting directly
+    const parentId = randomUUID();
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      parentId: grandparent.id,
+      projectId: null,
+      title: "Parent issue (no project)",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const child = await svc.create(companyId, {
+      title: "Child issue",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      // projectId intentionally omitted
+    });
+
+    expect(child.projectId).toBe(projectId);
+  });
+
+  it("respects explicit projectId override even when parent has a different one", async () => {
+    const { companyId, projectId: parentProjectId } = await seedCompanyAndProject();
+    const childProjectId = randomUUID();
+    await db.insert(projects).values({
+      id: childProjectId,
+      companyId,
+      name: "Child Project",
+      status: "in_progress",
+    });
+    const parent = await svc.create(companyId, {
+      title: "Parent issue",
+      status: "todo",
+      priority: "medium",
+      projectId: parentProjectId,
+    });
+
+    const child = await svc.create(companyId, {
+      title: "Child issue with explicit project",
+      status: "todo",
+      priority: "medium",
+      parentId: parent.id,
+      projectId: childProjectId, // explicitly override
+    });
+
+    expect(child.projectId).toBe(childProjectId);
+  });
+});

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -26,6 +26,7 @@ import {
   companyPortabilityService,
   companyService,
   feedbackService,
+  issueService,
   logActivity,
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
@@ -466,6 +467,16 @@ export function companyRoutes(db: Db, storage?: StorageService) {
       return;
     }
     res.json({ ok: true });
+  });
+
+  router.post("/:companyId/admin/backfill-project-ids", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertBoard(req);
+    assertCompanyAccess(req, companyId);
+    const dryRun = req.query.dryRun === "true" || req.query.dryRun === "1";
+    const issueSvc = issueService(db);
+    const result = await issueSvc.backfillProjectIds(companyId, dryRun);
+    res.json(result);
   });
 
   return router;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import { and, asc, desc, eq, gt, inArray, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -777,6 +777,7 @@ async function getWorkspaceInheritanceIssue(
       projectWorkspaceId: issues.projectWorkspaceId,
       executionWorkspaceId: issues.executionWorkspaceId,
       executionWorkspaceSettings: issues.executionWorkspaceSettings,
+      parentId: issues.parentId,
     })
     .from(issues)
     .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
@@ -785,6 +786,33 @@ async function getWorkspaceInheritanceIssue(
     throw notFound("Workspace inheritance issue not found");
   }
   return issue;
+}
+
+async function resolveAncestorProjectId(
+  db: Pick<Db, "execute">,
+  companyId: string,
+  issueId: string,
+): Promise<string | null> {
+  // Walk ancestor chain via recursive CTE to find first non-null projectId.
+  // Depth cap prevents runaway queries on pathological trees.
+  const rows = await db.execute<{ project_id: string | null }>(sql`
+    WITH RECURSIVE ancestor_chain AS (
+      SELECT id, project_id, parent_id, 0 AS depth
+      FROM issues
+      WHERE id = ${issueId}::uuid AND company_id = ${companyId}::uuid
+      UNION ALL
+      SELECT i.id, i.project_id, i.parent_id, ac.depth + 1
+      FROM issues i
+      INNER JOIN ancestor_chain ac ON i.id = ac.parent_id
+      WHERE i.company_id = ${companyId}::uuid AND ac.depth < 50
+    )
+    SELECT project_id
+    FROM ancestor_chain
+    WHERE project_id IS NOT NULL
+    ORDER BY depth ASC
+    LIMIT 1
+  `);
+  return rows.rows[0]?.project_id ?? null;
 }
 
 function touchedByUserCondition(companyId: string, userId: string) {
@@ -4733,8 +4761,12 @@ export function issueService(db: Db) {
           issueData.executionWorkspaceSettings !== undefined;
         if (workspaceInheritanceIssueId) {
           const workspaceSource = await getWorkspaceInheritanceIssue(tx, companyId, workspaceInheritanceIssueId);
-          if (issueData.projectId == null && workspaceSource.projectId) {
-            issueData.projectId = workspaceSource.projectId;
+          if (issueData.projectId == null) {
+            const inherited = workspaceSource.projectId
+              ?? (workspaceSource.parentId
+                ? await resolveAncestorProjectId(tx, companyId, workspaceSource.parentId)
+                : null);
+            if (inherited) issueData.projectId = inherited;
           }
           if (projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
             projectWorkspaceId = workspaceSource.projectWorkspaceId;
@@ -6256,6 +6288,33 @@ export function issueService(db: Db) {
         project: a.projectId ? projectMap.get(a.projectId) ?? null : null,
         goal: a.goalId ? goalMap.get(a.goalId) ?? null : null,
       }));
+    },
+
+    backfillProjectIds: async (companyId: string, dryRun = false) => {
+      const candidates = await db
+        .select({ id: issues.id, parentId: issues.parentId })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), isNull(issues.projectId), isNotNull(issues.parentId)));
+
+      let updated = 0;
+      let skipped = 0;
+      let errored = 0;
+
+      for (const candidate of candidates) {
+        try {
+          if (!candidate.parentId) { skipped++; continue; }
+          const inherited = await resolveAncestorProjectId(db, companyId, candidate.parentId);
+          if (!inherited) { skipped++; continue; }
+          if (!dryRun) {
+            await db.update(issues).set({ projectId: inherited }).where(eq(issues.id, candidate.id));
+          }
+          updated++;
+        } catch {
+          errored++;
+        }
+      }
+
+      return { updated, skipped, errored, total: candidates.length, dryRun };
     },
   };
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -812,7 +812,8 @@ async function resolveAncestorProjectId(
     ORDER BY depth ASC
     LIMIT 1
   `);
-  return rows.rows[0]?.project_id ?? null;
+  const first = Array.isArray(rows) ? rows[0] as { project_id: string | null } | undefined : undefined;
+  return first?.project_id ?? null;
 }
 
 function touchedByUserCondition(companyId: string, userId: string) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Child issues are created via `POST /api/companies/:companyId/issues` with a `parentId`
> - `projectId` was not being propagated to child issues when agents created follow-up work
> - The issue service already had one-level inheritance via `getWorkspaceInheritanceIssue`, but stopped if the direct parent's `projectId` was also null
> - This PR extends the inheritance to walk the full ancestor chain via a recursive CTE
> - The benefit is that nested child issues keep their project context, enabling correct project scoping, cost attribution, and UI grouping

## Linked Issues or Issue Description

Refs: JIN-378 (internal Paperclip task tracker)

## What Changed

- **`server/src/services/issues.ts`**:
  - Added `parentId` to the `getWorkspaceInheritanceIssue` select so the function can tell whether to recurse
  - Added `resolveAncestorProjectId(db, companyId, issueId)` — uses a recursive CTE with depth cap 50 to walk ancestor chain and return first non-null `project_id`
  - Modified the `svc.create` workspace inheritance block to fall back to `resolveAncestorProjectId` when the direct source has no `projectId`
  - Added `backfillProjectIds(companyId, dryRun?)` service method to fix historical orphaned issues
  - Added `isNotNull` to drizzle-orm import
- **`server/src/routes/companies.ts`**:
  - Added `POST /api/companies/:companyId/admin/backfill-project-ids` endpoint (board-only, supports `?dryRun=true`)
- **`server/src/__tests__/issues-service.test.ts`**:
  - Added 3 integration tests: direct parent inheritance, grandparent recursive inheritance, explicit override

## Verification

```bash
# Run new tests
cd server && pnpm test -- --grep "projectId inheritance"

# Dry-run backfill on a local instance
curl -X POST http://localhost:3100/api/companies/<id>/admin/backfill-project-ids?dryRun=true \
  -H "Authorization: Bearer $TOKEN"
# Returns: { updated: N, skipped: M, errored: 0, total: N+M, dryRun: true }

# Apply backfill
curl -X POST http://localhost:3100/api/companies/<id>/admin/backfill-project-ids
```

## Risks

- The recursive CTE has a depth cap of 50, preventing runaway queries on degenerate trees
- `resolveAncestorProjectId` is only called when the direct parent has no `projectId` — no extra DB roundtrip in the common case where the direct parent has one
- `backfillProjectIds` iterates candidates one-by-one; for very large datasets this may be slow, but it is a one-time operation
- Backfill endpoint is board-only; no agent can trigger it

## Model Used

Anthropic Claude Sonnet 4.6 (`claude-sonnet-4-6`), 200k context window, tool use mode (Claude Code CLI agent).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)