### PR TITLE
claude_local に Recovery fallback agent 設定項目を追加

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -498,6 +498,12 @@ export interface CreateConfigValues {
   runtimeServicesJson?: string;
   defaultEnvironmentId?: string;
   maxTurnsPerRun: number;
+  /**
+   * Optional codex recovery fallback agent id. When set, recovery ownership for
+   * transient-upstream failures fails over to this agent instead of the legacy
+   * manager/creator/executive selection. Empty/unset preserves legacy behavior.
+   */
+  recoveryFallbackAgentId?: string;
   heartbeatEnabled: boolean;
   intervalSec: number;
   /** Arbitrary key-value pairs populated by schema-driven config fields. */

--- a/packages/adapters/claude-local/src/ui/build-config.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.ts
@@ -95,5 +95,8 @@ export function buildClaudeLocalConfig(v: CreateConfigValues): Record<string, un
   }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  if (v.recoveryFallbackAgentId && v.recoveryFallbackAgentId.trim()) {
+    ac.recoveryFallbackAgentId = v.recoveryFallbackAgentId.trim();
+  }
   return ac;
 }

--- a/ui/src/adapters/claude-local/config-fields.test.tsx
+++ b/ui/src/adapters/claude-local/config-fields.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClaudeLocalAdvancedFields } from "./config-fields";
+import type { AdapterConfigFieldsProps, AdapterFieldAgentOption } from "../types";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const AGENTS: AdapterFieldAgentOption[] = [
+  { id: "codex-1", name: "Codex One", adapterType: "codex_local", status: "active" },
+  { id: "codex-2", name: "Codex Two", adapterType: "codex_local", status: "active" },
+  // self-reference: codex but must be excluded as a candidate
+  { id: "self-claude", name: "Self Agent", adapterType: "codex_local", status: "active" },
+  // non-codex: must be excluded
+  { id: "claude-x", name: "Claude X", adapterType: "claude_local", status: "active" },
+  // terminated codex: must be excluded
+  { id: "codex-dead", name: "Dead Codex", adapterType: "codex_local", status: "terminated" },
+];
+
+function editProps(
+  overrides: Partial<AdapterConfigFieldsProps> = {},
+): AdapterConfigFieldsProps {
+  return {
+    mode: "edit",
+    isCreate: false,
+    adapterType: "claude_local",
+    values: null,
+    set: null,
+    config: {},
+    eff: (<T,>(_group: "adapterConfig", _field: string, original: T) => original) as AdapterConfigFieldsProps["eff"],
+    mark: vi.fn(),
+    models: [],
+    agents: AGENTS,
+    selfAgentId: "self-claude",
+    ...overrides,
+  };
+}
+
+describe("ClaudeLocalAdvancedFields recovery fallback agent", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: AdapterConfigFieldsProps) {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <ClaudeLocalAdvancedFields {...props} />
+        </TooltipProvider>,
+      );
+    });
+  }
+
+  function optionLabels(): string[] {
+    return Array.from(container.querySelectorAll("option")).map(
+      (o) => o.textContent ?? "",
+    );
+  }
+
+  it("lists only same-company codex candidates, excluding self, non-codex and terminated", () => {
+    render(editProps());
+    const labels = optionLabels();
+    expect(labels).toContain("Unset (default recovery owner)");
+    expect(labels).toContain("Codex One");
+    expect(labels).toContain("Codex Two");
+    expect(labels).not.toContain("Self Agent");
+    expect(labels).not.toContain("Claude X");
+    expect(labels).not.toContain("Dead Codex");
+  });
+
+  it("commits the selected agent id via mark", () => {
+    const mark = vi.fn();
+    render(editProps({ mark }));
+    const select = container.querySelector("select")!;
+    act(() => {
+      select.value = "codex-2";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "recoveryFallbackAgentId", "codex-2");
+  });
+
+  it("clearing the selection stores undefined (legacy behavior)", () => {
+    const mark = vi.fn();
+    render(editProps({ mark, config: { recoveryFallbackAgentId: "codex-1" } }));
+    const select = container.querySelector("select")!;
+    act(() => {
+      select.value = "";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "recoveryFallbackAgentId", undefined);
+  });
+
+  it("warns when a stored fallback points at the agent itself", () => {
+    render(editProps({ config: { recoveryFallbackAgentId: "self-claude" } }));
+    expect(container.textContent).toContain("cannot be its own recovery fallback");
+  });
+
+  it("warns when a stored fallback is non-codex", () => {
+    render(editProps({ config: { recoveryFallbackAgentId: "claude-x" } }));
+    expect(container.textContent).toContain("must be a codex agent");
+  });
+});

--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -15,6 +15,14 @@ const inputClass =
 const instructionsFileHint =
   "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime.";
 
+const recoveryFallbackHint =
+  "Optional. When a run of this agent fails on a transient upstream (usage / rate-limit) condition, recovery is handed to the selected codex agent instead of the default manager/creator/executive owner. Candidates are codex agents in the same company. Leave unset to keep the default recovery behavior.";
+
+// Mirrors the failover target in server/src/services/recovery/adapter-failover.ts
+// (FAILOVER_FALLBACK_ADAPTER_TYPE). Recovery failover routes to codex agents, so
+// the picker only offers — and validates against — this adapter type.
+const FAILOVER_FALLBACK_ADAPTER_TYPE = "codex_local";
+
 export function ClaudeLocalConfigFields({
   mode,
   isCreate,
@@ -77,7 +85,53 @@ export function ClaudeLocalAdvancedFields({
   config,
   eff,
   mark,
+  agents,
+  selfAgentId,
 }: AdapterConfigFieldsProps) {
+  const agentList = agents ?? [];
+  const candidates = agentList.filter(
+    (a) =>
+      a.adapterType === FAILOVER_FALLBACK_ADAPTER_TYPE &&
+      a.id !== selfAgentId &&
+      a.status !== "terminated",
+  );
+  const recoveryFallbackValue = isCreate
+    ? values!.recoveryFallbackAgentId ?? ""
+    : eff(
+        "adapterConfig",
+        "recoveryFallbackAgentId",
+        String(config.recoveryFallbackAgentId ?? ""),
+      );
+  const commitRecoveryFallback = (next: string) =>
+    isCreate
+      ? set!({ recoveryFallbackAgentId: next || undefined })
+      : mark("adapterConfig", "recoveryFallbackAgentId", next || undefined);
+
+  // Surface stored values the backend recovery guard would not honor. New
+  // selections are always valid because the dropdown only offers codex,
+  // non-self, non-terminated candidates — these checks only fire on a
+  // previously-saved value that has since become invalid.
+  const selectedAgent = agentList.find((a) => a.id === recoveryFallbackValue);
+  let recoveryFallbackWarning: string | null = null;
+  if (recoveryFallbackValue) {
+    if (recoveryFallbackValue === selfAgentId) {
+      recoveryFallbackWarning =
+        "An agent cannot be its own recovery fallback. Pick a different codex agent.";
+    } else if (!selectedAgent) {
+      recoveryFallbackWarning =
+        "The configured fallback agent no longer exists; recovery will fall back to the default owner.";
+    } else if (selectedAgent.adapterType !== FAILOVER_FALLBACK_ADAPTER_TYPE) {
+      recoveryFallbackWarning =
+        "Recovery fallback must be a codex agent; this selection will be ignored by recovery.";
+    } else if (selectedAgent.status === "terminated") {
+      recoveryFallbackWarning =
+        "The configured fallback agent is terminated and will be ignored by recovery.";
+    }
+  }
+  const showStaleFallbackOption =
+    Boolean(recoveryFallbackValue) &&
+    !candidates.some((a) => a.id === recoveryFallbackValue);
+
   return (
     <>
       <ToggleField
@@ -132,6 +186,38 @@ export function ClaudeLocalAdvancedFields({
             className={inputClass}
           />
         )}
+      </Field>
+      <Field label="Recovery fallback agent" hint={recoveryFallbackHint}>
+        <select
+          value={recoveryFallbackValue}
+          onChange={(e) => commitRecoveryFallback(e.target.value)}
+          className={inputClass}
+        >
+          <option value="">Unset (default recovery owner)</option>
+          {candidates.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+          {showStaleFallbackOption && (
+            <option value={recoveryFallbackValue}>
+              {selectedAgent
+                ? `${selectedAgent.name} (invalid selection)`
+                : `${recoveryFallbackValue} (unknown agent)`}
+            </option>
+          )}
+        </select>
+        {recoveryFallbackWarning ? (
+          <p className="mt-1 text-xs text-amber-400">{recoveryFallbackWarning}</p>
+        ) : candidates.length === 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            No codex agents are available in this company yet.
+          </p>
+        ) : recoveryFallbackValue && selectedAgent ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Current: {selectedAgent.name}
+          </p>
+        ) : null}
       </Field>
     </>
   );

--- a/ui/src/adapters/types.ts
+++ b/ui/src/adapters/types.ts
@@ -16,6 +16,14 @@ export interface TranscriptParserSource {
   createStdoutParser?: StdoutParserFactory;
 }
 
+/** Minimal agent shape consumed by adapter-config dropdowns (e.g. recovery fallback). */
+export interface AdapterFieldAgentOption {
+  id: string;
+  name: string;
+  adapterType: string | null;
+  status?: string;
+}
+
 export interface AdapterConfigFieldsProps {
   mode: "create" | "edit";
   isCreate: boolean;
@@ -32,6 +40,10 @@ export interface AdapterConfigFieldsProps {
   mark: (group: "adapterConfig", field: string, value: unknown) => void;
   /** Available models for dropdowns */
   models: { id: string; label: string }[];
+  /** Same-company agents available for adapter-config dropdowns (e.g. recovery fallback). */
+  agents?: AdapterFieldAgentOption[];
+  /** Id of the agent being edited; used to exclude self-references in pickers. Undefined in create mode. */
+  selfAgentId?: string;
   /** When true, hides the instructions file path field (e.g. during import where it's set automatically) */
   hideInstructionsFile?: boolean;
 }

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -401,7 +401,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const { data: companyAgents = [] } = useQuery({
     queryKey: selectedCompanyId ? queryKeys.agents.list(selectedCompanyId) : ["agents", "none", "list"],
     queryFn: () => agentsApi.list(selectedCompanyId!),
-    enabled: Boolean(!isCreate && selectedCompanyId),
+    // Needed in both edit (reportsTo, recovery fallback) and create (recovery
+    // fallback dropdown on the hire form) modes whenever a company is selected.
+    enabled: Boolean(selectedCompanyId),
   });
 
   /** Props passed to adapter-specific config field components */
@@ -415,6 +417,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     eff: eff as <T>(group: "adapterConfig", field: string, original: T) => T,
     mark: mark as (group: "adapterConfig", field: string, value: unknown) => void,
     models,
+    agents: companyAgents,
+    selfAgentId: isCreate ? undefined : props.agent.id,
     hideInstructionsFile,
   };
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery subsystem decides who takes over a stranded run; `server/src/services/recovery/adapter-failover.ts` can hand a transient-upstream (usage / rate-limit) failure to a configured codex fallback agent instead of the default manager/creator/executive owner
> - That backend mechanism already reads `agents.adapter_config.recoveryFallbackAgentId`, but there was no UI to view or set it, so the capability was effectively unreachable for operators
> - Operators need to configure this without hand-editing adapter config JSON, and need to be steered away from values the backend would reject (self-reference, non-codex)
> - This pull request adds a "Recovery fallback agent" dropdown to the claude_local Advanced settings that lists same-company codex agents and persists the selection as `adapterConfig.recoveryFallbackAgentId`
> - The benefit is that recovery failover is now configurable from the agent config UI on both the hire form and existing-agent edit, with validation that mirrors the backend guard's intent

## Linked Issues or Issue Description

No public GitHub issue. Problem addressed (feature):

- **What**: The recovery failover mechanism (transient-upstream failures handing off to a configured codex agent) had no UI surface. The value `adapterConfig.recoveryFallbackAgentId` could only be set by editing raw config.
- **Why**: Make the existing backend capability usable from the agent configuration UI, with guard-aligned validation so operators cannot pick values the backend would silently ignore.

## What Changed

- `ui/src/adapters/claude-local/config-fields.tsx`: added a "Recovery fallback agent" field to `ClaudeLocalAdvancedFields`. It shows the current value and offers a dropdown of same-company codex agents (`adapterType === "codex_local"`), excluding the agent itself and terminated agents. Empty = unset = legacy behavior. A stored value the backend would not honor (self, non-codex, missing, terminated) is still displayed and flagged with an inline warning.
- `ui/src/components/AgentConfigForm.tsx`: pass the company agent list and the edited agent's id (`selfAgentId`) into the adapter field props, and enable the company-agents query in create mode too so the dropdown is populated on the hire form.
- `ui/src/adapters/types.ts`: extended `AdapterConfigFieldsProps` with optional `agents` and `selfAgentId`, plus a minimal `AdapterFieldAgentOption` shape.
- `packages/adapter-utils/src/types.ts`: added optional `recoveryFallbackAgentId` to `CreateConfigValues` (hire path).
- `packages/adapters/claude-local/src/ui/build-config.ts`: write `recoveryFallbackAgentId` into the built adapter config when set (hire payload).
- `ui/src/adapters/claude-local/config-fields.test.tsx`: new display test covering candidate filtering (self / non-codex / terminated exclusion), commit-on-select, clear-to-unset, and the self/non-codex stored-value warnings.

### Backend guard alignment note

`decideRecoveryFailover` in `adapter-failover.ts` rejects self-reference (`self_failover`), loop-guards a stranded run already on `codex_local`, and requires the fallback agent to exist and be invokable. It does **not** itself re-validate that the fallback agent's `adapterType` is codex — the codex constraint lives in the design constant `FAILOVER_FALLBACK_ADAPTER_TYPE = "codex_local"` (the documented failover target). This UI enforces the same intent at configuration time by only offering codex, non-self, non-terminated candidates, and by flagging any previously-stored value that no longer satisfies those conditions. So self-reference rejection matches the backend's `self_failover`; the "non-codex" rejection is enforced at the UI/config seam, consistent with the design that failover routes to codex.

## Verification

- `cd ui && npx vitest run src/adapters/claude-local/config-fields.test.tsx` → 5 passed
- `cd packages/adapters/claude-local && npx vitest run` → 14 passed
- `cd server && npx vitest run src/services/recovery` → 17 passed (existing recovery tests green)
- `pnpm typecheck`: no new errors from this change. There is one pre-existing, unrelated `ui` error in `src/components/AgentActionButtons.test.tsx` (react-query `MockInstance` variance) that also reproduces on a clean base with these changes stashed; it is not introduced here.
- Manual: in the agent config UI (Advanced section of a claude_local agent), the "Recovery fallback agent" dropdown lists same-company codex agents; selecting one and saving persists `adapterConfig.recoveryFallbackAgentId`; clearing it removes the value.

## Risks

Low risk. The field is additive and optional; unset preserves the existing recovery behavior exactly. The only behavioral change beyond the new field is broadening the company-agents query to also run in create mode (one extra read used to populate the dropdown). No server, schema, or migration changes.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`, 1M context), extended thinking, with tool use / code execution in Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
