### PR TITLE
fix: prefer implementation owners for liveness recovery

### DIFF
--- a/server/src/__tests__/issue-liveness.test.ts
+++ b/server/src/__tests__/issue-liveness.test.ts
@@ -128,6 +128,65 @@ describe("issue graph liveness classifier", () => {
     ]);
   });
 
+  it("prefers implementation-capable recovery owners over read-only handoff owners for implementation blockers", () => {
+    const pausedImplementerId = "paused-implementer";
+    const readOnlyHandoffId = "hilda";
+    const implementationOwnerId = "cto-implementation-owner";
+
+    const findings = classifyIssueGraphLiveness({
+      issues: [
+        issue(),
+        issue({
+          id: blockerId,
+          identifier: "PAP-1704",
+          title: "Fix liveness recovery selector",
+          description: "Implement the platform change and add a regression test.",
+          status: "todo",
+          assigneeAgentId: pausedImplementerId,
+          createdByAgentId: null,
+        }),
+      ],
+      relations: blocks,
+      agents: [
+        agent(),
+        agent({
+          id: pausedImplementerId,
+          name: "Paused Implementer",
+          role: "engineer",
+          status: "paused",
+          reportsTo: readOnlyHandoffId,
+        }),
+        agent({
+          id: readOnlyHandoffId,
+          name: "Hilda",
+          role: "researcher",
+          title: "Documentation Indexer",
+          capabilities: "Read-only source indexing and handoff notes.",
+          status: "idle",
+          reportsTo: null,
+        }),
+        agent({
+          id: implementationOwnerId,
+          name: "CTO",
+          role: "cto",
+          title: "Engineering owner",
+          capabilities: "Can edit source, run tests, and release platform fixes.",
+          status: "idle",
+          reportsTo: null,
+        }),
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      state: "blocked_by_uninvokable_assignee",
+      recommendedOwnerAgentId: implementationOwnerId,
+    });
+    expect(findings[0]?.recommendedOwnerCandidateAgentIds).toEqual([implementationOwnerId]);
+    expect(findings[0]?.recommendedAction).toContain("implementation-capable active owner");
+    expect(findings[0]?.recommendedAction).toContain("diagnosis/handoff only");
+  });
+
   it("does not flag a live blocked chain with an active assignee and wake path", () => {
     const findings = classifyIssueGraphLiveness({
       issues: [

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -16,6 +16,7 @@ export interface IssueLivenessIssueInput {
   companyId: string;
   identifier: string | null;
   title: string;
+  description?: string | null;
   status: string;
   projectId?: string | null;
   goalId?: string | null;
@@ -42,6 +43,7 @@ export interface IssueLivenessAgentInput {
   name: string;
   role: string;
   title?: string | null;
+  capabilities?: string | null;
   status: string;
   reportsTo?: string | null;
 }
@@ -125,6 +127,83 @@ function isInvokableAgent(
   agentsById: Map<string, IssueLivenessAgentInput>,
 ) {
   return Boolean(agent && isAgentInvokable({ agent, agents: [...agentsById.values()] }));
+}
+
+const IMPLEMENTATION_AGENT_ROLE_PATTERNS = [
+  /\bcto\b/i,
+  /\bengineer\b/i,
+  /\bdeveloper\b/i,
+  /\bdevops\b/i,
+  /\bcoder\b/i,
+];
+
+const READ_ONLY_AGENT_PATTERNS = [
+  /\bresearch(er)?\b/i,
+  /\bdocumentation\b/i,
+  /\bindexer\b/i,
+  /\bread[-\s]?only\b/i,
+];
+
+const IMPLEMENTATION_ISSUE_PATTERNS = [
+  /\bimplement(ation)?\b/i,
+  /\bfix\b/i,
+  /\bbuild\b/i,
+  /\bcode\b/i,
+  /\bfrontend\b/i,
+  /\bbackend\b/i,
+  /\bapi\b/i,
+  /\bcomponent\b/i,
+  /\bmigration\b/i,
+  /\bschema\b/i,
+  /\bdeploy(ment)?\b/i,
+];
+
+function roleFitText(agent: IssueLivenessAgentInput) {
+  return [agent.role, agent.title, agent.capabilities]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ");
+}
+
+function isReadOnlyAgent(agent: IssueLivenessAgentInput) {
+  const text = roleFitText(agent);
+  return READ_ONLY_AGENT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function isImplementationCapableAgent(
+  agent: IssueLivenessAgentInput | null | undefined,
+  agentsById: Map<string, IssueLivenessAgentInput>,
+) {
+  if (!agent || !isInvokableAgent(agent, agentsById) || isReadOnlyAgent(agent)) return false;
+  const text = roleFitText(agent);
+  return IMPLEMENTATION_AGENT_ROLE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function isImplementationIssue(issue: IssueLivenessIssueInput) {
+  const text = [issue.title, issue.description]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join("\n");
+  return IMPLEMENTATION_ISSUE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function ownerCandidatesForIssueWork(
+  issue: IssueLivenessIssueInput,
+  candidates: IssueLivenessOwnerCandidate[],
+  agentsById: Map<string, IssueLivenessAgentInput>,
+) {
+  if (!isImplementationIssue(issue)) return candidates;
+
+  const executionCandidates = candidates.filter((candidate) =>
+    isImplementationCapableAgent(agentsById.get(candidate.agentId), agentsById)
+  );
+  return executionCandidates.length > 0 ? executionCandidates : candidates;
+}
+
+function recoveryActionForIssueWork(issue: IssueLivenessIssueInput) {
+  if (!isImplementationIssue(issue)) {
+    return `Review ${issueLabel(issue)} and assign it to an active owner or replace the blocker with an actionable issue.`;
+  }
+
+  return `Review ${issueLabel(issue)} and assign executable implementation work to an implementation-capable active owner. If no implementation-capable agent is active, a read-only owner may produce diagnosis/handoff only; leave the executable issue blocked on a named engineer/CTO action rather than treating the read-only assignment as recovered.`;
 }
 
 function hasActiveExecutionPath(
@@ -307,7 +386,7 @@ function ownerCandidatesForRecoveryIssue(
     );
   }
 
-  return candidates;
+  return ownerCandidatesForIssueWork(issue, candidates, agentsById);
 }
 
 function incidentKey(input: {
@@ -551,8 +630,7 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
         recoveryIssue: blocker,
         recommendedOwnerCandidateAgentIds: ownerCandidates.map((candidate) => candidate.agentId),
         recommendedOwnerCandidates: ownerCandidates,
-        recommendedAction:
-          `Review ${issueLabel(blocker)} and assign it to an active owner or replace the blocker with an actionable issue.`,
+        recommendedAction: recoveryActionForIssueWork(blocker),
         blockerIssueId: blocker.id,
       });
     }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2762,6 +2762,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         companyId: issues.companyId,
         identifier: issues.identifier,
         title: issues.title,
+        description: issues.description,
         status: issues.status,
         projectId: issues.projectId,
         goalId: issues.goalId,
@@ -2811,6 +2812,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           name: agents.name,
           role: agents.role,
           title: agents.title,
+          capabilities: agents.capabilities,
           status: agents.status,
           reportsTo: agents.reportsTo,
         })


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Its issue-graph liveness recovery detects blocked work whose blocker has no executable path.
> - The recovery classifier already recommends owner candidates, and the recovery service later uses the first budget-available candidate.
> - Implementation blockers need a different owner-fit bar than diagnosis or handoff work.
> - A read-only documentation/indexing agent can inspect and summarize, but cannot execute source changes or release fixes.
> - This pull request narrows candidate ordering for implementation-shaped blockers so implementation-capable active agents are preferred when available.
> - The benefit is recovery can still preserve read-only fallback visibility without silently treating read-only assignment as an executable implementation path.

## Linked Issues or Issue Description

No public GitHub issue found for this exact role-fit bug.

Bug description:
- What happened: issue-graph liveness recovery could clear a `blocked_by_uninvokable_assignee` incident by recommending an active read-only/documentation agent first for an implementation blocker.
- Expected behavior: implementation-shaped blockers should prefer active implementation-capable owners; if none are available, read-only owners should be treated as diagnosis/handoff only.
- Steps to reproduce: classify a blocked issue whose implementation blocker is assigned to a paused engineer whose reporting chain leads to an active read-only documentation/indexing agent while an active CTO/engineer candidate also exists.
- Version/commit: observed against local package `@paperclipai/server@2026.529.0`; fixed from current `master` at `823c2b11`.
- Deployment mode: local trusted Paperclip instance.

Related PR search: I found adjacent liveness/recovery PRs, including #6155 and #7635, but no duplicate for implementation role-fit vs read-only handoff fallback.

## What Changed

- Added implementation-work detection from issue title/description in the issue-graph liveness classifier.
- Added role-fit filtering that excludes read-only/documentation/indexing agents from implementation-capable recovery owners while preserving normal candidate ordering for non-implementation work.
- Updated recovery service input collection to include issue descriptions and agent capability summaries.
- Added a regression test proving an implementation blocker prefers a CTO/engineering owner over a Hilda-style read-only handoff owner and emits handoff-only fallback guidance.

## Verification

- `corepack pnpm exec vitest run server/src/__tests__/issue-liveness.test.ts server/src/__tests__/recovery-classifiers.test.ts` — 20 tests passed.
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && corepack pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.

Note: `corepack pnpm --filter @paperclipai/server typecheck` could not run directly in this shell because that package script shells out to bare `pnpm`, which is not installed as a shim. I ran the same underlying steps through Corepack explicitly.

## Risks

- Low-to-medium behavior risk: implementation detection is heuristic-based, so some issue titles/descriptions may be classified as implementation work because they contain terms such as `fix`, `api`, or `schema`.
- Mitigation: the filter only changes ordering when at least one implementation-capable active candidate exists; otherwise the existing fallback candidates remain available with explicit handoff-only action text.
- Non-implementation liveness recovery ordering is unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, Codex-local runtime, tool-enabled coding workflow with shell, git, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
