### PR TITLE
feat(secrets): company-scoped plugin secret resolution (SAG-3546)

### DIFF
--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -147,7 +147,7 @@ export interface HostServices {
 
   /** Provides `secrets.resolve`. */
   secrets: {
-    resolve(params: WorkerToHostMethods["secrets.resolve"][0]): Promise<string>;
+    resolve(params: WorkerToHostMethods["secrets.resolve"][0], context?: WorkerHostCallContext): Promise<string>;
   };
 
   /** Provides `activity.log`. */
@@ -696,8 +696,8 @@ export function createHostClientHandlers(
     }),
 
     // Secrets
-    "secrets.resolve": gated("secrets.resolve", async (params) => {
-      return services.secrets.resolve(params);
+    "secrets.resolve": gated("secrets.resolve", async (params, context) => {
+      return services.secrets.resolve(params, context);
     }),
 
     // Activity

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -307,8 +307,9 @@ describe.sequential("plugin install and upgrade authz", () => {
     expect(mockLifecycle.unload).toHaveBeenCalledWith(pluginId, true);
   }, 20_000);
 
-  it("rejects plugin config saves that contain secret refs even for instance admins", async () => {
+  it("allows instance admins to save plugin config containing secret-ref values", async () => {
     readyPlugin();
+    mockRegistry.upsertConfig.mockResolvedValue({ id: pluginId });
 
     const { app } = await createApp({
       type: "board",
@@ -326,9 +327,11 @@ describe.sequential("plugin install and upgrade authz", () => {
         },
       });
 
-    expect(res.status).toBe(422);
-    expect(res.body.error).toMatch(/secret references are disabled/i);
-    expect(mockRegistry.upsertConfig).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(mockRegistry.upsertConfig).toHaveBeenCalledWith(
+      pluginId,
+      expect.objectContaining({ configJson: { apiKeyRef: "77777777-7777-4777-8777-777777777777" } }),
+    );
   }, 20_000);
 
   it("allows instance admins to upgrade plugins", async () => {

--- a/server/src/__tests__/plugin-secrets-handler.test.ts
+++ b/server/src/__tests__/plugin-secrets-handler.test.ts
@@ -1,29 +1,222 @@
-import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
-  createPluginSecretsHandler,
-  PLUGIN_SECRET_REFS_DISABLED_MESSAGE,
-} from "../services/plugin-secrets-handler.js";
+  companies,
+  companySecretBindings,
+  companySecretProviderConfigs,
+  companySecretVersions,
+  companySecrets,
+  createDb,
+  secretAccessEvents,
+} from "@paperclipai/db";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+import { secretService } from "../services/secrets.js";
+import { createPluginSecretsHandler } from "../services/plugin-secrets-handler.js";
 
-describe("createPluginSecretsHandler", () => {
-  it("fails closed for plugin secret resolution until company scoping lands", async () => {
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping plugin secrets handler tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (no DB required)
+// ---------------------------------------------------------------------------
+
+describe("createPluginSecretsHandler — format validation", () => {
+  it("rejects an empty secretRef", async () => {
     const handler = createPluginSecretsHandler({
       db: {} as never,
       pluginId: "11111111-1111-4111-8111-111111111111",
     });
-
     await expect(
-      handler.resolve({ secretRef: "77777777-7777-4777-8777-777777777777" }),
-    ).rejects.toThrow(PLUGIN_SECRET_REFS_DISABLED_MESSAGE);
+      handler.resolve({ secretRef: "" }),
+    ).rejects.toMatchObject({ name: "InvalidSecretRefError" });
   });
 
-  it("still rejects malformed secret refs before the feature-disable guard", async () => {
+  it("rejects a non-UUID secretRef", async () => {
     const handler = createPluginSecretsHandler({
       db: {} as never,
       pluginId: "11111111-1111-4111-8111-111111111111",
     });
-
     await expect(
       handler.resolve({ secretRef: "not-a-uuid" }),
-    ).rejects.toThrow(/invalid secret reference/i);
+    ).rejects.toMatchObject({ name: "InvalidSecretRefError" });
+  });
+
+  it("rejects when no company scope is in the context", async () => {
+    const handler = createPluginSecretsHandler({
+      db: {} as never,
+      pluginId: "11111111-1111-4111-8111-111111111111",
+    });
+    // No context at all — treated as not-found (same error shape)
+    await expect(
+      handler.resolve({ secretRef: "77777777-7777-4777-8777-777777777777" }),
+    ).rejects.toMatchObject({ name: "InvalidSecretRefError" });
+  });
+
+  it("rejects when context has no invocationScope", async () => {
+    const handler = createPluginSecretsHandler({
+      db: {} as never,
+      pluginId: "11111111-1111-4111-8111-111111111111",
+    });
+    await expect(
+      handler.resolve({ secretRef: "77777777-7777-4777-8777-777777777777" }, {}),
+    ).rejects.toMatchObject({ name: "InvalidSecretRefError" });
+  });
+
+  it("error message for invalid ref does not include resolved value context", async () => {
+    const handler = createPluginSecretsHandler({
+      db: {} as never,
+      pluginId: "11111111-1111-4111-8111-111111111111",
+    });
+    const err = await handler.resolve({ secretRef: "bad-ref" }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message.toLowerCase()).not.toContain("password");
+    expect(err.message.toLowerCase()).not.toContain("secret value");
+  });
+
+  it("rate-limit trips after 30 resolutions per minute", async () => {
+    const handler = createPluginSecretsHandler({
+      db: {} as never,
+      pluginId: "22222222-2222-4222-8222-222222222222",
+    });
+    const ref = "77777777-7777-4777-8777-777777777777";
+    // All 30 will get InvalidSecretRefError (no DB), not RateLimitExceededError
+    for (let i = 0; i < 30; i++) {
+      await handler.resolve({ secretRef: ref }).catch(() => {});
+    }
+    // 31st must be rate-limited
+    await expect(
+      handler.resolve({ secretRef: ref }),
+    ).rejects.toMatchObject({ name: "RateLimitExceededError" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests (requires embedded Postgres)
+// ---------------------------------------------------------------------------
+
+describeEmbeddedPostgres("createPluginSecretsHandler — DB integration", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+  const previousKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+  const secretsTmpDir = path.join(os.tmpdir(), `paperclip-plugin-secrets-handler-${randomUUID()}`);
+
+  beforeAll(async () => {
+    mkdirSync(secretsTmpDir, { recursive: true });
+    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = path.join(secretsTmpDir, "master.key");
+    const started = await startEmbeddedPostgresTestDatabase("plugin-secrets-handler-");
+    stopDb = started.cleanup;
+    db = createDb(started.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(secretAccessEvents);
+    await db.delete(companySecretBindings);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecrets);
+    await db.delete(companySecretProviderConfigs);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await stopDb?.();
+    if (previousKeyFile === undefined) {
+      delete process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+    } else {
+      process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = previousKeyFile;
+    }
+    rmSync(secretsTmpDir, { recursive: true, force: true });
+  });
+
+  async function seedCompany(name = "Acme") {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name,
+      issuePrefix: `T${companyId.slice(0, 7)}`.toUpperCase(),
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return companyId;
+  }
+
+  it("same-company resolve returns the secret value", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+    const secret = await svc.create(companyId, {
+      name: `my-secret-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "hunter2",
+    });
+
+    const handler = createPluginSecretsHandler({ db, pluginId: randomUUID() });
+    const result = await handler.resolve(
+      { secretRef: secret.id },
+      { invocationScope: { companyId } },
+    );
+    expect(result).toBe("hunter2");
+  });
+
+  it("cross-company resolve rejects with the not-found-shaped error (no existence oracle)", async () => {
+    const companyA = await seedCompany("A");
+    const companyB = await seedCompany("B");
+    const svc = secretService(db);
+    const secretOfA = await svc.create(companyA, {
+      name: `a-secret-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "a-value",
+    });
+
+    const handler = createPluginSecretsHandler({ db, pluginId: randomUUID() });
+    const err = await handler.resolve(
+      { secretRef: secretOfA.id },
+      { invocationScope: { companyId: companyB } },
+    ).catch((e) => e);
+
+    // Same error shape as not-found — do not leak that the secret exists for A
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("InvalidSecretRefError");
+    expect(err.message).not.toContain("a-value");
+    expect(err.message).not.toContain(companyA);
+  });
+
+  it("resolving a non-existent UUID rejects with InvalidSecretRefError", async () => {
+    const companyId = await seedCompany();
+    const handler = createPluginSecretsHandler({ db, pluginId: randomUUID() });
+    await expect(
+      handler.resolve(
+        { secretRef: randomUUID() },
+        { invocationScope: { companyId } },
+      ),
+    ).rejects.toMatchObject({ name: "InvalidSecretRefError" });
+  });
+
+  it("resolved value never appears in any thrown error message", async () => {
+    const companyA = await seedCompany("A");
+    const companyB = await seedCompany("B");
+    const svc = secretService(db);
+    const secretOfA = await svc.create(companyA, {
+      name: `sensitive-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "super-sensitive-payload",
+    });
+
+    const handler = createPluginSecretsHandler({ db, pluginId: randomUUID() });
+    const err = await handler.resolve(
+      { secretRef: secretOfA.id },
+      { invocationScope: { companyId: companyB } },
+    ).catch((e) => e);
+
+    expect(String(err)).not.toContain("super-sensitive-payload");
+    expect(JSON.stringify(err)).not.toContain("super-sensitive-payload");
   });
 });

--- a/server/src/__tests__/plugin-secrets-host-services.test.ts
+++ b/server/src/__tests__/plugin-secrets-host-services.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHostClientHandlers } from "../../../packages/plugins/sdk/src/host-client-factory.js";
+import { buildHostServices } from "../services/plugin-host-services.js";
+
+const resolveSecretValue = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: vi.fn(() => ({ resolveSecretValue })),
+}));
+
+function createEventBusStub() {
+  return {
+    forPlugin() {
+      return {
+        emit: vi.fn(),
+        subscribe: vi.fn(),
+        clear: vi.fn(),
+      };
+    },
+  } as any;
+}
+
+describe("plugin secrets host services bridge", () => {
+  it("forwards worker invocation scope to the plugin secrets handler", async () => {
+    resolveSecretValue.mockResolvedValue("resolved-value");
+
+    const services = buildHostServices(
+      {} as never,
+      "plugin-record-id",
+      "acme.secrets",
+      createEventBusStub(),
+    );
+    const handlers = createHostClientHandlers({
+      pluginId: "acme.secrets",
+      capabilities: ["secrets.read-ref"],
+      services,
+    });
+
+    const result = await handlers["secrets.resolve"](
+      { secretRef: "77777777-7777-4777-8777-777777777777" },
+      { invocationScope: { companyId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" } },
+    );
+
+    expect(result).toBe("resolved-value");
+    expect(resolveSecretValue).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "77777777-7777-4777-8777-777777777777",
+      "latest",
+    );
+
+    services.dispose();
+  });
+});

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -75,10 +75,6 @@ import {
   requireLocalFolderDeclaration,
   setStoredLocalFolder,
 } from "../services/plugin-local-folders.js";
-import {
-  extractSecretRefPathsFromConfig,
-  PLUGIN_SECRET_REFS_DISABLED_MESSAGE,
-} from "../services/plugin-secrets-handler.js";
 import { badRequest, forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -2174,12 +2170,6 @@ export function pluginRoutes(
     }
 
     try {
-      const secretRefsByPath = extractSecretRefPathsFromConfig(body.configJson, schema);
-      if (secretRefsByPath.size > 0) {
-        res.status(422).json({ error: PLUGIN_SECRET_REFS_DISABLED_MESSAGE });
-        return;
-      }
-
       const result = await registry.upsertConfig(plugin.id, {
         configJson: body.configJson,
       });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1229,8 +1229,8 @@ export function buildHostServices(
     },
 
     secrets: {
-      async resolve(params) {
-        return secretsHandler.resolve(params);
+      async resolve(params, context) {
+        return secretsHandler.resolve(params, context);
       },
     },
 

--- a/server/src/services/plugin-secrets-handler.ts
+++ b/server/src/services/plugin-secrets-handler.ts
@@ -34,11 +34,14 @@
  */
 
 import type { Db } from "@paperclipai/db";
+import type { WorkerHostCallContext } from "@paperclipai/plugin-sdk";
 import {
   collectSecretRefPaths,
   isUuidSecretRef,
   readConfigValueAtPath,
 } from "./json-schema-secret-refs.js";
+import { secretService } from "./secrets.js";
+import { HttpError } from "../errors.js";
 
 export const PLUGIN_SECRET_REFS_DISABLED_MESSAGE =
   "Plugin secret references are disabled until company-scoped plugin config lands";
@@ -149,11 +152,12 @@ export interface PluginSecretsService {
    * Resolve a secret reference to its current plaintext value.
    *
    * @param params - Contains the `secretRef` (UUID of the secret)
+   * @param context - Worker call context carrying the acting company scope
    * @returns The resolved secret value
-   * @throws {Error} If the secret is not found, has no versions, or
-   *   the provider fails to resolve
+   * @throws {Error} with name `InvalidSecretRefError` if the secret is not
+   *   found, cross-company, or the ref is invalid (same shape — no oracle)
    */
-  resolve(params: PluginSecretsResolveParams): Promise<string>;
+  resolve(params: PluginSecretsResolveParams, context?: WorkerHostCallContext): Promise<string>;
 }
 
 /**
@@ -199,13 +203,13 @@ function createRateLimiter(maxAttempts: number, windowMs: number) {
 export function createPluginSecretsHandler(
   options: PluginSecretsHandlerOptions,
 ): PluginSecretsService {
-  const { pluginId } = options;
+  const { db, pluginId } = options;
 
   // Rate limit: max 30 resolution attempts per plugin per minute
   const rateLimiter = createRateLimiter(30, 60_000);
 
   return {
-    async resolve(params: PluginSecretsResolveParams): Promise<string> {
+    async resolve(params: PluginSecretsResolveParams, context?: WorkerHostCallContext): Promise<string> {
       const { secretRef } = params;
 
       // ---------------------------------------------------------------
@@ -230,9 +234,29 @@ export function createPluginSecretsHandler(
         throw invalidSecretRef(trimmedRef);
       }
 
-      // Fail closed until plugin config and worker runtime both carry an
-      // explicit company scope for secret bindings and resolution.
-      throw new Error(PLUGIN_SECRET_REFS_DISABLED_MESSAGE);
+      // ---------------------------------------------------------------
+      // 2. Require an acting company scope (per-invocation)
+      // ---------------------------------------------------------------
+      const actingCompanyId = context?.invocationScope?.companyId;
+      if (!actingCompanyId) {
+        // No company scope — treat as not-found; do not reveal why
+        throw invalidSecretRef(trimmedRef);
+      }
+
+      // ---------------------------------------------------------------
+      // 3. Resolve via the secret provider, enforcing ownership
+      //    Map ownership/not-found errors to InvalidSecretRefError so
+      //    callers cannot distinguish "doesn't exist" from "belongs to
+      //    another company" (PLUGIN_SPEC §22 — no cross-company oracle).
+      // ---------------------------------------------------------------
+      try {
+        return await secretService(db).resolveSecretValue(actingCompanyId, trimmedRef, "latest");
+      } catch (err) {
+        if (err instanceof HttpError && (err.status === 404 || err.status === 422)) {
+          throw invalidSecretRef(trimmedRef);
+        }
+        throw err;
+      }
     },
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Plugins can receive secret references in configuration and resolve those references at runtime through host services.
> - Secret resolution must be company-scoped so a plugin worker cannot read another company's secrets or oracle whether a cross-company UUID exists.
> - The previous runtime path failed closed because the worker invocation scope was not threaded all the way into secret resolution.
> - This pull request makes #7823 the canonical narrow fix for company-scoped plugin secret resolution and incorporates the required host-services context bridge from duplicate PR #7842 without its unrelated changes.
> - The benefit is that plugin secret refs can resolve for the acting company while preserving cross-company isolation and focused review scope.

## Linked Issues or Issue Description

Refs #7823
Refs #7842
Refs SAG-3546
Refs SAG-6298

Duplicate/related PR search: #7842 covered the same plugin-secret runtime bug but also included unrelated API and loop-guard commits plus failing checks. This PR is the canonical focused path.

## What Changed

- Threaded `WorkerHostCallContext` through the plugin SDK `secrets.resolve` host handler.
- Implemented company-scoped plugin secret resolution with UUID validation, same-shaped cross-company/not-found errors, and rate limiting.
- Removed the plugin-config save guard that rejected secret-ref values after runtime company scoping landed.
- Added integration coverage for same-company resolution, cross-company rejection, not-found masking, and resolved-value leak prevention.
- Added a host-services bridge regression test proving invocation scope reaches the secret resolver from the SDK handler path.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/plugin-secrets-host-services.test.ts server/src/__tests__/plugin-secrets-handler.test.ts` — 2 files passed, 11 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.

## Risks

- Secret refs in plugin config now persist and resolve at runtime, so any missed company-scope propagation would break plugin secret access; the new host-services bridge test covers that path.
- Provider errors are masked as `InvalidSecretRefError` after UUID validation to avoid cross-company oracles, which reduces worker-facing diagnostics by design.
- This PR intentionally does not include #7842's unrelated `packages/api` and loop-guard commits.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5.5, tool-enabled coding agent. Context window size was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge