### PR TITLE
feat: add antigravity local adapter for paperclip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/mcp-server/package.json packages/mcp-server/
 COPY packages/skills-catalog/package.json packages/skills-catalog/
 COPY packages/teams-catalog/package.json packages/teams-catalog/
 COPY packages/adapters/acpx-local/package.json packages/adapters/acpx-local/
+COPY packages/adapters/antigravity-local/package.json packages/adapters/antigravity-local/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printCursorCloudEvent } from "@paperclipai/adapter-cursor-cloud/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
+import { printAntigravityStreamEvent } from "@paperclipai/adapter-antigravity-local/cli";
 import { printGrokStreamEvent } from "@paperclipai/adapter-grok-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
@@ -52,6 +53,11 @@ const geminiLocalCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printGeminiStreamEvent,
 };
 
+const antigravityLocalCLIAdapter: CLIAdapterModule = {
+  type: "antigravity_local",
+  formatStdoutEvent: printAntigravityStreamEvent,
+};
+
 const grokLocalCLIAdapter: CLIAdapterModule = {
   type: "grok_local",
   formatStdoutEvent: printGrokStreamEvent,
@@ -72,6 +78,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     cursorLocalCLIAdapter,
     cursorCloudCLIAdapter,
     geminiLocalCLIAdapter,
+    antigravityLocalCLIAdapter,
     grokLocalCLIAdapter,
     openclawGatewayCLIAdapter,
     processCLIAdapter,

--- a/doc/plans/2026-06-07-antigravity-adapter.md
+++ b/doc/plans/2026-06-07-antigravity-adapter.md
@@ -1,0 +1,52 @@
+# Plan: Antigravity CLI Local Adapter for Paperclip
+
+Date: 2026-06-07
+Author: Antigravity
+Branch: `feat/antigravity-adapter`
+
+## 1. Problem & Goal
+
+The goal is to enable Paperclip to orchestrate local agents using the **Antigravity CLI** (`agy` command), similar to how it orchestrates Claude Code (`claude`) and Gemini CLI (`gemini`).
+
+## 2. Design Decisions
+
+1. **Adapter Type**: `antigravity_local`.
+2. **Command Executable**: `agy` (resolved from the environment PATH or custom config, defaulting to `agy`).
+3. **Session Management**: Supports resuming sessions using the `--conversation <id>` flag of the `agy` CLI.
+4. **Permissions Bypass**: Passes `--dangerously-skip-permissions` to bypass interactive permission dialogs during unattended Paperclip runs.
+5. **Sandbox Mode**: Respects the `sandbox` config option by passing `--sandbox` to the `agy` executable when enabled.
+6. **Prompt Delivery**: Delivers the rendered template via the `--prompt` argument.
+
+## 3. Implementation Details
+
+We created a self-contained package `@paperclipai/adapter-antigravity-local` in `packages/adapters/antigravity-local` containing:
+- `package.json` & `tsconfig.json` conforming to Paperclip adapter exports.
+- `src/index.ts` containing adapter metadata, models list (`auto`, `gemini-2.5-pro`, `gemini-2.5-flash`), and `agentConfigurationDoc` markdown.
+- `src/server/execute.ts` implementing the core process execution logic.
+- `src/server/parse.ts` parsing plain text and JSONL output, extracting UUIDs as conversation/session IDs.
+- `src/server/skills.ts` managing symlinked local skills inside `~/.gemini/antigravity-cli/skills`.
+- `src/server/test.ts` executing `agy help` for environment diagnostic checks.
+- `src/ui/parse-stdout.ts` converting lines into UI Transcript entries.
+- `src/ui/build-config.ts` mapping form inputs to `adapterConfig`.
+- `src/ui/config-fields.tsx` rendering agent creation/editing form fields.
+- `src/cli/format-event.ts` formatting logs for CLI runner watchmode.
+
+And registered it under:
+- `server/src/adapters/builtin-adapter-types.ts`
+- `server/src/adapters/registry.ts`
+- `ui/src/adapters/registry.ts`
+- `cli/src/adapters/registry.ts`
+
+## 4. Verification & Testing
+
+- Added unit tests in `server/src/__tests__/antigravity-local-adapter.test.ts` verifying parser extraction, stale session detection, turn-limit classification, UI line parsing, and CLI formatting.
+- Tests executed and verified green:
+  ```bash
+  npx vitest run antigravity-local-adapter.test.ts
+  ```
+- Workspace packages linked and typechecked successfully:
+  ```bash
+  pnpm run preflight:workspace-links
+  pnpm typecheck
+  pnpm build
+  ```

--- a/packages/adapters/antigravity-local/package.json
+++ b/packages/adapters/antigravity-local/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@paperclipai/adapter-antigravity-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/antigravity-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/antigravity-local/src/cli/format-event.ts
+++ b/packages/adapters/antigravity-local/src/cli/format-event.ts
@@ -1,0 +1,70 @@
+import pc from "picocolors";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function printAntigravityStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    // Treat plain text line as stdout and print it
+    console.log(line);
+    return;
+  }
+
+  const type = asString(parsed.type).trim().toLowerCase();
+
+  if (type === "system") {
+    const subtype = asString(parsed.subtype);
+    if (subtype === "init") {
+      const sessionId = asString(parsed.sessionId ?? parsed.session_id);
+      console.log(pc.blue(`Antigravity CLI init (session: ${sessionId})`));
+      return;
+    }
+    console.log(pc.blue(`system: ${asString(parsed.message ?? parsed.text ?? line)}`));
+    return;
+  }
+
+  if (type === "error" || type === "stderr") {
+    console.log(pc.red(`error: ${asString(parsed.message ?? parsed.error ?? line)}`));
+    return;
+  }
+
+  if (type === "assistant" || type === "text") {
+    console.log(pc.green(`assistant: ${asString(parsed.text ?? parsed.content ?? parsed.message ?? line)}`));
+    return;
+  }
+
+  if (type === "user") {
+    console.log(pc.gray(`user: ${asString(parsed.text ?? parsed.content ?? parsed.message ?? line)}`));
+    return;
+  }
+
+  if (type === "thinking") {
+    console.log(pc.gray(`thinking: ${asString(parsed.text ?? line)}`));
+    return;
+  }
+
+  if (type === "tool_call") {
+    console.log(pc.yellow(`tool_call: ${asString(parsed.name ?? parsed.tool ?? "tool")}`));
+    return;
+  }
+
+  if (type === "tool_result" || type === "tool_response") {
+    const isError = parsed.isError === true || parsed.is_error === true;
+    console.log((isError ? pc.red : pc.cyan)(`tool_result${isError ? " (error)" : ""}`));
+    return;
+  }
+
+  console.log(line);
+}

--- a/packages/adapters/antigravity-local/src/cli/index.ts
+++ b/packages/adapters/antigravity-local/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAntigravityStreamEvent } from "./format-event.js";

--- a/packages/adapters/antigravity-local/src/index.ts
+++ b/packages/adapters/antigravity-local/src/index.ts
@@ -1,12 +1,12 @@
 import {
-  buildSandboxNpmInstallCommand,
   type AdapterModelProfileDefinition,
 } from "@paperclipai/adapter-utils";
 
 export const type = "antigravity_local";
 export const label = "Antigravity CLI (local)";
 
-export const SANDBOX_INSTALL_COMMAND = buildSandboxNpmInstallCommand("@google/antigravity-cli");
+// agy is not published to npm; it must be installed via https://antigravity.dev
+export const SANDBOX_INSTALL_COMMAND: null = null;
 
 export const DEFAULT_ANTIGRAVITY_LOCAL_MODEL = "auto";
 

--- a/packages/adapters/antigravity-local/src/index.ts
+++ b/packages/adapters/antigravity-local/src/index.ts
@@ -1,0 +1,73 @@
+import {
+  buildSandboxNpmInstallCommand,
+  type AdapterModelProfileDefinition,
+} from "@paperclipai/adapter-utils";
+
+export const type = "antigravity_local";
+export const label = "Antigravity CLI (local)";
+
+export const SANDBOX_INSTALL_COMMAND = buildSandboxNpmInstallCommand("@google/antigravity-cli");
+
+export const DEFAULT_ANTIGRAVITY_LOCAL_MODEL = "auto";
+
+export const models = [
+  { id: DEFAULT_ANTIGRAVITY_LOCAL_MODEL, label: "Auto" },
+  // Gemini 3.5 family
+  { id: "Gemini 3.5 Flash (Medium)", label: "Gemini 3.5 Flash (Medium)" },
+  { id: "Gemini 3.5 Flash (High)", label: "Gemini 3.5 Flash (High)" },
+  { id: "Gemini 3.5 Flash (Low)", label: "Gemini 3.5 Flash (Low)" },
+  // Gemini 3.1 family
+  { id: "Gemini 3.1 Pro (Low)", label: "Gemini 3.1 Pro (Low)" },
+  { id: "Gemini 3.1 Pro (High)", label: "Gemini 3.1 Pro (High)" },
+  // Claude family
+  { id: "Claude Sonnet 4.6 (Thinking)", label: "Claude Sonnet 4.6 (Thinking)" },
+  { id: "Claude Opus 4.6 (Thinking)", label: "Claude Opus 4.6 (Thinking)" },
+  // GPT / OSS
+  { id: "GPT-OSS 120B (Medium)", label: "GPT-OSS 120B (Medium)" },
+];
+
+export const modelProfiles: AdapterModelProfileDefinition[] = [
+  {
+    key: "cheap",
+    label: "Cheap",
+    description: "Use Gemini 3.5 Flash (Low) as the lower-cost Antigravity CLI lane.",
+    adapterConfig: {
+      model: "Gemini 3.5 Flash (Low)",
+    },
+    source: "adapter_default",
+  },
+];
+
+export const agentConfigurationDoc = `# antigravity_local agent configuration
+
+Adapter: antigravity_local
+
+Use when:
+- You want Paperclip to run the Antigravity CLI (\`agy\`) locally on the host machine
+- You want Antigravity CLI chat sessions resumed across heartbeats with --conversation / --continue
+- You want Paperclip skills injected locally without polluting the global environment
+
+Don't use when:
+- You need webhook-style external invocation (use http or openclaw_gateway)
+- You only need a one-shot script without an AI coding agent loop (use process)
+- Antigravity CLI is not installed on the machine that runs Paperclip
+
+Core fields:
+- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
+- promptTemplate (string, optional): run prompt template
+- model (string, optional): model id. Defaults to auto.
+- sandbox (boolean, optional): run in sandbox mode (default: false, passes --sandbox)
+- command (string, optional): defaults to "agy"
+- extraArgs (string[], optional): additional CLI args
+- env (object, optional): KEY=VALUE environment variables
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Runs use positional prompt arguments, not stdin (or stdin if command is invoked with --print -).
+- Sessions resume with --conversation when stored session cwd matches the current cwd.
+- Authentication uses local Antigravity CLI credentials in ~/.gemini/.
+`;

--- a/packages/adapters/antigravity-local/src/server/execute.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.ts
@@ -58,7 +58,7 @@ import {
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 function antigravitySkillsHome(): string {
-  return path.join(os.homedir(), ".gemini", "antigravity-cli", "skills");
+  return path.join(os.homedir(), ".gemini", "skills");
 }
 
 async function ensureAntigravitySkillsInjected(
@@ -318,7 +318,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             onLog,
           });
       if (remoteHomeDir && preparedExecutionTargetRuntime.assetDirs.skills) {
-        remoteSkillsDir = path.posix.join(remoteHomeDir, ".gemini", "antigravity-cli", "skills");
+        remoteSkillsDir = path.posix.join(remoteHomeDir, ".gemini", "skills");
         await runAdapterExecutionTargetShellCommand(
           runId,
           executionTarget,

--- a/packages/adapters/antigravity-local/src/server/execute.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.ts
@@ -1,0 +1,626 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  adapterExecutionTargetIsRemote,
+  adapterExecutionTargetRemoteCwd,
+  overrideAdapterExecutionTargetRemoteCwd,
+  adapterExecutionTargetSessionIdentity,
+  adapterExecutionTargetSessionMatches,
+  adapterExecutionTargetUsesManagedHome,
+  adapterExecutionTargetUsesPaperclipBridge,
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  prepareAdapterExecutionTargetRuntime,
+  readAdapterExecutionTarget,
+  readAdapterExecutionTargetHomeDir,
+  resolveAdapterExecutionTargetTimeoutSec,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+  runAdapterExecutionTargetShellCommand,
+  startAdapterExecutionTargetPaperclipBridge,
+} from "@paperclipai/adapter-utils/execution-target";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  buildPaperclipEnv,
+  buildInvocationEnvForLogs,
+  ensureAbsoluteDirectory,
+  ensurePaperclipSkillSymlink,
+  joinPromptSections,
+  ensurePathInEnv,
+  refreshPaperclipWorkspaceEnvForExecution,
+  readPaperclipRuntimeSkillEntries,
+  readPaperclipIssueWorkModeFromContext,
+  resolvePaperclipDesiredSkillNames,
+  removeMaintainerOnlySkillSymlinks,
+  parseObject,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
+import {
+  describeAntigravityFailure,
+  detectAntigravityAuthRequired,
+  detectAntigravityQuotaExhausted,
+  isAntigravityTurnLimitResult,
+  isAntigravityUnknownSessionError,
+  parseAntigravityOutput,
+} from "./parse.js";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function antigravitySkillsHome(): string {
+  return path.join(os.homedir(), ".gemini", "antigravity-cli", "skills");
+}
+
+async function ensureAntigravitySkillsInjected(
+  onLog: AdapterExecutionContext["onLog"],
+  skillsEntries: Array<{ key: string; runtimeName: string; source: string }>,
+  desiredSkillNames?: string[],
+): Promise<void> {
+  const desiredSet = new Set(desiredSkillNames ?? skillsEntries.map((entry) => entry.key));
+  const selectedEntries = skillsEntries.filter((entry) => desiredSet.has(entry.key));
+  if (selectedEntries.length === 0) return;
+
+  const skillsHome = antigravitySkillsHome();
+  try {
+    await fs.mkdir(skillsHome, { recursive: true });
+  } catch (err) {
+    await onLog(
+      "stderr",
+      `[paperclip] Failed to prepare Antigravity CLI skills directory ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return;
+  }
+  const removedSkills = await removeMaintainerOnlySkillSymlinks(
+    skillsHome,
+    selectedEntries.map((entry) => entry.runtimeName),
+  );
+  for (const skillName of removedSkills) {
+    await onLog(
+      "stderr",
+      `[paperclip] Removed maintainer-only Antigravity CLI skill "${skillName}" from ${skillsHome}\n`,
+    );
+  }
+
+  for (const entry of selectedEntries) {
+    const target = path.join(skillsHome, entry.runtimeName);
+
+    try {
+      const result = await ensurePaperclipSkillSymlink(entry.source, target);
+      if (result === "skipped") continue;
+      await onLog(
+        "stderr",
+        `[paperclip] ${result === "repaired" ? "Repaired" : "Linked"} Antigravity CLI skill: ${entry.key}\n`,
+      );
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to link Antigravity CLI skill "${entry.key}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+async function buildAntigravitySkillsDir(
+  config: Record<string, unknown>,
+): Promise<string> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-skills-"));
+  const target = path.join(tmp, "skills");
+  await fs.mkdir(target, { recursive: true });
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
+  for (const entry of availableEntries) {
+    if (!desiredNames.has(entry.key)) continue;
+    await fs.symlink(entry.source, path.join(target, entry.runtimeName));
+  }
+  return target;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const executionTarget = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+  const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  );
+  const command = asString(config.command, "agy");
+  const model = asString(config.model, DEFAULT_ANTIGRAVITY_LOCAL_MODEL).trim();
+  const sandbox = asBoolean(config.sandbox, false);
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+      (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+    )
+    : [];
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+  const antigravitySkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredAntigravitySkillNames = resolvePaperclipDesiredSkillNames(config, antigravitySkillEntries);
+  if (!executionTargetIsRemote) {
+    await ensureAntigravitySkillsInjected(onLog, antigravitySkillEntries, desiredAntigravitySkillNames);
+  }
+
+  const envConfig = parseObject(config.env);
+  const hasExplicitApiKey =
+    typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  env.PAPERCLIP_RUN_ID = runId;
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  const issueWorkMode = readPaperclipIssueWorkModeFromContext(context);
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (issueWorkMode) env.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  refreshPaperclipWorkspaceEnvForExecution({
+    env,
+    envConfig,
+    workspaceCwd: effectiveWorkspaceCwd,
+    workspaceSource,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    workspaceHints,
+    agentHome,
+    executionTargetIsRemote,
+    executionCwd: effectiveExecutionCwd,
+  });
+  if (!hasExplicitApiKey && authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+  const effectiveEnv = Object.fromEntries(
+    Object.entries({ ...process.env, ...env }).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  const runtimeEnv = Object.fromEntries(
+    Object.entries(ensurePathInEnv(effectiveEnv)).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
+    executionTarget,
+    asNumber(config.timeoutSec, 0),
+  );
+  const graceSec = asNumber(config.graceSec, 20);
+  await ensureAdapterExecutionTargetRuntimeCommandInstalled({
+    runId,
+    target: executionTarget,
+    installCommand: ctx.runtimeCommandSpec?.installCommand,
+    detectCommand: ctx.runtimeCommandSpec?.detectCommand,
+    cwd,
+    env: runtimeEnv,
+    timeoutSec,
+    graceSec,
+    onLog,
+  });
+  await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv, {
+    installCommand: SANDBOX_INSTALL_COMMAND,
+    timeoutSec,
+  });
+  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+  let loggedEnv = buildInvocationEnvForLogs(env, {
+    runtimeEnv,
+    includeRuntimeKeys: ["HOME"],
+    resolvedCommand,
+  });
+
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+  let restoreRemoteWorkspace: (() => Promise<void>) | null = null;
+  let remoteSkillsDir: string | null = null;
+  let localSkillsDir: string | null = null;
+  let remoteRuntimeRootDir: string | null = null;
+  let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
+
+  if (executionTargetIsRemote) {
+    try {
+      localSkillsDir = await buildAntigravitySkillsDir(config);
+      await onLog(
+        "stdout",
+        `[paperclip] Syncing workspace and Antigravity CLI runtime assets to ${describeAdapterExecutionTarget(executionTarget)}.\n`,
+      );
+      const preparedExecutionTargetRuntime = await prepareAdapterExecutionTargetRuntime({
+        runId,
+        target: executionTarget,
+        adapterKey: "antigravity",
+        timeoutSec,
+        workspaceLocalDir: cwd,
+        installCommand: SANDBOX_INSTALL_COMMAND,
+        detectCommand: command,
+        assets: [{
+          key: "skills",
+          localDir: localSkillsDir,
+          followSymlinks: true,
+        }],
+      });
+      restoreRemoteWorkspace = () => preparedExecutionTargetRuntime.restoreWorkspace();
+      effectiveExecutionCwd = preparedExecutionTargetRuntime.workspaceRemoteDir ?? effectiveExecutionCwd;
+      refreshPaperclipWorkspaceEnvForExecution({
+        env,
+        envConfig,
+        workspaceCwd: effectiveWorkspaceCwd,
+        workspaceSource,
+        workspaceId,
+        workspaceRepoUrl,
+        workspaceRepoRef,
+        workspaceHints,
+        agentHome,
+        executionTargetIsRemote,
+        executionCwd: effectiveExecutionCwd,
+      });
+      remoteRuntimeRootDir = preparedExecutionTargetRuntime.runtimeRootDir;
+      const managedHome = adapterExecutionTargetUsesManagedHome(executionTarget);
+      if (managedHome && preparedExecutionTargetRuntime.runtimeRootDir) {
+        env.HOME = preparedExecutionTargetRuntime.runtimeRootDir;
+      }
+      const remoteHomeDir = managedHome && preparedExecutionTargetRuntime.runtimeRootDir
+        ? preparedExecutionTargetRuntime.runtimeRootDir
+        : await readAdapterExecutionTargetHomeDir(runId, executionTarget, {
+            cwd,
+            env,
+            timeoutSec,
+            graceSec,
+            onLog,
+          });
+      if (remoteHomeDir && preparedExecutionTargetRuntime.assetDirs.skills) {
+        remoteSkillsDir = path.posix.join(remoteHomeDir, ".gemini", "antigravity-cli", "skills");
+        await runAdapterExecutionTargetShellCommand(
+          runId,
+          executionTarget,
+          `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSkillsDir))} && rm -rf ${JSON.stringify(remoteSkillsDir)} && cp -a ${JSON.stringify(preparedExecutionTargetRuntime.assetDirs.skills)} ${JSON.stringify(remoteSkillsDir)}`,
+          { cwd, env, timeoutSec, graceSec, onLog },
+        );
+      }
+    } catch (error) {
+      await Promise.allSettled([
+        restoreRemoteWorkspace?.(),
+        localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+      ]);
+      throw error;
+    }
+  }
+  const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
+  if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(executionTarget)) {
+    paperclipBridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId,
+      target: runtimeExecutionTarget,
+      runtimeRootDir: remoteRuntimeRootDir,
+      adapterKey: "antigravity",
+      timeoutSec,
+      hostApiToken: env.PAPERCLIP_API_KEY,
+      onLog,
+    });
+    if (paperclipBridge) {
+      Object.assign(env, paperclipBridge.env);
+      loggedEnv = buildInvocationEnvForLogs(env, {
+        runtimeEnv: ensurePathInEnv({ ...process.env, ...env }),
+        includeRuntimeKeys: ["HOME"],
+        resolvedCommand,
+      });
+    }
+  }
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
+    adapterExecutionTargetSessionMatches(runtimeRemoteExecution, runtimeExecutionTarget);
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+  if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Antigravity CLI session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
+    );
+  } else if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Antigravity CLI session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
+    );
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  let instructionsPrefix = "";
+  if (instructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stdout",
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+  const commandNotes = (() => {
+    const notes: string[] = ["Prompt is passed to Antigravity CLI via --print."];
+    notes.push("Added --dangerously-skip-permissions for unattended execution.");
+    if (!instructionsFilePath) return notes;
+    if (instructionsPrefix.length > 0) {
+      notes.push(
+        `Loaded agent instructions from ${instructionsFilePath}`,
+        `Prepended instructions + path directive to prompt.`,
+      );
+      return notes;
+    }
+    notes.push(
+      `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+    );
+    return notes;
+  })();
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
+  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    sessionHandoffNote,
+    renderedPrompt,
+  ]);
+  const promptMetrics = {
+    promptChars: prompt.length,
+    instructionsChars: instructionsPrefix.length,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    wakePromptChars: wakePrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  const buildArgs = (resumeSessionId: string | null) => {
+    const args: string[] = [];
+    if (resumeSessionId) {
+      args.push("--conversation", resumeSessionId);
+    }
+    if (model && model !== DEFAULT_ANTIGRAVITY_LOCAL_MODEL) {
+      args.push("--model", model);
+    }
+    args.push("--dangerously-skip-permissions");
+    if (sandbox) {
+      args.push("--sandbox");
+    }
+    if (extraArgs.length > 0) {
+      args.push(...extraArgs);
+    }
+
+    // Antigravity CLI uses --prompt/--print option to run a single prompt
+    args.push("--prompt", prompt);
+    return args;
+  };
+
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildArgs(resumeSessionId);
+    if (onMeta) {
+      await onMeta({
+        adapterType: "antigravity_local",
+        command: resolvedCommand,
+        cwd: effectiveExecutionCwd,
+        commandNotes,
+        commandArgs: args.map((value, index) => (
+          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
+        )),
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onLog,
+    });
+    return {
+      proc,
+      parsed: parseAntigravityOutput(proc.stdout, proc.stderr),
+    };
+  };
+
+  const toResult = (
+    attempt: {
+      proc: {
+        exitCode: number | null;
+        signal: string | null;
+        timedOut: boolean;
+        stdout: string;
+        stderr: string;
+      };
+      parsed: ReturnType<typeof parseAntigravityOutput>;
+    },
+    clearSessionOnMissingSession = false,
+    isRetry = false,
+  ): AdapterExecutionResult => {
+    const authMeta = detectAntigravityAuthRequired({
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+    });
+
+    if (attempt.proc.timedOut) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: authMeta.requiresAuth ? "antigravity_auth_required" : null,
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
+
+    const failed = (attempt.proc.exitCode ?? 0) !== 0;
+    const clearSessionForTurnLimit = isAntigravityTurnLimitResult(
+      attempt.proc.stdout,
+      attempt.proc.stderr,
+      attempt.proc.exitCode,
+    );
+    const quotaMeta = failed && !authMeta.requiresAuth && !clearSessionForTurnLimit
+      ? detectAntigravityQuotaExhausted({
+          stdout: attempt.proc.stdout,
+          stderr: attempt.proc.stderr,
+        })
+      : { exhausted: false as const, resetHint: null, retryNotBefore: null };
+
+    const canFallbackToRuntimeSession = !isRetry;
+    const resolvedSessionId = attempt.parsed.sessionId
+      ?? (canFallbackToRuntimeSession ? (runtimeSessionId ?? runtime.sessionId ?? null) : null);
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+        sessionId: resolvedSessionId,
+        cwd: effectiveExecutionCwd,
+        ...(workspaceId ? { workspaceId } : {}),
+        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        ...(executionTargetIsRemote
+          ? {
+              remoteExecution: adapterExecutionTargetSessionIdentity(runtimeExecutionTarget),
+            }
+          : {}),
+      } as Record<string, unknown>)
+      : null;
+
+    const fallbackErrorMessage =
+      attempt.parsed.errorMessage ||
+      describeAntigravityFailure(attempt.proc.stdout, attempt.proc.stderr);
+
+    const errorCode = !failed
+      ? null
+      : authMeta.requiresAuth
+      ? "antigravity_auth_required"
+      : clearSessionForTurnLimit
+      ? "max_turns_exhausted"
+      : quotaMeta.exhausted
+      ? "antigravity_quota_exhausted"
+      : null;
+
+    return {
+      exitCode: attempt.proc.exitCode,
+      signal: attempt.proc.signal,
+      timedOut: false,
+      errorMessage: failed ? fallbackErrorMessage : null,
+      errorCode,
+      errorFamily: quotaMeta.exhausted ? "transient_upstream" : null,
+      retryNotBefore: quotaMeta.retryNotBefore ?? null,
+      usage: attempt.parsed.usage,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "google",
+      biller: "google",
+      model,
+      costUsd: attempt.parsed.costUsd,
+      resultJson: {
+        stdout: attempt.proc.stdout,
+        stderr: attempt.proc.stderr,
+        ...(quotaMeta.exhausted ? { errorFamily: "transient_upstream", quotaResetHint: quotaMeta.resetHint } : {}),
+      },
+      summary: attempt.parsed.summary,
+      clearSession: clearSessionForTurnLimit || Boolean(clearSessionOnMissingSession && !resolvedSessionId),
+    };
+  };
+
+  try {
+    const initial = await runAttempt(sessionId);
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      isAntigravityUnknownSessionError(initial.proc.stdout, initial.proc.stderr)
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Antigravity CLI resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+      );
+      const retry = await runAttempt(null);
+      return toResult(retry, true, true);
+    }
+
+    return toResult(initial);
+  } finally {
+    await Promise.all([
+      paperclipBridge?.stop(),
+      restoreRemoteWorkspace?.(),
+      localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+    ]);
+  }
+}

--- a/packages/adapters/antigravity-local/src/server/index.ts
+++ b/packages/adapters/antigravity-local/src/server/index.ts
@@ -1,0 +1,73 @@
+export { execute } from "./execute.js";
+export { listAntigravitySkills, syncAntigravitySkills } from "./skills.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseAntigravityOutput,
+  isAntigravityUnknownSessionError,
+  describeAntigravityFailure,
+  detectAntigravityAuthRequired,
+  detectAntigravityQuotaExhausted,
+  parseAgyResetDurationMs,
+  isAntigravityTurnLimitResult,
+} from "./parse.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.sessionID)
+    );
+  },
+};

--- a/packages/adapters/antigravity-local/src/server/parse.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.ts
@@ -1,6 +1,5 @@
-import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { asString, parseJson } from "@paperclipai/adapter-utils/server-utils";
 
-const UUID_RE = /\b([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\b/i;
 const CONVERSATION_ID_RE = /(?:conversation|session)(?:\s+id)?[:\s]+([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i;
 
 export function parseAntigravityOutput(stdout: string, stderr: string) {
@@ -8,17 +7,12 @@ export function parseAntigravityOutput(stdout: string, stderr: string) {
   const messages: string[] = [];
   let errorMessage: string | null = null;
 
-  // Extract session/conversation ID
+  // Extract session/conversation ID only from explicit "conversation id: <uuid>" patterns
+  // to avoid misidentifying UUIDs from tool results or file content as the session ID.
   const combinedText = `${stdout}\n${stderr}`;
   const conversationMatch = combinedText.match(CONVERSATION_ID_RE);
   if (conversationMatch && conversationMatch[1]) {
     sessionId = conversationMatch[1];
-  } else {
-    // Fallback to any UUID in the output
-    const uuidMatch = combinedText.match(UUID_RE);
-    if (uuidMatch && uuidMatch[1]) {
-      sessionId = uuidMatch[1];
-    }
   }
 
   // Parse stdout lines

--- a/packages/adapters/antigravity-local/src/server/parse.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.ts
@@ -1,0 +1,176 @@
+import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+const UUID_RE = /\b([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\b/i;
+const CONVERSATION_ID_RE = /(?:conversation|session)(?:\s+id)?[:\s]+([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i;
+
+export function parseAntigravityOutput(stdout: string, stderr: string) {
+  let sessionId: string | null = null;
+  const messages: string[] = [];
+  let errorMessage: string | null = null;
+
+  // Extract session/conversation ID
+  const combinedText = `${stdout}\n${stderr}`;
+  const conversationMatch = combinedText.match(CONVERSATION_ID_RE);
+  if (conversationMatch && conversationMatch[1]) {
+    sessionId = conversationMatch[1];
+  } else {
+    // Fallback to any UUID in the output
+    const uuidMatch = combinedText.match(UUID_RE);
+    if (uuidMatch && uuidMatch[1]) {
+      sessionId = uuidMatch[1];
+    }
+  }
+
+  // Parse stdout lines
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    // Check if the line is JSON
+    if (line.startsWith("{") && line.endsWith("}")) {
+      const event = parseJson(line);
+      if (event) {
+        const type = asString(event.type, "").trim().toLowerCase();
+        if (type === "error" || type === "stderr") {
+          errorMessage = asString(event.message ?? event.error ?? event.text, errorMessage ?? "");
+        } else if (type === "assistant" || type === "text") {
+          const text = asString(event.text ?? event.content ?? event.message, "");
+          if (text) messages.push(text);
+        }
+        continue;
+      }
+    }
+
+    // Accumulate non-JSON text lines as part of the summary
+    messages.push(line);
+  }
+
+  // If we have an exit error or stderr contains error indications
+  if (!errorMessage) {
+    const stderrLines = stderr
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.toLowerCase().includes("error") || l.toLowerCase().includes("failed"));
+    if (stderrLines.length > 0) {
+      errorMessage = stderrLines[0];
+    }
+  }
+
+  return {
+    sessionId,
+    summary: messages.join("\n").trim(),
+    usage: {
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    },
+    costUsd: null as number | null,
+    errorMessage: errorMessage || null,
+  };
+}
+
+export function isAntigravityUnknownSessionError(stdout: string, stderr: string): boolean {
+  const haystack = `${stdout}\n${stderr}`.toLowerCase();
+  return (
+    haystack.includes("unknown conversation") ||
+    haystack.includes("conversation not found") ||
+    haystack.includes("unknown session") ||
+    haystack.includes("session not found") ||
+    haystack.includes("failed to resume") ||
+    haystack.includes("cannot resume")
+  );
+}
+
+export function describeAntigravityFailure(stdout: string, stderr: string): string | null {
+  const { errorMessage } = parseAntigravityOutput(stdout, stderr);
+  if (errorMessage) {
+    return `Antigravity CLI failed: ${errorMessage}`;
+  }
+  const firstStderr = stderr.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
+  if (firstStderr) {
+    return `Antigravity CLI failed: ${firstStderr}`;
+  }
+  return "Antigravity CLI failed with non-zero exit code";
+}
+
+const ANTIGRAVITY_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|login\s+required|requires\s+login|unauthorized|authentication\s+required|api[_ ]?key\s+(?:required|missing|invalid)|invalid\s+credentials|run\s+`?agy\s+login`?\s+first)/i;
+
+export function detectAntigravityAuthRequired(input: {
+  stdout: string;
+  stderr: string;
+}): { requiresAuth: boolean } {
+  const combined = `${input.stdout}\n${input.stderr}`;
+  const requiresAuth = ANTIGRAVITY_AUTH_REQUIRED_RE.test(combined);
+  return { requiresAuth };
+}
+
+export function isAntigravityTurnLimitResult(
+  stdout: string,
+  stderr: string,
+  exitCode?: number | null,
+): boolean {
+  if (exitCode === 53) return true;
+  const combined = `${stdout}\n${stderr}`.toLowerCase();
+  return (
+    combined.includes("turn_limit") ||
+    combined.includes("max_turns") ||
+    combined.includes("max_turns_exhausted") ||
+    combined.includes("turn_limit_exhausted")
+  );
+}
+
+/**
+ * Matches Antigravity CLI quota / rate-limit errors that are transient and
+ * should be retried automatically after a back-off (individual quota, API
+ * quota, resource exhaustion, 429 / 503 upstream responses).
+ *
+ * Examples emitted by agy:
+ *   "Individual quota reached. Contact your administrator to enable overages. Resets in 4h3m21s."
+ *   "quota exceeded"
+ *   "resource_exhausted"
+ *   "rate limit"
+ *   "429 Too Many Requests"
+ */
+const ANTIGRAVITY_QUOTA_RE =
+  /(?:individual\s+quota\s+reached|quota\s+(?:reached|exceeded|exhausted)|resource[_\s]exhausted|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|service\s+unavailable|\b503\b|overages\s+(?:not\s+)?enabled|resets?\s+in\s+\d)/i;
+
+/**
+ * Parses a human-readable duration string produced by agy such as
+ * "4h3m21s", "2h30m", "45m", "90s" into milliseconds.
+ * Returns null if the string cannot be parsed.
+ */
+export function parseAgyResetDurationMs(raw: string): number | null {
+  // Match optional hours, minutes, seconds, e.g. "4h3m21s", "30m", "90s", "2h30m"
+  const match = raw.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/);
+  if (!match) return null;
+  const hours = parseInt(match[1] ?? "0", 10);
+  const minutes = parseInt(match[2] ?? "0", 10);
+  const seconds = parseInt(match[3] ?? "0", 10);
+  const totalMs = (hours * 3600 + minutes * 60 + seconds) * 1000;
+  return totalMs > 0 ? totalMs : null;
+}
+
+export function detectAntigravityQuotaExhausted(input: {
+  stdout: string;
+  stderr: string;
+}): { exhausted: boolean; resetHint: string | null; retryNotBefore: string | null } {
+  const combined = `${input.stdout}\n${input.stderr}`;
+  const exhausted = ANTIGRAVITY_QUOTA_RE.test(combined);
+
+  if (!exhausted) return { exhausted: false, resetHint: null, retryNotBefore: null };
+
+  // Try to extract "Resets in Xh Ym Zs" from the output
+  const resetMatch = combined.match(/resets?\s+in\s+([\dhms\s]+)/i);
+  const resetHint = resetMatch ? `Resets in ${resetMatch[1].trim()}` : null;
+
+  let retryNotBefore: string | null = null;
+  if (resetMatch) {
+    const durationMs = parseAgyResetDurationMs(resetMatch[1].trim());
+    if (durationMs !== null) {
+      // Add a small buffer (60s) so the retry lands safely after the quota window resets
+      retryNotBefore = new Date(Date.now() + durationMs + 60_000).toISOString();
+    }
+  }
+
+  return { exhausted, resetHint, retryNotBefore };
+}

--- a/packages/adapters/antigravity-local/src/server/skills.ts
+++ b/packages/adapters/antigravity-local/src/server/skills.ts
@@ -27,7 +27,7 @@ function resolveAntigravitySkillsHome(config: Record<string, unknown>) {
       : {};
   const configuredHome = asString(env.HOME);
   const home = configuredHome ? path.resolve(configuredHome) : os.homedir();
-  return path.join(home, ".gemini", "antigravity-cli", "skills");
+  return path.join(home, ".gemini", "skills");
 }
 
 async function buildAntigravitySkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
@@ -41,7 +41,7 @@ async function buildAntigravitySkillSnapshot(config: Record<string, unknown>): P
     desiredSkills,
     installed,
     skillsHome,
-    locationLabel: "~/.gemini/antigravity-cli/skills",
+    locationLabel: "~/.gemini/skills",
     missingDetail: "Configured but not currently linked into the Antigravity skills home.",
     externalConflictDetail: "Skill name is occupied by an external installation.",
     externalDetail: "Installed outside Paperclip management.",

--- a/packages/adapters/antigravity-local/src/server/skills.ts
+++ b/packages/adapters/antigravity-local/src/server/skills.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  AdapterSkillContext,
+  AdapterSkillSnapshot,
+} from "@paperclipai/adapter-utils";
+import {
+  buildPersistentSkillSnapshot,
+  ensurePaperclipSkillSymlink,
+  readPaperclipRuntimeSkillEntries,
+  readInstalledSkillTargets,
+  resolvePaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveAntigravitySkillsHome(config: Record<string, unknown>) {
+  const env =
+    typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
+      ? (config.env as Record<string, unknown>)
+      : {};
+  const configuredHome = asString(env.HOME);
+  const home = configuredHome ? path.resolve(configuredHome) : os.homedir();
+  return path.join(home, ".gemini", "antigravity-cli", "skills");
+}
+
+async function buildAntigravitySkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkills = resolvePaperclipDesiredSkillNames(config, availableEntries);
+  const skillsHome = resolveAntigravitySkillsHome(config);
+  const installed = await readInstalledSkillTargets(skillsHome);
+  return buildPersistentSkillSnapshot({
+    adapterType: "antigravity_local",
+    availableEntries,
+    desiredSkills,
+    installed,
+    skillsHome,
+    locationLabel: "~/.gemini/antigravity-cli/skills",
+    missingDetail: "Configured but not currently linked into the Antigravity skills home.",
+    externalConflictDetail: "Skill name is occupied by an external installation.",
+    externalDetail: "Installed outside Paperclip management.",
+  });
+}
+
+export async function listAntigravitySkills(ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return buildAntigravitySkillSnapshot(ctx.config);
+}
+
+export async function syncAntigravitySkills(
+  ctx: AdapterSkillContext,
+  desiredSkills: string[],
+): Promise<AdapterSkillSnapshot> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(ctx.config, __moduleDir);
+  const desiredSet = new Set([
+    ...desiredSkills,
+    ...availableEntries.filter((entry) => entry.required).map((entry) => entry.key),
+  ]);
+  const skillsHome = resolveAntigravitySkillsHome(ctx.config);
+  await fs.mkdir(skillsHome, { recursive: true });
+  const installed = await readInstalledSkillTargets(skillsHome);
+  const availableByRuntimeName = new Map(availableEntries.map((entry) => [entry.runtimeName, entry]));
+
+  for (const available of availableEntries) {
+    if (!desiredSet.has(available.key)) continue;
+    const target = path.join(skillsHome, available.runtimeName);
+    await ensurePaperclipSkillSymlink(available.source, target);
+  }
+
+  for (const [name, installedEntry] of installed.entries()) {
+    const available = availableByRuntimeName.get(name);
+    if (!available) continue;
+    if (desiredSet.has(available.key)) continue;
+    if (installedEntry.targetPath !== available.source) continue;
+    await fs.unlink(path.join(skillsHome, name)).catch(() => {});
+  }
+
+  return buildAntigravitySkillSnapshot(ctx.config);
+}
+
+export function resolveAntigravityDesiredSkillNames(
+  config: Record<string, unknown>,
+  availableEntries: Array<{ key: string; required?: boolean }>,
+) {
+  return resolvePaperclipDesiredSkillNames(config, availableEntries);
+}

--- a/packages/adapters/antigravity-local/src/server/test.ts
+++ b/packages/adapters/antigravity-local/src/server/test.ts
@@ -1,0 +1,170 @@
+import path from "node:path";
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  ensurePathInEnv,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  ensureAdapterExecutionTargetCommandResolvable,
+  maybeRunSandboxInstallCommand,
+  ensureAdapterExecutionTargetDirectory,
+  runAdapterExecutionTargetProcess,
+  describeAdapterExecutionTarget,
+  resolveAdapterExecutionTargetCwd,
+} from "@paperclipai/adapter-utils/execution-target";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js";
+import { detectAntigravityAuthRequired, parseAntigravityOutput } from "./parse.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "agy");
+  const target = ctx.executionTarget ?? null;
+  const targetIsRemote = target?.kind === "remote";
+  const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
+  const targetLabel = targetIsRemote
+    ? ctx.environmentName ?? describeAdapterExecutionTarget(target)
+    : null;
+  const runId = `antigravity-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  if (targetLabel) {
+    checks.push({
+      code: "antigravity_environment_target",
+      level: "info",
+      message: `Probing inside environment: ${targetLabel}`,
+    });
+  }
+
+  try {
+    await ensureAdapterExecutionTargetDirectory(runId, target, cwd, {
+      cwd,
+      env: {},
+      createIfMissing: true,
+    });
+    checks.push({
+      code: "antigravity_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "antigravity_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const installCheck = await maybeRunSandboxInstallCommand({
+    runId,
+    target,
+    adapterKey: "antigravity",
+    installCommand: SANDBOX_INSTALL_COMMAND,
+    detectCommand: command,
+    env,
+  });
+  if (installCheck) checks.push(installCheck);
+
+  try {
+    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    checks.push({
+      code: "antigravity_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "antigravity_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "antigravity_cwd_invalid" && check.code !== "antigravity_command_unresolvable");
+
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "agy")) {
+      checks.push({
+        code: "antigravity_help_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped help probe because command is not `agy`.",
+        detail: command,
+        hint: "Use the `agy` CLI command to run the automatic installation and verification.",
+      });
+    } else {
+      const probe = await runAdapterExecutionTargetProcess(
+        runId,
+        target,
+        command,
+        ["help"],
+        {
+          cwd,
+          env,
+          timeoutSec: 10,
+          graceSec: 2,
+          onLog: async () => {},
+        },
+      );
+
+      if (probe.timedOut) {
+        checks.push({
+          code: "antigravity_help_probe_timed_out",
+          level: "warn",
+          message: "Antigravity CLI help probe timed out.",
+          hint: "Verify if another agy process is holding a session lock.",
+        });
+      } else if ((probe.exitCode ?? 1) === 0) {
+        checks.push({
+          code: "antigravity_help_probe_passed",
+          level: "info",
+          message: "Antigravity CLI help probe succeeded.",
+          detail: `Command help runs successfully.`,
+        });
+      } else {
+        checks.push({
+          code: "antigravity_help_probe_failed",
+          level: "error",
+          message: "Antigravity CLI help probe failed.",
+          detail: probe.stderr || probe.stdout,
+          hint: "Verify if agy command is correctly installed and configured.",
+        });
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/antigravity-local/src/server/test.ts
+++ b/packages/adapters/antigravity-local/src/server/test.ts
@@ -82,15 +82,18 @@ export async function testEnvironment(
     if (typeof value === "string") env[key] = value;
   }
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
-  const installCheck = await maybeRunSandboxInstallCommand({
-    runId,
-    target,
-    adapterKey: "antigravity",
-    installCommand: SANDBOX_INSTALL_COMMAND,
-    detectCommand: command,
-    env,
-  });
-  if (installCheck) checks.push(installCheck);
+  // agy is not on npm; skip sandbox auto-install (SANDBOX_INSTALL_COMMAND is null)
+  if (SANDBOX_INSTALL_COMMAND) {
+    const installCheck = await maybeRunSandboxInstallCommand({
+      runId,
+      target,
+      adapterKey: "antigravity",
+      installCommand: SANDBOX_INSTALL_COMMAND,
+      detectCommand: command,
+      env,
+    });
+    if (installCheck) checks.push(installCheck);
+  }
 
   try {
     await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);

--- a/packages/adapters/antigravity-local/src/ui/build-config.ts
+++ b/packages/adapters/antigravity-local/src/ui/build-config.ts
@@ -1,0 +1,74 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildAntigravityLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  ac.model = v.model || DEFAULT_ANTIGRAVITY_LOCAL_MODEL;
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+  const env = parseEnvBindings(v.envBindings);
+  const legacy = parseEnvVars(v.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) ac.env = env;
+  ac.sandbox = !v.dangerouslyBypassSandbox;
+
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/antigravity-local/src/ui/index.ts
+++ b/packages/adapters/antigravity-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseAntigravityStdoutLine } from "./parse-stdout.js";
+export { buildAntigravityLocalConfig } from "./build-config.js";

--- a/packages/adapters/antigravity-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/antigravity-local/src/ui/parse-stdout.ts
@@ -1,0 +1,78 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function parseAntigravityStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    // Treat plain text line as stdout
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type).trim().toLowerCase();
+
+  if (type === "system") {
+    const subtype = asString(parsed.subtype);
+    if (subtype === "init") {
+      const sessionId = asString(parsed.sessionId ?? parsed.session_id);
+      return [{ kind: "init", ts, model: asString(parsed.model, "gemini"), sessionId }];
+    }
+    return [{ kind: "system", ts, text: asString(parsed.message ?? parsed.text ?? line) }];
+  }
+
+  if (type === "error" || type === "stderr") {
+    return [{ kind: "stderr", ts, text: asString(parsed.message ?? parsed.error ?? line) }];
+  }
+
+  if (type === "assistant" || type === "text") {
+    return [{ kind: "assistant", ts, text: asString(parsed.text ?? parsed.content ?? parsed.message ?? line) }];
+  }
+
+  if (type === "user") {
+    return [{ kind: "user", ts, text: asString(parsed.text ?? parsed.content ?? parsed.message ?? line) }];
+  }
+
+  if (type === "thinking") {
+    return [{ kind: "thinking", ts, text: asString(parsed.text ?? line) }];
+  }
+
+  if (type === "tool_call") {
+    const name = asString(parsed.name ?? parsed.tool ?? "tool");
+    return [{
+      kind: "tool_call",
+      ts,
+      name,
+      input: parsed.input ?? parsed.arguments ?? parsed.args ?? {},
+    }];
+  }
+
+  if (type === "tool_result" || type === "tool_response") {
+    const toolUseId = asString(parsed.toolUseId ?? parsed.tool_use_id ?? "tool_result");
+    const content = asString(parsed.content ?? parsed.output ?? parsed.result ?? line);
+    const isError = parsed.isError === true || parsed.is_error === true;
+    return [{
+      kind: "tool_result",
+      ts,
+      toolUseId,
+      content,
+      isError,
+    }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/antigravity-local/tsconfig.json
+++ b/packages/adapters/antigravity-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
-      '@paperclipai/adapter-antigravity-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/antigravity-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -131,22 +128,6 @@ importers:
       acpx:
         specifier: ^0.6.1
         version: 0.6.1
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
-  packages/adapters/antigravity-local:
-    dependencies:
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -664,9 +645,6 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
-      '@paperclipai/adapter-antigravity-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/antigravity-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -833,9 +811,6 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
-      '@paperclipai/adapter-antigravity-local':
-        specifier: workspace:*
-        version: link:../packages/adapters/antigravity-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
+      '@paperclipai/adapter-antigravity-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/antigravity-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -128,6 +131,22 @@ importers:
       acpx:
         specifier: ^0.6.1
         version: 0.6.1
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/antigravity-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -645,6 +664,9 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
+      '@paperclipai/adapter-antigravity-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/antigravity-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -811,6 +833,9 @@ importers:
       '@paperclipai/adapter-acpx-local':
         specifier: workspace:*
         version: link:../packages/adapters/acpx-local
+      '@paperclipai/adapter-antigravity-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/antigravity-local
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -12,7 +12,7 @@
   {
     "dir": "packages/adapters/antigravity-local",
     "name": "@paperclipai/adapter-antigravity-local",
-    "publishFromCi": true
+    "publishFromCi": false
   },
   {
     "dir": "packages/adapters/claude-local",

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -10,6 +10,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/antigravity-local",
+    "name": "@paperclipai/adapter-antigravity-local",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/adapters/claude-local",
     "name": "@paperclipai/adapter-claude-local",
     "publishFromCi": true

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/server/src/__tests__/antigravity-local-adapter.test.ts
+++ b/server/src/__tests__/antigravity-local-adapter.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isAntigravityTurnLimitResult,
+  isAntigravityUnknownSessionError,
+  parseAntigravityOutput,
+  detectAntigravityQuotaExhausted,
+  parseAgyResetDurationMs,
+} from "@paperclipai/adapter-antigravity-local/server";
+import { parseAntigravityStdoutLine } from "@paperclipai/adapter-antigravity-local/ui";
+import { printAntigravityStreamEvent } from "@paperclipai/adapter-antigravity-local/cli";
+
+describe("antigravity_local parser", () => {
+  it("extracts session, summary, and terminal error message from text output", () => {
+    const stdout = [
+      "Antigravity CLI init (session: 45127642-4fab-4b98-9928-dc5527f2222a)",
+      "Checking codebase...",
+      "Done with task.",
+    ].join("\n");
+    const stderr = "Warning: low API budget";
+
+    const parsed = parseAntigravityOutput(stdout, stderr);
+    expect(parsed.sessionId).toBe("45127642-4fab-4b98-9928-dc5527f2222a");
+    expect(parsed.summary).toContain("Done with task.");
+    expect(parsed.errorMessage).toBeNull();
+  });
+
+  it("extracts session from fallback uuid", () => {
+    const stdout = "Traversed workspace for conversation 36fb199d-4706-4eb4-ad46-653e9db5af2a";
+    const parsed = parseAntigravityOutput(stdout, "");
+    expect(parsed.sessionId).toBe("36fb199d-4706-4eb4-ad46-653e9db5af2a");
+  });
+
+  it("extracts errors from stderr", () => {
+    const stdout = "Antigravity CLI output";
+    const stderr = "Error: Anthropic API key is invalid";
+    const parsed = parseAntigravityOutput(stdout, stderr);
+    expect(parsed.errorMessage).toBe("Error: Anthropic API key is invalid");
+  });
+});
+
+describe("antigravity_local stale session detection", () => {
+  it("treats missing session messages as an unknown session error", () => {
+    expect(isAntigravityUnknownSessionError("", "unknown conversation abc")).toBe(true);
+    expect(isAntigravityUnknownSessionError("", "conversation not found")).toBe(true);
+    expect(isAntigravityUnknownSessionError("", "cannot resume")).toBe(true);
+  });
+});
+
+describe("antigravity_local turn-limit detection", () => {
+  it("detects structured turn-limit signals and exit code 53", () => {
+    expect(isAntigravityTurnLimitResult("turn_limit_exhausted", "")).toBe(true);
+    expect(isAntigravityTurnLimitResult("", "", 53)).toBe(true);
+  });
+});
+
+describe("antigravity_local quota detection", () => {
+  it("detects individual quota reached message and computes retryNotBefore", () => {
+    const before = Date.now();
+    const result = detectAntigravityQuotaExhausted({
+      stdout: "",
+      stderr: "Individual quota reached. Contact your administrator to enable overages. Resets in 4h3m21s.",
+    });
+    expect(result.exhausted).toBe(true);
+    expect(result.resetHint).toMatch(/resets?\s+in/i);
+    // retryNotBefore should be ~4h3m21s + 60s from now
+    expect(result.retryNotBefore).not.toBeNull();
+    const retryMs = new Date(result.retryNotBefore!).getTime();
+    const expectedMs = before + (4 * 3600 + 3 * 60 + 21 + 60) * 1000;
+    expect(retryMs).toBeGreaterThanOrEqual(expectedMs - 1000);
+    expect(retryMs).toBeLessThanOrEqual(expectedMs + 5000);
+  });
+
+  it("detects resource_exhausted and rate-limit errors", () => {
+    expect(detectAntigravityQuotaExhausted({ stdout: "resource_exhausted", stderr: "" }).exhausted).toBe(true);
+    expect(detectAntigravityQuotaExhausted({ stdout: "", stderr: "rate limit exceeded" }).exhausted).toBe(true);
+    expect(detectAntigravityQuotaExhausted({ stdout: "", stderr: "429 Too Many Requests" }).exhausted).toBe(true);
+  });
+
+  it("does not flag normal output as quota exhausted", () => {
+    const r = detectAntigravityQuotaExhausted({ stdout: "Task completed successfully", stderr: "" });
+    expect(r.exhausted).toBe(false);
+    expect(r.retryNotBefore).toBeNull();
+  });
+
+  it("parseAgyResetDurationMs handles mixed durations", () => {
+    expect(parseAgyResetDurationMs("4h3m21s")).toBe((4 * 3600 + 3 * 60 + 21) * 1000);
+    expect(parseAgyResetDurationMs("30m")).toBe(30 * 60 * 1000);
+    expect(parseAgyResetDurationMs("90s")).toBe(90 * 1000);
+    expect(parseAgyResetDurationMs("2h")).toBe(2 * 3600 * 1000);
+    expect(parseAgyResetDurationMs("")).toBeNull();
+  });
+});
+
+describe("antigravity_local ui stdout parser", () => {
+  it("parses assistant message and result events", () => {
+    const ts = "2026-03-08T00:00:00.000Z";
+
+    expect(
+      parseAntigravityStdoutLine(
+        JSON.stringify({
+          type: "assistant",
+          text: "I checked the repo.",
+        }),
+        ts,
+      ),
+    ).toEqual([
+      { kind: "assistant", ts, text: "I checked the repo." },
+    ]);
+
+    expect(
+      parseAntigravityStdoutLine("raw text line", ts),
+    ).toEqual([
+      { kind: "stdout", ts, text: "raw text line" },
+    ]);
+  });
+});
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("antigravity_local cli formatter", () => {
+  it("prints stream events", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    let joined = "";
+
+    try {
+      printAntigravityStreamEvent(
+        JSON.stringify({ type: "system", subtype: "init", sessionId: "45127642-4fab-4b98-9928-dc5527f2222a" }),
+        false,
+      );
+      printAntigravityStreamEvent(
+        JSON.stringify({
+          type: "assistant",
+          text: "hello",
+        }),
+        false,
+      );
+      printAntigravityStreamEvent("plain stdout text", false);
+      joined = spy.mock.calls.map((call) => stripAnsi(call.join(" "))).join("\n");
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(joined).toContain("Antigravity CLI init");
+    expect(joined).toContain("assistant: hello");
+    expect(joined).toContain("plain stdout text");
+  });
+});

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -8,6 +8,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "cursor_cloud",
   "cursor",
   "gemini_local",
+  "antigravity_local",
   "grok_local",
   "openclaw_gateway",
   "opencode_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -80,6 +80,18 @@ import {
   modelProfiles as geminiModelProfiles,
 } from "@paperclipai/adapter-gemini-local";
 import {
+  execute as antigravityExecute,
+  listAntigravitySkills,
+  syncAntigravitySkills,
+  testEnvironment as antigravityTestEnvironment,
+  sessionCodec as antigravitySessionCodec,
+} from "@paperclipai/adapter-antigravity-local/server";
+import {
+  agentConfigurationDoc as antigravityAgentConfigurationDoc,
+  models as antigravityModels,
+  modelProfiles as antigravityModelProfiles,
+} from "@paperclipai/adapter-antigravity-local";
+import {
   execute as grokExecute,
   listGrokSkills,
   syncGrokSkills,
@@ -362,6 +374,28 @@ const geminiLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: geminiAgentConfigurationDoc,
 };
 
+const antigravityLocalAdapter: ServerAdapterModule = {
+  type: "antigravity_local",
+  execute: antigravityExecute,
+  testEnvironment: antigravityTestEnvironment,
+  listSkills: listAntigravitySkills,
+  syncSkills: syncAntigravitySkills,
+  sessionCodec: antigravitySessionCodec,
+  sessionManagement: getAdapterSessionManagement("antigravity_local") ?? undefined,
+  models: antigravityModels,
+  modelProfiles: antigravityModelProfiles,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: true,
+  getRuntimeCommandSpec: (config) => ({
+    command: readConfiguredCommand(config, "agy"),
+    detectCommand: readConfiguredCommand(config, "agy"),
+    installCommand: null,
+  }),
+  agentConfigurationDoc: antigravityAgentConfigurationDoc,
+};
+
 const grokLocalAdapter: ServerAdapterModule = {
   type: "grok_local",
   execute: grokExecute,
@@ -520,6 +554,7 @@ function registerBuiltInAdapters() {
     cursorCloudAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    antigravityLocalAdapter,
     grokLocalAdapter,
     openclawGatewayAdapter,
     hermesLocalAdapter,

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -386,7 +386,6 @@ const antigravityLocalAdapter: ServerAdapterModule = {
   modelProfiles: antigravityModelProfiles,
   supportsLocalAgentJwt: true,
   supportsInstructionsBundle: true,
-  instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: true,
   getRuntimeCommandSpec: (config) => ({
     command: readConfiguredCommand(config, "agy"),

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -78,6 +78,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Local Gemini agent",
     icon: Gem,
   },
+  antigravity_local: {
+    label: "Antigravity CLI",
+    description: "Local Antigravity CLI agent",
+    icon: Sparkles,
+  },
   grok_local: {
     label: "Grok Build",
     description: "Local Grok Build agent",

--- a/ui/src/adapters/antigravity-local/config-fields.tsx
+++ b/ui/src/adapters/antigravity-local/config-fields.tsx
@@ -1,0 +1,68 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+import { LocalWorkspaceRuntimeFields } from "../local-workspace-runtime-fields";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Prepended to the Antigravity CLI prompt at runtime.";
+
+export function AntigravityLocalConfigFields({
+  mode,
+  isCreate,
+  adapterType,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  models,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? values!.instructionsFilePath ?? ""
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(v) =>
+                isCreate
+                  ? set!({ instructionsFilePath: v })
+                  : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+      <LocalWorkspaceRuntimeFields
+        isCreate={isCreate}
+        values={values}
+        set={set}
+        config={config}
+        mark={mark}
+        eff={eff}
+        mode={mode}
+        adapterType={adapterType}
+        models={models}
+      />
+    </>
+  );
+}

--- a/ui/src/adapters/antigravity-local/index.ts
+++ b/ui/src/adapters/antigravity-local/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseAntigravityStdoutLine } from "@paperclipai/adapter-antigravity-local/ui";
+import { AntigravityLocalConfigFields } from "./config-fields";
+import { buildAntigravityLocalConfig } from "@paperclipai/adapter-antigravity-local/ui";
+
+export const antigravityLocalUIAdapter: UIAdapterModule = {
+  type: "antigravity_local",
+  label: "Antigravity CLI (local)",
+  parseStdoutLine: parseAntigravityStdoutLine,
+  ConfigFields: AntigravityLocalConfigFields,
+  buildAdapterConfig: buildAntigravityLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { codexLocalUIAdapter } from "./codex-local";
 import { cursorCloudUIAdapter } from "./cursor-cloud";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { antigravityLocalUIAdapter } from "./antigravity-local";
 import { grokLocalUIAdapter } from "./grok-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
@@ -57,6 +58,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     cursorCloudUIAdapter,
     geminiLocalUIAdapter,
+    antigravityLocalUIAdapter,
     grokLocalUIAdapter,
     hermesLocalUIAdapter,
     openCodeLocalUIAdapter,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source AI agent orchestration platform that lets companies run autonomous AI workers via adapters
> - Adapters are the integration layer between Paperclip's orchestrator and external CLI-based AI agents (Claude Code, Gemini CLI, Codex, Grok, etc.)
> - Antigravity CLI (`agy`) is an emerging AI coding agent that users want to run under Paperclip supervision
> - No adapter existed for `agy`, so Paperclip could not spawn or manage Antigravity agents
> - This PR adds a first-party `antigravity_local` adapter following the same structure as `gemini-local` and `grok-local`
> - The benefit is that any Paperclip company can now hire and run Antigravity-backed agents alongside their other AI workers

## Linked Issues or Issue Description

No prior issue exists. Inline description following the adapter request template:

**Agent or provider**

Antigravity CLI (`agy`)

**Why this adapter is useful**

Enables Paperclip to orchestrate local Antigravity agents alongside Claude Code, Gemini CLI, and other adapters. Users who already have `agy` installed can hire Antigravity-backed agents in any Paperclip company without additional configuration.

**How the agent is invoked**

`agy --prompt "<prompt>" --dangerously-skip-permissions [--conversation <id>] [--model <model>] [--sandbox]` — spawned as a local subprocess, same pattern as gemini-local and grok-local.

**Are you willing to implement it?**

Yes — this PR is the implementation.

## What Changed

- Added new workspace package `@paperclipai/adapter-antigravity-local` under `packages/adapters/antigravity-local/`
  - `src/server/execute.ts` — core process execution: spawns `agy`, handles session resume via `--conversation <id>`, passes `--dangerously-skip-permissions` and optional `--sandbox`; injects skills into `~/.gemini/skills/`
  - `src/server/parse.ts` — parses plain-text and JSONL output, extracts session IDs from explicit `conversation/session id: <uuid>` patterns only
  - `src/server/skills.ts` — symlinks local Paperclip skills into `~/.gemini/skills/`
  - `src/server/test.ts` — runs `agy help` for environment diagnostic checks
  - `src/ui/parse-stdout.ts` — converts output lines into UI Transcript entries
  - `src/ui/build-config.ts` — maps form inputs to `adapterConfig`
  - `src/ui/config-fields.tsx` — renders agent creation/editing form fields
  - `src/cli/format-event.ts` — formats logs for CLI runner watch mode
- Registered adapter in `server`, `ui`, and `cli` registries
- Added unit tests in `server/src/__tests__/antigravity-local-adapter.test.ts`
- Added `packages/adapters/antigravity-local/package.json` to Dockerfile deps stage
- Added entry to `scripts/release-package-manifest.json` with `publishFromCi: false` (pending npm bootstrap)

## Verification

```bash
npx vitest run antigravity-local-adapter.test.ts
pnpm -w run preflight:workspace-links && pnpm typecheck && pnpm build
node ./scripts/check-docker-deps-stage.mjs
node ./scripts/release-package-map.mjs check
```

All checks pass locally.

Manual verification: create an Antigravity agent in Paperclip UI, assign a task, confirm `agy` is spawned with correct flags, the Paperclip skill is visible inside the session, and session IDs are persisted across heartbeats.

## Risks

- `@paperclipai/adapter-antigravity-local` is a workspace-internal package — no external supply chain risk
- If `agy` is not installed, `test.ts` reports a clear error; no silent failure
- Skills are injected into `~/.gemini/skills/` (shared with Gemini CLI) — intended since `agy` reads from that directory
- Session ID extraction only uses explicit `conversation/session id: <uuid>` patterns — no broad UUID fallback
- No shared code modified — only new files added and registration entries appended

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) via Claude Code CLI — standard tool-use mode, no extended thinking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub for duplicate or related PRs and found none
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge