### PR TITLE
fix: sanitize opencode_local comment outputs (SAG-722)

### DIFF
--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -185,4 +185,30 @@ describe("sanitizeModelText", () => {
   it("returns null for whitespace-only input", () => {
     expect(sanitizeModelText("   \n  ")).toBeNull();
   });
+
+  // SAG-772 canary: Llama-70b emits prose then inline {"type":"function",...}
+  it("returns null when inline tool-call JSON is embedded after prose (SAG-772 canary)", () => {
+    const leaked =
+      'First, I need to check if there are any new comments on the issue since my last update.\n\n{"type": "function", "name": "get_issue_comments", "parameters": {"issue_id": "SAG-772"}}';
+    expect(sanitizeModelText(leaked)).toBeNull();
+  });
+
+  it("returns null for inline tool call with no spaces around colon", () => {
+    const leaked = 'Checking status.\n{"type":"function","name":"fetch_issue","parameters":{}}';
+    expect(sanitizeModelText(leaked)).toBeNull();
+  });
+
+  it("drops inline tool-call blocks via parseOpenCodeJsonl (end-to-end)", () => {
+    const leaked =
+      'First, I need to check if there are any new comments on the issue since my last update.\n\n{"type": "function", "name": "get_issue_comments", "parameters": {"issue_id": "SAG-772"}}';
+    const clean = "Canary complete — all tests passing.";
+    const stdout = [
+      JSON.stringify({ type: "text", sessionID: "s1", part: { text: leaked } }),
+      JSON.stringify({ type: "text", sessionID: "s1", part: { text: clean } }),
+    ].join("\n");
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.summary).toBe(clean);
+    expect(parsed.summary).not.toContain('"type": "function"');
+    expect(parsed.summary).not.toContain("First, I need to check");
+  });
 });

--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseOpenCodeJsonl, isOpenCodeUnknownSessionError } from "./parse.js";
+import { parseOpenCodeJsonl, isOpenCodeUnknownSessionError, sanitizeModelText } from "./parse.js";
 
 describe("parseOpenCodeJsonl", () => {
   it("parses assistant text, usage, cost, and errors", () => {
@@ -73,5 +73,109 @@ describe("parseOpenCodeJsonl", () => {
     expect(isOpenCodeUnknownSessionError("Session not found: s_123", "")).toBe(true);
     expect(isOpenCodeUnknownSessionError("", "unknown session id")).toBe(true);
     expect(isOpenCodeUnknownSessionError("all good", "")).toBe(false);
+  });
+
+  // SAG-722: leaked tool-call JSON, system-prompt echoes, and internal XML must
+  // be filtered from the summary produced by parseOpenCodeJsonl.
+
+  it("drops pure tool-call JSON text events from the summary (AC1, AC5)", () => {
+    const toolCallJson = JSON.stringify({
+      type: "function",
+      name: "fetch_issue",
+      parameters: { issue_id: "SAG-704" },
+    });
+    const stdout = [
+      JSON.stringify({ type: "text", sessionID: "s1", part: { text: toolCallJson } }),
+      JSON.stringify({ type: "text", sessionID: "s1", part: { text: "Done — updated the issue." } }),
+    ].join("\n");
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.summary).toBe("Done — updated the issue.");
+    expect(parsed.summary).not.toContain('"type": "function"');
+  });
+
+  it("drops text events whose content is a bare JSON array (AC1)", () => {
+    const arrayJson = JSON.stringify([{ tool: "bash", args: ["ls"] }]);
+    const stdout = JSON.stringify({ type: "text", sessionID: "s1", part: { text: arrayJson } });
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.summary).toBe("");
+  });
+
+  it("drops echoed system-prompt wakeup text (AC2)", () => {
+    const wakeText = "You are woken by reason: issue_assigned for issue SAG-677. Your task is…";
+    const stdout = [
+      JSON.stringify({ type: "text", sessionID: "s1", part: { text: wakeText } }),
+      JSON.stringify({ type: "text", sessionID: "s1", part: { text: "Acknowledged. Moving to in_progress." } }),
+    ].join("\n");
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.summary).toBe("Acknowledged. Moving to in_progress.");
+    expect(parsed.summary).not.toContain("You are woken by reason");
+  });
+
+  it("drops echoed agent-identity system-prompt lines (AC2)", () => {
+    const agentLine = "You are agent f3c48afc running as CTO. Here is your context…";
+    const stdout = JSON.stringify({ type: "text", sessionID: "s1", part: { text: agentLine } });
+    expect(parseOpenCodeJsonl(stdout).summary).toBe("");
+  });
+
+  it("strips <analysis> and <thinking> XML blocks, keeps surrounding text (AC3)", () => {
+    const raw = "<analysis>I need to check the issue first.</analysis>\n\nMoved to in_progress.";
+    const stdout = JSON.stringify({ type: "text", sessionID: "s1", part: { text: raw } });
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.summary).toBe("Moved to in_progress.");
+    expect(parsed.summary).not.toContain("<analysis>");
+  });
+
+  it("drops text events that consist solely of an internal XML block (AC3)", () => {
+    const raw = "<thinking>Let me think about this carefully.</thinking>";
+    const stdout = JSON.stringify({ type: "text", sessionID: "s1", part: { text: raw } });
+    expect(parseOpenCodeJsonl(stdout).summary).toBe("");
+  });
+
+  it("passes through normal natural-language update text unchanged", () => {
+    const text = "## Update\n\n- Filed sub-task SAG-723\n- Moved status to in_progress";
+    const stdout = JSON.stringify({ type: "text", sessionID: "s1", part: { text } });
+    expect(parseOpenCodeJsonl(stdout).summary).toBe(text);
+  });
+});
+
+// SAG-722: regression guard — sanitizeModelText directly
+
+describe("sanitizeModelText", () => {
+  it("returns null for pure tool-call JSON (AC5 regression guard)", () => {
+    expect(sanitizeModelText('{"type": "function", "name": "fetch_issue", "parameters": {}}')).toBeNull();
+  });
+
+  it("returns null for JSON that starts with {\"type\": \"function\" (AC5)", () => {
+    const s = JSON.stringify({ type: "function", name: "bash", parameters: { cmd: "ls" } });
+    expect(sanitizeModelText(s)).toBeNull();
+  });
+
+  it("returns null for a JSON array payload", () => {
+    expect(sanitizeModelText('[{"tool":"bash"}]')).toBeNull();
+  });
+
+  it("returns null for wake-payload echo lines", () => {
+    expect(sanitizeModelText("You are woken by reason: issue_assigned")).toBeNull();
+    expect(sanitizeModelText("You are agent abc123 running as CTO")).toBeNull();
+    expect(sanitizeModelText("The above agent instructions were loaded from /path")).toBeNull();
+    expect(sanitizeModelText("Treat this wake payload as the highest-priority context")).toBeNull();
+  });
+
+  it("strips internal XML blocks and returns remaining text", () => {
+    expect(sanitizeModelText("<analysis>internal</analysis>\n\nPosted comment.")).toBe("Posted comment.");
+    expect(sanitizeModelText("<thinking>internal</thinking>\n\nDone.")).toBe("Done.");
+  });
+
+  it("returns null when nothing remains after stripping XML", () => {
+    expect(sanitizeModelText("<analysis>only internal content here</analysis>")).toBeNull();
+  });
+
+  it("returns natural-language text unchanged", () => {
+    const text = "Moved issue to in_progress and posted update.";
+    expect(sanitizeModelText(text)).toBe(text);
+  });
+
+  it("returns null for whitespace-only input", () => {
+    expect(sanitizeModelText("   \n  ")).toBeNull();
   });
 });

--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -198,6 +198,33 @@ describe("sanitizeModelText", () => {
     expect(sanitizeModelText(leaked)).toBeNull();
   });
 
+  // SAG-819 fixture: 8b IC (llama3.1:8b Countertop Estimator) emitted the bare
+  // {"name":...,"parameters":...} dialect with NO "type":"function" wrapper —
+  // the original INLINE_TOOL_CALL_RE missed it. Comment 72f09e77 on SAG-819.
+  it("returns null when 8b IC leaks bare {name,parameters} tool-call form (SAG-819#72f09e77)", () => {
+    const leaked =
+      'I apologize for the issue. Let me try to look up the documentation on Countertop Estimator on another platform.  \n\n{"name": "webfetch", "parameters": {"url":"https://www.google.com/search?q=Countertop+Estimator"}}';
+    expect(sanitizeModelText(leaked)).toBeNull();
+  });
+
+  it("returns null when model leaks bare {name,arguments} tool-call form", () => {
+    const leaked =
+      'Looking it up now.\n{"name": "search", "arguments": {"query": "foo"}}';
+    expect(sanitizeModelText(leaked)).toBeNull();
+  });
+
+  it("returns null when model leaks {tool,args} bridge dialect", () => {
+    const leaked = 'Running command.\n{"tool": "bash", "args": ["ls", "-la"]}';
+    expect(sanitizeModelText(leaked)).toBeNull();
+  });
+
+  it("does not over-match: prose mentioning a JSON object with a name key is preserved", () => {
+    // A legitimate status update that happens to mention the literal string
+    // {"name":"..."} but without an adjacent parameters/arguments key.
+    const text = 'Found a config entry: {"name":"prod-cluster"} in the registry.';
+    expect(sanitizeModelText(text)).toBe(text);
+  });
+
   it("drops inline tool-call blocks via parseOpenCodeJsonl (end-to-end)", () => {
     const leaked =
       'First, I need to check if there are any new comments on the issue since my last update.\n\n{"type": "function", "name": "get_issue_comments", "parameters": {"issue_id": "SAG-772"}}';

--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -161,6 +161,13 @@ describe("sanitizeModelText", () => {
     expect(sanitizeModelText("Treat this wake payload as the highest-priority context")).toBeNull();
   });
 
+  it("returns null when the model self-identifies as an agent (internal monologue, SAG-773 evidence)", () => {
+    // SSI Director leaked: "I am agent 7cc4dafd... The latest comment on issue SAG-773..."
+    const leaked =
+      "I am agent 7cc4dafd-b41f-469c-b8ea-7b4110a11fe8 (SSI Director). The latest comment on issue SAG-773 is from agent 3ab7fa06. I will respond with a status update.";
+    expect(sanitizeModelText(leaked)).toBeNull();
+  });
+
   it("strips internal XML blocks and returns remaining text", () => {
     expect(sanitizeModelText("<analysis>internal</analysis>\n\nPosted comment.")).toBe("Posted comment.");
     expect(sanitizeModelText("<thinking>internal</thinking>\n\nDone.")).toBe("Done.");

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -30,16 +30,29 @@ const SYSTEM_PROMPT_ECHO_PATTERNS: RegExp[] = [
 // Match full <tag>…</tag> blocks for known internal-reasoning wrappers.
 const INTERNAL_XML_BLOCK_RE = /<(analysis|thinking|antml:thinking|antml:function_calls)>[\s\S]*?<\/\1>/gi;
 
-// Detect JSON tool-call objects embedded mid-text (e.g. Llama-70b emitting
-// prose then {"type":"function",...} when it can't use the structured channel).
-const INLINE_TOOL_CALL_RE = /\{\s*"type"\s*:\s*"function"/i;
+// Detect JSON tool-call objects embedded mid-text. Models leak several dialects
+// when they can't use the structured channel — broadened from the original
+// {"type":"function",...} form after SAG-819#72f09e77 (8b IC leaked the bare
+// {"name":"webfetch","parameters":{...}} shape that the narrower detector missed).
+const INLINE_TOOL_CALL_PATTERNS: RegExp[] = [
+  // OpenAI-style: {"type":"function", ...}
+  /\{\s*"type"\s*:\s*"function"/i,
+  // Bare-name dialect (Llama/Qwen 8b): {"name":"<ident>", ..., "parameters"|"arguments": ...}
+  /\{\s*"name"\s*:\s*"[A-Za-z_][\w.\-]*"[\s\S]{0,200}?"(?:parameters|arguments)"\s*:/i,
+  // OpenCode bridge dialect: {"tool":"<ident>", ..., "args"|"input": ...}
+  /\{\s*"tool"\s*:\s*"[A-Za-z_][\w.\-]*"[\s\S]{0,200}?"(?:args|input|arguments|parameters)"\s*:/i,
+];
+
+function hasInlineToolCall(text: string): boolean {
+  return INLINE_TOOL_CALL_PATTERNS.some((re) => re.test(text));
+}
 
 export function sanitizeModelText(text: string): string | null {
   if (isPureJson(text)) return null;
   if (SYSTEM_PROMPT_ECHO_PATTERNS.some((re) => re.test(text.trimStart()))) return null;
   // Drop blocks where the model slipped an inline text-mode tool call anywhere
   // in the text — the prose that precedes the JSON is also internal reasoning.
-  if (INLINE_TOOL_CALL_RE.test(text)) return null;
+  if (hasInlineToolCall(text)) return null;
   const stripped = text.replace(INTERNAL_XML_BLOCK_RE, "").trim();
   return stripped.length > 0 ? stripped : null;
 }

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -21,6 +21,7 @@ function isPureJson(text: string): boolean {
 const SYSTEM_PROMPT_ECHO_PATTERNS: RegExp[] = [
   /^You are woken by reason:/i,
   /^You are agent\b/i,
+  /^I am agent\b/i,
   /^The above agent instructions were loaded from\b/i,
   /^This base directory is authoritative for\b/i,
   /^Treat this wake payload as/i,

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -1,5 +1,43 @@
 import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
 
+// ---------------------------------------------------------------------------
+// SAG-722: comment sanitization — strip leaked tool-call JSON, echoed system
+// prompts, and internal-reasoning XML blocks before text reaches the summary.
+// ---------------------------------------------------------------------------
+
+function isPureJson(text: string): boolean {
+  const t = text.trim();
+  if (t.length < 2) return false;
+  const first = t[0];
+  if (first !== "{" && first !== "[") return false;
+  try {
+    JSON.parse(t);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SYSTEM_PROMPT_ECHO_PATTERNS: RegExp[] = [
+  /^You are woken by reason:/i,
+  /^You are agent\b/i,
+  /^The above agent instructions were loaded from\b/i,
+  /^This base directory is authoritative for\b/i,
+  /^Treat this wake payload as/i,
+];
+
+// Match full <tag>…</tag> blocks for known internal-reasoning wrappers.
+const INTERNAL_XML_BLOCK_RE = /<(analysis|thinking|antml:thinking|antml:function_calls)>[\s\S]*?<\/\1>/gi;
+
+export function sanitizeModelText(text: string): string | null {
+  if (isPureJson(text)) return null;
+  if (SYSTEM_PROMPT_ECHO_PATTERNS.some((re) => re.test(text.trimStart()))) return null;
+  const stripped = text.replace(INTERNAL_XML_BLOCK_RE, "").trim();
+  return stripped.length > 0 ? stripped : null;
+}
+
+// ---------------------------------------------------------------------------
+
 function errorText(value: unknown): string {
   if (typeof value === "string") return value;
   const rec = parseObject(value);
@@ -46,7 +84,10 @@ export function parseOpenCodeJsonl(stdout: string) {
     if (type === "text") {
       const part = parseObject(event.part);
       const text = asString(part.text, "").trim();
-      if (text) messages.push(text);
+      if (text) {
+        const sanitized = sanitizeModelText(text);
+        if (sanitized) messages.push(sanitized);
+      }
       continue;
     }
 

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -30,9 +30,16 @@ const SYSTEM_PROMPT_ECHO_PATTERNS: RegExp[] = [
 // Match full <tag>…</tag> blocks for known internal-reasoning wrappers.
 const INTERNAL_XML_BLOCK_RE = /<(analysis|thinking|antml:thinking|antml:function_calls)>[\s\S]*?<\/\1>/gi;
 
+// Detect JSON tool-call objects embedded mid-text (e.g. Llama-70b emitting
+// prose then {"type":"function",...} when it can't use the structured channel).
+const INLINE_TOOL_CALL_RE = /\{\s*"type"\s*:\s*"function"/i;
+
 export function sanitizeModelText(text: string): string | null {
   if (isPureJson(text)) return null;
   if (SYSTEM_PROMPT_ECHO_PATTERNS.some((re) => re.test(text.trimStart()))) return null;
+  // Drop blocks where the model slipped an inline text-mode tool call anywhere
+  // in the text — the prose that precedes the JSON is also internal reasoning.
+  if (INLINE_TOOL_CALL_RE.test(text)) return null;
   const stripped = text.replace(INTERNAL_XML_BLOCK_RE, "").trim();
   return stripped.length > 0 ? stripped : null;
 }

--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -63,6 +63,21 @@ describe("buildHeartbeatRunIssueComment", () => {
   it("returns null when there is no usable final text", () => {
     expect(buildHeartbeatRunIssueComment({ costUsd: 1.2 })).toBeNull();
   });
+
+  // SAG-722 regression guard: pure JSON must never reach the comment body.
+  it("returns null and does not post when summary is pure tool-call JSON (AC5)", () => {
+    const leaked = JSON.stringify({ type: "function", name: "fetch_issue", parameters: { issue_id: "SAG-704" } });
+    expect(buildHeartbeatRunIssueComment({ summary: leaked })).toBeNull();
+  });
+
+  it("returns null when summary is a JSON array", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: '[{"tool":"bash"}]' })).toBeNull();
+  });
+
+  it("passes through natural-language summaries unchanged", () => {
+    const text = "Moved issue to in_progress and posted update.";
+    expect(buildHeartbeatRunIssueComment({ summary: text })).toBe(text);
+  });
 });
 
 describe("mergeHeartbeatRunResultJson", () => {

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -92,6 +92,20 @@ export function summarizeHeartbeatRunResultJson(
   return Object.keys(summary).length > 0 ? summary : null;
 }
 
+// SAG-722 regression guard: suppress a comment that is pure JSON (leaked tool-call payload).
+function isLeakedToolCallJson(text: string): boolean {
+  const t = text.trim();
+  if (t.length < 2) return false;
+  const first = t[0];
+  if (first !== "{" && first !== "[") return false;
+  try {
+    JSON.parse(t);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
 ): string | null {
@@ -99,10 +113,18 @@ export function buildHeartbeatRunIssueComment(
     return null;
   }
 
-  return (
+  const candidate =
     readCommentText(resultJson.summary)
     ?? readCommentText(resultJson.result)
     ?? readCommentText(resultJson.message)
-    ?? null
-  );
+    ?? null;
+
+  if (candidate && isLeakedToolCallJson(candidate)) {
+    console.error(
+      `[paperclip] SAG-722: Suppressed comment that is pure JSON (likely leaked tool-call). First 200 chars: ${candidate.slice(0, 200)}`,
+    );
+    return null;
+  }
+
+  return candidate;
 }


### PR DESCRIPTION
## Problem

`opencode_local`-backed agents were leaking raw tool-call JSON, internal reasoning XML (`<thinking>`, `<analysis>`), and system-prompt echo fragments into Paperclip issue comments. This caused noisy, unreadable comment threads and exposed internal prompt structure.

## Changes

Five targeted fixes across `packages/adapters/opencode-local` and `server`:

| Commit | Fix |
|--------|-----|
| `380745c2` | `sanitizeModelText()` — strip leaked tool-call JSON and internal reasoning from comment summaries |
| `538ab34d` | `buildHeartbeatRunIssueComment` — regression guard: suppress comment if summary is pure JSON |
| `7b523da0` | Suppress `'I am agent …'` self-identification monologue lines |
| `9fe27867` | Drop inline text-mode tool calls embedded after prose |
| `6c135529` | Broaden inline tool-call detector to bare `{name, parameters}` dialect |

## Tests

37 tests pass (26 in `parse.test.ts` + 11 in `heartbeat-run-summary.test.ts`):

```
✓ |@paperclipai/adapter-opencode-local| src/server/parse.test.ts (26 tests) 9ms
✓ |@paperclipai/server| src/__tests__/heartbeat-run-summary.test.ts (11 tests) 6ms

Test Files  2 passed (2)
     Tests  37 passed (37)
  Duration  628ms
```

## Linked Issues

- Closes SAG-722

Co-Authored-By: Paperclip <noreply@paperclip.ing>