### PR TITLE
fix(recovery): guard stale-run watchdog against TOCTOU false positives

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -574,6 +574,45 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(noisyResult).toMatchObject({ scanned: 0, created: 0 });
   });
 
+  it("suppresses runs that reached a terminal state between the scan snapshot and evaluation", async () => {
+    // TOCTOU guard regression: the candidate query filters on `status = 'running'` only,
+    // so a run whose finalizer already stamped `finished_at` (status write lagging) is
+    // still snapshotted as a stale candidate. The identical seed without `finished_at`
+    // produces `created: 1` (see "creates one medium-priority evaluation issue ..."), so
+    // this asserts the live re-read — not the candidate filter — suppresses the false flag.
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    // Run reaches terminal mid-scan: finished_at stamped while status still reads 'running'.
+    await db
+      .update(heartbeatRuns)
+      .set({ finishedAt: now })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ scanned: 1, created: 0, skipped: 1 });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+
+    const [suppression] = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_suppressed_terminal"),
+        ),
+      );
+    expect(suppression?.entityId).toBe(runId);
+  });
+
   it("records watchdog decisions through recovery owner authorization", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, managerId, runId } = await seedRunningRun({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1451,6 +1451,50 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     run: typeof heartbeatRuns.$inferSelect;
     now: Date;
   }) {
+    // Stale-run watchdog TOCTOU guard.
+    // scanSilentActiveRuns() snapshots runs that are `status = 'running'` at query time
+    // and then processes them sequentially. A run can reach a terminal state
+    // (succeeded/failed/cancelled, or `finished_at` stamped while the status write lags)
+    // between the snapshot and this evaluation. The create path below trusts the stale
+    // snapshot (`input.run`) and would file a false "Review silent active run" issue.
+    // Re-read the live row and suppress the evaluation when the run is no longer live.
+    // The read path (`buildRunOutputSilence`) already gates on `status === 'running'`;
+    // this brings the create path in line. Defensive: never let the guard throw out of
+    // the scan loop.
+    try {
+      const [liveRun] = await db
+        .select({ status: heartbeatRuns.status, finishedAt: heartbeatRuns.finishedAt })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.companyId, input.run.companyId)))
+        .limit(1);
+      if (!liveRun || liveRun.status !== "running" || liveRun.finishedAt != null) {
+        try {
+          await logActivity(db, {
+            companyId: input.run.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: input.run.agentId,
+            runId: input.run.id,
+            action: "heartbeat.output_stale_suppressed_terminal",
+            entityType: "heartbeat_run",
+            entityId: input.run.id,
+            details: {
+              source: "recovery.scan_silent_active_runs",
+              liveStatus: liveRun?.status ?? "missing",
+              finishedAt: liveRun?.finishedAt?.toISOString() ?? null,
+            },
+          });
+        } catch {
+          // best-effort audit log; never block suppression on it
+        }
+        return { kind: "skipped" as const };
+      }
+    } catch (guardError) {
+      logger.warn(
+        { err: guardError, runId: input.run.id },
+        "stale-run terminal guard failed; proceeding with stock evaluation",
+      );
+    }
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);


### PR DESCRIPTION
## Problem

`scanSilentActiveRuns()` snapshots runs with `status='running'` and processes them **sequentially**. A run can reach a terminal state (`succeeded`/`failed`/`cancelled`, or `finished_at` stamped while the status write lags) **between the snapshot and the evaluation call**. The create path trusted the stale snapshot and filed false _"Review silent active run"_ issues.

On a production instance this produced ~38% false-positive flags (141/372 evaluations) against runs that had already succeeded cleanly.

The read path (`buildRunOutputSilence`) already gates on `status === 'running'`; the create path did not.

## Fix

At the top of `createOrUpdateStaleRunEvaluation()`, re-read the live `heartbeat_runs` row and return `{kind:'skipped'}` when the run is no longer live (`status !== 'running'` **or** `finishedAt != null`). The guard is:

- **Defensive** — wrapped in `try/catch`; a DB error falls through to stock behavior.
- **Audited** — suppressed evaluations emit a `heartbeat.output_stale_suppressed_terminal` activity-log entry.
- **Minimal** — one extra point read per stale candidate (typically ≤100 rows per scan cycle).

## Regression test

Added to `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`:

> _"suppresses runs that reached a terminal state between the scan snapshot and evaluation"_

Seeds a run with `finished_at` already stamped (simulating the TOCTOU window) while `status` still reads `'running'` (so the candidate query still picks it up). Asserts `{scanned:1, created:0, skipped:1}` and a suppression activity-log entry. The identical seed **without** `finished_at` produces `created:1`, confirming the guard — not the candidate filter — is what suppresses the false flag.

All 14 watchdog tests pass locally (embedded Postgres, `pnpm exec vitest run`).

## Related

Derived from hotfix applied to a production Paperclip instance (board approval `4be2e89f`). Root-cause writeup available in the instance ledger.