### PR TITLE
fix: company import is unreachable — prefix-less Settings links + headless auth-login crash

### DIFF
--- a/cli/src/client/board-auth.ts
+++ b/cli/src/client/board-auth.ts
@@ -169,25 +169,26 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export function openUrl(url: string): boolean {
-  const platform = process.platform;
+function spawnDetached(command: string, args: string[]): boolean {
   try {
-    if (platform === "darwin") {
-      const child = spawn("open", [url], { detached: true, stdio: "ignore" });
-      child.unref();
-      return true;
-    }
-    if (platform === "win32") {
-      const child = spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" });
-      child.unref();
-      return true;
-    }
-    const child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    // A missing launcher (e.g. no xdg-open on a headless server) emits an
+    // asynchronous 'error' event rather than throwing. Without a handler that
+    // becomes an unhandled error and crashes the process before the auth poll
+    // loop runs, so swallow it — opening a browser is best-effort.
+    child.on("error", () => {});
     child.unref();
     return true;
   } catch {
     return false;
   }
+}
+
+export function openUrl(url: string): boolean {
+  const platform = process.platform;
+  if (platform === "darwin") return spawnDetached("open", [url]);
+  if (platform === "win32") return spawnDetached("cmd", ["/c", "start", "", url]);
+  return spawnDetached("xdg-open", [url]);
 }
 
 export async function loginBoardCli(params: {

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -10,6 +10,7 @@ import { companiesApi } from "../api/companies";
 import { assetsApi } from "../api/assets";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { queryKeys } from "../lib/queryKeys";
+import { Link } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { Settings, CloudUpload, Download, Upload } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
@@ -373,28 +374,28 @@ export function CompanySettings() {
         <div className="rounded-md border border-border px-4 py-4">
           <p className="text-sm text-muted-foreground">
             Import and export have moved to dedicated pages accessible from the{" "}
-            <a href="/org" className="underline hover:text-foreground">Org Chart</a> header.
+            <Link to="/org" className="underline hover:text-foreground">Org Chart</Link> header.
           </p>
           <div className="mt-3 flex flex-wrap items-center gap-2">
             {cloudSyncEnabled ? (
               <Button size="sm" asChild>
-                <a href="/company/settings/cloud-upstream">
+                <Link to="/company/settings/cloud-upstream">
                   <CloudUpload className="mr-1.5 h-3.5 w-3.5" />
                   Send to Paperclip Cloud
-                </a>
+                </Link>
               </Button>
             ) : null}
             <Button size="sm" variant="outline" asChild>
-              <a href="/company/export">
+              <Link to="/company/export">
                 <Download className="mr-1.5 h-3.5 w-3.5" />
                 Export
-              </a>
+              </Link>
             </Button>
             <Button size="sm" variant="outline" asChild>
-              <a href="/company/import">
+              <Link to="/company/import">
                 <Upload className="mr-1.5 h-3.5 w-3.5" />
                 Import
-              </a>
+              </Link>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Two independent defects make the company-import flow unusable; both sit on the path a self-hoster hits when trying to import a company.

## 1. Company Settings import/export buttons error with "No company matches prefix COMPANY"

The **Import**, **Export**, and **Send to Paperclip Cloud** buttons (and the inline **Org Chart** link) on the Company Settings page are raw `<a href="/company/...">` anchors. Because all board routes are mounted under `:companyPrefix` (`App.tsx`), a hard navigation to the prefix-less `/company/import` makes the router bind `companyPrefix="company"` → `normalizeCompanyPrefix` → `"COMPANY"` → no matching company → the `invalid_company_prefix` error page ("No company matches prefix COMPANY").

**Fix:** use the prefix-aware `Link` from `@/lib/router`, which runs `applyCompanyPrefix(to, activePrefix)` before navigating — the pattern already used by the working buttons in `OrgChart.tsx`. `Link` is `forwardRef`, so it stays compatible with `<Button asChild>`.

- `ui/src/pages/CompanySettings.tsx` — add `import { Link } from "@/lib/router"`; swap 4 `<a href>` → `<Link to>`.

## 2. `paperclipai auth login` crashes on a headless server

`openUrl()` (`cli/src/client/board-auth.ts`) spawns the platform browser-opener (`xdg-open` on Linux) and only catches *synchronous* throws. On a headless box `xdg-open` is absent, so `spawn` emits an asynchronous `error` (ENOENT) event with no listener — Node treats that as unhandled and aborts the process, right after the approval URL is printed but **before** the challenge poll loop. Result: `auth login` can never complete on a server, so the CLI can't obtain board access (every `company`/board command then 403s with "Board access required").

**Fix:** attach a no-op `error` handler to the spawned child (browser-open is best-effort) so a missing launcher is ignored and the poll loop runs. The three platform branches now go through one `spawnDetached` helper.

- `cli/src/client/board-auth.ts` — add `child.on("error", () => {})`.

## Test plan

- Company Settings → **Import** / **Export** / **Send to Paperclip Cloud** now navigate to `/{PREFIX}/company/...` and load; behaviour matches the Org Chart header buttons.
- On a headless host (no `xdg-open`), `paperclipai auth login` prints the approval URL and keeps polling instead of crashing; approving in the browser stores the credential and `auth whoami` succeeds.

> Note: `ui/src/pages/InviteUxLab.tsx` has the same raw-anchor pattern (`/company/settings/members`) — left out as it's a dev/lab page, but worth a follow-up.
