### PR TITLE
fix(auth): return 401 for unauthenticated writes in local_trusted mode

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -96,6 +96,22 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         }
       }
       if (runIdHeader) req.actor.runId = runIdHeader;
+      // In local_trusted mode, reject write requests that carry no Authorization
+      // header and no browser-style Origin/Referer. This prevents API clients
+      // (agents, curl, scripts) that accidentally omit their Authorization header
+      // from having mutations silently attributed to the local-board user instead
+      // of receiving a clear 401. Browser-originated writes from the board UI
+      // carry an Origin header and are unaffected.
+      if (
+        opts.deploymentMode === "local_trusted" &&
+        req.actor.source === "local_implicit" &&
+        (req.method === "POST" || req.method === "PATCH" || req.method === "PUT" || req.method === "DELETE") &&
+        !req.header("origin") &&
+        !req.header("referer")
+      ) {
+        _res.status(401).json({ error: "Unauthorized", message: "Write requests require an Authorization header." });
+        return;
+      }
       next();
       return;
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane for zero-human AI companies, managing agents and their work through a board and API
> - The `actorMiddleware` in `server/src/middleware/auth.ts` sets a default actor for every request; in `local_trusted` mode the default is the `local-board` user
> - When an API client sends a write request with no `Authorization` header, the middleware falls through without resolving any real identity and calls `next()` with `local-board` as the actor
> - This caused real incidents: agent heartbeats that accidentally omitted their Authorization header had their comments and updates attributed to the board user instead of the agent, breaking audit trails and making the board's history unreliable
> - Write operations (POST/PATCH/PUT/DELETE) with no `Authorization` header and no browser `Origin`/`Referer` should receive a 401 so the error surfaces immediately rather than silently poisoning attribution
> - The check targets API-style calls (no Origin/Referer); browser-originated writes from the board UI carry an `Origin: http://127.0.0.1:3100` header and are unaffected

## Linked Issues or Issue Description

**Bug: silent local-board attribution for unauthenticated write requests**

- **What happened:** In `local_trusted` deployment mode, POST/PATCH/PUT/DELETE requests with no `Authorization` header and no browser `Origin`/`Referer` were accepted and attributed to `local-board` (the board user) instead of returning a 401.
- **Expected behaviour:** The request fails with `401 Unauthorized` so the caller (typically an agent that forgot its header) knows immediately.
- **Steps to reproduce:**
  ```bash
  # No Authorization header
  curl -s -X POST "http://127.0.0.1:3100/api/issues/$ISSUE_ID/comments"     -H "Content-Type: application/json"     -d '{"body": "Test"}'
  # Before: 200 OK, authorUserId=local-board
  # After:  401 Unauthorized
  ```
- **Paperclip version:** 2026.428.0 (local_trusted mode)
- **Observed impact:** Agent comments appearing under the board user's name; three comments misattributed in a real session

## What Changed

- `server/src/middleware/auth.ts`: Added a guard in the no-bearer-token branch that returns `401 { error: "Unauthorized" }` when all of the following are true:
  - `deploymentMode === "local_trusted"`
  - `req.actor.source === "local_implicit"` (no auth was resolved)
  - HTTP method is POST, PATCH, PUT, or DELETE
  - No `origin` header (not a browser request)
  - No `referer` header (not a browser request)

## Verification

```bash
# 1. Unauthenticated API write — should now be 401
curl -s -w " HTTP:%{http_code}" -X POST "http://127.0.0.1:3100/api/issues/x/comments"   -H "Content-Type: application/json" -d '{"body":"test"}'
# → {"error":"Unauthorized",...} HTTP:401

# 2. GET — still works without auth
curl -s -w " HTTP:%{http_code}" "http://127.0.0.1:3100/api/health"
# → {...} HTTP:200

# 3. Browser-style write with Origin — not blocked (board UI unaffected)
curl -s -o /dev/null -w "HTTP:%{http_code}" -X POST "http://127.0.0.1:3100/api/issues/x/comments"   -H "Content-Type: application/json" -H "Origin: http://127.0.0.1:3100" -d '{"body":"test"}'
# → HTTP:404 (auth passed, issue not found — correct)

# 4. Authenticated agent write — still works with valid token
curl -s -o /dev/null -w "HTTP:%{http_code}" -X POST "http://127.0.0.1:3100/api/issues/x/comments"   -H "Content-Type: application/json" -H "Authorization: Bearer <valid-agent-key>" -d '{"body":"test"}'
# → HTTP:404 (auth passed, issue not found — correct)
```

All four cases verified locally on the patched server (version 2026.428.0, local_trusted mode).

## Risks

- **Board UI mutations:** Browser writes carry an `Origin` header, so they are unaffected. Only pure API calls (curl, agent SDKs) without any browser headers hit the new guard.
- **Scripts relying on unauthenticated writes:** Any script that currently relies on the silent local-board fallback will now receive a 401. This is the intended outcome — those scripts were creating mis-attributed data.
- **Reverse proxies that strip Origin:** If a proxy strips the `Origin` header from browser requests, the board UI would start receiving 401s on writes. This is an edge case unlikely to occur in the intended single-user local-trusted setup.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200K tokens
- Capabilities: tool use, multi-step reasoning, code generation and review
- Mode: agentic (Claude Code / Paperclip Brokk agent)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (manual verification — no unit test added; existing test suite has no middleware auth unit tests)
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge