### PR TITLE
fix: let recovery-action owner officer resolve false_positive/cancelled (CAS-6623)

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -958,6 +958,108 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("allows the recovery owner to retire its own action as a false positive without board access", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ status: "done", assigneeAgentId: null, assigneeUserId: "board-user" })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "stranded_assigned_issue",
+      fingerprint: "stranded:owner-false-positive",
+      evidence: { latestIssueStatus: "done" },
+      nextAction: "Restore a live execution path or record an intentional manual resolution.",
+      wakePolicy: { type: "manual" },
+    });
+    const runId = randomUUID();
+    const app = createApp({
+      type: "agent",
+      agentId: managerId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    await seedHeartbeatRun({
+      companyId,
+      agentId: managerId,
+      runId,
+      issueId: sourceIssueId,
+    });
+
+    const resolved = await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "false_positive",
+        sourceIssueStatus: "done",
+        resolutionNote: "Owner confirmed harmless false-positive on an already-done issue.",
+      })
+      .expect(200);
+
+    expect(resolved.body.issue).toMatchObject({
+      id: sourceIssueId,
+      status: "done",
+      activeRecoveryAction: null,
+    });
+    expect(resolved.body.recoveryAction).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "false_positive",
+    });
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+  });
+
+  it("rejects a peer agent retiring another owner's action as a false positive", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "stranded_assigned_issue",
+      fingerprint: "stranded:peer-false-positive",
+      evidence: { latestIssueStatus: "done" },
+      nextAction: "Restore a live execution path or record an intentional manual resolution.",
+      wakePolicy: { type: "manual" },
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: coderId,
+      companyId,
+      runId: randomUUID(),
+      source: "agent_jwt",
+    });
+
+    await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "false_positive",
+        sourceIssueStatus: "done",
+        resolutionNote: "Peer agent should not be able to retire another owner's action.",
+      })
+      .expect(403);
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "active",
+      outcome: null,
+      resolvedAt: null,
+    });
+  });
+
   it("rejects blocked recovery resolution when the source issue has no first-class blockers", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1015,7 +1015,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
   });
 
-  it("rejects a peer agent retiring another owner's action as a false positive", async () => {
+  it("rejects an assignee peer retiring another owner's action as a false positive", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     await db.update(issues).set({ status: "done" }).where(eq(issues.id, sourceIssueId));
     const recoveryActionSvc = issueRecoveryActionService(db);
@@ -1039,7 +1039,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       source: "agent_jwt",
     });
 
-    await request(app)
+    const rejected = await request(app)
       .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
       .send({
         actionId: action.id,
@@ -1048,6 +1048,9 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         resolutionNote: "Peer agent should not be able to retire another owner's action.",
       })
       .expect(403);
+    expect(rejected.body).toMatchObject({
+      error: "Board access required",
+    });
 
     const [actionRow] = await db
       .select()

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2821,7 +2821,21 @@ export function issueRoutes(
 
     const { actionId, outcome, sourceIssueStatus, resolutionNote } = req.body;
     if (outcome === "false_positive" || outcome === "cancelled") {
-      assertBoard(req);
+      // false_positive / cancelled dispositions retire a recovery action without
+      // restoring a live execution path, so they stay gated behind board access.
+      // The single exception is the recovery action's own owner agent: it already
+      // passed assertRecoveryActionAuthority above, and an owner officer must be
+      // able to retire its own stale/false-positive action via `--as <owner>`
+      // without an un-mintable board-admin identity. Peers (assignee-only or
+      // checkout-override agents that are not the owner) still require board.
+      const actorIsRecoveryOwner =
+        req.actor.type === "agent" &&
+        !!req.actor.agentId &&
+        !!activeRecoveryAction &&
+        activeRecoveryAction.ownerAgentId === req.actor.agentId;
+      if (!actorIsRecoveryOwner) {
+        assertBoard(req);
+      }
     }
 
     const actor = getActorInfo(req);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The recovery subsystem raises recovery actions (e.g. `stranded_assigned_issue`) that an owning agent is meant to be able to triage and retire.
> - The resolve route `POST /api/issues/:id/recovery-actions/resolve` hard-gated the retiring outcomes (`false_positive`, `cancelled`) behind `assertBoard(req)`, which only passes for `req.actor.type === "board"`.
> - Officer/agent callers authenticate as `req.actor.type === "agent"`, so a recovery action's own owner agent could never retire its own stale/false-positive action via `--as <owner>` — it got a clean `403 Forbidden` and needed an un-mintable board-admin identity (like the sibling `force-release` route).
> - This pull request scopes that board gate so it is skipped only when the caller is the recovery action's owner agent — who already passes `assertRecoveryActionAuthority` earlier in the same route.
> - The benefit is that an owner agent can self-service retiring its own false-positive recovery actions, while board-admin and peer-agent restrictions stay exactly as they were.

## Linked Issues or Issue Description

No existing GitHub issue — describing the underlying problem inline (bug-report shaped). Related but non-duplicate recovery PRs for context: #6464, #6615, #6013, #6465 (they add/auto-resolve resolve endpoints or clear stranded actions; none scope the owner ACL on the resolve route).

**What happened**
Calling the recovery-action resolve route with an owner agent identity (`--as <owner>`) and outcome `false_positive` (or `cancelled`) returns `403 Forbidden`. The owner can resolve `restored`/`blocked` outcomes but not the two retiring dispositions, because those are gated behind `assertBoard(req)` and an agent identity is never `type === "board"`.

**Expected behavior**
The recovery action's own owner agent should be able to retire its own action as `false_positive`/`cancelled` without a board-admin identity, since it already passes `assertRecoveryActionAuthority` for this route.

**Steps to reproduce**
1. Have an active recovery action (e.g. `stranded_assigned_issue`) owned by agent A on an issue.
2. As agent A (`req.actor.type === "agent"`), `POST /api/issues/:id/recovery-actions/resolve` with `{ outcome: "false_positive", sourceIssueStatus: "done" }`.
3. Observe `403 Forbidden` raised by `assertBoard`, even though A is the action's owner.

**Paperclip version**
Reproduced on master against `server/src/routes/issues.ts` (the branch base).

**Deployment mode**
Self-hosted / local board server, with officer agent identities authenticated via the local agent JWT path.

## What Changed

- `server/src/routes/issues.ts` — in the recovery-action resolve route, only call `assertBoard(req)` for the `false_positive`/`cancelled` outcomes when the actor is NOT the recovery action's owner agent. Owner agents (already authorized by `assertRecoveryActionAuthority`) now fall through and can resolve their own action.
- `server/src/__tests__/issue-recovery-actions.test.ts` — added two regression tests (see Verification).

```ts
const actorIsRecoveryOwner =
  req.actor.type === "agent" &&
  !!req.actor.agentId &&
  !!activeRecoveryAction &&
  activeRecoveryAction.ownerAgentId === req.actor.agentId;
if (!actorIsRecoveryOwner) {
  assertBoard(req);
}
```

## Verification

- `pnpm exec tsc --noEmit` — clean.
- `pnpm run build` (full server build) — clean.
- `issue-recovery-actions.test.ts` — 23 tests green, including two new regression cases:
  - owner agent retires its own action as `false_positive` without board access → 200, action resolved.
  - a peer agent that only passes assignee-authority (not the owner) is still rejected with 403; the action stays active.
- Sibling `issue-agent-mutation-ownership-routes.test.ts` also green (60 tests combined).

## Risks

- Low risk and tightly scoped. Board-admin behavior is unchanged — non-owner callers still hit `assertBoard`.
- Only the recovery action's owner agent gains the ability to retire its **own** action; peer/assignee-only agents that are not the owner are unaffected (still 403).
- `force-release` and other board-admin routes are untouched. No schema or migration changes.

## Model Used

Anthropic Claude — **Opus 4.8** (model id `claude-opus-4-8`, 1M-token context), run via Claude Code with agentic tool use (file editing, shell, running the test suite) and extended reasoning. The implementation and tests were authored by the agent and reviewed before this PR was opened.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub for similar/duplicate PRs (open and recently closed) and confirmed this is not a duplicate; the closest related PRs are referenced above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

Tracking (Casaconomy): CAS-6623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
