### PR TITLE
feat(opencode-local): issue-context cheat-sheet in local wake prompt (SAG-3397)

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -10,8 +10,10 @@ import {
   buildRuntimeMountedSkillSnapshot,
   buildInvocationEnvForLogs,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  joinPromptSections,
   materializePaperclipSkillCopy,
   refreshPaperclipWorkspaceEnvForExecution,
+  renderLocalIssueContextCheatSheet,
   renderPaperclipWakePrompt,
   runningProcesses,
   runChildProcess,
@@ -1159,5 +1161,39 @@ describe("appendWithByteCap", () => {
     expect(output).not.toContain("\uFFFD");
     expect(Buffer.from(output, "utf8").toString("utf8")).toBe(output);
     expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("renderLocalIssueContextCheatSheet", () => {
+  it("renders cheat-sheet containing the actual issue id for a local adapter wake with issue id", () => {
+    const issueId = "abc-123-def";
+    const cheatSheet = renderLocalIssueContextCheatSheet(issueId);
+
+    expect(cheatSheet).toContain(issueId);
+    expect(cheatSheet).toContain("heartbeat-context");
+    expect(cheatSheet).toContain("$PAPERCLIP_API_KEY");
+    expect(cheatSheet).toContain("$PAPERCLIP_API_URL");
+  });
+
+  it("returns empty string (absent) when issue id is null or absent (non-local adapter gate)", () => {
+    expect(renderLocalIssueContextCheatSheet(null)).toBe("");
+    expect(renderLocalIssueContextCheatSheet(undefined)).toBe("");
+    expect(renderLocalIssueContextCheatSheet("")).toBe("");
+    expect(renderLocalIssueContextCheatSheet("   ")).toBe("");
+  });
+
+  it("section appears before the main heartbeat template in the joined prompt for a local wake", () => {
+    const issueId = "sag-3397-test-id";
+    const cheatSheet = renderLocalIssueContextCheatSheet(issueId);
+    const wakeSection = "## Paperclip Wake Payload\n- reason: issue_assigned";
+    const mainTemplate = DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE;
+
+    const prompt = joinPromptSections([cheatSheet, wakeSection, mainTemplate]);
+
+    const cheatPos = prompt.indexOf(issueId);
+    const mainPos = prompt.indexOf("Execution contract:");
+    expect(cheatPos).toBeGreaterThan(-1);
+    expect(mainPos).toBeGreaterThan(-1);
+    expect(cheatPos).toBeLessThan(mainPos);
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -889,6 +889,23 @@ export function renderPaperclipWakePrompt(
   return lines.join("\n").trim();
 }
 
+export function renderLocalIssueContextCheatSheet(issueId: string | null | undefined): string {
+  const id = typeof issueId === "string" && issueId.trim() ? issueId.trim() : null;
+  if (!id) return "";
+  return [
+    `## Your issue is ${id}. Read it with tools you ALREADY have (bash + curl + the \`paperclip\` skill). Do NOT grep the repo for issue text.`,
+    `# Read the thread:`,
+    `curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/issues/${id}/heartbeat-context"`,
+    `curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$PAPERCLIP_API_URL/api/issues/${id}/comments?order=asc"`,
+    `# Post a status comment:`,
+    `curl -sS -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -H "Content-Type: application/json" \\`,
+    `  "$PAPERCLIP_API_URL/api/issues/${id}/comments" -d '{"body":"<markdown>"}'`,
+    `# Set status (todo|in_progress|in_review|blocked|done):`,
+    `curl -sS -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -H "Content-Type: application/json" \\`,
+    `  "$PAPERCLIP_API_URL/api/issues/${id}" -d '{"status":"in_progress","comment":"<markdown>"}'`,
+  ].join("\n");
+}
+
 export function redactEnvForLogs(env: Record<string, string>): Record<string, string> {
   const redacted: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -35,6 +35,7 @@ import {
   ensurePaperclipSkillSymlink,
   ensurePathInEnv,
   refreshPaperclipWorkspaceEnvForExecution,
+  renderLocalIssueContextCheatSheet,
   renderTemplate,
   renderPaperclipWakePrompt,
   stringifyPaperclipWakePayload,
@@ -532,9 +533,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
     const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
     const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+    const issueContextCheatSheet = renderLocalIssueContextCheatSheet(wakeTaskId);
     const prompt = joinPromptSections([
       instructionsPrefix,
       renderedBootstrapPrompt,
+      issueContextCheatSheet,
       wakePrompt,
       sessionHandoffNote,
       renderedPrompt,
@@ -543,6 +546,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       promptChars: prompt.length,
       instructionsChars: instructionsPrefix.length,
       bootstrapPromptChars: renderedBootstrapPrompt.length,
+      issueContextCheatSheetChars: issueContextCheatSheet.length,
       wakePromptChars: wakePrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,


### PR DESCRIPTION
Fixes #7720

## Thinking Path

> - Paperclip orchestrates AI agents; local agents (opencode_local / gemma4) receive a wake prompt assembled by `execute.ts` in the opencode-local adapter
> - Gemma4 agents were blind-grepping the repo for their own issue text instead of using the curl/API commands already available to them
> - The root cause is discoverability: weak local models do not know the exact API commands to read their issue thread without being shown them explicitly
> - Skills and env vars are confirmed present (CTO audit on SAG-3394) — the gap is that the commands are not surfaced in the wake prompt
> - This PR adds `renderLocalIssueContextCheatSheet(issueId)` to `adapter-utils/server-utils` and injects the rendered cheat-sheet into the `opencode_local` wake prompt before the wake-payload section
> - The benefit is that every local agent wake hands the model the exact curl commands to read its thread, post a comment, and set status — no grepping required

## Linked Issues or Issue Description

No public GitHub issue is linked. Inline issue description from PR title: `feat(opencode-local): issue-context cheat-sheet in local wake prompt (SAG-3397)`.

## What Changed

- **`packages/adapter-utils/src/server-utils.ts`**: Export `renderLocalIssueContextCheatSheet(issueId: string | null | undefined): string` — returns a markdown cheat-sheet with curl commands when an issue id is present; empty string otherwise (gate for non-local callers)
- **`packages/adapters/opencode-local/src/server/execute.ts`**: Import and call `renderLocalIssueContextCheatSheet(wakeTaskId)`; inject the result as a new section in `joinPromptSections` before the wake-payload section; add `issueContextCheatSheetChars` to `promptMetrics`
- **`packages/adapter-utils/src/server-utils.test.ts`**: 3 new unit tests — renders with actual issue id, returns empty for null/undefined/blank, section appears before main heartbeat template in joined prompt

## Verification

```bash
./node_modules/.bin/vitest run packages/adapter-utils/src/server-utils.test.ts
# 42 tests pass (39 pre-existing + 3 new)

pnpm --filter @paperclipai/adapter-utils typecheck
pnpm --filter @paperclipai/adapter-opencode-local typecheck
# Both clean
```

Manual: trigger a local gemma4 agent wake and confirm the injected prompt contains the curl cheat-sheet section before the Paperclip Wake Payload section.

## Risks

- Prompt length increases by ~400 chars per wake when an issue id is present; negligible for local models with large context windows
- Empty string returned when no issue id — no change to cloud/non-local adapter prompts
- No new tool, MCP server, or package added (prompt/section text only)

## Model Used

- Provider: Anthropic
- Model ID: claude-sonnet-4-6
- Context window: 200K tokens
- Capabilities: tool use, code execution, multi-file editing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
- [x] I searched the GitHub PR list for similar or duplicate PRs before opening this one