### PR TITLE
recovery: never write status='blocked' with empty blockedBy[] (ALAA-965)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1330,7 +1330,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(0);
   });
 
-  it("blocks a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
+  it("stops a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
     const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
     const projectId = randomUUID();
     const projectWorkspaceId = randomUUID();
@@ -1388,10 +1388,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       },
     });
 
+    // ALAA-965: the workspace-validation escalation has no first-class
+    // blockers, so the issue lands in `todo` (never blocked + empty) while
+    // the workspace_validation recovery action carries the repair path.
     const issue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const row = rows[0] ?? null;
-        return row?.status === "blocked" ? row : null;
+        return row?.status === "todo" && row.executionRunId === null ? row : null;
       }),
     );
     expect(issue?.executionRunId).toBeNull();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2239,6 +2239,92 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  // ALAA-965: when no invokable recovery owner is available, the recovery
+  // sweep used to flip the issue to status='blocked' with an empty
+  // blockedByIssueIds[], which the Board UI renders as the misleading
+  // 'Work blocked until moved back to todo' footer. The route fix in
+  // routes/issues.ts rejects that write at the API surface; this test pins
+  // the service-layer invariant: when the recovery action escalates to the
+  // board (ownerAgentId === null) and no first-class blockers exist, the
+  // issue falls back to `todo` so the assignee can re-claim once a live
+  // execution path is available.
+  it("returns stranded assigned work to todo (never blocked+empty) when the recovery action escalates to the board", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    // Hard-stop the sole candidate (the assignee itself) so
+    // resolveStrandedIssueRecoveryOwnerAgentId returns null and the recovery
+    // action escalates to the board (ownerAgentId === null).
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 1,
+      hardStopEnabled: true,
+      isActive: true,
+    });
+    await db.insert(costEvents).values({
+      companyId,
+      agentId,
+      issueId,
+      provider: "test",
+      biller: "test",
+      billingType: "tokens",
+      model: "test-model",
+      costCents: 1,
+      occurredAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(
+        and(
+          eq(issueRecoveryActions.companyId, companyId),
+          eq(issueRecoveryActions.sourceIssueId, issueId),
+        ),
+      );
+    expect(recoveryActions).toHaveLength(1);
+    expect(recoveryActions[0]).toMatchObject({
+      ownerType: "board",
+      ownerAgentId: null,
+    });
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    // ALAA-965: this assertion is the heart of the fix — *no* `blocked` here.
+    expect(issue?.status).toBe("todo");
+
+    // And critically: no first-class blockers were recorded — confirming the
+    // bad `blocked + empty blockedBy[]` invariant is no longer produced.
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
+
+    // Activity log reflects the actual status written.
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.entityId, issueId),
+        eq(activityLog.action, "issue.updated"),
+      ));
+    expect(activity.some((event) => {
+      const details = event.details as Record<string, unknown> | null;
+      return details?.status === "todo"
+        && details?.source === "recovery.reconcile_stranded_assigned_issue";
+    })).toBe(true);
+
+    // The latest run id is referenced so the test fixture stays anchored.
+    expect(runId).toBeTruthy();
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",
@@ -2288,7 +2374,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(recoveryIssues).toHaveLength(1);
     expect(recoveryIssues[0]).toMatchObject({
       id: issueId,
-      status: "blocked",
+      // ALAA-965: with no first-class blockers, the in-place escalation
+      // returns the recovery issue to `todo` instead of producing the
+      // misleading `blocked + empty blockedBy[]` state.
+      status: "todo",
       parentId: sourceIssueId,
       originId: sourceIssueId,
       originRunId: sourceRunId,
@@ -2314,6 +2403,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("recovery issues do not create nested `stranded_issue_recovery` issues");
     expect(comments[0]?.body).toContain(`Recovery issue: [${recoveryIssues[0]?.identifier}]`);
     expect(comments[0]?.body).toContain("Next action:");
+    expect(comments[0]?.body).toContain("returned to `todo`");
   });
 
   it("assigns open unassigned blockers back to their creator agent", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -828,7 +828,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(issues)
       .where(eq(issues.id, input.issueId))
       .then((rows) => rows[0] ?? null);
-    expect(sourceIssue?.status).toBe("blocked");
+    // ALAA-965: source-scoped escalation never writes status='blocked' with an
+    // empty blockedByIssueIds[]; with no first-class blockers seeded, the
+    // issue falls back to `todo` while the recovery action carries the work.
+    expect(sourceIssue?.status).toBe("todo");
 
     return action;
   }
@@ -1074,7 +1077,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
-  it("blocks the issue when process-loss retry is exhausted and the immediate continuation recovery also fails", async () => {
+  it("returns the issue to todo when process-loss retry is exhausted and the immediate continuation recovery also fails", async () => {
     mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
 
     const { companyId, agentId, runId, issueId } = await seedRunFixture({
@@ -1117,15 +1120,17 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       retryOfRunId: runId,
     });
 
-    const blockedIssue = await waitForValue(async () =>
+    // ALAA-965: the only seeded blocker is already resolved, so the
+    // escalation writes `todo` (never `blocked` with empty blockedBy[]).
+    const escalatedIssue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const issue = rows[0] ?? null;
-        return issue?.status === "blocked" ? issue : null;
+        return issue?.status === "todo" ? issue : null;
       })
     );
-    expect(blockedIssue?.status).toBe("blocked");
-    expect(blockedIssue?.executionRunId).toBeNull();
-    expect(blockedIssue?.checkoutRunId).toBeNull();
+    expect(escalatedIssue?.status).toBe("todo");
+    expect(escalatedIssue?.executionRunId).toBeNull();
+    expect(escalatedIssue?.checkoutRunId).toBeNull();
     if (!continuationRun?.id) throw new Error("Expected continuation recovery run to exist");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
@@ -1149,7 +1154,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
-  it("blocks failed recovery work in place during immediate terminal-run cleanup", async () => {
+  it("returns failed recovery work to todo in place during immediate terminal-run cleanup", async () => {
     const sourceIssueId = randomUUID();
     const { companyId, agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",
@@ -1195,10 +1200,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(1);
     expect(runs[0]?.status).toBe("failed");
 
+    // ALAA-965: the recovery issue blocks its source but has no blockers of
+    // its own, so the in-place escalation returns it to `todo` instead of
+    // producing the `blocked + empty blockedBy[]` state.
     const recoveryIssue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const issue = rows[0] ?? null;
-        return issue?.status === "blocked" ? issue : null;
+        return issue?.status === "todo" ? issue : null;
       })
     );
     expect(recoveryIssue?.assigneeAgentId).toBe(agentId);
@@ -1220,6 +1228,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("stopped automatic stranded-work recovery");
     expect(comments[0]?.body).toContain("recovery issues do not create nested `stranded_issue_recovery` issues");
     expect(comments[0]?.body).toContain("Latest retry failure details were withheld from the issue thread");
+    expect(comments[0]?.body).toContain("returned to `todo`");
     expect(comments[0]?.body).not.toContain("sk-test-recovery-secret");
     await expect(sourceBlockerIssueIds(companyId, sourceIssueId)).resolves.toEqual([issueId]);
   });
@@ -1773,7 +1782,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(JSON.stringify(recoveryAction.evidence)).not.toContain("sk-test-successful-handoff-secret");
 
     const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(sourceIssue?.status).toBe("blocked");
+    // ALAA-965: no first-class blockers exist, so the escalation writes
+    // `todo` — never `blocked` with an empty blockedByIssueIds[].
+    expect(sourceIssue?.status).toBe("todo");
     await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
@@ -2203,7 +2214,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
-  it("blocks assigned todo work after the one automatic dispatch recovery was already used", async () => {
+  it("keeps assigned todo work in todo after the one automatic dispatch recovery was already used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",
       runStatus: "failed",
@@ -2219,7 +2230,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: no first-class blockers, so the escalation keeps `todo`.
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -2690,7 +2702,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
-  it("blocks stranded in-progress work after the continuation retry was already used", async () => {
+  it("returns stranded in-progress work to todo after the continuation retry was already used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
@@ -2704,7 +2716,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: no first-class blockers, so the escalation writes `todo`.
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -2830,7 +2843,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: no first-class blockers, so the escalation writes `todo`.
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -2967,7 +2981,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: no first-class blockers, so the escalation writes `todo`.
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -3055,7 +3070,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
   });
 
-  it("blocks stranded recovery issues in place instead of creating nested recovery issues", async () => {
+  it("returns stranded recovery issues to todo in place instead of creating nested recovery issues", async () => {
     const sourceIssueId = randomUUID();
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
@@ -3094,7 +3109,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const recoveryIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(recoveryIssue?.status).toBe("blocked");
+    // ALAA-965: the recovery issue blocks its source but has no blockers of
+    // its own, so the in-place escalation returns it to `todo`.
+    expect(recoveryIssue?.status).toBe("todo");
     expect(recoveryIssue?.assigneeAgentId).toBe(agentId);
     expect(recoveryIssue?.originKind).toBe("stranded_issue_recovery");
     expect(recoveryIssue?.originId).toBe(sourceIssueId);
@@ -3114,6 +3131,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("stopped automatic stranded-work recovery");
     expect(comments[0]?.body).toContain("Latest retry failure details were withheld from the issue thread");
     expect(comments[0]?.body).toContain("recovery issues do not create nested `stranded_issue_recovery` issues");
+    expect(comments[0]?.body).toContain("returned to `todo`");
     await expect(sourceBlockerIssueIds(companyId, sourceIssueId)).resolves.toEqual([issueId]);
   });
 
@@ -3292,7 +3310,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeups).toHaveLength(2);
   });
 
-  it("blocks stranded in-progress work after a productive continuation retry was already used", async () => {
+  it("returns stranded in-progress work to todo after a productive continuation retry was already used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
@@ -3308,7 +3326,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: no first-class blockers, so the escalation writes `todo`.
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1086,4 +1086,78 @@ describe("agent issue mutation checkout ownership", () => {
     }));
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
+
+  // ALAA-965: an agent PATCH that would leave the issue at status='blocked'
+  // with no first-class blockers produces a Board UI footer that misleads
+  // operators ("Work blocked until moved back to todo"). The route must
+  // reject the write so that only well-formed `blocked` writes reach the
+  // service layer.
+  it("rejects agent PATCH that would leave status=blocked with no first-class blockers", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("blocked_requires_blocker");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts agent PATCH to status=blocked when the request names first-class blockers", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked", blockedByIssueIds: [recoveryActionId] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "blocked" }),
+    );
+  });
+
+  it("accepts agent PATCH to status=blocked when the issue already has first-class blockers", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: recoveryActionId }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "blocked" }),
+    );
+  });
+
+  it("allows board users to PATCH status=blocked with no first-class blockers", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+
+    const res = await request(await createApp(boardActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "blocked" }),
+    );
+  });
 });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -308,8 +308,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
 
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    // ALAA-965: no first-class blockers exist, so the escalation writes
+    // `todo` — never `blocked` with an empty blockedByIssueIds[] — even
+    // though a recovery owner is assigned.
     expect(updatedIssue).toMatchObject({
-      status: "blocked",
+      status: "todo",
     });
     const recoveryIssues = await db
       .select()
@@ -379,7 +382,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
-  it("keeps the source issue blocked when source-scoped wakeup is claimed synchronously", async () => {
+  it("re-asserts the recovery status when source-scoped wakeup is claimed synchronously", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
     const enqueueWakeup = vi.fn(async () => {
@@ -408,7 +411,10 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
 
     const [afterFirst] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(afterFirst?.status).toBe("blocked");
+    // ALAA-965: the synchronous wakeup flipped the issue to in_progress; the
+    // re-assert path re-fetches the (empty) unresolved blocker list and
+    // restores `todo` rather than writing blocked + empty blockedBy[].
+    expect(afterFirst?.status).toBe("todo");
     expect(afterFirst?.assigneeAgentId).toBe(coderId);
 
     const secondLatestRun = {
@@ -437,7 +443,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       attemptCount: 2,
     });
     const [afterSecond] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(afterSecond?.status).toBe("blocked");
+    expect(afterSecond?.status).toBe("todo");
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id));
     expect(comments).toHaveLength(1);
@@ -485,7 +491,165 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
     expect(recoveryIssues).toHaveLength(1);
-    expect(recoveryIssues[0]?.status).toBe("blocked");
+    // ALAA-965: the recovery issue has no first-class blockers, so the
+    // in-place escalation returns it to `todo` instead of blocked + empty.
+    expect(recoveryIssues[0]?.status).toBe("todo");
+  });
+
+  // ALAA-965 regression: a recovery owner on the assignee field does not
+  // excuse the `blocked + empty blockedBy[]` state — the Board UI footer
+  // fires on that data combination regardless of who is assigned.
+  it("never writes blocked with an empty blockedBy[] when a recovery owner is assigned", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actionRows).toHaveLength(1);
+    expect(actionRows[0]?.ownerAgentId).not.toBeNull();
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue?.status).toBe("todo");
+    const blockerRelations = await db
+      .select()
+      .from(issueRelations)
+      .where(
+        and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.relatedIssueId, sourceIssue.id),
+          eq(issueRelations.type, "blocks"),
+        ),
+      );
+    expect(blockerRelations).toHaveLength(0);
+  });
+
+  it("keeps the source issue blocked when unresolved first-class blockers exist", async () => {
+    const { companyId, coderId, sourceIssue, prefix } = await seedCompany();
+    const blockerIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Unresolved prerequisite",
+      status: "todo",
+      priority: "medium",
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: sourceIssue.id,
+      type: "blocks",
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue?.status).toBe("blocked");
+    const blockerRelations = await db
+      .select()
+      .from(issueRelations)
+      .where(
+        and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.relatedIssueId, sourceIssue.id),
+          eq(issueRelations.type, "blocks"),
+        ),
+      );
+    expect(blockerRelations.map((row) => row.issueId)).toEqual([blockerIssueId]);
+  });
+
+  // ALAA-965 regression for the re-assert path: blockers that resolve while
+  // the source-scoped wakeup runs synchronously must not be replayed from the
+  // stale pre-update capture as phantom blocker references.
+  it("does not replay stale blocker ids when the re-assert path runs after blockers resolve", async () => {
+    const { companyId, managerId, coderId, sourceIssue, prefix } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
+    const blockerIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Prerequisite resolved mid-escalation",
+      status: "todo",
+      priority: "medium",
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: sourceIssue.id,
+      type: "blocks",
+    });
+    const enqueueWakeup = vi.fn(async () => {
+      await db.update(issues).set({ status: "done" }).where(eq(issues.id, blockerIssueId));
+      await db.update(issues).set({ status: "in_progress" }).where(eq(issues.id, sourceIssue.id));
+      return null;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    // The blocker resolved before the re-assert write, so the refreshed list
+    // is empty: the issue returns to `todo` with no phantom blocker rows.
+    expect(updatedIssue?.status).toBe("todo");
+    expect(updatedIssue?.assigneeAgentId).toBe(coderId);
+    const blockerRelations = await db
+      .select()
+      .from(issueRelations)
+      .where(
+        and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.relatedIssueId, sourceIssue.id),
+          eq(issueRelations.type, "blocks"),
+        ),
+      );
+    expect(blockerRelations).toHaveLength(0);
   });
 
   it("exposes active recovery actions on the issue read API", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4794,6 +4794,35 @@ export function issueRoutes(
     ) {
       updateFields.status = "todo";
     }
+    // ALAA-965: reject agent PATCH whose net effect would leave the issue at
+    // status='blocked' with no first-class blockers. Board users keep the
+    // explicit override; system actors write through the service layer, not
+    // this route. The check has to run after the comment-driven status
+    // coercion above, so we evaluate the *effective* status the route is
+    // about to write.
+    if (req.actor.type === "agent") {
+      const effectiveStatus = (updateFields.status as string | undefined) ?? existing.status;
+      if (effectiveStatus === "blocked") {
+        const incomingBlockerIds = Array.isArray(req.body.blockedByIssueIds)
+          ? (req.body.blockedByIssueIds as unknown[]).filter(
+              (value): value is string => typeof value === "string",
+            )
+          : null;
+        const existingBlockerIds =
+          existingRelations
+            ? existingRelations.blockedBy.map((relation) => relation.id)
+            : (await svc.getRelationSummaries(existing.id)).blockedBy.map((relation) => relation.id);
+        const effectiveBlockerIds = incomingBlockerIds ?? existingBlockerIds;
+        if (effectiveBlockerIds.length === 0) {
+          res.status(400).json({
+            error: "blocked_requires_blocker",
+            message:
+              "Agent PATCH may not leave status='blocked' with no first-class blockers. Either include blockedByIssueIds, or move the issue to a different status.",
+          });
+          return;
+        }
+      }
+    }
     let cancelledScheduledRetryRunId: string | null = null;
     if (
       commentBody &&

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2183,6 +2183,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     previousStatus: "todo" | "in_progress";
     latestRun: LatestIssueRun;
     prefix: string;
+    nextStatus: "blocked" | "todo";
   }) {
     const runLink = input.latestRun
       ? runUiLink({ id: input.latestRun.id, agentId: input.latestRun.agentId }, input.prefix)
@@ -2190,18 +2191,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const retryReason = readNonEmptyString(parseObject(input.latestRun?.contextSnapshot)?.retryReason) ?? "none";
     const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
 
+    // ALAA-965: when no first-class blockers remain we fall back to `todo`
+    // rather than producing the misleading `blocked + empty blockers` state.
+    const nextActionLine = input.nextStatus === "blocked"
+      ? "Next action: the current recovery owner should inspect the failed run evidence, restore a live execution path or record the manual resolution, then move this recovery issue out of `blocked`."
+      : "Next action: returned to `todo` because no first-class blockers remain on this recovery issue. The assigned recovery owner should re-claim it once a live execution path is available, or record the manual resolution.";
+
     return [
       "Paperclip stopped automatic stranded-work recovery for this recovery issue.",
       "",
       `- Recovery issue: ${issueUiLink({ identifier: input.issue.identifier, id: input.issue.id }, input.prefix)}`,
       `- Previous status: \`${input.previousStatus}\``,
+      `- Next status: \`${input.nextStatus}\``,
       `- Latest run: ${runLink}`,
       `- Latest run status: \`${input.latestRun?.status ?? "unknown"}\``,
       `- Retry reason: \`${retryReason}\``,
       failureSummary ? `- Failure: ${failureSummary.trim()}` : "- Failure: none recorded",
       "- Guard: recovery issues do not create nested `stranded_issue_recovery` issues.",
       "",
-      "Next action: the current recovery owner should inspect the failed run evidence, restore a live execution path or record the manual resolution, then move this recovery issue out of `blocked`.",
+      nextActionLine,
     ].join("\n");
   }
 
@@ -2210,7 +2218,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     previousStatus: "todo" | "in_progress";
     latestRun: LatestIssueRun;
   }) {
-    const updated = await issuesSvc.update(input.issue.id, { status: "blocked" });
+    // ALAA-965: never produce status=blocked with empty blockedBy[]. A
+    // recovery issue that has lost its execution path with no remaining
+    // first-class blockers falls back to `todo` so it can be re-claimed on
+    // the next sweep, instead of being trapped in a misleading
+    // 'blocked + empty' state that requires a manual sweep to reset.
+    const blockerIds = await existingUnresolvedBlockerIssueIds(
+      input.issue.companyId,
+      input.issue.id,
+    );
+    const nextStatus: "blocked" | "todo" = blockerIds.length > 0 ? "blocked" : "todo";
+    const updated = await issuesSvc.update(input.issue.id, { status: nextStatus });
     if (!updated) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -2221,6 +2239,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         previousStatus: input.previousStatus,
         latestRun: input.latestRun,
         prefix,
+        nextStatus,
       }),
       {},
     );
@@ -2236,7 +2255,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityId: input.issue.id,
       details: {
         identifier: input.issue.identifier,
-        status: "blocked",
+        status: nextStatus,
         previousStatus: input.previousStatus,
         source: "recovery.reconcile_stranded_recovery_issue",
         latestRunId: input.latestRun?.id ?? null,
@@ -2311,8 +2330,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    // ALAA-965: never produce status=blocked with empty blockedBy[]. When the
+    // recovery action has no owner (board-escalation path) and there are no
+    // first-class blockers on the source, falling back to `todo` keeps the
+    // assignee able to re-claim once a live execution path returns, instead
+    // of stranding the issue in a misleading 'blocked + empty' state that
+    // requires a manual sweep to reset. When a recovery owner exists, the
+    // recovery action itself is the live "blocker", so we keep `blocked`.
+    const initialStatus: "blocked" | "todo" =
+      recoveryAction.ownerAgentId !== null || blockerIds.length > 0 ? "blocked" : "todo";
     const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
+      status: initialStatus,
       blockedByIssueIds: blockerIds,
       assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
@@ -2402,7 +2430,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityId: input.issue.id,
       details: {
         identifier: input.issue.identifier,
-        status: "blocked",
+        // ALAA-965: reflect actual status written (may be `todo` when no blockers).
+        status: initialStatus,
         previousStatus: input.previousStatus,
         source: input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
           ? "recovery.reconcile_successful_run_handoff_missing_state"
@@ -2442,6 +2471,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         (currentIssue.status !== "blocked" ||
           currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
       ) {
+        // This branch only runs when recoveryAction.ownerAgentId === input.issue.assigneeAgentId
+        // (truthy by the outer guard), so the ALAA-965 invariant is already
+        // satisfied by the recovery action — keep `blocked` here regardless of
+        // blockerIds, to mirror the initial-write logic above.
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2330,15 +2330,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    // ALAA-965: never produce status=blocked with empty blockedBy[]. When the
-    // recovery action has no owner (board-escalation path) and there are no
-    // first-class blockers on the source, falling back to `todo` keeps the
-    // assignee able to re-claim once a live execution path returns, instead
-    // of stranding the issue in a misleading 'blocked + empty' state that
-    // requires a manual sweep to reset. When a recovery owner exists, the
-    // recovery action itself is the live "blocker", so we keep `blocked`.
-    const initialStatus: "blocked" | "todo" =
-      recoveryAction.ownerAgentId !== null || blockerIds.length > 0 ? "blocked" : "todo";
+    // ALAA-965: never produce status=blocked with empty blockedBy[]. The
+    // Board UI footer ("Work on this issue is blocked until it is moved back
+    // to todo") is purely data-driven on status='blocked' + empty blockedBy,
+    // so a recovery owner on the assignee field does not excuse the state.
+    // `blocked` is written only when first-class blockers exist; otherwise we
+    // fall back to `todo` so the owner (or original assignee) can re-claim
+    // the issue without a manual sweep.
+    const initialStatus: "blocked" | "todo" = blockerIds.length > 0 ? "blocked" : "todo";
     const updated = await issuesSvc.update(input.issue.id, {
       status: initialStatus,
       blockedByIssueIds: blockerIds,
@@ -2466,18 +2465,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .from(issues)
         .where(eq(issues.id, input.issue.id))
         .limit(1);
+      // ALAA-965: re-fetch the unresolved blocker list instead of reusing the
+      // early `blockerIds` capture — blockers may have resolved (or appeared)
+      // during the comment/activity writes above, and replaying the stale list
+      // would re-attach phantom blocker references. The intended status obeys
+      // the same invariant as the initial write: `blocked` only with
+      // first-class blockers, `todo` otherwise.
+      const refreshedBlockerIds = await existingUnresolvedBlockerIssueIds(
+        input.issue.companyId,
+        input.issue.id,
+      );
+      const intendedStatus: "blocked" | "todo" =
+        refreshedBlockerIds.length > 0 ? "blocked" : "todo";
       if (
         currentIssue &&
-        (currentIssue.status !== "blocked" ||
+        (currentIssue.status !== intendedStatus ||
           currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
       ) {
-        // This branch only runs when recoveryAction.ownerAgentId === input.issue.assigneeAgentId
-        // (truthy by the outer guard), so the ALAA-965 invariant is already
-        // satisfied by the recovery action — keep `blocked` here regardless of
-        // blockerIds, to mirror the initial-write logic above.
         const reblocked = await issuesSvc.update(input.issue.id, {
-          status: "blocked",
-          blockedByIssueIds: blockerIds,
+          status: intendedStatus,
+          blockedByIssueIds: refreshedBlockerIds,
           assigneeAgentId: recoveryAction.ownerAgentId,
         });
         if (reblocked) return reblocked;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server's recovery service (`server/src/services/recovery/service.ts`) reconciles stranded assigned issues and recovery issues when agents lose their execution path
> - Several escalation code paths wrote `status='blocked'` with an empty `blockedByIssueIds[]`, and the issues PATCH route accepted that write from agents
> - The Board UI footer ("Work on this issue is blocked until it is moved back to todo") is purely data-driven on that combination, so affected issues strand with a misleading dead-end footer and need a manual operator sweep to recover
> - This pull request enforces a single invariant at both the service and route layers: `blocked` is written only when unresolved first-class blockers exist; otherwise escalation falls back to `todo` so the assignee can re-claim the work
> - The benefit is that boards no longer accumulate stuck `blocked + empty` issues, and operators can retire periodic unblock sweeps

## Linked Issues or Issue Description

No public issue exists; describing the bug in-PR per the bug-report template:

- **What happened:** When the stranded-work recovery sweep escalated an issue (recovery owner assigned, board escalation, or in-place recovery-issue escalation), it wrote `status='blocked'` with `blockedByIssueIds: []`. The Board UI then rendered the "Work on this issue is blocked until it is moved back to todo" footer with no blocker to resolve, leaving the issue stranded until a human (or a scheduled sweep) manually PATCHed it back to `todo`. The synchronous-wake re-assert branch additionally replayed a stale pre-update blocker capture, which could re-attach already-resolved (phantom) blocker references.
- **Expected behavior:** `status='blocked'` is only ever persisted together with at least one unresolved first-class blocker. Escalations with no blockers land in `todo` with the recovery action carrying the live recovery path.
- **Steps to reproduce:** Assign an issue to an agent, let its run strand (e.g. kill the local adapter process past the retry budget) with no `blocks` relations pointing at the issue, and let `reconcileStrandedAssignedIssues` run. Before this change the issue lands in `blocked` with an empty blocker list.
- **Environment:** Reproduced on Paperclip server v0.3.x (npx runtime) on a Windows 11 host; the bug is platform-independent server logic.

Related: supersedes #7851 (earlier draft of the same fix from this fork; closed in favor of this PR). A search for duplicate or related PRs (`blocked empty blockedBy`, `recovery blocked blockers`) found no other open or merged PRs addressing this.

## What Changed

- `escalateStrandedRecoveryIssueInPlace`: reads the unresolved blocker list before the update and falls back to `status='todo'` when it is empty; the escalation comment states the actual next status ("returned to `todo` ...") instead of telling operators to move the issue out of `blocked`
- `escalateStrandedAssignedIssue` initial write: `initialStatus` is `'blocked'` only when `blockerIds.length > 0`, regardless of whether a recovery owner is assigned (Greptile P1) — a recovery owner on the assignee field does not stop the data-driven Board footer from firing
- `escalateStrandedAssignedIssue` re-assert branch (synchronous wake claims): re-fetches the unresolved blocker list instead of replaying the stale early `blockerIds` capture (no phantom blocker references), and applies the same blocked-only-with-blockers invariant when re-asserting status
- `routes/issues.ts`: the agent-facing PATCH guard rejects `status='blocked'` writes that would leave `blockedByIssueIds` empty (board users can still override)
- Tests: updated the stale assertions that pinned the old blocked-in-place behavior (`heartbeat-process-recovery.test.ts`, `issue-recovery-actions.test.ts`, including the shared `expectSourceScopedStrandedRecoveryAction` helper), and added regression coverage: owner-assigned escalation never writes blocked+empty; `blocked` is kept when unresolved blockers exist; the re-assert path does not replay blockers resolved mid-escalation

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean
- `npx vitest run src/__tests__/issue-recovery-actions.test.ts` — 24/24 passing (embedded Postgres), including the three new ALAA-965 regression cases
- `npx vitest run src/__tests__/heartbeat-process-recovery.test.ts` — 48 passing, 1 skipped; the 2 remaining local failures (`queues exactly one retry when the recorded local pid is dead`, `blocks a git-sensitive local adapter before launch ...`) are pre-existing Windows-host environment failures, reproduced on the unmodified base commit, and pass in Linux CI
- Reviewer path: the `General tests (server)` and `Verify serialized server suites` CI jobs exercise the updated suites end-to-end

## Risks

- Behavioral shift: stranded-work escalations with no first-class blockers now land in `todo` instead of `blocked`. Dashboards or automations that keyed on `blocked` as "recovery in progress" should key on the active recovery action instead (the recovery action lifecycle is unchanged)
- The re-assert branch now writes `todo` over a synchronously-claimed `in_progress` when no blockers remain — same stomp window as the previous unconditional `blocked` re-write, with a recoverable status instead of a dead-end one
- No migrations; no API surface changes beyond the PATCH guard rejecting a previously-accepted invalid write from agent actors (board actors are exempt)

## Model Used

- Provider/model: Anthropic Claude (Claude Code CLI), model `claude-fable-5`
- Reasoning mode: extended thinking enabled
- Tool use: file edit/search tools, git/gh CLI, local vitest + embedded Postgres runs
- Human direction: change scope and review-finding triage specified by the Alamut board (ALAA-965 / ALAA-972 / ALAA-974); all changes reviewed before push

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes (no docs reference the old behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending re-run on this push)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending re-review of this push)
- [x] I will address all Greptile and reviewer comments before requesting merge
