### PR TITLE
Fix local agent runtime API URL selection

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -17,6 +17,18 @@ describe("runtime API discovery", () => {
     ).toBe("https://paperclip.example.com");
   });
 
+  it("can prefer the bind host for loopback-local runtime callbacks", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: "https://paperclipmbp.kingfisher-halibut.ts.net",
+        allowedHostnames: ["paperclipmbp.kingfisher-halibut.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+        preferBindHost: true,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
   it("builds ordered callback candidates from explicit, allowed, bind, and interface hosts", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -91,6 +91,28 @@ function buildTestConfig(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createEmptyDrizzleMock() {
+  const makeEmptyQuery = () => {
+    const rows: unknown[] = [];
+    const promise = Promise.resolve(rows);
+    return {
+      where: vi.fn(() => Promise.resolve(rows)),
+      then: promise.then.bind(promise),
+      catch: promise.catch.bind(promise),
+      finally: promise.finally.bind(promise),
+    };
+  };
+
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => makeEmptyQuery()),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(async () => undefined),
+    })),
+  };
+}
+
 vi.mock("node:http", () => ({
   createServer: vi.fn(() => fakeServer),
 }));
@@ -374,5 +396,26 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+
+  it("uses loopback as the local trusted runtime API URL even with public hostnames configured", async () => {
+    process.env.PAPERCLIP_API_URL = "https://paperclipmbp.kingfisher-halibut.ts.net";
+    createDbMock.mockReturnValueOnce(createEmptyDrizzleMock() as never);
+    loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bind: "loopback",
+      host: "127.0.0.1",
+      allowedHostnames: ["paperclipmbp.kingfisher-halibut.ts.net"],
+      authBaseUrlMode: "explicit",
+      authPublicBaseUrl: "https://paperclipmbp.kingfisher-halibut.ts.net",
+    }));
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("https://paperclipmbp.kingfisher-halibut.ts.net");
+    expect(process.env.PAPERCLIP_API_URL).toBe("https://paperclipmbp.kingfisher-halibut.ts.net");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
+    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")[0]).toBe("http://127.0.0.1:3210");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -665,15 +665,18 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
+  const preferLoopbackRuntimeApiUrl =
+    config.deploymentMode === "local_trusted" && isLoopbackHost(runtimeListenHost);
   const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
+    preferBindHost: preferLoopbackRuntimeApiUrl,
   });
   const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
   const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
-    preferredApiUrl: configuredApiUrl,
+    preferredApiUrl: preferLoopbackRuntimeApiUrl ? runtimeApiUrl : configuredApiUrl,
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -51,7 +51,13 @@ export function choosePrimaryRuntimeApiUrl(input: {
   allowedHostnames: string[];
   bindHost: string;
   port: number;
+  preferBindHost?: boolean;
 }): string {
+  const bindHost = normalizeHost(input.bindHost);
+  if (input.preferBindHost && bindHost && !isWildcardHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const explicitPublicBaseUrl = input.authPublicBaseUrl?.trim();
   if (explicitPublicBaseUrl) {
     try {
@@ -68,7 +74,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Local adapters call back into the Paperclip API through environment variables injected by the server.
> - macOS Tailscale MagicDNS can be unavailable even while the local Paperclip server and Tailscale IP are reachable.
> - When a local-trusted Paperclip instance is bound to loopback but also has a public auth hostname configured, agents should use loopback for runtime callbacks instead of depending on MagicDNS.
> - This pull request keeps the public API URL stable for browser/auth surfaces while preferring the loopback bind host for local runtime callback discovery.
> - The benefit is that local agents keep calling Paperclip reliably on macOS even when the tailnet MagicDNS resolver is not reachable.

## What Changed

- Added a `preferBindHost` option to runtime API URL selection.
- Used that option for `local_trusted` loopback-bound servers so `PAPERCLIP_RUNTIME_API_URL` and runtime candidates prefer `http://127.0.0.1:<port>`.
- Preserved externally configured `PAPERCLIP_API_URL` for public/browser-facing behavior.
- Added regression coverage for local-trusted loopback runtime URLs with a public MagicDNS auth hostname configured.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/runtime-api.test.ts src/__tests__/server-startup-feedback-export.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server build`
- Manual DAT-5812 smoke in a heartbeat shell: `curl -sS -o /tmp/dat5812-current.out -w 'current_url_http=%{http_code} remote_ip=%{remote_ip} err=%{errormsg}\n' "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/heartbeat-context"` returned `current_url_http=200 remote_ip=127.0.0.1 err=`.
- Confirmed the MagicDNS hostname still fails locally with `Could not resolve host: paperclipmbp.kingfisher-halibut.ts.net`, so the fix is Paperclip runtime env URL configuration, not a macOS/Tailscale DNS repair.

## Risks

- Low risk. The change is limited to local-trusted loopback-bound server runtime callback env selection. Public/auth URL behavior remains unchanged, and non-loopback binds still use the existing public-host preference.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via Paperclip `codex_local` (GPT-5-based Codex coding agent; exact backend revision is not surfaced in the runtime), with tool use, shell execution, GitHub API use, and local TypeScript/Vitest verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
