### PR TITLE
Fix cancelled child blocker attention samples

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -255,6 +255,37 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("does not surface a cancelled child as the blocker sample after a replacement blocker exists", async () => {
+    const { companyId } = await createCompany("PBRP");
+    const parentId = await insertIssue({ companyId, identifier: "PBRP-1", title: "Parent", status: "blocked" });
+    const replacementBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBRP-2",
+      title: "Human-owned replacement blocker",
+      status: "backlog",
+      assigneeUserId: "board-user-1",
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBRP-3",
+      title: "Cancelled stale child",
+      status: "cancelled",
+      parentId,
+    });
+    await block({ companyId, blockerIssueId: replacementBlockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_dependency",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBRP-2",
+    });
+  });
+
   it("covers recursive blocker chains when the downstream leaf has active work", async () => {
     const { companyId, agentId } = await createCompany("PBR");
     const parentId = await insertIssue({ companyId, identifier: "PBR-1", title: "Parent", status: "blocked" });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1173,6 +1173,7 @@ const BLOCKER_ATTENTION_ACTIVE_WAKE_STATUSES = ["queued", "deferred_issue_execut
 const BLOCKER_ATTENTION_PENDING_INTERACTION_STATUSES = ["pending"];
 const BLOCKER_ATTENTION_PENDING_APPROVAL_STATUSES = ["pending", "revision_requested"];
 const BLOCKER_ATTENTION_OPEN_RECOVERY_ORIGIN_KIND = "harness_liveness_escalation";
+const BLOCKER_ATTENTION_CHILD_TERMINAL_STATUSES = ["done", "cancelled"];
 const PRODUCTIVITY_REVIEW_ORIGIN_KIND = "issue_productivity_review";
 const PRODUCTIVITY_REVIEW_TERMINAL_STATUSES = ["done", "cancelled"];
 const PRODUCTIVITY_REVIEW_ACTIVITY_ACTIONS = [
@@ -1605,7 +1606,7 @@ async function listIssueBlockerAttentionMap(
           and(
             eq(issues.companyId, companyId),
             inArray(issues.parentId, chunk),
-            ne(issues.status, "done"),
+            notInArray(issues.status, BLOCKER_ATTENTION_CHILD_TERMINAL_STATUSES),
           ),
         );
       const [explicitBlockerRows, childRows] = await Promise.all([


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue graph control plane computes blocker attention metadata for blocked work.
> - Explicit dependency blockers and active child issues are both considered when explaining why a blocked issue is waiting.
> - Cancelled child issues are terminal and should not keep acting as active child blockers after replacement work exists.
> - The stale WEI-3196 sample showed a cancelled child winning the blocker attention sample even though replacement blockers were present.
> - This pull request keeps explicit cancelled dependency edges unresolved, but removes terminal children from blocker-attention child traversal.
> - The benefit is blocked parents report the live blocker path instead of stale cancelled child samples.

## Linked Issues or Issue Description

Refs #7577, #7454, #7303.

Bug fix context:
- What happened: blocked issue attention could report a cancelled child issue as the sample blocker after replacement blocker work existed.
- Expected behavior: terminal child issues should not participate as active child blocker-attention samples; explicit cancelled dependency edges should remain unresolved until replaced or removed.
- Steps to reproduce: create a blocked parent with a covered replacement blocker plus a cancelled child; list blocker attention for the parent.
- Paperclip version/commit: reproduced against the local June 9, 2026 instance before this source fix.
- Deployment mode: local trusted Paperclip instance using packaged `npx paperclipai run`.

## What Changed

- Excluded `done` and `cancelled` child issues from blocker-attention child traversal.
- Added a regression test covering a blocked parent with a replacement blocker plus a cancelled stale child.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-blocker-attention.test.ts`
- Live instance before deploy still reports stale WEI-3196 because it is running the packaged `npx paperclipai run` server, not this source branch.

## Risks

- Low risk: this only changes implicit child blocker traversal for terminal children. Explicit `blockedByIssueIds` edges to cancelled blockers remain unresolved and still require operator replacement/removal.

## Model Used

- OpenAI GPT-5.5 Codex via Codex CLI, code execution enabled, local repository and Paperclip API access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I searched for similar open/closed PRs and linked prior PRs above
- [x] I will address all Greptile and reviewer comments before requesting merge

