### PR TITLE
fix(heartbeat): fail fast when a requested model profile is unsupported (RUD-1052)

### DIFF
--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -4,6 +4,7 @@ import {
   type AdapterModelProfileDefinition,
 } from "../adapters/index.js";
 import {
+  buildUnsupportedModelProfileAdapterResult,
   mergeModelProfileAdapterConfig,
   normalizeModelProfileWakeContext,
   resolveModelProfileApplication,
@@ -143,5 +144,67 @@ describe("heartbeat model profile application", () => {
     });
 
     expect(contextSnapshot).toMatchObject({ modelProfile: "cheap" });
+  });
+
+  it("synthesizes a failed adapter result when the adapter does not support the requested profile", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [],
+      agentRuntimeConfig: {},
+      issueModelProfile: "cheap",
+      contextSnapshot: {},
+    });
+
+    const result = buildUnsupportedModelProfileAdapterResult({
+      adapterType: "grok_local",
+      modelProfile,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.timedOut).toBe(false);
+    expect(result.errorCode).toBe("model_profile_not_supported");
+    expect(result.errorMessage).toMatch(/grok_local/);
+    expect(result.errorMessage).toMatch(/cheap/);
+    expect(result.errorMessage).toMatch(/no-op fallback/);
+    expect(result.clearSession).toBe(false);
+    expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0, cachedInputTokens: 0 });
+    expect(result.errorMeta).toMatchObject({
+      modelProfile: {
+        requested: "cheap",
+        applied: null,
+        fallbackReason: "adapter_profile_not_supported",
+      },
+    });
+    expect(result.resultJson).toMatchObject({
+      modelProfile: {
+        requested: "cheap",
+        applied: null,
+        fallbackReason: "adapter_profile_not_supported",
+      },
+    });
+  });
+
+  it("explains a runtime-disabled profile distinctly from a missing adapter profile", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [cheapProfile],
+      agentRuntimeConfig: {
+        modelProfiles: {
+          cheap: { enabled: false },
+        },
+      },
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap" },
+    });
+
+    const result = buildUnsupportedModelProfileAdapterResult({
+      adapterType: "codex_local",
+      modelProfile,
+    });
+
+    expect(result.errorCode).toBe("model_profile_not_supported");
+    expect(result.errorMessage).toMatch(/disabled/);
+    expect(result.errorMessage).not.toMatch(/no-op fallback/);
+    expect(result.errorMeta).toMatchObject({
+      modelProfile: { fallbackReason: "agent_runtime_profile_disabled" },
+    });
   });
 });

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -207,4 +207,35 @@ describe("heartbeat model profile application", () => {
       modelProfile: { fallbackReason: "agent_runtime_profile_disabled" },
     });
   });
+
+  it("reproduces the CTO RUD-900 path: grok_local wake-context cheap request fails fast", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [],
+      agentRuntimeConfig: {},
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap" },
+    });
+
+    const result = buildUnsupportedModelProfileAdapterResult({
+      adapterType: "grok_local",
+      modelProfile,
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "wake_context",
+      applied: null,
+      configSource: null,
+      fallbackReason: "adapter_profile_not_supported",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.timedOut).toBe(false);
+    expect(result.errorCode).toBe("model_profile_not_supported");
+    expect(result.errorMessage).toMatch(/grok_local/);
+    expect(result.errorMessage).toMatch(/cheap/);
+    expect(result.clearSession).toBe(false);
+    expect(result.errorMeta).toMatchObject({
+      modelProfile: { requestedBy: "wake_context" },
+    });
+  });
 });

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -238,4 +238,33 @@ describe("heartbeat model profile application", () => {
       modelProfile: { requestedBy: "wake_context" },
     });
   });
+
+  it("explains a profile-resolution failure distinctly from a missing adapter profile", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [],
+      agentRuntimeConfig: {},
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap" },
+      profileResolutionFallbackReason: "adapter_profile_resolution_failed",
+    });
+
+    const result = buildUnsupportedModelProfileAdapterResult({
+      adapterType: "claude_local",
+      modelProfile,
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      applied: null,
+      fallbackReason: "adapter_profile_resolution_failed",
+    });
+    expect(result.errorCode).toBe("model_profile_not_supported");
+    expect(result.errorMessage).toMatch(/Failed to resolve model profiles/);
+    expect(result.errorMessage).toMatch(/claude_local/);
+    expect(result.errorMessage).toMatch(/cheap/);
+    expect(result.errorMessage).not.toMatch(/no-op fallback/);
+    expect(result.errorMeta).toMatchObject({
+      modelProfile: { fallbackReason: "adapter_profile_resolution_failed" },
+    });
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1582,6 +1582,65 @@ function mergeModelProfileRunMetadata(
   };
 }
 
+function unsupportedModelProfileErrorMessage(input: {
+  adapterType: string | null;
+  modelProfile: ModelProfileApplication;
+}): string {
+  const requested = input.modelProfile.requested ?? "unknown";
+  const reason = input.modelProfile.fallbackReason ?? "adapter_profile_not_supported";
+  const adapter = input.adapterType ?? "unknown";
+  if (reason === "agent_runtime_profile_disabled") {
+    return (
+      `Requested model profile "${requested}" is disabled for this agent ` +
+      `(adapter=${adapter}). Re-enable it under the agent's runtime profile settings, ` +
+      `or use an adapter that supports the profile.`
+    );
+  }
+  if (reason === "adapter_profile_resolution_failed") {
+    return (
+      `Failed to resolve model profiles for adapter "${adapter}" while handling ` +
+      `requested profile "${requested}". Aborting instead of running a no-op.`
+    );
+  }
+  return (
+    `Adapter "${adapter}" does not support model profile "${requested}". ` +
+    `Aborting instead of running a no-op fallback that would record 0 tokens. ` +
+    `Use an adapter that advertises the profile, or remove the profile request.`
+  );
+}
+
+export function buildUnsupportedModelProfileAdapterResult(input: {
+  adapterType: string | null;
+  modelProfile: ModelProfileApplication;
+}): AdapterExecutionResult {
+  const errorMessage = unsupportedModelProfileErrorMessage(input);
+  const metadata = modelProfileRunMetadata(input.modelProfile);
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    errorMessage,
+    errorCode: "model_profile_not_supported",
+    errorMeta: metadata ? { modelProfile: metadata } : undefined,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+    },
+    sessionId: null,
+    sessionParams: null,
+    sessionDisplayId: null,
+    provider: null,
+    biller: null,
+    model: null,
+    billingType: null,
+    costUsd: null,
+    resultJson: metadata ? { modelProfile: metadata } : null,
+    summary: errorMessage,
+    clearSession: false,
+  };
+}
+
 export function summarizeHeartbeatRunContextSnapshot(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> | null {
@@ -8759,6 +8818,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
 
       let adapterResult: Awaited<ReturnType<typeof adapter.execute>>;
+      if (modelProfileApplication.fallbackReason) {
+        const unsupportedResult = buildUnsupportedModelProfileAdapterResult({
+          adapterType: agent.adapterType,
+          modelProfile: modelProfileApplication,
+        });
+        await onLog(
+          "stderr",
+          `[paperclip] ${unsupportedResult.errorMessage}\n`,
+        );
+        await recordWorkspaceFinalize("failed", {
+          errorMessage: unsupportedResult.errorMessage ?? null,
+        });
+        await appendRunEvent(currentRun, seq++, {
+          eventType: "adapter.invoke",
+          stream: "system",
+          level: "error",
+          message: "model profile fallback rejected; skipping adapter execution",
+          payload: {
+            adapterType: agent.adapterType,
+            ...(unsupportedResult.errorMeta ?? {}),
+          },
+        });
+        adapterResult = unsupportedResult;
+      } else {
       try {
         adapterResult = await adapter.execute({
           runId: run.id,
@@ -8809,6 +8892,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           );
         }
         throw adapterErr;
+      }
       }
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8827,72 +8827,92 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           "stderr",
           `[paperclip] ${unsupportedResult.errorMessage}\n`,
         );
-        await recordWorkspaceFinalize("failed", {
-          errorMessage: unsupportedResult.errorMessage ?? null,
-        });
-        await appendRunEvent(currentRun, seq++, {
-          eventType: "adapter.invoke",
-          stream: "system",
-          level: "error",
-          message: "model profile fallback rejected; skipping adapter execution",
-          payload: {
-            adapterType: agent.adapterType,
-            ...(unsupportedResult.errorMeta ?? {}),
-          },
-        });
-        adapterResult = unsupportedResult;
-      } else {
-      try {
-        adapterResult = await adapter.execute({
-          runId: run.id,
-          agent,
-          runtime: runtimeForAdapter,
-          config: runtimeConfig,
-          context,
-          runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
-          executionTarget,
-          executionTransport: remoteExecution
-            ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
-            : undefined,
-          onLog,
-          onMeta: onAdapterMeta,
-          onSpawn: async (meta) => {
-            await persistRunProcessMetadata(run.id, {
-              pid: meta.pid,
-              processGroupId:
-                "processGroupId" in meta && typeof meta.processGroupId === "number"
-                  ? meta.processGroupId
-                  : null,
-              startedAt: meta.startedAt,
-            });
-          },
-          authToken: authToken ?? undefined,
-        });
-        // Adapter returned cleanly, which means its workspace-restore finally
-        // block also ran without throwing. Record the workspace_finalize
-        // barrier so dependents that share this executionWorkspace can wake.
-        // If recording the barrier itself fails, propagate as a run failure
-        // rather than silently leaving dependents stranded behind a missing
-        // finalize row.
-        await recordWorkspaceFinalize("succeeded");
-      } catch (adapterErr) {
-        // Adapter (or its restore finally) threw — or the finalize record
-        // write itself threw. Either way the workspace may be in a partial
-        // state. Best-effort record finalize=failed so the dependent readiness
-        // check keeps the gate closed instead of waking on stale local state,
-        // and surface the original error to the caller.
+        // Record the workspace_finalize=failed barrier so dependents that
+        // share this executionWorkspace do not wake into a half-initialized
+        // state. The record is best-effort: a transient DB write failure
+        // must not mask the model_profile_not_supported run failure, so we
+        // swallow any throw with a warning and let the run surface the
+        // synthesized adapter result.
         try {
           await recordWorkspaceFinalize("failed", {
-            errorMessage: adapterErr instanceof Error ? adapterErr.message : String(adapterErr),
+            errorMessage: unsupportedResult.errorMessage ?? null,
           });
         } catch (recordErr) {
           logger.warn(
             { err: recordErr, runId: run.id, executionWorkspaceId: persistedExecutionWorkspace?.id ?? null },
-            "failed to record workspace_finalize=failed operation; dependents may remain gated",
+            "failed to record workspace_finalize=failed operation on model profile fast-fail; dependents may remain gated",
           );
         }
-        throw adapterErr;
-      }
+        try {
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "adapter.invoke",
+            stream: "system",
+            level: "error",
+            message: "model profile fallback rejected; skipping adapter execution",
+            payload: {
+              adapterType: agent.adapterType,
+              ...(unsupportedResult.errorMeta ?? {}),
+            },
+          });
+        } catch (eventErr) {
+          logger.warn(
+            { err: eventErr, runId: run.id },
+            "failed to append adapter.invoke run event on model profile fast-fail",
+          );
+        }
+        adapterResult = unsupportedResult;
+      } else {
+        try {
+          adapterResult = await adapter.execute({
+            runId: run.id,
+            agent,
+            runtime: runtimeForAdapter,
+            config: runtimeConfig,
+            context,
+            runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
+            executionTarget,
+            executionTransport: remoteExecution
+              ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }
+              : undefined,
+            onLog,
+            onMeta: onAdapterMeta,
+            onSpawn: async (meta) => {
+              await persistRunProcessMetadata(run.id, {
+                pid: meta.pid,
+                processGroupId:
+                  "processGroupId" in meta && typeof meta.processGroupId === "number"
+                    ? meta.processGroupId
+                    : null,
+                startedAt: meta.startedAt,
+              });
+            },
+            authToken: authToken ?? undefined,
+          });
+          // Adapter returned cleanly, which means its workspace-restore finally
+          // block also ran without throwing. Record the workspace_finalize
+          // barrier so dependents that share this executionWorkspace can wake.
+          // If recording the barrier itself fails, propagate as a run failure
+          // rather than silently leaving dependents stranded behind a missing
+          // finalize row.
+          await recordWorkspaceFinalize("succeeded");
+        } catch (adapterErr) {
+          // Adapter (or its restore finally) threw — or the finalize record
+          // write itself threw. Either way the workspace may be in a partial
+          // state. Best-effort record finalize=failed so the dependent readiness
+          // check keeps the gate closed instead of waking on stale local state,
+          // and surface the original error to the caller.
+          try {
+            await recordWorkspaceFinalize("failed", {
+              errorMessage: adapterErr instanceof Error ? adapterErr.message : String(adapterErr),
+            });
+          } catch (recordErr) {
+            logger.warn(
+              { err: recordErr, runId: run.id, executionWorkspaceId: persistedExecutionWorkspace?.id ?? null },
+              "failed to record workspace_finalize=failed operation; dependents may remain gated",
+            );
+          }
+          throw adapterErr;
+        }
       }
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service in `server/src/services/heartbeat.ts` resolves a `ModelProfileApplication` (e.g. `modelProfile.cheap`) per run by intersecting the wake/issue profile request with what the agent's adapter actually supports.
> - When the adapter does not support the requested profile, `resolveModelProfileApplication` returns a `fallbackReason` (e.g. `adapter_profile_not_supported`) and an empty `adapterConfig`. Today, heartbeat then proceeds to invoke the adapter with the unchanged base config — producing a silent 0-token, 0-output run for adapters like `grok_local`.
> - This pattern (grok_local + cheap profile + 0 tokens) is what keeps reappearing in CTO productivity reviews, because the watchdog sees a "succeeded" run with no useful action.
> - This pull request fails fast at the heartbeat invocation site whenever the profile application carries a `fallbackReason`, returning a synthetic failed `AdapterExecutionResult` with explicit `errorCode`, a human-readable message, and the profile metadata attached.
> - The benefit is that every `modelProfile.X`-not-supported run is now a real failed run that watchdog/recovery can classify, and operators get a one-line actionable error that names the adapter and the profile.

## Linked Issues or Issue Description

The user-visible bug, repro, expected behavior, and acceptance criteria are below — written in the bug-report template style because the upstream `paperclipai/paperclip` repo has no public issue number for this work (it is tracked internally as CTO follow-up to a previous silent-run disposition review; this PR is the technical fix the public repo should take to remove the silent-no-op path on every adapter that does not support model profiles).

### Bug

### What happened
When a Paperclip agent's adapter is asked for a `modelProfile` it does not support, the run is recorded as **succeeded** with `inputTokens=0`, `outputTokens=0`, and no model output. The run is silently a no-op.

### Expected behavior
Paperclip should either apply the requested profile (with an adapter that supports it) or fail the run with an explicit, machine-readable error that names the adapter, the requested profile, and the fallback reason — so the watchdog does not misclassify a no-op as a healthy 0-token run.

### Steps to reproduce
1. Configure an agent with `adapterType = grok_local`. (`grok_local` advertises no model profiles.)
2. Trigger a run whose wake context includes `modelProfile = "cheap"` (this is what the recovery / status-only lane currently does for several CTO-level silent-run reviews).
3. Observe: the run is persisted with `exitCode = 0`, no `errorMessage`, and `inputTokens = outputTokens = 0`.

**Why it matters.** Silent no-op runs trigger the CTO output-silence watchdog and create recurring "silent active run" reviews that waste human + agent time. Each such review ends in a false-positive disposition because the underlying problem is not a hung process — it is a *correct* `fallbackReason` that heartbeat ignores.

### Paperclip version / commit
This affects any version where the model-profile resolution path exists in `server/src/services/heartbeat.ts` (i.e. since the `modelProfile.cheap` lane was introduced for recovery). Deployment mode: any.

### Acceptance criteria

- `modelProfile.X` requests for an adapter that does not advertise profile `X` produce a **failed** run with `errorCode = "model_profile_not_supported"` and a one-line actionable `errorMessage` naming the adapter and profile.
- Adapters that *do* support the requested profile are completely untouched (no behavior change on the success path).
- The smallest regression coverage proves the new behavior: a unit test that synthesizes the failure response and asserts the `errorCode` / `errorMessage` / `errorMeta` / `resultJson.modelProfile` shape, plus a second test that distinguishes the `agent_runtime_profile_disabled` case (operator can re-enable the profile) from the `adapter_profile_not_supported` case (operator must switch adapter).

## What Changed

- New `buildUnsupportedModelProfileAdapterResult` helper in `server/src/services/heartbeat.ts` that synthesizes an `AdapterExecutionResult` for any `modelProfile.fallbackReason` (`adapter_profile_not_supported`, `agent_runtime_profile_disabled`, `adapter_profile_resolution_failed`). The result has `exitCode=1`, `errorCode="model_profile_not_supported"`, no usage/session/provider/biller/model, an explanatory message that names the adapter and requested profile, and the original `modelProfile` metadata preserved in `errorMeta`/`resultJson`.
- Heartbeat invocation block now short-circuits into that synthetic result when `modelProfileApplication.fallbackReason` is set, before calling `adapter.execute`. We also record `workspace_finalize=failed` (best-effort, with a warning log on recorder error) and an `adapter.invoke` `error` run event (best-effort, with a warning log on recorder error) so dependents waiting on this execution workspace do not wake into a half-initialized state. The recorder calls mirror the existing error-protection pattern used by the adapter-execute catch block, so a transient DB write failure does not mask the synthesized `model_profile_not_supported` run failure.
- Follow-up commit hardened the fast-fail path per Greptile review: wrapped `recordWorkspaceFinalize` and `appendRunEvent` in nested try/catch with `logger.warn`, re-indented the existing try/catch inside the new `else` block, and added test coverage for the `adapter_profile_resolution_failed` branch.
- New unit tests in `server/src/__tests__/heartbeat-model-profile.test.ts`:
  - synthesizes a failed result with the right `errorCode` / `errorMessage` / `errorMeta` / `resultJson` for `adapter_profile_not_supported`;
  - produces a distinct message for `agent_runtime_profile_disabled` so operators see the right remediation;
  - reproduces the CTO RUD-900 wake-context path (grok_local + cheap) end-to-end;
  - produces a distinct message for `adapter_profile_resolution_failed`.

## Verification

- `pnpm --filter @paperclipai/server typecheck` → passes.
- `npx vitest run server/src/__tests__/heartbeat-model-profile.test.ts` → 9/9 tests pass (5 pre-existing + 4 new).
- Recovery / profile-hint suites still green: `npx vitest run src/services/recovery/model-profile-hint.test.ts src/services/recovery/successful-run-handoff.test.ts` → 24/24 pass.
- Manual scenario: an agent with `adapterType=grok_local` whose wake context contains `modelProfile=cheap` (the only path that exposes the bug today) now produces a run with `errorCode=model_profile_not_supported`, `fallbackReason=adapter_profile_not_supported`, and a clear `errorMessage` naming `grok_local` and `cheap`. The watchdog will no longer see a 0-token succeeded run.

## Risks

- **Low risk.** The change only affects the path where the profile application *already* has a non-null `fallbackReason` — a path that today is a silent no-op. Adapters whose profile resolves cleanly (`fallbackReason=null`) go through the unchanged `adapter.execute` call. The recovery flow that uses `modelProfile.cheap` as a status-only hint keeps working for adapters that *do* support cheap (e.g. `codex_local`); for adapters that don't (e.g. `grok_local`), recovery now fails fast with an explicit reason rather than producing a silent 0-token run, which is the intended behavior.
- The synthetic adapter result omits `provider` / `biller` / `model` — ledger code that requires those values should already handle nulls (it does for normal failed runs), but worth eyeballing in staging.
- The fast-fail recorder calls (`recordWorkspaceFinalize` and `appendRunEvent`) are best-effort: a transient DB write error is logged as a warning and the run still surfaces the synthesized `model_profile_not_supported` failure. This matches the error-protection pattern already used in the catch block of the regular adapter-execute path.
- No schema changes. No migrations. No new dependencies.

## Model Used

- `minimax-coding-plan/MiniMax-M3` (the model serving this Paperclip CTO agent) — autonomous coding tool, tool-use enabled, large context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have linked any related issues (inline issue description above, per commitperclip's request — this PR is from a CTO agent whose tracking lives on a separate Paperclip control plane, not a public `paperclipai/paperclip` issue number)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] Tests pass locally (`pnpm typecheck` + targeted vitest on model-profile and recovery suites)
- [x] I have used the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
