### PR TITLE
fix(heartbeat): atomically advance checkoutRunId on process-loss retry

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1000,7 +1000,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
-    expect(issue?.checkoutRunId).toBe(runId);
+    expect(issue?.checkoutRunId).toBe(retryRun?.id ?? null);
   });
 
   it("releases active environment leases when an orphaned run is reaped", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5575,6 +5575,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await tx
           .update(issues)
           .set({
+            checkoutRunId: retryRun.id,
             executionRunId: retryRun.id,
             executionAgentNameKey: normalizeAgentNameKey(agent.name),
             executionLockedAt: now,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open-source orchestration platform for AI agents, where heartbeat runs track agent execution on assigned issues.
> - The heartbeat service's `reapOrphanedRuns` handles agent processes that died unexpectedly, marking their runs failed and queuing a retry.
> - When a retry run is queued, `enqueueProcessLossRetry` atomically updates `executionRunId` to the new retry run in a DB transaction, but left `checkoutRunId` pointing at the now-terminal original run.
> - `startNextQueuedRunForAgent` then immediately claims and fires `void executeRun(retryRunId)` as a fire-and-forget; inside `executeRun`, `issuesSvc.checkout` calls `adoptStaleCheckoutRun` to advance `checkoutRunId` asynchronously.
> - This creates a race window between `reapOrphanedRuns` returning and the test reading `checkoutRunId`: sometimes `adoptStaleCheckoutRun` wins and the test sees `retryRunId`, sometimes it loses and sees `originalRunId`.
> - This pull request closes the race by adding `checkoutRunId: retryRun.id` to the same `UPDATE issues` transaction in `enqueueProcessLossRetry`, transferring checkout ownership atomically before `startNextQueuedRunForAgent` fires.
> - The benefit is that `checkoutRunId` is deterministic by the time `reapOrphanedRuns` returns; the subsequent `issuesSvc.checkout` call in `executeRun` hits the idempotent same-run-lock path and exits cleanly.

## Linked Issues or Issue Description

No public GitHub issue; the underlying bug is described inline below.

### What happened?

`server/src/__tests__/heartbeat-process-recovery.test.ts` intermittently observes `checkoutRunId` as the retry run ID instead of the original run ID after orphaned-process recovery queues exactly one retry.

### Expected behavior

After `reapOrphanedRuns()` resolves, the issue checkout owner should be deterministic and match the retry run created for process-loss recovery.

### Steps to reproduce

1. Run `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "queues exactly one retry when the recorded local pid is dead" --no-file-parallelism --maxWorkers=1` repeatedly.
2. Observe that the focused test can fail nondeterministically when the retry execution adopts the stale checkout before the test reads the issue row.
3. CI also observed the mismatch in serialized server shard 1/4.

### Paperclip version or commit

Pull request head commit `a4150a3498cdebb1e354676b07a998566a5e60f0`, based on `paperclipai/paperclip` `master`.

### Deployment mode

Local dev / CI test run.

## What Changed

- `server/src/services/heartbeat.ts` - in `enqueueProcessLossRetry`'s DB transaction, add `checkoutRunId: retryRun.id` to the `UPDATE issues` SET clause alongside the existing `executionRunId: retryRun.id`. The WHERE guard (`executionRunId = originalRunId`) keeps this conditional on owning the execution lock.
- `server/src/__tests__/heartbeat-process-recovery.test.ts` - update the single assertion from `.toBe(runId)` (stale original run) to `.toBe(retryRun?.id ?? null)` to match the now-deterministic value.

## Verification

```bash
# Focused test passed locally once, then passed 3/3 repeated:
pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts \
  -t "queues exactly one retry when the recorded local pid is dead" \
  --no-file-parallelism --maxWorkers=1
```

PR CI is green for build, typecheck/release registry, general server tests, all serialized server shards including `Verify serialized server suites (1/4)`, e2e, security checks, and Greptile.

## Risks

- **Low.** The change is strictly additive to a SET clause that already ran inside the same transaction. The WHERE guard (`executionRunId = originalRunId`) is unchanged, so the update only fires when the reap legitimately owned the issue's execution lock. The `claimQueuedRun` and `executeRun` checkout path both become no-ops for this field through the idempotent same-run-lock path.
- No migration needed: `checkoutRunId` already accepts any run ID; this just sets it one step earlier.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200K
- Capabilities: tool use, code execution, multi-step reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
