### PR TITLE
feat(ui): installable standalone PWA for iOS home-screen (TON-2311)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#18181b" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Paperclip" />
     <title>Paperclip</title>
     <!-- PAPERCLIP_RUNTIME_BRANDING_START -->

--- a/ui/public/site.webmanifest
+++ b/ui/public/site.webmanifest
@@ -5,7 +5,7 @@
   "description": "AI-powered project management and agent coordination platform",
   "start_url": "/",
   "scope": "/",
-  "display": "browser",
+  "display": "standalone",
   "orientation": "any",
   "theme_color": "#18181b",
   "background_color": "#18181b",

--- a/ui/src/lib/pwa-install-mode.test.ts
+++ b/ui/src/lib/pwa-install-mode.test.ts
@@ -6,15 +6,17 @@ import { describe, expect, it } from "vitest";
 const uiRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 describe("PWA install mode", () => {
-  it("opens home-screen launches with browser controls visible", () => {
+  it("installs to the home screen as a chromeless standalone app (TON-2311)", () => {
     const manifest = JSON.parse(readFileSync(resolve(uiRoot, "public/site.webmanifest"), "utf8")) as {
       display?: string;
     };
     const html = readFileSync(resolve(uiRoot, "index.html"), "utf8");
 
-    expect(manifest.display).toBe("browser");
-    expect(html).not.toContain('name="mobile-web-app-capable"');
-    expect(html).not.toContain('name="apple-mobile-web-app-capable"');
-    expect(html).not.toContain('name="apple-mobile-web-app-status-bar-style"');
+    // Standalone display drops the browser URL bar on Android/Chrome installs.
+    expect(manifest.display).toBe("standalone");
+    // iOS only honors add-to-home-screen standalone mode via these legacy metas.
+    expect(html).toContain('name="mobile-web-app-capable" content="yes"');
+    expect(html).toContain('name="apple-mobile-web-app-capable" content="yes"');
+    expect(html).toContain('name="apple-mobile-web-app-status-bar-style"');
   });
 });

--- a/ui/src/lib/pwa-install-mode.test.ts
+++ b/ui/src/lib/pwa-install-mode.test.ts
@@ -19,4 +19,21 @@ describe("PWA install mode", () => {
     expect(html).toContain('name="apple-mobile-web-app-capable" content="yes"');
     expect(html).toContain('name="apple-mobile-web-app-status-bar-style"');
   });
+
+  it("meets Android/Chrome installability criteria (TON-2311)", () => {
+    const manifest = JSON.parse(readFileSync(resolve(uiRoot, "public/site.webmanifest"), "utf8")) as {
+      name?: string;
+      start_url?: string;
+      icons?: Array<{ sizes?: string; purpose?: string }>;
+    };
+
+    // Chrome's add-to-home-screen / install prompt requires name + start_url,
+    // 192px and 512px icons, and a maskable icon for adaptive launcher icons.
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.start_url).toBeTruthy();
+    const sizes = new Set((manifest.icons ?? []).map((i) => i.sizes));
+    expect(sizes.has("192x192")).toBe(true);
+    expect(sizes.has("512x512")).toBe(true);
+    expect((manifest.icons ?? []).some((i) => (i.purpose ?? "").includes("maskable"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and its web board is the primary human touchpoint.
> - The boss reaches the board from an iPhone by typing the URL every time, which is tedious; he asked for an installable, app-like experience with no URL bar.
> - The PWA scaffolding (service worker + manifest) already shipped, but `display: browser` plus missing iOS metas meant add-to-home-screen still opened Safari chrome.
> - This PR flips the manifest to `standalone` and adds the iOS capability metas so the home-screen launch is chromeless.
> - The same change satisfies Android/Chrome installability (192/512/maskable icons + service worker already present).
> - The benefit is a one-tap, URL-bar-free app on both iOS and Android.

## What Changed

- `ui/public/site.webmanifest`: `display` `browser` → `standalone`.
- `ui/index.html`: add `mobile-web-app-capable`, `apple-mobile-web-app-capable`, and `apple-mobile-web-app-status-bar-style` metas.
- `ui/src/lib/pwa-install-mode.test.ts`: assert standalone install (iOS) and Android/Chrome installability criteria.

## Verification

- `npx vitest run src/lib/pwa-install-mode.test.ts` → 2 tests pass.
- Manual: iPhone Safari → Share → Add to Home Screen launches without the URL bar.

## Risks

- Low risk: manifest + meta-tag change only. iOS add-to-home-screen works over HTTP; Android install additionally requires an HTTPS origin, tracked separately.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended reasoning, via Claude Code (tool use + local test execution).

Related batch PRs: #7793, #7809.

## Dedup search

- [x] I searched the open and recently-closed GitHub PRs for similar or duplicate PRs and confirmed there is no overlap.
