### PR TITLE
fix(server): never produce status=blocked with empty blockedBy[]

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -828,7 +828,12 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(issues)
       .where(eq(issues.id, input.issueId))
       .then((rows) => rows[0] ?? null);
-    expect(sourceIssue?.status).toBe("blocked");
+    // ALAA-965: the recovery service no longer parks an issue in
+    // status=blocked with an empty blockedBy[] set. None of the heartbeat
+    // recovery fixtures seed an unresolved blocker on the source issue, so the
+    // recovery write falls back to "todo" and the recovery action's wake is
+    // what restores the live execution path.
+    expect(sourceIssue?.status).toBe("todo");
 
     return action;
   }
@@ -1117,13 +1122,17 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       retryOfRunId: runId,
     });
 
+    // ALAA-965: the only seeded blocker on this issue is `done`, so
+    // `existingUnresolvedBlockerIssueIds` returns []. The recovery write
+    // therefore falls back to "todo" instead of producing the old
+    // blocked-with-empty-blockers state.
     const blockedIssue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const issue = rows[0] ?? null;
-        return issue?.status === "blocked" ? issue : null;
+        return issue?.status === "todo" ? issue : null;
       })
     );
-    expect(blockedIssue?.status).toBe("blocked");
+    expect(blockedIssue?.status).toBe("todo");
     expect(blockedIssue?.executionRunId).toBeNull();
     expect(blockedIssue?.checkoutRunId).toBeNull();
     if (!continuationRun?.id) throw new Error("Expected continuation recovery run to exist");
@@ -1195,10 +1204,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(1);
     expect(runs[0]?.status).toBe("failed");
 
+    // ALAA-965: the recovery issue has no unresolved blockers of its own, so
+    // the in-place escalation now writes status=todo (instead of the old
+    // blocked-with-empty-blockers state).
     const recoveryIssue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const issue = rows[0] ?? null;
-        return issue?.status === "blocked" ? issue : null;
+        return issue?.status === "todo" ? issue : null;
       })
     );
     expect(recoveryIssue?.assigneeAgentId).toBe(agentId);
@@ -1379,10 +1391,12 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       },
     });
 
+    // ALAA-965: workspace-validation recovery now writes status=todo when no
+    // unresolved blockers exist.
     const issue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
         const row = rows[0] ?? null;
-        return row?.status === "blocked" ? row : null;
+        return row?.status === "todo" ? row : null;
       }),
     );
     expect(issue?.executionRunId).toBeNull();
@@ -1773,7 +1787,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(JSON.stringify(recoveryAction.evidence)).not.toContain("sk-test-successful-handoff-secret");
 
     const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(sourceIssue?.status).toBe("blocked");
+    // ALAA-965: no unresolved blockers exist on this source issue, so the
+    // recovery write falls back to "todo".
+    expect(sourceIssue?.status).toBe("todo");
     await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
@@ -2219,7 +2235,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: the recovery service no longer parks an issue in
+    // status=blocked with an empty blockedBy[] set; with no unresolved
+    // blockers seeded the escalation falls back to "todo".
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -2286,9 +2305,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
     expect(recoveryIssues).toHaveLength(1);
+    // ALAA-965: the in-place recovery write falls back to "todo" when there
+    // are no unresolved blockers on the recovery issue itself.
     expect(recoveryIssues[0]).toMatchObject({
       id: issueId,
-      status: "blocked",
+      status: "todo",
       parentId: sourceIssueId,
       originId: sourceIssueId,
       originRunId: sourceRunId,
@@ -2614,7 +2635,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: the recovery service no longer parks an issue in
+    // status=blocked with an empty blockedBy[] set; with no unresolved
+    // blockers seeded the escalation falls back to "todo".
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -2740,7 +2764,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: the recovery service no longer parks an issue in
+    // status=blocked with an empty blockedBy[] set; with no unresolved
+    // blockers seeded the escalation falls back to "todo".
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -2877,7 +2904,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: the recovery service no longer parks an issue in
+    // status=blocked with an empty blockedBy[] set; with no unresolved
+    // blockers seeded the escalation falls back to "todo".
+    expect(issue?.status).toBe("todo");
 
     await expectSourceScopedStrandedRecoveryAction({
       companyId,
@@ -3004,7 +3034,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const recoveryIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(recoveryIssue?.status).toBe("blocked");
+    // ALAA-965: the recovery issue has no unresolved blockers on itself, so
+    // the in-place escalation now falls back to status=todo.
+    expect(recoveryIssue?.status).toBe("todo");
     expect(recoveryIssue?.assigneeAgentId).toBe(agentId);
     expect(recoveryIssue?.originKind).toBe("stranded_issue_recovery");
     expect(recoveryIssue?.originId).toBe(sourceIssueId);
@@ -3218,7 +3250,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("blocked");
+    // ALAA-965: the recovery service no longer parks an issue in
+    // status=blocked with an empty blockedBy[] set; with no unresolved
+    // blockers seeded the escalation falls back to "todo".
+    expect(issue?.status).toBe("todo");
 
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,

--- a/server/src/__tests__/issue-blocked-requires-blocker-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-requires-blocker-routes.test.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres ALAA-965 PATCH-guard route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+// ALAA-965: PATCH /api/issues/:id must reject agent writes that would leave
+// the issue in `status=blocked` with an empty blockedBy[] set. Board writes
+// retain the previous behavior because the board is the authoritative human
+// override path.
+describeEmbeddedPostgres("ALAA-965 PATCH guard: blocked_requires_blocker", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-alaa965-patch-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(actor: Express.Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function agentActor(companyId: string, agentId: string, runId: string): Express.Request["actor"] {
+    return {
+      type: "agent",
+      agentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    };
+  }
+
+  function boardActor(companyId: string): Express.Request["actor"] {
+    return {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+      isInstanceAdmin: false,
+      source: "session",
+    };
+  }
+
+  async function seedCompanyAgentAndIssue(input: {
+    issueStatus?: "todo" | "in_progress" | "blocked";
+    seedBlockerIssue?: boolean;
+  } = {}) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const prefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "ALAA965 Co",
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "ALAA-965 subject issue",
+      status: input.issueStatus ?? "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${prefix}-1`,
+    });
+    if (input.seedBlockerIssue) {
+      await db.insert(issues).values({
+        id: blockerIssueId,
+        companyId,
+        title: "Live blocker",
+        status: "in_progress",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: `${prefix}-2`,
+      });
+      await db.insert(issueRelations).values({
+        id: randomUUID(),
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: issueId,
+        type: "blocks",
+      });
+    }
+    return { companyId, agentId, runId, issueId, blockerIssueId };
+  }
+
+  it("rejects an agent PATCH that sets status=blocked with no blockers", async () => {
+    const { companyId, agentId, runId, issueId } = await seedCompanyAgentAndIssue();
+
+    const res = await request(createApp(agentActor(companyId, agentId, runId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body).toMatchObject({ error: "blocked_requires_blocker" });
+
+    const [row] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(row?.status).toBe("in_progress");
+  });
+
+  it("rejects an agent PATCH that sets status=blocked with blockedByIssueIds=[]", async () => {
+    const { companyId, agentId, runId, issueId } = await seedCompanyAgentAndIssue();
+
+    const res = await request(createApp(agentActor(companyId, agentId, runId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked", blockedByIssueIds: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body).toMatchObject({ error: "blocked_requires_blocker" });
+  });
+
+  it("accepts an agent PATCH that sets status=blocked with a named blocker", async () => {
+    const { companyId, agentId, runId, issueId, blockerIssueId } =
+      await seedCompanyAgentAndIssue({ seedBlockerIssue: true });
+
+    const res = await request(createApp(agentActor(companyId, agentId, runId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked", blockedByIssueIds: [blockerIssueId] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const [row] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(row?.status).toBe("blocked");
+  });
+
+  it("accepts an agent PATCH that omits status but updates blockedByIssueIds while the issue is already blocked-with-blocker", async () => {
+    const { companyId, agentId, runId, issueId, blockerIssueId } =
+      await seedCompanyAgentAndIssue({ issueStatus: "blocked", seedBlockerIssue: true });
+
+    const res = await request(createApp(agentActor(companyId, agentId, runId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [blockerIssueId], title: "still blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.title).toBe("still blocked");
+  });
+
+  it("rejects an agent PATCH that clears blockers while leaving status=blocked", async () => {
+    const { companyId, agentId, runId, issueId } =
+      await seedCompanyAgentAndIssue({ issueStatus: "blocked", seedBlockerIssue: true });
+
+    const res = await request(createApp(agentActor(companyId, agentId, runId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body).toMatchObject({ error: "blocked_requires_blocker" });
+  });
+
+  it("accepts a board PATCH that sets status=blocked with no blockers", async () => {
+    // ALAA-965 only restricts the agent write path. The board remains the
+    // authoritative override and can park an issue in status=blocked with no
+    // blockers when an operator explicitly chooses to.
+    const { companyId, issueId } = await seedCompanyAgentAndIssue();
+
+    const res = await request(createApp(boardActor(companyId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const [row] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(row?.status).toBe("blocked");
+  });
+});

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -308,8 +308,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
 
     const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    // ALAA-965: no live blockers were seeded, so the escalated issue must not
+    // be parked in `status=blocked` with an empty blockedBy[] set. It falls
+    // back to `todo` so a fresh assignment cycle can run.
     expect(updatedIssue).toMatchObject({
-      status: "blocked",
+      status: "todo",
     });
     const recoveryIssues = await db
       .select()
@@ -408,7 +411,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
 
     const [afterFirst] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(afterFirst?.status).toBe("blocked");
+    // ALAA-965: enqueueWakeup synchronously flipped the issue to "in_progress",
+    // so the re-block path runs. With no live blockers it must fall back to
+    // "todo" rather than parking the issue in `status=blocked` + empty
+    // blockedBy[].
+    expect(afterFirst?.status).toBe("todo");
     expect(afterFirst?.assigneeAgentId).toBe(coderId);
 
     const secondLatestRun = {
@@ -437,7 +444,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       attemptCount: 2,
     });
     const [afterSecond] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
-    expect(afterSecond?.status).toBe("blocked");
+    // ALAA-965: same invariant — no live blockers => "todo", not "blocked".
+    expect(afterSecond?.status).toBe("todo");
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id));
     expect(comments).toHaveLength(1);
@@ -485,7 +493,10 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
     expect(recoveryIssues).toHaveLength(1);
-    expect(recoveryIssues[0]?.status).toBe("blocked");
+    // ALAA-965: the in-place recovery-issue escalation respects the same
+    // invariant — without seeded blockers, the recovery issue must not be
+    // parked in `status=blocked` with no blockers.
+    expect(recoveryIssues[0]?.status).toBe("todo");
   });
 
   it("exposes active recovery actions on the issue read API", async () => {
@@ -1136,6 +1147,179 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "resolved",
       outcome: "false_positive",
       resolutionNote: "Recovery signal was stale; return to review.",
+    });
+  });
+
+  describe("ALAA-965: never produce status=blocked with empty blockedBy[]", () => {
+    async function seedBlockerOnSourceIssue(input: {
+      companyId: string;
+      sourceIssueId: string;
+      prefix: string;
+    }) {
+      const blockerIssueId = randomUUID();
+      await db.insert(issues).values({
+        id: blockerIssueId,
+        companyId: input.companyId,
+        title: "Live blocker",
+        status: "in_progress",
+        priority: "medium",
+        issueNumber: 99,
+        identifier: `${input.prefix}-99`,
+      });
+      await db.insert(issueRelations).values({
+        id: randomUUID(),
+        companyId: input.companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: input.sourceIssueId,
+        type: "blocks",
+      });
+      return blockerIssueId;
+    }
+
+    it("escalateStrandedAssignedIssue (initial write) keeps status=blocked when a live blocker exists", async () => {
+      const { companyId, coderId, sourceIssueId, sourceIssue, prefix } = await seedCompany();
+      const blockerIssueId = await seedBlockerOnSourceIssue({ companyId, sourceIssueId, prefix });
+      const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+      await recovery.escalateStrandedAssignedIssue({
+        issue: sourceIssue,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "adapter failed",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        },
+        comment: "Automatic continuation recovery failed.",
+      });
+
+      const [updated] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(updated?.status).toBe("blocked");
+      const blockerRows = await db
+        .select()
+        .from(issueRelations)
+        .where(and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.relatedIssueId, sourceIssueId),
+          eq(issueRelations.type, "blocks"),
+        ));
+      expect(blockerRows.map((row) => row.issueId)).toContain(blockerIssueId);
+    });
+
+    it("escalateStrandedAssignedIssue (initial write) falls back to status=todo when no blocker exists", async () => {
+      const { coderId, sourceIssueId, sourceIssue } = await seedCompany();
+      const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+      await recovery.escalateStrandedAssignedIssue({
+        issue: sourceIssue,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "adapter failed",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        },
+        comment: "Automatic continuation recovery failed.",
+      });
+
+      const [updated] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(updated?.status).toBe("todo");
+    });
+
+    it("escalateStrandedAssignedIssue (re-block path) keeps status=blocked when a live blocker exists", async () => {
+      const { companyId, managerId, coderId, sourceIssueId, sourceIssue, prefix } = await seedCompany();
+      await seedBlockerOnSourceIssue({ companyId, sourceIssueId, prefix });
+      // Pause the manager so the recovery owner falls back to the source
+      // assignee (coder), which is the prerequisite for the re-block path to
+      // run (recoveryAction.ownerAgentId === input.issue.assigneeAgentId).
+      await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
+      // Force the re-block path: enqueueWakeup synchronously flips the issue
+      // back to in_progress so the post-write check sees a stale status.
+      const enqueueWakeup = vi.fn(async () => {
+        await db.update(issues).set({ status: "in_progress" }).where(eq(issues.id, sourceIssueId));
+        return null;
+      });
+      const recovery = recoveryService(db, { enqueueWakeup });
+
+      await recovery.escalateStrandedAssignedIssue({
+        issue: sourceIssue,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "adapter failed",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        },
+      });
+
+      const [afterReblock] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+      expect(afterReblock?.status).toBe("blocked");
+    });
+
+    it("escalateStrandedRecoveryIssueInPlace keeps status=blocked when a live blocker exists on the recovery issue", async () => {
+      const { companyId, managerId, sourceIssueId, prefix } = await seedCompany();
+      const recoveryIssueId = randomUUID();
+      await db.insert(issues).values({
+        id: recoveryIssueId,
+        companyId,
+        title: "Recover stalled issue",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: managerId,
+        parentId: sourceIssueId,
+        issueNumber: 2,
+        identifier: `${prefix}-2`,
+        originKind: "stranded_issue_recovery",
+        originId: sourceIssueId,
+        originFingerprint: `stranded_issue_recovery:${sourceIssueId}`,
+      });
+      // Seed a live blocker on the recovery issue itself.
+      const blockerIssueId = randomUUID();
+      await db.insert(issues).values({
+        id: blockerIssueId,
+        companyId,
+        title: "Recovery-issue blocker",
+        status: "in_progress",
+        priority: "medium",
+        issueNumber: 3,
+        identifier: `${prefix}-3`,
+      });
+      await db.insert(issueRelations).values({
+        id: randomUUID(),
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: recoveryIssueId,
+        type: "blocks",
+      });
+
+      const [recoveryIssue] = await db.select().from(issues).where(eq(issues.id, recoveryIssueId));
+      const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+      await recovery.escalateStrandedAssignedIssue({
+        issue: recoveryIssue!,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: managerId,
+          status: "failed",
+          error: "adapter failed",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        },
+      });
+
+      const [updated] = await db.select().from(issues).where(eq(issues.id, recoveryIssueId));
+      expect(updated?.status).toBe("blocked");
     });
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4794,6 +4794,33 @@ export function issueRoutes(
     ) {
       updateFields.status = "todo";
     }
+    // ALAA-965: reject agent PATCH that would leave status=blocked with no
+    // blockers. A blocked issue with empty blockedBy[] is unreachable (no
+    // blocker can be cleared) and silently strands work; the recovery service
+    // also enforces this invariant on its own writes.
+    {
+      const effectiveStatus =
+        typeof updateFields.status === "string" ? updateFields.status : existing.status;
+      if (req.actor.type === "agent" && effectiveStatus === "blocked") {
+        const incomingBlockerIds = Array.isArray(req.body.blockedByIssueIds)
+          ? (req.body.blockedByIssueIds as unknown[]).filter(
+              (value): value is string => typeof value === "string",
+            )
+          : null;
+        const existingBlockerIds = existingRelations
+          ? existingRelations.blockedBy.map((relation) => relation.id)
+          : (await svc.getRelationSummaries(existing.id)).blockedBy.map((relation) => relation.id);
+        const effectiveBlockerIds = incomingBlockerIds ?? existingBlockerIds;
+        if (effectiveBlockerIds.length === 0) {
+          res.status(400).json({
+            error: "blocked_requires_blocker",
+            message:
+              "Agent PATCH may not leave status='blocked' with no blockers. Set status='todo' or include at least one blocker in blockedByIssueIds.",
+          });
+          return;
+        }
+      }
+    }
     let cancelledScheduledRetryRunId: string | null = null;
     if (
       commentBody &&

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2210,7 +2210,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     previousStatus: "todo" | "in_progress";
     latestRun: LatestIssueRun;
   }) {
-    const updated = await issuesSvc.update(input.issue.id, { status: "blocked" });
+    // ALAA-965: never produce status=blocked with an empty blockedBy[] set.
+    // Read existing unresolved blockers; if none, fall back to status=todo so
+    // the issue surfaces for normal assignment rather than rotting in a
+    // blocked-without-blocker state that no agent can clear.
+    const existingBlockers = await existingUnresolvedBlockerIssueIds(
+      input.issue.companyId,
+      input.issue.id,
+    );
+    const nextStatus: "blocked" | "todo" = existingBlockers.length > 0 ? "blocked" : "todo";
+    const updated = await issuesSvc.update(input.issue.id, { status: nextStatus });
     if (!updated) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -2236,7 +2245,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityId: input.issue.id,
       details: {
         identifier: input.issue.identifier,
-        status: "blocked",
+        status: nextStatus,
         previousStatus: input.previousStatus,
         source: "recovery.reconcile_stranded_recovery_issue",
         latestRunId: input.latestRun?.id ?? null,
@@ -2311,8 +2320,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    // ALAA-965: don't produce status=blocked with an empty blockedBy[] set.
+    const nextStatus: "blocked" | "todo" = blockerIds.length > 0 ? "blocked" : "todo";
     const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
+      status: nextStatus,
       blockedByIssueIds: blockerIds,
       assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
@@ -2402,7 +2413,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       entityId: input.issue.id,
       details: {
         identifier: input.issue.identifier,
-        status: "blocked",
+        // ALAA-965: log the status actually written, which may be "todo" when
+        // there are no live blockers.
+        status: nextStatus,
         previousStatus: input.previousStatus,
         source: input.recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
           ? "recovery.reconcile_successful_run_handoff_missing_state"
@@ -2442,8 +2455,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         (currentIssue.status !== "blocked" ||
           currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
       ) {
+        // ALAA-965: don't re-block with an empty blockedBy[] set.
+        const reblockStatus: "blocked" | "todo" = blockerIds.length > 0 ? "blocked" : "todo";
         const reblocked = await issuesSvc.update(input.issue.id, {
-          status: "blocked",
+          status: reblockStatus,
           blockedByIssueIds: blockerIds,
           assigneeAgentId: recoveryAction.ownerAgentId,
         });


### PR DESCRIPTION
## Summary

A `status=blocked` issue with an empty `blockedBy[]` set is unreachable: no blocker can be cleared to wake it, so it silently strands work and only an out-of-band sweep recovers it. Three writes in the recovery service and one in the `PATCH /api/issues/:id` agent path were producing this state. This PR enforces the invariant — *every* `status=blocked` write must be paired with a non-empty `blockedBy[]` — at all four sites, with route-level rejection for agent PATCH and a `status=todo` fallback inside recovery.

### Changes

**`server/src/services/recovery/service.ts`**
- `escalateStrandedRecoveryIssueInPlace`: read existing unresolved blockers and write `nextStatus = blockerIds.length > 0 ? "blocked" : "todo"`. Activity-log `status` field reflects the actual write.
- `escalateStrandedAssignedIssue` (initial write): same invariant; activity-log status updated.
- `escalateStrandedAssignedIssue` (re-block path): same invariant on the post-wake re-write.

**`server/src/routes/issues.ts`**
- PATCH handler now rejects agent writes that would leave the issue's effective status as `blocked` with no blockers, returning `400 { error: "blocked_requires_blocker", message: ... }`. Effective status considers both `updateFields.status` and the existing row; effective blockers consider both `req.body.blockedByIssueIds` and the existing relation summary. Board PATCH unchanged (the board is the authoritative human override).

### Tests

- **New** `server/src/__tests__/issue-blocked-requires-blocker-routes.test.ts` — 6 cases covering: agent rejected (no blockers / empty blockers array / clearing existing blockers), agent accepted with named blocker, agent accepted on no-status PATCH while already blocked-with-blocker, and board accepted (override path retained).
- **New** ALAA-965 describe block in `server/src/__tests__/issue-recovery-actions.test.ts` — 4 cases proving each of the three recovery paths (in-place, initial write, re-block) writes `blocked` when a live blocker exists and falls back to `todo` when none do.
- Existing recovery + heartbeat tests that asserted the old blocked-with-empty-blockers behavior are updated to `"todo"` with an ALAA-965 reference comment, since that *is* the bug being fixed.

### Backstory / production validation

We hit this in production: agents were writing `status=blocked` with no blockers, then the parent's status PATCH would self-trigger `issue_status_changed` wakes and the CEO had to run a per-heartbeat sweep (`scripts/ceo_unblock_sweep.py`) to PATCH affected issues back to `todo`. The fix was first deployed as a dist-JS hot-patch against `paperclipai@2026.529.0` running locally; this PR ports the same four edits onto the TypeScript source. Once a release including this PR lands, the local sweep policy and hot-patch can be retired.

## Test plan

- [x] `pnpm vitest run server/src/__tests__/issue-blocked-requires-blocker-routes.test.ts` — 6/6 pass
- [x] `pnpm vitest run server/src/__tests__/issue-recovery-actions.test.ts` — 25/25 pass (includes 4 new ALAA-965 cases)
- [x] `pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — 48/49 pass; the one remaining failure (`queues exactly one retry when the recorded local pid is dead`) reproduces unchanged on `upstream/master` (pre-existing flake, unrelated to this PR)
- [x] `tsc --noEmit` shows no new errors in any touched file