### PR TITLE
fix(productivity-review): gate auto-assignment to capable manager-tier adapters (SAG-711)

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -210,6 +210,138 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
   });
 
+  // SAG-668 / SAG-661 scenario: a productivity review must NOT be auto-assigned to a
+  // small-model `opencode_local` engineer that lacks manager-style judgement. Under the
+  // OLD logic the review routed to the source agent's reporting manager regardless of
+  // adapter capability — so a small-model CTO (here, an opencode_local manager) would
+  // have been picked. The NEW logic gates on manager-capable adapters and falls back to
+  // the CEO. The helper below seeds an org whose only manager-tier candidates are
+  // small-model opencode_local agents plus a CEO, so we can prove the routing change.
+  async function seedSmallModelOrg(opts?: { ceoAdapterType?: string; managerAdapterType?: string }) {
+    const companyId = randomUUID();
+    const ceoId = randomUUID();
+    const ctoId = randomUUID();
+    const coderId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `PR${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const createdAt = new Date("2026-04-28T10:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Small Model Co",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ceoId,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+        status: "idle",
+        adapterType: opts?.ceoAdapterType ?? "claude_local",
+        adapterConfig: opts?.ceoAdapterType === "claude_local" || !opts?.ceoAdapterType
+          ? { model: "claude-opus-4" }
+          : {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: ctoId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        // Small-model opencode_local manager — the kind that SAG-668/SAG-661 wrongly routed to.
+        adapterType: opts?.managerAdapterType ?? "opencode_local",
+        adapterConfig: { model: "qwen2.5-coder:7b" },
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: coderId,
+        companyId,
+        name: "Coder",
+        role: "engineer",
+        status: "idle",
+        reportsTo: ctoId,
+        adapterType: "opencode_local",
+        adapterConfig: { model: "qwen2.5-coder:7b" },
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Implement data import",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: coderId,
+      originKind: "manual",
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      startedAt: createdAt,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    return { companyId, ceoId, ctoId, coderId, issueId, issuePrefix, createdAt };
+  }
+
+  it("routes to the CEO instead of a small-model opencode_local manager (SAG-668 / SAG-661)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    // Pool of manager-tier candidates is ONLY small-model opencode_local agents, plus a
+    // capable claude_local CEO. The source agent reports to the small-model CTO.
+    const seeded = await seedSmallModelOrg({ managerAdapterType: "opencode_local" });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+    const reviews = await listProductivityReviews(seeded.companyId);
+
+    expect(result.created).toBe(1);
+    expect(reviews).toHaveLength(1);
+    // OLD logic would have routed to the small-model CTO (seeded.ctoId) — i.e. "would
+    // have routed differently". NEW logic routes to the capable CEO instead.
+    expect(reviews[0]?.assigneeAgentId).toBe(seeded.ceoId);
+    expect(reviews[0]?.assigneeAgentId).not.toBe(seeded.ctoId);
+  });
+
+  it("routes to a claude_local manager when one exists in a mixed pool (SAG-668 / SAG-661)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    // Mixed pool: small-model opencode_local engineers + a capable claude_local manager.
+    // Here the CTO is the capable claude_local manager; the CEO is also claude_local.
+    const seeded = await seedSmallModelOrg({ managerAdapterType: "claude_local" });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+    const reviews = await listProductivityReviews(seeded.companyId);
+
+    expect(result.created).toBe(1);
+    expect(reviews).toHaveLength(1);
+    // The claude_local CTO is the source agent's reporting manager and is manager-capable,
+    // so it is preferred over the CEO fallback.
+    expect(reviews[0]?.assigneeAgentId).toBe(seeded.ctoId);
+  });
+
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -224,6 +224,34 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return Boolean(agent && !["paused", "terminated", "pending_approval"].includes(agent.status));
   }
 
+  // Productivity reviews require manager-style judgement (decide to close, snooze,
+  // reroute, decompose, or stop work). Small-model `opencode_local` engineers cannot
+  // be trusted to make that call, so auto-assigning a review to one (as happened in
+  // SAG-668 / SAG-661) just churns. Gate auto-assignment to capable manager-tier
+  // adapters and let the caller fall back to the CEO when none qualify.
+  //
+  // We gate on adapterType / adapterConfig.model rather than the `capabilities`
+  // column because `capabilities` is a free-text summary string (see the agent join
+  // request shape), not a structured/enumerated signal we can reliably test.
+  // TODO: replace this with a proper structured capability system (e.g. a
+  // `manager_judgement` capability flag) and gate on that as the primary signal,
+  // treating adapter type/model only as a secondary heuristic.
+  //
+  // `opencode_local` is denied unless its model is on this allowlist. The allowlist
+  // is intentionally EMPTY by default: no opencode_local model qualifies as
+  // manager-capable until one is explicitly proven and added here.
+  const MANAGER_CAPABLE_OPENCODE_MODELS: ReadonlySet<string> = new Set<string>();
+
+  function isManagerCapableAdapter(agent: AgentRow): boolean {
+    if (agent.adapterType === "opencode_local") {
+      const model = typeof agent.adapterConfig?.model === "string" ? agent.adapterConfig.model : "";
+      return MANAGER_CAPABLE_OPENCODE_MODELS.has(model);
+    }
+    // `claude_local` (any hosted Claude model) and other manager-tier adapters
+    // (e.g. `codex_local`, `process`) are treated as capable.
+    return true;
+  }
+
   async function isProductivityReviewDescendant(issue: Pick<IssueRow, "companyId" | "parentId">) {
     let parentId = issue.parentId;
     let depth = 0;
@@ -541,18 +569,41 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .orderBy(sql`case when ${agents.role} = 'cto' then 0 else 1 end`, asc(agents.createdAt), asc(agents.id));
     candidateIds.push(...roleCandidates.map((agent) => agent.id));
 
+    const isAssignable = async (candidate: AgentRow | null) => {
+      if (!candidate || candidate.companyId !== sourceIssue.companyId || !isAgentInvokable(candidate)) return false;
+      const budgetBlock = await budgets.getInvocationBlock(sourceIssue.companyId, candidate.id, {
+        issueId: sourceIssue.id,
+        projectId: sourceIssue.projectId ?? null,
+      });
+      return !budgetBlock;
+    };
+
+    // First pass: prefer the prioritized candidates (reporting manager, creator,
+    // project lead, CTO, CEO), but only accept ones with manager-capable adapters.
+    // This skips small-model `opencode_local` engineers (the SAG-668 / SAG-661 bug).
     const seen = new Set<string>();
     for (const agentId of candidateIds) {
       if (seen.has(agentId)) continue;
       seen.add(agentId);
       const candidate = await getAgent(agentId);
-      if (!candidate || candidate.companyId !== sourceIssue.companyId || !isAgentInvokable(candidate)) continue;
-      const budgetBlock = await budgets.getInvocationBlock(sourceIssue.companyId, candidate.id, {
-        issueId: sourceIssue.id,
-        projectId: sourceIssue.projectId ?? null,
-      });
-      if (!budgetBlock) return candidate.id;
+      if (!candidate || !isManagerCapableAdapter(candidate)) continue;
+      if (await isAssignable(candidate)) return candidate.id;
     }
+
+    // Fallback: when no capable manager-tier candidate qualifies, route to the CEO
+    // rather than auto-assigning to a small-model engineer. The CEO is the capable
+    // manager of last resort for review judgement.
+    const ceoCandidates = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.companyId, sourceIssue.companyId), eq(agents.role, "ceo")))
+      .orderBy(asc(agents.createdAt), asc(agents.id));
+    for (const { id: ceoId } of ceoCandidates) {
+      const candidate = await getAgent(ceoId);
+      if (!candidate || !isManagerCapableAdapter(candidate)) continue;
+      if (await isAssignable(candidate)) return candidate.id;
+    }
+
     return null;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Productivity-review issues are part of the control-plane workflow that asks a manager-tier agent to inspect recent issue history and decide whether work should continue, pause, or close.
> - That judgement depends on enough reasoning quality to read the thread, understand the outcome, and apply the decision to the source issue.
> - The existing productivity-review router picked from the normal leadership chain without checking whether the chosen adapter/model was suitable for manager-style judgement.
> - In the SAG environment, that let small-model `opencode_local` agents receive `productivity_review` assignments they could not reliably resolve, including the SAG-668 and SAG-661 incidents that later needed CEO recovery.
> - This pull request adds a focused capability gate to productivity-review owner selection while preserving the existing priority order among capable candidates.
> - The benefit is that productivity reviews route to a capable manager-tier adapter, or fall back to the CEO, instead of stranding review loops on unsuitable small local models.

## Linked Issues or Issue Description

No public GitHub issue exists for this internal Paperclip company incident. Source issue: SAG-711, under parent SAG-703.

## What happened?

Productivity-review auto-assignment could select a small-model `opencode_local` manager candidate because the router did not check adapter capability before assigning a new `productivity_review` issue.

## Expected behavior

Productivity-review issues should be assigned only to manager-capable adapters, with small-model `opencode_local` agents denied by default unless their model is explicitly allowlisted.

## Steps to reproduce

1. Create a productivity-review routing pool where an engineer reports to an `opencode_local` CTO on a small local model.
2. Include a CEO using `claude_local` in the same company.
3. Trigger productivity-review owner selection.
4. Under the previous logic, the small-model CTO could be selected before CEO fallback.

## Paperclip version or commit

PR head `94083f63ef6e4766493751afe6bb0714b6e862e6` on branch `dmndbrp-oss:sag-711-capability-gate`.

## Deployment mode

Paperclip framework code running a local-trusted company with mixed adapter types; observed in SAG incidents SAG-668 and SAG-661.

## Additional context

Searched GitHub PRs and issues for `productivity review router capability gate`; no duplicate public PRs or issues were found.

## What Changed

- Updated `server/src/services/productivity-review.ts` so `resolveReviewOwnerAgentId` filters productivity-review candidates through `isManagerCapableAdapter` before assigning a review owner.
- Denied `opencode_local` candidates unless `adapterConfig.model` is present in `MANAGER_CAPABLE_OPENCODE_MODELS`, which is intentionally empty by default.
- Treated `claude_local` and the existing manager-tier adapter set (`codex_local`, `process`) as capable for this targeted fix.
- Added an explicit capability-checked CEO fallback when no prioritized capable manager candidate qualifies.
- Added a TODO noting that this heuristic should eventually be replaced by a structured manager-judgement capability flag; the current `capabilities` field is nullable free text, not a reliable gate.
- Added focused regression tests covering the two required routing scenarios: only small-model `opencode_local` pool routes to CEO, and mixed pool routes to a `claude_local` CTO.

## Verification

- Focused local verification by implementer: `pnpm vitest run server/src/__tests__/productivity-review-service.test.ts` passed with `1` test file and `13` tests.
- Independent reviewer verification in clean checkout `/tmp/paperclip-pr7832-review`: `pnpm install --frozen-lockfile` completed successfully with plugin SDK bin-link warnings only.
- Independent reviewer verification in clean checkout: `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/productivity-review-service.test.ts` passed with `1` test file and `13` tests.
- CI status at review time: core PR workflow checks passed, including policy, typecheck/release registry, general tests, serialized server suites, build, canary dry run, e2e, verify, Greptile Review, Socket checks, security review, and Snyk.
- `commitperclip PR Review` failed on head `94083f63ef6e4766493751afe6bb0714b6e862e6` because the inline issue description used prose labels instead of standalone issue-template headings; this update changes the description to recognized bug-report headings.

## Risks

- Low schema/API/UI risk: the change is scoped to productivity-review owner selection and focused service tests; it does not change database schema, public API contracts, or UI behavior.
- Routing behavior changes intentionally for `opencode_local` productivity-review candidates: small models are skipped unless explicitly allowlisted, so those reviews may route to CEO more often in companies without a capable manager-tier adapter.
- The manager-capability signal is still a heuristic based on adapter type and model configuration. A future structured capability such as `manager_judgement` would be stronger.
- `codex_local` and `process` remain treated as manager-capable because SAG-711 only required denying small-model `opencode_local`; broadening that deny policy should be handled as a separate product decision.

## Model Used

- Anthropic Claude Code using Claude Opus 4.8 produced or assisted with the implementation, tests, and original PR body, with tool use and code execution in the Paperclip monorepo.
- OpenAI Codex Engineering Director (gpt-5.5) handled the stale-check recovery and updated this PR description to match the actual `commitperclip` linked-issue detector, using shell/GitHub CLI access and Paperclip issue context.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Do not merge without DoE sign-off.