### PR TITLE
fix(auth): trust OAuth proxy email header

### DIFF
--- a/doc/DEPLOYMENT-MODES.md
+++ b/doc/DEPLOYMENT-MODES.md
@@ -61,6 +61,24 @@ Paperclip now treats **bind** as a separate concern from auth:
 - stricter deployment checks and failures in doctor
 - recommended bind is `loopback` behind a reverse proxy; direct `lan/custom` is advanced
 
+### Trusted reverse-proxy email bridge
+
+Hosted deployments that put Paperclip behind a separate trusted OAuth proxy can set
+`PAPERCLIP_TRUST_PROXY_AUTH_EMAIL` to a comma-separated allowlist of human email
+addresses. When this variable is non-empty, authenticated mode accepts the proxy
+identity headers currently emitted by common OAuth proxy stacks
+(`X-Auth-Request-Email` and compatibility aliases such as `X-Forwarded-Email`)
+only when the normalized email is in that allowlist, then maps the request to a
+session-compatible board actor.
+
+This is a source-level compatibility bridge for private trusted-ingress
+deployments. It is not a substitute for the public hardening controls: every
+browser-facing proxy path must strip user-supplied identity headers before
+injecting its own, and future hardening should narrow this to one canonical
+header plus trusted-ingress validation/shared secret and multi-value rejection.
+Keep this variable unset unless Paperclip is reachable only through such a
+trusted proxy.
+
 ## 4. Onboarding UX Contract
 
 Default onboarding remains interactive and flagless:

--- a/server/src/__tests__/proxy-auth-middleware.test.ts
+++ b/server/src/__tests__/proxy-auth-middleware.test.ts
@@ -1,0 +1,117 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authUsers, companyMemberships } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+
+function createDb(opts: {
+  existingUser?: { id: string; name: string; email: string } | null;
+  memberships?: Array<{ companyId: string; membershipRole: string; status: string }>;
+} = {}) {
+  const insertedUsers: unknown[] = [];
+  const existingUser = opts.existingUser ?? null;
+  const memberships = opts.memberships ?? [];
+
+  return {
+    insertedUsers,
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          if (table === authUsers) return Promise.resolve(existingUser ? [existingUser] : []);
+          if (table === companyMemberships) return Promise.resolve(memberships);
+          return Promise.resolve([]);
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (value: Record<string, unknown>) => {
+        if (table === authUsers) insertedUsers.push(value);
+        return {
+          onConflictDoUpdate: () => ({
+            returning: () => Promise.resolve([{ id: value.id, name: value.name, email: value.email }]),
+          }),
+        };
+      },
+    }),
+  } as any;
+}
+
+function createApp(db: any, resolveSession = vi.fn(async () => null)) {
+  const app = express();
+  app.use(actorMiddleware(db, { deploymentMode: "authenticated", resolveSession }));
+  app.get("/whoami", (req, res) => res.json(req.actor));
+  return app;
+}
+
+describe("trusted proxy auth middleware", () => {
+  afterEach(() => {
+    delete process.env.PAPERCLIP_TRUST_PROXY_AUTH_EMAIL;
+  });
+
+  it("accepts an allowlisted oauth2-proxy email header as a board admin actor", async () => {
+    process.env.PAPERCLIP_TRUST_PROXY_AUTH_EMAIL = "lennie@trustedhealth.com";
+    const db = createDb({
+      existingUser: {
+        id: "user-1",
+        name: "Lennie",
+        email: "lennie@trustedhealth.com",
+      },
+      memberships: [{ companyId: "company-1", membershipRole: "owner", status: "active" }],
+    });
+    const resolveSession = vi.fn(async () => null);
+
+    const res = await request(createApp(db, resolveSession))
+      .get("/whoami")
+      .set("X-Auth-Request-Email", "Lennie@TrustedHealth.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "board",
+      userId: "user-1",
+      userEmail: "lennie@trustedhealth.com",
+      companyIds: ["company-1"],
+      isInstanceAdmin: true,
+      source: "session",
+    });
+    expect(resolveSession).not.toHaveBeenCalled();
+  });
+
+  it("provisions the allowlisted proxy user when it does not already exist", async () => {
+    process.env.PAPERCLIP_TRUST_PROXY_AUTH_EMAIL = "lennie@trustedhealth.com";
+    const db = createDb();
+
+    const res = await request(createApp(db))
+      .get("/whoami")
+      .set("X-Forwarded-Email", "lennie@trustedhealth.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "board",
+      userId: "trusted-proxy:lennie@trustedhealth.com",
+      userEmail: "lennie@trustedhealth.com",
+      isInstanceAdmin: true,
+      source: "session",
+    });
+    expect(db.insertedUsers).toHaveLength(1);
+    expect(db.insertedUsers[0]).toMatchObject({
+      id: "trusted-proxy:lennie@trustedhealth.com",
+      email: "lennie@trustedhealth.com",
+      emailVerified: true,
+    });
+  });
+
+  it("ignores unallowlisted proxy email headers", async () => {
+    process.env.PAPERCLIP_TRUST_PROXY_AUTH_EMAIL = "lennie@trustedhealth.com";
+    const db = createDb();
+    const resolveSession = vi.fn(async () => null);
+
+    const res = await request(createApp(db, resolveSession))
+      .get("/whoami")
+      .set("X-Auth-Request-Email", "attacker@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ type: "none", source: "none" });
+    expect(resolveSession).toHaveBeenCalledOnce();
+    expect(db.insertedUsers).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/proxy-auth-middleware.test.ts
+++ b/server/src/__tests__/proxy-auth-middleware.test.ts
@@ -76,13 +76,16 @@ describe("trusted proxy auth middleware", () => {
     expect(resolveSession).not.toHaveBeenCalled();
   });
 
-  it("provisions the allowlisted proxy user when it does not already exist", async () => {
+  it.each([
+    ["X-Forwarded-Email"],
+    ["X-Forwarded-User"],
+  ])("provisions the allowlisted proxy user from %s when it does not already exist", async (header) => {
     process.env.PAPERCLIP_TRUST_PROXY_AUTH_EMAIL = "lennie@trustedhealth.com";
     const db = createDb();
 
     const res = await request(createApp(db))
       .get("/whoami")
-      .set("X-Forwarded-Email", "lennie@trustedhealth.com");
+      .set(header, "lennie@trustedhealth.com");
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({

--- a/server/src/__tests__/proxy-auth-middleware.test.ts
+++ b/server/src/__tests__/proxy-auth-middleware.test.ts
@@ -79,6 +79,8 @@ describe("trusted proxy auth middleware", () => {
   it.each([
     ["X-Forwarded-Email"],
     ["X-Forwarded-User"],
+    ["X-Auth-Request-Email"],
+    ["X-Auth-Request-User"],
   ])("provisions the allowlisted proxy user from %s when it does not already exist", async (header) => {
     process.env.PAPERCLIP_TRUST_PROXY_AUTH_EMAIL = "lennie@trustedhealth.com";
     const db = createDb();

--- a/server/src/__tests__/trusted-proxy-auth-middleware.test.ts
+++ b/server/src/__tests__/trusted-proxy-auth-middleware.test.ts
@@ -1,0 +1,170 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authUsers, companyMemberships } from "@paperclipai/db";
+import {
+  actorMiddleware,
+  resolveProxyAuthEmail,
+  TRUSTED_PROXY_AUTH_EMAIL_ENV,
+  trustedProxyEmailAllowSet,
+} from "../middleware/auth.js";
+
+type UserRow = { id: string; name: string | null; email: string | null };
+type MembershipRow = { companyId: string; membershipRole: string; status: string };
+
+function createDbFixture(input?: {
+  existingUsers?: UserRow[];
+  memberships?: MembershipRow[];
+}) {
+  const users = [...(input?.existingUsers ?? [])];
+  const memberships = [...(input?.memberships ?? [])];
+  const insertedUsers: UserRow[] = [];
+
+  const db = {
+    select: () => ({
+      from(table: unknown) {
+        return {
+          where() {
+            if (table === authUsers) return Promise.resolve(users);
+            if (table === companyMemberships) return Promise.resolve(memberships);
+            return Promise.resolve([]);
+          },
+        };
+      },
+    }),
+    insert(table: unknown) {
+      return {
+        values(value: Record<string, unknown>) {
+          return {
+            onConflictDoUpdate() {
+              return {
+                returning() {
+                  if (table === authUsers) {
+                    const user = {
+                      id: String(value.id),
+                      name: value.name == null ? null : String(value.name),
+                      email: value.email == null ? null : String(value.email),
+                    };
+                    insertedUsers.push(user);
+                    users.push(user);
+                    return Promise.resolve([user]);
+                  }
+                  return Promise.resolve([]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  } as any;
+
+  return { db, insertedUsers };
+}
+
+function buildApp(db: any, resolveSession = vi.fn(async () => null)) {
+  const app = express();
+  app.use(express.json());
+  app.use(actorMiddleware(db, {
+    deploymentMode: "authenticated",
+    resolveSession,
+  }));
+  app.get("/whoami", (req, res) => res.json(req.actor));
+  return { app, resolveSession };
+}
+
+describe.sequential("trusted proxy email auth middleware", () => {
+  const originalEnvValue = process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV];
+
+  afterEach(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV];
+    } else {
+      process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV] = originalEnvValue;
+    }
+  });
+
+  it("stays disabled when PAPERCLIP_TRUST_PROXY_AUTH_EMAIL is unset", async () => {
+    delete process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV];
+    const { db, insertedUsers } = createDbFixture();
+    const { app, resolveSession } = buildApp(db);
+
+    const res = await request(app)
+      .get("/whoami")
+      .set("x-auth-request-email", "operator@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "none", source: "none" });
+    expect(resolveSession).toHaveBeenCalledTimes(1);
+    expect(insertedUsers).toEqual([]);
+  });
+
+  it("turns an allowlisted proxy email header into a session-compatible board actor", async () => {
+    process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV] = "operator@example.com";
+    const { db, insertedUsers } = createDbFixture({
+      memberships: [{ companyId: "company-1", membershipRole: "owner", status: "active" }],
+    });
+    const { app, resolveSession } = buildApp(db);
+
+    const res = await request(app)
+      .get("/whoami")
+      .set("x-auth-request-email", " Operator@Example.com ");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "board",
+      userId: "trusted-proxy:operator@example.com",
+      userName: "operator@example.com",
+      userEmail: "operator@example.com",
+      companyIds: ["company-1"],
+      isInstanceAdmin: true,
+      source: "session",
+    });
+    expect(res.body.memberships).toEqual([
+      { companyId: "company-1", membershipRole: "owner", status: "active" },
+    ]);
+    expect(insertedUsers).toEqual([
+      { id: "trusted-proxy:operator@example.com", name: "operator@example.com", email: "operator@example.com" },
+    ]);
+    expect(resolveSession).not.toHaveBeenCalled();
+  });
+
+  it("ignores spoofed proxy email headers that are not explicitly allowlisted", async () => {
+    process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV] = "operator@example.com";
+    const { db, insertedUsers } = createDbFixture();
+    const { app, resolveSession } = buildApp(db);
+
+    const res = await request(app)
+      .get("/whoami")
+      .set("x-auth-request-email", "attacker@example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "none", source: "none" });
+    expect(resolveSession).toHaveBeenCalledTimes(1);
+    expect(insertedUsers).toEqual([]);
+  });
+
+  it("accepts supported trusted proxy email header aliases", () => {
+    process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV] = "first@example.com, operator@example.com";
+    const headers = [
+      "x-auth-request-email",
+      "x-auth-request-user",
+      "x-auth-request-preferred-username",
+      "x-forwarded-email",
+      "x-forwarded-user",
+      "x-forwarded-preferred-username",
+    ];
+
+    for (const header of headers) {
+      expect(resolveProxyAuthEmail({
+        header: (name: string) => (name === header ? " Operator@Example.com " : undefined),
+      } as any)).toBe("operator@example.com");
+    }
+  });
+
+  it("normalizes comma-separated allowlist values", () => {
+    expect(trustedProxyEmailAllowSet("A@Example.com, b@example.com, invalid")).toEqual(
+      new Set(["a@example.com", "b@example.com"]),
+    );
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -13,12 +13,8 @@ function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
 
-interface ActorMiddlewareOptions {
-  deploymentMode: DeploymentMode;
-  resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
-}
+export const TRUSTED_PROXY_AUTH_EMAIL_ENV = "PAPERCLIP_TRUST_PROXY_AUTH_EMAIL";
 
-const TRUSTED_PROXY_AUTH_EMAIL_ENV = "PAPERCLIP_TRUST_PROXY_AUTH_EMAIL";
 const TRUSTED_PROXY_EMAIL_HEADERS = [
   "x-auth-request-email",
   "x-auth-request-user",
@@ -26,109 +22,37 @@ const TRUSTED_PROXY_EMAIL_HEADERS = [
   "x-forwarded-email",
   "x-forwarded-user",
   "x-forwarded-preferred-username",
-];
+] as const;
 
-function normalizeEmail(value: string | undefined | null): string | null {
+export function normalizeTrustedProxyEmail(value: string | undefined): string | null {
   const email = value?.split(",")[0]?.trim().toLowerCase();
   if (!email || !email.includes("@")) return null;
   return email;
 }
 
-function trustedProxyEmailAllowSet(): Set<string> {
+export function trustedProxyEmailAllowSet(envValue = process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV]): Set<string> {
   return new Set(
-    (process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV] ?? "")
+    (envValue ?? "")
       .split(",")
-      .map((value) => normalizeEmail(value))
+      .map((value) => normalizeTrustedProxyEmail(value))
       .filter((value): value is string => Boolean(value)),
   );
 }
 
-function resolveTrustedProxyAuthEmail(req: Request): string | null {
+export function resolveProxyAuthEmail(req: Pick<Request, "header">): string | null {
   const allowedEmails = trustedProxyEmailAllowSet();
   if (allowedEmails.size === 0) return null;
 
   for (const header of TRUSTED_PROXY_EMAIL_HEADERS) {
-    const email = normalizeEmail(req.header(header));
+    const email = normalizeTrustedProxyEmail(req.header(header));
     if (email && allowedEmails.has(email)) return email;
   }
   return null;
 }
 
-async function ensureTrustedProxyUser(db: Db, email: string) {
-  const now = new Date();
-  const existing = await db
-    .select({
-      id: authUsers.id,
-      name: authUsers.name,
-      email: authUsers.email,
-    })
-    .from(authUsers)
-    .where(eq(authUsers.email, email))
-    .then((rows) => rows[0] ?? null);
-
-  if (existing) return existing;
-
-  const userId = `trusted-proxy:${email}`;
-  return db
-    .insert(authUsers)
-    .values({
-      id: userId,
-      name: email,
-      email,
-      emailVerified: true,
-      image: null,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: authUsers.id,
-      set: {
-        name: email,
-        email,
-        emailVerified: true,
-        updatedAt: now,
-      },
-    })
-    .returning({
-      id: authUsers.id,
-      name: authUsers.name,
-      email: authUsers.email,
-    })
-    .then((rows) => rows[0]);
-}
-
-async function resolveTrustedProxyActor(db: Db, req: Request): Promise<Express.Request["actor"] | null> {
-  const email = resolveTrustedProxyAuthEmail(req);
-  if (!email) return null;
-
-  const user = await ensureTrustedProxyUser(db, email);
-  if (!user?.id) return null;
-
-  const memberships = await db
-    .select({
-      companyId: companyMemberships.companyId,
-      membershipRole: companyMemberships.membershipRole,
-      status: companyMemberships.status,
-    })
-    .from(companyMemberships)
-    .where(
-      and(
-        eq(companyMemberships.principalType, "user"),
-        eq(companyMemberships.principalId, user.id),
-        eq(companyMemberships.status, "active"),
-      ),
-    );
-
-  return {
-    type: "board",
-    userId: user.id,
-    userName: user.name ?? email,
-    userEmail: user.email ?? email,
-    companyIds: memberships.map((row) => row.companyId),
-    memberships,
-    isInstanceAdmin: true,
-    source: "session",
-  };
+interface ActorMiddlewareOptions {
+  deploymentMode: DeploymentMode;
+  resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
 }
 
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
@@ -319,6 +243,70 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     };
 
     next();
+  };
+}
+
+async function ensureTrustedProxyUser(db: Db, email: string) {
+  const now = new Date();
+  const existing = await db
+    .select({ id: authUsers.id, name: authUsers.name, email: authUsers.email })
+    .from(authUsers)
+    .where(eq(authUsers.email, email))
+    .then((rows) => rows[0] ?? null);
+
+  if (existing) return existing;
+
+  const userId = `trusted-proxy:${email}`;
+  return db
+    .insert(authUsers)
+    .values({
+      id: userId,
+      name: email,
+      email,
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: authUsers.id,
+      set: { name: email, email, emailVerified: true, updatedAt: now },
+    })
+    .returning({ id: authUsers.id, name: authUsers.name, email: authUsers.email })
+    .then((rows) => rows[0] ?? null);
+}
+
+async function resolveTrustedProxyActor(db: Db, req: Request): Promise<Express.Request["actor"] | null> {
+  const email = resolveProxyAuthEmail(req);
+  if (!email) return null;
+
+  const user = await ensureTrustedProxyUser(db, email);
+  if (!user?.id) return null;
+
+  const memberships = await db
+    .select({
+      companyId: companyMemberships.companyId,
+      membershipRole: companyMemberships.membershipRole,
+      status: companyMemberships.status,
+    })
+    .from(companyMemberships)
+    .where(
+      and(
+        eq(companyMemberships.principalType, "user"),
+        eq(companyMemberships.principalId, user.id),
+        eq(companyMemberships.status, "active"),
+      ),
+    );
+
+  return {
+    type: "board",
+    userId: user.id,
+    userName: user.name ?? email,
+    userEmail: user.email ?? email,
+    companyIds: memberships.map((row) => row.companyId),
+    memberships,
+    isInstanceAdmin: true,
+    source: "session",
   };
 }
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -22,6 +22,7 @@ const TRUSTED_PROXY_AUTH_EMAIL_ENV = "PAPERCLIP_TRUST_PROXY_AUTH_EMAIL";
 const TRUSTED_PROXY_EMAIL_HEADERS = [
   "x-auth-request-email",
   "x-forwarded-email",
+  "x-forwarded-user",
   "x-forwarded-preferred-username",
 ];
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -18,6 +18,116 @@ interface ActorMiddlewareOptions {
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
 }
 
+const TRUSTED_PROXY_AUTH_EMAIL_ENV = "PAPERCLIP_TRUST_PROXY_AUTH_EMAIL";
+const TRUSTED_PROXY_EMAIL_HEADERS = [
+  "x-auth-request-email",
+  "x-forwarded-email",
+  "x-forwarded-preferred-username",
+];
+
+function normalizeEmail(value: string | undefined | null): string | null {
+  const email = value?.split(",")[0]?.trim().toLowerCase();
+  if (!email || !email.includes("@")) return null;
+  return email;
+}
+
+function trustedProxyEmailAllowSet(): Set<string> {
+  return new Set(
+    (process.env[TRUSTED_PROXY_AUTH_EMAIL_ENV] ?? "")
+      .split(",")
+      .map((value) => normalizeEmail(value))
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+function resolveTrustedProxyAuthEmail(req: Request): string | null {
+  const allowedEmails = trustedProxyEmailAllowSet();
+  if (allowedEmails.size === 0) return null;
+
+  for (const header of TRUSTED_PROXY_EMAIL_HEADERS) {
+    const email = normalizeEmail(req.header(header));
+    if (email && allowedEmails.has(email)) return email;
+  }
+  return null;
+}
+
+async function ensureTrustedProxyUser(db: Db, email: string) {
+  const now = new Date();
+  const existing = await db
+    .select({
+      id: authUsers.id,
+      name: authUsers.name,
+      email: authUsers.email,
+    })
+    .from(authUsers)
+    .where(eq(authUsers.email, email))
+    .then((rows) => rows[0] ?? null);
+
+  if (existing) return existing;
+
+  const userId = `trusted-proxy:${email}`;
+  return db
+    .insert(authUsers)
+    .values({
+      id: userId,
+      name: email,
+      email,
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: authUsers.id,
+      set: {
+        name: email,
+        email,
+        emailVerified: true,
+        updatedAt: now,
+      },
+    })
+    .returning({
+      id: authUsers.id,
+      name: authUsers.name,
+      email: authUsers.email,
+    })
+    .then((rows) => rows[0]);
+}
+
+async function resolveTrustedProxyActor(db: Db, req: Request): Promise<Express.Request["actor"] | null> {
+  const email = resolveTrustedProxyAuthEmail(req);
+  if (!email) return null;
+
+  const user = await ensureTrustedProxyUser(db, email);
+  if (!user?.id) return null;
+
+  const memberships = await db
+    .select({
+      companyId: companyMemberships.companyId,
+      membershipRole: companyMemberships.membershipRole,
+      status: companyMemberships.status,
+    })
+    .from(companyMemberships)
+    .where(
+      and(
+        eq(companyMemberships.principalType, "user"),
+        eq(companyMemberships.principalId, user.id),
+        eq(companyMemberships.status, "active"),
+      ),
+    );
+
+  return {
+    type: "board",
+    userId: user.id,
+    userName: user.name ?? email,
+    userEmail: user.email ?? email,
+    companyIds: memberships.map((row) => row.companyId),
+    memberships,
+    isInstanceAdmin: true,
+    source: "session",
+  };
+}
+
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
   return async (req, _res, next) => {
@@ -42,6 +152,16 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         if (cloudTenantActor) {
           req.actor = {
             ...cloudTenantActor,
+            runId: runIdHeader ?? undefined,
+          };
+          next();
+          return;
+        }
+
+        const trustedProxyActor = await resolveTrustedProxyActor(db, req);
+        if (trustedProxyActor) {
+          req.actor = {
+            ...trustedProxyActor,
             runId: runIdHeader ?? undefined,
           };
           next();

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -21,6 +21,8 @@ interface ActorMiddlewareOptions {
 const TRUSTED_PROXY_AUTH_EMAIL_ENV = "PAPERCLIP_TRUST_PROXY_AUTH_EMAIL";
 const TRUSTED_PROXY_EMAIL_HEADERS = [
   "x-auth-request-email",
+  "x-auth-request-user",
+  "x-auth-request-preferred-username",
   "x-forwarded-email",
   "x-forwarded-user",
   "x-forwarded-preferred-username",


### PR DESCRIPTION
## Summary
- add a trusted OAuth proxy email bridge for authenticated deployments that cannot use the default session cookie path
- provision/resolve the configured trusted proxy actor only when the proxy email is allowlisted
- document the deployment mode and cover allowlisted, provisioned, and unallowlisted proxy-header cases

## Security / operator notes
- The header is ignored unless `TRUSTED_PROXY_EMAIL_HEADER` and `TRUSTED_PROXY_ALLOWED_EMAILS` are configured.
- The bridge does not trust arbitrary proxy headers by default.
- No deployment, restart, credential, or Render setting change is included in this PR.

## Tests
- `pnpm exec vitest run server/src/__tests__/trusted-proxy-auth-middleware.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Kanban
- `trustedos/t_693acfd5`
