### PR TITLE
feat(plugin-sdk): add createRequire banner to node-platform ESM worker preset (SAG-3543)

### DIFF
--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -104,6 +104,7 @@
     "build": "pnpm --filter @paperclipai/shared build && tsc",
     "clean": "rm -rf dist",
     "ensure-build-deps": "node ../../../scripts/ensure-plugin-build-deps.mjs",
+    "test": "vitest run",
     "typecheck": "pnpm --filter @paperclipai/shared build && tsc --noEmit",
     "dev:server": "tsx src/dev-cli.ts"
   },
@@ -114,6 +115,7 @@
   "devDependencies": {
     "@types/node": "^24.6.0",
     "@types/react": "^19.0.8",
+    "esbuild": "^0.28.0",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {

--- a/packages/plugins/sdk/src/bundlers.ts
+++ b/packages/plugins/sdk/src/bundlers.ts
@@ -5,6 +5,16 @@
  * with esbuild or rollup without re-implementing host contract defaults.
  */
 
+/**
+ * Two-line shim added to every node-platform ESM worker bundle.
+ * esbuild's __require stub checks `typeof require !== "undefined"` first,
+ * so this transparently covers any CJS transitive dep that calls require().
+ */
+const NODE_WORKER_CREATE_REQUIRE_BANNER = [
+  "import { createRequire as __pcCreateRequire } from 'module';",
+  "const require = __pcCreateRequire(import.meta.url);",
+].join("\n");
+
 export interface PluginBundlerPresetInput {
   pluginRoot?: string;
   manifestEntry?: string;
@@ -13,6 +23,11 @@ export interface PluginBundlerPresetInput {
   outdir?: string;
   sourcemap?: boolean;
   minify?: boolean;
+  /**
+   * Custom JS banner injected at the top of the node-platform worker ESM bundle.
+   * Set to `false` to opt out of the default createRequire shim entirely.
+   */
+  nodeWorkerBanner?: string | false;
 }
 
 export interface EsbuildLikeOptions {
@@ -25,6 +40,7 @@ export interface EsbuildLikeOptions {
   sourcemap?: boolean;
   minify?: boolean;
   external?: string[];
+  banner?: { js?: string };
 }
 
 export interface RollupLikeConfig {
@@ -34,6 +50,7 @@ export interface RollupLikeConfig {
     format: "es";
     sourcemap?: boolean;
     entryFileNames?: string;
+    banner?: string;
   };
   external?: string[];
   plugins?: unknown[];
@@ -74,6 +91,10 @@ export function createPluginBundlerPresets(input: PluginBundlerPresetInput = {})
   const sourcemap = input.sourcemap ?? true;
   const minify = input.minify ?? false;
 
+  const workerBannerJs = input.nodeWorkerBanner === false
+    ? undefined
+    : (input.nodeWorkerBanner ?? NODE_WORKER_CREATE_REQUIRE_BANNER);
+
   const esbuildWorker: EsbuildLikeOptions = {
     entryPoints: [workerEntry],
     outdir,
@@ -84,6 +105,7 @@ export function createPluginBundlerPresets(input: PluginBundlerPresetInput = {})
     sourcemap,
     minify,
     external: ["react", "react-dom"],
+    ...(workerBannerJs !== undefined ? { banner: { js: workerBannerJs } } : {}),
   };
 
   const esbuildManifest: EsbuildLikeOptions = {
@@ -118,6 +140,7 @@ export function createPluginBundlerPresets(input: PluginBundlerPresetInput = {})
       format: "es",
       sourcemap,
       entryFileNames: "worker.js",
+      ...(workerBannerJs !== undefined ? { banner: workerBannerJs } : {}),
     },
     external: ["react", "react-dom"],
   };

--- a/packages/plugins/sdk/tests/bundlers-worker-load.test.ts
+++ b/packages/plugins/sdk/tests/bundlers-worker-load.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression test: node-platform ESM worker bundles must not crash with
+ * "Dynamic require of X is not supported" when CJS transitive deps call
+ * require(<builtin>) at load time.
+ *
+ * The fix is the createRequire banner added to the esbuild worker preset in
+ * createPluginBundlerPresets(). This test builds a fixture worker that imports
+ * a synthetic CJS module calling require("buffer"), then loads the *built*
+ * dist bundle in a child process — the only approach that catches packaging
+ * regressions that mocked unit tests miss (SAG-3542 / SAG-3543).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import esbuild from "esbuild";
+import { createPluginBundlerPresets } from "../src/bundlers.js";
+
+// ---------------------------------------------------------------------------
+// Fixture setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let workerWithBannerPath: string;
+let workerWithoutBannerPath: string;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "pc-sdk-bundler-test-"));
+
+  const srcDir = join(tmpDir, "src");
+  mkdirSync(srcDir);
+
+  // Synthetic CJS module that calls require("buffer") at load time —
+  // mirrors the safe-buffer → jws → jsonwebtoken chain from @azure/msal-node.
+  writeFileSync(
+    join(tmpDir, "cjs-require-builtin.cjs"),
+    [
+      "// Simulates a CJS dep (safe-buffer/jws) that requires a Node builtin.",
+      'const buf = require("buffer");',
+      "module.exports = { Buffer: buf.Buffer };",
+    ].join("\n"),
+  );
+
+  // Minimal fixture worker that imports the CJS dep.
+  writeFileSync(
+    join(srcDir, "worker.ts"),
+    [
+      "// Fixture: imports a CJS dep that calls require('buffer') at load time.",
+      'import cjsDep from "../cjs-require-builtin.cjs";',
+      "export default { name: 'fixture-worker', cjsDep };",
+    ].join("\n"),
+  );
+
+  const workerEntry = join(srcDir, "worker.ts");
+
+  // Build WITH the default banner (createRequire present).
+  const presetsWithBanner = createPluginBundlerPresets({
+    workerEntry,
+    outdir: join(tmpDir, "dist-with-banner"),
+    sourcemap: false,
+  });
+  await esbuild.build(presetsWithBanner.esbuild.worker);
+  workerWithBannerPath = join(tmpDir, "dist-with-banner", "worker.js");
+
+  // Build WITHOUT the banner (opt-out via nodeWorkerBanner: false).
+  const presetsNoBanner = createPluginBundlerPresets({
+    workerEntry,
+    outdir: join(tmpDir, "dist-no-banner"),
+    sourcemap: false,
+    nodeWorkerBanner: false,
+  });
+  await esbuild.build(presetsNoBanner.esbuild.worker);
+  workerWithoutBannerPath = join(tmpDir, "dist-no-banner", "worker.js");
+}, 60_000);
+
+afterAll(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Child-process loader helper
+// ---------------------------------------------------------------------------
+
+function loadBundleInChildProcess(workerPath: string): {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+} {
+  const workerUrl = `file://${workerPath}`;
+  // Strip PAPERCLIP_* vars so any runWorker() call fails fast (no host
+  // connection) rather than spinning a retry loop that delays the child exit.
+  const childEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !k.startsWith("PAPERCLIP_")) {
+      childEnv[k] = v;
+    }
+  }
+
+  const loaderScript = `
+import("${workerUrl}")
+  .then(() => process.exit(0))
+  .catch((e) => {
+    const msg = String(e?.message ?? e);
+    if (msg.includes("Dynamic require")) {
+      process.stderr.write("[regression] Dynamic-require at load: " + msg + "\\n");
+      process.exit(1);
+    }
+    // Any other error (e.g. worker failing to reach Paperclip host) is not a
+    // packaging regression — the banner did its job.
+    process.exit(0);
+  });
+`;
+
+  const result = spawnSync(process.execPath, ["--input-type=module"], {
+    input: loaderScript,
+    timeout: 15_000,
+    encoding: "utf8",
+    env: childEnv,
+  });
+
+  return {
+    status: result.status,
+    stderr: result.stderr ?? "",
+    stdout: result.stdout ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createPluginBundlerPresets — node worker ESM + CJS compat banner", () => {
+  it("default preset: dist/worker.js loads without a Dynamic-require error", () => {
+    const { status, stderr, stdout } = loadBundleInChildProcess(workerWithBannerPath);
+    const combined = stderr + stdout;
+
+    expect(
+      combined,
+      "dist/worker.js crashed with a Dynamic-require error — " +
+        "the createRequire banner in the worker preset may be missing",
+    ).not.toContain("Dynamic require");
+
+    expect(
+      status,
+      `child exited with code ${status}; stderr: ${stderr}`,
+    ).not.toBe(1);
+  });
+
+  it("nodeWorkerBanner: false — no banner means Dynamic-require error appears (sanity check)", () => {
+    // This test proves the regression test is exercising the right code path:
+    // removing the banner MUST cause the load-time crash on the fixture.
+    const { stderr, stdout } = loadBundleInChildProcess(workerWithoutBannerPath);
+    const combined = stderr + stdout;
+
+    expect(
+      combined,
+      "Expected a Dynamic-require error when banner is suppressed, but none appeared — " +
+        "the fixture may not be triggering the CJS require path",
+    ).toContain("Dynamic require");
+  });
+});

--- a/packages/plugins/sdk/tests/worker-bundle-load.test.ts
+++ b/packages/plugins/sdk/tests/worker-bundle-load.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression test for the node-platform ESM worker createRequire banner.
+ *
+ * Verifies that a worker bundle built with the SDK preset can load CJS
+ * transitive deps that call require(<builtin>) at module-load time, without
+ * throwing "Dynamic require of X is not supported".
+ *
+ * Background: on Node.js <=22.11.x (pre-native-require-in-ESM), esbuild's
+ * __require shim throws when `typeof require === "undefined"`. The createRequire
+ * banner makes require available so the shim passes through. Node.js >=22.12.0
+ * provides require natively in ESM, so the runtime test passes unconditionally
+ * there — the important invariant for fleet plugins is that the banner is
+ * present in the bundle so plugins work on the target (node20).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+import * as esbuild from "esbuild";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createPluginBundlerPresets } from "../src/bundlers.js";
+
+describe("worker-bundle-load: node-platform ESM with CJS require(builtin)", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pc-sdk-bundle-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function buildFixtureBundle(opts: {
+    tmpDir: string;
+    nodeWorkerBanner?: string | false;
+  }): Promise<string> {
+    const { tmpDir, nodeWorkerBanner } = opts;
+    const srcDir = path.join(tmpDir, "src");
+    const outDir = path.join(tmpDir, "dist");
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.mkdirSync(outDir, { recursive: true });
+
+    // Fake CJS dep that calls require("buffer") at module load time — the
+    // same pattern that causes the crash in msal-node transitive deps.
+    fs.writeFileSync(
+      path.join(srcDir, "fake-cjs-dep.cjs"),
+      'module.exports.getBuffer = function() { return require("buffer").Buffer; };\n',
+    );
+
+    // Minimal worker entry that imports the CJS dep and exercises require().
+    const workerEntry = path.join(srcDir, "worker.ts");
+    fs.writeFileSync(
+      workerEntry,
+      [
+        "import { getBuffer } from './fake-cjs-dep.cjs';",
+        "console.log(String(getBuffer().isBuffer(null)));",
+      ].join("\n") + "\n",
+    );
+
+    const presets = createPluginBundlerPresets({
+      workerEntry,
+      outdir: outDir,
+      sourcemap: false,
+      ...(nodeWorkerBanner !== undefined ? { nodeWorkerBanner } : {}),
+    });
+
+    await esbuild.build(presets.esbuild.worker);
+
+    // esbuild names the output after the entry file: worker.ts → worker.js
+    return path.join(outDir, "worker.js");
+  }
+
+  function runBundle(bundlePath: string): { exitCode: number | null; combined: string } {
+    // Load the ESM bundle via `node --input-type=module` so the temp dir does
+    // not need a package.json with "type":"module".
+    const result = spawnSync(
+      process.execPath,
+      ["--input-type=module"],
+      {
+        input: `import ${JSON.stringify(pathToFileURL(bundlePath).href)};\n`,
+        timeout: 15_000,
+        encoding: "utf-8",
+      },
+    );
+    return {
+      exitCode: result.status,
+      combined: (result.stdout ?? "") + (result.stderr ?? ""),
+    };
+  }
+
+  // --- Unit tests: banner presence in config objects ---
+
+  it("default preset esbuild worker config has createRequire banner", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.banner?.js).toContain("createRequire");
+    expect(presets.esbuild.worker.banner?.js).toContain("import.meta.url");
+  });
+
+  it("default preset rollup worker output config has createRequire banner", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.rollup.worker.output.banner).toContain("createRequire");
+    expect(presets.rollup.worker.output.banner).toContain("import.meta.url");
+  });
+
+  it("nodeWorkerBanner:false omits banner from esbuild and rollup configs", () => {
+    const presets = createPluginBundlerPresets({ nodeWorkerBanner: false });
+    expect(presets.esbuild.worker.banner).toBeUndefined();
+    expect(presets.rollup.worker.output.banner).toBeUndefined();
+  });
+
+  it("custom nodeWorkerBanner string is forwarded to esbuild and rollup", () => {
+    const custom = "// custom banner";
+    const presets = createPluginBundlerPresets({ nodeWorkerBanner: custom });
+    expect(presets.esbuild.worker.banner?.js).toBe(custom);
+    expect(presets.rollup.worker.output.banner).toBe(custom);
+  });
+
+  it("banner is absent from UI and manifest esbuild presets (browser/node manifest)", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    // manifest is node+esm but does not have CJS-interop concerns (externalized deps)
+    expect(presets.esbuild.manifest.banner).toBeUndefined();
+    // ui bundle is browser-targeted, never needs require()
+    expect(presets.esbuild.ui?.banner).toBeUndefined();
+  });
+
+  // --- Integration test: bundle built with banner loads cleanly ---
+
+  it("bundle built with default preset executes without Dynamic require crash", async () => {
+    const tmpDir = makeTempDir();
+    const bundlePath = await buildFixtureBundle({ tmpDir });
+
+    // Confirm the banner is baked into the bundle source.
+    const bundleSrc = fs.readFileSync(bundlePath, "utf-8");
+    expect(bundleSrc).toContain("createRequire");
+
+    // Run the bundle. On Node >=22.12 require() is natively available in ESM;
+    // on older runtimes the banner is what makes this succeed.
+    const { exitCode, combined } = runBundle(bundlePath);
+    expect(combined).not.toMatch(/Dynamic require/i);
+    expect(exitCode).toBe(0);
+  });
+
+  it("bundle built with nodeWorkerBanner:false does not contain createRequire", async () => {
+    const tmpDir = makeTempDir();
+    const bundlePath = await buildFixtureBundle({ tmpDir, nodeWorkerBanner: false });
+
+    const bundleSrc = fs.readFileSync(bundlePath, "utf-8");
+    expect(bundleSrc).not.toContain("createRequire");
+    // The __require shim IS still present (esbuild-generated)
+    expect(bundleSrc).toContain("__require");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,9 @@ importers:
       '@types/react':
         specifier: ^19.0.8
         version: 19.2.14
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- **Root cause (from SAG-3542):** Any `platform: "node"` ESM worker bundle that pulls in a CJS transitive dep calling `require(<builtin>)` at load time crashes with `Error: Dynamic require of "X" is not supported` from esbuild's `__require` shim. SAG-3542 fixed this with a per-plugin workaround in m365-outlook; this PR hoists the fix into the SDK so the whole bug class is killed fleet-wide.
- **Fix:** `createPluginBundlerPresets()` now injects a two-line `createRequire` banner into the `esbuild.worker` and `rollup.worker` presets by default. `nodeWorkerBanner: false` opts out; a custom string overrides.
- **Tests:** 4 new config-unit tests (banner present, absent, custom, absent from UI/manifest) + 2 load-smoke integration tests (child `node --input-type=module` with and without banner). 25/25 tests pass.

## Files changed

- `packages/plugins/sdk/src/bundlers.ts` — `NODE_WORKER_CREATE_REQUIRE_BANNER` constant; `nodeWorkerBanner` input option; banner wired into esbuild + rollup worker presets; `banner` added to interface types
- `packages/plugins/sdk/tests/worker-bundle-load.test.ts` — config-unit + esbuild integration regression tests
- `packages/plugins/sdk/tests/bundlers-worker-load.test.ts` — child-process load-smoke (positive + negative)
- `packages/plugins/sdk/package.json` — `test: vitest run` script; `esbuild` devDependency

## Test plan

- [ ] `pnpm typecheck && pnpm test && pnpm build` in `packages/plugins/sdk` — 0 errors, 25/25 tests, build clean ✅ (verified locally)
- [ ] `pnpm test` output: `Test Files 5 passed (5)`, `Tests 25 passed (25)`

## Landing gate

Plugin-sdk ships in the live npx-distributed `paperclipai` package. A local rebuild alone does **not** land this fleet-wide — merge + host restart is board-gated (fork is pull-only). This PR is ready for review; merge/deploy goes through the board.

**Note for m365-outlook:** The manual `createRequire` banner in `m365-outlook/esbuild.config.mjs` (applied in SAG-3542) is now redundant. When m365-outlook next rebuilds against the updated SDK, the manual banner should be removed to avoid double-injection. That cleanup is a trivial follow-up in the plugin repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)