### PR TITLE
fix(ui): type invalidateQueries spy to restore tsc -b build (VANA-484)

### DIFF
--- a/ui/src/components/AgentActionButtons.test.tsx
+++ b/ui/src/components/AgentActionButtons.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Agent } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 import { AgentActionButtons } from "./AgentActionButtons";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
@@ -94,7 +95,7 @@ describe("AgentActionButtons", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot> | null;
   let queryClient: QueryClient;
-  let invalidateQueries: ReturnType<typeof vi.spyOn>;
+  let invalidateQueries: MockInstance<QueryClient["invalidateQueries"]>;
 
   beforeEach(() => {
     container = document.createElement("div");


### PR DESCRIPTION
## 背景 (VANA-484)
`pnpm --filter @paperclipai/ui build`（= `tsc -b && vite build`）が `tsc -b` 段階で失敗し、UI の標準ビルドが赤。release/deploy が `pnpm build`（= `pnpm -r build`）経由だと ui の dist が再生成されず、stale バンドル配信のリスク（VANA-455 で 5/28 ビルドが実際に配信された）。

## エラー
```
src/components/AgentActionButtons.test.tsx(106,5): error TS2322:
  MockInstance<...invalidateQueries...> is not assignable to
  MockInstance<(this: unknown, ...args: unknown[]) => unknown>
```
`invalidateQueries` 変数を broad な `ReturnType<typeof vi.spyOn>`（default の procedure シグネチャ）で型付けしていたため、vitest 4 でジェネリックな `invalidateQueries` シグネチャが代入不可。本件 recoveryFallback 機能とは無関係の既存破損。

## 修正
spy を実メソッドのシグネチャに合わせて型付け：
```ts
import type { MockInstance } from "vitest";
let invalidateQueries: MockInstance<QueryClient["invalidateQueries"]>;
```
mock の振る舞い・テストのアサーション意図は不変（型付けのみ）。

## 検証
- `pnpm --filter @paperclipai/ui build` → green（`tsc -b` 成功 + `vite build` 完了）
- `vitest run AgentActionButtons.test.tsx` → 3 passed

## CI / 再発防止 (受け入れ条件#3)
CI の `build` job (`.github/workflows/pr.yml`) は `pnpm build` = `pnpm -r build` を実行し、これは ui の `tsc -b && vite build` を含む。`build` は `summary` gate (pr.yml:177) の needs に入っており merge を block する。つまり stale dist 再発の CI ガードは既に存在しており、本 PR でそれを green に戻すことで再有効化される（CI 追加変更は不要）。

worker 直マージ不可（core/UI 変更）。CEO レビューへ。