### PR TITLE
Keep Codex OSS agents on local model for cheap profile

### DIFF
--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -75,6 +75,78 @@ describe("heartbeat model profile application", () => {
     });
   });
 
+  it("keeps the primary local OSS model when the adapter default cheap profile is hosted Codex", async () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: await listAdapterModelProfiles("codex_local"),
+      agentRuntimeConfig: {},
+      issueModelProfile: "cheap",
+      contextSnapshot: {},
+    });
+
+    const merged = mergeModelProfileAdapterConfig({
+      baseConfig: {
+        model: "gpt-oss:20b",
+        modelReasoningEffort: "high",
+        extraArgs: ["--oss", "--local-provider=ollama"],
+      },
+      modelProfile,
+      issueAdapterConfig: null,
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      applied: "cheap",
+      configSource: "adapter_default",
+      adapterConfig: {
+        model: "gpt-5.3-codex-spark",
+      },
+    });
+    expect(merged).toEqual({
+      model: "gpt-oss:20b",
+      modelReasoningEffort: "high",
+      extraArgs: ["--oss", "--local-provider=ollama"],
+    });
+  });
+
+  it("allows an explicit runtime cheap profile to choose a local OSS model", async () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: await listAdapterModelProfiles("codex_local"),
+      agentRuntimeConfig: {
+        modelProfiles: {
+          cheap: {
+            adapterConfig: {
+              model: "qwen2.5-coder:1.5b",
+              modelReasoningEffort: "medium",
+            },
+          },
+        },
+      },
+      issueModelProfile: "cheap",
+      contextSnapshot: {},
+    });
+
+    const merged = mergeModelProfileAdapterConfig({
+      baseConfig: {
+        model: "gpt-oss:20b",
+        modelReasoningEffort: "high",
+        extraArgs: ["--oss", "--local-provider=ollama"],
+      },
+      modelProfile,
+      issueAdapterConfig: null,
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      applied: "cheap",
+      configSource: "agent_runtime",
+    });
+    expect(merged).toEqual({
+      model: "qwen2.5-coder:1.5b",
+      modelReasoningEffort: "medium",
+      extraArgs: ["--oss", "--local-provider=ollama"],
+    });
+  });
+
   it("lets agent runtime profile config customize adapter defaults", () => {
     const modelProfile = resolveModelProfileApplication({
       adapterModelProfiles: [cheapProfile],

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1546,6 +1546,53 @@ export function resolveModelProfileApplication(input: {
   };
 }
 
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function configUsesCodexOssLocalProvider(config: Record<string, unknown>): boolean {
+  const extraArgs = readStringArray(config.extraArgs);
+  const usesOss = extraArgs.includes("--oss");
+  const usesLocalProvider = extraArgs.some((arg) =>
+    arg === "--local-provider=ollama" || arg.startsWith("--local-provider="),
+  );
+  return usesOss && usesLocalProvider;
+}
+
+function isHostedCodexModelId(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return (
+    normalized.startsWith("gpt-") ||
+    normalized === "o3" ||
+    normalized === "o4-mini" ||
+    normalized === "o3-mini" ||
+    normalized === "codex-mini-latest"
+  );
+}
+
+function modelProfileAdapterConfigForBase(input: {
+  baseConfig: Record<string, unknown>;
+  modelProfile: ModelProfileApplication;
+}): Record<string, unknown> {
+  const adapterConfig = input.modelProfile.adapterConfig ?? {};
+  const profileModel = readNonEmptyString(adapterConfig.model);
+
+  if (
+    input.modelProfile.configSource === "adapter_default" &&
+    profileModel &&
+    isHostedCodexModelId(profileModel) &&
+    readNonEmptyString(input.baseConfig.model) &&
+    configUsesCodexOssLocalProvider(input.baseConfig)
+  ) {
+    const { model: _model, ...withoutModel } = adapterConfig;
+    return withoutModel;
+  }
+
+  return adapterConfig;
+}
+
 export function mergeModelProfileAdapterConfig(input: {
   baseConfig: Record<string, unknown>;
   modelProfile: ModelProfileApplication;
@@ -1553,7 +1600,10 @@ export function mergeModelProfileAdapterConfig(input: {
 }): Record<string, unknown> {
   return {
     ...input.baseConfig,
-    ...(input.modelProfile.adapterConfig ?? {}),
+    ...modelProfileAdapterConfigForBase({
+      baseConfig: input.baseConfig,
+      modelProfile: input.modelProfile,
+    }),
     ...(input.issueAdapterConfig ?? {}),
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents can run through several adapters, including `codex_local` for local Codex execution.
> - `codex_local` also supports OSS/local execution through `--oss --local-provider=ollama` with a local model such as `gpt-oss:20b`.
> - Heartbeat recovery and status-only runs use a cheap model profile so they can be lighter than normal task execution.
> - The adapter default cheap profile currently points at a hosted Codex model, which is correct for hosted Codex but wrong for explicit local OSS agents.
> - This pull request keeps explicit local OSS agents on their configured local model when the cheap profile only came from adapter defaults.
> - The benefit is that local deployments can keep recovery/status runs fully local while preserving explicit runtime cheap-profile overrides.

## Linked Issues or Issue Description

No existing issue found after searching Paperclip issues and PRs for `codex_local cheap profile OSS`. Related search result: this PR only.

### What happened?

A `codex_local` agent configured for local OSS execution with `--oss --local-provider=ollama` and base model `gpt-oss:20b` could still inherit the adapter default cheap profile model `gpt-5.3-codex-spark` for heartbeat recovery/status-only runs.

### Expected behavior

Explicit OSS/local agents should keep their configured local model unless runtime config explicitly overrides the cheap profile.

### Steps to reproduce

1. Configure a `codex_local` agent with `adapterConfig.model = "gpt-oss:20b"`.
2. Set `adapterConfig.extraArgs = ["--oss", "--local-provider=ollama"]`.
3. Merge the `cheap` model profile from adapter defaults into that base config for a recovery/status-only run.
4. Observe that the default hosted Codex cheap model can replace the explicit local OSS model.

### Paperclip version or commit

Current `master` before this PR.

### Deployment mode

Local dev / self-hosted Paperclip using `codex_local` with Ollama.

## What Changed

- Added detection for `codex_local` OSS/local adapter configs that already specify a local base model.
- Strip only hosted-Codex default cheap-profile model overrides in that OSS/local case.
- Preserve explicit runtime cheap-profile overrides, including alternate local cheap models.
- Added regression tests for the `gpt-oss:20b` local OSS configuration and explicit runtime override behavior.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-model-profile.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check HEAD~1..HEAD`

## Risks

Low risk. The behavior only changes when all of these are true: the cheap profile came from adapter defaults, the default model is a hosted Codex model, the base config already has a model, and the base config explicitly uses OSS/local provider flags. Explicit runtime cheap-profile overrides are preserved.

Rollback: revert this commit. Runtime config overrides remain the existing escape hatch.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 class model in Codex desktop, with shell/GitHub CLI tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
