### PR TITLE
fix(server): RFC 5987 Content-Disposition for non-ASCII attachment filenames

### DIFF
--- a/server/src/__tests__/content-disposition.test.ts
+++ b/server/src/__tests__/content-disposition.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContentDisposition } from "../lib/content-disposition.js";
+
+const LATIN1_SAFE = /^[\x00-\xff]*$/;
+
+describe("buildContentDisposition", () => {
+  it("leaves a plain ASCII filename untouched and omits filename*", () => {
+    expect(buildContentDisposition("attachment", "report.pdf")).toBe(
+      'attachment; filename="report.pdf"',
+    );
+  });
+
+  it("appends an RFC 5987 filename* for non-ASCII (Korean) filenames", () => {
+    const value = buildContentDisposition("attachment", "사업자등록증.xlsx");
+    expect(value).toBe(
+      "attachment; filename=\"______.xlsx\"; filename*=UTF-8''%EC%82%AC%EC%97%85%EC%9E%90%EB%93%B1%EB%A1%9D%EC%A6%9D.xlsx",
+    );
+    // The whole header must be Latin-1 safe so res.setHeader never throws
+    // ERR_INVALID_CHAR (the root cause of the attachment-download 500).
+    expect(LATIN1_SAFE.test(value)).toBe(true);
+  });
+
+  it("honours the inline disposition", () => {
+    expect(buildContentDisposition("inline", "사진.png")).toBe(
+      "inline; filename=\"__.png\"; filename*=UTF-8''%EC%82%AC%EC%A7%84.png",
+    );
+  });
+
+  it("strips quotes from the ASCII fallback and preserves them in filename*", () => {
+    const value = buildContentDisposition("attachment", 'in"voice.pdf');
+    expect(value).toBe(
+      "attachment; filename=\"invoice.pdf\"; filename*=UTF-8''in%22voice.pdf",
+    );
+  });
+
+  it("percent-encodes characters that are not valid RFC 5987 attr-chars", () => {
+    // The fallback can represent ASCII `'()*` verbatim inside the quoted
+    // string, but once a non-ASCII byte forces a filename*, those characters
+    // must be percent-encoded because they are not valid RFC 5987 attr-chars.
+    const value = buildContentDisposition("attachment", "café(1)'*.txt");
+    expect(value).toContain("filename*=UTF-8''caf%C3%A9%281%29%27%2A.txt");
+  });
+
+  it("keeps an all-ASCII name with special characters in the quoted fallback", () => {
+    expect(buildContentDisposition("attachment", "a'b(c)*.txt")).toBe(
+      "attachment; filename=\"a'b(c)*.txt\"",
+    );
+  });
+
+  it("falls back to a default name when no printable ASCII remains", () => {
+    // Only quote/backslash characters: stripped from the fallback, leaving it
+    // empty, so the default name is used while filename* preserves the bytes.
+    const value = buildContentDisposition("attachment", '"\\"');
+    expect(value).toBe(
+      "attachment; filename=\"download\"; filename*=UTF-8''%22%5C%22",
+    );
+  });
+
+  it("falls back to a default name for empty or nullish filenames", () => {
+    expect(buildContentDisposition("attachment", "")).toBe(
+      'attachment; filename="download"',
+    );
+    expect(buildContentDisposition("attachment", null)).toBe(
+      'attachment; filename="download"',
+    );
+    expect(buildContentDisposition("attachment", undefined)).toBe(
+      'attachment; filename="download"',
+    );
+  });
+
+  it("produces Latin-1 safe output for a range of non-ASCII scripts", () => {
+    for (const name of ["café.txt", "naïve.doc", "日本語.zip", "Ω.csv", "🎉.gif"]) {
+      expect(LATIN1_SAFE.test(buildContentDisposition("attachment", name))).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/server/src/lib/content-disposition.ts
+++ b/server/src/lib/content-disposition.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers for building RFC 6266 / RFC 5987 compliant `Content-Disposition`
+ * response headers.
+ *
+ * Node's `res.setHeader` rejects header values containing bytes outside the
+ * Latin-1 range and throws `TypeError [ERR_INVALID_CHAR]`. Inlining a raw
+ * UTF-8 filename such as `사업자등록증.xlsx` therefore turns attachment
+ * downloads into HTTP 500s.
+ *
+ * RFC 6266 solves this by emitting an ASCII-only `filename="..."` fallback for
+ * legacy clients plus a percent-encoded `filename*=UTF-8''...` parameter
+ * (RFC 5987 ext-value) that modern clients prefer. Every byte of the resulting
+ * header is then Latin-1 safe while non-ASCII names are preserved end to end.
+ */
+
+/**
+ * Percent-encode a string as an RFC 5987 `ext-value` (the portion after
+ * `UTF-8''`). `encodeURIComponent` leaves a handful of characters unescaped
+ * that are not valid `attr-char`s (`'`, `(`, `)`, `*`), so those are encoded
+ * explicitly. The `|`, `^` and `` ` `` characters are valid `attr-char`s and
+ * are decoded back to keep the value compact and readable.
+ */
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value)
+    .replace(
+      /['()*]/g,
+      (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+    )
+    .replace(/%(7C|60|5E)/gi, (_match, hex: string) =>
+      String.fromCharCode(parseInt(hex, 16)),
+    );
+}
+
+/**
+ * Build the ASCII-only fallback used in the quoted `filename="..."` parameter.
+ * Any non-printable or non-ASCII code point is replaced with `_`, and
+ * characters that would break the quoted-string (`"` and `\`) are removed.
+ * Falls back to `download` when nothing printable remains.
+ */
+function asciiFallbackFilename(filename: string): string {
+  const fallback = filename
+    .replace(/[^\x20-\x7e]/g, "_")
+    .replace(/["\\]/g, "");
+  return fallback.length > 0 ? fallback : "download";
+}
+
+/**
+ * Build a safe `Content-Disposition` header value.
+ *
+ * @param disposition `"attachment"` or `"inline"`.
+ * @param filename The original (possibly non-ASCII) filename.
+ * @returns A header value whose every byte is Latin-1 safe. When `filename`
+ *   contains characters the ASCII fallback could not represent verbatim, an
+ *   RFC 5987 `filename*=UTF-8''...` parameter is appended.
+ */
+export function buildContentDisposition(
+  disposition: "attachment" | "inline",
+  filename: string | null | undefined,
+): string {
+  const name = filename && filename.length > 0 ? filename : "download";
+  const fallback = asciiFallbackFilename(name);
+  let value = `${disposition}; filename="${fallback}"`;
+  if (fallback !== name) {
+    value += `; filename*=UTF-8''${encodeRfc5987(name)}`;
+  }
+  return value;
+}

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -76,6 +76,7 @@ import {
   collapseDuplicatePendingHumanJoinRequests,
   findReusableHumanJoinRequest,
 } from "../lib/join-request-dedupe.js";
+import { buildContentDisposition } from "../lib/content-disposition.js";
 import { assertAuthenticated, assertCompanyAccess } from "./authz.js";
 import {
   claimBoardOwnership,
@@ -3249,7 +3250,7 @@ export function accessRoutes(
       res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
     }
     const filename = logoAsset.originalFilename ?? "company-logo";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    res.setHeader("Content-Disposition", buildContentDisposition("inline", filename));
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -8,6 +8,7 @@ import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { buildContentDisposition } from "../lib/content-disposition.js";
 const SVG_CONTENT_TYPE = "image/svg+xml";
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
   "image/png",
@@ -328,7 +329,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
       res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
     }
     const filename = asset.originalFilename ?? "asset";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    res.setHeader("Content-Disposition", buildContentDisposition("inline", filename));
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -136,6 +136,7 @@ import {
   resolveCoreTrustPreset,
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
+import { buildContentDisposition } from "../lib/content-disposition.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -6968,7 +6969,7 @@ export function issueRoutes(
     const disposition = parseBooleanQuery(req.query.download)
       ? "attachment"
       : isInlineAttachmentContentType(responseContentType) ? "inline" : "attachment";
-    res.setHeader("Content-Disposition", `${disposition}; filename=\"${filename.replaceAll("\"", "")}\"`);
+    res.setHeader("Content-Disposition", buildContentDisposition(disposition, filename));
 
     object.stream.on("error", (err) => {
       next(err);


### PR DESCRIPTION
## Thinking Path

> - Paperclip serves user-uploaded files back to the browser from three response routes: issue attachment content (`server/src/routes/issues.ts`), asset content (`server/src/routes/assets.ts`), and company-logo content (`server/src/routes/access.ts`).
> - Each route built the `Content-Disposition` header by inlining the raw `originalFilename` into `filename="..."`.
> - Node's `res.setHeader` rejects any header value containing bytes outside the Latin-1 range and throws `TypeError [ERR_INVALID_CHAR]`. A filename such as `사업자등록증.xlsx` contains multi-byte UTF-8 characters, so the throw turns the whole download into an unhandled **HTTP 500**.
> - RFC 6266 + RFC 5987 are the standard fix: emit an ASCII-only `filename="..."` fallback for legacy clients plus a percent-encoded `filename*=UTF-8''...` parameter that modern clients prefer. Every byte of the resulting header is then Latin-1 safe and the original UTF-8 name survives end to end.
> - The same one-line pattern existed at all three sites, so a single shared helper fixes them uniformly and is unit-testable in isolation.

## Linked Issues or Issue Description

Fixes #7493

This PR closes upstream issue #7493 (non-ASCII filenames mojibaked / 500 in `Content-Disposition` response headers, missing RFC 5987 `filename*`).

- **What happened:** Downloading any attachment/asset whose filename contains non-ASCII characters (Korean, Japanese, accented Latin, …) returned **HTTP 500**. Example: downloading `사업자등록증.xlsx`.
- **Expected:** The file downloads, and modern clients see the original UTF-8 filename.
- **Root cause:** The route inlined the raw UTF-8 filename into the `Content-Disposition` header; `res.setHeader` throws `ERR_INVALID_CHAR` on the non-Latin-1 bytes.
- **Deployment mode:** Reproduced on a local embedded-postgres install (`paperclipai` npm package); the affected route is `dist/routes/issues.js`'s single `setHeader("Content-Disposition", …)` line.

## What Changed

- Add `server/src/lib/content-disposition.ts` exporting `buildContentDisposition(disposition, filename)`, which builds an RFC 6266 / RFC 5987 header value:
  - ASCII fallback `filename="..."` (non-printable/non-ASCII → `_`, quotes/backslashes stripped, defaulting to `download` when nothing printable remains);
  - appends `filename*=UTF-8''<encoded>` only when the fallback could not represent the name verbatim, using a strict RFC 5987 `ext-value` encoder (also percent-encodes `'`, `(`, `)`, `*`, which `encodeURIComponent` leaves unescaped).
- Apply it at the three response sites that set `Content-Disposition`:
  - `server/src/routes/issues.ts` — issue attachment content (honours the existing `attachment`/`inline` disposition);
  - `server/src/routes/assets.ts` — asset content (`inline`);
  - `server/src/routes/access.ts` — company-logo content (`inline`).
- Add `server/src/__tests__/content-disposition.test.ts` covering ASCII pass-through, Korean/Japanese/accented/CJK/emoji names, the `inline` disposition, quote stripping with preservation in `filename*`, attr-char encoding, empty/null/undefined fallback, and a Latin-1-safety invariant over the full header.

## Verification

- `tsc --noEmit` (server) — clean.
- `vitest run src/__tests__/content-disposition.test.ts` — 9/9 passing.

## Notes

Companion to #7624 (the upload-side multipart-filename UTF-8 fix). That PR corrects how non-ASCII filenames are **stored**; this PR corrects how they are **served**. The two touch the same route files but are independent and separately reviewable, so they are kept as distinct PRs against `master`.
