### PR TITLE
fix(heartbeat): Share activeRunExecutions across service instances.

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -81,6 +81,7 @@ vi.mock("../adapters/index.ts", async () => {
 });
 
 import {
+  activeRunExecutions,
   heartbeatService,
   redactDetectedSuccessfulRunProgressSummaryForBoard,
 } from "../services/heartbeat.ts";
@@ -287,6 +288,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       model: "test-model",
     }));
     runningProcesses.clear();
+    activeRunExecutions.clear();
     for (const child of childProcesses) {
       child.kill("SIGKILL");
     }
@@ -1032,6 +1034,26 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(lease?.status).toBe("failed");
     expect(lease?.releasedAt).toBeTruthy();
+  });
+
+  it("does not reap a running run tracked by another heartbeat service instance", async () => {
+    const { runId } = await seedRunFixture({
+      processPid: 999_999_999,
+      includeIssue: false,
+    });
+    const schedulerHeartbeat = heartbeatService(db);
+    heartbeatService(db);
+
+    activeRunExecutions.add(runId);
+    try {
+      const result = await schedulerHeartbeat.reapOrphanedRuns();
+      expect(result.reaped).toBe(0);
+
+      const run = await schedulerHeartbeat.getRun(runId);
+      expect(run?.status).toBe("running");
+    } finally {
+      activeRunExecutions.delete(runId);
+    }
   });
 
   it.skipIf(process.platform === "win32")("reaps orphaned descendant process groups when the parent pid is already gone", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1041,10 +1041,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processPid: 999_999_999,
       includeIssue: false,
     });
-    const schedulerHeartbeat = heartbeatService(db);
-    heartbeatService(db);
-
     activeRunExecutions.add(runId);
+    
+    const schedulerHeartbeat = heartbeatService(db);
     try {
       const result = await schedulerHeartbeat.reapOrphanedRuns();
       expect(result.reaped).toBe(0);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2986,6 +2986,14 @@ export interface HeartbeatServiceOptions {
   environmentRuntime?: HeartbeatEnvironmentRuntime;
 }
 
+/**
+ * Process-wide set of heartbeat run ids currently inside executeRun().
+ * Must be shared across every heartbeatService() instance: routes, scheduler,
+ * and plugin host services each construct their own service object, but orphan
+ * reap on one instance must see runs started by another.
+ */
+export const activeRunExecutions = new Set<string>();
+
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({
@@ -3007,7 +3015,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     environmentRuntime,
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
-  const activeRunExecutions = new Set<string>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };


### PR DESCRIPTION
Each `heartbeatService()` call had its own `activeRunExecutions` set, so orphan reap on the scheduler could mark runs as orphaned while they were still executing on another instance (routes, plugin host). Hoist the set to module scope and add a cross-instance reap guard test.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent work is driven by the heartbeat subsystem, which starts runs, tracks in-flight execution, and recovers from crashes via orphan reap
> - `heartbeatService(db)` is a factory: the server constructs separate instances for the scheduler, HTTP routes, and plugin host services
> - Orphan reap (`reapOrphanedRuns`) skips runs listed in `activeRunExecutions`, but that set was scoped per service instance
> - A run started by one instance (e.g. a route handling a wakeup) was invisible to the scheduler instance’s reap loop, so legitimately running work could be marked orphaned and finalized early
> - This pull request hoists `activeRunExecutions` to a process-wide module-level set shared by every `heartbeatService()` instance
> - The benefit is that periodic and startup orphan reap correctly respects all in-flight runs regardless of which service object started them

## Linked Issues or Issue Description

No pre-existing issue. Bug description (per `bug_report.yml`):

**What happened?**  
Runs still executing inside `executeRun()` on one `heartbeatService()` instance could be reaped as orphaned when `reapOrphanedRuns()` ran on a different instance (scheduler tick or startup recovery), because each instance maintained its own `activeRunExecutions` set.

**Expected behavior**  
Orphan reap should skip any run currently inside `executeRun()` anywhere in the process, regardless of which `heartbeatService()` object started it.

**Steps to reproduce**
1. Start a Paperclip server with the heartbeat scheduler enabled (`pnpm dev`).
2. Trigger a long-running agent run via a route-owned `heartbeatService()` instance.
3. While the run is in `executeRun()`, invoke `reapOrphanedRuns()` from a separately constructed `heartbeatService()` instance (as the scheduler does every tick).
4. Before this fix, the reap path could treat the run as orphaned if it was not in the scheduler instance’s local set and no matching `runningProcesses` entry existed.

**Paperclip version or commit:** `master` (pre-fix); branch `fix/active-run-executions-process-wide`

**Deployment mode:** Local dev (`pnpm dev`) / any single-process server deployment

**Agent adapter(s) involved:** Not adapter-specific (core heartbeat bug)

## What Changed

- Export a process-wide `activeRunExecutions` `Set` at module scope in `heartbeat.ts`, with a comment explaining why it must be shared across instances.
- Remove the per-instance `activeRunExecutions` local inside `heartbeatService()`.
- Add a test in `heartbeat-process-recovery.test.ts` asserting that reap on one instance does not reap a run tracked in the shared set by another instance.
- Clear `activeRunExecutions` in test teardown alongside `runningProcesses`.

## Verification

```sh
pnpm --filter @paperclipai/server test server/src/__tests__/heartbeat-process-recovery.test.ts
```

Specifically covers the new case: `"does not reap a running run tracked by another heartbeat service instance"`.

Manual sanity check (optional): run a long agent task under `pnpm dev` and confirm the run is not prematurely finalized during the scheduler’s periodic orphan reap (5-minute staleness threshold).

## Risks

Low risk. Behavioural change is narrowly scoped: orphan reap now sees the same in-flight run set the whole process uses. The set is still maintained by existing `executeRun()` add/delete in `try`/`finally`; no API or schema changes. Theoretical concern is stale entries if a run crashed without cleanup, but that was already possible per-instance and is unchanged in recovery semantics.

## Model Used

Cursor - GPT-5.5 Medium

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A — server-only)*
- [ ] I have updated relevant documentation to reflect my changes *(N/A — internal invariant, no user-facing doc change)*
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

---
