### PR TITLE
Add Claude Fable 5 and Mythos 5 to the model selector

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -7,6 +7,8 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @anthropic-ai/claude-code
 
 export const models = [
   { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+  { id: "claude-fable-5", label: "Claude Fable 5" },
+  { id: "claude-mythos-5", label: "Claude Mythos 5" },
   { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -10,6 +10,7 @@ const ANTHROPIC_API_VERSION = "2023-06-01";
 /** AWS Bedrock model IDs — region-qualified identifiers required by the Bedrock API. */
 const BEDROCK_MODELS: AdapterModel[] = [
   { id: "us.anthropic.claude-opus-4-8-v1", label: "Bedrock Opus 4.8" },
+  { id: "us.anthropic.claude-fable-5-v1", label: "Bedrock Fable 5" },
   { id: "us.anthropic.claude-opus-4-6-v1", label: "Bedrock Opus 4.6" },
   { id: "us.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
   { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -58,6 +58,10 @@ describe("adapter model listing", () => {
 
     expect(models).toEqual(claudeFallbackModels);
     expect(models.some((model) => model.id === "claude-opus-4-8")).toBe(true);
+    // Newer flagship models are offered, but Opus 4.8 stays the default (first) option.
+    expect(models[0]?.id).toBe("claude-opus-4-8");
+    expect(models.some((model) => model.id === "claude-fable-5")).toBe(true);
+    expect(models.some((model) => model.id === "claude-mythos-5")).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Adds the newly released Claude models from the [models overview](https://platform.claude.com/docs/en/about-claude/models/overview) to the `claude_local` adapter's model selector:

- **Claude Fable 5** (`claude-fable-5`) — generally available as of 2026-06-09, Anthropic's most capable widely-released model.
- **Claude Mythos 5** (`claude-mythos-5`) — limited availability (Project Glasswing).

**Opus 4.8 stays first in the list so it remains the default selection** — per the request, the new flagship models are *offered* but not defaulted (not Fable, not Mythos).

## Changes

- `packages/adapters/claude-local/src/index.ts` — add `claude-fable-5` and `claude-mythos-5` to the adapter model list, right after `claude-opus-4-8`.
- `packages/adapters/claude-local/src/server/models.ts` — add the Fable 5 Bedrock identifier (`us.anthropic.claude-fable-5-v1`) to the Bedrock fallback list. Mythos 5 is limited-availability on Bedrock, so it's intentionally left out of that fallback.
- `server/src/__tests__/adapter-models.test.ts` — assert the new models are present and that `claude-opus-4-8` remains first (the default).

These flow through the single `claudeModels` source, so they also appear in the ACPX combined list (`registry.ts` prefixes them with `Claude:`) and are recognized by the ACPX Claude model filter. The UI selector reads models dynamically from the adapter, so no UI changes are needed.

## Testing

- `npx vitest run src/__tests__/adapter-models.test.ts` — 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)