### PR TITLE
feat(ui): Recovery fallback agent field for claude_local (VANA-481) + tsc -b build fix (VANA-484)

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -498,6 +498,12 @@ export interface CreateConfigValues {
   runtimeServicesJson?: string;
   defaultEnvironmentId?: string;
   maxTurnsPerRun: number;
+  /**
+   * Optional codex recovery fallback agent id. When set, recovery ownership for
+   * transient-upstream failures fails over to this agent instead of the legacy
+   * manager/creator/executive selection. Empty/unset preserves legacy behavior.
+   */
+  recoveryFallbackAgentId?: string;
   heartbeatEnabled: boolean;
   intervalSec: number;
   /** Arbitrary key-value pairs populated by schema-driven config fields. */

--- a/packages/adapters/claude-local/src/ui/build-config.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.ts
@@ -95,5 +95,8 @@ export function buildClaudeLocalConfig(v: CreateConfigValues): Record<string, un
   }
   if (v.command) ac.command = v.command;
   if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  if (v.recoveryFallbackAgentId && v.recoveryFallbackAgentId.trim()) {
+    ac.recoveryFallbackAgentId = v.recoveryFallbackAgentId.trim();
+  }
   return ac;
 }

--- a/ui/src/adapters/claude-local/config-fields.test.tsx
+++ b/ui/src/adapters/claude-local/config-fields.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClaudeLocalAdvancedFields } from "./config-fields";
+import type { AdapterConfigFieldsProps, AdapterFieldAgentOption } from "../types";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const AGENTS: AdapterFieldAgentOption[] = [
+  { id: "codex-1", name: "Codex One", adapterType: "codex_local", status: "active" },
+  { id: "codex-2", name: "Codex Two", adapterType: "codex_local", status: "active" },
+  // self-reference: codex but must be excluded as a candidate
+  { id: "self-claude", name: "Self Agent", adapterType: "codex_local", status: "active" },
+  // non-codex: must be excluded
+  { id: "claude-x", name: "Claude X", adapterType: "claude_local", status: "active" },
+  // terminated codex: must be excluded
+  { id: "codex-dead", name: "Dead Codex", adapterType: "codex_local", status: "terminated" },
+];
+
+function editProps(
+  overrides: Partial<AdapterConfigFieldsProps> = {},
+): AdapterConfigFieldsProps {
+  return {
+    mode: "edit",
+    isCreate: false,
+    adapterType: "claude_local",
+    values: null,
+    set: null,
+    config: {},
+    eff: (<T,>(_group: "adapterConfig", _field: string, original: T) => original) as AdapterConfigFieldsProps["eff"],
+    mark: vi.fn(),
+    models: [],
+    agents: AGENTS,
+    selfAgentId: "self-claude",
+    ...overrides,
+  };
+}
+
+describe("ClaudeLocalAdvancedFields recovery fallback agent", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: AdapterConfigFieldsProps) {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <ClaudeLocalAdvancedFields {...props} />
+        </TooltipProvider>,
+      );
+    });
+  }
+
+  function optionLabels(): string[] {
+    return Array.from(container.querySelectorAll("option")).map(
+      (o) => o.textContent ?? "",
+    );
+  }
+
+  it("lists only same-company codex candidates, excluding self, non-codex and terminated", () => {
+    render(editProps());
+    const labels = optionLabels();
+    expect(labels).toContain("Unset (default recovery owner)");
+    expect(labels).toContain("Codex One");
+    expect(labels).toContain("Codex Two");
+    expect(labels).not.toContain("Self Agent");
+    expect(labels).not.toContain("Claude X");
+    expect(labels).not.toContain("Dead Codex");
+  });
+
+  it("commits the selected agent id via mark", () => {
+    const mark = vi.fn();
+    render(editProps({ mark }));
+    const select = container.querySelector("select")!;
+    act(() => {
+      select.value = "codex-2";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "recoveryFallbackAgentId", "codex-2");
+  });
+
+  it("clearing the selection stores undefined (legacy behavior)", () => {
+    const mark = vi.fn();
+    render(editProps({ mark, config: { recoveryFallbackAgentId: "codex-1" } }));
+    const select = container.querySelector("select")!;
+    act(() => {
+      select.value = "";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "recoveryFallbackAgentId", undefined);
+  });
+
+  it("warns when a stored fallback points at the agent itself", () => {
+    render(editProps({ config: { recoveryFallbackAgentId: "self-claude" } }));
+    expect(container.textContent).toContain("cannot be its own recovery fallback");
+  });
+
+  it("warns when a stored fallback is non-codex", () => {
+    render(editProps({ config: { recoveryFallbackAgentId: "claude-x" } }));
+    expect(container.textContent).toContain("must be a codex agent");
+  });
+});

--- a/ui/src/adapters/claude-local/config-fields.tsx
+++ b/ui/src/adapters/claude-local/config-fields.tsx
@@ -15,6 +15,14 @@ const inputClass =
 const instructionsFileHint =
   "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Injected into the system prompt at runtime.";
 
+const recoveryFallbackHint =
+  "Optional. When a run of this agent fails on a transient upstream (usage / rate-limit) condition, recovery is handed to the selected codex agent instead of the default manager/creator/executive owner. Candidates are codex agents in the same company. Leave unset to keep the default recovery behavior.";
+
+// Mirrors the failover target in server/src/services/recovery/adapter-failover.ts
+// (FAILOVER_FALLBACK_ADAPTER_TYPE). Recovery failover routes to codex agents, so
+// the picker only offers — and validates against — this adapter type.
+const FAILOVER_FALLBACK_ADAPTER_TYPE = "codex_local";
+
 export function ClaudeLocalConfigFields({
   mode,
   isCreate,
@@ -77,7 +85,53 @@ export function ClaudeLocalAdvancedFields({
   config,
   eff,
   mark,
+  agents,
+  selfAgentId,
 }: AdapterConfigFieldsProps) {
+  const agentList = agents ?? [];
+  const candidates = agentList.filter(
+    (a) =>
+      a.adapterType === FAILOVER_FALLBACK_ADAPTER_TYPE &&
+      a.id !== selfAgentId &&
+      a.status !== "terminated",
+  );
+  const recoveryFallbackValue = isCreate
+    ? values!.recoveryFallbackAgentId ?? ""
+    : eff(
+        "adapterConfig",
+        "recoveryFallbackAgentId",
+        String(config.recoveryFallbackAgentId ?? ""),
+      );
+  const commitRecoveryFallback = (next: string) =>
+    isCreate
+      ? set!({ recoveryFallbackAgentId: next || undefined })
+      : mark("adapterConfig", "recoveryFallbackAgentId", next || undefined);
+
+  // Surface stored values the backend recovery guard would not honor. New
+  // selections are always valid because the dropdown only offers codex,
+  // non-self, non-terminated candidates — these checks only fire on a
+  // previously-saved value that has since become invalid.
+  const selectedAgent = agentList.find((a) => a.id === recoveryFallbackValue);
+  let recoveryFallbackWarning: string | null = null;
+  if (recoveryFallbackValue) {
+    if (recoveryFallbackValue === selfAgentId) {
+      recoveryFallbackWarning =
+        "An agent cannot be its own recovery fallback. Pick a different codex agent.";
+    } else if (!selectedAgent) {
+      recoveryFallbackWarning =
+        "The configured fallback agent no longer exists; recovery will fall back to the default owner.";
+    } else if (selectedAgent.adapterType !== FAILOVER_FALLBACK_ADAPTER_TYPE) {
+      recoveryFallbackWarning =
+        "Recovery fallback must be a codex agent; this selection will be ignored by recovery.";
+    } else if (selectedAgent.status === "terminated") {
+      recoveryFallbackWarning =
+        "The configured fallback agent is terminated and will be ignored by recovery.";
+    }
+  }
+  const showStaleFallbackOption =
+    Boolean(recoveryFallbackValue) &&
+    !candidates.some((a) => a.id === recoveryFallbackValue);
+
   return (
     <>
       <ToggleField
@@ -132,6 +186,38 @@ export function ClaudeLocalAdvancedFields({
             className={inputClass}
           />
         )}
+      </Field>
+      <Field label="Recovery fallback agent" hint={recoveryFallbackHint}>
+        <select
+          value={recoveryFallbackValue}
+          onChange={(e) => commitRecoveryFallback(e.target.value)}
+          className={inputClass}
+        >
+          <option value="">Unset (default recovery owner)</option>
+          {candidates.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+          {showStaleFallbackOption && (
+            <option value={recoveryFallbackValue}>
+              {selectedAgent
+                ? `${selectedAgent.name} (invalid selection)`
+                : `${recoveryFallbackValue} (unknown agent)`}
+            </option>
+          )}
+        </select>
+        {recoveryFallbackWarning ? (
+          <p className="mt-1 text-xs text-amber-400">{recoveryFallbackWarning}</p>
+        ) : candidates.length === 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            No codex agents are available in this company yet.
+          </p>
+        ) : recoveryFallbackValue && selectedAgent ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Current: {selectedAgent.name}
+          </p>
+        ) : null}
       </Field>
     </>
   );

--- a/ui/src/adapters/types.ts
+++ b/ui/src/adapters/types.ts
@@ -16,6 +16,14 @@ export interface TranscriptParserSource {
   createStdoutParser?: StdoutParserFactory;
 }
 
+/** Minimal agent shape consumed by adapter-config dropdowns (e.g. recovery fallback). */
+export interface AdapterFieldAgentOption {
+  id: string;
+  name: string;
+  adapterType: string | null;
+  status?: string;
+}
+
 export interface AdapterConfigFieldsProps {
   mode: "create" | "edit";
   isCreate: boolean;
@@ -32,6 +40,10 @@ export interface AdapterConfigFieldsProps {
   mark: (group: "adapterConfig", field: string, value: unknown) => void;
   /** Available models for dropdowns */
   models: { id: string; label: string }[];
+  /** Same-company agents available for adapter-config dropdowns (e.g. recovery fallback). */
+  agents?: AdapterFieldAgentOption[];
+  /** Id of the agent being edited; used to exclude self-references in pickers. Undefined in create mode. */
+  selfAgentId?: string;
   /** When true, hides the instructions file path field (e.g. during import where it's set automatically) */
   hideInstructionsFile?: boolean;
 }

--- a/ui/src/components/AgentActionButtons.test.tsx
+++ b/ui/src/components/AgentActionButtons.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Agent } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 import { AgentActionButtons } from "./AgentActionButtons";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
@@ -94,7 +95,7 @@ describe("AgentActionButtons", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot> | null;
   let queryClient: QueryClient;
-  let invalidateQueries: ReturnType<typeof vi.spyOn>;
+  let invalidateQueries: MockInstance<QueryClient["invalidateQueries"]>;
 
   beforeEach(() => {
     container = document.createElement("div");

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -401,7 +401,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const { data: companyAgents = [] } = useQuery({
     queryKey: selectedCompanyId ? queryKeys.agents.list(selectedCompanyId) : ["agents", "none", "list"],
     queryFn: () => agentsApi.list(selectedCompanyId!),
-    enabled: Boolean(!isCreate && selectedCompanyId),
+    // Needed in both edit (reportsTo, recovery fallback) and create (recovery
+    // fallback dropdown on the hire form) modes whenever a company is selected.
+    enabled: Boolean(selectedCompanyId),
   });
 
   /** Props passed to adapter-specific config field components */
@@ -415,6 +417,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     eff: eff as <T>(group: "adapterConfig", field: string, original: T) => T,
     mark: mark as (group: "adapterConfig", field: string, value: unknown) => void,
     models,
+    agents: companyAgents,
+    selfAgentId: isCreate ? undefined : props.agent.id,
     hideInstructionsFile,
   };
 


### PR DESCRIPTION
## What
Lands the **Recovery fallback agent** Advanced-config field for `claude_local` adapters, plus the VANA-484 `tsc -b` build fix, onto `master`. Makes the feature durable (it was previously only on a fork branch and served from a fragile temp `ui/dist`).

## Why
VANA-455/VANA-491: Founder reported the "Recovery fallback agent" item not appearing. Root cause: the feature commit (`80e164ea`) never durably landed on `origin/master` — the running instance was serving a temp dist built off a fork branch, which vanishes on the next rebuild. This PR makes it permanent.

## Commits
- `recovery fallback UI` (was `80e164ea`): `recoveryFallbackAgentId` UI/types/wiring for `claude_local` — hire + PATCH both persist the field.
  - `ui/src/adapters/types.ts`: `AdapterConfigFieldsProps` gains `agents?` / `selfAgentId?`
  - `ui/src/components/AgentConfigForm.tsx`: `adapterFieldProps` passes `agents: companyAgents` / `selfAgentId`
  - `packages/adapter-utils/src/types.ts`, `claude-local/config-fields.tsx` (+ test), `build-config.ts`
- `tsc fix` (was `8238dc5f`, VANA-484): type the `invalidateQueries` spy so `pnpm --filter @paperclipai/ui build` (tsc -b) is green.

## Notes
- `git merge-tree` against current `origin/master` (`0a2230b2`): **0 conflicts**.
- This **supersedes PR #7768** (the standalone VANA-484 tsc fix) — both changes are included here; #7768 can be closed once this merges.
- Acceptance: after merge, the running instance is rebuilt from master and verified in-browser (Recovery fallback agent field shows `rv-codex-recovery`, with self/non-codex/terminated exclusion).

Tracking: VANA-491.