### PR TITLE
feat(opencode-local): add --thinking flag to emit reasoning events

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -549,7 +549,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     const buildArgs = (resumeSessionId: string | null) => {
-      const args = ["run", "--format", "json"];
+      const args = ["run", "--format", "json", "--thinking"];
       if (resumeSessionId) args.push("--session", resumeSessionId);
       if (model) args.push("--model", model);
       if (variant) args.push("--variant", variant);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents
> - The opencode_local adapter runs `opencode run --format json` and streams the JSON events to the dashboard
> - Without `--thinking`, opencode suppresses `reasoning` events from stdout in non-interactive mode
> - The dashboard was showing only tool calls and step summaries — no assistant reasoning appeared in transcripts
> - This made the opencode_local adapter feel much less transparent than the claude_local adapter, which streams thinking blocks natively
> - This pull request adds `--thinking` to the CLI args so reasoning events are emitted
> - The UI parser already handles `type: "reasoning"` → `<thinking />` transcript entries, so no UI changes needed
> - The benefit is parity: opencode_local agents now show their reasoning in the dashboard

## Linked Issues

No existing issue — this was found during local testing after migrating agents from claude_local to opencode_local. The gap was that reasoning output was silently suppressed.

## What Changed

- Added `--thinking` flag to the CLI args built by `buildArgs()` in `execute.ts`

## Verification

1. Start Paperclip server with the rebuilt adapter
2. Dispatch an agent using the opencode_local adapter
3. Open the run transcript on the dashboard
4. Confirm reasoning blocks appear alongside tool calls in the "nice" and "raw" views
5. Toggle to "raw" and verify `type: "reasoning"` entries are present with their text content

## Risks

Low risk. `--thinking` only controls whether OpenCode emits existing reasoning tokens to stdout — it does not change model behavior, token consumption, or billing. The LLM generates the same reasoning internally either way.

## Model Used

deepseek-v4-flash:cloud — reasoning during implementation. No generative model used for code changes (the change is 1 line plus this PR body).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge