### PR TITLE
Bound Codex recovery compaction handoffs

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -41,6 +41,7 @@ import {
 import {
   parseCodexJsonl,
   extractCodexRetryNotBefore,
+  isCodexRemoteCompactInputTooLargeError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
 } from "./parse.js";
@@ -177,6 +178,9 @@ type CodexTransientFallbackMode =
   | "fresh_session"
   | "fresh_session_safer_invocation";
 
+const CODEX_RECOVERY_HANDOFF_MAX_CHARS = 12_000;
+const CODEX_RECOVERY_HANDOFF_SECTION_MAX_CHARS = 4_000;
+
 function readCodexTransientFallbackMode(context: Record<string, unknown>): CodexTransientFallbackMode | null {
   const value = asString(context.codexTransientFallbackMode, "").trim();
   switch (value) {
@@ -196,6 +200,76 @@ function fallbackModeUsesSaferInvocation(mode: CodexTransientFallbackMode | null
 
 function fallbackModeUsesFreshSession(mode: CodexTransientFallbackMode | null): boolean {
   return mode === "fresh_session" || mode === "fresh_session_safer_invocation";
+}
+
+function truncateCodexRecoveryHandoffText(value: string | null | undefined, maxChars = CODEX_RECOVERY_HANDOFF_SECTION_MAX_CHARS): string {
+  const normalized = value?.trim();
+  if (!normalized) return "";
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 80)).trimEnd()}\n[paperclip truncated bounded recovery handoff section: ${normalized.length} chars]`;
+}
+
+function readContextString(context: Record<string, unknown>, key: string): string | null {
+  const value = asString(context[key], "").trim();
+  return value.length > 0 ? value : null;
+}
+
+function isRecoveryOrContinuationContext(context: Record<string, unknown>): boolean {
+  const wakeReason = readContextString(context, "wakeReason") ?? "";
+  const retryReason = readContextString(context, "retryReason") ?? "";
+  const source = readContextString(context, "source") ?? "";
+  return /(?:recovery|continuation)/i.test(`${wakeReason}\n${retryReason}\n${source}`);
+}
+
+function buildBoundedCodexRecoveryHandoffPrompt(input: {
+  context: Record<string, unknown>;
+  previousSessionId: string | null;
+  errorMessage: string;
+  sessionHandoffNote: string;
+}): string {
+  const wake = parseObject(input.context.paperclipWake);
+  const wakeIssue = parseObject(wake.issue);
+  const continuationSummary = parseObject(input.context.paperclipContinuationSummary);
+  const wakeContinuationSummary = parseObject(wake.continuationSummary);
+  const livenessContinuation = parseObject(wake.livenessContinuation);
+  const issueId = asString(wakeIssue.id, readContextString(input.context, "issueId") ?? readContextString(input.context, "taskId") ?? "unknown");
+  const issueIdentifier = asString(wakeIssue.identifier, "");
+  const issueTitle = asString(wakeIssue.title, "");
+  const issueStatus = asString(wakeIssue.status, "");
+  const continuationSummaryBody =
+    asString(continuationSummary.body, "").trim() ||
+    asString(wakeContinuationSummary.body, "").trim();
+  const livenessInstruction = asString(livenessContinuation.instruction, "").trim();
+  const lines = [
+    "Paperclip bounded recovery handoff:",
+    input.previousSessionId ? `- Previous Codex session: ${input.previousSessionId}` : "",
+    "- Reason: Codex remote compaction rejected the previous resumed session because its context exceeded the model window.",
+    "- Safety: this fresh-session handoff intentionally omits raw transcript and full issue-thread content.",
+    `- Wake reason: ${readContextString(input.context, "wakeReason") ?? "unknown"}`,
+    `- Retry reason: ${readContextString(input.context, "retryReason") ?? "unknown"}`,
+    `- Source: ${readContextString(input.context, "source") ?? "unknown"}`,
+    `- Retry of run: ${readContextString(input.context, "retryOfRunId") ?? "none"}`,
+    `- Source issue: ${[issueIdentifier, issueTitle].filter(Boolean).join(" ") || issueId}${issueStatus ? ` (${issueStatus})` : ""}`,
+    "",
+    "Previous compaction failure:",
+    truncateCodexRecoveryHandoffText(input.errorMessage, 1_500),
+    "",
+    continuationSummaryBody
+      ? `Bounded continuation summary:\n${truncateCodexRecoveryHandoffText(continuationSummaryBody, 5_000)}`
+      : "",
+    livenessInstruction
+      ? `\nRun liveness instruction:\n${truncateCodexRecoveryHandoffText(livenessInstruction, 1_500)}`
+      : "",
+    input.sessionHandoffNote
+      ? `\nExisting handoff note:\n${truncateCodexRecoveryHandoffText(input.sessionHandoffNote, 1_500)}`
+      : "",
+    "",
+    "Next action:",
+    "- Continue from this bounded summary only.",
+    "- Inspect source issue/run metadata through Paperclip APIs if needed; do not assume raw transcript context is available.",
+    "- Restore a live execution path or record a valid disposition before ending the heartbeat.",
+  ].filter(Boolean);
+  return truncateCodexRecoveryHandoffText(lines.join("\n"), CODEX_RECOVERY_HANDOFF_MAX_CHARS);
 }
 
 function buildCodexTransientHandoffNote(input: {
@@ -677,7 +751,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
-  const runAttempt = async (resumeSessionId: string | null) => {
+  const runAttempt = async (
+    resumeSessionId: string | null,
+    promptForAttempt = prompt,
+    promptMetricsForAttempt = promptMetrics,
+    commandNotesForAttempt = commandNotes,
+  ) => {
     const execArgs = buildCodexExecArgs(
       forceSaferInvocation ? { ...config, fastMode: false } : config,
       {
@@ -688,8 +767,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const args = execArgs.args;
     const commandNotesWithFastMode =
       execArgs.fastModeIgnoredReason == null
-        ? commandNotes
-        : [...commandNotes, execArgs.fastModeIgnoredReason];
+        ? commandNotesForAttempt
+        : [...commandNotesForAttempt, execArgs.fastModeIgnoredReason];
     if (onMeta) {
       await onMeta({
         adapterType: "codex_local",
@@ -697,12 +776,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         cwd: effectiveExecutionCwd,
         commandNotes: commandNotesWithFastMode,
         commandArgs: args.map((value, idx) => {
-          if (idx === args.length - 1 && value !== "-") return `<prompt ${prompt.length} chars>`;
+          if (idx === args.length - 1 && value !== "-") return `<prompt ${promptForAttempt.length} chars>`;
           return value;
         }),
         env: loggedEnv,
-        prompt,
-        promptMetrics,
+        prompt: promptForAttempt,
+        promptMetrics: promptMetricsForAttempt,
         context,
       });
     }
@@ -710,7 +789,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
       cwd,
       env,
-      stdin: prompt,
+      stdin: promptForAttempt,
       timeoutSec,
       graceSec,
       onSpawn,
@@ -838,6 +917,46 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
+      return toResult(retry, true, true);
+    }
+    const initialErrorMessage = initial.parsed.errorMessage ?? initial.proc.stderr;
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      isRecoveryOrContinuationContext(context) &&
+      isCodexRemoteCompactInputTooLargeError({
+        stdout: initial.proc.stdout,
+        stderr: initial.rawStderr,
+        errorMessage: initialErrorMessage,
+      })
+    ) {
+      const boundedPrompt = buildBoundedCodexRecoveryHandoffPrompt({
+        context,
+        previousSessionId: sessionId,
+        errorMessage: initialErrorMessage,
+        sessionHandoffNote,
+      });
+      await onLog(
+        "stdout",
+        `[paperclip] Codex remote compaction input exceeded the model window while resuming "${sessionId}"; retrying once with a fresh bounded recovery handoff (${boundedPrompt.length} chars).\n`,
+      );
+      const retry = await runAttempt(
+        null,
+        boundedPrompt,
+        {
+          promptChars: boundedPrompt.length,
+          instructionsChars: 0,
+          bootstrapPromptChars: 0,
+          wakePromptChars: 0,
+          sessionHandoffChars: 0,
+          heartbeatPromptChars: 0,
+        },
+        [
+          ...commandNotes,
+          "Codex remote compaction exceeded the model context window; retried with a fresh bounded recovery handoff.",
+        ],
+      );
       return toResult(retry, true, true);
     }
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -213,14 +213,25 @@ function sanitizeBoundedRecoveryContinuationSummary(value: string | null | undef
   const normalized = value?.replace(/\r\n/g, "\n").trim();
   if (!normalized) return "";
 
+  const nonEmptyLines = normalized
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const repeatedLineCount = new Map<string, number>();
+  for (const line of nonEmptyLines) {
+    if (line.length < 80) continue;
+    repeatedLineCount.set(line, (repeatedLineCount.get(line) ?? 0) + 1);
+  }
+
   const hasTranscriptMarkers =
     /(^|\n)\s*(system|developer|user|assistant|tool|commentary|observation)\s*:/im.test(normalized) ||
     /<\|(?:system|developer|user|assistant|tool|commentary|observation)[^>]*\|>/i.test(normalized) ||
     /(^|\n)\s*```/.test(normalized);
   const hasOversizedLines = normalized.split("\n").some((line) => line.trim().length > 500);
   const hasRepeatedConversationContent = /(.{16,}?)(?:\1){4,}/s.test(normalized);
+  const hasRepeatedLongLines = Array.from(repeatedLineCount.values()).some((count) => count >= 3);
 
-  if (hasTranscriptMarkers || hasOversizedLines || hasRepeatedConversationContent) {
+  if (hasTranscriptMarkers || hasOversizedLines || hasRepeatedConversationContent || hasRepeatedLongLines) {
     return [
       "[paperclip omitted unsafe continuation-summary body from bounded recovery handoff]",
       "Use Paperclip issue/run metadata APIs to rebuild the minimum context needed.",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -209,6 +209,27 @@ function truncateCodexRecoveryHandoffText(value: string | null | undefined, maxC
   return `${normalized.slice(0, Math.max(0, maxChars - 80)).trimEnd()}\n[paperclip truncated bounded recovery handoff section: ${normalized.length} chars]`;
 }
 
+function sanitizeBoundedRecoveryContinuationSummary(value: string | null | undefined): string {
+  const normalized = value?.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return "";
+
+  const hasTranscriptMarkers =
+    /(^|\n)\s*(system|developer|user|assistant|tool|commentary|observation)\s*:/im.test(normalized) ||
+    /<\|(?:system|developer|user|assistant|tool|commentary|observation)[^>]*\|>/i.test(normalized) ||
+    /(^|\n)\s*```/.test(normalized);
+  const hasOversizedLines = normalized.split("\n").some((line) => line.trim().length > 500);
+  const hasRepeatedConversationContent = /(.{16,}?)(?:\1){4,}/s.test(normalized);
+
+  if (hasTranscriptMarkers || hasOversizedLines || hasRepeatedConversationContent) {
+    return [
+      "[paperclip omitted unsafe continuation-summary body from bounded recovery handoff]",
+      "Use Paperclip issue/run metadata APIs to rebuild the minimum context needed.",
+    ].join("\n");
+  }
+
+  return truncateCodexRecoveryHandoffText(normalized, 1_500);
+}
+
 function readContextString(context: Record<string, unknown>, key: string): string | null {
   const value = asString(context[key], "").trim();
   return value.length > 0 ? value : null;
@@ -239,6 +260,7 @@ function buildBoundedCodexRecoveryHandoffPrompt(input: {
   const continuationSummaryBody =
     asString(continuationSummary.body, "").trim() ||
     asString(wakeContinuationSummary.body, "").trim();
+  const sanitizedContinuationSummaryBody = sanitizeBoundedRecoveryContinuationSummary(continuationSummaryBody);
   const livenessInstruction = asString(livenessContinuation.instruction, "").trim();
   const lines = [
     "Paperclip bounded recovery handoff:",
@@ -254,8 +276,8 @@ function buildBoundedCodexRecoveryHandoffPrompt(input: {
     "Previous compaction failure:",
     truncateCodexRecoveryHandoffText(input.errorMessage, 1_500),
     "",
-    continuationSummaryBody
-      ? `Bounded continuation summary:\n${truncateCodexRecoveryHandoffText(continuationSummaryBody, 5_000)}`
+    sanitizedContinuationSummaryBody
+      ? `Bounded continuation summary:\n${sanitizedContinuationSummaryBody}`
       : "",
     livenessInstruction
       ? `\nRun liveness instruction:\n${truncateCodexRecoveryHandoffText(livenessInstruction, 1_500)}`

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -136,5 +136,19 @@ describe("isCodexTransientUpstreamError", () => {
         ].join("\n"),
       }),
     ).toBe(false);
+    expect(
+      isCodexTransientUpstreamError({
+        errorMessage: [
+          "Error running remote compact task: {",
+          '  "error": {',
+          '    "message": "Your input exceeds the context window of this model. Please adjust your input and try again.",',
+          '    "type": "invalid_request_error",',
+          '    "param": "input",',
+          '    "code": "context_length_exceeded"',
+          "  }",
+          "}",
+        ].join("\n"),
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -8,6 +8,8 @@ import {
 const CODEX_TRANSIENT_UPSTREAM_RE =
   /(?:we(?:'|’)re\s+currently\s+experiencing\s+high\s+demand|temporary\s+errors|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|server\s+overloaded|service\s+unavailable|try\s+again\s+later)/i;
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
+const CODEX_REMOTE_COMPACT_INPUT_TOO_LARGE_RE =
+  /(?:remote\s+compact\s+task|compact_remote|pre-sampling\s+compact)[\s\S]*(?:context_length_exceeded|input\s+exceeds\s+the\s+context\s+window|failing_compaction_request_model_visible_bytes)/i;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
 
@@ -252,10 +254,19 @@ export function isCodexTransientUpstreamError(input: {
 }): boolean {
   const haystack = buildCodexErrorHaystack(input);
 
+  if (isCodexRemoteCompactInputTooLargeError(input)) return false;
   if (extractCodexRetryNotBefore(input) != null) return true;
   if (!CODEX_TRANSIENT_UPSTREAM_RE.test(haystack)) return false;
   // Keep automatic retries scoped to the observed remote-compaction/high-demand
   // failure shape, plus explicit usage-limit windows that tell us when retrying
   // becomes safe again.
   return CODEX_REMOTE_COMPACTION_RE.test(haystack) || /high\s+demand|temporary\s+errors/i.test(haystack);
+}
+
+export function isCodexRemoteCompactInputTooLargeError(input: {
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  return CODEX_REMOTE_COMPACT_INPUT_TOO_LARGE_RE.test(buildCodexErrorHaystack(input));
 }

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -854,6 +854,106 @@ describe("codex execute", () => {
     }
   });
 
+  it("omits repeated raw continuation-summary content even without transcript markers", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-bounded-recovery-repeat-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const repeatedRawLine =
+      "Operator note copied from prior run: raw conversation excerpt about retry sequencing and issue-thread replay that must never be forwarded verbatim.";
+    const unsafeSummary = [
+      "Summary: retry the issue from the latest bounded state.",
+      repeatedRawLine,
+      repeatedRawLine,
+      repeatedRawLine,
+      "Keep the retry focused on the current issue only.",
+    ].join("\n");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeCompactOverflowThenSuccessCodexCommand(commandPath, capturePath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-bounded-recovery-repeat",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: {
+            sessionId: "codex-session-saturated",
+            cwd: workspace,
+          },
+          sessionDisplayId: "codex-session-saturated",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Heartbeat prompt should stay out of the bounded recovery retry.",
+        },
+        context: {
+          issueId: "issue-1",
+          taskId: "issue-1",
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+          retryOfRunId: "previous-run",
+          paperclipContinuationSummary: {
+            key: "continuation-summary",
+            title: "Continuation Summary",
+            body: unsafeSummary,
+            updatedAt: "2026-06-04T12:05:56.840Z",
+          },
+          paperclipWake: {
+            reason: "issue_continuation_needed",
+            issue: {
+              id: "issue-1",
+              identifier: "TEST-1416",
+              title: "Retry repeated summary leak",
+              status: "in_progress",
+              priority: "medium",
+            },
+            comments: [],
+            commentIds: [],
+            commentWindow: {
+              requestedCount: 0,
+              includedCount: 0,
+              missingCount: 0,
+            },
+            truncated: false,
+            fallbackFetchNeeded: false,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as {
+        attempts: Array<{ argv: string[]; prompt: string }>;
+      };
+      expect(capture.attempts).toHaveLength(2);
+      expect(capture.attempts[1]?.prompt).toContain(
+        "[paperclip omitted unsafe continuation-summary body from bounded recovery handoff]",
+      );
+      expect(capture.attempts[1]?.prompt).not.toContain(repeatedRawLine);
+      expect(capture.attempts[1]?.prompt.match(new RegExp(repeatedRawLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))?.length ?? 0).toBe(0);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("renders execution-stage wake instructions for reviewer and executor roles", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-stage-wake-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -42,6 +42,49 @@ process.exit(1);
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeCompactOverflowThenSuccessCodexCommand(commandPath: string, capturePath: string): Promise<void> {
+  const statePath = `${commandPath}.state.json`;
+  const compactError = [
+    "Error running remote compact task: {",
+    '  "error": {',
+    '    "message": "Your input exceeds the context window of this model. Please adjust your input and try again.",',
+    '    "type": "invalid_request_error",',
+    '    "param": "input",',
+    '    "code": "context_length_exceeded"',
+    "  }",
+    "}",
+  ].join("\\n");
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const statePath = ${JSON.stringify(statePath)};
+const capturePath = ${JSON.stringify(capturePath)};
+const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : { attempts: [] };
+const prompt = fs.readFileSync(0, "utf8");
+const attempt = {
+  argv: process.argv.slice(2),
+  prompt,
+};
+state.attempts.push(attempt);
+fs.writeFileSync(statePath, JSON.stringify(state), "utf8");
+fs.writeFileSync(capturePath, JSON.stringify(state), "utf8");
+
+if (state.attempts.length === 1) {
+  console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-saturated" }));
+  console.log(JSON.stringify({ type: "error", message: ${JSON.stringify(compactError)} }));
+  console.log(JSON.stringify({ type: "turn.failed", error: { message: ${JSON.stringify(compactError)} } }));
+  console.error("ERROR codex_core::compact_remote: failing_compaction_request_model_visible_bytes=419244 compact_error context_length_exceeded");
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ type: "thread.started", thread_id: "codex-session-fresh" }));
+console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "recovered" } }));
+console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 12, cached_input_tokens: 0, output_tokens: 3 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 type CapturePayload = {
   argv: string[];
   prompt: string;
@@ -674,6 +717,123 @@ describe("codex execute", () => {
       expect(capture.prompt).toContain("Issue continuation summary for the next fresh session.");
       expect(commandNotes).toContain("Codex transient fallback requested safer invocation settings for this retry.");
       expect(commandNotes).toContain("Codex transient fallback forced a fresh session with a continuation handoff.");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries recovery compact overflows with a fresh bounded handoff", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-bounded-recovery-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    const oversizedSummary = `safe summary start\n${"oversized raw transcript ".repeat(30_000)}\nsafe summary end`;
+    await fs.mkdir(workspace, { recursive: true });
+    await writeCompactOverflowThenSuccessCodexCommand(commandPath, capturePath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    const logs: LogEntry[] = [];
+    let metaPrompts: string[] = [];
+    let commandNotes: string[][] = [];
+    try {
+      const result = await execute({
+        runId: "run-bounded-recovery",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: {
+            sessionId: "codex-session-saturated",
+            cwd: workspace,
+          },
+          sessionDisplayId: "codex-session-saturated",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: `Full heartbeat prompt should not be resent. ${"raw issue thread ".repeat(20_000)}`,
+        },
+        context: {
+          issueId: "issue-1",
+          taskId: "issue-1",
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+          retryOfRunId: "previous-run",
+          paperclipContinuationSummary: {
+            key: "continuation-summary",
+            title: "Continuation Summary",
+            body: oversizedSummary,
+            updatedAt: "2026-06-04T12:05:56.840Z",
+          },
+          paperclipWake: {
+            reason: "issue_continuation_needed",
+            issue: {
+              id: "issue-1",
+              identifier: "TEST-1415",
+              title: "Review silent active run",
+              status: "in_progress",
+              priority: "medium",
+            },
+            comments: [],
+            commentIds: [],
+            commentWindow: {
+              requestedCount: 0,
+              includedCount: 0,
+              missingCount: 0,
+            },
+            truncated: false,
+            fallbackFetchNeeded: false,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async (stream, chunk) => {
+          logs.push({ stream, chunk });
+        },
+        onMeta: async (meta) => {
+          metaPrompts = [...metaPrompts, meta.prompt ?? ""];
+          commandNotes = [...commandNotes, meta.commandNotes ?? []];
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+      expect(result.sessionId).toBe("codex-session-fresh");
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as {
+        attempts: Array<{ argv: string[]; prompt: string }>;
+      };
+      expect(capture.attempts).toHaveLength(2);
+      expect(capture.attempts[0]?.argv).toEqual(expect.arrayContaining(["resume", "codex-session-saturated", "-"]));
+      expect(capture.attempts[1]?.argv).toEqual(expect.arrayContaining(["exec", "--json", "-"]));
+      expect(capture.attempts[1]?.argv).not.toContain("resume");
+      expect(capture.attempts[1]?.prompt.length).toBeLessThanOrEqual(12_000);
+      expect(capture.attempts[1]?.prompt).toContain("Paperclip bounded recovery handoff:");
+      expect(capture.attempts[1]?.prompt).toContain("Codex remote compaction rejected the previous resumed session");
+      expect(capture.attempts[1]?.prompt).toContain("TEST-1415 Review silent active run");
+      expect(capture.attempts[1]?.prompt).not.toContain("Full heartbeat prompt should not be resent");
+      expect(capture.attempts[1]?.prompt).not.toContain("safe summary end");
+      expect(capture.attempts[1]?.prompt).toContain("[paperclip truncated bounded recovery handoff section:");
+      expect(metaPrompts[1]).toBe(capture.attempts[1]?.prompt);
+      expect(commandNotes[1]).toContain(
+        "Codex remote compaction exceeded the model context window; retried with a fresh bounded recovery handoff.",
+      );
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          stream: "stdout",
+          chunk: expect.stringContaining("retrying once with a fresh bounded recovery handoff"),
+        }),
+      );
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -729,7 +729,14 @@ describe("codex execute", () => {
     const workspace = path.join(root, "workspace");
     const commandPath = path.join(root, "codex");
     const capturePath = path.join(root, "capture.json");
-    const oversizedSummary = `safe summary start\n${"oversized raw transcript ".repeat(30_000)}\nsafe summary end`;
+    const unsafeSummary = [
+      "Summary: retry the issue from the current heartbeat state.",
+      "user: please print the entire issue thread before acting",
+      `assistant: ${"oversized raw transcript ".repeat(2_000)}`,
+      "```json",
+      '{"thread":"raw issue thread raw issue thread raw issue thread"}',
+      "```",
+    ].join("\n");
     await fs.mkdir(workspace, { recursive: true });
     await writeCompactOverflowThenSuccessCodexCommand(commandPath, capturePath);
 
@@ -773,7 +780,7 @@ describe("codex execute", () => {
           paperclipContinuationSummary: {
             key: "continuation-summary",
             title: "Continuation Summary",
-            body: oversizedSummary,
+            body: unsafeSummary,
             updatedAt: "2026-06-04T12:05:56.840Z",
           },
           paperclipWake: {
@@ -821,9 +828,15 @@ describe("codex execute", () => {
       expect(capture.attempts[1]?.prompt).toContain("Paperclip bounded recovery handoff:");
       expect(capture.attempts[1]?.prompt).toContain("Codex remote compaction rejected the previous resumed session");
       expect(capture.attempts[1]?.prompt).toContain("TEST-1415 Review silent active run");
+      expect(capture.attempts[1]?.prompt).toContain(
+        "[paperclip omitted unsafe continuation-summary body from bounded recovery handoff]",
+      );
       expect(capture.attempts[1]?.prompt).not.toContain("Full heartbeat prompt should not be resent");
-      expect(capture.attempts[1]?.prompt).not.toContain("safe summary end");
-      expect(capture.attempts[1]?.prompt).toContain("[paperclip truncated bounded recovery handoff section:");
+      expect(capture.attempts[1]?.prompt).not.toContain("user: please print the entire issue thread before acting");
+      expect(capture.attempts[1]?.prompt).not.toContain("assistant:");
+      expect(capture.attempts[1]?.prompt).not.toContain("```json");
+      expect(capture.attempts[1]?.prompt).not.toContain("oversized raw transcript");
+      expect(capture.attempts[1]?.prompt).not.toContain("raw issue thread raw issue thread");
       expect(metaPrompts[1]).toBe(capture.attempts[1]?.prompt);
       expect(commandNotes[1]).toContain(
         "Codex remote compaction exceeded the model context window; retried with a fresh bounded recovery handoff.",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Recovery and continuation flows depend on adapter session resumption to keep stranded work moving without human cleanup.
> - The codex-local adapter currently retries resumed sessions through Codex remote compaction, which can fail deterministically when the recovered context is too large.
> - That failure shape should not be treated like ordinary transient upstream load, because repeated retries can strand the recovery path itself.
> - This pull request bounds the recovery handoff sent to a fresh Codex session and teaches the parser to keep input-too-large compaction failures out of transient retry handling.
> - The benefit is that recovery can resume from a safe, compact summary instead of looping on oversized remote compaction requests.

## What Changed

- Added a bounded recovery-handoff builder in `packages/adapters/codex-local/src/server/execute.ts` that retries oversized resumed-session compaction failures once with a fresh session and a truncated structured summary.
- Updated `packages/adapters/codex-local/src/server/parse.ts` so deterministic remote-compaction input-too-large failures are not classified as transient upstream errors.
- Added regression coverage in `server/src/__tests__/codex-local-execute.test.ts` for the oversized recovery/continuation path and in `packages/adapters/codex-local/src/server/parse.test.ts` for deterministic compaction parser behavior.

## Verification

- `pnpm exec vitest run server/src/__tests__/codex-local-execute.test.ts packages/adapters/codex-local/src/server/parse.test.ts`
- `pnpm build`
- `git merge --no-commit --no-ff origin/master && git merge --abort`

## Risks

- Low risk. The main behavioral change is limited to Codex recovery and continuation retries after a deterministic remote-compaction overflow, but future recovery prompt changes should preserve the bounded handoff limits and summary-only safety assumptions.

## Model Used

- Provider: GitHub Copilot
- Model: `github-copilot/gpt-5.4`
- Context window: not exposed in this environment
- Capabilities: tool use, code execution, repository reads/edits, targeted test/build verification

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes:` / `Closes:` / `Refs:` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #7733