### PR TITLE
perf(adapters): lazy-load acpx-local execute/test to cut cold-boot codex-acp import (#7795)

### DIFF
--- a/packages/adapters/acpx-local/package.json
+++ b/packages/adapters/acpx-local/package.json
@@ -15,6 +15,11 @@
   "exports": {
     ".": "./src/index.ts",
     "./server": "./src/server/index.ts",
+    "./server/execute": "./src/server/execute.ts",
+    "./server/test": "./src/server/test.ts",
+    "./server/config-schema": "./src/server/config-schema.ts",
+    "./server/session-codec": "./src/server/session-codec.ts",
+    "./server/skills": "./src/server/skills.ts",
     "./ui": "./src/ui/index.ts",
     "./cli": "./src/cli/index.ts"
   },
@@ -28,6 +33,26 @@
       "./server": {
         "types": "./dist/server/index.d.ts",
         "import": "./dist/server/index.js"
+      },
+      "./server/execute": {
+        "types": "./dist/server/execute.d.ts",
+        "import": "./dist/server/execute.js"
+      },
+      "./server/test": {
+        "types": "./dist/server/test.d.ts",
+        "import": "./dist/server/test.js"
+      },
+      "./server/config-schema": {
+        "types": "./dist/server/config-schema.d.ts",
+        "import": "./dist/server/config-schema.js"
+      },
+      "./server/session-codec": {
+        "types": "./dist/server/session-codec.d.ts",
+        "import": "./dist/server/session-codec.js"
+      },
+      "./server/skills": {
+        "types": "./dist/server/skills.d.ts",
+        "import": "./dist/server/skills.js"
       },
       "./ui": {
         "types": "./dist/ui/index.d.ts",

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -549,3 +549,19 @@ describe("resolveExternalAdapterRegistration", () => {
     expect(resolved.sessionManagement).toBeUndefined();
   });
 });
+
+describe("acpx_local adapter lazy-loads codex-acp (#7795)", () => {
+  it("keeps execute/testEnvironment callable and the lightweight pieces wired without eager codex-acp import", async () => {
+    const adapter = requireServerAdapter("acpx_local");
+    // Heavy entry points must remain callable (now lazy dynamic-import wrappers).
+    expect(typeof adapter.execute).toBe("function");
+    expect(typeof adapter.testEnvironment).toBe("function");
+    // Lightweight, codex-acp-free pieces stay statically wired.
+    expect(adapter.sessionCodec).toBeDefined();
+    expect(typeof adapter.getConfigSchema).toBe("function");
+    // The clean config-schema sub-path resolves and returns a schema object.
+    const schema = await adapter.getConfigSchema!();
+    expect(schema).toBeTruthy();
+    expect(typeof schema).toBe("object");
+  });
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -8,14 +8,17 @@ import {
   buildSandboxNpmInstallCommand,
   getAdapterSessionManagement,
 } from "@paperclipai/adapter-utils";
+// #7795: the acpx-local "/server" barrel re-exports execute.ts + test.ts, which
+// statically pull in @zed-industries/codex-acp (~165MB). Importing the barrel at
+// module scope dominated cold serverless boot (10s–300s hangs). Import only the
+// lightweight, codex-acp-free pieces statically, and lazy-load execute/test via
+// dynamic import so the heavy dependency is paid only when a run actually executes.
+import { sessionCodec as acpxSessionCodec } from "@paperclipai/adapter-acpx-local/server/session-codec";
+import { getConfigSchema as getAcpxConfigSchema } from "@paperclipai/adapter-acpx-local/server/config-schema";
 import {
-  execute as acpxExecute,
-  testEnvironment as acpxTestEnvironment,
-  sessionCodec as acpxSessionCodec,
-  getConfigSchema as getAcpxConfigSchema,
   listAcpxSkills,
   syncAcpxSkills,
-} from "@paperclipai/adapter-acpx-local/server";
+} from "@paperclipai/adapter-acpx-local/server/skills";
 import {
   agentConfigurationDoc as acpxAgentConfigurationDoc,
   models as acpxModels,
@@ -266,6 +269,13 @@ const claudeLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: claudeAgentConfigurationDoc,
   getQuotaWindows: claudeGetQuotaWindows,
 };
+
+// #7795: lazy-load the heavy execute/test implementations (they pull
+// @zed-industries/codex-acp ~165MB) so cold boot never pays that import cost.
+const acpxExecute: ServerAdapterModule["execute"] = (ctx) =>
+  import("@paperclipai/adapter-acpx-local/server/execute").then((m) => m.execute(ctx));
+const acpxTestEnvironment: ServerAdapterModule["testEnvironment"] = (ctx) =>
+  import("@paperclipai/adapter-acpx-local/server/test").then((m) => m.testEnvironment(ctx));
 
 const acpxLocalAdapter: ServerAdapterModule = {
   type: "acpx_local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs agents through pluggable adapters; the server adapter registry wires up every builtin adapter at module scope.
> - #7785 traced cold serverless boot hangs (10s–300s on `/api/health` + `get-session`, blocking login/nav) to `boot-timing: module-import` being dominated by `@zed-industries/codex-acp` (~165MB).
> - That dependency is pulled by a single static edge: the registry imports the `acpx-local/server` barrel, which re-exports `execute.ts` + `test.ts`, which import codex-acp — all evaluated eagerly on every cold boot.
> - An audit confirms acpx-local is the ONLY builtin adapter importing a heavy SDK at module scope, so breaking this one edge removes the dominant cost.
> - This PR splits the import: the codex-acp-free pieces load statically; `execute`/`testEnvironment` become dynamic-import wrappers, so codex-acp is paid only when a run actually executes.
> - The benefit is cold boots no longer evaluate ~165MB of adapter runtime, cutting the module-import hang.

## What Changed

- `packages/adapters/acpx-local/package.json`: add `./server/{execute,test,config-schema,session-codec,skills}` sub-path exports (both the dev `src` map and the `publishConfig` `dist` map), so consumers can import the lightweight modules without pulling the heavy barrel.
- `server/src/adapters/registry.ts`: import `sessionCodec`/`getConfigSchema`/`listAcpxSkills`/`syncAcpxSkills` from the clean sub-paths; replace the static `execute`/`testEnvironment` imports with lazy `import()` wrappers.
- `server/src/__tests__/adapter-registry.test.ts`: assert the `acpx_local` adapter keeps `execute`/`testEnvironment` callable, `sessionCodec` wired, and `getConfigSchema()` resolves via the clean sub-path.

## Verification

- `npx tsc --noEmit` (server) clean with the new exports resolved.
- `npx vitest run src/__tests__/adapter-registry.test.ts -t "#7795"` → passes (adapter interface preserved, clean sub-path resolves).
- Audit: `grep` across `packages/adapters/*/src` shows acpx-local is the only adapter importing a heavy SDK (codex-acp/acpx) at module scope.

## Risks

- Low/medium. `execute`/`testEnvironment` are now async dynamic-import wrappers; both are already always `await`ed by callers (`heartbeat.ts` `await adapter.execute(...)`), so behavior is unchanged. The lightweight modules (`session-codec`, `config-schema`, `skills`) are verified codex-acp-free, so static-importing them is safe. First acpx run pays a one-time dynamic-import cost (acceptable vs. boot-path hang). Does not change adapter semantics or output.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended reasoning, via Claude Code (tool use + local typecheck/test execution).

Refs #7795, #7785. Scope note: this fixes the dominant adapter-registry import edge (the root cause ValDola-stack pinpointed). The other #7795 items — boot-path I/O hard-cap, Vercel cron warmer, and not redirecting to /auth on transient timeout — remain separate follow-ups.

## Dedup search

- [x] I searched the open and recently-closed GitHub PRs for similar or duplicate PRs (adapter lazy-load / cold-boot / codex-acp) and found none addressing this edge.
