### PR TITLE
fix(codex): add heartbeat token guardrails

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -258,6 +258,8 @@ If the `codex` CLI is not installed or not on `PATH`, `codex_local` agent runs f
 
 Local adapters require their corresponding CLI/session setup on the machine running Paperclip. External adapters are installed through the adapter/plugin flow and should not require hardcoded imports in `server/` or `ui/`.
 
+Codex local sessions use Codex native context management, but Paperclip still enforces a raw-input guardrail: by default a saved `codex_local` session is rotated before the next heartbeat once the latest run reports at least 2,000,000 raw input tokens. Override this per agent through `runtimeConfig.heartbeat.sessionCompaction.maxRawInputTokens`; set it to `0` only when intentionally disabling the guardrail. Run detail invocation metadata shows prompt contributor estimates and the residual raw-input portion attributable to resumed session history, previous tool output, or native context state.
+
 ## Worktree-local Instances
 
 When developing from multiple git worktrees, do not point two Paperclip servers at the same embedded PostgreSQL data directory.

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -786,6 +786,10 @@ Behavior:
 - `thin`: send IDs and pointers only; agent fetches context via API
 - `fat`: include current assignments, goal summary, budget snapshot, and recent comments
 
+Agent heartbeat prompts and recovery handoffs should prefer compact issue context (`GET /api/issues/:issueId/heartbeat-context`) plus targeted comment APIs before full issue or thread reads. Full issue/thread reads remain opt-in when the compact context is insufficient.
+
+`codex_local` keeps Codex native context management, but Paperclip enforces a default raw-input session guardrail: if the latest saved-session run reports at least 2,000,000 raw input tokens, the next heartbeat starts a fresh session with a compact handoff. Per-agent `runtimeConfig.heartbeat.sessionCompaction.maxRawInputTokens` may lower, raise, or explicitly disable (`0`) that threshold.
+
 ## 11.5 Recovery Model Profiles
 
 The optional `modelProfiles.cheap` lane is not a retry worker lane. Paperclip may request the cheap profile only for status-only recovery coordination, and those wakes must include guard context that prevents deliverable work and document/plan updates (`allowDeliverableWork: false`, `allowDocumentUpdates: false`, `resumeRequiresNormalModel: true`).

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -119,6 +119,7 @@ export const DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE = [
   "- Comments, documents, screenshots, work products, and `Remaining` bullets are evidence, not valid liveness paths by themselves.",
   "- Final disposition checklist: mark `done` when complete; use `in_review` only with a real reviewer, approval, interaction, or monitor path; use `blocked` only with first-class blockers or a named unblock owner/action; create delegated follow-up issues with blockers when another agent owns the next step; keep `in_progress` only when a live continuation path exists.",
   "- Prefer the smallest verification that proves the change; do not default to full workspace typecheck/build/test on every heartbeat unless the task scope warrants it.",
+  "- When gathering issue context, start with GET /api/issues/{issueId}/heartbeat-context and targeted comment APIs. Full issue/thread reads are opt-in when compact context is insufficient.",
   "- Use child issues for parallel or long delegated work instead of polling agents, sessions, or processes.",
   "- If woken by a human comment on a dependency-blocked issue, respond or triage the comment without treating the blocked deliverable work as unblocked.",
   "- Create child issues directly when you know what needs to be done; use issue-thread interactions when the board/user must choose suggested tasks, answer structured questions, or confirm a proposal.",

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -36,6 +36,13 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   maxSessionAgeHours: 0,
 };
 
+const CODEX_SESSION_GUARDRAIL_POLICY: SessionCompactionPolicy = {
+  enabled: true,
+  maxSessionRuns: 0,
+  maxRawInputTokens: DEFAULT_SESSION_COMPACTION_POLICY.maxRawInputTokens,
+  maxSessionAgeHours: 0,
+};
+
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
   "acpx_local",
   "claude_local",
@@ -62,7 +69,7 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
   codex_local: {
     supportsSessionResume: true,
     nativeContextManagement: "confirmed",
-    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+    defaultSessionCompaction: CODEX_SESSION_GUARDRAIL_POLICY,
   },
   cursor_cloud: {
     supportsSessionResume: true,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -116,6 +116,7 @@ export interface AdapterInvocationMeta {
   env?: Record<string, string>;
   prompt?: string;
   promptMetrics?: Record<string, number>;
+  inputContextAttribution?: Record<string, unknown>;
   context?: Record<string, unknown>;
 }
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -177,6 +177,8 @@ type CodexTransientFallbackMode =
   | "fresh_session"
   | "fresh_session_safer_invocation";
 
+const APPROX_CHARS_PER_TOKEN = 4;
+
 function readCodexTransientFallbackMode(context: Record<string, unknown>): CodexTransientFallbackMode | null {
   const value = asString(context.codexTransientFallbackMode, "").trim();
   switch (value) {
@@ -211,10 +213,70 @@ function buildCodexTransientHandoffNote(input: {
     input.continuationSummaryBody
       ? `- Issue continuation summary: ${input.continuationSummaryBody.slice(0, 1_500)}`
       : "",
+    "- Context recovery: start with /api/issues/{issueId}/heartbeat-context and targeted comment APIs; use full issue/thread reads only when compact context is insufficient.",
     "Continue from the current task state. Rebuild only the minimum context you need.",
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function estimateTokensFromChars(chars: number): number {
+  if (!Number.isFinite(chars) || chars <= 0) return 0;
+  return Math.ceil(chars / APPROX_CHARS_PER_TOKEN);
+}
+
+function jsonChars(value: unknown): number {
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function contributorMetric(key: string, label: string, chars: number, source: string) {
+  const normalizedChars = Math.max(0, Math.floor(chars));
+  return {
+    key,
+    label,
+    source,
+    chars: normalizedChars,
+    estimatedTokens: estimateTokensFromChars(normalizedChars),
+  };
+}
+
+function buildCodexInputContextAttribution(input: {
+  promptChars: number;
+  instructionsChars: number;
+  bootstrapPromptChars: number;
+  wakePromptChars: number;
+  wakePayloadJsonChars: number;
+  sessionHandoffChars: number;
+  heartbeatPromptChars: number;
+  contextSnapshotJsonChars: number;
+  resumedSession: boolean;
+}) {
+  const contributors = [
+    contributorMetric("agent_instructions", "Agent instructions prefix", input.instructionsChars, "stdin_prompt"),
+    contributorMetric("bootstrap_prompt", "Bootstrap prompt", input.bootstrapPromptChars, "stdin_prompt"),
+    contributorMetric("wake_prompt", "Wake payload prompt", input.wakePromptChars, "stdin_prompt"),
+    contributorMetric("wake_payload_json", "Wake payload JSON", input.wakePayloadJsonChars, "environment"),
+    contributorMetric("session_handoff", "Session handoff", input.sessionHandoffChars, "stdin_prompt"),
+    contributorMetric("heartbeat_prompt", "Heartbeat contract prompt", input.heartbeatPromptChars, "stdin_prompt"),
+    contributorMetric("context_snapshot_json", "Adapter context snapshot", input.contextSnapshotJsonChars, "adapter_context"),
+  ];
+  const promptEstimatedTokens = estimateTokensFromChars(input.promptChars);
+
+  return {
+    version: 1,
+    estimator: `ceil(chars/${APPROX_CHARS_PER_TOKEN})`,
+    resumedSession: input.resumedSession,
+    promptChars: input.promptChars,
+    promptEstimatedTokens,
+    contributors,
+    note:
+      "Raw input tokens can exceed prompt estimates when Codex includes resumed session history, previous tool outputs, or native context-management state.",
+  };
 }
 
 export async function ensureCodexSkillsInjected(
@@ -668,14 +730,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     sessionHandoffNote,
     renderedPrompt,
   ]);
+  const sessionHandoffChars = codexFallbackHandoffNote.length + sessionHandoffNote.length;
+  const contextSnapshotJsonChars = jsonChars(context);
+  const wakePayloadJsonChars = wakePayloadJson?.length ?? 0;
   const promptMetrics = {
     promptChars: prompt.length,
     instructionsChars,
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
-    sessionHandoffChars: sessionHandoffNote.length,
+    wakePayloadJsonChars,
+    sessionHandoffChars,
     heartbeatPromptChars: renderedPrompt.length,
+    contextSnapshotJsonChars,
+    promptEstimatedTokens: estimateTokensFromChars(prompt.length),
+    staticPromptEstimatedTokens: estimateTokensFromChars(
+      promptInstructionsPrefix.length + renderedBootstrapPrompt.length + renderedPrompt.length,
+    ),
   };
+  const inputContextAttribution = buildCodexInputContextAttribution({
+    ...promptMetrics,
+    resumedSession: Boolean(sessionId),
+  });
 
   const runAttempt = async (resumeSessionId: string | null) => {
     const execArgs = buildCodexExecArgs(
@@ -703,6 +778,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         env: loggedEnv,
         prompt,
         promptMetrics,
+        inputContextAttribution,
         context,
       });
     }
@@ -816,6 +892,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resultJson: {
         stdout: attempt.proc.stdout,
         stderr: attempt.proc.stderr,
+        inputContextAttribution: {
+          ...inputContextAttribution,
+          rawInputTokens: attempt.parsed.usage.inputTokens,
+          rawCachedInputTokens: attempt.parsed.usage.cachedInputTokens,
+          rawOutputTokens: attempt.parsed.usage.outputTokens,
+        },
         ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
         ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
         ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -396,6 +396,7 @@ describe("codex execute", () => {
     const previousHome = process.env.HOME;
     process.env.HOME = root;
 
+    let inputContextAttribution: Record<string, unknown> | null = null;
     try {
       const result = await execute({
         runId: "run-wake",
@@ -465,6 +466,12 @@ describe("codex execute", () => {
         },
         authToken: "run-jwt-token",
         onLog: async () => {},
+        onMeta: async (meta) => {
+          inputContextAttribution =
+            typeof meta.inputContextAttribution === "object" && meta.inputContextAttribution !== null
+              ? meta.inputContextAttribution
+              : null;
+        },
       });
 
       expect(result.exitCode).toBe(0);
@@ -486,6 +493,29 @@ describe("codex execute", () => {
       );
       expect(capture.prompt).toContain("First comment");
       expect(capture.prompt).toContain("Second comment");
+      expect(inputContextAttribution).toMatchObject({
+        version: 1,
+        resumedSession: false,
+      });
+      const contributors = Array.isArray(inputContextAttribution?.contributors)
+        ? inputContextAttribution.contributors as Array<Record<string, unknown>>
+        : [];
+      expect(contributors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "wake_payload_json",
+            chars: expect.any(Number),
+            estimatedTokens: expect.any(Number),
+          }),
+          expect.objectContaining({
+            key: "wake_prompt",
+            chars: expect.any(Number),
+            estimatedTokens: expect.any(Number),
+          }),
+        ]),
+      );
+      expect(contributors.find((row) => row.key === "wake_payload_json")?.chars).toBeGreaterThan(0);
+      expect(contributors.find((row) => row.key === "wake_prompt")?.estimatedTokens).toBeGreaterThan(0);
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1288,13 +1288,16 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
+  it("keeps a raw-input guardrail for codex while leaving native session management otherwise intact", () => {
     expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
-      maxRawInputTokens: 0,
+      maxRawInputTokens: 2_000_000,
       maxSessionAgeHours: 0,
     });
+  });
+
+  it("disables Paperclip-managed rotation by default for claude local", () => {
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4110,6 +4110,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       input.continuationSummaryBody
         ? `- Issue continuation summary: ${input.continuationSummaryBody.slice(0, 1_500)}`
         : "",
+      "- Context recovery: start with /api/issues/{issueId}/heartbeat-context and targeted comment APIs; use full issue/thread reads only when compact context is insufficient.",
       "Continue from the current task state. Rebuild only the minimum context you need.",
     ]
       .filter(Boolean)

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -71,6 +71,8 @@ If already checked out by you, returns normally. If owned by another agent: `409
 
 If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling the API. It is the fastest path for comment wakes and may already include the exact new comments that triggered this run. For comment-driven wakes, reflect the new comment context first, then fetch broader history only if needed.
 
+Do not use full `GET /api/issues/{issueId}` or full-thread reads as the default context source. Treat them as opt-in fallbacks when `heartbeat-context`, the inline wake payload, or targeted comment APIs are insufficient.
+
 Use comments incrementally:
 
 - if `PAPERCLIP_WAKE_COMMENT_ID` is set, fetch that exact comment first with `GET /api/issues/{issueId}/comments/{commentId}`
@@ -402,7 +404,7 @@ If `plan` already exists, fetch the current document first and send its latest `
 | My compact inbox                      | `GET /api/agents/me/inbox-lite`                                                                                                 |
 | My assignments                        | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=todo,in_progress,in_review,blocked`                            |
 | Checkout task                         | `POST /api/issues/:issueId/checkout`                                                                                            |
-| Get task + ancestors                  | `GET /api/issues/:issueId`                                                                                                      |
+| Full task + ancestors (opt-in)        | `GET /api/issues/:issueId`                                                                                                      |
 | Compact heartbeat context             | `GET /api/issues/:issueId/heartbeat-context`                                                                                    |
 | Update task                           | `PATCH /api/issues/:issueId` (optional `comment` field)                                                                         |
 | Get comments / delta / single         | `GET /api/issues/:issueId/comments[?after=:commentId&order=asc]` • `/comments/:commentId`                                       |

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -313,11 +313,53 @@ function asNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+type InputContextContributor = {
+  key: string;
+  label: string;
+  source: string;
+  chars: number;
+  estimatedTokens: number;
+};
+
+function readInputContextAttribution(payload: Record<string, unknown>): Record<string, unknown> | null {
+  return asRecord(payload.inputContextAttribution);
+}
+
+function readInputContextContributors(attribution: Record<string, unknown> | null): InputContextContributor[] {
+  const contributors = Array.isArray(attribution?.contributors) ? attribution.contributors : [];
+  return contributors
+    .map((value) => {
+      const row = asRecord(value);
+      if (!row) return null;
+      const key = asNonEmptyString(row.key);
+      const label = asNonEmptyString(row.label);
+      const source = asNonEmptyString(row.source) ?? "unknown";
+      const chars = asFiniteNumber(row.chars) ?? 0;
+      const estimatedTokens = asFiniteNumber(row.estimatedTokens) ?? 0;
+      if (!key || !label) return null;
+      return {
+        key,
+        label,
+        source,
+        chars,
+        estimatedTokens,
+      };
+    })
+    .filter((value): value is InputContextContributor => value !== null)
+    .filter((value) => value.chars > 0 || value.estimatedTokens > 0);
+}
+
 export function RunInvocationCard({
   payload,
+  run,
   censorUsernameInLogs,
 }: {
   payload: Record<string, unknown>;
+  run?: HeartbeatRun;
   censorUsernameInLogs: boolean;
 }) {
   const rawCommandLine = [
@@ -336,6 +378,21 @@ export function RunInvocationCard({
     || payload.prompt !== undefined
     || payload.context !== undefined
     || payload.env !== undefined;
+  const attribution = readInputContextAttribution(payload);
+  const contributorRows = readInputContextContributors(attribution);
+  const promptEstimatedTokens = asFiniteNumber(attribution?.promptEstimatedTokens);
+  const promptChars = asFiniteNumber(attribution?.promptChars);
+  const usage = asRecord(run?.usageJson ?? null);
+  const rawInputTokens =
+    usageNumber(usage, "rawInputTokens", "inputTokens", "input_tokens");
+  const carriedContextTokens =
+    rawInputTokens > 0 && promptEstimatedTokens !== null
+      ? Math.max(0, rawInputTokens - promptEstimatedTokens)
+      : 0;
+  const hasAttribution =
+    contributorRows.length > 0
+    || promptEstimatedTokens !== null
+    || rawInputTokens > 0;
 
   return (
     <div className="rounded-lg border border-border bg-background/60 p-3 space-y-2">
@@ -345,6 +402,38 @@ export function RunInvocationCard({
       )}
       {typeof payload.cwd === "string" && (
         <div className="text-xs break-all"><span className="text-muted-foreground">Working dir: </span><span className="font-mono">{payload.cwd}</span></div>
+      )}
+      {hasAttribution && (
+        <div className="rounded-md border border-border/70 bg-background/70 p-2">
+          <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+            {rawInputTokens > 0 && (
+              <span>Raw input <span className="font-mono text-foreground">{formatTokens(rawInputTokens)}</span></span>
+            )}
+            {promptEstimatedTokens !== null && (
+              <span>Prompt estimate <span className="font-mono text-foreground">{formatTokens(promptEstimatedTokens)}</span></span>
+            )}
+            {carriedContextTokens > 0 && (
+              <span>Session/tools/native <span className="font-mono text-foreground">{formatTokens(carriedContextTokens)}</span></span>
+            )}
+            {promptChars !== null && (
+              <span>{promptChars.toLocaleString("en-US")} chars</span>
+            )}
+          </div>
+          {contributorRows.length > 0 && (
+            <div className="grid gap-1 text-[11px]">
+              {contributorRows.map((row) => (
+                <div
+                  key={row.key}
+                  className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2"
+                >
+                  <span className="truncate text-muted-foreground">{row.label}</span>
+                  <span className="font-mono tabular-nums">{formatTokens(row.estimatedTokens)}</span>
+                  <span className="font-mono tabular-nums text-muted-foreground">{row.chars.toLocaleString("en-US")}c</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       )}
       {hasAdvancedDetails && (
         <Collapsible>
@@ -4004,7 +4093,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
         censorUsernameInLogs={censorUsernameInLogs}
       />
       {adapterInvokePayload && (
-        <RunInvocationCard payload={adapterInvokePayload} censorUsernameInLogs={censorUsernameInLogs} />
+        <RunInvocationCard payload={adapterInvokePayload} run={run} censorUsernameInLogs={censorUsernameInLogs} />
       )}
 
       <div className="flex items-center justify-between">


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat execution is where assigned agents receive wake payloads, issue context, and adapter-specific session state.
> - Codex local relies heavily on native context management, so its saved sessions were left without Paperclip-side rotation thresholds.
> - Long-running heartbeat agents can accumulate very large raw input token loads across resumed Codex sessions, especially when they recover context from full issue/thread reads.
> - Operators need both guardrails to rotate oversized sessions and run-detail attribution to understand where prompt/context load came from.
> - This pull request adds a Codex-specific raw-input rotation default, lightweight attribution telemetry, and guidance to prefer compact heartbeat context APIs.
> - The benefit is bounded Codex heartbeat sessions with clearer diagnostics and lower accidental context-load growth.

## Linked Issues or Issue Description

Refs #3813
Refs #7238
Related PRs: #3905, #7334

## What Changed

- Added a Codex local session guardrail policy that rotates saved heartbeat sessions once the latest raw input reaches the default session raw-input threshold, while leaving run-count and age thresholds native-context managed.
- Added Codex input-context attribution to adapter invocation metadata/result JSON, including prompt estimates, wake payload/context snapshot character counts, static prompt estimate, and residual session/tools/native context tokens.
- Surfaced attribution in the Agent Detail run invocation card so operators can compare raw input, prompt estimate, contributor rows, and residual context.
- Updated heartbeat recovery guidance in the default agent prompt, transient Codex handoff note, server session handoff note, bundled Paperclip skill, and docs to start with `/api/issues/{issueId}/heartbeat-context` plus targeted comment APIs before full issue/thread reads.
- Updated tests for the Codex-specific compaction policy and metadata attribution path.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts server/src/__tests__/codex-local-execute.test.ts` -> 82 tests passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` -> passed.
- `pnpm --filter @paperclipai/adapter-codex-local typecheck` -> passed.
- `pnpm --filter @paperclipai/server typecheck` -> passed.
- `pnpm --filter @paperclipai/ui typecheck` -> passed.
- `git diff --check` -> clean.
- `git diff --cached --check` -> clean before commit.
- Attempted `pnpm exec vitest run ui/src/pages/AgentDetail.test.tsx`; no such test file exists in this repository.
- No before/after UI screenshot captured; the UI change is covered by `@paperclipai/ui` typecheck only.

## Risks

- Codex sessions may rotate more often for agents with very large resumed raw-input loads; this is intended but can increase session startup frequency.
- Token attribution is approximate for prompt contributors because estimates use character counts divided by four.
- Residual attribution intentionally groups resumed session history, tool output, and Codex native context state because Codex does not expose finer-grained raw input contributors.
- No database migration or schema change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex via Codex CLI coding agent, large-context tool use, reasoning mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
