### PR TITLE
Single-flight lease for shared execution workspaces

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -572,3 +572,67 @@ For a board operator, the intended meaning is:
 - blockers explain waiting
 
 That is the execution contract Paperclip should present to operators.
+
+## 15. Workspace/Branch Single-Flight Lease
+
+Issue checkout (`§5`) guarantees that a single issue is owned by one heartbeat
+run at a time. It does **not**, on its own, prevent two runs arriving through
+**different issues** from targeting the **same shared execution workspace** — the
+same on-disk local checkout or SSH `remoteWorkspacePath`. Without an additional
+guard, both runs can `git checkout`/commit/push against the same working tree and
+corrupt each other (the "RTR-12 near-miss" class of bug).
+
+### Invariant
+
+> At most one **active** `ephemeral` `environment_leases` row may exist for a
+> given (`environment_id`, `execution_workspace_id`) at any time.
+
+This is enforced in two layers, both durable in the control plane (not in agent
+instructions or process-local locks):
+
+1. **Database (authoritative).** A partial unique index
+   `environment_leases_active_workspace_singleflight_idx` over
+   (`environment_id`, `execution_workspace_id`) `WHERE status = 'active' AND
+   execution_workspace_id IS NOT NULL AND lease_policy = 'ephemeral'`
+   (migration `0099`). Even under a race, the second `INSERT` fails with
+   `unique_violation` (SQLSTATE 23505).
+2. **Service (`environmentService.acquireLease`).** Before inserting it resolves
+   any existing active lease on the workspace and:
+   - **Re-entrant** — same `heartbeat_run_id` already holds it → reuse the lease
+     (this preserves existing same-issue / same-run `checkoutRunId` behavior).
+   - **Live conflict** — a *different*, non-terminal run holds it → throw
+     `EnvironmentLeaseConflictError`. The run orchestrator maps this to the
+     `lease_conflict` error code so the competing run **defers cleanly** rather
+     than reporting broken infrastructure.
+   - **Stale holder** — the holder's `heartbeat_run` is terminal
+     (`succeeded`/`failed`/`cancelled`/`timed_out`), orphaned (`heartbeat_run_id`
+     is null), or past `expires_at` → the stale lease is transitioned to
+     `expired` and the new run **adopts** the workspace. This prevents an
+     abandoned lease from permanently deadlocking the workspace.
+
+A lost insert race (both runs pass the pre-check, the index rejects the loser) is
+caught and re-surfaced as the same `EnvironmentLeaseConflictError`.
+
+### Scope and residual risk
+
+- **Scope.** The guard applies only to `ephemeral` leases bound to a concrete
+  `execution_workspace_id`, i.e. local/SSH shared checkouts. Workspace-less
+  leases and `reuse_by_environment` (sandbox reuse) leases are intentionally
+  **not** single-flight-guarded, because each realizes/needs its own provider
+  workspace and reuse there is sequential by design. If a future driver shares a
+  physical checkout under a non-ephemeral policy, extend the index predicate.
+- **Workspace granularity, not branch.** The single-flight key is the execution
+  *workspace* (the physical checkout), not the git branch. This is deliberate:
+  two runs on *different* branches inside the *same* shared clone still race
+  `git` state, so guarding at the workspace level is the safe granularity. An
+  environment that realizes a distinct working tree per branch is represented by
+  distinct `execution_workspace_id`s and is therefore already correctly
+  separated.
+- **Cross-environment / external mutation.** The guard is scoped per
+  `environment_id`. Two environments pointed at the same physical path, or
+  out-of-band mutation of the checkout, are out of scope and remain the
+  operator's responsibility.
+- **Stale detection latency.** Adoption keys off the holder run's heartbeat
+  status; a wedged process that has not yet been marked terminal by the
+  watchdog (`§11`) still holds its lease until then. This is intentionally
+  conservative — preferring a brief deferral over racing a possibly-live run.

--- a/packages/db/src/migrations/0099_environment_lease_workspace_singleflight.sql
+++ b/packages/db/src/migrations/0099_environment_lease_workspace_singleflight.sql
@@ -1,0 +1,37 @@
+-- Single-flight guardrail for shared execution workspaces.
+--
+-- Before this migration, `environment_leases` could hold multiple ACTIVE
+-- ephemeral leases pointing at the same (environment_id, execution_workspace_id),
+-- which allowed two heartbeat runs — even ones arriving through different
+-- issues — to concurrently mutate the same shared local/SSH checkout/branch
+-- (the RTR-12 near-miss class of bug).
+--
+-- Step 1 backfills existing data so the unique index can be created safely:
+-- where duplicate active ephemeral leases already exist for a workspace, keep
+-- the most recently acquired one active and expire the rest.
+WITH ranked AS (
+	SELECT
+		id,
+		row_number() OVER (
+			PARTITION BY environment_id, execution_workspace_id
+			ORDER BY acquired_at DESC, created_at DESC
+		) AS rn
+	FROM environment_leases
+	WHERE status = 'active'
+		AND execution_workspace_id IS NOT NULL
+		AND lease_policy = 'ephemeral'
+)
+UPDATE environment_leases AS el
+SET
+	status = 'expired',
+	released_at = now(),
+	last_used_at = now(),
+	updated_at = now(),
+	failure_reason = COALESCE(el.failure_reason, 'superseded: single-flight workspace lease backfill')
+FROM ranked
+WHERE el.id = ranked.id
+	AND ranked.rn > 1;--> statement-breakpoint
+-- Step 2 enforces the invariant durably going forward.
+CREATE UNIQUE INDEX "environment_leases_active_workspace_singleflight_idx"
+	ON "environment_leases" USING btree ("environment_id", "execution_workspace_id")
+	WHERE "status" = 'active' AND "execution_workspace_id" IS NOT NULL AND "lease_policy" = 'ephemeral';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -694,6 +694,13 @@
       "when": 1780534200000,
       "tag": "0098_project_icon",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1780534400000,
+      "tag": "0099_environment_lease_workspace_singleflight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/environment_leases.ts
+++ b/packages/db/src/schema/environment_leases.ts
@@ -1,4 +1,5 @@
-import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { environments } from "./environments.js";
 import { executionWorkspaces } from "./execution_workspaces.js";
@@ -42,5 +43,17 @@ export const environmentLeases = pgTable(
     heartbeatRunIdx: index("environment_leases_heartbeat_run_idx").on(table.heartbeatRunId),
     companyLastUsedIdx: index("environment_leases_company_last_used_idx").on(table.companyId, table.lastUsedAt),
     providerLeaseIdx: index("environment_leases_provider_lease_idx").on(table.providerLeaseId),
+    // Single-flight guard: at most one ACTIVE ephemeral lease may hold a given
+    // shared execution workspace at a time. This is the durable, control-plane
+    // enforcement of the workspace/branch single-flight invariant — two
+    // heartbeat runs (even via different issues) cannot concurrently lease the
+    // same local/SSH shared checkout. Scoped to ephemeral leases bound to a
+    // concrete executionWorkspaceId; sandbox/reuse leases and workspace-less
+    // leases are intentionally excluded (see environments.ts acquireLease).
+    activeWorkspaceSingleFlightIdx: uniqueIndex("environment_leases_active_workspace_singleflight_idx")
+      .on(table.environmentId, table.executionWorkspaceId)
+      .where(
+        sql`${table.status} = 'active' and ${table.executionWorkspaceId} is not null and ${table.leasePolicy} = 'ephemeral'`,
+      ),
   }),
 );

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -1,12 +1,21 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
-import { agents, companies, createDb, environmentLeases, environments, heartbeatRuns } from "@paperclipai/db";
+import {
+  agents,
+  companies,
+  createDb,
+  environmentLeases,
+  environments,
+  executionWorkspaces,
+  heartbeatRuns,
+  projects,
+} from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { environmentService } from "../services/environments.ts";
+import { EnvironmentLeaseConflictError, environmentService } from "../services/environments.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -31,6 +40,8 @@ describeEmbeddedPostgres("environmentService leases", () => {
 
   afterEach(async () => {
     await db.delete(environmentLeases);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(environments);
@@ -87,7 +98,48 @@ describeEmbeddedPostgres("environmentService leases", () => {
       updatedAt: new Date(),
     });
 
-    return { companyId, agentId, environmentId, runId };
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared checkout",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared",
+      strategyType: "shared_checkout",
+      name: "rtr-project shared clone",
+      status: "active",
+      providerType: "local_fs",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return { companyId, agentId, environmentId, runId, projectId, executionWorkspaceId };
+  }
+
+  async function seedRun(
+    companyId: string,
+    agentId: string,
+    status: "queued" | "scheduled_retry" | "running" | "succeeded" | "failed" | "cancelled" | "timed_out" = "running",
+  ): Promise<string> {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return runId;
   }
 
   it("acquires and releases a lease for a run", async () => {
@@ -140,6 +192,213 @@ describeEmbeddedPostgres("environmentService leases", () => {
 
     const stillActive = await svc.listLeases(environmentId, { status: "active" });
     expect(stillActive.map((lease) => lease.id)).toEqual([otherLease.id]);
+  });
+
+  it("reuses the existing workspace lease when the same run re-acquires (re-entrant)", async () => {
+    const { companyId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+
+    const first = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      issueId: null,
+      heartbeatRunId: runId,
+      leasePolicy: "ephemeral",
+    });
+    const second = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      issueId: null,
+      heartbeatRunId: runId,
+      leasePolicy: "ephemeral",
+    });
+
+    expect(second.id).toBe(first.id);
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active).toHaveLength(1);
+  });
+
+  it("rejects a second run acquiring the same workspace through a different issue", async () => {
+    const { companyId, agentId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+    const otherRunId = await seedRun(companyId, agentId, "running");
+
+    // Distinct heartbeat runs model distinct issue checkouts targeting the same
+    // shared workspace (issueId left null to avoid seeding the issues table; the
+    // single-flight key is environment + execution workspace, not issue).
+    const holder = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      issueId: null,
+      heartbeatRunId: runId,
+      leasePolicy: "ephemeral",
+    });
+
+    await expect(
+      svc.acquireLease({
+        companyId,
+        environmentId,
+        executionWorkspaceId,
+        issueId: null,
+        heartbeatRunId: otherRunId,
+        leasePolicy: "ephemeral",
+      }),
+    ).rejects.toBeInstanceOf(EnvironmentLeaseConflictError);
+
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active.map((lease) => lease.id)).toEqual([holder.id]);
+  });
+
+  it("enforces single-flight durably at the database level (partial unique index)", async () => {
+    // Defense in depth: even if app-level logic is bypassed, the DB must reject a
+    // second active ephemeral lease for the same (environment, execution workspace).
+    const { companyId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+
+    await db.insert(environmentLeases).values({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      status: "active",
+      leasePolicy: "ephemeral",
+      acquiredAt: new Date(),
+      lastUsedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const error = await db
+      .insert(environmentLeases)
+      .values({
+        companyId,
+        environmentId,
+        executionWorkspaceId,
+        heartbeatRunId: runId,
+        status: "active",
+        leasePolicy: "ephemeral",
+        acquiredAt: new Date(),
+        lastUsedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .then(() => null)
+      .catch((err: unknown) => err);
+
+    expect(error).toBeTruthy();
+    // Drizzle wraps the driver error; the unique_violation (23505) is somewhere
+    // in the cause chain.
+    const codes: unknown[] = [];
+    let cursor: unknown = error;
+    for (let depth = 0; depth < 8 && cursor && typeof cursor === "object"; depth += 1) {
+      codes.push((cursor as { code?: unknown }).code);
+      cursor = (cursor as { cause?: unknown }).cause;
+    }
+    expect(codes).toContain("23505");
+  });
+
+  it("adopts a workspace lease whose holding run has terminated", async () => {
+    const { companyId, agentId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+
+    const stale = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "ephemeral",
+    });
+    // The previous run died without releasing its lease.
+    await db.update(heartbeatRuns).set({ status: "failed" }).where(eq(heartbeatRuns.id, runId));
+
+    const adopterRunId = await seedRun(companyId, agentId, "running");
+    const adopted = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: adopterRunId,
+      leasePolicy: "ephemeral",
+    });
+
+    expect(adopted.id).not.toBe(stale.id);
+    expect(adopted.heartbeatRunId).toBe(adopterRunId);
+
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active.map((lease) => lease.id)).toEqual([adopted.id]);
+
+    const previous = await svc.getLeaseById(stale.id);
+    expect(previous?.status).toBe("expired");
+  });
+
+  it("adopts a workspace lease that has passed its expiry", async () => {
+    const { companyId, agentId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+
+    const stale = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "ephemeral",
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const adopterRunId = await seedRun(companyId, agentId, "running");
+    const adopted = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: adopterRunId,
+      leasePolicy: "ephemeral",
+    });
+
+    expect(adopted.id).not.toBe(stale.id);
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active.map((lease) => lease.id)).toEqual([adopted.id]);
+  });
+
+  it("does not single-flight non-ephemeral (reuse) leases on the same workspace", async () => {
+    const { companyId, agentId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+    const otherRunId = await seedRun(companyId, agentId, "running");
+
+    const first = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "reuse_by_environment",
+    });
+    const second = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: otherRunId,
+      leasePolicy: "reuse_by_environment",
+    });
+
+    expect(second.id).not.toBe(first.id);
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active).toHaveLength(2);
+  });
+
+  it("does not single-flight leases without an execution workspace", async () => {
+    const { companyId, agentId, environmentId, runId } = await seedEnvironment();
+    const otherRunId = await seedRun(companyId, agentId, "running");
+
+    const first = await svc.acquireLease({
+      companyId,
+      environmentId,
+      heartbeatRunId: runId,
+      leasePolicy: "ephemeral",
+    });
+    const second = await svc.acquireLease({
+      companyId,
+      environmentId,
+      heartbeatRunId: otherRunId,
+      leasePolicy: "ephemeral",
+    });
+
+    expect(second.id).not.toBe(first.id);
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active).toHaveLength(2);
   });
 
   it("creates and then reuses the default local environment for a company", async () => {

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -379,6 +379,69 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(active).toHaveLength(2);
   });
 
+  it("does not treat a coexisting reuse lease as an ephemeral single-flight conflict", async () => {
+    // A live `reuse_by_environment` lease shares the workspace with an incoming
+    // ephemeral acquisition. The single-flight guard is scoped to ephemeral
+    // leases (matching the partial unique index), so the ephemeral acquire must
+    // succeed and both leases must remain active rather than colliding.
+    const { companyId, agentId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+    const ephemeralRunId = await seedRun(companyId, agentId, "running");
+
+    const reuse = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "reuse_by_environment",
+    });
+    const ephemeral = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: ephemeralRunId,
+      leasePolicy: "ephemeral",
+    });
+
+    expect(ephemeral.id).not.toBe(reuse.id);
+    // The reuse lease was neither conflicted-on nor expired.
+    expect((await svc.getLeaseById(reuse.id))?.status).toBe("active");
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active.map((lease) => lease.id).sort()).toEqual([reuse.id, ephemeral.id].sort());
+  });
+
+  it("does not expire a coexisting reuse lease whose holding run has terminated", async () => {
+    // The dangerous cross-policy mode: a `reuse_by_environment` lease persists
+    // past its holding run by design, so a terminal run does not make it stale.
+    // An ephemeral acquirer on the same workspace must not adopt/expire it as if
+    // it were an abandoned single-flight holder.
+    const { companyId, agentId, environmentId, runId, executionWorkspaceId } = await seedEnvironment();
+
+    const reuse = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: runId,
+      leasePolicy: "reuse_by_environment",
+    });
+    // The reuse lease's originating run finishes; the sandbox lease lives on.
+    await db.update(heartbeatRuns).set({ status: "succeeded" }).where(eq(heartbeatRuns.id, runId));
+
+    const ephemeralRunId = await seedRun(companyId, agentId, "running");
+    const ephemeral = await svc.acquireLease({
+      companyId,
+      environmentId,
+      executionWorkspaceId,
+      heartbeatRunId: ephemeralRunId,
+      leasePolicy: "ephemeral",
+    });
+
+    expect(ephemeral.id).not.toBe(reuse.id);
+    // Pre-fix, the unscoped lookup would have expired this reuse lease here.
+    expect((await svc.getLeaseById(reuse.id))?.status).toBe("active");
+    const active = await svc.listLeases(environmentId, { status: "active" });
+    expect(active.map((lease) => lease.id).sort()).toEqual([reuse.id, ephemeral.id].sort());
+  });
+
   it("does not single-flight leases without an execution workspace", async () => {
     const { companyId, agentId, environmentId, runId } = await seedEnvironment();
     const otherRunId = await seedRun(companyId, agentId, "running");

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -24,7 +24,7 @@ import type {
   ExecutionWorkspace,
   ExecutionWorkspaceConfig,
 } from "@paperclipai/shared";
-import { environmentService } from "./environments.js";
+import { environmentService, EnvironmentLeaseConflictError } from "./environments.js";
 import {
   environmentRuntimeService,
   buildEnvironmentLeaseContext,
@@ -58,6 +58,7 @@ export type EnvironmentErrorCode =
   | "unsupported_adapter_environment"
   | "probe_failed"
   | "lease_acquire_failed"
+  | "lease_conflict"
   | "workspace_realization_failed"
   | "transport_resolution_failed"
   | "lease_release_failed"
@@ -212,6 +213,20 @@ export function environmentRunOrchestrator(
     try {
       return await environmentRuntime.acquireRunLease(input);
     } catch (err) {
+      // Another live run already holds this shared workspace lease. Surface a
+      // distinct, non-failure code so the caller can defer cleanly instead of
+      // treating it as broken infrastructure.
+      if (err instanceof EnvironmentLeaseConflictError) {
+        throw new EnvironmentRunError(
+          "lease_conflict",
+          `Execution workspace for environment "${input.environment.name}" is already leased by another active run; deferring.`,
+          {
+            environmentId: input.environment.id,
+            driver: input.environment.driver,
+            cause: err,
+          },
+        );
+      }
       throw new EnvironmentRunError(
         "lease_acquire_failed",
         `Failed to acquire lease for environment "${input.environment.name}" (${input.environment.driver}): ${err instanceof Error ? err.message : String(err)}`,

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -157,7 +157,13 @@ async function leaseHolderIsStale(db: Db, lease: EnvironmentLeaseRow, now: Date)
   return !(LIVE_HEARTBEAT_RUN_STATUSES as readonly string[]).includes(run.status);
 }
 
-/** Most-recent ACTIVE lease holding a given (environment, execution workspace), if any. */
+/**
+ * Most-recent ACTIVE single-flight lease holding a given (environment, execution
+ * workspace), if any. Scoped to {@link SINGLE_FLIGHT_LEASE_POLICY} so it matches
+ * the partial unique index (`lease_policy = 'ephemeral'`) exactly: a coexisting
+ * `reuse_by_environment` lease on the same workspace must neither be returned as
+ * a conflict nor be expired as a "stale" single-flight holder.
+ */
 async function findActiveWorkspaceLease(
   db: Db,
   environmentId: string,
@@ -171,6 +177,7 @@ async function findActiveWorkspaceLease(
         eq(environmentLeases.environmentId, environmentId),
         eq(environmentLeases.executionWorkspaceId, executionWorkspaceId),
         eq(environmentLeases.status, "active"),
+        eq(environmentLeases.leasePolicy, SINGLE_FLIGHT_LEASE_POLICY),
       ),
     )
     .orderBy(desc(environmentLeases.acquiredAt), desc(environmentLeases.createdAt))
@@ -333,8 +340,8 @@ export function environmentService(db: Db) {
       const heartbeatRunId = input.heartbeatRunId ?? null;
       const leasePolicy = input.leasePolicy ?? "ephemeral";
 
-      const insertLease = async (): Promise<EnvironmentLease> => {
-        const row = await db
+      const insertLease = async (executor: Db = db): Promise<EnvironmentLease> => {
+        const row = await executor
           .insert(environmentLeases)
           .values({
             companyId: input.companyId,
@@ -399,19 +406,33 @@ export function environmentService(db: Db) {
         if (!(await leaseHolderIsStale(db, existing, now))) {
           throw conflictFrom(existing);
         }
-        await db
-          .update(environmentLeases)
-          .set({
-            status: "expired",
-            releasedAt: now,
-            lastUsedAt: now,
-            updatedAt: now,
-            failureReason: existing.failureReason ?? "superseded: stale single-flight workspace lease",
-          })
-          .where(and(eq(environmentLeases.id, existing.id), eq(environmentLeases.status, "active")));
       }
 
       try {
+        // Stale-holder adoption must be atomic: expiring the old lease and
+        // inserting the replacement in two independent statements risks leaving
+        // the workspace unoccupied if the process dies between them. Wrap both in
+        // one transaction so a crash rolls back to the prior state and the run can
+        // retry cleanly. The `status = 'active'` guard makes the expire a no-op if
+        // a concurrent acquirer already adopted the holder, in which case our
+        // insert trips the partial unique index and is handled below. The plain
+        // no-contention insert (no existing holder) stays outside a transaction.
+        if (existing) {
+          return await db.transaction(async (tx) => {
+            const txDb = tx as unknown as Db;
+            await txDb
+              .update(environmentLeases)
+              .set({
+                status: "expired",
+                releasedAt: now,
+                lastUsedAt: now,
+                updatedAt: now,
+                failureReason: existing.failureReason ?? "superseded: stale single-flight workspace lease",
+              })
+              .where(and(eq(environmentLeases.id, existing.id), eq(environmentLeases.status, "active")));
+            return insertLease(txDb);
+          });
+        }
         return await insertLease();
       } catch (err) {
         // Lost a race to a concurrent acquirer; the partial unique index rejects

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { environmentLeases, environments } from "@paperclipai/db";
+import { environmentLeases, environments, heartbeatRuns } from "@paperclipai/db";
 import {
   ENVIRONMENT_DRIVERS,
   ENVIRONMENT_LEASE_CLEANUP_STATUSES,
@@ -74,6 +74,107 @@ function toEnvironmentLease(row: EnvironmentLeaseRow): EnvironmentLease {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+}
+
+/**
+ * Heartbeat run statuses that still represent a live, executing run. A lease
+ * whose holding run is NOT in one of these states is considered abandoned and
+ * may be adopted by a new acquirer (see {@link leaseHolderIsStale}). Kept in
+ * sync with the terminal-status helpers in services/heartbeat.ts.
+ */
+const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "scheduled_retry", "running"] as const;
+
+/**
+ * Lease policies that participate in the single-flight workspace guardrail.
+ * Only ephemeral, single-use leases bound to a shared execution workspace
+ * (local/SSH checkouts) are guarded; sandbox `reuse_by_environment` leases and
+ * workspace-less leases keep their prior multi-acquire behavior.
+ */
+const SINGLE_FLIGHT_LEASE_POLICY: EnvironmentLeasePolicy = "ephemeral";
+
+/**
+ * Thrown when a heartbeat run tries to acquire an ephemeral lease for a shared
+ * execution workspace that another live, non-terminal run already holds. Code
+ * paths that set up a run should treat this as "another run owns the
+ * workspace — defer", not as a hard infrastructure failure.
+ */
+export class EnvironmentLeaseConflictError extends Error {
+  readonly code = "environment_lease_conflict";
+  readonly environmentId: string;
+  readonly executionWorkspaceId: string;
+  readonly conflictingLeaseId: string;
+  readonly conflictingRunId: string | null;
+  readonly conflictingIssueId: string | null;
+
+  constructor(details: {
+    environmentId: string;
+    executionWorkspaceId: string;
+    conflictingLeaseId: string;
+    conflictingRunId: string | null;
+    conflictingIssueId: string | null;
+  }) {
+    super(
+      `Execution workspace ${details.executionWorkspaceId} is already leased by an active run` +
+        (details.conflictingRunId ? ` (run ${details.conflictingRunId})` : "") +
+        `; refusing to acquire a concurrent single-flight lease.`,
+    );
+    this.name = "EnvironmentLeaseConflictError";
+    this.environmentId = details.environmentId;
+    this.executionWorkspaceId = details.executionWorkspaceId;
+    this.conflictingLeaseId = details.conflictingLeaseId;
+    this.conflictingRunId = details.conflictingRunId;
+    this.conflictingIssueId = details.conflictingIssueId;
+  }
+}
+
+/**
+ * Postgres unique_violation (SQLSTATE 23505), surfaced by the `postgres` driver.
+ * Drizzle wraps the driver error in a DrizzleQueryError, so walk the cause chain.
+ */
+function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; depth < 8 && current && typeof current === "object"; depth += 1) {
+    if ((current as { code?: unknown }).code === "23505") return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * A workspace lease is adoptable (stale) when it is expired, orphaned of a
+ * heartbeat run, or its holding run has reached a terminal state. Live holders
+ * are NOT stale and must block a competing acquirer.
+ */
+async function leaseHolderIsStale(db: Db, lease: EnvironmentLeaseRow, now: Date): Promise<boolean> {
+  if (lease.expiresAt && lease.expiresAt.getTime() <= now.getTime()) return true;
+  if (!lease.heartbeatRunId) return true;
+  const run = await db
+    .select({ status: heartbeatRuns.status })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, lease.heartbeatRunId))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return true;
+  return !(LIVE_HEARTBEAT_RUN_STATUSES as readonly string[]).includes(run.status);
+}
+
+/** Most-recent ACTIVE lease holding a given (environment, execution workspace), if any. */
+async function findActiveWorkspaceLease(
+  db: Db,
+  environmentId: string,
+  executionWorkspaceId: string,
+): Promise<EnvironmentLeaseRow | null> {
+  return db
+    .select()
+    .from(environmentLeases)
+    .where(
+      and(
+        eq(environmentLeases.environmentId, environmentId),
+        eq(environmentLeases.executionWorkspaceId, executionWorkspaceId),
+        eq(environmentLeases.status, "active"),
+      ),
+    )
+    .orderBy(desc(environmentLeases.acquiredAt), desc(environmentLeases.createdAt))
+    .then((rows) => rows[0] ?? null);
 }
 
 export function environmentService(db: Db) {
@@ -228,34 +329,108 @@ export function environmentService(db: Db) {
       metadata?: Record<string, unknown> | null;
     }): Promise<EnvironmentLease> => {
       const now = new Date();
-      const row = await db
-        .insert(environmentLeases)
-        .values({
-          companyId: input.companyId,
-          environmentId: input.environmentId,
-          executionWorkspaceId: input.executionWorkspaceId ?? null,
-          issueId: input.issueId ?? null,
-          heartbeatRunId: input.heartbeatRunId ?? null,
-          status: "active",
-          leasePolicy: input.leasePolicy ?? "ephemeral",
-          provider: input.provider ?? null,
-          providerLeaseId: input.providerLeaseId ?? null,
-          acquiredAt: now,
-          lastUsedAt: now,
-          expiresAt: input.expiresAt ?? null,
-          releasedAt: null,
-          failureReason: null,
-          cleanupStatus: null,
-          metadata: input.metadata ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning()
-        .then((rows) => rows[0] ?? null);
-      if (!row) {
-        throw new Error("Failed to acquire environment lease");
+      const executionWorkspaceId = input.executionWorkspaceId ?? null;
+      const heartbeatRunId = input.heartbeatRunId ?? null;
+      const leasePolicy = input.leasePolicy ?? "ephemeral";
+
+      const insertLease = async (): Promise<EnvironmentLease> => {
+        const row = await db
+          .insert(environmentLeases)
+          .values({
+            companyId: input.companyId,
+            environmentId: input.environmentId,
+            executionWorkspaceId,
+            issueId: input.issueId ?? null,
+            heartbeatRunId,
+            status: "active",
+            leasePolicy,
+            provider: input.provider ?? null,
+            providerLeaseId: input.providerLeaseId ?? null,
+            acquiredAt: now,
+            lastUsedAt: now,
+            expiresAt: input.expiresAt ?? null,
+            releasedAt: null,
+            failureReason: null,
+            cleanupStatus: null,
+            metadata: input.metadata ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!row) {
+          throw new Error("Failed to acquire environment lease");
+        }
+        return toEnvironmentLease(row);
+      };
+
+      // Single-flight guard only applies to ephemeral leases bound to a concrete
+      // shared execution workspace (local/SSH checkouts). Workspace-less leases
+      // and sandbox reuse leases keep their prior multi-acquire behavior.
+      const singleFlight = executionWorkspaceId !== null && leasePolicy === SINGLE_FLIGHT_LEASE_POLICY;
+      if (!singleFlight) {
+        return insertLease();
       }
-      return toEnvironmentLease(row);
+
+      const conflictFrom = (lease: EnvironmentLeaseRow): EnvironmentLeaseConflictError =>
+        new EnvironmentLeaseConflictError({
+          environmentId: input.environmentId,
+          executionWorkspaceId,
+          conflictingLeaseId: lease.id,
+          conflictingRunId: lease.heartbeatRunId ?? null,
+          conflictingIssueId: lease.issueId ?? null,
+        });
+
+      const existing = await findActiveWorkspaceLease(db, input.environmentId, executionWorkspaceId);
+      if (existing) {
+        // Re-entrant: the same run already owns this workspace lease. Preserve
+        // existing same-issue/run behavior by reusing it rather than failing.
+        if (heartbeatRunId !== null && existing.heartbeatRunId === heartbeatRunId) {
+          const touched = await db
+            .update(environmentLeases)
+            .set({ lastUsedAt: now, updatedAt: now })
+            .where(eq(environmentLeases.id, existing.id))
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          return toEnvironmentLease(touched ?? existing);
+        }
+        // A different run holds the workspace. Adopt it only if its holder is
+        // stale/terminal so abandoned leases can't deadlock the workspace.
+        if (!(await leaseHolderIsStale(db, existing, now))) {
+          throw conflictFrom(existing);
+        }
+        await db
+          .update(environmentLeases)
+          .set({
+            status: "expired",
+            releasedAt: now,
+            lastUsedAt: now,
+            updatedAt: now,
+            failureReason: existing.failureReason ?? "superseded: stale single-flight workspace lease",
+          })
+          .where(and(eq(environmentLeases.id, existing.id), eq(environmentLeases.status, "active")));
+      }
+
+      try {
+        return await insertLease();
+      } catch (err) {
+        // Lost a race to a concurrent acquirer; the partial unique index rejects
+        // the second active lease. Surface it as a clean conflict, not a 500.
+        if (isUniqueViolation(err)) {
+          const winner = await findActiveWorkspaceLease(db, input.environmentId, executionWorkspaceId);
+          if (winner && winner.heartbeatRunId !== heartbeatRunId) {
+            throw conflictFrom(winner);
+          }
+          throw new EnvironmentLeaseConflictError({
+            environmentId: input.environmentId,
+            executionWorkspaceId,
+            conflictingLeaseId: winner?.id ?? "unknown",
+            conflictingRunId: winner?.heartbeatRunId ?? null,
+            conflictingIssueId: winner?.issueId ?? null,
+          });
+        }
+        throw err;
+      }
     },
 
     releaseLease: async (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents execute heartbeat runs against an execution environment; the durable `environment_leases` table records who holds an environment/workspace
> - Issue checkout enforces single ownership *per issue*, but the lease path does **not** stop two runs arriving through *different issues* from acquiring an active lease on the **same shared execution workspace** (the same local checkout or SSH `remoteWorkspacePath`)
> - Two such runs can then `git checkout`/commit/push against one working tree and corrupt each other — a real concurrency hazard on shared local/SSH environments
> - This pull request adds a durable single-flight guard so at most one active ephemeral lease can hold a given `(environment, execution workspace)` at a time, with explicit stale-holder adoption so abandoned leases never deadlock
> - The benefit is that concurrent heartbeat runs can no longer race the same shared checkout, while same-run re-acquire and sandbox/reuse leases are unaffected

## Linked Issues or Issue Description

No upstream GitHub issue exists; describing in-PR using the bug report template fields.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip or can reproduce on `master`.
- [x] I have confirmed the error originates in Paperclip itself, not in my agent adapter, API provider, or local configuration.

### What happened?

`environmentService.acquireLease` (`server/src/services/environments.ts`) does a blind `INSERT` into `environment_leases`. All execution drivers (local/ssh/sandbox) funnel through it via `environment-runtime.ts`. There is no uniqueness on active `(environment_id, execution_workspace_id)`, so multiple active leases can coexist for one shared workspace and two heartbeat runs from different issues can mutate the same local/SSH checkout concurrently.

### Expected behavior

Acquiring a lease for a shared workspace already held by another live run should fail/defer cleanly. An abandoned holder whose heartbeat run is terminal, orphaned, or expired should be adoptable without permanent deadlock.

### Steps to reproduce

1. Create or use two runnable issues that resolve to the same local/SSH execution workspace.
2. Start two heartbeat runs close together so both attempt to acquire the same `execution_workspace_id` through environment lease acquisition.
3. Observe that, before this PR, both runs can get active leases and run code/PR-mutating work against the same checkout.

### Paperclip version or commit

Reproduced against the published `@paperclipai/server` 2026.529.0 behavior and verified the patch applies cleanly onto `paperclipai/paperclip` `master` @ `393e6f5`.

### Deployment mode

Local/self-hosted Paperclip server with local execution workspaces.

### Installation method

npm/npx published package for the observed instance; built from source for the verified patch.

### Agent adapter(s) involved

Codex and core execution runtime. The bug is not adapter-specific; it is in the control-plane lease path.

### Database mode

Embedded Postgres/PGlite-compatible migration path; tests ran against embedded Postgres with migrations applied.

### Access context

Agent heartbeat runs using bearer API credentials.

### Node.js version

Not version-specific.

### Operating system

Observed on macOS local execution workspaces; the bug is control-plane lease state and applies to local/SSH shared workspace modes.

### Relevant logs or output

No stack trace is required. The failure mode is two active `environment_leases` rows for the same active ephemeral `(environment_id, execution_workspace_id)` held by different live runs.

### Relevant config

No secrets or config are required. The affected path is any local/SSH execution workspace that resolves multiple runs to the same `execution_workspace_id`.

### Additional context

This PR adds a durable partial unique index plus service-level live-run conflict handling and stale adoption. It intentionally scopes the guard to active ephemeral leases with a concrete execution workspace, leaving workspace-less and reusable sandbox leases unchanged.

### Privacy checklist

- [x] I have reviewed all pasted output for PII, usernames, file paths, API keys, tokens, company names, and redacted where necessary.


## What Changed

- **DB (authoritative):** new migration `0099_environment_lease_workspace_singleflight.sql` adds a **partial unique index** over `(environment_id, execution_workspace_id)` `WHERE status='active' AND execution_workspace_id IS NOT NULL AND lease_policy='ephemeral'`, preceded by a backfill that expires pre-existing duplicate active ephemeral leases so the index applies safely on live data. Mirrored in the Drizzle schema (`packages/db/src/schema/environment_leases.ts`).
- **Service:** `environmentService.acquireLease` now, for ephemeral leases bound to a concrete execution workspace, resolves any existing active lease and:
  - reuses it when the **same** `heartbeat_run_id` re-acquires (re-entrant — preserves existing same-issue behavior);
  - throws a new `EnvironmentLeaseConflictError` when a **different live** run holds it;
  - **adopts** the workspace (expires the old lease) when the holder is terminal (`succeeded|failed|cancelled|timed_out`), orphaned, or past `expires_at`.
  A lost insert race (unique-violation 23505) re-surfaces as the same conflict.
- **Orchestrator:** `environment-run-orchestrator.ts` maps the conflict to a distinct `lease_conflict` error code so a competing run defers cleanly instead of reporting broken infrastructure.
- **Docs:** `doc/execution-semantics.md` §15 documents the invariant + residual risk.
- **Tests:** 8 new focused cases in `server/src/__tests__/environment-service.test.ts`.

Scope is intentionally narrow: only `ephemeral` leases with a concrete `execution_workspace_id` (local/SSH shared checkouts) are guarded. Workspace-less leases and `reuse_by_environment` (sandbox reuse) leases keep prior behavior.

## Verification

Run against an embedded Postgres with all migrations (incl. `0099`) applied:

```
cd server && pnpm exec vitest run src/__tests__/environment-service.test.ts
# 13 passed (13)
```

New/covered cases:
- reuses the existing workspace lease when the same run re-acquires (re-entrant)
- rejects a second run acquiring the same workspace through a different issue
- enforces single-flight durably at the database level (partial unique index)
- adopts a workspace lease whose holding run has terminated / has passed its expiry
- does not single-flight non-ephemeral (reuse) or workspace-less leases

Also: `@paperclipai/db` migration-numbering check + `tsc --noEmit` pass for changed files.

## Risks

- **Migration safety:** the index is partial and is created after a same-transaction backfill that expires duplicate active ephemeral leases (keeping the most recently acquired). On a healthy DB there should be no duplicates; the backfill is defensive.
- **Behavioral shift:** a second concurrent run on the same shared ephemeral workspace now fails fast with `lease_conflict` instead of silently double-acquiring. This is the intended fix. Same-run re-acquire, sandbox reuse, and workspace-less leases are unchanged.
- **Stale detection latency:** adoption keys off the holder run's heartbeat status, so a wedged-but-not-yet-terminal run still holds its lease until the watchdog marks it terminal (conservative by design).
- Low risk overall; no API or UI surface changes.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking + tool use / local code execution (ran the vitest suite and typecheck locally).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (tightly-scoped concurrency bug fix)
- [x] I have searched GitHub for duplicate or related PRs and linked them above (searched `lease workspace` / `single-flight lease` / `concurrent workspace branch`; none found)
- [x] I have either (a) linked existing issues OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will be evaluated by CI on this PR)
- [ ] Greptile is 5/5 with no open P2s (will be evaluated on this PR; I will address comments)
- [x] I will address all Greptile and reviewer comments before requesting merge

