### PR TITLE
feat(adapter): kill opencode child process when issue reaches done/cancelled (SAG-3390)

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -104,6 +104,7 @@ export interface AdapterExecutionTargetProcessOptions {
    * onLog is suppressed and incremental chunks flow through `onLog` instead.
    */
   runLogTail?: SandboxRunLogTailFactory | null;
+  killSignalPromise?: Promise<void>;
 }
 
 export interface AdapterExecutionTargetShellOptions {
@@ -484,6 +485,7 @@ export async function runAdapterExecutionTargetProcess(
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,
+    killSignalPromise: options.killSignalPromise,
     remoteExecution: adapterExecutionTargetToRemoteSpec(target),
   });
 }

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -504,6 +504,53 @@ describe("runChildProcess", () => {
     expect(await waitForPidExit(descendantPid, 2_000)).toBe(true);
   });
 
+  it.skipIf(process.platform === "win32")("terminates a long-running child when killSignalPromise resolves", async () => {
+    let resolveKillSignal!: () => void;
+    const killSignalPromise = new Promise<void>((resolve) => {
+      resolveKillSignal = resolve;
+    });
+
+    const resultPromise = runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        onLog: async () => {},
+        killSignalPromise,
+      },
+    );
+
+    setTimeout(resolveKillSignal, 100);
+
+    const result = await resultPromise;
+    expect(result.timedOut).toBe(false);
+    expect(result.signal).toBe("SIGTERM");
+  });
+
+  it.skipIf(process.platform === "win32")("does not hang when killSignalPromise is already resolved on entry", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "process.stdout.write('done\\n');"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        killSignalPromise: Promise.resolve(),
+      },
+    );
+
+    // Process either completed naturally or was SIGTERM'd — both are correct;
+    // the important invariant is that it does not hang.
+    expect(result.timedOut).toBe(false);
+  });
+
   it.skipIf(process.platform === "win32")("cleans up a still-running child after terminal output", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2824,6 +2824,7 @@ export async function runChildProcess(
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
     terminalResultCleanup?: TerminalResultCleanupOptions;
+    killSignalPromise?: Promise<void>;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
   },
@@ -2885,6 +2886,7 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        let killSignalFired = false;
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -2927,6 +2929,18 @@ export async function runChildProcess(
             }, Math.max(1, opts.graceSec) * 1000);
           }, graceMs);
         };
+
+        if (opts.killSignalPromise) {
+          void opts.killSignalPromise.then(() => {
+            if (killSignalFired || timedOut || terminalCleanupStarted) return;
+            killSignalFired = true;
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            setTimeout(() => {
+              if (!runningProcesses.has(runId)) return;
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }).catch(() => { /* ignore poll-side errors */ });
+        }
 
         const timeout =
           opts.timeoutSec > 0

--- a/packages/adapters/opencode-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.remote.test.ts
@@ -3,6 +3,16 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+type MockRunChildProcessResult = {
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  stdout: string;
+  stderr: string;
+  pid: number | null;
+  startedAt: string | null;
+};
+
 const {
   runChildProcess,
   ensureCommandResolvable,
@@ -13,7 +23,12 @@ const {
   syncDirectoryToSsh,
   startAdapterExecutionTargetPaperclipBridge,
 } = vi.hoisted(() => ({
-  runChildProcess: vi.fn(async (_runId: string, _command: string, args: string[]) => {
+  runChildProcess: vi.fn(async (
+    _runId: string,
+    _command: string,
+    args: string[],
+    _opts?: { killSignalPromise?: Promise<void> },
+  ): Promise<MockRunChildProcessResult> => {
     if (args.includes("models")) {
       return {
         exitCode: 0,
@@ -100,15 +115,56 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
 
 import { execute } from "./execute.js";
 
+function mockDefaultRunChildProcess() {
+  runChildProcess.mockImplementation(async (
+    _runId: string,
+    _command: string,
+    args: string[],
+    _opts?: { killSignalPromise?: Promise<void> },
+  ): Promise<MockRunChildProcessResult> => {
+    if (args.includes("models")) {
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "opencode/gpt-5-nano\nopenai/gpt-4.1\n",
+        stderr: "",
+        pid: 122,
+        startedAt: new Date().toISOString(),
+      };
+    }
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "step_start", sessionID: "session_123" }),
+        JSON.stringify({ type: "text", sessionID: "session_123", part: { text: "hello" } }),
+        JSON.stringify({
+          type: "step_finish",
+          sessionID: "session_123",
+          part: { cost: 0.001, tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } } },
+        }),
+      ].join("\n"),
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    };
+  });
+}
+
 describe("opencode remote execution", () => {
   const cleanupDirs: string[] = [];
   const originalOpenCodeAllowAllModels = process.env.OPENCODE_ALLOW_ALL_MODELS;
 
   beforeEach(() => {
+    mockDefaultRunChildProcess();
     delete process.env.OPENCODE_ALLOW_ALL_MODELS;
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
     if (originalOpenCodeAllowAllModels === undefined) {
       delete process.env.OPENCODE_ALLOW_ALL_MODELS;
@@ -285,6 +341,9 @@ describe("opencode remote execution", () => {
         config: {
           command: "opencode",
           model: "opencode/gpt-5-nano",
+          env: {
+            PAPERCLIP_API_URL: "http://127.0.0.1:4310",
+          },
         },
         context: {
           paperclipWorkspace: {
@@ -375,5 +434,186 @@ describe("opencode remote execution", () => {
       | undefined;
     expect(call?.[2]).toContain("--session");
     expect(call?.[2]).toContain("session-123");
+  });
+
+  it.each(["done", "cancelled"] as const)(
+    "terminates the OpenCode run when the assigned issue becomes %s",
+    async (status) => {
+      vi.useFakeTimers();
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-poller-"));
+      cleanupDirs.push(rootDir);
+      const workspaceDir = path.join(rootDir, "workspace");
+      await mkdir(workspaceDir, { recursive: true });
+
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status }), { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      runChildProcess.mockImplementation(async (
+        _runId: string,
+        _command: string,
+        args: string[],
+        opts?: { killSignalPromise?: Promise<void> },
+      ): Promise<MockRunChildProcessResult> => {
+        if (args.includes("models")) {
+          return {
+            exitCode: 0,
+            signal: null,
+            timedOut: false,
+            stdout: "opencode/gpt-5-nano\n",
+            stderr: "",
+            pid: 122,
+            startedAt: new Date().toISOString(),
+          };
+        }
+        await expect(opts?.killSignalPromise).resolves.toBeUndefined();
+        return {
+          exitCode: null,
+          signal: "SIGTERM",
+          timedOut: false,
+          stdout: [
+            JSON.stringify({ type: "step_start", sessionID: "session_terminated" }),
+            JSON.stringify({
+              type: "step_finish",
+              sessionID: "session_terminated",
+              part: { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+            }),
+          ].join("\n"),
+          stderr: "",
+          pid: 123,
+          startedAt: new Date().toISOString(),
+        };
+      });
+
+      const logs: string[] = [];
+      const resultPromise = execute({
+        runId: `run-issue-${status}`,
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "OpenCode Builder",
+          adapterType: "opencode_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: "opencode",
+          model: "opencode/gpt-5-nano",
+          env: {
+            PAPERCLIP_API_URL: "http://127.0.0.1:4310",
+          },
+        },
+        context: {
+          taskId: "issue-123",
+          paperclipWorkspace: {
+            cwd: workspaceDir,
+            source: "project_primary",
+          },
+        },
+        executionTransport: {
+          remoteExecution: {
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteWorkspacePath: "/remote/workspace",
+            remoteCwd: "/remote/workspace",
+            privateKey: "PRIVATE KEY",
+            knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+            strictHostKeyChecking: true,
+          },
+        },
+        authToken: "run-token",
+        onLog: async (_stream, chunk) => {
+          logs.push(chunk);
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(runChildProcess.mock.calls.some((entry) => (entry[2] as string[]).includes("run"))).toBe(true);
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await resultPromise;
+
+      const runCall = runChildProcess.mock.calls.find((entry) => (entry[2] as string[]).includes("run")) as
+        | [string, string, string[], { killSignalPromise?: Promise<void> }]
+        | undefined;
+      expect(runCall?.[3].killSignalPromise).toBeInstanceOf(Promise);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:4310/api/issues/issue-123",
+        expect.objectContaining({
+          headers: { authorization: "Bearer run-token" },
+        }),
+      );
+      expect(logs.join("")).toContain(`Issue issue-123 set to ${status}; terminating opencode process`);
+      expect(result.signal).toBe("SIGTERM");
+    },
+  );
+
+  it("cancels the issue-done poller when the OpenCode run exits naturally", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-poller-cleanup-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: "in_progress" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    const result = await execute({
+      runId: "run-natural-exit",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Builder",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "opencode",
+        model: "opencode/gpt-5-nano",
+        env: {
+          PAPERCLIP_API_URL: "http://127.0.0.1:4310",
+        },
+      },
+      context: {
+        taskId: "issue-natural",
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      authToken: "run-token",
+      onLog: async () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    const runCall = runChildProcess.mock.calls.find((entry) => (entry[2] as string[]).includes("run")) as
+      | [string, string, string[], { killSignalPromise?: Promise<void> }]
+      | undefined;
+    expect(runCall?.[3].killSignalPromise).toBeInstanceOf(Promise);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -206,6 +206,59 @@ async function buildOpenCodeSkillsDir(config: Record<string, unknown>): Promise<
   return target;
 }
 
+const ISSUE_TERMINAL_STATUSES = new Set(["done", "cancelled"]);
+const ISSUE_DONE_POLL_INTERVAL_MS = 10_000;
+
+interface IssueDonePoller {
+  signal: Promise<void>;
+  cancel: () => void;
+}
+
+function startIssueDonePoller(
+  apiUrl: string,
+  authToken: string,
+  issueId: string,
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>,
+): IssueDonePoller {
+  let cancelled = false;
+  let timer: NodeJS.Timeout | null = null;
+
+  const signal = new Promise<void>((resolve) => {
+    const poll = () => {
+      if (cancelled) return;
+      void fetch(`${apiUrl}/api/issues/${encodeURIComponent(issueId)}`, {
+        headers: { authorization: `Bearer ${authToken}` },
+        signal: AbortSignal.timeout(8_000),
+      })
+        .then((res) => (res.ok ? (res.json() as Promise<{ status?: unknown }>) : null))
+        .then((data) => {
+          if (cancelled) return;
+          if (data && typeof data.status === "string" && ISSUE_TERMINAL_STATUSES.has(data.status)) {
+            void onLog("stderr", `[paperclip] Issue ${issueId} set to ${data.status}; terminating opencode process to prevent zombie run\n`).catch(() => {});
+            resolve();
+            return;
+          }
+          if (!cancelled) timer = setTimeout(poll, ISSUE_DONE_POLL_INTERVAL_MS);
+        })
+        .catch(() => {
+          if (!cancelled) timer = setTimeout(poll, ISSUE_DONE_POLL_INTERVAL_MS);
+        });
+    };
+    timer = setTimeout(poll, ISSUE_DONE_POLL_INTERVAL_MS);
+  });
+
+  return {
+    signal,
+    cancel: () => {
+      cancelled = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
   const executionTarget = readAdapterExecutionTarget({
@@ -581,6 +634,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       return args;
     };
 
+    let issuePoller: IssueDonePoller | null = null;
+
     const runAttempt = async (resumeSessionId: string | null) => {
       const args = buildArgs(resumeSessionId);
       if (onMeta) {
@@ -607,6 +662,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         onRuntimeProgress: ctx.onRuntimeProgress,
         onLog,
         runLogTail: paperclipBridge?.runLogTail,
+        killSignalPromise: issuePoller?.signal,
       });
       return {
         proc,
@@ -688,6 +744,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       };
     };
 
+    if (wakeTaskId && authToken && env.PAPERCLIP_API_URL) {
+      issuePoller = startIssueDonePoller(env.PAPERCLIP_API_URL, authToken, wakeTaskId, onLog);
+    }
+
     try {
       const initial = await runAttempt(sessionId);
       const initialFailed =
@@ -707,6 +767,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
       return toResult(initial);
     } finally {
+      issuePoller?.cancel();
       await Promise.all([
         paperclipBridge?.stop(),
         restoreRemoteWorkspace?.(),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The opencode-local adapter spawns a child process to run the opencode CLI for each agent heartbeat
> - When an issue transitions to `done` or `cancelled` mid-run (e.g. cancelled by a board user or resolved by another agent), the spawned opencode process has no knowledge of this and continues consuming compute/API tokens until it finishes naturally or times out
> - This leads to orphaned zombie runs that waste resources and may cause duplicate side-effects (writes, tool calls)
> - This PR implements a lightweight poller (`startIssueDonePoller`) that checks `GET /api/issues/:id` every 10 s using the run auth token and, on transition to `done` or `cancelled`, resolves a `killSignalPromise` passed into `runChildProcess`
> - `runChildProcess` was extended with a `killSignalPromise` option: when the promise resolves, SIGTERM is sent to the child, followed by SIGKILL after `graceSec`
> - The benefit is that orphaned processes are terminated within one poll interval (≤ 10 s) with no lingering resource use

## Linked Issues or Issue Description

Refs: #7709 (SAG-3385 — this work was incorrectly bundled into that PR and is split out here per CTO review comment `c82b0ead`)

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: Added `killSignalPromise?: Promise<void>` option to `runChildProcess`. When the promise resolves, SIGTERM is sent to the child process; after `graceSec` seconds, SIGKILL is sent if the process is still running. A `killSignalFired` guard prevents double-signalling with the existing timeout path.
- `packages/adapter-utils/src/execution-target.ts`: Thread `killSignalPromise` through `AdapterExecutionTargetProcessOptions` → `runAdapterExecutionTargetProcess` → `runChildProcess`.
- `packages/adapters/opencode-local/src/server/execute.ts`: Added `startIssueDonePoller` which polls `GET /api/issues/:id` every 10 s. On `done`/`cancelled` status, resolves a `Promise<void>` (the kill signal). The poller is started before `runAttempt` when `wakeTaskId` and `authToken` are both present, and cancelled in the `finally` block to prevent leaks on natural exit.
- `packages/adapter-utils/src/server-utils.test.ts`: Two new tests covering (a) child killed when `killSignalPromise` resolves mid-run, and (b) no hang when the promise is already resolved on entry.

## Verification

```bash
# Run the targeted tests covering the killSignalPromise path
npx vitest run packages/adapter-utils/src/server-utils.test.ts
# → All 41 tests pass, including:
# ✓ terminates a long-running child when killSignalPromise resolves
# ✓ does not hang when killSignalPromise is already resolved on entry
```

Manual verification path:
1. Start a heartbeat against a long-running opencode session
2. In parallel, PATCH the issue to `done` via the API
3. Within ≤ 10 s, the opencode process receives SIGTERM and exits cleanly
4. The `finally` block cancels the poller — no timer leak on natural exit

## Risks

- **Poll latency**: up to 10 s between issue status change and process kill. This is well within the 60 s AC window cited in the original SAG-3304 spec. Reducing the interval would increase API load.
- **Auth token expiry**: if the run JWT expires before the issue reaches done, the poller's fetch returns non-ok and silently reschedules. The child process continues to run. This is the safe-fail direction (no spurious kills).
- **Low risk overall**: the kill path is only triggered by an explicit status transition; normal exits always cancel the poller first via the `finally` block.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`) — Anthropic, 200k context window, tool use, code execution. Assisted with code review, commit analysis, PR splitting strategy, and PR text generation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge