### PR TITLE
docs(release): v2026.609.0 changelog

### DIFF
--- a/releases/v2026.609.0.md
+++ b/releases/v2026.609.0.md
@@ -1,0 +1,40 @@
+# v2026.609.0
+
+> Released: 2026-06-09
+
+## Highlights
+
+- **Company Artifacts** - Files, media, and documents your agents produce are now first-class. A new company-scoped Artifacts page indexes every work product across issues and runs, groups them by task stack by default, and supports upload and rich playback — including video artifact thumbnails — so you can inspect what your agents made without opening each issue one by one. ([#7621](https://github.com/paperclipai/paperclip/pull/7621), [#7654](https://github.com/paperclipai/paperclip/pull/7654), [#7667](https://github.com/paperclipai/paperclip/pull/7667), [#7248](https://github.com/paperclipai/paperclip/pull/7248), @cryppadotta)
+- **Collapsible sidebar rail and takeover panes** - The primary navigation can now collapse to a persisted rail with hover/focus peek, giving contextual pages — especially company settings and plugin routes — far more horizontal room while keeping global navigation one click away. ([#7824](https://github.com/paperclipai/paperclip/pull/7824), @cryppadotta)
+- **Rich issue attachments with video** - Issues now accept video attachments and render rich inline previews, including standalone PWA browser controls and inline video playback, so screen recordings and media land directly in the thread instead of as opaque downloads. ([#7361](https://github.com/paperclipai/paperclip/pull/7361), [#7360](https://github.com/paperclipai/paperclip/pull/7360), @cryppadotta)
+- **Checkbox confirmation interactions** - Issue-thread interactions can now ask the board or user to confirm one or more options via a structured checkbox payload, with consistent validation across the API, CLI, plugin helpers, and UI — and free-text "other" answers now render as proper links. ([#7649](https://github.com/paperclipai/paperclip/pull/7649), @cryppadotta)
+- **Information Architecture refresh (experimental)** - An opt-in visual refresh of the project and agent surfaces makes high-frequency workflows easier to scan, and instance settings now live under company settings so configuration is discoverable from one place. ([#7543](https://github.com/paperclipai/paperclip/pull/7543), @scotttong; [#7680](https://github.com/paperclipai/paperclip/pull/7680), @cryppadotta)
+- **Automated PR quality and security gates** - `commitperclip` now runs automated quality and security gates on incoming PRs — checking for a linked issue, test coverage, a complete template, and a clean lockfile, plus a dedup-search check — so contributors get fast, consistent feedback and maintainers spend review time where it counts. Paired with new low-trust review containment that gives reviewers of untrusted content a narrowly-scoped, prompt-injection-resistant authority preset. ([#6469](https://github.com/paperclipai/paperclip/pull/6469), @brandonburr; [#7632](https://github.com/paperclipai/paperclip/pull/7632), [#7530](https://github.com/paperclipai/paperclip/pull/7530), @cryppadotta)
+
+## Improvements
+
+- **Harder-working agents** - Operators get a direct, audited recovery path with a new clear-error agent action and live-run stop finalization actions, while invalid agents (terminated, paused, pending-approval) are centrally prevented from receiving new assignments or runs — so your instance stays consistent and tries harder before involving you. ([#7695](https://github.com/paperclipai/paperclip/pull/7695), [#7679](https://github.com/paperclipai/paperclip/pull/7679), [#7663](https://github.com/paperclipai/paperclip/pull/7663), @cryppadotta)
+- **Sharper wake boundaries** - Document-scoped comments are now treated as review context instead of firing the same wake path as top-level issue comments, and issue comment wake handoffs were refined — so agents wake on the activity that actually needs them. ([#7766](https://github.com/paperclipai/paperclip/pull/7766), [#7678](https://github.com/paperclipai/paperclip/pull/7678), @cryppadotta)
+- **External adapter overrides for built-ins** - External adapter plugins can now hot-install over a built-in adapter type (for example a newer `hermes` implementation) while keeping the built-in available as a fallback, matching the registry's existing override behavior. ([#7394](https://github.com/paperclipai/paperclip/pull/7394), @HenkDz)
+- **Gemini CLI bundled in the image** - The production Docker image now bakes in the Gemini CLI so the `gemini_local` adapter works out of the box alongside `claude`, `codex`, and `opencode`. ([#7693](https://github.com/paperclipai/paperclip/pull/7693), @davison)
+- **New Claude models in the selector** - Claude Fable 5 and Mythos 5 are now offered in the `claude_local` adapter's model selector (Opus 4.8 stays the default). ([#7826](https://github.com/paperclipai/paperclip/pull/7826), @cryppadotta)
+- **Routines respect paused projects** - Scheduled routine ticks are now suppressed while a project is paused, archived routines are hidden from the routines page, and the routines view now defaults to grouping by project. ([#7502](https://github.com/paperclipai/paperclip/pull/7502), @dosthcpp)
+- **Deleted comments are redacted** - Deleted issue comments are now redacted atomically, with regression coverage, so removed content doesn't linger in the thread. ([#7554](https://github.com/paperclipai/paperclip/pull/7554), @cryppadotta)
+- **Stronger CLI and API parity** - The CLI now sends `X-Paperclip-Run-Id` so agents can mutate their own issues via the CLI, plus broader OpenAPI spec coverage, auth metadata, and CLI/API parity tests. ([#7642](https://github.com/paperclipai/paperclip/pull/7642), [#4579](https://github.com/paperclipai/paperclip/pull/4579), [#6626](https://github.com/paperclipai/paperclip/pull/6626), @aronprins)
+- **Login accessibility** - The login screen now ships proper accessibility and password-manager metadata for a smoother sign-in. ([#7660](https://github.com/paperclipai/paperclip/pull/7660), @cryppadotta)
+- **Safer workspaces** - Git-sensitive adapter workspaces are now guarded, archived companies no longer wake agents, and experimental settings survive across retired feature flags. ([#7644](https://github.com/paperclipai/paperclip/pull/7644), [#7478](https://github.com/paperclipai/paperclip/pull/7478), @cryppadotta)
+
+## Fixes
+
+- **Foreign tracker keys no longer link as Paperclip issues** - Keys from other trackers in your text are no longer mistakenly turned into Paperclip issue links. ([#7511](https://github.com/paperclipai/paperclip/pull/7511), @pmn4)
+- **Agents can use plugin tools** - Agent-issued JWTs are now accepted by the plugin tool endpoints (`GET/POST /api/plugins/tools`), so agents can actually call the plugin capabilities built for them. ([#7480](https://github.com/paperclipai/paperclip/pull/7480), @devinfoley)
+- **Plugin worker resolution** - The plugin tool dispatcher now propagates `pluginDbId` so `worker.isRunning` resolves correctly. ([#5671](https://github.com/paperclipai/paperclip/pull/5671), @Ramon-nassa)
+- **Issue anchor binding** - `anchor.createdAt` is now coerced to a `Date` before the postgres binding, fixing an insert failure on annotation anchors. ([#5220](https://github.com/paperclipai/paperclip/pull/5220), @aperim-agent)
+- **Hermes resume state** - Hermes resume session state is now guarded during heartbeats so resumed runs pick up cleanly. ([#7516](https://github.com/paperclipai/paperclip/pull/7516), @andrewylies)
+- **Dev runner snapshot race** - Fixed a dev-runner snapshot race and the document comment panel layering, with regression coverage. ([#7362](https://github.com/paperclipai/paperclip/pull/7362), @cryppadotta)
+
+## Contributors
+
+Thank you to everyone who contributed to this release!
+
+@andrewylies, @aperim-agent, @aronprins, @brandonburr, @davison, @dosthcpp, @HenkDz, @pmn4, @Ramon-nassa


### PR DESCRIPTION
## Summary

Adds the user-facing stable release changelog for **v2026.609.0** (released 2026-06-09), generated per `.agents/skills/release-changelog/SKILL.md` from the diff between `v2026.529.0` (last stable) and `origin/master` — 119 non-merge commits.

## Highlights covered
- Company Artifacts (page, task-stack grouping, playback, video thumbnails)
- Collapsible sidebar rail and takeover panes
- Rich issue attachments with video
- Checkbox confirmation interactions
- Information Architecture refresh (experimental) + instance settings under company settings
- Automated PR quality/security gates + low-trust review containment

## Notes
- No breaking changes — all 5 new migrations (0094–0098) are additive (backfills, tombstones, annotation links, source-trust tagging, project icon).
- Contributor list excludes founders and bots per skill rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)