### PR TITLE
fix(plugins): use unlinkSync for stale plugin-sdk symlink (Node 25 EISDIR)

### DIFF
--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, lstatSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, lstatSync, unlinkSync, symlinkSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,7 +20,9 @@ mkdirSync(scopeDir, { recursive: true });
 try {
   const stat = lstatSync(linkTarget);
   if (stat.isSymbolicLink()) {
-    rmSync(linkTarget, { force: true });
+    // unlinkSync removes the symlink itself; rmSync follows it into the SDK
+    // directory and throws ERR_FS_EISDIR on Node 25+.
+    unlinkSync(linkTarget);
   } else {
     console.log("  i Keeping existing installed @paperclipai/plugin-sdk directory in place");
     process.exit(0);


### PR DESCRIPTION
## Problem

`pnpm install` fails on Node 25+ during the plugin `postinstall` (`scripts/link-plugin-dev-sdk.mjs`) for every package that links the local `@paperclipai/plugin-sdk`:

```
Error: EEXIST: file already exists, symlink '../../../sdk' -> '.../node_modules/@paperclipai/plugin-sdk'
    at symlinkSync (node:fs:1855:11)
    at file:///.../scripts/link-plugin-dev-sdk.mjs:33:1
```

## Root cause

Node 25 changed `rmSync` behavior: on a symlink that points to a directory it now follows the link and throws `ERR_FS_EISDIR` ("Path is a directory") instead of unlinking the symlink. In this script the `rmSync(linkTarget, { force: true })` call sits inside a `try` whose `catch` is meant for "target does not exist yet". The EISDIR throw is swallowed there, so execution falls through to `symlinkSync(...)`, which then fails with `EEXIST` because the stale symlink is still present.

Reproduces deterministically on Node 25.2.1; works on Node 20-24.

## Fix

Use `unlinkSync(linkTarget)` to remove the symlink. `unlinkSync` removes the link itself without following it, which is the correct call for a symlink and restores idempotency across all supported Node versions. One-line change plus the import.

## Test

`pnpm install` now completes cleanly on Node 25.2.1; re-running it stays green (idempotent).