### PR TITLE
fix(gemini-local): fresh session when resuming a paused/terminated run

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.remote.test.ts
@@ -320,4 +320,153 @@ describe("gemini remote execution", () => {
     expect(restoreWorkspaceFromSshExecution).toHaveBeenCalledTimes(1);
     expect(runChildProcess).not.toHaveBeenCalled();
   });
+
+  it("starts a fresh session instead of resuming when the prior run was paused mid-execution", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-paused-resume-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const managedRemoteWorkspace = "/remote/workspace/.paperclip-runtime/runs/run-paused-resume/workspace";
+    await mkdir(workspaceDir, { recursive: true });
+
+    const result = await execute({
+      runId: "run-paused-resume",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Gemini Builder",
+        adapterType: "gemini_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "session-123",
+        sessionParams: {
+          sessionId: "session-123",
+          cwd: managedRemoteWorkspace,
+          remoteExecution: {
+            transport: "ssh",
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteCwd: managedRemoteWorkspace,
+          },
+        },
+        sessionDisplayId: "session-123",
+        taskKey: null,
+      },
+      config: {
+        command: "gemini",
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+        // The heartbeat sets this when resuming a run that was paused/terminated
+        // mid-execution; the adapter must not resume the wedged session.
+        resumedFromPausedRun: true,
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).not.toContain("--resume");
+    expect(call?.[2]).not.toContain("session-123");
+    // The fresh run's own session id is persisted, never the wedged one.
+    expect(result.sessionParams).toMatchObject({ sessionId: "gemini-session-1" });
+    expect(result.sessionId).toBe("gemini-session-1");
+  });
+
+  it("does not re-adopt the paused run's stale session id when the fresh run emits none", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-paused-nofallback-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const managedRemoteWorkspace = "/remote/workspace/.paperclip-runtime/runs/run-paused-nofallback/workspace";
+    await mkdir(workspaceDir, { recursive: true });
+
+    // Fresh run that emits no session id of its own.
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "message", role: "assistant", content: "done" }),
+        JSON.stringify({
+          type: "result",
+          status: "success",
+          stats: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+        }),
+      ].join("\n"),
+      stderr: "",
+      pid: 321,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-paused-nofallback",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Gemini Builder",
+        adapterType: "gemini_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "session-123",
+        sessionParams: {
+          sessionId: "session-123",
+          cwd: managedRemoteWorkspace,
+          remoteExecution: {
+            transport: "ssh",
+            host: "127.0.0.1",
+            port: 2222,
+            username: "fixture",
+            remoteCwd: managedRemoteWorkspace,
+          },
+        },
+        sessionDisplayId: "session-123",
+        taskKey: null,
+      },
+      config: {
+        command: "gemini",
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+        resumedFromPausedRun: true,
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+    expect(call?.[2]).not.toContain("--resume");
+    expect(result.sessionId ?? null).toBeNull();
+    expect(result.sessionParams ?? null).toBeNull();
+    expect(result.clearSession).toBe(true);
+  });
 });

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -409,21 +409,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
   const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
+  // When the run we are resuming was paused or terminated mid-execution, its
+  // prior Gemini session was cut off mid-turn and is potentially wedged (stale
+  // run context/auth that surfaces as 401/500 and hallucinated routes). Start a
+  // fresh session instead of resuming the wedged one. Healthy resumes (e.g. the
+  // successful-run handoff) do not set this flag and keep their session.
+  const resumedFromPausedRun = asBoolean(context.resumedFromPausedRun, false);
   const canResumeSession =
     runtimeSessionId.length > 0 &&
+    !resumedFromPausedRun &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
     adapterExecutionTargetSessionMatches(runtimeRemoteExecution, runtimeExecutionTarget);
   const sessionId = canResumeSession ? runtimeSessionId : null;
-  if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
-    await onLog(
-      "stdout",
-      `[paperclip] Gemini session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
-    );
-  } else if (runtimeSessionId && !canResumeSession) {
-    await onLog(
-      "stdout",
-      `[paperclip] Gemini session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
-    );
+  if (runtimeSessionId && !canResumeSession) {
+    if (resumedFromPausedRun) {
+      await onLog(
+        "stdout",
+        `[paperclip] Gemini session "${runtimeSessionId}" belonged to a run that was paused or terminated mid-execution; starting a fresh session instead of resuming the potentially wedged one.\n`,
+      );
+    } else if (executionTargetIsRemote) {
+      await onLog(
+        "stdout",
+        `[paperclip] Gemini session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
+      );
+    } else {
+      await onLog(
+        "stdout",
+        `[paperclip] Gemini session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
+      );
+    }
   }
 
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
@@ -562,7 +576,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       parsed: ReturnType<typeof parseGeminiJsonl>;
     },
     clearSessionOnMissingSession = false,
-    isRetry = false,
+    forceFreshSession = false,
   ): AdapterExecutionResult => {
     const authMeta = detectGeminiAuthRequired({
       parsed: attempt.parsed.resultEvent,
@@ -597,8 +611,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       attempt.proc.exitCode,
     );
 
-    // On retry, don't fall back to old session ID — the old session was stale
-    const canFallbackToRuntimeSession = !isRetry;
+    // When we deliberately abandoned the prior session — a resume retry after an
+    // unknown-session error, or a fresh start because the resumed run was paused
+    // mid-execution — don't fall back to the old session id; it was stale.
+    const canFallbackToRuntimeSession = !forceFreshSession;
     const resolvedSessionId = attempt.parsed.sessionId
       ?? (canFallbackToRuntimeSession ? (runtimeSessionId ?? runtime.sessionId ?? null) : null);
     const resolvedSessionParams = resolvedSessionId
@@ -649,6 +665,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  // We had a session id but deliberately did not resume it because the run we
+  // are resuming was paused/terminated mid-execution (see `resumedFromPausedRun`
+  // above). The initial attempt therefore already ran fresh; make sure we never
+  // re-adopt the abandoned, potentially wedged session id if it emits none.
+  const startedFreshAfterPause = resumedFromPausedRun && runtimeSessionId.length > 0;
   try {
     const initial = await runAttempt(sessionId);
     if (
@@ -663,6 +684,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
       const retry = await runAttempt(null);
       return toResult(retry, true, true);
+    }
+
+    if (startedFreshAfterPause) {
+      return toResult(initial, true, true);
     }
 
     return toResult(initial);

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -7,6 +7,7 @@ import {
   assertGitSensitiveAdapterWorkspaceValid,
   buildRealizedExecutionWorkspaceFromPersisted,
   buildExplicitResumeSessionOverride,
+  resumeRunWasInterruptedMidExecution,
   deriveTaskKeyWithHeartbeatFallback,
   extractWakeCommentIds,
   formatRuntimeWorkspaceWarningLog,
@@ -930,6 +931,31 @@ describe("comment wake batching", () => {
     expect(merged.commentId).toBe("comment-2");
     expect(merged.wakeCommentId).toBe("comment-2");
     expect(merged.paperclipWake).toBeUndefined();
+  });
+});
+
+describe("resumeRunWasInterruptedMidExecution", () => {
+  it("flags runs paused or terminated mid-execution", () => {
+    expect(resumeRunWasInterruptedMidExecution("paused")).toBe(true);
+    expect(resumeRunWasInterruptedMidExecution("terminated")).toBe(true);
+    expect(resumeRunWasInterruptedMidExecution("PAUSED")).toBe(true);
+    expect(resumeRunWasInterruptedMidExecution("  paused  ")).toBe(true);
+  });
+
+  it("does not flag cleanly finished or normal runs", () => {
+    for (const status of [
+      "succeeded",
+      "completed",
+      "failed",
+      "running",
+      "queued",
+      "skipped",
+      null,
+      undefined,
+      "",
+    ]) {
+      expect(resumeRunWasInterruptedMidExecution(status)).toBe(false);
+    }
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1747,6 +1747,33 @@ type ResumeSessionRow = {
   lastRunId: string | null;
 };
 
+/**
+ * Heartbeat run statuses that indicate the prior run was interrupted *during*
+ * execution (paused or killed mid-turn) rather than finishing cleanly.
+ *
+ * When a sessioned adapter resumes one of these runs, the underlying agent
+ * session can be wedged: it was cut off mid-turn and its cached run context
+ * (including now-stale run auth) no longer reflects the fresh resumed run,
+ * which has surfaced as 401/500 failures and hallucinated API routes on resume.
+ * Adapters use this signal to start a fresh session instead of resuming the
+ * wedged one. Cleanly-finished runs (e.g. "succeeded"/"completed", as used by
+ * the successful-run handoff) are intentionally excluded so healthy resumes
+ * keep their session continuity.
+ */
+export const INTERRUPTED_MID_RUN_RESUME_STATUSES = new Set<string>([
+  "paused",
+  "terminated",
+]);
+
+export function resumeRunWasInterruptedMidExecution(
+  status: string | null | undefined,
+): boolean {
+  return (
+    typeof status === "string" &&
+    INTERRUPTED_MID_RUN_RESUME_STATUSES.has(status.trim().toLowerCase())
+  );
+}
+
 export function buildExplicitResumeSessionOverride(input: {
   adapterType?: string | null;
   resumeFromRunId: string;
@@ -4146,6 +4173,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resumeRun = await db
       .select({
         id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         resultJson: heartbeatRuns.resultJson,
         sessionIdBefore: heartbeatRuns.sessionIdBefore,
@@ -4190,6 +4218,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       taskId: readNonEmptyString(resumeContext.taskId) ?? readNonEmptyString(resumeContext.issueId),
       sessionDisplayId: sessionOverride.sessionDisplayId,
       sessionParams: sessionOverride.sessionParams,
+      resumedFromPausedRun: resumeRunWasInterruptedMidExecution(resumeRun.status),
     };
   }
 
@@ -9842,6 +9871,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         enrichedContextSnapshot.taskKey = explicitResumeSession.taskKey;
       }
       issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
+    }
+    // Signal a fresh-session start to sessioned adapters when resuming a run that
+    // was interrupted mid-execution; clear any value carried forward from the
+    // source context so healthy resumes/normal wakes are never affected.
+    if (explicitResumeSession?.resumedFromPausedRun) {
+      enrichedContextSnapshot.resumedFromPausedRun = true;
+    } else {
+      delete enrichedContextSnapshot.resumedFromPausedRun;
     }
     const effectiveTaskKey = readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
     const sessionBefore =


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each agent runs through a provider **adapter** (here, `gemini-local`), and runs can be **paused** or **terminated** mid-execution and later **resumed**
> - Sessioned adapters resume by passing the prior agent session id (`--resume`) so the model keeps its context across heartbeats
> - But when the prior run was cut off *mid-turn* (paused/terminated), that Gemini CLI session is wedged: its cached run context/auth is stale, so resuming it surfaced `401`/`500` failures and the model then hallucinated non-existent API routes
> - The interim agent-side `401`/`500` recovery masked the symptom but not the cause; the durable fix belongs at the adapter level
> - This pull request makes the resume path detect a prior run that was interrupted mid-execution and signal the adapter to start a **fresh** session instead of resuming the wedged one
> - The benefit is that a reviewer (or any sessioned agent) that gets paused mid-run recovers cleanly on resume, while healthy resumes and normal wakes keep full session continuity

## Linked Issues or Issue Description

No GitHub issue exists; describing the bug in-PR (Path B).

**Bug:** A `gemini_local` code-reviewer run that was paused mid-execution resumed onto its prior Gemini CLI session via `--resume`. That session had been cut off mid-turn and its cached run context/auth was no longer valid, producing `401`/`500` responses; the model then hallucinated `404` API routes. Tracked internally as ARCA-57 (report) → ARCA-58 (durable fix) → ARCA-59 (this implementation), board approval `ff0027d4`.

**Expected:** On resume of a run that was interrupted mid-execution, the adapter starts a fresh session rather than reusing the wedged one. Healthy resumes (e.g. the successful-run handoff) and normal new-review wakes are unaffected.

## What Changed

- **`server/src/services/heartbeat.ts`** — Added `INTERRUPTED_MID_RUN_RESUME_STATUSES` (`paused`, `terminated`) and the `resumeRunWasInterruptedMidExecution()` predicate. The explicit-resume query now selects the prior run's `status`, and the resume-session override carries `resumedFromPausedRun`. During context-snapshot enrichment, `resumedFromPausedRun` is set only for interrupted-mid-run resumes and explicitly **deleted** otherwise, so no value can leak forward into a healthy resume or a normal wake.
- **`packages/adapters/gemini-local/src/server/execute.ts`** — When `resumedFromPausedRun` is set, `canResumeSession` is forced false (no `--resume` of the wedged session) and a distinct log line is emitted. Renamed the internal `isRetry` flag to `forceFreshSession` (it now covers both the unknown-session retry and the fresh-after-pause case) and guarded against re-adopting the abandoned session id if the fresh run emits none (`startedFreshAfterPause`).
- **Tests** — `execute.remote.test.ts` adds fresh-session-on-resume coverage for the adapter; `heartbeat-workspace-session.test.ts` adds coverage for the `resumeRunWasInterruptedMidExecution` status predicate.

## Verification

Run locally from the repo root:

```bash
# adapter fresh-session-on-resume coverage (5 tests)
npx vitest run packages/adapters/gemini-local/src/server/execute.remote.test.ts

# heartbeat resume-status predicate coverage (70 tests in file)
cd server && npx vitest run src/__tests__/heartbeat-workspace-session.test.ts

# types compile clean
( cd packages/adapters/gemini-local && npx tsc --noEmit )
( cd server && npx tsc --noEmit )
```

All four pass locally: adapter 5/5, heartbeat 70/70, both typechecks exit 0.

## Risks

- **Low risk.** Behavior change is gated entirely on `resumedFromPausedRun`, which is only true when the resumed run's status is `paused`/`terminated`. Cleanly-finished runs (`succeeded`/`completed`) are excluded by construction, so the successful-run handoff and normal new-review wakes keep their existing session-continuity behavior.
- The enrichment path explicitly clears the flag when not applicable, preventing a stale value from carrying forward across resumes.
- Scope is confined to the resume decision and the `gemini-local` adapter; no auth code, schema, or migration is touched. The signal (`INTERRUPTED_MID_RUN_RESUME_STATUSES`) is exported so other sessioned adapters can adopt it later without re-deriving the status set.

## Model Used

Claude Opus 4.8 (Anthropic), model ID `claude-opus-4-8`, with extended thinking and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI change
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending CI run on this PR
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending automated review
- [x] I will address all Greptile and reviewer comments before requesting merge
