### PR TITLE
feat(issue-chat): newest-first issue feed with pinned pending confirmations

### DIFF
--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -806,10 +806,10 @@ describe("IssueChatThread", () => {
     scrollHost.remove();
   });
 
-  // Regression for PAP-2672: when the merged feed ends with a non-comment row
-  // (run/timeline/embedded output) we still want Jump to latest to land on the
-  // last comment, not whichever activity row sorts last.
-  it("targets the latest comment row when trailing rows are non-comments (PAP-2672)", () => {
+  // PAP-2672, newest-first variant: the merged feed renders newest at the top,
+  // so Jump to latest scrolls the container to offset 0 regardless of which row
+  // (comment vs trailing run/timeline output) sorts where.
+  it("scrolls to the top when jumping to latest in the newest-first feed (PAP-2672)", () => {
     const lastComment = issueChatLongThreadComments.at(-1);
     expect(lastComment).toBeDefined();
     const trailingRunStart = new Date(new Date(lastComment!.createdAt).getTime() + 60_000);
@@ -902,16 +902,11 @@ describe("IssueChatThread", () => {
       .filter(hasSmoothScrollBehavior);
     expect(smoothCalls.length).toBeGreaterThan(0);
 
-    // For align="end" with the very last index, tanstack-virtual short-circuits
-    // to getMaxScrollOffset() (= scrollHeight - clientHeight = 199_200 here).
-    // A jump to the latest comment row (one slot earlier) lands at item.end -
-    // clientHeight, which is strictly less. Asserting top < maxScrollOffset
-    // proves the button isn't routing to the trailing run row.
-    const maxScrollOffset = 200_000 - 800;
+    // Newest-first feed: "latest" lives at the top, so Jump to latest drives the
+    // scroll container straight to offset 0 — no settle loop and no dependence
+    // on whichever (non-comment) row sorts last.
     const lastTop = smoothCalls[smoothCalls.length - 1]?.top;
-    expect(typeof lastTop).toBe("number");
-    expect(lastTop as number).toBeLessThan(maxScrollOffset);
-    expect(lastTop as number).toBeGreaterThan(0);
+    expect(lastTop).toBe(0);
 
     act(() => {
       root.unmount();
@@ -962,12 +957,8 @@ describe("IssueChatThread", () => {
     });
   });
 
-  it("uses comments rendered by onRefreshLatestComments before resolving latest", async () => {
-    const scrolledIds: string[] = [];
-    const originalScrollIntoView = Element.prototype.scrollIntoView;
-    Element.prototype.scrollIntoView = vi.fn(function scrollIntoView(this: Element) {
-      scrolledIds.push(this.id);
-    }) as unknown as typeof Element.prototype.scrollIntoView;
+  it("scrolls to the top after onRefreshLatestComments resolves on Jump to latest", async () => {
+    const scrollToMock = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
 
     const olderComment = {
       id: "comment-before-refresh",
@@ -1029,15 +1020,17 @@ describe("IssueChatThread", () => {
       await new Promise((resolve) => window.requestAnimationFrame(resolve));
     });
 
-    expect(scrolledIds).toContain("comment-comment-after-refresh");
+    expect(
+      scrollToMock.mock.calls.some(([arg]) => (arg as ScrollToOptions | undefined)?.top === 0),
+    ).toBe(true);
 
-    Element.prototype.scrollIntoView = originalScrollIntoView;
+    scrollToMock.mockRestore();
     act(() => {
       root.unmount();
     });
   });
 
-  it("findLatestCommentMessageIndex prefers the last comment-anchored row (PAP-2672)", () => {
+  it("findLatestCommentMessageIndex prefers the last comment-anchored row, or first when newest-first (PAP-2672)", () => {
     const messages = [
       { metadata: { custom: { anchorId: "comment-a" } } },
       { metadata: { custom: { anchorId: "run-1" } } },
@@ -1046,6 +1039,8 @@ describe("IssueChatThread", () => {
       { metadata: { custom: { anchorId: "activity-3" } } },
     ];
     expect(findLatestCommentMessageIndex(messages as never)).toBe(2);
+    // Newest-first feed: the newest comment is the first comment-anchored row.
+    expect(findLatestCommentMessageIndex(messages as never, true)).toBe(0);
     expect(
       findLatestCommentMessageIndex([
         { metadata: { custom: { anchorId: "run-only" } } },
@@ -2150,7 +2145,8 @@ describe("IssueChatThread", () => {
     const dock = container.querySelector('[data-testid="issue-chat-composer-dock"]') as HTMLDivElement | null;
     expect(dock).not.toBeNull();
     expect(dock?.className).toContain("sticky");
-    expect(dock?.className).toContain("bottom-[calc(env(safe-area-inset-bottom)+20px)]");
+    // Full (newest-first) feed docks the composer at the top, near fresh messages.
+    expect(dock?.className).toContain("top-[calc(env(safe-area-inset-top)+8px)]");
     expect(dock?.className).toContain("z-20");
 
     const composer = container.querySelector('[data-testid="issue-chat-composer"]') as HTMLDivElement | null;
@@ -2367,6 +2363,8 @@ describe("IssueChatThread", () => {
     });
   });
 
+  // The bottom spacer (submit-scroll reserve) only exists in the bottom-docked
+  // embedded variant; the newest-first full feed scrolls to the top instead.
   it("renders the bottom spacer with zero height until the user has submitted", () => {
     const root = createRoot(container);
 
@@ -2374,6 +2372,7 @@ describe("IssueChatThread", () => {
       root.render(
         <MemoryRouter>
           <IssueChatThread
+            variant="embedded"
             comments={[{
               id: "comment-spacer-1",
               companyId: "company-1",

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -2788,7 +2788,19 @@ function findMessageAnchorIndex(messages: readonly ThreadMessage[], anchorId: st
   return messages.findIndex((message) => issueChatMessageAnchorId(message) === anchorId);
 }
 
-export function findLatestCommentMessageIndex(messages: readonly ThreadMessage[]): number {
+export function findLatestCommentMessageIndex(
+  messages: readonly ThreadMessage[],
+  newestFirst = false,
+): number {
+  // In a newest-first feed the newest comment is the first comment-anchored
+  // row (lowest index); otherwise it is the last.
+  if (newestFirst) {
+    for (let index = 0; index < messages.length; index += 1) {
+      const anchorId = issueChatMessageAnchorId(messages[index]);
+      if (anchorId && anchorId.startsWith("comment-")) return index;
+    }
+    return -1;
+  }
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const anchorId = issueChatMessageAnchorId(messages[index]);
     if (anchorId && anchorId.startsWith("comment-")) return index;
@@ -3061,15 +3073,17 @@ const VirtualizedIssueChatThreadListInner = forwardRef<
     },
     scrollToLatest: (options) => {
       if (messages.length === 0) return;
-      virtualizer.scrollToIndex(messages.length - 1, {
-        align: "end",
+      // Newest-first (full) feed: the latest row sits at the top (index 0).
+      const newestFirst = variant === "full";
+      virtualizer.scrollToIndex(newestFirst ? 0 : messages.length - 1, {
+        align: newestFirst ? "start" : "end",
         behavior: options?.behavior ?? "smooth",
       });
     },
     measure: () => {
       virtualizer.measure();
     },
-  }), [messages.length, virtualizer]);
+  }), [messages.length, variant, virtualizer]);
 
   useLayoutEffect(() => {
     return () => {
@@ -3933,6 +3947,10 @@ export function IssueChatThread({
         agentMap,
         currentUserId,
         userLabelMap,
+        // The full issue feed reads newest-first (top to bottom) with pending
+        // confirmations pinned to the top. The embedded run-output view keeps
+        // its natural chronological (oldest-first) reading order.
+        newestFirst: variant === "full",
       }),
     [
       comments,
@@ -3949,6 +3967,7 @@ export function IssueChatThread({
       agentMap,
       currentUserId,
       userLabelMap,
+      variant,
     ],
   );
   const stableMessagesRef = useRef<readonly ThreadMessage[]>([]);
@@ -4037,7 +4056,10 @@ export function IssueChatThread({
   });
 
   useEffect(() => {
-    const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
+    // The newest user message: in the newest-first (full) feed it is the first
+    // user-role row; otherwise (chronological) the last.
+    const lastUserMessage = (variant === "full" ? messages : [...messages].reverse())
+      .find((m) => m.role === "user");
     const lastUserId = lastUserMessage?.id ?? null;
 
     if (
@@ -4046,21 +4068,29 @@ export function IssueChatThread({
       && lastUserId !== lastUserMessageIdRef.current
     ) {
       pendingSubmitScrollRef.current = false;
-      const custom = lastUserMessage?.metadata.custom as { anchorId?: unknown } | undefined;
-      const anchorId = typeof custom?.anchorId === "string" ? custom.anchorId : null;
-      if (anchorId) {
-        const reserve = Math.round(window.innerHeight * SUBMIT_SCROLL_RESERVE_VH);
-        spacerBaselineAnchorRef.current = anchorId;
-        spacerInitialReserveRef.current = reserve;
-        setBottomSpacerHeight(reserve);
+      if (variant === "full") {
+        // Newest-first feed: the just-sent message is pinned at the top, so no
+        // bottom spacer reserve is needed — just bring the top into view.
         requestAnimationFrame(() => {
-          scrollToThreadAnchor(anchorId, { align: "start", behavior: "smooth" });
+          scrollThreadToTop();
         });
+      } else {
+        const custom = lastUserMessage?.metadata.custom as { anchorId?: unknown } | undefined;
+        const anchorId = typeof custom?.anchorId === "string" ? custom.anchorId : null;
+        if (anchorId) {
+          const reserve = Math.round(window.innerHeight * SUBMIT_SCROLL_RESERVE_VH);
+          spacerBaselineAnchorRef.current = anchorId;
+          spacerInitialReserveRef.current = reserve;
+          setBottomSpacerHeight(reserve);
+          requestAnimationFrame(() => {
+            scrollToThreadAnchor(anchorId, { align: "start", behavior: "smooth" });
+          });
+        }
       }
     }
 
     lastUserMessageIdRef.current = lastUserId;
-  }, [messageAnchorIndex, messages, useVirtualizedThread]);
+  }, [messageAnchorIndex, messages, useVirtualizedThread, variant]);
 
   useLayoutEffect(() => {
     const anchorId = spacerBaselineAnchorRef.current;
@@ -4134,7 +4164,30 @@ export function IssueChatThread({
     };
   }, [location.hash, messageAnchorIndex, messages, useVirtualizedThread]);
 
+  // Scroll the issue page back to the top. In the newest-first (full) feed the
+  // latest content lives at the top, so "jump to latest" and post-submit scroll
+  // both resolve to this. Mirrors IssueDetail's on-open scroll-to-top.
+  function scrollThreadToTop(behavior: ScrollBehavior = "smooth") {
+    if (typeof window === "undefined") return;
+    // Drive whichever element actually scrolls the thread: the overflow-auto
+    // `<main id="main-content">` ancestor on desktop, else the window (mobile /
+    // perf fixture). Mirrors the virtualizer's findScrollContainer detection.
+    const mainContent = document.getElementById("main-content");
+    if (mainContent) {
+      const overflowY = window.getComputedStyle(mainContent).overflowY;
+      if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") {
+        mainContent.scrollTo({ top: 0, behavior });
+        return;
+      }
+    }
+    window.scrollTo({ top: 0, behavior });
+  }
+
   function jumpToLatestFallback() {
+    if (variant === "full") {
+      scrollThreadToTop();
+      return;
+    }
     if (useVirtualizedThread) {
       virtualizedThreadRef.current?.scrollToLatest({ behavior: "smooth" });
       return;
@@ -4155,6 +4208,13 @@ export function IssueChatThread({
   // that element is at the scroll container's bottom (or scroll position
   // and content height stop changing).
   function scrollToLatestCommentWithSettle(messageSnapshot: readonly ThreadMessage[] = latestMessagesRef.current) {
+    if (variant === "full") {
+      // Newest-first feed: "latest" lives at the top. Scrolling to the top is
+      // exact, so the settle convergence loop (which exists to fight the
+      // virtualizer's estimated bottom on long threads) is unnecessary.
+      scrollThreadToTop();
+      return;
+    }
     const latestCommentIndex = findLatestCommentMessageIndex(messageSnapshot);
     if (latestCommentIndex < 0) {
       jumpToLatestFallback();
@@ -4377,10 +4437,112 @@ export function IssueChatThread({
   }
   const errorBoundaryResetKey = String(errorBoundaryResetVersionRef.current);
 
+  // The full issue feed renders newest-first, so the composer (and its action
+  // notices) live at the TOP of the thread. The embedded run-output view keeps
+  // the chat convention with the composer docked at the bottom.
+  const composerAtTop = variant === "full";
+
+  const threadNotices = showComposer ? (
+    <div data-testid="issue-chat-thread-notices" className="space-y-2">
+      <IssueAssignedBacklogNotice
+        issueStatus={issueStatus ?? ""}
+        assigneeAgent={assignedAgent}
+        assigneeUserId={assigneeUserId}
+        onResume={onResumeFromBacklog}
+        resuming={resumeFromBacklogPending}
+      />
+      {recoveryAction ? (
+        <IssueRecoveryActionCard
+          action={recoveryAction}
+          agentMap={agentMap}
+          onResolve={onResolveRecoveryAction}
+          canFalsePositive={canFalsePositiveRecoveryAction}
+        />
+      ) : null}
+      {legacyRecoverySourceIssue ? (
+        <SystemNotice
+          tone="info"
+          label="Legacy recovery task"
+          body={
+            <span>
+              Legacy recovery task. Newer recovery actions live on the source task
+              {legacyRecoverySourceIssue.identifier ? (
+                <>
+                  {" — "}
+                  <Link
+                    to={legacyRecoverySourceIssue.href}
+                    className="underline-offset-2 hover:underline"
+                  >
+                    {legacyRecoverySourceIssue.identifier}
+                    {legacyRecoverySourceIssue.title ? (
+                      <span className="text-muted-foreground">
+                        {" "}
+                        — {legacyRecoverySourceIssue.title}
+                      </span>
+                    ) : null}
+                  </Link>
+                </>
+              ) : (
+                "."
+              )}
+            </span>
+          }
+        />
+      ) : null}
+      <IssueBlockedNotice
+        issueId={issueId}
+        issueStatus={issueStatus}
+        blockers={unresolvedBlockers}
+        blockerAttention={blockerAttention}
+        successfulRunHandoff={recoveryAction ? null : successfulRunHandoff}
+        scheduledRetry={scheduledRetry}
+        agentName={
+          successfulRunHandoff?.assigneeAgentId
+            ? agentMap?.get(successfulRunHandoff.assigneeAgentId)?.name ?? null
+            : null
+        }
+      />
+      <IssueAssigneePausedNotice agent={assignedAgent} />
+    </div>
+  ) : null;
+
+  const composerDock = showComposer ? (
+    <div
+      ref={composerViewportAnchorRef}
+      data-testid="issue-chat-composer-dock"
+      className={cn(
+        "z-20 space-y-2",
+        composerAtTop
+          ? "sticky top-[calc(env(safe-area-inset-top)+8px)] bg-gradient-to-b from-background via-background/95 to-background/0 pb-6"
+          : "sticky bottom-[calc(env(safe-area-inset-bottom)+20px)] bg-gradient-to-t from-background via-background/95 to-background/0 pt-6",
+      )}
+    >
+      <IssueChatComposer
+        ref={composerRef}
+        onImageUpload={imageUploadHandler}
+        onAttachImage={onAttachImage}
+        draftKey={draftKey}
+        enableReassign={enableReassign}
+        reassignOptions={reassignOptions}
+        currentAssigneeValue={currentAssigneeValue}
+        suggestedAssigneeValue={suggestedAssigneeValue}
+        mentions={mentions}
+        agentMap={agentMap}
+        composerDisabledReason={composerDisabledReason}
+        composerHint={composerHint}
+        issueStatus={issueStatus}
+        issueWorkMode={issueWorkMode}
+        onWorkModeChange={onWorkModeChange}
+      />
+    </div>
+  ) : null;
+
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       <IssueChatCtx.Provider value={chatCtx}>
       <div className={cn(variant === "embedded" ? "space-y-3" : "space-y-4")}>
+        {composerAtTop ? composerDock : null}
+        {composerAtTop ? threadNotices : null}
         {resolvedShowJumpToLatest ? (
           <div className="flex justify-end">
             <button
@@ -4438,72 +4600,10 @@ export function IssueChatThread({
                   />
               ))
             )}
-              {showComposer ? (
-                <div data-testid="issue-chat-thread-notices" className="space-y-2">
-                  <IssueAssignedBacklogNotice
-                    issueStatus={issueStatus ?? ""}
-                    assigneeAgent={assignedAgent}
-                    assigneeUserId={assigneeUserId}
-                    onResume={onResumeFromBacklog}
-                    resuming={resumeFromBacklogPending}
-                  />
-                  {recoveryAction ? (
-                    <IssueRecoveryActionCard
-                      action={recoveryAction}
-                      agentMap={agentMap}
-                      onResolve={onResolveRecoveryAction}
-                      canFalsePositive={canFalsePositiveRecoveryAction}
-                    />
-                  ) : null}
-                  {legacyRecoverySourceIssue ? (
-                    <SystemNotice
-                      tone="info"
-                      label="Legacy recovery task"
-                      body={
-                        <span>
-                          Legacy recovery task. Newer recovery actions live on the source task
-                          {legacyRecoverySourceIssue.identifier ? (
-                            <>
-                              {" — "}
-                              <Link
-                                to={legacyRecoverySourceIssue.href}
-                                className="underline-offset-2 hover:underline"
-                              >
-                                {legacyRecoverySourceIssue.identifier}
-                                {legacyRecoverySourceIssue.title ? (
-                                  <span className="text-muted-foreground">
-                                    {" "}
-                                    — {legacyRecoverySourceIssue.title}
-                                  </span>
-                                ) : null}
-                              </Link>
-                            </>
-                          ) : (
-                            "."
-                          )}
-                        </span>
-                      }
-                    />
-                  ) : null}
-                  <IssueBlockedNotice
-                    issueId={issueId}
-                    issueStatus={issueStatus}
-                    blockers={unresolvedBlockers}
-                    blockerAttention={blockerAttention}
-                    successfulRunHandoff={recoveryAction ? null : successfulRunHandoff}
-                    scheduledRetry={scheduledRetry}
-                    agentName={
-                      successfulRunHandoff?.assigneeAgentId
-                        ? agentMap?.get(successfulRunHandoff.assigneeAgentId)?.name ?? null
-                        : null
-                    }
-                  />
-                  <IssueAssigneePausedNotice agent={assignedAgent} />
-                </div>
-              ) : null}
+              {composerAtTop ? null : threadNotices}
               {footer ? <div data-testid="issue-chat-thread-footer">{footer}</div> : null}
               <div ref={bottomAnchorRef} />
-              {showComposer ? (
+              {!composerAtTop && showComposer ? (
                 <div
                   aria-hidden
                   data-testid="issue-chat-bottom-spacer"
@@ -4514,31 +4614,7 @@ export function IssueChatThread({
           </div>
         </IssueChatErrorBoundary>
 
-        {showComposer ? (
-          <div
-            ref={composerViewportAnchorRef}
-            data-testid="issue-chat-composer-dock"
-            className="sticky bottom-[calc(env(safe-area-inset-bottom)+20px)] z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
-          >
-            <IssueChatComposer
-              ref={composerRef}
-              onImageUpload={imageUploadHandler}
-              onAttachImage={onAttachImage}
-              draftKey={draftKey}
-              enableReassign={enableReassign}
-              reassignOptions={reassignOptions}
-              currentAssigneeValue={currentAssigneeValue}
-              suggestedAssigneeValue={suggestedAssigneeValue}
-              mentions={mentions}
-              agentMap={agentMap}
-              composerDisabledReason={composerDisabledReason}
-              composerHint={composerHint}
-              issueStatus={issueStatus}
-              issueWorkMode={issueWorkMode}
-              onWorkModeChange={onWorkModeChange}
-            />
-          </div>
-        ) : null}
+        {composerAtTop ? null : composerDock}
       </div>
       </IssueChatCtx.Provider>
     </AssistantRuntimeProvider>

--- a/ui/src/lib/issue-chat-messages.test.ts
+++ b/ui/src/lib/issue-chat-messages.test.ts
@@ -531,6 +531,59 @@ describe("buildIssueChatMessages", () => {
     });
   });
 
+  it("renders newest-first and pins pending confirmations to the top", () => {
+    const agentMap = new Map<string, Agent>([["agent-1", createAgent("agent-1", "CodexCoder")]]);
+    const messages = buildIssueChatMessages({
+      comments: [
+        createComment(),
+        createComment({
+          id: "comment-2",
+          authorAgentId: "agent-1",
+          authorUserId: null,
+          body: "I made the change.",
+          createdAt: new Date("2026-04-06T12:03:00.000Z"),
+          updatedAt: new Date("2026-04-06T12:03:00.000Z"),
+          runId: "run-1",
+          runAgentId: "agent-1",
+        }),
+      ],
+      interactions: [
+        // Pending confirmation — must pin to the very top regardless of time.
+        createRequestConfirmation(),
+        // Resolved confirmation — not pinned; sorts by time like any other row.
+        createRequestConfirmation({
+          id: "confirmation-2",
+          status: "accepted",
+          createdAt: new Date("2026-04-06T11:58:00.000Z"),
+          updatedAt: new Date("2026-04-06T11:58:00.000Z"),
+        }),
+      ],
+      timelineEvents: [
+        {
+          id: "event-1",
+          createdAt: new Date("2026-04-06T11:59:00.000Z"),
+          actorType: "user",
+          actorId: "user-1",
+          statusChange: { from: "done", to: "todo" },
+        },
+      ],
+      linkedRuns: [],
+      liveRuns: [],
+      agentMap,
+      currentUserId: "user-1",
+      newestFirst: true,
+    });
+
+    expect(messages.map((message) => `${message.role}:${message.id}`)).toEqual([
+      // Pinned pending confirmation first, then everything newest -> oldest.
+      "system:interaction:confirmation-1",
+      "assistant:comment-2",
+      "user:comment-1",
+      "system:activity:event-1",
+      "system:interaction:confirmation-2",
+    ]);
+  });
+
   it("merges thread interactions into the same chronological feed as comments and runs", () => {
     const messages = buildIssueChatMessages({
       comments: [

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -87,6 +87,10 @@ type MessageWithOrder = {
   createdAtMs: number;
   order: number;
   message: ThreadMessage;
+  // When true (and the feed is rendered newest-first), this item is pinned to
+  // the very top of the thread regardless of its timestamp — used for pending
+  // confirmation requests that await the user's action.
+  pinned?: boolean;
 };
 
 type SortBoundaryItem = {
@@ -897,6 +901,10 @@ export function buildIssueChatMessages(args: {
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
   userLabelMap?: ReadonlyMap<string, string> | null;
+  // Render the feed newest-first (top to bottom). Pending confirmation requests
+  // are pinned above everything else. Defaults to false (chronological) so the
+  // embedded run-output view keeps its natural oldest-first reading order.
+  newestFirst?: boolean;
 }) {
   const {
     comments,
@@ -914,6 +922,7 @@ export function buildIssueChatMessages(args: {
     agentMap,
     currentUserId,
     userLabelMap,
+    newestFirst = false,
   } = args;
 
   const orderedMessages: MessageWithOrder[] = [];
@@ -941,6 +950,9 @@ export function buildIssueChatMessages(args: {
     orderedMessages.push({
       createdAtMs: handoffAtMs ?? createdAtMs,
       order: 2,
+      // Pending confirmation requests await the user's action — pin them to the
+      // top of the newest-first feed so they are never buried below the history.
+      pinned: interaction.kind === "request_confirmation" && interaction.status === "pending",
       message: createInteractionMessage(interaction),
     });
   }
@@ -993,6 +1005,16 @@ export function buildIssueChatMessages(args: {
 
   return orderedMessages
     .sort((a, b) => {
+      if (newestFirst) {
+        // Pinned items (pending confirmations) float to the very top.
+        const aPinned = a.pinned ? 1 : 0;
+        const bPinned = b.pinned ? 1 : 0;
+        if (aPinned !== bPinned) return bPinned - aPinned;
+        // Everything else is newest-first (top to bottom).
+        if (a.createdAtMs !== b.createdAtMs) return b.createdAtMs - a.createdAtMs;
+        if (a.order !== b.order) return a.order - b.order;
+        return b.message.id.localeCompare(a.message.id);
+      }
       if (a.createdAtMs !== b.createdAtMs) return a.createdAtMs - b.createdAtMs;
       if (a.order !== b.order) return a.order - b.order;
       return a.message.id.localeCompare(b.message.id);


### PR DESCRIPTION
## What

The full issue conversation feed (`IssueChatThread` with `variant="full"`) now reads **newest-first**:

- **Newest messages at the top**, oldest at the bottom (reverse chronological).
- **Pending `request_confirmation` interactions are pinned to the very top**, so items awaiting the user's action are never buried in the history.
- **The composer (and its action notices) dock at the top**, next to the freshest messages.

The embedded run-output view (`variant="embedded"`, used by `RunChatSurface`) is intentionally **unchanged** — it keeps its natural chronological (oldest-first) reading order with the composer docked at the bottom.

## Why

In a long-running issue thread the most relevant content is the latest activity and any confirmation the agent is waiting on. Surfacing those at the top removes the need to scroll to the bottom on every visit.

## How

- `buildIssueChatMessages` gains a `newestFirst` flag. When set, pending confirmations are pinned first, then the remaining items sort newest → oldest. Default stays `false` (chronological) for the embedded variant.
- `IssueChatThread` (`variant="full"`):
  - composer + action notices move to a `sticky top` dock;
  - "Jump to latest", post-submit scroll and the settle loop now target the **top** of the thread;
  - `findLatestCommentMessageIndex` is direction-aware; the virtualizer's `scrollToLatest` targets index 0;
  - the bottom spacer reserve (only meaningful for a bottom-anchored chat) is dropped for the full feed.

## Tests

- New unit test covering newest-first ordering + a pinned pending confirmation.
- Updated `IssueChatThread` tests for the top-docked composer, jump-to-top, and the direction-aware helper.
- `ui` typecheck (`tsc -b`) clean; affected vitest suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
