### PR TITLE
fix(recovery): wake current assignee instead of manager on stranded-issue recovery

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2239,6 +2239,63 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  // Regression test for FIX-89:
+  // The stranded-issue recovery owner used to be resolved via assignee.reportsTo
+  // first, which created an infinite reassign loop when the assignee's manager
+  // was also the issue creator (the creator agent would receive the recovery
+  // wake and reassign back to the original assignee, repeating forever).
+  // Recovery should now target the current assignee directly; the manager /
+  // creator chain remains as fallback for the cases below.
+  it("targets the current assignee for stranded recovery even when the assignee's manager is the issue creator", async () => {
+    const { companyId, agentId: assigneeAgentId, runId, issueId } =
+      await seedStrandedIssueFixture({
+        status: "todo",
+        runStatus: "failed",
+        retryReason: "assignment_recovery",
+        runErrorCode: "process_lost",
+      });
+
+    const ceoAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: ceoAgentId,
+      companyId,
+      name: "CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db
+      .update(agents)
+      .set({ reportsTo: ceoAgentId })
+      .where(eq(agents.id, assigneeAgentId));
+    await db
+      .update(issues)
+      .set({ createdByAgentId: ceoAgentId })
+      .where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    // expectSourceScopedStrandedRecoveryAction asserts ownerAgentId, previousOwnerAgentId,
+    // and returnOwnerAgentId all equal the agentId argument. The fix means all three
+    // converge on the assignee — not on the assignee's manager.
+    const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId: assigneeAgentId,
+      issueId,
+      runId,
+      previousStatus: "todo",
+      retryReason: "assignment_recovery",
+    });
+    expect(recoveryAction.ownerAgentId).not.toBe(ceoAgentId);
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1845,6 +1845,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function resolveStrandedIssueRecoveryOwnerAgentId(issue: typeof issues.$inferSelect) {
     const candidateIds: string[] = [];
+    if (issue.assigneeAgentId) candidateIds.push(issue.assigneeAgentId);
     if (issue.assigneeAgentId) {
       const assignee = await getAgent(issue.assigneeAgentId);
       if (assignee?.reportsTo) candidateIds.push(assignee.reportsTo);
@@ -1861,7 +1862,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .where(and(eq(agents.companyId, issue.companyId), inArray(agents.role, ["cto", "ceo"])))
       .orderBy(sql`case when ${agents.role} = 'cto' then 0 else 1 end`, asc(agents.createdAt));
     candidateIds.push(...roleCandidates.map((agent) => agent.id));
-    if (issue.assigneeAgentId) candidateIds.push(issue.assigneeAgentId);
 
     const seen = new Set<string>();
     for (const agentId of candidateIds) {


### PR DESCRIPTION
## Problem

`resolveStrandedIssueRecoveryOwnerAgentId` in `server/src/services/recovery/service.ts` chose the recovery owner from this candidate list, in order:

1. `assignee.reportsTo` (assignee's manager)
2. `creator.reportsTo`
3. `createdByAgentId` (creator)
4. company CTO
5. company CEO
6. `assigneeAgentId` (assignee — last-resort fallback at line 1864)

When the assignee's manager was also the issue creator — common when execs delegate work to direct reports — candidate #1 (the manager/creator) won. The wake landed on the manager, who reassigned the issue back to the original assignee, the work stranded again, the manager got woken again, and so on. Reproduced on a real company with assignee=CMO, creator=CEO, CMO.reportsTo=CEO: ~8 reassign-and-restrand cycles in 24h.

## Fix

Move `assigneeAgentId` to the head of the candidate list. The existing dedup `Set` + `isAgentInvokable` + budget-block checks preserve the full manager → creator → CTO/CEO fallback chain for the cases where the assignee is paused, budget-blocked, or otherwise non-invokable.

Two-edit diff: insert at the start of `candidateIds`, delete from the end.

## Behavioral implications

After this PR, the recovery owner converges with the existing `previousOwnerAgentId` and `returnOwnerAgentId` fields on `issue_recovery_actions` (which already record the assignee). The three fields now agree in the common case, which is the more sensible invariant — the "return target" the system already tracks IS the agent who should resume.

`reconcileUnassignedBlockingIssues` (the other place that falls back to creator) is unchanged and remains correct — it's explicitly gated to issues with no assignee (`isNull(assigneeAgentId) AND isNull(assigneeUserId)`).

## Test

Added a regression test in `heartbeat-process-recovery.test.ts`:
- Multi-agent fixture where `assignee.reportsTo == createdByAgentId`
- Triggers escalation via `reconcileStrandedAssignedIssues()`
- Asserts the source-scoped recovery action's `ownerAgentId` equals the assignee, not the manager

Existing `expectSourceScopedStrandedRecoveryAction` already validates `ownerAgentId`, `previousOwnerAgentId`, `returnOwnerAgentId`, the agent wake target, and the recovery run's context — all converge on the assignee with this change.

## Note on pre-existing failure

`"queues exactly one retry when the recorded local pid is dead"` (line 968) fails locally on master both with and without this change — same assertion (`expect(issue?.checkoutRunId).toBe(runId)`). Independent of this PR; flagging in case it's already known.