### PR TITLE
Repair stale typed review handoff routing

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -9,6 +9,7 @@ const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
+const opsAgentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
@@ -413,11 +414,13 @@ describe("agent issue mutation checkout ownership", () => {
     mockAgentService.getById.mockImplementation(async (id: string) => {
       if (id === ownerAgentId) return makeAgent(ownerAgentId);
       if (id === peerAgentId) return makeAgent(peerAgentId);
+      if (id === opsAgentId) return makeAgent(opsAgentId, { role: "general" });
       return null;
     });
     mockAgentService.list.mockResolvedValue([
       makeAgent(ownerAgentId),
       makeAgent(peerAgentId),
+      makeAgent(opsAgentId, { role: "general" }),
     ]);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: null });
     mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "PAP" });
@@ -910,6 +913,118 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status).toBe(200);
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows assignment-authorized agents to repair stale in_review ownership to the typed reviewer", async () => {
+    const reviewStageId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const reviewIssue = makeIssue({
+      status: "in_review",
+      assigneeAgentId: ownerAgentId,
+      assigneeUserId: null,
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [
+          {
+            id: reviewStageId,
+            type: "review",
+            approvalsNeeded: 1,
+            participants: [
+              { id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", type: "agent", agentId: peerAgentId, userId: null },
+            ],
+          },
+        ],
+      },
+      executionState: {
+        status: "pending",
+        currentStageId: reviewStageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: peerAgentId, userId: null },
+        returnAssignee: { type: "agent", agentId: ownerAgentId, userId: null },
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: null,
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(reviewIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...reviewIssue,
+      ...patch,
+    }));
+    mockAgentService.resolveByReference.mockResolvedValueOnce({
+      ambiguous: false,
+      agent: makeAgent(peerAgentId),
+    });
+
+    const res = await request(await createApp(peerActor({ agentId: opsAgentId })))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        assigneeAgentId: peerAgentId,
+        comment: "Repairing stale review ownership to the active reviewer.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "tasks:assign",
+      resource: expect.objectContaining({
+        type: "issue",
+        issueId,
+        assigneeAgentId: peerAgentId,
+        assigneeUserId: null,
+      }),
+    }));
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "in_review",
+        assigneeAgentId: peerAgentId,
+        assigneeUserId: null,
+        executionState: expect.objectContaining({
+          status: "pending",
+          currentParticipant: expect.objectContaining({ type: "agent", agentId: peerAgentId }),
+        }),
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Repairing stale review ownership to the active reviewer.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects agent attempts to take over a human-owned in_review issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "in_review",
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        executionState: {
+          status: "pending",
+          currentStageId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          currentStageIndex: 0,
+          currentStageType: "review",
+          currentParticipant: { type: "user", userId: "local-board", agentId: null },
+          returnAssignee: { type: "agent", agentId: ownerAgentId, userId: null },
+          reviewRequest: null,
+          completedStageIds: [],
+          lastDecisionId: null,
+          lastDecisionOutcome: null,
+          monitor: null,
+        },
+      }),
+    );
+
+    const res = await request(await createApp(peerActor({ agentId: opsAgentId })))
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot reassign a human-owned issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -337,6 +337,8 @@ describe("issue execution policy routes", () => {
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       expect.objectContaining({
         status: "in_review",
+        assigneeAgentId: "44444444-4444-4444-8444-444444444444",
+        assigneeUserId: null,
         executionState: expect.objectContaining({
           status: "pending",
           currentParticipant: expect.objectContaining({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -152,6 +152,10 @@ const promoteLowTrustOutputSchema = z.object({
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
 type IssueRouteSnapshot = typeof issueRows.$inferSelect;
+type ReviewHandoffRepairTarget = {
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+};
 type RecoveryRevalidationTrigger =
   | "issue_update"
   | "comment"
@@ -1725,6 +1729,83 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  function reviewHandoffRepairTargetForPatch(
+    body: Record<string, unknown>,
+    issue: {
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+      executionState?: unknown;
+    },
+  ): ReviewHandoffRepairTarget | null {
+    if (issue.status !== "in_review" || issue.assigneeUserId) return null;
+    const allowedKeys = new Set(["assigneeAgentId", "assigneeUserId", "comment", "status"]);
+    if (Object.keys(body).some((key) => !allowedKeys.has(key))) return null;
+    if (body.status !== undefined && body.status !== "in_review") return null;
+
+    const state = parseIssueExecutionState(issue.executionState);
+    const participant = state?.status === "pending" ? state.currentParticipant : null;
+    if (!participant) return null;
+
+    if (participant.type === "agent" && participant.agentId) {
+      if (issue.assigneeAgentId === participant.agentId) return null;
+      if (body.assigneeAgentId !== participant.agentId) return null;
+      if (body.assigneeUserId !== undefined && body.assigneeUserId !== null) return null;
+      return { assigneeAgentId: participant.agentId, assigneeUserId: null };
+    }
+
+    if (participant.type === "user" && participant.userId) {
+      if (body.assigneeUserId !== participant.userId) return null;
+      if (body.assigneeAgentId !== undefined && body.assigneeAgentId !== null) return null;
+      return { assigneeAgentId: null, assigneeUserId: participant.userId };
+    }
+
+    return null;
+  }
+
+  async function hasReviewHandoffRepairAssignmentAuthority(
+    req: Request,
+    issue: {
+      id: string;
+      companyId: string;
+      projectId: string | null;
+      parentId: string | null;
+    },
+    target: ReviewHandoffRepairTarget,
+  ) {
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "tasks:assign",
+      resource: {
+        type: "issue",
+        companyId: issue.companyId,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: target.assigneeAgentId,
+        assigneeUserId: target.assigneeUserId,
+      },
+      scope: {
+        issueId: issue.id,
+        projectId: issue.projectId,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: target.assigneeAgentId,
+        assigneeUserId: target.assigneeUserId,
+      },
+    });
+    return decision;
+  }
+
+  function isAgentHumanOwnedAssigneeTakeover(
+    req: Request,
+    issue: { assigneeUserId: string | null },
+    body: Record<string, unknown>,
+  ) {
+    if (req.actor.type !== "agent" || !issue.assigneeUserId) return false;
+    if (typeof body.assigneeAgentId === "string" && body.assigneeAgentId.trim().length > 0) return true;
+    return body.assigneeUserId !== undefined && body.assigneeUserId !== issue.assigneeUserId;
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -1736,7 +1817,9 @@ export function issueRoutes(
       status: string;
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
+      executionState?: unknown;
     },
+    options?: { reviewHandoffRepairTarget?: ReviewHandoffRepairTarget | null },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1755,6 +1838,25 @@ export function issueRoutes(
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
+      }
+      if (options?.reviewHandoffRepairTarget) {
+        const decision = await hasReviewHandoffRepairAssignmentAuthority(
+          req,
+          issue,
+          options.reviewHandoffRepairTarget,
+        );
+        if (decision.allowed) return true;
+        res.status(403).json({
+          error: decision.explanation,
+          details: {
+            issueId: issue.id,
+            assigneeAgentId: issue.assigneeAgentId,
+            actorAgentId,
+            status: issue.status,
+            reviewHandoffRepair: true,
+          },
+        });
+        return false;
       }
       if (issue.status === "in_progress") {
         res.status(409).json({
@@ -4638,7 +4740,12 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (isAgentHumanOwnedAssigneeTakeover(req, existing, req.body)) {
+      res.status(403).json({ error: "Agent cannot reassign a human-owned issue" });
+      return;
+    }
+    const reviewHandoffRepairTarget = reviewHandoffRepairTargetForPatch(req.body, existing);
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { reviewHandoffRepairTarget }))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);

--- a/ui/src/components/AgentActionButtons.test.tsx
+++ b/ui/src/components/AgentActionButtons.test.tsx
@@ -5,6 +5,7 @@ import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Agent } from "@paperclipai/shared";
+import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentActionButtons } from "./AgentActionButtons";
 
@@ -94,7 +95,7 @@ describe("AgentActionButtons", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot> | null;
   let queryClient: QueryClient;
-  let invalidateQueries: ReturnType<typeof vi.spyOn>;
+  let invalidateQueries: MockInstance<QueryClient["invalidateQueries"]>;
 
   beforeEach(() => {
     container = document.createElement("div");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI-agent companies.
> - Issues are the work-routing primitive, and `in_review` is how completed work waits for a reviewer.
> - Execution-policy review stages already record the active reviewer in `executionState.currentParticipant`.
> - Ops can see stale review items where that typed reviewer is recorded but the issue assignee still points at the implementer.
> - Existing peer-agent mutation guards correctly protect active ownership, but they also block this narrow queue-repair routing unless Ops has broader checkout-management authority.
> - This pull request permits only assignment-authorized agents to repair stale typed-review ownership to the recorded participant, while preserving the existing human-owned and board-owned protections.
> - The benefit is repairable review queues without making Ops a general issue mutator.

## Linked Issues or Issue Description

Refs #6983
Refs #6252
Refs #5248

Internal: Refs [DAT-5792](/DAT/issues/DAT-5792).

## What Changed

- Added a narrow review-handoff repair path for `PATCH /api/issues/:id` when an issue is already `in_review`, has a pending execution state, and `executionState.currentParticipant` names the typed reviewer.
- Requires `tasks:assign` authority before the repair path can bypass the peer-agent mutation guard.
- Restricts repair payloads to assignment/status/comment fields and requires the requested assignee to exactly match the typed reviewer.
- Blocks agent attempts to reassign human-owned review issues, preserving board-only ownership rules.
- Added route regression coverage for Ops repair of stale agent-owned review routing and for rejection of human-owned takeover attempts.
- Strengthened execution-policy handoff coverage so explicit typed reviewer transitions must clear stale implementer assignment.
- Fixed a UI test mock type that caused `pnpm build` to fail on current `master` while validating this PR.

## Verification

- `pnpm vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts ui/src/components/AgentActionButtons.test.tsx` passed: 3 files, 52 tests. The UI tests still emit existing React `act(...)` warnings.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/ui typecheck` passed.
- `pnpm build` passed. Existing warnings remain for `::highlight(...)` CSS pseudo-elements, a dynamic import chunk warning in `MarkdownEditor.tsx`, and large chunks.

## Risks

- Behavioral risk is bounded to already-`in_review` issues whose execution state names a concrete current participant; arbitrary reassignment remains blocked by the existing mutation guard.
- Assignment-authorized Ops agents gain a repair route for stale typed review ownership, but only to the recorded reviewer and only with a constrained patch shape.
- Human-owned and board-owned issues are explicitly protected from agent takeover.
- No database migration or API shape change is required; documentation was not changed because clients continue using the existing PATCH API.

ROADMAP.md checked: this sits inside planned Agent Reviews and Approvals work and is a small repair to that workflow, not a new roadmap surface. Related GitHub issues/PRs were searched for `review handoff in_review assignee` and linked above.

## Model Used

OpenAI Codex, GPT-5 coding model, tool-enabled local development session with shell, git, focused test execution, and medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI behavior change)
- [x] I have updated relevant documentation to reflect my changes (N/A: existing PATCH API shape is unchanged)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
