### PR TITLE
feat: reconcile merged PR references on issue reads

### DIFF
--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -9,6 +9,7 @@ const mockIssueService = vi.hoisted(() => ({
   getAncestors: vi.fn(),
   getRelationSummaries: vi.fn(),
   findMentionedProjectIds: vi.fn(),
+  reconcileAutoCloseFromMergedPullRequestReference: vi.fn(async () => null),
   getCommentCursor: vi.fn(),
   getComment: vi.fn(),
   listBlockerAttention: vi.fn(),

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { asc, eq } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { sql } from "drizzle-orm";
 import {
   activityLog,
@@ -17,10 +17,12 @@ import {
   issueComments,
   issueInboxArchives,
   issueDocuments,
+  issueLabels,
   issuePlanDecompositions,
   issueRelations,
   issueThreadInteractions,
   issues,
+  labels,
   projectWorkspaces,
   projects,
   workspaceOperations,

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4535,3 +4535,584 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     expect(record?.childIssues.every((child) => typeof child.title === "string")).toBe(true);
   });
 });
+describeEmbeddedPostgres("issueService repo-backed terminal-state gate", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  async function seedRepoBackedIssue(args?: {
+    repoUrl?: string;
+    title?: string;
+    description?: string;
+    identifier?: string;
+    originKind?: string | null;
+  }) {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const workspaceId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Server",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "primary",
+      sourceType: "git_repo",
+      repoUrl: args?.repoUrl ?? "https://github.com/paperclipai/paperclip.git",
+      repoRef: "origin/main",
+      defaultRef: "origin/main",
+      isPrimary: true,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      projectWorkspaceId: workspaceId,
+      title: args?.title ?? "Repo-backed issue",
+      description: args?.description ?? "No PR linked here.",
+      status: "todo",
+      priority: "high",
+      identifier: args?.identifier ?? "PAP-9000",
+      originKind: args?.originKind ?? "manual",
+    });
+
+    return { companyId, projectId, workspaceId, issueId };
+  }
+
+  async function attachIssueDocumentRevision(input: {
+    companyId: string;
+    issueId: string;
+    key: string;
+    revisionNumber: number;
+    body?: string;
+  }) {
+    const documentId = randomUUID();
+    const revisionId = randomUUID();
+    const body = input.body ?? "Triage decision";
+    await db.insert(documents).values({
+      id: documentId,
+      companyId: input.companyId,
+      title: input.key,
+      format: "markdown",
+      latestBody: body,
+      latestRevisionId: revisionId,
+      latestRevisionNumber: input.revisionNumber,
+      createdByAgentId: null,
+      updatedByAgentId: null,
+    });
+    await db.insert(documentRevisions).values({
+      id: revisionId,
+      companyId: input.companyId,
+      documentId,
+      revisionNumber: input.revisionNumber,
+      title: input.key,
+      format: "markdown",
+      body,
+      createdByAgentId: null,
+    });
+    await db.insert(issueDocuments).values({
+      companyId: input.companyId,
+      issueId: input.issueId,
+      documentId,
+      key: input.key,
+    });
+  }
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-terminal-gate-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    await db.delete(issueComments);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("rejects terminal transitions for repo-backed issues without a verified merged PR", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Close without proof",
+      description: "No PR linked here.",
+      identifier: "PAP-9001",
+    });
+
+    await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({
+        code: "repo_backed_terminal_state_gate_failed",
+        missing: "merged_pr",
+      }),
+    });
+
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("does not reference any PR URL");
+  });
+
+  it("allows terminal transitions after verifying a merged PR in the issue thread", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ merged: true }),
+    } as Response)));
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Close with merged PR",
+      description: "Reference: https://github.com/paperclipai/paperclip/pull/3303",
+      identifier: "PAP-9002",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+  });
+
+  it("accepts bare PR references against the repo-backed workspace repo", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ merged: true }),
+    } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Close with bare PR reference",
+      description: "Reference: PR #3303",
+      identifier: "PAP-9002AA",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/repos/paperclipai/paperclip/pulls/3303");
+  });
+
+  it("accepts GitHub SSH-alias repo bindings when verifying a merged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ merged: true }),
+    } as Response)));
+
+    const { issueId } = await seedRepoBackedIssue({
+      repoUrl: "git@github.com-paperclip:paperclipai/paperclip.git",
+      title: "Close with merged PR on aliased host",
+      description: "Reference: https://github.com/paperclipai/paperclip/pull/3303",
+      identifier: "PAP-9002A",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+  });
+
+  it("allows repo-backed decision deliverables when terminalEvidence resolves to a document revision", async () => {
+    const { companyId, issueId } = await seedRepoBackedIssue({
+      title: "Decision-backed close",
+      description: [
+        "deliverable: decision",
+        "subjectRepo: Alchemist-DevAI/wotww-planner",
+        "terminalEvidence: document:edg5792_rescue_triage#rev:1",
+      ].join("\n"),
+      identifier: "PAP-9002B",
+    });
+    await attachIssueDocumentRevision({
+      companyId,
+      issueId,
+      key: "edg5792_rescue_triage",
+      revisionNumber: 1,
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+  });
+
+  it("keeps explicit code deliverables behind merged PR proof", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Explicit code deliverable",
+      description: "deliverable: code",
+      identifier: "PAP-9002C",
+    });
+
+    await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({
+        code: "repo_backed_terminal_state_gate_failed",
+        missing: "merged_pr",
+      }),
+    });
+  });
+
+  it("allows routine_execution terminal closes without PR proof when no code-deliverable signal exists", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Daily health routine",
+      description: "Operational work is complete: daily health sweep ran successfully and found no anomalies.",
+      identifier: "PAP-9002C1",
+      originKind: "routine_execution",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+  });
+
+  it("allows routine_execution terminal closes when an explicit non-code deliverable label overrides template code hints", async () => {
+    const { companyId, issueId } = await seedRepoBackedIssue({
+      title: "[EAB-AUDIT-WEEKLY] Run /gstack-agent-audit",
+      description: [
+        "Weekly agent reliability audit. Run /gstack-agent-audit.",
+        "Run: `node ~/.claude/skills/gstack/agent-audit/audit.cjs`",
+        "- `governance/audits/weekly/{this-week-ISO-date}.json` with full lint + behavioural-rate summary",
+      ].join("\n"),
+      identifier: "PAP-9002C1A",
+      originKind: "routine_execution",
+    });
+    const labelId = randomUUID();
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "deliverable:doc",
+      color: "#2563eb",
+    });
+    await db.insert(issueLabels).values({
+      companyId,
+      issueId,
+      labelId,
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+  });
+
+  it("keeps routine_execution code lanes behind merged PR proof", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Routine code lane",
+      description: "deliverable: code",
+      identifier: "PAP-9002C2",
+      originKind: "routine_execution",
+    });
+
+    await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({
+        code: "repo_backed_terminal_state_gate_failed",
+        missing: "merged_pr",
+      }),
+    });
+  });
+
+  it("verifies cross-repo code PRs against subjectRepo instead of the workspace repo", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ merged: true }),
+    } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Cross-repo code deliverable",
+      description: [
+        "deliverable: code",
+        "subjectRepo: Alchemist-DevAI/wotww-planner",
+        "Reference: https://github.com/Alchemist-DevAI/wotww-planner/pull/123",
+      ].join("\n"),
+      identifier: "PAP-9002D",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/repos/Alchemist-DevAI/wotww-planner/pulls/123");
+  });
+
+  it("binds bare cross-repo PR references to subjectRepo instead of the workspace repo", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ merged: true }),
+    } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Cross-repo bare PR reference",
+      description: [
+        "deliverable: code",
+        "subjectRepo: Alchemist-DevAI/paperclip",
+        "Reference: PR #1",
+      ].join("\n"),
+      identifier: "PAP-9002D1",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/repos/Alchemist-DevAI/paperclip/pulls/1");
+    expect(String(url)).not.toContain("/repos/paperclipai/paperclip/pulls/1");
+  });
+
+  it("verifies explicit PR URLs against their own repo even when the workspace repo differs", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ merged: true }),
+    } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Fork PR reference",
+      description: "Reference: https://github.com/Alchemist-DevAI/paperclip/pull/950",
+      identifier: "PAP-9002D2",
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/repos/Alchemist-DevAI/paperclip/pulls/950");
+    expect(String(url)).not.toContain("/repos/paperclipai/paperclip/pulls/950");
+  });
+
+  it("auto-closes a repo-backed issue from a merged pull-request work product", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        html_url: "https://github.com/Alchemist-DevAI/paperclip/pull/950",
+        merge_commit_sha: "abc123def456",
+        merged: true,
+        merged_at: "2026-06-09T00:00:00.000Z",
+      }),
+    } as Response)));
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Auto-close from merged work product",
+      description: "Waiting for merged fork PR.",
+      identifier: "PAP-9002D3",
+    });
+
+    const result = await svc.autoCloseFromMergedPullRequestWorkProduct({
+      issueId,
+      workProduct: {
+        type: "pull_request",
+        status: "merged",
+        url: "https://github.com/Alchemist-DevAI/paperclip/pull/950",
+      },
+    });
+
+    expect(result?.issue.status).toBe("done");
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+    expect(comments.at(-1)?.body).toContain("auto-closed");
+    expect(comments.at(-1)?.body).toContain("mergedAt: 2026-06-09T00:00:00.000Z");
+    expect(comments.at(-1)?.body).toContain("commit: abc123def456");
+  });
+
+  it("auto-closes a repo-backed issue from a merged PR URL already present in the thread", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        html_url: "https://github.com/Alchemist-DevAI/paperclip/pull/952",
+        merge_commit_sha: "abc123def952",
+        merged: true,
+        merged_at: "2026-06-09T02:00:00.000Z",
+      }),
+    } as Response)));
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Auto-close from threaded PR reference",
+      description: "Reference: https://github.com/Alchemist-DevAI/paperclip/pull/952",
+      identifier: "PAP-9002D3A",
+    });
+
+    const result = await svc.reconcileAutoCloseFromMergedPullRequestReference(issueId);
+
+    expect(result?.issue.status).toBe("done");
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+    expect(comments.at(-1)?.body).toContain("auto-closed");
+    expect(comments.at(-1)?.body).toContain("PR: Alchemist-DevAI/paperclip #952");
+    expect(comments.at(-1)?.body).toContain("mergedAt: 2026-06-09T02:00:00.000Z");
+    expect(comments.at(-1)?.body).toContain("commit: abc123def952");
+  });
+
+  it("does not auto-close a thread-only PR reference for non-code deliverables", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        html_url: "https://github.com/Alchemist-DevAI/paperclip/pull/953",
+        merge_commit_sha: "abc123def953",
+        merged: true,
+        merged_at: "2026-06-09T03:00:00.000Z",
+      }),
+    } as Response)));
+
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Diagnostic issue with PR in thread",
+      description: [
+        "deliverable: diagnostic",
+        "Reference: https://github.com/Alchemist-DevAI/paperclip/pull/953",
+      ].join("\n"),
+      identifier: "PAP-9002D3B",
+    });
+
+    const result = await svc.reconcileAutoCloseFromMergedPullRequestReference(issueId);
+
+    expect(result).toBeNull();
+    const issue = await svc.getById(issueId);
+    expect(issue?.status).toBe("todo");
+  });
+
+  it("does not auto-close when a [DAN] thread question remains unanswered", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        html_url: "https://github.com/Alchemist-DevAI/paperclip/pull/951",
+        merge_commit_sha: "abc123def789",
+        merged: true,
+        merged_at: "2026-06-09T01:00:00.000Z",
+      }),
+    } as Response)));
+
+    const { companyId, issueId } = await seedRepoBackedIssue({
+      title: "Blocked by open Dan question",
+      description: "Waiting for answer.",
+      identifier: "PAP-9002D4",
+    });
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      authorUserId: "local-board",
+      authorType: "user",
+      body: "[DAN] Should this merge wait for a second review?",
+    });
+
+    const result = await svc.autoCloseFromMergedPullRequestWorkProduct({
+      issueId,
+      workProduct: {
+        type: "pull_request",
+        status: "merged",
+        url: "https://github.com/Alchemist-DevAI/paperclip/pull/951",
+      },
+    });
+
+    expect(result).toBeNull();
+    const issue = await svc.getById(issueId);
+    expect(issue?.status).toBe("todo");
+  });
+
+  it("rejects decision-style terminal transitions when terminalEvidence is missing", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Decision without evidence",
+      description: [
+        "deliverable: decision",
+        "subjectRepo: Alchemist-DevAI/wotww-planner",
+      ].join("\n"),
+      identifier: "PAP-9002E",
+    });
+
+    await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({
+        code: "repo_backed_terminal_state_gate_failed",
+        missing: "terminal_evidence",
+      }),
+    });
+  });
+
+  it("accepts prefixed structured non-code signals from the latest agent comment", async () => {
+    const { companyId, issueId, agentId } = await seedRepoBackedIssue({
+      title: "Comment-backed diagnostic close",
+      description: "Investigated the runtime and attached the diagnostic report.",
+      identifier: "PAP-9002E1",
+      originKind: "routine_execution",
+    });
+    await attachIssueDocumentRevision({
+      companyId,
+      issueId,
+      key: "deploy_freshness_run_20260609",
+      revisionNumber: 1,
+    });
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      body: [
+        "[EAB]: deliverable: diagnostic",
+        "terminalEvidence: document:deploy_freshness_run_20260609#rev:1",
+        "Guard run complete.",
+      ].join("\n"),
+    });
+
+    const updated = await svc.update(issueId, { status: "done" });
+    expect(updated?.status).toBe("done");
+  });
+
+  it("fails closed for title-only triage issues without structured terminal signals", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "[TRIAGE] title-only exemption should fail",
+      description: "Investigated the situation but left no structured signals.",
+      identifier: "PAP-9002F",
+    });
+
+    await expect(svc.update(issueId, { status: "done" })).rejects.toMatchObject({
+      status: 422,
+      details: expect.objectContaining({
+        code: "repo_backed_terminal_state_gate_failed",
+        missing: "merged_pr",
+      }),
+    });
+  });
+
+  it("allows human-authored terminal transitions without repo-backed PR verification", async () => {
+    const { issueId } = await seedRepoBackedIssue({
+      title: "Board can close directly",
+      description: "No PR linked here.",
+      identifier: "PAP-9003",
+    });
+
+    const updated = await svc.update(issueId, { status: "done", actorUserId: "local-board" });
+    expect(updated?.status).toBe("done");
+
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2354,7 +2354,7 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
-    const rawResult = await svc.list(companyId, {
+    const listedIssues = await svc.list(companyId, {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | undefined,
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
@@ -2388,9 +2388,13 @@ export function issueRoutes(
       sortField: sortField === "updated" ? "updated" : undefined,
       sortDir: sortDir === "asc" || sortDir === "desc" ? sortDir : undefined,
     });
-    const result = await actorCanReadCompanyScope(req, companyId)
-      ? rawResult
-      : await filterIssuesForActor(req, rawResult);
+    const visibleIssues = await actorCanReadCompanyScope(req, companyId)
+      ? listedIssues
+      : await filterIssuesForActor(req, listedIssues);
+    const result = await Promise.all(visibleIssues.map(async (issue) => {
+      const reconciled = await svc.reconcileAutoCloseFromMergedPullRequestReference(issue.id);
+      return reconciled?.issue ?? issue;
+    }));
     const issueIds = result.map((issue) => issue.id);
     const [handoffStates, recoveryActionByIssue] = await Promise.all([
       listSuccessfulRunHandoffStates(db, companyId, issueIds),
@@ -2702,13 +2706,15 @@ export function issueRoutes(
 
   router.get("/issues/:id", async (req, res) => {
     const id = req.params.id as string;
-    const issue = await svc.getById(id);
+    let issue = await svc.getById(id);
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
     assertCompanyAccess(req, issue.companyId);
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
+    const reconciled = await svc.reconcileAutoCloseFromMergedPullRequestReference(issue.id);
+    issue = reconciled?.issue ?? issue;
     const [
       { project, goal },
       ancestors,
@@ -3698,8 +3704,31 @@ export function issueRoutes(
       entityId: issue.id,
       details: { workProductId: product.id, type: product.type, provider: product.provider },
     });
+    const autoClosed = await svc.autoCloseFromMergedPullRequestWorkProduct({
+      issueId: issue.id,
+      workProduct: product,
+    });
+    if (autoClosed) {
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: actor.runId,
+        action: "issue.auto_closed_from_merged_pull_request",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          workProductId: product.id,
+          repo: `${autoClosed.pullRequest.repo.owner}/${autoClosed.pullRequest.repo.repo}`,
+          pullNumber: autoClosed.pullRequest.pullNumber,
+          mergedAt: autoClosed.pullRequest.mergedAt,
+          mergeCommitSha: autoClosed.pullRequest.mergeCommitSha,
+        },
+      });
+    }
     await revalidateActiveSourceRecoveryAfterCommittedWrite({
-      issue,
+      issue: autoClosed?.issue ?? issue,
       trigger: "work_product",
       actor,
       workProductChanged: true,
@@ -3903,8 +3932,31 @@ export function issueRoutes(
       entityId: existing.issueId,
       details: { workProductId: product.id, changedKeys: Object.keys(req.body).sort() },
     });
+    const autoClosed = await svc.autoCloseFromMergedPullRequestWorkProduct({
+      issueId: existing.issueId,
+      workProduct: product,
+    });
+    if (autoClosed) {
+      await logActivity(db, {
+        companyId: existing.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: actor.runId,
+        action: "issue.auto_closed_from_merged_pull_request",
+        entityType: "issue",
+        entityId: existing.issueId,
+        details: {
+          workProductId: product.id,
+          repo: `${autoClosed.pullRequest.repo.owner}/${autoClosed.pullRequest.repo.repo}`,
+          pullNumber: autoClosed.pullRequest.pullNumber,
+          mergedAt: autoClosed.pullRequest.mergedAt,
+          mergeCommitSha: autoClosed.pullRequest.mergeCommitSha,
+        },
+      });
+    }
     await revalidateActiveSourceRecoveryAfterCommittedWrite({
-      issue,
+      issue: autoClosed?.issue ?? issue,
       trigger: "work_product",
       actor,
       workProductChanged: true,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -75,6 +75,7 @@ import { redactSensitiveText } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
+import { ghFetch, gitHubApiBase } from "./github-fetch.js";
 import { assertAssignableAgent } from "./agent-assignability.js";
 import {
   isVerifiedIssueTreeControlInteractionWake,
@@ -100,6 +101,14 @@ const ISSUE_COMMENT_RUN_LOG_DERIVATION_CHUNK_BYTES = 256_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS = 60_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_MAX_PARALLEL_READS = 8;
 const DELETED_ISSUE_COMMENT_BODY = "";
+const REPO_BACKED_TERMINAL_GATE_CODE = "repo_backed_terminal_state_gate_failed";
+const TERMINAL_GATE_NON_CODE_DELIVERABLES = new Set([
+  "decision",
+  "diagnostic",
+  "report",
+  "artifact",
+  "investigation",
+]);
 function assertTransition(from: string, to: string) {
   if (from === to) return;
   if (!ALL_ISSUE_STATUSES.includes(to)) {
@@ -5537,6 +5546,10 @@ export function issueService(db: Db) {
         issueData.projectWorkspaceId !== undefined ? issueData.projectWorkspaceId : existing.projectWorkspaceId;
       const nextExecutionWorkspaceId =
         issueData.executionWorkspaceId !== undefined ? issueData.executionWorkspaceId : existing.executionWorkspaceId;
+      const nextExecutionState =
+        issueData.executionState !== undefined ? issueData.executionState : existing.executionState;
+      const nextDescription =
+        issueData.description !== undefined ? issueData.description : existing.description;
       const nextExecutionWorkspacePreference =
         issueData.executionWorkspacePreference !== undefined
           ? issueData.executionWorkspacePreference

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -131,6 +131,432 @@ function readStringFromRecord(record: unknown, key: string) {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+type RepoCoordinates = {
+  host: string;
+  owner: string;
+  repo: string;
+};
+
+type PullRequestReference = {
+  repo: RepoCoordinates;
+  pullNumber: number;
+  url: string | null;
+};
+
+type PullRequestDetails = {
+  repo: RepoCoordinates;
+  pullNumber: number;
+  url: string | null;
+  merged: boolean;
+  mergedAt: string | null;
+  mergeCommitSha: string | null;
+};
+
+function normalizeRepoHost(host: string) {
+  const normalized = host.trim().toLowerCase();
+  if (normalized === "github.com" || normalized.startsWith("github.com-")) {
+    return "github.com";
+  }
+  return normalized;
+}
+
+function parseRepoCoordinates(rawUrl: string | null | undefined): RepoCoordinates | null {
+  const trimmed = rawUrl?.trim();
+  if (!trimmed) return null;
+  try {
+    const sshMatch = trimmed.match(/^git@([^:]+):([^/]+)\/(.+?)(?:\.git)?$/i);
+    if (sshMatch) {
+      return {
+        host: normalizeRepoHost(sshMatch[1]!),
+        owner: sshMatch[2]!,
+        repo: sshMatch[3]!.replace(/\.git$/i, ""),
+      };
+    }
+
+    const parsed = new URL(trimmed);
+    const parts = parsed.pathname.replace(/\/+$/, "").split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    return {
+      host: normalizeRepoHost(parsed.hostname),
+      owner: parts[0]!,
+      repo: parts[1]!.replace(/\.git$/i, ""),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseSubjectRepoCoordinates(rawValue: string | null | undefined): RepoCoordinates | null {
+  const trimmed = rawValue?.trim();
+  if (!trimmed) return null;
+  const simple = trimmed.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
+  if (simple) {
+    return {
+      host: "github.com",
+      owner: simple[1]!,
+      repo: simple[2]!,
+    };
+  }
+  const withHost = trimmed.match(/^github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/i);
+  if (withHost) {
+    return {
+      host: "github.com",
+      owner: withHost[1]!,
+      repo: withHost[2]!,
+    };
+  }
+  return parseRepoCoordinates(trimmed);
+}
+
+function repoCoordinatesEqual(expected: RepoCoordinates | null, actual: RepoCoordinates | null) {
+  if (!expected || !actual) return false;
+  return expected.host === actual.host && expected.owner === actual.owner && expected.repo === actual.repo;
+}
+
+function repoLabel(repo: RepoCoordinates) {
+  return `${repo.owner}/${repo.repo}`;
+}
+
+function parsePullRequestReferenceFromUrl(rawUrl: string | null | undefined): PullRequestReference | null {
+  const trimmed = rawUrl?.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    const host = normalizeRepoHost(parsed.hostname);
+    const parts = parsed.pathname.replace(/\/+$/, "").split("/").filter(Boolean);
+    if (parts.length < 4 || parts[2] !== "pull") return null;
+    const pullNumber = Number.parseInt(parts[3] ?? "", 10);
+    if (!Number.isFinite(pullNumber) || pullNumber <= 0) return null;
+    return {
+      repo: {
+        host,
+        owner: parts[0]!,
+        repo: parts[1]!.replace(/\.git$/i, ""),
+      },
+      pullNumber,
+      url: `https://${host}/${parts[0]}/${parts[1]!.replace(/\.git$/i, "")}/pull/${pullNumber}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function serializePullRequestReference(ref: PullRequestReference) {
+  return `${ref.repo.host}/${ref.repo.owner}/${ref.repo.repo}#${ref.pullNumber}`;
+}
+
+function extractReferencedPullRequests(
+  text: string | null | undefined,
+  fallbackRepo: RepoCoordinates,
+): PullRequestReference[] {
+  if (!text) return [];
+  const matches = new Map<string, PullRequestReference>();
+  const urlPattern = /https?:\/\/github(?:\.com|\.com-[^\s/]+)\/[^\s)]+\/pull\/\d+/gi;
+  for (const match of text.matchAll(urlPattern)) {
+    const parsed = parsePullRequestReferenceFromUrl(match[0]);
+    if (!parsed) continue;
+    matches.set(serializePullRequestReference(parsed), parsed);
+  }
+  for (const match of text.matchAll(/\bPR\s*#(\d+)\b|(^|[^\w/])#(\d+)\b/gim)) {
+    const rawValue = match[1] ?? match[3] ?? "";
+    const pullNumber = Number.parseInt(rawValue, 10);
+    if (!Number.isFinite(pullNumber) || pullNumber <= 0) continue;
+    const ref: PullRequestReference = {
+      repo: fallbackRepo,
+      pullNumber,
+      url: null,
+    };
+    matches.set(serializePullRequestReference(ref), ref);
+  }
+  return Array.from(matches.values());
+}
+
+function extractMatchingPullRequestNumbers(text: string | null | undefined, repo: RepoCoordinates): number[] {
+  return extractReferencedPullRequests(text, repo)
+    .filter((ref) => repoCoordinatesEqual(ref.repo, repo))
+    .map((ref) => ref.pullNumber);
+}
+
+function parseTerminalGateDeliverable(value: string | null | undefined): TerminalGateDeliverable | null {
+  const normalized = value?.trim().toLowerCase();
+  switch (normalized) {
+    case "code":
+    case "decision":
+    case "audit":
+    case "diagnostic":
+    case "qa":
+    case "ops":
+    case "governance":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function parseRoutineExecutionDeliverableLabel(value: string | null | undefined): RoutineExecutionDeliverableLabel | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized?.startsWith("deliverable:")) return null;
+  const candidate = normalized.slice("deliverable:".length).trim();
+  if (!candidate) return null;
+  if (candidate === "doc") return "doc";
+  return parseTerminalGateDeliverable(candidate);
+}
+
+function parseTerminalGateDocumentEvidence(value: string | null | undefined): TerminalGateDocumentEvidence | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^document:([a-z0-9][a-z0-9_-]{0,63})#rev:(\d+)$/i);
+  if (!match) return null;
+  const revisionNumber = Number.parseInt(match[2] ?? "", 10);
+  if (!Number.isFinite(revisionNumber) || revisionNumber <= 0) return null;
+  return {
+    key: match[1]!,
+    revisionNumber,
+  };
+}
+
+function extractTerminalGateSignalsFromText(text: string | null | undefined): Partial<TerminalGateSignals> {
+  const signals: Partial<TerminalGateSignals> = {};
+  if (!text) return signals;
+  const fieldPrefix = String.raw`(?:\[[^\]\r\n]+\]\s*:\s*)?`;
+  const deliverableMatch = text.match(new RegExp(`^\\s*${fieldPrefix}deliverable\\s*:\\s*([^\\n\\r]+)\\s*$`, "im"));
+  const subjectRepoMatch = text.match(new RegExp(`^\\s*${fieldPrefix}subjectRepo\\s*:\\s*([^\\n\\r]+)\\s*$`, "im"));
+  const terminalEvidenceMatch = text.match(new RegExp(`^\\s*${fieldPrefix}terminalEvidence\\s*:\\s*([^\\n\\r]+)\\s*$`, "im"));
+  const deliverable = parseTerminalGateDeliverable(deliverableMatch?.[1] ?? null);
+  const subjectRepo = parseSubjectRepoCoordinates(subjectRepoMatch?.[1] ?? null);
+  const terminalEvidence = parseTerminalGateDocumentEvidence(terminalEvidenceMatch?.[1] ?? null);
+  if (deliverable) signals.deliverable = deliverable;
+  if (subjectRepo) signals.subjectRepo = subjectRepo;
+  if (terminalEvidence) signals.terminalEvidence = terminalEvidence;
+  return signals;
+}
+
+function mergeTerminalGateSignals(
+  description: string | null | undefined,
+  latestAgentComment: string | null | undefined,
+): TerminalGateSignals {
+  const descriptionSignals = extractTerminalGateSignalsFromText(description);
+  const latestCommentSignals = extractTerminalGateSignalsFromText(latestAgentComment);
+  return {
+    deliverable: latestCommentSignals.deliverable ?? descriptionSignals.deliverable ?? null,
+    subjectRepo: latestCommentSignals.subjectRepo ?? descriptionSignals.subjectRepo ?? null,
+    terminalEvidence: latestCommentSignals.terminalEvidence ?? descriptionSignals.terminalEvidence ?? null,
+  };
+}
+
+function hasRoutineExecutionCodeHints(text: string | null | undefined) {
+  if (!text) return false;
+  return /\bPR\s*#\d+\b|https?:\/\/github\.com\/[^\s]+\/pull\/\d+|\b(?:src|server|packages|ui|scripts|lib|app)\/|\b[a-z0-9_.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|sql|sh|ya?ml)\b/i.test(text);
+}
+
+function canAutoExemptRoutineExecutionTerminalClose(input: {
+  originKind: string | null | undefined;
+  signals: TerminalGateSignals;
+  description: string | null | undefined;
+  latestAgentComment: string | null | undefined;
+  labelNames: string[];
+}) {
+  if (input.originKind !== "routine_execution") return false;
+  const explicitLabelDeliverable = input.labelNames
+    .map((name) => parseRoutineExecutionDeliverableLabel(name))
+    .find((value): value is RoutineExecutionDeliverableLabel => Boolean(value))
+    ?? null;
+  if (explicitLabelDeliverable === "code") return false;
+  if (explicitLabelDeliverable) return true;
+  if (input.signals.deliverable === "code") return false;
+  if (input.signals.deliverable && TERMINAL_GATE_NON_CODE_DELIVERABLES.has(input.signals.deliverable)) {
+    return false;
+  }
+  return !hasRoutineExecutionCodeHints(input.description) && !hasRoutineExecutionCodeHints(input.latestAgentComment);
+}
+
+function readTerminalStateExemption(value: unknown) {
+  if (!value || typeof value !== "object") return null;
+  const exemption = (value as Record<string, unknown>).terminalStateExemption;
+  if (!exemption || typeof exemption !== "object") return null;
+  const record = exemption as Record<string, unknown>;
+  const kind = typeof record.kind === "string" ? record.kind.trim() : "";
+  const reason = typeof record.reason === "string" ? record.reason.trim() : "";
+  const grantedByUserId = typeof record.grantedByUserId === "string" ? record.grantedByUserId.trim() : "";
+  const grantedByAgentId = typeof record.grantedByAgentId === "string" ? record.grantedByAgentId.trim() : "";
+  if (kind !== REPO_BACKED_TERMINAL_GATE_EXEMPTION_KIND || !reason) return null;
+  if (!grantedByUserId && !grantedByAgentId) return null;
+  return {
+    kind,
+    reason,
+    grantedByUserId: grantedByUserId || null,
+    grantedByAgentId: grantedByAgentId || null,
+    createdAt: typeof record.createdAt === "string" ? record.createdAt : null,
+  };
+}
+
+async function resolveIssueRepoBinding(input: {
+  dbOrTx: any;
+  companyId: string;
+  projectId: string | null;
+  projectWorkspaceId: string | null;
+  executionWorkspaceId: string | null;
+}) {
+  if (input.executionWorkspaceId) {
+    const executionWorkspace = await input.dbOrTx
+      .select({ repoUrl: executionWorkspaces.repoUrl })
+      .from(executionWorkspaces)
+      .where(
+        and(
+          eq(executionWorkspaces.id, input.executionWorkspaceId),
+          eq(executionWorkspaces.companyId, input.companyId),
+        ),
+      )
+      .then((rows: Array<{ repoUrl: string | null }>) => rows[0] ?? null);
+    const executionRepo = parseRepoCoordinates(executionWorkspace?.repoUrl ?? null);
+    if (executionRepo) return executionRepo;
+  }
+
+  if (input.projectWorkspaceId) {
+    const workspace = await input.dbOrTx
+      .select({ repoUrl: projectWorkspaces.repoUrl })
+      .from(projectWorkspaces)
+      .where(
+        and(
+          eq(projectWorkspaces.id, input.projectWorkspaceId),
+          eq(projectWorkspaces.companyId, input.companyId),
+        ),
+      )
+      .then((rows: Array<{ repoUrl: string | null }>) => rows[0] ?? null);
+    const workspaceRepo = parseRepoCoordinates(workspace?.repoUrl ?? null);
+    if (workspaceRepo) return workspaceRepo;
+  }
+
+  if (!input.projectId) return null;
+  const primaryWorkspace = await input.dbOrTx
+    .select({ repoUrl: projectWorkspaces.repoUrl })
+    .from(projectWorkspaces)
+    .where(
+      and(
+        eq(projectWorkspaces.companyId, input.companyId),
+        eq(projectWorkspaces.projectId, input.projectId),
+        eq(projectWorkspaces.isPrimary, true),
+      ),
+    )
+    .then((rows: Array<{ repoUrl: string | null }>) => rows[0] ?? null);
+  return parseRepoCoordinates(primaryWorkspace?.repoUrl ?? null);
+}
+
+async function verifyMergedPullRequestForRepo(input: {
+  repo: RepoCoordinates;
+  pullNumber: number;
+}) {
+  const details = await fetchPullRequestDetails(input);
+  return details.merged;
+}
+
+async function fetchPullRequestDetails(input: {
+  repo: RepoCoordinates;
+  pullNumber: number;
+}): Promise<PullRequestDetails> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+  };
+  const token =
+    process.env.GITHUB_TOKEN?.trim()
+    || process.env.GITHUB_TOKEN_PERSONAL?.trim()
+    || process.env.GH_TOKEN?.trim()
+    || "";
+  if (token) headers.authorization = `Bearer ${token}`;
+  const response = await ghFetch(
+    `${gitHubApiBase(input.repo.host)}/repos/${input.repo.owner}/${input.repo.repo}/pulls/${input.pullNumber}`,
+    { headers },
+  );
+  if (!response.ok) {
+    throw new Error(`GitHub returned ${response.status} while verifying pull #${input.pullNumber}.`);
+  }
+  const payload = await response.json() as {
+    html_url?: string;
+    merge_commit_sha?: string | null;
+    merged?: boolean;
+    merged_at?: string | null;
+  };
+  return {
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    url: typeof payload.html_url === "string" ? payload.html_url : null,
+    merged: payload.merged === true,
+    mergedAt: typeof payload.merged_at === "string" ? payload.merged_at : null,
+    mergeCommitSha: typeof payload.merge_commit_sha === "string" ? payload.merge_commit_sha : null,
+  };
+}
+
+function hasUnansweredCloseBlockingThreadComment(comments: Array<{
+  body: string | null;
+  authorAgentId: string | null;
+  authorUserId: string | null;
+  authorType?: string | null;
+}>) {
+  let pendingMarker = false;
+  for (const comment of comments) {
+    const body = comment.body ?? "";
+    if (/^\s*(?:\[[^\]\r\n]+\]\s*:\s*)?\[(?:DAN|NEEDS-FIX)\]/im.test(body)) {
+      pendingMarker = true;
+      continue;
+    }
+    if (!pendingMarker) continue;
+    if (comment.authorType === "system") continue;
+    if (comment.authorAgentId || comment.authorUserId) {
+      pendingMarker = false;
+    }
+  }
+  return pendingMarker;
+}
+
+async function recordRepoBackedTerminalGateComment(input: {
+  dbHandle: Db;
+  issueId: string;
+  companyId: string;
+  body: string;
+}) {
+  await input.dbHandle.insert(issueComments).values({
+    companyId: input.companyId,
+    issueId: input.issueId,
+    authorAgentId: null,
+    authorUserId: null,
+    authorType: "system",
+    body: input.body,
+    presentation: {
+      kind: "system_notice",
+      tone: "warning",
+      title: "Repo-backed terminal-state gate",
+      detailsDefaultOpen: false,
+    },
+  });
+  await input.dbHandle
+    .update(issues)
+    .set({ updatedAt: new Date() })
+    .where(eq(issues.id, input.issueId));
+}
+
+async function issueDocumentRevisionExists(input: {
+  dbOrTx: any;
+  companyId: string;
+  issueId: string;
+  key: string;
+  revisionNumber: number;
+}) {
+  const row = await input.dbOrTx
+    .select({ documentId: issueDocuments.documentId })
+    .from(issueDocuments)
+    .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+    .innerJoin(documentRevisions, eq(documentRevisions.documentId, documents.id))
+    .where(and(
+      eq(issueDocuments.companyId, input.companyId),
+      eq(issueDocuments.issueId, input.issueId),
+      eq(issueDocuments.key, input.key),
+      eq(documentRevisions.companyId, input.companyId),
+      eq(documentRevisions.revisionNumber, input.revisionNumber),
+    ))
+    .then((rows: Array<{ documentId: string }>) => rows[0] ?? null);
+  return Boolean(row);
+}
+
 function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
   settings: ReturnType<typeof parseIssueExecutionWorkspaceSettings>,
 ) {
@@ -3795,7 +4221,105 @@ export function issueService(db: Db) {
     });
   }
 
-  return {
+  async function resolveMergedPullRequestDetailsForThreadAutoClose(issue: typeof issues.$inferSelect) {
+    if (!["todo", "in_progress", "in_review"].includes(issue.status)) return null;
+
+    const repoBinding = await resolveIssueRepoBinding({
+      dbOrTx: db,
+      companyId: issue.companyId,
+      projectId: issue.projectId,
+      projectWorkspaceId: issue.projectWorkspaceId,
+      executionWorkspaceId: issue.executionWorkspaceId,
+    });
+    if (!repoBinding) return null;
+
+    const issueLabelRows = await db
+      .select({ name: labels.name })
+      .from(issueLabels)
+      .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+      .where(eq(issueLabels.issueId, issue.id));
+    const latestAgentComment = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(and(
+        eq(issueComments.issueId, issue.id),
+        sql`${issueComments.authorAgentId} is not null`,
+      ))
+      .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+      .limit(1)
+      .then((rows: Array<{ body: string }>) => rows[0]?.body ?? null);
+    const gateSignals = mergeTerminalGateSignals(issue.description, latestAgentComment);
+    if (canAutoExemptRoutineExecutionTerminalClose({
+      originKind: issue.originKind,
+      signals: gateSignals,
+      description: issue.description,
+      latestAgentComment,
+      labelNames: issueLabelRows.map((row) => row.name),
+    })) {
+      return null;
+    }
+    if (gateSignals.deliverable && TERMINAL_GATE_NON_CODE_DELIVERABLES.has(gateSignals.deliverable)) {
+      return null;
+    }
+
+    const verificationRepo = gateSignals.subjectRepo ?? repoBinding;
+    const commentRows = await db
+      .select({
+        body: issueComments.body,
+        authorAgentId: issueComments.authorAgentId,
+        authorUserId: issueComments.authorUserId,
+        authorType: issueComments.authorType,
+      })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issue.id))
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+    if (hasUnansweredCloseBlockingThreadComment(commentRows)) {
+      return null;
+    }
+
+    const pullReferences = new Map<string, PullRequestReference>();
+    for (const ref of extractReferencedPullRequests(issue.description, verificationRepo)) {
+      pullReferences.set(serializePullRequestReference(ref), ref);
+    }
+    for (const row of commentRows) {
+      for (const ref of extractReferencedPullRequests(row.body, verificationRepo)) {
+        pullReferences.set(serializePullRequestReference(ref), ref);
+      }
+    }
+
+    let firstVerificationError: unknown = null;
+    for (const ref of pullReferences.values()) {
+      try {
+        const details = await fetchPullRequestDetails({ repo: ref.repo, pullNumber: ref.pullNumber });
+        if (details.merged) return details;
+      } catch (error) {
+        firstVerificationError ??= error;
+      }
+    }
+
+    if (firstVerificationError) {
+      logger.warn(
+        { issueId: issue.id, error: firstVerificationError },
+        "Thread-only auto-close skipped: merged PR details could not be verified.",
+      );
+    }
+    return null;
+  }
+
+  function buildMergedPullRequestAutoCloseComment(input: {
+    issue: { id: string; identifier: string | null };
+    pullRequest: PullRequestDetails;
+    fallbackUrl?: string | null;
+  }) {
+    return [
+      `Paperclip auto-closed ${input.issue.identifier ?? input.issue.id} after verifying merged PR ${input.pullRequest.url ?? input.fallbackUrl ?? `#${input.pullRequest.pullNumber}`}.`,
+      `PR: ${repoLabel(input.pullRequest.repo)} #${input.pullRequest.pullNumber}`,
+      `mergedAt: ${input.pullRequest.mergedAt ?? "unknown"}`,
+      `commit: ${input.pullRequest.mergeCommitSha ?? "unknown"}`,
+    ].join("\n");
+  }
+
+  const service = {
     clearExecutionRunIfTerminal,
 
     list: async (companyId: string, filters?: IssueFilters) => {
@@ -5046,6 +5570,142 @@ export function issueService(db: Db) {
         }
       }
 
+      const nextStatus = issueData.status ?? existing.status;
+      const requiresRepoBackedTerminalGate =
+        !actorUserId && (nextStatus === "done" || (nextStatus === "in_review" && Boolean(nextAssigneeUserId)));
+      if (requiresRepoBackedTerminalGate) {
+        const explicitExemption = readTerminalStateExemption(nextExecutionState);
+        if (!explicitExemption) {
+          const repoBinding = await resolveIssueRepoBinding({
+            dbOrTx,
+            companyId: existing.companyId,
+            projectId: nextProjectId,
+            projectWorkspaceId: nextProjectWorkspaceId,
+            executionWorkspaceId: nextExecutionWorkspaceId,
+          });
+          if (repoBinding) {
+            const issueLabelRows = nextLabelIds !== undefined
+              ? await dbOrTx
+                .select({ name: labels.name })
+                .from(labels)
+                .where(and(
+                  eq(labels.companyId, existing.companyId),
+                  inArray(labels.id, nextLabelIds),
+                ))
+              : await dbOrTx
+                .select({ name: labels.name })
+                .from(issueLabels)
+                .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+                .where(eq(issueLabels.issueId, existing.id));
+            const latestAgentComment = await dbOrTx
+              .select({ body: issueComments.body })
+              .from(issueComments)
+              .where(and(
+                eq(issueComments.issueId, existing.id),
+                sql`${issueComments.authorAgentId} is not null`,
+              ))
+              .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+              .limit(1)
+              .then((rows: Array<{ body: string }>) => rows[0]?.body ?? null);
+            const gateSignals = mergeTerminalGateSignals(nextDescription, latestAgentComment);
+            if (canAutoExemptRoutineExecutionTerminalClose({
+              originKind: existing.originKind,
+              signals: gateSignals,
+              description: nextDescription,
+              latestAgentComment,
+              labelNames: issueLabelRows.map((row: { name: string }) => row.name),
+            })) {
+              // Routine execution issues can terminate without PR proof when they are
+              // plainly operational and carry no code-deliverable signal.
+            } else {
+              const verificationRepo = gateSignals.subjectRepo ?? repoBinding;
+              if (gateSignals.deliverable && TERMINAL_GATE_NON_CODE_DELIVERABLES.has(gateSignals.deliverable)) {
+                const evidence = gateSignals.terminalEvidence;
+                const evidenceExists = evidence
+                  ? await issueDocumentRevisionExists({
+                      dbOrTx,
+                      companyId: existing.companyId,
+                      issueId: existing.id,
+                      key: evidence.key,
+                      revisionNumber: evidence.revisionNumber,
+                    })
+                  : false;
+                if (!evidenceExists) {
+                  const reason = evidence
+                    ? `Paperclip refused a terminal transition for repo-backed ${gateSignals.deliverable} issue ${existing.identifier ?? existing.id} because terminalEvidence document:${evidence.key}#rev:${evidence.revisionNumber} does not resolve to an issue document revision.`
+                    : `Paperclip refused a terminal transition for repo-backed ${gateSignals.deliverable} issue ${existing.identifier ?? existing.id} because structured terminalEvidence is required.`;
+                  await recordRepoBackedTerminalGateComment({
+                    dbHandle: db,
+                    issueId: existing.id,
+                    companyId: existing.companyId,
+                    body: reason,
+                  });
+                  throw unprocessable(
+                    "Repo-backed non-code terminal transitions require document-backed terminalEvidence.",
+                    {
+                      code: REPO_BACKED_TERMINAL_GATE_CODE,
+                      repo: repoLabel(verificationRepo),
+                      missing: "terminal_evidence",
+                    },
+                  );
+                }
+              } else {
+                const commentBodies = await dbOrTx
+                  .select({ body: issueComments.body })
+                  .from(issueComments)
+                  .where(eq(issueComments.issueId, existing.id));
+                const pullReferences = new Map<string, PullRequestReference>();
+                for (const ref of extractReferencedPullRequests(nextDescription, verificationRepo)) {
+                  pullReferences.set(serializePullRequestReference(ref), ref);
+                }
+                for (const row of commentBodies) {
+                  for (const ref of extractReferencedPullRequests(row.body, verificationRepo)) {
+                    pullReferences.set(serializePullRequestReference(ref), ref);
+                  }
+                }
+
+                let verifiedMergedPull = false;
+                let verificationFailure: string | null = null;
+                for (const ref of pullReferences.values()) {
+                  try {
+                    if (await verifyMergedPullRequestForRepo({ repo: ref.repo, pullNumber: ref.pullNumber })) {
+                      verifiedMergedPull = true;
+                      break;
+                    }
+                  } catch (error) {
+                    verificationFailure = error instanceof Error ? error.message : String(error);
+                    break;
+                  }
+                }
+
+                if (!verifiedMergedPull) {
+                  const targetRepoLabel = repoLabel(verificationRepo);
+                  const reason = verificationFailure
+                    ? `Paperclip could not verify a merged PR for repo-backed issue close on ${targetRepoLabel}: ${verificationFailure}`
+                    : pullReferences.size === 0
+                      ? `Paperclip refused a terminal transition for repo-backed issue ${existing.identifier ?? existing.id} because the issue thread does not reference any PR URL for ${targetRepoLabel}.`
+                      : `Paperclip refused a terminal transition for repo-backed issue ${existing.identifier ?? existing.id} because none of the referenced PRs for ${targetRepoLabel} are verified merged.`;
+                  await recordRepoBackedTerminalGateComment({
+                    dbHandle: db,
+                    issueId: existing.id,
+                    companyId: existing.companyId,
+                    body: reason,
+                  });
+                  throw unprocessable(
+                    "Repo-backed issues may only move to a terminal state after a verified merged PR or explicit exemption.",
+                    {
+                      code: REPO_BACKED_TERMINAL_GATE_CODE,
+                      repo: targetRepoLabel,
+                      missing: verificationFailure ? "merged_pr_verification_failed" : "merged_pr",
+                    },
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+
       applyStatusSideEffects(issueData.status, patch);
       if (issueData.status && issueData.status !== "done") {
         patch.completedAt = null;
@@ -5906,6 +6566,125 @@ export function issueService(db: Db) {
       return redactIssueComment(comment, currentUserRedactionOptions.enabled);
     },
 
+    reconcileAutoCloseFromMergedPullRequestReference: async (issueId: string) => {
+      const issue = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
+      if (!issue) return null;
+
+      const details = await resolveMergedPullRequestDetailsForThreadAutoClose(issue);
+      if (!details) return null;
+
+      try {
+        await service.addComment(
+          issueId,
+          buildMergedPullRequestAutoCloseComment({ issue, pullRequest: details }),
+          {},
+          {
+            authorType: "system",
+            presentation: {
+              kind: "system_notice",
+              tone: "info",
+              title: "Merged pull request auto-close",
+              detailsDefaultOpen: false,
+            },
+          },
+        );
+        const updatedIssue = await service.update(issueId, { status: "done" });
+        return updatedIssue
+          ? {
+              issue: updatedIssue,
+              pullRequest: details,
+            }
+          : null;
+      } catch (error) {
+        logger.warn({ issueId, error }, "Thread-only auto-close failed after merged PR verification.");
+        return null;
+      }
+    },
+
+    autoCloseFromMergedPullRequestWorkProduct: async (input: {
+      issueId: string;
+      workProduct: {
+        type: string;
+        status: string;
+        url?: string | null;
+      };
+    }) => {
+      if (input.workProduct.type !== "pull_request" || input.workProduct.status !== "merged") {
+        return null;
+      }
+      const pullRef = parsePullRequestReferenceFromUrl(input.workProduct.url ?? null);
+      if (!pullRef) return null;
+
+      let details: PullRequestDetails;
+      try {
+        details = await fetchPullRequestDetails({ repo: pullRef.repo, pullNumber: pullRef.pullNumber });
+      } catch (error) {
+        logger.warn({ issueId: input.issueId, error }, "Auto-close skipped: merged PR details could not be verified.");
+        return null;
+      }
+      if (!details.merged) return null;
+
+      const issue = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, input.issueId))
+        .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
+      if (!issue || !["todo", "in_progress", "in_review"].includes(issue.status)) {
+        return null;
+      }
+
+      const commentRows = await db
+        .select({
+          body: issueComments.body,
+          authorAgentId: issueComments.authorAgentId,
+          authorUserId: issueComments.authorUserId,
+          authorType: issueComments.authorType,
+        })
+        .from(issueComments)
+        .where(eq(issueComments.issueId, input.issueId))
+        .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+      if (hasUnansweredCloseBlockingThreadComment(commentRows)) {
+        return null;
+      }
+
+      const evidenceComment = buildMergedPullRequestAutoCloseComment({
+        issue,
+        pullRequest: details,
+        fallbackUrl: input.workProduct.url ?? null,
+      });
+
+      try {
+        await service.addComment(
+          input.issueId,
+          evidenceComment,
+          {},
+          {
+            authorType: "system",
+            presentation: {
+              kind: "system_notice",
+              tone: "info",
+              title: "Merged pull request auto-close",
+              detailsDefaultOpen: false,
+            },
+          },
+        );
+        const updatedIssue = await service.update(input.issueId, { status: "done" });
+        return updatedIssue
+          ? {
+              issue: updatedIssue,
+              pullRequest: details,
+            }
+          : null;
+      } catch (error) {
+        logger.warn({ issueId: input.issueId, error }, "Auto-close failed after merged PR verification.");
+        return null;
+      }
+    },
+
     createAttachment: async (input: {
       issueId: string;
       issueCommentId?: string | null;
@@ -6258,4 +7037,5 @@ export function issueService(db: Db) {
       }));
     },
   };
+  return service;
 }


### PR DESCRIPTION
## Summary
- reconcile merged PR thread references on issue reads so repo-backed issues can auto-close from description/comment PR URLs
- keep repo-backed terminal-state verification aligned with the transplanted helper and route behavior on upstream master
- add focused regression coverage for the terminal gate and thread-only auto-close path

## Verification
- pnpm vitest run server/src/__tests__/issues-service.test.ts server/src/__tests__/issues-goal-context-routes.test.ts server/src/__tests__/multilingual-issues-routes.test.ts server/src/__tests__/issue-scheduled-retry-routes.test.ts