### PR TITLE
[codex] Fix blocker release wakes after workspace reuse

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -482,6 +482,7 @@ V1 non-terminal liveness rule:
 - agent-owned `todo`, `in_progress`, `in_review`, and `blocked` issues must have a live execution path, an explicit waiting path, or an explicit recovery path
 - `in_review` is healthy only when a typed execution participant, pending issue-thread interaction or approval, user owner, active run, queued wake, or explicit recovery action owns the next action
 - a blocked chain is covered only when each unresolved leaf issue is live or explicitly waiting
+- blocker edges release from the blocker issue's own `done` state and required terminal finalization evidence, not from the latest operation recorded on a reused execution workspace
 - when Paperclip cannot safely infer the next action, it surfaces the problem through visible blocked/recovery work instead of silently completing or reassigning work
 - explicit recovery actions are the liveness primitive; source-scoped actions are the default form, issue-backed recovery is a fallback for independent repair work or safety boundaries, and comments alone are evidence rather than a healthy liveness path
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -152,6 +152,20 @@ Blocked issues should stay idle while blockers remain unresolved. Paperclip shou
 
 If a parent is truly waiting on a child, model that with blockers. Do not rely on the parent/child relationship alone.
 
+#### Blocker release and finalization
+
+A blocker edge is released by the blocker issue's own completion state and required finalization evidence.
+
+For dependency purposes, the resolved fact is about the blocker issue itself:
+
+- the blocker issue is `done`
+- the blocker issue has completed any required terminal finalization for that status, such as durable status/activity persistence and any required post-run disposition evidence
+- every unresolved blocker leaf in the chain satisfies the same issue-local completion contract
+
+The resolved fact is not derived from the latest operation on a reused execution workspace. A later workspace operation may prove that a specific queued wake cannot be delivered coherently, but it must not make an already-completed blocker look unresolved again. Workspace coherence failures belong to adapter delivery and liveness recovery; they should repair, retry once where safe, or surface an explicit recovery action for the dependent issue instead of cancelling the dependent run as dependency-blocked.
+
+`cancelled` blockers are terminal but not dependency completion. If a cancelled issue should no longer block downstream work, the blocker edge must be explicitly removed or replaced with the real remaining dependency.
+
 ## 7. Accepted-Plan Decomposition
 
 An accepted plan confirmation is permission to decompose one specific accepted plan revision into child issues.

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -551,12 +551,16 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
 
     finishReleaseRun();
     await waitForCondition(async () => {
-      const run = await db
-        .select({ status: heartbeatRuns.status })
+      const row = await db
+        .select({
+          runStatus: heartbeatRuns.status,
+          wakeStatus: agentWakeupRequests.status,
+        })
         .from(heartbeatRuns)
+        .leftJoin(agentWakeupRequests, eq(agentWakeupRequests.id, heartbeatRuns.wakeupRequestId))
         .where(eq(heartbeatRuns.id, releasedWake!.id))
         .then((rows) => rows[0] ?? null);
-      return run?.status === "succeeded";
+      return row?.runStatus === "succeeded" && row.wakeStatus === "completed";
     });
 
     const blockerReleaseRunCount = await db

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -399,6 +399,188 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     expect(noActiveRuns).toBe(true);
   });
 
+  it("does not let skipped blocker-resolved wakes suppress the released barrier and dedupes repeats", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const firstBlockerId = randomUUID();
+    const secondBlockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: firstBlockerId,
+        companyId,
+        title: "First blocker",
+        status: "done",
+        priority: "high",
+      },
+      {
+        id: secondBlockerId,
+        companyId,
+        title: "Second blocker",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Dependent work",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values([
+      {
+        companyId,
+        issueId: firstBlockerId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      },
+      {
+        companyId,
+        issueId: secondBlockerId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      },
+    ]);
+
+    const barrierIds = [firstBlockerId, secondBlockerId];
+    const sortedBarrierIds = [...barrierIds].sort();
+    const releaseKey = `issue_blockers_resolved:${blockedIssueId}:${sortedBarrierIds.join(",")}`;
+    const prematureWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: blockedIssueId, resolvedBlockerIssueId: firstBlockerId, blockerIssueIds: barrierIds },
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        wakeReason: "issue_blockers_resolved",
+        resolvedBlockerIssueId: firstBlockerId,
+        blockerIssueIds: barrierIds,
+      },
+    });
+    expect(prematureWake).toBeNull();
+
+    const skippedWake = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(sql`${agentWakeupRequests.payload} ->> 'issueId' = ${blockedIssueId}`)
+      .then((rows) => rows[0] ?? null);
+    expect(skippedWake).toMatchObject({
+      status: "skipped",
+      reason: "issue_dependencies_blocked",
+      idempotencyKey: releaseKey,
+    });
+
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: new Date() })
+      .where(eq(issues.id, secondBlockerId));
+
+    let finishReleaseRun!: () => void;
+    const releaseRunFinished = new Promise<void>((resolve) => {
+      finishReleaseRun = resolve;
+    });
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await releaseRunFinished;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Released blocker barrier run complete.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const releasedWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: blockedIssueId, resolvedBlockerIssueId: secondBlockerId, blockerIssueIds: barrierIds },
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        wakeReason: "issue_blockers_resolved",
+        resolvedBlockerIssueId: secondBlockerId,
+        blockerIssueIds: barrierIds,
+      },
+    });
+    expect(releasedWake).not.toBeNull();
+
+    const duplicateWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: blockedIssueId, resolvedBlockerIssueId: secondBlockerId, blockerIssueIds: barrierIds },
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        wakeReason: "issue_blockers_resolved",
+        resolvedBlockerIssueId: secondBlockerId,
+        blockerIssueIds: barrierIds,
+      },
+    });
+    expect(duplicateWake?.id ?? null).toBe(releasedWake!.id);
+
+    finishReleaseRun();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, releasedWake!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const blockerReleaseRunCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${blockedIssueId}`,
+          sql`${heartbeatRuns.contextSnapshot} ->> 'wakeReason' = 'issue_blockers_resolved'`,
+        ),
+      )
+      .then((rows) => rows[0]?.count ?? 0);
+    const releaseWakeRows = await db
+      .select({
+        status: agentWakeupRequests.status,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.idempotencyKey, releaseKey));
+
+    expect(blockerReleaseRunCount).toBe(1);
+    expect(releaseWakeRows.map((row) => row.status).sort()).toEqual(["coalesced", "completed", "skipped"]);
+  }, 30_000);
+
   it("honors maxConcurrentRuns 1 by leaving a second assignment wake queued", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2592,6 +2592,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(workspaceOperations);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -2641,6 +2642,105 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
 
     expect(blockerRelations.blocks.map((relation) => relation.id)).toEqual([blockedId]);
     expect(blockedRelations.blockedBy.map((relation) => relation.id)).toEqual([blockerId]);
+  });
+
+  it("ignores malformed cross-company blocker relations in summaries, readiness, and dependent wakes", async () => {
+    const companyA = randomUUID();
+    const companyB = randomUUID();
+    const localBlockerId = randomUUID();
+    const localBlockedId = randomUUID();
+    const foreignBlockerId = randomUUID();
+    const foreignDependentId = randomUUID();
+    const foreignAssigneeAgentId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyA,
+        name: "Paperclip A",
+        issuePrefix: `A${companyA.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: companyB,
+        name: "Paperclip B",
+        issuePrefix: `B${companyB.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    await db.insert(agents).values({
+      id: foreignAssigneeAgentId,
+      companyId: companyB,
+      name: "Foreign assignee",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values([
+      {
+        id: localBlockerId,
+        companyId: companyA,
+        title: "Local blocker",
+        status: "done",
+        priority: "medium",
+      },
+      {
+        id: localBlockedId,
+        companyId: companyA,
+        title: "Local blocked issue",
+        status: "blocked",
+        priority: "medium",
+      },
+      {
+        id: foreignBlockerId,
+        companyId: companyB,
+        title: "Foreign blocker",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: foreignDependentId,
+        companyId: companyB,
+        title: "Foreign dependent",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: foreignAssigneeAgentId,
+      },
+    ]);
+
+    await db.insert(issueRelations).values([
+      {
+        companyId: companyA,
+        issueId: foreignBlockerId,
+        relatedIssueId: localBlockedId,
+        type: "blocks",
+      },
+      {
+        companyId: companyA,
+        issueId: localBlockerId,
+        relatedIssueId: foreignDependentId,
+        type: "blocks",
+      },
+    ]);
+
+    await expect(svc.getDependencyReadiness(localBlockedId)).resolves.toMatchObject({
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      isDependencyReady: true,
+    });
+    await expect(svc.getRelationSummaries(localBlockedId)).resolves.toMatchObject({
+      blockedBy: [],
+      blocks: [],
+    });
+    await expect(svc.getRelationSummaries(localBlockerId)).resolves.toMatchObject({
+      blockedBy: [],
+      blocks: [],
+    });
+    await expect(svc.listWakeableBlockedDependents(localBlockerId)).resolves.toEqual([]);
   });
 
   it("adds terminal blockers to immediate blocked-by summaries", async () => {
@@ -2767,6 +2867,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     const projectId = randomUUID();
     const projectWorkspaceId = randomUUID();
     const executionWorkspaceId = randomUUID();
+    const blockerRunId = randomUUID();
 
     await db.insert(companies).values({
       id: companyId,
@@ -2834,6 +2935,15 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
         assigneeAgentId,
       },
     ]);
+    await db.insert(heartbeatRuns).values({
+      id: blockerRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId: blockerId, taskId: blockerId },
+    });
     await svc.update(dependentId, { blockedByIssueIds: [blockerId] });
 
     // A run touched the workspace (prepare phase) but has not yet recorded
@@ -2841,6 +2951,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.insert(workspaceOperations).values({
       companyId,
       executionWorkspaceId,
+      heartbeatRunId: blockerRunId,
       phase: "worktree_prepare",
       status: "succeeded",
       startedAt: new Date("2026-05-23T22:00:00.000Z"),
@@ -2857,6 +2968,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.insert(workspaceOperations).values({
       companyId,
       executionWorkspaceId,
+      heartbeatRunId: blockerRunId,
       phase: "workspace_finalize",
       status: "failed",
       startedAt: new Date("2026-05-23T22:05:00.000Z"),
@@ -2868,6 +2980,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.insert(workspaceOperations).values({
       companyId,
       executionWorkspaceId,
+      heartbeatRunId: blockerRunId,
       phase: "workspace_finalize",
       status: "succeeded",
       startedAt: new Date("2026-05-23T22:10:00.000Z"),
@@ -2883,6 +2996,154 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
       isDependencyReady: true,
       pendingFinalizeBlockerIssueIds: [],
+    });
+  });
+
+  it("keeps a reused-workspace blocker ready when a later sibling operation is unfinalized", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const blockerRunId = randomUUID();
+    const siblingRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "QA",
+      role: "qa",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared workspace project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Shared workspace",
+      sourceType: "local_path",
+      visibility: "default",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Shared exec workspace",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    const blockerId = randomUUID();
+    const siblingId = randomUUID();
+    const dependentId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        projectId,
+        title: "Completed blocker",
+        status: "done",
+        priority: "medium",
+        executionWorkspaceId,
+      },
+      {
+        id: siblingId,
+        companyId,
+        projectId,
+        title: "Later sibling",
+        status: "in_progress",
+        priority: "medium",
+        executionWorkspaceId,
+        assigneeAgentId,
+      },
+      {
+        id: dependentId,
+        companyId,
+        projectId,
+        title: "Dependent",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId,
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: blockerRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "succeeded",
+        contextSnapshot: { issueId: blockerId, taskId: blockerId },
+      },
+      {
+        id: siblingRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: { issueId: siblingId, taskId: siblingId },
+      },
+    ]);
+    await db.insert(workspaceOperations).values([
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: blockerRunId,
+        phase: "worktree_prepare",
+        status: "succeeded",
+        startedAt: new Date("2026-05-23T22:00:00.000Z"),
+      },
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: blockerRunId,
+        phase: "workspace_finalize",
+        status: "succeeded",
+        startedAt: new Date("2026-05-23T22:10:00.000Z"),
+      },
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: siblingRunId,
+        phase: "worktree_prepare",
+        status: "succeeded",
+        startedAt: new Date("2026-05-23T22:15:00.000Z"),
+      },
+    ]);
+    await svc.update(dependentId, { blockedByIssueIds: [blockerId] });
+
+    await expect(svc.listWakeableBlockedDependents(blockerId)).resolves.toEqual([
+      expect.objectContaining({
+        id: dependentId,
+        assigneeAgentId,
+        blockerIssueIds: [blockerId],
+      }),
+    ]);
+    await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
     });
   });
 
@@ -3121,11 +3382,11 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     expect(await svc.getWakeableParentAfterChildCompletion(parentId)).toMatchObject({
       id: parentId,
       assigneeAgentId,
-      childIssueIds: [childA, childB],
-      childIssueSummaries: [
+      childIssueIds: expect.arrayContaining([childA, childB]),
+      childIssueSummaries: expect.arrayContaining([
         expect.objectContaining({ id: childA, title: "Child A", status: "done" }),
         expect.objectContaining({ id: childB, title: "Child B", status: "cancelled" }),
-      ],
+      ]),
       childIssueSummaryTruncated: false,
     });
   });
@@ -3472,6 +3733,79 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     expect(followUp.executionWorkspacePreference).toBe("reuse_existing");
     expect(followUp.executionWorkspaceSettings).toEqual({
       mode: "operator_branch",
+    });
+  });
+
+  it("rejects cross-company workspace inheritance sources", async () => {
+    const companyA = randomUUID();
+    const companyB = randomUUID();
+    const projectId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyA,
+        name: "Paperclip A",
+        issuePrefix: `A${companyA.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: companyB,
+        name: "Paperclip B",
+        issuePrefix: `B${companyB.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId: companyB,
+      name: "Foreign workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId: companyB,
+      projectId,
+      name: "Foreign workspace",
+    });
+
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId: companyB,
+      projectId,
+      projectWorkspaceId,
+      mode: "operator_branch",
+      strategyType: "git_worktree",
+      name: "Foreign operator branch",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId: companyB,
+      projectId,
+      projectWorkspaceId,
+      title: "Foreign source issue",
+      status: "todo",
+      priority: "medium",
+      executionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: {
+        mode: "operator_branch",
+      },
+    });
+
+    await expect(svc.create(companyA, {
+      title: "Cross-company inheritance should fail",
+      inheritExecutionWorkspaceFromIssueId: sourceIssueId,
+    })).rejects.toMatchObject({
+      status: 404,
     });
   });
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3103,6 +3103,139 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 
+  it("keeps a legacy blocker finalize barrier when a later sibling has run-attributed workspace ops", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const siblingRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "QA",
+      role: "qa",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared workspace project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Shared workspace",
+      sourceType: "local_path",
+      visibility: "default",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Shared exec workspace",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    const blockerId = randomUUID();
+    const siblingId = randomUUID();
+    const dependentId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        projectId,
+        title: "Legacy predecessor",
+        status: "done",
+        priority: "medium",
+        executionWorkspaceId,
+      },
+      {
+        id: siblingId,
+        companyId,
+        projectId,
+        title: "Later sibling",
+        status: "in_progress",
+        priority: "medium",
+        executionWorkspaceId,
+      },
+      {
+        id: dependentId,
+        companyId,
+        projectId,
+        title: "Dependent",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId,
+      },
+    ]);
+    await db.insert(heartbeatRuns).values({
+      id: siblingRunId,
+      companyId,
+      agentId: assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: { issueId: siblingId, taskId: siblingId },
+    });
+    await db.insert(workspaceOperations).values([
+      {
+        companyId,
+        executionWorkspaceId,
+        phase: "worktree_prepare",
+        status: "succeeded",
+        startedAt: new Date("2026-05-23T22:00:00.000Z"),
+      },
+      {
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: siblingRunId,
+        phase: "worktree_prepare",
+        status: "succeeded",
+        startedAt: new Date("2026-05-23T22:15:00.000Z"),
+      },
+    ]);
+    await svc.update(dependentId, { blockedByIssueIds: [blockerId] });
+
+    await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
+      isDependencyReady: false,
+      pendingFinalizeBlockerIssueIds: [blockerId],
+      unresolvedBlockerIssueIds: [blockerId],
+    });
+
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      phase: "workspace_finalize",
+      status: "succeeded",
+      startedAt: new Date("2026-05-23T22:20:00.000Z"),
+    });
+
+    await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+    });
+  });
+
   it("keeps a reused-workspace blocker ready when a later sibling operation is unfinalized", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2999,6 +2999,110 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 
+  it("keeps the workspace-finalize barrier for legacy operations without heartbeatRunId", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "QA",
+      role: "qa",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Shared workspace project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Shared workspace",
+      sourceType: "local_path",
+      visibility: "default",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Shared exec workspace",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    const blockerId = randomUUID();
+    const dependentId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        projectId,
+        title: "Legacy predecessor",
+        status: "done",
+        priority: "medium",
+        executionWorkspaceId,
+      },
+      {
+        id: dependentId,
+        companyId,
+        projectId,
+        title: "Dependent",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId,
+      },
+    ]);
+    await svc.update(dependentId, { blockedByIssueIds: [blockerId] });
+
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      phase: "worktree_prepare",
+      status: "succeeded",
+      startedAt: new Date("2026-05-23T22:00:00.000Z"),
+    });
+
+    await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
+      isDependencyReady: false,
+      pendingFinalizeBlockerIssueIds: [blockerId],
+      unresolvedBlockerIssueIds: [blockerId],
+    });
+
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      phase: "workspace_finalize",
+      status: "succeeded",
+      startedAt: new Date("2026-05-23T22:10:00.000Z"),
+    });
+
+    await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+    });
+  });
+
   it("keeps a reused-workspace blocker ready when a later sibling operation is unfinalized", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10407,12 +10407,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return { kind: "skipped" as const, dependencyGate: true as const };
         }
 
-        if (!activeExecutionRun && reason === BLOCKER_RELEASE_WAKE_REASON && effectiveIdempotencyKey) {
+        if (reason === BLOCKER_RELEASE_WAKE_REASON && effectiveIdempotencyKey) {
           const existingReleaseWake = await findExistingBlockerReleaseWake(tx, {
             companyId: issue.companyId,
             idempotencyKey: effectiveIdempotencyKey,
           });
           if (existingReleaseWake) {
+            const existingReleaseRun = existingReleaseWake.runId
+              ? await tx
+                .select()
+                .from(heartbeatRuns)
+                .where(eq(heartbeatRuns.id, existingReleaseWake.runId))
+                .then((rows) => rows[0] ?? null)
+              : null;
             await tx.insert(agentWakeupRequests).values({
               companyId: agent.companyId,
               agentId,
@@ -10435,7 +10442,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 updatedAt: new Date(),
               })
               .where(eq(agentWakeupRequests.id, existingReleaseWake.id));
-            return { kind: "duplicate" as const };
+            return existingReleaseRun
+              ? { kind: "existing" as const, run: existingReleaseRun }
+              : { kind: "duplicate" as const };
           }
         }
 
@@ -10601,6 +10610,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       if (outcome.kind === "deferred" || outcome.kind === "duplicate") return null;
+      if (outcome.kind === "existing") return outcome.run;
       if (outcome.kind === "skipped") {
         if ("dependencyGate" in outcome && outcome.dependencyGate && reason === BLOCKER_RELEASE_WAKE_REASON) {
           await requeueBlockerReleaseWakeIfDependencyGateCleared({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10612,7 +10612,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (outcome.kind === "deferred" || outcome.kind === "duplicate") return null;
       if (outcome.kind === "existing") return outcome.run;
       if (outcome.kind === "skipped") {
-        if ("dependencyGate" in outcome && outcome.dependencyGate && reason === BLOCKER_RELEASE_WAKE_REASON) {
+        if ("dependencyGate" in outcome && outcome.dependencyGate && reason === BLOCKER_RELEASE_WAKE_REASON && issueId) {
           await requeueBlockerReleaseWakeIfDependencyGateCleared({
             companyId: agent.companyId,
             agentId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1376,6 +1376,92 @@ interface WakeupOptions {
   contextSnapshot?: Record<string, unknown>;
 }
 
+const BLOCKER_RELEASE_WAKE_REASON = "issue_blockers_resolved";
+const BLOCKER_RELEASE_IDEMPOTENT_WAKE_STATUSES = [
+  "queued",
+  "deferred_issue_execution",
+  "claimed",
+  "coalesced",
+  "completed",
+];
+
+function normalizeBlockerReleaseIds(value: unknown) {
+  return Array.isArray(value)
+    ? [...new Set(value.filter((item): item is string => typeof item === "string" && item.trim().length > 0))]
+      .sort()
+    : [];
+}
+
+function buildBlockerReleaseIdempotencyKey(input: {
+  issueId: string;
+  blockerIssueIds: string[];
+}) {
+  const blockerFingerprint = input.blockerIssueIds.length > 0 ? input.blockerIssueIds.join(",") : "no-blockers";
+  return `${BLOCKER_RELEASE_WAKE_REASON}:${input.issueId}:${blockerFingerprint}`;
+}
+
+async function listIssueBlockerIdsForReleaseFingerprint(
+  dbOrTx: Pick<Db, "select">,
+  companyId: string,
+  issueId: string,
+) {
+  const rows = await dbOrTx
+    .select({ id: issueRelations.issueId })
+    .from(issueRelations)
+    .where(
+      and(
+        eq(issueRelations.companyId, companyId),
+        eq(issueRelations.relatedIssueId, issueId),
+        eq(issueRelations.type, "blocks"),
+      ),
+    );
+  return normalizeBlockerReleaseIds(rows.map((row) => row.id));
+}
+
+async function resolveBlockerReleaseIdempotencyKey(input: {
+  dbOrTx: Pick<Db, "select">;
+  companyId: string;
+  issueId: string;
+  payload: Record<string, unknown> | null;
+  contextSnapshot: Record<string, unknown>;
+}) {
+  const payloadBlockerIds = normalizeBlockerReleaseIds(input.payload?.blockerIssueIds);
+  const contextBlockerIds = normalizeBlockerReleaseIds(input.contextSnapshot.blockerIssueIds);
+  const blockerIssueIds = contextBlockerIds.length > 0
+    ? contextBlockerIds
+    : payloadBlockerIds.length > 0
+      ? payloadBlockerIds
+      : await listIssueBlockerIdsForReleaseFingerprint(input.dbOrTx, input.companyId, input.issueId);
+  return buildBlockerReleaseIdempotencyKey({ issueId: input.issueId, blockerIssueIds });
+}
+
+async function findExistingBlockerReleaseWake(
+  dbOrTx: Pick<Db, "select">,
+  input: {
+    companyId: string;
+    idempotencyKey: string;
+  },
+) {
+  return dbOrTx
+    .select({
+      id: agentWakeupRequests.id,
+      runId: agentWakeupRequests.runId,
+      status: agentWakeupRequests.status,
+      coalescedCount: agentWakeupRequests.coalescedCount,
+    })
+    .from(agentWakeupRequests)
+    .where(
+      and(
+        eq(agentWakeupRequests.companyId, input.companyId),
+        eq(agentWakeupRequests.idempotencyKey, input.idempotencyKey),
+        inArray(agentWakeupRequests.status, BLOCKER_RELEASE_IDEMPOTENT_WAKE_STATUSES),
+      ),
+    )
+    .orderBy(asc(agentWakeupRequests.requestedAt), asc(agentWakeupRequests.id))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
 type UsageTotals = {
   inputTokens: number;
   cachedInputTokens: number;
@@ -6833,7 +6919,89 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
+    if (readNonEmptyString(parseObject(cancelled.contextSnapshot).wakeReason) === BLOCKER_RELEASE_WAKE_REASON) {
+      await requeueBlockerReleaseWakeIfDependencyGateCleared({
+        companyId: cancelled.companyId,
+        agentId: cancelled.agentId,
+        issueId,
+        contextSnapshot: parseObject(cancelled.contextSnapshot),
+        payload: {
+          issueId,
+          unresolvedBlockerIssueIds,
+          cancelledDependencyGateRunId: cancelled.id,
+        },
+        sourceRun: cancelled,
+      });
+    }
+
     return cancelled;
+  }
+
+  async function requeueBlockerReleaseWakeIfDependencyGateCleared(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    contextSnapshot: Record<string, unknown>;
+    payload: Record<string, unknown> | null;
+    sourceRun?: typeof heartbeatRuns.$inferSelect;
+  }) {
+    const readiness = await issuesSvc
+      .listDependencyReadiness(input.companyId, [input.issueId])
+      .then((rows) => rows.get(input.issueId) ?? null);
+    if (!readiness?.isDependencyReady || readiness.blockerIssueIds.length === 0) return null;
+
+    const contextSnapshot = {
+      ...input.contextSnapshot,
+      issueId: input.issueId,
+      taskId: input.issueId,
+      wakeReason: BLOCKER_RELEASE_WAKE_REASON,
+      source: "issue.dependencies_gate_requeue",
+      blockerIssueIds: readiness.blockerIssueIds,
+      ...(input.sourceRun ? { requeuedAfterDependencyGateRunId: input.sourceRun.id } : {}),
+    };
+    const payload = {
+      ...(input.payload ?? {}),
+      issueId: input.issueId,
+      blockerIssueIds: readiness.blockerIssueIds,
+      ...(input.sourceRun ? { requeuedAfterDependencyGateRunId: input.sourceRun.id } : {}),
+    };
+    const idempotencyKey = await resolveBlockerReleaseIdempotencyKey({
+      dbOrTx: db,
+      companyId: input.companyId,
+      issueId: input.issueId,
+      payload,
+      contextSnapshot,
+    });
+    const existingWake = await findExistingBlockerReleaseWake(db, {
+      companyId: input.companyId,
+      idempotencyKey,
+    });
+    if (existingWake) return null;
+
+    if (input.sourceRun) {
+      await appendRunEvent(input.sourceRun, await nextRunEventSeq(input.sourceRun.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: "Requeued blocker-resolved wake because the dependency gate cleared after cancellation",
+        payload: {
+          issueId: input.issueId,
+          blockerIssueIds: readiness.blockerIssueIds,
+          idempotencyKey,
+        },
+      });
+    }
+
+    return enqueueWakeup(input.agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: BLOCKER_RELEASE_WAKE_REASON,
+      payload,
+      contextSnapshot,
+      idempotencyKey,
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat",
+    });
   }
 
   type QueuedRunStaleness =
@@ -9800,6 +9968,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       payload,
     });
     let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+    let effectiveIdempotencyKey = opts.idempotencyKey ?? null;
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
@@ -9818,7 +9987,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: "skipped",
         requestedByActorType: opts.requestedByActorType ?? null,
         requestedByActorId: opts.requestedByActorId ?? null,
-        idempotencyKey: opts.idempotencyKey ?? null,
+        idempotencyKey: effectiveIdempotencyKey,
         finishedAt: new Date(),
         ...patch,
       });
@@ -9896,6 +10065,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // project workspace even when context.projectId wasn't set by the caller.
     if (projectId && !readNonEmptyString(enrichedContextSnapshot.projectId)) {
       enrichedContextSnapshot.projectId = projectId;
+    }
+
+    if (reason === BLOCKER_RELEASE_WAKE_REASON && issueId && !effectiveIdempotencyKey) {
+      effectiveIdempotencyKey = await resolveBlockerReleaseIdempotencyKey({
+        dbOrTx: db,
+        companyId: agent.companyId,
+        issueId,
+        payload,
+        contextSnapshot: enrichedContextSnapshot,
+      });
+      enrichedContextSnapshot.blockerReleaseFingerprint = effectiveIdempotencyKey;
     }
 
     const budgetBlock = await budgets.getInvocationBlock(agent.companyId, agentId, {
@@ -10018,7 +10198,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
+            idempotencyKey: effectiveIdempotencyKey,
             finishedAt: new Date(),
           });
           return { kind: "skipped" as const };
@@ -10221,10 +10401,42 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
+            idempotencyKey: effectiveIdempotencyKey,
             finishedAt: new Date(),
           });
-          return { kind: "skipped" as const };
+          return { kind: "skipped" as const, dependencyGate: true as const };
+        }
+
+        if (!activeExecutionRun && reason === BLOCKER_RELEASE_WAKE_REASON && effectiveIdempotencyKey) {
+          const existingReleaseWake = await findExistingBlockerReleaseWake(tx, {
+            companyId: issue.companyId,
+            idempotencyKey: effectiveIdempotencyKey,
+          });
+          if (existingReleaseWake) {
+            await tx.insert(agentWakeupRequests).values({
+              companyId: agent.companyId,
+              agentId,
+              source,
+              triggerDetail,
+              reason,
+              payload,
+              status: "coalesced",
+              coalescedCount: 1,
+              requestedByActorType: opts.requestedByActorType ?? null,
+              requestedByActorId: opts.requestedByActorId ?? null,
+              idempotencyKey: effectiveIdempotencyKey,
+              runId: existingReleaseWake.runId,
+              finishedAt: new Date(),
+            });
+            await tx
+              .update(agentWakeupRequests)
+              .set({
+                coalescedCount: (existingReleaseWake.coalescedCount ?? 0) + 1,
+                updatedAt: new Date(),
+              })
+              .where(eq(agentWakeupRequests.id, existingReleaseWake.id));
+            return { kind: "duplicate" as const };
+          }
         }
 
         if (activeExecutionRun) {
@@ -10269,7 +10481,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               coalescedCount: 1,
               requestedByActorType: opts.requestedByActorType ?? null,
               requestedByActorId: opts.requestedByActorId ?? null,
-              idempotencyKey: opts.idempotencyKey ?? null,
+              idempotencyKey: effectiveIdempotencyKey,
               runId: mergedRun.id,
               finishedAt: new Date(),
             });
@@ -10334,7 +10546,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             status: "deferred_issue_execution",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
+            idempotencyKey: effectiveIdempotencyKey,
           });
 
           return { kind: "deferred" as const };
@@ -10352,7 +10564,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             status: "queued",
             requestedByActorType: opts.requestedByActorType ?? null,
             requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
+            idempotencyKey: effectiveIdempotencyKey,
           })
           .returning()
           .then((rows) => rows[0]);
@@ -10388,7 +10600,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "queued" as const, run: newRun };
       });
 
-      if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
+      if (outcome.kind === "deferred" || outcome.kind === "duplicate") return null;
+      if (outcome.kind === "skipped") {
+        if ("dependencyGate" in outcome && outcome.dependencyGate && reason === BLOCKER_RELEASE_WAKE_REASON) {
+          await requeueBlockerReleaseWakeIfDependencyGateCleared({
+            companyId: agent.companyId,
+            agentId,
+            issueId,
+            contextSnapshot: enrichedContextSnapshot,
+            payload,
+          });
+        }
+        return null;
+      }
       if (outcome.kind === "coalesced") {
         await startNextQueuedRunForAgent(agent.id);
         return outcome.run;
@@ -10462,7 +10686,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         coalescedCount: 1,
         requestedByActorType: opts.requestedByActorType ?? null,
         requestedByActorId: opts.requestedByActorId ?? null,
-        idempotencyKey: opts.idempotencyKey ?? null,
+        idempotencyKey: effectiveIdempotencyKey,
         runId: mergedRun.id,
         finishedAt: new Date(),
       });
@@ -10481,7 +10705,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: "queued",
         requestedByActorType: opts.requestedByActorType ?? null,
         requestedByActorId: opts.requestedByActorId ?? null,
-        idempotencyKey: opts.idempotencyKey ?? null,
+        idempotencyKey: effectiveIdempotencyKey,
       })
       .returning()
       .then((rows) => rows[0]);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -655,6 +655,77 @@ export async function listUnfinalizedExecutionWorkspaceIds(
   return unfinalized;
 }
 
+type DoneBlockerFinalizeTarget = {
+  blockerIssueId: string;
+  executionWorkspaceId: string | null;
+};
+
+async function listPendingFinalizeBlockerIssueIds(
+  dbOrTx: Pick<Db, "select">,
+  companyId: string,
+  blockers: DoneBlockerFinalizeTarget[],
+): Promise<Set<string>> {
+  const targets = blockers.filter((blocker) => blocker.executionWorkspaceId);
+  const pending = new Set<string>();
+  if (targets.length === 0) return pending;
+
+  const blockerIdsByWorkspaceId = new Map<string, Set<string>>();
+  for (const target of targets) {
+    if (!target.executionWorkspaceId) continue;
+    const blockerIds = blockerIdsByWorkspaceId.get(target.executionWorkspaceId) ?? new Set<string>();
+    blockerIds.add(target.blockerIssueId);
+    blockerIdsByWorkspaceId.set(target.executionWorkspaceId, blockerIds);
+  }
+
+  const rows = await dbOrTx
+    .select({
+      executionWorkspaceId: workspaceOperations.executionWorkspaceId,
+      phase: workspaceOperations.phase,
+      status: workspaceOperations.status,
+      startedAt: workspaceOperations.startedAt,
+      contextIssueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`,
+      contextTaskId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskId'`,
+    })
+    .from(workspaceOperations)
+    .leftJoin(heartbeatRuns, eq(workspaceOperations.heartbeatRunId, heartbeatRuns.id))
+    .where(
+      and(
+        eq(workspaceOperations.companyId, companyId),
+        inArray(workspaceOperations.executionWorkspaceId, [...blockerIdsByWorkspaceId.keys()]),
+      ),
+    );
+
+  const latestByBlockerIssueId = new Map<string, { phase: string; status: string; startedAt: Date }>();
+  for (const row of rows) {
+    if (!row.executionWorkspaceId) continue;
+    const blockerIds = blockerIdsByWorkspaceId.get(row.executionWorkspaceId);
+    if (!blockerIds) continue;
+    const runIssueIds = [row.contextIssueId, row.contextTaskId].filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    );
+    for (const blockerIssueId of runIssueIds) {
+      if (!blockerIds.has(blockerIssueId)) continue;
+      const current = latestByBlockerIssueId.get(blockerIssueId);
+      if (!current || row.startedAt > current.startedAt) {
+        latestByBlockerIssueId.set(blockerIssueId, {
+          phase: row.phase,
+          status: row.status,
+          startedAt: row.startedAt,
+        });
+      }
+    }
+  }
+
+  for (const target of targets) {
+    const latest = latestByBlockerIssueId.get(target.blockerIssueId);
+    if (!latest) continue; // no blocker-specific workspace ops recorded -> no finalize barrier
+    if (latest.phase === "workspace_finalize" && latest.status === "succeeded") continue;
+    pending.add(target.blockerIssueId);
+  }
+
+  return pending;
+}
+
 async function listIssueDependencyReadinessMap(
   dbOrTx: Pick<Db, "select">,
   companyId: string,
@@ -680,23 +751,28 @@ async function listIssueDependencyReadinessMap(
       and(
         eq(issueRelations.companyId, companyId),
         eq(issueRelations.type, "blocks"),
+        eq(issues.companyId, companyId),
         inArray(issueRelations.relatedIssueId, uniqueIssueIds),
       ),
     );
 
-  // Collect executionWorkspaceIds of "done" blockers — these are the only ones
-  // subject to the workspace-finalize barrier. Blockers that aren't done already
-  // mark the dependent as not-ready and don't need a finalize check.
-  const doneBlockerWorkspaceIds = new Set<string>();
+  // Collect "done" blockers with execution workspaces — these are the only ones
+  // subject to the workspace-finalize barrier. The barrier is blocker-specific:
+  // a later sibling can reuse the same workspace without making this already-done
+  // blocker unresolved again.
+  const doneBlockers: DoneBlockerFinalizeTarget[] = [];
   for (const row of blockerRows) {
     if (row.blockerStatus === "done" && row.blockerExecutionWorkspaceId) {
-      doneBlockerWorkspaceIds.add(row.blockerExecutionWorkspaceId);
+      doneBlockers.push({
+        blockerIssueId: row.blockerIssueId,
+        executionWorkspaceId: row.blockerExecutionWorkspaceId,
+      });
     }
   }
-  const unfinalizedWorkspaceIds = await listUnfinalizedExecutionWorkspaceIds(
+  const pendingFinalizeBlockerIssueIds = await listPendingFinalizeBlockerIssueIds(
     dbOrTx,
     companyId,
-    [...doneBlockerWorkspaceIds],
+    doneBlockers,
   );
 
   for (const row of blockerRows) {
@@ -711,9 +787,9 @@ async function listIssueDependencyReadinessMap(
       current.isDependencyReady = false;
     } else if (
       row.blockerExecutionWorkspaceId &&
-      unfinalizedWorkspaceIds.has(row.blockerExecutionWorkspaceId)
+      pendingFinalizeBlockerIssueIds.has(row.blockerIssueId)
     ) {
-      // Workspace-finalize barrier: the blocker's most recent run on its
+      // Workspace-finalize barrier: the blocker's own most recent run on its
       // execution workspace hasn't recorded a successful workspace_finalize.
       // Treat the dependent as not-ready until sync-back lands (or the run
       // finalizes); a subsequent finalize wake will re-evaluate readiness.
@@ -2145,6 +2221,7 @@ async function blockedByMapForIssues(
         and(
           eq(issueRelations.companyId, companyId),
           eq(issueRelations.type, "blocks"),
+          eq(issues.companyId, companyId),
           inArray(issueRelations.relatedIssueId, issueIdChunk),
         ),
       );
@@ -3525,6 +3602,7 @@ export function issueService(db: Db) {
           and(
             eq(issueRelations.companyId, companyId),
             eq(issueRelations.type, "blocks"),
+            eq(issues.companyId, companyId),
             inArray(issueRelations.relatedIssueId, uniqueIssueIds),
           ),
         ),
@@ -3545,6 +3623,7 @@ export function issueService(db: Db) {
           and(
             eq(issueRelations.companyId, companyId),
             eq(issueRelations.type, "blocks"),
+            eq(issues.companyId, companyId),
             inArray(issueRelations.issueId, uniqueIssueIds),
           ),
         ),
@@ -4256,6 +4335,7 @@ export function issueService(db: Db) {
             eq(issueRelations.companyId, blockerIssue.companyId),
             eq(issueRelations.type, "blocks"),
             eq(issueRelations.issueId, blockerIssueId),
+            eq(issues.companyId, blockerIssue.companyId),
           ),
         );
       if (candidates.length === 0) return [];

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -697,7 +697,6 @@ async function listPendingFinalizeBlockerIssueIds(
 
   const latestByBlockerIssueId = new Map<string, { phase: string; status: string; startedAt: Date }>();
   const latestLegacyByWorkspaceId = new Map<string, { phase: string; status: string; startedAt: Date }>();
-  const workspacesWithRunAttributedOps = new Set<string>();
   for (const row of rows) {
     if (!row.executionWorkspaceId) continue;
     const blockerIds = blockerIdsByWorkspaceId.get(row.executionWorkspaceId);
@@ -716,7 +715,6 @@ async function listPendingFinalizeBlockerIssueIds(
       }
       continue;
     }
-    workspacesWithRunAttributedOps.add(row.executionWorkspaceId);
     for (const blockerIssueId of runIssueIds) {
       if (!blockerIds.has(blockerIssueId)) continue;
       const current = latestByBlockerIssueId.get(blockerIssueId);
@@ -733,9 +731,7 @@ async function listPendingFinalizeBlockerIssueIds(
   for (const target of targets) {
     const workspaceId = target.executionWorkspaceId;
     const latest = latestByBlockerIssueId.get(target.blockerIssueId) ??
-      (workspaceId && !workspacesWithRunAttributedOps.has(workspaceId)
-        ? latestLegacyByWorkspaceId.get(workspaceId)
-        : null);
+      (workspaceId ? latestLegacyByWorkspaceId.get(workspaceId) : null);
     if (!latest) continue; // no blocker-specific workspace ops recorded -> no finalize barrier
     if (latest.phase === "workspace_finalize" && latest.status === "succeeded") continue;
     pending.add(target.blockerIssueId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -696,6 +696,8 @@ async function listPendingFinalizeBlockerIssueIds(
     );
 
   const latestByBlockerIssueId = new Map<string, { phase: string; status: string; startedAt: Date }>();
+  const latestLegacyByWorkspaceId = new Map<string, { phase: string; status: string; startedAt: Date }>();
+  const workspacesWithRunAttributedOps = new Set<string>();
   for (const row of rows) {
     if (!row.executionWorkspaceId) continue;
     const blockerIds = blockerIdsByWorkspaceId.get(row.executionWorkspaceId);
@@ -703,6 +705,18 @@ async function listPendingFinalizeBlockerIssueIds(
     const runIssueIds = [row.contextIssueId, row.contextTaskId].filter(
       (value): value is string => typeof value === "string" && value.length > 0,
     );
+    if (runIssueIds.length === 0) {
+      const current = latestLegacyByWorkspaceId.get(row.executionWorkspaceId);
+      if (!current || row.startedAt > current.startedAt) {
+        latestLegacyByWorkspaceId.set(row.executionWorkspaceId, {
+          phase: row.phase,
+          status: row.status,
+          startedAt: row.startedAt,
+        });
+      }
+      continue;
+    }
+    workspacesWithRunAttributedOps.add(row.executionWorkspaceId);
     for (const blockerIssueId of runIssueIds) {
       if (!blockerIds.has(blockerIssueId)) continue;
       const current = latestByBlockerIssueId.get(blockerIssueId);
@@ -717,7 +731,11 @@ async function listPendingFinalizeBlockerIssueIds(
   }
 
   for (const target of targets) {
-    const latest = latestByBlockerIssueId.get(target.blockerIssueId);
+    const workspaceId = target.executionWorkspaceId;
+    const latest = latestByBlockerIssueId.get(target.blockerIssueId) ??
+      (workspaceId && !workspacesWithRunAttributedOps.has(workspaceId)
+        ? latestLegacyByWorkspaceId.get(workspaceId)
+        : null);
     if (!latest) continue; // no blocker-specific workspace ops recorded -> no finalize barrier
     if (latest.phase === "workspace_finalize" && latest.status === "succeeded") continue;
     pending.add(target.blockerIssueId);

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -223,6 +223,43 @@ describe("IssueBlockedNotice", () => {
     expect(node.textContent).toBe("");
   });
 
+  it("renders live-next-step copy for blocked issues needing attention with no unresolved blockers", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "attention_required",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+
+    expect(node.textContent).toContain("This task is blocked but the system has no live next step.");
+    expect(node.textContent).toContain("Earlier blockers resolved, and no recovery path or scheduled retry is active.");
+    expect(node.textContent).not.toContain("Work on this task is blocked until it is moved back to todo.");
+    expect(node.querySelector('[data-blocker-attention-state="needs_attention_no_blockers"]')).not.toBeNull();
+  });
+
+  it("keeps the moved-back-to-todo fallback for manually parked blocked issues", () => {
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        blockerAttention={null}
+      />,
+    );
+
+    expect(node.textContent).toContain("Work on this task is blocked until it is moved back to todo.");
+    expect(node.textContent).not.toContain("This task is blocked but the system has no live next step.");
+  });
+
   it("renders a recovery indicator on a blocker chip when the blocker has an active recovery action", () => {
     const node = render(
       <IssueBlockedNotice

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -157,6 +157,8 @@ export function IssueBlockedNotice({
     return collected;
   })();
   const showParkedRow = parkedBlockers.length > 0;
+  const showNeedsAttentionNoBlockers =
+    blockerAttention?.state === "needs_attention" && blockers.length === 0 && issueStatus === "blocked";
   const stalledLeafIdentifier =
     blockerAttention?.sampleStalledBlockerIdentifier ?? blockerAttention?.sampleBlockerIdentifier ?? null;
   const stalledLeafBlockers = (() => {
@@ -199,7 +201,9 @@ export function IssueBlockedNotice({
 
   return (
     <div
-      data-blocker-attention-state={blockerAttention?.state}
+      data-blocker-attention-state={
+        showNeedsAttentionNoBlockers ? "needs_attention_no_blockers" : blockerAttention?.state
+      }
       data-successful-run-handoff={showSuccessfulRunHandoff ? "required" : undefined}
       className="mb-3 rounded-md border border-amber-300/70 bg-amber-50/90 px-3 py-2.5 text-sm text-amber-950 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100"
     >
@@ -257,15 +261,37 @@ export function IssueBlockedNotice({
           ) : null}
           {blockers.length > 0 || issueStatus === "blocked" ? (
             <>
-              <p className="leading-5">
-                {blockers.length > 0
-                  ? isStalled
-                    ? stalledLeafBlockers.length > 1
-                      ? <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled reviews below or remove them as blockers.</>
-                      : <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled review below or remove it as a blocker.</>
-                    : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still wake the assignee for questions or triage.</>
-                  : <>Work on this task is blocked until it is moved back to todo. Comments still wake the assignee for questions or triage.</>}
-              </p>
+              {showNeedsAttentionNoBlockers ? (
+                <>
+                  <p className="font-medium leading-5">
+                    This task is blocked but the system has no live next step.
+                  </p>
+                  <p className="leading-5">
+                    Earlier blockers resolved, and no recovery path or scheduled retry is active. The assignee
+                    needs to either move it back to{" "}
+                    <code className="rounded bg-amber-100 px-1 py-0.5 text-[12px] dark:bg-amber-400/15">
+                      todo
+                    </code>{" "}
+                    so a fresh run is queued, or add a real blocker if work genuinely can't proceed.
+                  </p>
+                  {blockerAttention.coveredBlockerCount > 0 ? (
+                    <p className="text-xs leading-5 text-amber-800 dark:text-amber-200">
+                      Some ancestor blockers are still covered by active work — see the "Ultimately waiting on" row
+                      below.
+                    </p>
+                  ) : null}
+                </>
+              ) : (
+                <p className="leading-5">
+                  {blockers.length > 0
+                    ? isStalled
+                      ? stalledLeafBlockers.length > 1
+                        ? <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled reviews below or remove them as blockers.</>
+                        : <>Work on this task is blocked by {blockerLabel}, but the chain is stalled in review without a clear next step. Resolve the stalled review below or remove it as a blocker.</>
+                      : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still wake the assignee for questions or triage.</>
+                    : <>Work on this task is blocked until it is moved back to todo. Comments still wake the assignee for questions or triage.</>}
+                </p>
+              )}
               {blockers.length > 0 ? (
                 <div className="flex flex-wrap gap-1.5">
                   {blockers.map(renderBlockerChip)}

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -274,7 +274,7 @@ export function IssueBlockedNotice({
                     </code>{" "}
                     so a fresh run is queued, or add a real blocker if work genuinely can't proceed.
                   </p>
-                  {blockerAttention.coveredBlockerCount > 0 ? (
+                  {(blockerAttention?.coveredBlockerCount ?? 0) > 0 ? (
                     <p className="text-xs leading-5 text-amber-800 dark:text-amber-200">
                       Some ancestor blockers are still covered by active work — see the "Ultimately waiting on" row
                       below.

--- a/ui/src/components/StatusIcon.test.tsx
+++ b/ui/src/components/StatusIcon.test.tsx
@@ -77,6 +77,28 @@ describe("StatusIcon", () => {
     expect(html).not.toContain("border-dashed");
   });
 
+  it("labels attention-required blocked issues with no unresolved blockers as needing assignee action", () => {
+    const html = renderToStaticMarkup(
+      <StatusIcon
+        status="blocked"
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "attention_required",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+
+    expect(html).toContain('data-blocker-attention-state="needs_attention"');
+    expect(html).toContain('aria-label="Blocked · no live continuation path — assignee needs to act"');
+    expect(html).toContain("border-red-600");
+  });
+
   it("shows active covered work on mixed attention-required blockers", () => {
     const html = renderToStaticMarkup(
       <StatusIcon

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -49,6 +49,9 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
   }
 
   if (blockerAttention.reason === "attention_required") {
+    if (blockerAttention.unresolvedBlockerCount === 0) {
+      return "Blocked · no live continuation path — assignee needs to act";
+    }
     const count = blockerAttention.attentionBlockerCount || blockerAttention.unresolvedBlockerCount;
     const attentionCopy = `${count} ${count === 1 ? "blocker needs" : "blockers need"} attention`;
     const coveredCount = blockerAttention.coveredBlockerCount;

--- a/ui/storybook/stories/status-language.stories.tsx
+++ b/ui/storybook/stories/status-language.stories.tsx
@@ -176,6 +176,18 @@ const coveredBlockedMatrix: CoveredBlockedCell[] = [
     expectedCopy: "Blocked · 1 unresolved blocker needs attention",
   },
   {
+    label: "Needs attention (no unresolved blockers)",
+    status: "blocked",
+    blockerAttention: attention({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 0,
+      attentionBlockerCount: 0,
+    }),
+    expectedVisual: "solid red ring",
+    expectedCopy: "Blocked · no live continuation path — assignee needs to act",
+  },
+  {
     label: "Non-blocked with prop ignored",
     status: "in_progress",
     blockerAttention: attention({
@@ -220,7 +232,8 @@ function summaryBlocker(
 type BlockedNoticeStateLabel =
   | "Default covered"
   | "Stalled (single leaf)"
-  | "Stalled (multiple leaves)";
+  | "Stalled (multiple leaves)"
+  | "Needs attention (no blockers)";
 
 type BlockedNoticeFixture = {
   label: BlockedNoticeStateLabel;
@@ -318,6 +331,18 @@ const blockedNoticeFixtures: BlockedNoticeFixture[] = [
       sampleStalledBlockerIdentifier: "PAP-2284",
     }),
   },
+  {
+    label: "Needs attention (no blockers)",
+    caption: "Earlier blockers resolved, but no live run, recovery path, or scheduled retry remains.",
+    blockers: [],
+    blockerAttention: attention({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 0,
+      coveredBlockerCount: 0,
+      attentionBlockerCount: 0,
+    }),
+  },
 ];
 
 function BlockedNoticeSurface({
@@ -340,7 +365,7 @@ function BlockedNoticeSurface({
             {size} · {mode}
           </span>
         </div>
-        <div className={isMobile ? "max-w-[358px] px-3 py-3" : "min-w-[620px] px-4 py-3"}>
+        <div className={isMobile ? "max-w-[358px] px-3 py-3" : "max-w-[620px] px-4 py-3"}>
           <IssueBlockedNotice
             issueStatus="blocked"
             blockers={fixture.blockers}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip issue dependencies decide when blocked work can safely resume.
> - Dependency release wakes were being tied too closely to the latest execution workspace operation.
> - Reused workspaces can later fail or cancel for reasons unrelated to whether the blocker issue itself is complete.
> - That made already-resolved blockers appear unresolved again, leaving downstream work stopped without a real live continuation path.
> - This pull request makes blocker release depend on issue-local completion evidence and idempotent wake fingerprints instead.
> - The benefit is that resolved blocker chains reliably release downstream work, while true liveness gaps remain visible and recoverable.

## Linked Issues or Issue Description

Bug report, described in-PR because the source tickets are internal Paperclip issues (PAP-10674 / PAP-10750), not public GitHub issues.

### What happened

A dependent issue could remain stopped after its blocker had already reached `done`. The release wake could be skipped or deduped based on a later operation from a reused execution workspace, so the blocker looked unresolved even though the blocker issue itself was complete.

### Expected behavior

Dependency readiness should release from the blocker issue's own `done` state plus required terminal finalization evidence. Later workspace operations from sibling runs must not make the completed blocker unresolved again.

### Steps to reproduce

Create a blocked dependent, complete the blocker on an execution workspace, then reuse the same workspace for another run that records a later non-finalized or cancelled operation. The dependent release wake can be suppressed even though its blocker is complete.

### Paperclip version or commit

Reproduced from the branch base before this PR; fixed in this PR head.

### Deployment mode

Local Paperclip control-plane runtime with isolated/reused execution workspaces.

## What Changed

- Documented the blocker release contract in `doc/execution-semantics.md` and the V1 liveness rules.
- Added idempotency-key handling for `issue_blockers_resolved` wakes using the dependent issue plus blocker set as the release fingerprint.
- Requeue blocker release wakes when a dependency-gate cancellation later observes that all blockers are actually complete.
- Tightened dependency readiness so blocker release checks use issue-local blocker completion state, with a legacy fallback for workspace operations without `heartbeatRunId`.
- Added server regression coverage for skipped blocker-release wakes, reused-workspace readiness, legacy workspace operations, mixed legacy/attributed operations, and liveness recovery behavior.
- Updated blocked-state UI copy and status language for blocked issues that no longer have unresolved blockers but still have no live continuation path.

## Verification

- `git diff --check`
- `pnpm exec vitest run ui/src/components/IssueBlockedNotice.test.tsx ui/src/components/StatusIcon.test.tsx` — 14 tests passed
- `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts server/src/__tests__/issues-service.test.ts` — 80 tests passed
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- Greptile Review — 5/5, zero unresolved threads
- Checked `ROADMAP.md`; this is a targeted bugfix and does not duplicate a roadmap feature.
- Searched GitHub PRs/issues for `blocker release wake dependency gate`; no duplicates found.

## Risks

- Medium risk: dependency scheduling and heartbeat wake idempotency are central orchestration paths.
- Main behavioral risk is accidentally suppressing a legitimate repeat wake; the idempotency key includes the dependent issue and blocker set to keep the scope narrow.
- Legacy workspace-operation fallback is intentionally conservative when a blocker has no run-attributed operation history.
- No schema migrations are included.
- No `pnpm-lock.yaml`, `.github/workflows`, screenshots, or generated design images are included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex coding agent based on GPT-5, tool-enabled shell/GitHub workflow, medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

UI screenshot note: no screenshots are attached because this PR changes blocked-state wording/status treatment and the task explicitly asked not to add screenshots/images unless specifically part of the work; coverage is via component tests and Storybook fixture updates.