### PR TITLE
docs(execution-semantics): §9.4 Empty-heartbeat detection (PUL-3759)

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -456,7 +456,7 @@ Which action Paperclip picks is a per-company policy choice. Auto-downgrade is t
 
 This is distinct from productivity review. Productivity review asks whether an *assigned source issue* shows unusual progression patterns — no-comment terminal-run streaks, long active duration, high churn — and acts on the issue. Empty-heartbeat detection asks whether the *agent's scheduled wake schedule itself* is producing any work at all, and acts on the agent's `runtimeConfig`. One does not substitute for the other: a productive agent can still have an oversized heartbeat budget, and a misconfigured event-driven agent can still be doing productive work on every assignment wake.
 
-Empty-heartbeat detection runs on the periodic reconciliation loop alongside productivity review (§10, step 5).
+Empty-heartbeat detection runs on the periodic reconciliation loop as a distinct pass after productivity review (§10, step 6).
 
 ## 10. Startup and Periodic Reconciliation
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -435,19 +435,43 @@ Cheap model profiles are only for status-only operational recovery overhead. Pap
 
 Automatic retries that can continue source work must use the original/normal model lane. This includes failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, assigned-todo dispatch recovery, and any run that can update repo files, issue documents, plans, work products, or attachments. When a cheap status-only recovery determines that actual work remains, it must hand back to a normal-model worker run before source work or persistent deliverable updates resume. Cheap recovery hints must be scrubbed from copied retry, resume, child, and downstream source-work contexts.
 
+### 9.4 Empty-heartbeat detection
+
+Timer heartbeats exist for roles whose work is genuinely scheduled and independent of wake events. They are not the right delivery mechanism for roles whose responsibilities are entirely event-driven — mentions, routines firing, board comments, blocker-resolution wakes, assignment wakes, or external webhooks. An event-driven role with `runtimeConfig.heartbeat.enabled=true` will keep firing scheduled wakes whose inbox poll is the only observable effect, burning model spend and noise without producing work.
+
+Configuration rule:
+
+> An agent whose responsibilities are entirely event-driven MUST have `runtimeConfig.heartbeat.enabled=false`. Timer heartbeats are reserved for roles whose work is genuinely scheduled and independent of wake events.
+
+This is consistent with the hire-time default already documented in [`server/src/routes/llms.ts:49`](../server/src/routes/llms.ts) (`Timer heartbeats are opt-in for new hires. Leave runtimeConfig.heartbeat.enabled false unless the role truly needs scheduled work or the user explicitly asked for it.`) and the new-hire UI tooltip for `heartbeatInterval` ([`ui/src/components/agent-config-primitives.tsx`](../ui/src/components/agent-config-primitives.tsx) — "Run this agent automatically on a timer. Useful for periodic tasks like checking for new work."). Both surfaces frame timer heartbeats as opt-in. §9.4 codifies the runtime consequence when that default is set incorrectly.
+
+Detection rule:
+
+- Paperclip tracks, per agent with `heartbeat.enabled=true`, the productive output of each scheduled wake. A wake is "empty" when it produces no observable productive work: no comment, no issue status change, no issue created, no document or plan revision, no work product, no attachment, and no run output beyond the inbox poll itself. Assignment-wake runs, mention-wake runs, blocker-resolution-wake runs, and routine-firing runs are excluded from the streak — only the agent's own scheduled timer wakes count.
+- After `N` consecutive empty scheduled wakes (`N` configurable per company, default conservative), Paperclip takes one of two actions:
+  - **Auto-downgrade** the agent's `runtimeConfig.heartbeat.enabled` to `false` and post a notice comment on the agent surface explaining the downgrade, the streak length, and how to re-enable. The agent's event-driven wake paths (mentions, routines, assignments, blocker resolution) keep working unchanged.
+  - **Operator review** by opening or updating an explicit recovery action against the role, asking a permitted operator to confirm whether the role still warrants scheduled work. The visible comment is evidence, not the recovery path by itself.
+
+Which action Paperclip picks is a per-company policy choice. Auto-downgrade is the lower-friction default for self-managed companies; operator review is appropriate when the agent's heartbeat schedule reflects an explicit governance decision that a system should not silently revert.
+
+This is distinct from productivity review. Productivity review asks whether an *assigned source issue* shows unusual progression patterns — no-comment terminal-run streaks, long active duration, high churn — and acts on the issue. Empty-heartbeat detection asks whether the *agent's scheduled wake schedule itself* is producing any work at all, and acts on the agent's `runtimeConfig`. One does not substitute for the other: a productive agent can still have an oversized heartbeat budget, and a misconfigured event-driven agent can still be doing productive work on every assignment wake.
+
+Empty-heartbeat detection runs on the periodic reconciliation loop alongside productivity review (§10, step 5).
+
 ## 10. Startup and Periodic Reconciliation
 
 Startup recovery and periodic recovery are different from normal wakeup delivery.
 
-On startup and on the periodic recovery loop, Paperclip now does five things in sequence:
+On startup and on the periodic recovery loop, Paperclip now does six things in sequence:
 
 1. reap orphaned `running` runs
 2. resume persisted `queued` runs
 3. reconcile stranded assigned work
 4. scan silent active runs, revalidate their source issues, and either fold source-resolved watchdogs or create/update explicit watchdog recovery actions
 5. reconcile productivity reviews
+6. scan empty-heartbeat streaks per §9.4 and either auto-downgrade `heartbeat.enabled` or open an operator review action
 
-The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output. The productivity-review pass is later and separate; it reviews unusual progression patterns on assigned source issues, not stale run handles after a source issue already has a valid disposition.
+The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output. The productivity-review pass is later and separate; it reviews unusual progression patterns on assigned source issues, not stale run handles after a source issue already has a valid disposition. The empty-heartbeat pass is separate again; it acts on the agent's wake configuration when a role's scheduled timer is producing no observable work at all.
 
 ## 11. Silent Active-Run Watchdog
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Per-agent wake delivery includes a scheduled timer ("heartbeat") in addition to event-driven wakes (mentions, routines, board comments, blocker resolution)
> - Roles whose responsibilities are entirely event-driven do not need a timer; if `runtimeConfig.heartbeat.enabled=true` is set anyway, the agent fires scheduled wakes whose only observable effect is an inbox poll, burning model spend and producing no work
> - The Liaison incident in PUL-3203 made this concrete (Phase 0: CEO patched Liaison `heartbeat.enabled=false` live, 2026-06-09); without a written runtime contract, the same misconfiguration can reappear on any role
> - This pull request adds §9.4 "Empty-heartbeat detection" to `doc/execution-semantics.md`, codifying the configuration rule (event-driven roles MUST have `heartbeat.enabled=false`) and the detection rule (Paperclip should track consecutive empty scheduled wakes per agent and either auto-downgrade `heartbeat.enabled` or open an operator review action), and registers the new pass as step 6 of §10's periodic reconciliation sequence
> - The benefit is that runtime detection of misconfigured event-driven heartbeats now has a written contract that engineers can implement against, and the hire-time guidance in `server/src/routes/llms.ts:49` and the new-hire UI tooltip in `ui/src/components/agent-config-primitives.tsx` are explicitly cross-linked so the default-off intent at hire time matches what the runtime now enforces

## Linked Issues or Issue Description

Closes PUL-3759. Phase 1 of PUL-3203.

## What Changed

- `doc/execution-semantics.md`: adds §9.4 "Empty-heartbeat detection" with a configuration rule and a detection rule, and cross-links the hire-time guidance at `server/src/routes/llms.ts:49` and the new-hire UI tooltip in `ui/src/components/agent-config-primitives.tsx`
- `doc/execution-semantics.md`: extends §10's periodic reconciliation sequence from five steps to six, registering the empty-heartbeat pass as step 6 (distinct from productivity review at step 5)
- Closing paragraph of §9.4 explains why empty-heartbeat detection is not a substitute for productivity review: productivity review acts on assigned source issues, empty-heartbeat detection acts on the agent's `runtimeConfig.heartbeat.enabled`

## Verification

- [x] `git diff master -- doc/execution-semantics.md` shows only additive changes to §9.4 and §10
- [x] Cross-links to `server/src/routes/llms.ts:49` and `ui/src/components/agent-config-primitives.tsx` resolve to the documented hire-time guidance and the `heartbeatInterval` tooltip respectively (Greptile confirmed both)
- [x] Greptile cross-reference flag addressed: closing sentence of §9.4 now cites "§10, step 6" (was incorrectly "step 5", which is productivity review); commit `8579620e`
- [ ] Reviewer renders the doc in GitHub markdown view to confirm §9.4 fits the §9 Crash and Restart Recovery framing alongside §9.1–§9.3

## Risks

Low risk. Doc-only change. No code, schema, runtime, or migration impact. The contract codified here describes runtime behavior that does not exist yet — implementation will land in a follow-up PR under PUL-3203. The cross-linked source files (`server/src/routes/llms.ts:49`, `ui/src/components/agent-config-primitives.tsx`) are not modified by this PR and continue to reflect the existing hire-time default.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: 200K tokens
- Reasoning mode: standard (no extended thinking)
- Tool use: file reads/edits and shell via the Claude Code harness

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found beyond PUL-3203 parent)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass (doc-only change; CI green except the PR-template check this edit fixes)
- [N/A] I have added or updated tests where applicable (doc-only change)
- [N/A] If this change affects the UI, I have included before/after screenshots (no UI change)
- [x] I have updated relevant documentation to reflect my changes (this PR *is* the documentation update)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (commitperclip `review` check fails on the prior PR body; this edit should re-trigger it)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (cross-reference fix pushed in `8579620e`; awaiting re-review)
- [x] I will address all Greptile and reviewer comments before requesting merge

Filed from a fork because `pulsaragent` has READ-only access to `paperclipai/paperclip`. Happy to hand off to a maintainer for any rewording before merge.