### PR TITLE
fix(issues): close linked execution workspace on terminal issue transition (#7790)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4173,3 +4173,132 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     expect(record?.childIssues.every((child) => typeof child.title === "string")).toBe(true);
   });
 });
+
+describeEmbeddedPostgres("issueService.update closes terminal execution workspaces (#7790)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-ews-close-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "WS project",
+      status: "in_progress",
+    });
+    return { companyId, projectId };
+  }
+
+  async function insertWorkspace(companyId: string, projectId: string) {
+    const workspaceId = randomUUID();
+    await db.insert(executionWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      mode: "isolated_workspace",
+      strategyType: "issue_isolated",
+      name: "WS",
+      status: "active",
+      providerType: "local_fs",
+    });
+    return workspaceId;
+  }
+
+  for (const terminal of ["done", "cancelled"] as const) {
+    it(`closes the linked workspace when an issue transitions to ${terminal}`, async () => {
+      const { companyId, projectId } = await seed();
+      const workspaceId = await insertWorkspace(companyId, projectId);
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        projectId,
+        title: "Work",
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "user-1",
+        executionWorkspaceId: workspaceId,
+      });
+
+      await svc.update(issueId, { status: terminal });
+
+      const ws = await db
+        .select()
+        .from(executionWorkspaces)
+        .where(eq(executionWorkspaces.id, workspaceId))
+        .then((rows) => rows[0]);
+      expect(ws?.status).toBe("archived");
+      expect(ws?.closedAt).toBeInstanceOf(Date);
+      expect(ws?.cleanupEligibleAt).toBeInstanceOf(Date);
+      expect(ws?.cleanupReason).toBe(`issue_${terminal}`);
+    });
+  }
+
+  it("keeps a shared workspace open while another non-terminal issue still references it", async () => {
+    const { companyId, projectId } = await seed();
+    const workspaceId = await insertWorkspace(companyId, projectId);
+    const doneIssueId = randomUUID();
+    const activeIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: doneIssueId,
+        companyId,
+        projectId,
+        title: "Finishing",
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "user-1",
+        executionWorkspaceId: workspaceId,
+      },
+      {
+        id: activeIssueId,
+        companyId,
+        projectId,
+        title: "Still running",
+        status: "in_progress",
+        priority: "medium",
+        assigneeUserId: "user-1",
+        executionWorkspaceId: workspaceId,
+      },
+    ]);
+
+    await svc.update(doneIssueId, { status: "done" });
+
+    const ws = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, workspaceId))
+      .then((rows) => rows[0]);
+    expect(ws?.status).toBe("active");
+    expect(ws?.closedAt).toBeNull();
+    expect(ws?.cleanupEligibleAt).toBeNull();
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5073,6 +5073,48 @@ export function issueService(db: Db) {
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;
+        // GH #7790: when an issue reaches a terminal state, close its linked
+        // execution workspace so the row doesn't leak at status='active' with a
+        // null closed_at/cleanup_eligible_at forever. Only close when no other
+        // non-terminal issue still references the workspace, so shared
+        // workspaces stay open while other work is still using them.
+        if (
+          (issueData.status === "done" || issueData.status === "cancelled") &&
+          existing.executionWorkspaceId
+        ) {
+          const workspaceId = existing.executionWorkspaceId;
+          const otherActiveIssues = await tx
+            .select({ id: issues.id })
+            .from(issues)
+            .where(
+              and(
+                eq(issues.companyId, existing.companyId),
+                eq(issues.executionWorkspaceId, workspaceId),
+                ne(issues.id, id),
+                notInArray(issues.status, ["done", "cancelled"]),
+              ),
+            )
+            .limit(1);
+          if (otherActiveIssues.length === 0) {
+            const closedAt = new Date();
+            await tx
+              .update(executionWorkspaces)
+              .set({
+                status: "archived",
+                closedAt,
+                cleanupEligibleAt: closedAt,
+                cleanupReason: `issue_${issueData.status}`,
+                updatedAt: closedAt,
+              })
+              .where(
+                and(
+                  eq(executionWorkspaces.id, workspaceId),
+                  eq(executionWorkspaces.companyId, existing.companyId),
+                  isNull(executionWorkspaces.closedAt),
+                ),
+              );
+          }
+        }
         if (nextLabelIds !== undefined) {
           await syncIssueLabels(updated.id, existing.companyId, nextLabelIds, tx);
         }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; each issue/heartbeat can provision an `execution_workspaces` (ews) row for its sandbox.
> - Those rows track lifecycle via `closed_at` / `cleanup_eligible_at`, but #7790 found those columns are written in exactly one place — the explicit archive endpoint.
> - So every issue that finishes leaves its workspace stuck at `status='active'`, `closed_at IS NULL` forever — a steadily growing lifecycle leak with no reaper to catch it.
> - The primary, highest-volume gap is the issue terminal transition: `applyStatusSideEffects` stamps the issue done/cancelled but never touches the linked workspace.
> - This PR closes the linked workspace in the same update transaction when an issue goes terminal, guarded so shared workspaces stay open while other work still references them.
> - The benefit is that finished issues stop leaking active workspace rows, and closed rows become cleanup-eligible.

## What Changed

- `server/src/services/issues.ts`: in the issue-update transaction, when status becomes `done`/`cancelled` and the issue has a linked `executionWorkspaceId`, set the workspace `status='archived'`, `closed_at`, `cleanup_eligible_at`, `cleanup_reason='issue_<status>'`. Only fires when no other non-terminal issue references the workspace (shared-workspace safe) and only when `closed_at IS NULL` (idempotent).
- `server/src/__tests__/issues-service.test.ts`: embedded-Postgres tests for done + cancelled closing a dedicated workspace, and a shared workspace staying open while another active issue references it.

## Verification

- `npx vitest run src/__tests__/issues-service.test.ts -t "#7790"` → 3 pass.
- Server `tsc --noEmit` clean.

## Risks

- Low risk: additive, runs inside the existing update transaction; the shared-workspace reference guard prevents closing a workspace still in use, and the `closed_at IS NULL` guard makes it idempotent. Does not perform runtime/fs teardown (that remains the reaper/teardown path's job via `cleanup_eligible_at`). Note: #7790 also lists two further gaps (soft project-archive cascade, and a periodic reaper) — out of scope here; this fixes the dominant issue-transition leak.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended reasoning, via Claude Code (tool use + local embedded-Postgres test execution).

Closes #7790. Related contributions: #7809, #7792.

## Dedup search

- [x] I searched the open and recently-closed GitHub PRs for similar or duplicate PRs (incl. the execution-workspace / cascade area) and confirmed no open PR addresses the issue-terminal workspace close.
