### PR TITLE
fix(scheduler): claim due triggers with millisecond-precision comparison

### DIFF
--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -2346,7 +2346,10 @@ export function routineService(
             and(
               eq(routineTriggers.id, row.trigger.id),
               eq(routineTriggers.enabled, true),
-              eq(routineTriggers.nextRunAt, row.trigger.nextRunAt),
+              // Truncate both sides to milliseconds: Postgres timestamptz keeps microseconds but
+              // JS Date is ms-resolution, so an exact-equality claim silently matches 0 rows when
+              // next_run_at carries sub-millisecond digits (e.g. a hand-written now()).
+              sql`date_trunc('milliseconds', ${routineTriggers.nextRunAt}) = date_trunc('milliseconds', ${row.trigger.nextRunAt}::timestamptz)`,
             ),
           )
           .returning({ id: routineTriggers.id })


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, driven by an in-process scheduler that fires routine triggers on a cron cadence
> - `tickScheduledTriggers` claims each due `routine_trigger` with an optimistic lock before dispatching, so a trigger is never double-fired across ticks
> - That claim compares `next_run_at` with exact equality on a `timestamptz` column, but Postgres keeps microseconds while JS `Date` is millisecond resolution
> - So any trigger whose `next_run_at` carries sub-millisecond digits never matches: the UPDATE claims 0 rows and the trigger is skipped on every tick, silently (the tick log is guarded by `triggered > 0`)
> - This pull request truncates both sides of the claim comparison to milliseconds with `date_trunc`
> - The benefit is the scheduler can no longer be wedged by an externally written timestamp (direct SQL, seed, or pg_restore), with no schema change

## What Changed

- `server/src/services/routines.ts`: in the `tickScheduledTriggers` optimistic-lock claim, replaced the exact-equality `next_run_at` comparison with a `date_trunc('milliseconds', ...)` comparison on both sides.

## Verification

- Reproduction (before): `UPDATE routine_triggers SET next_run_at = now() WHERE id = '<active cron trigger>';` then watch the next tick. The trigger is skipped on every cycle, `result.triggered` stays 0, no log, no error.
- After the change: the same trigger is claimed and `next_run_at` advances to the next cron slot on the next tick.
- No automated test added: reproducing this requires a real Postgres microsecond round-trip (a mock DB cannot lose the precision), and there is no existing integration test around `tickScheduledTriggers`. Happy to add one against the e2e DB harness if you prefer.

## Risks

- Low. No schema change, no migration. The optimistic-concurrency guarantee is preserved: a concurrent tick that already advanced `next_run_at` to the next whole-minute slot produces a non-matching truncated value, so at most one tick claims each trigger per cycle. The only behavioral change is tolerance of sub-millisecond precision differences that never represent two distinct scheduled times.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), extended thinking enabled, with tool use and code execution, run via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #7787
