### PR TITLE
fix(server): cascade-delete child tables in company/agent/project hard-delete handlers (GH#7250)

### DIFF
--- a/server/src/__tests__/cascade-delete-service.test.ts
+++ b/server/src/__tests__/cascade-delete-service.test.ts
@@ -4,12 +4,17 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agentApiKeys,
   agents,
+  assets,
   companies,
   costEvents,
   createDb,
+  documents,
   heartbeatRuns,
+  issueAttachments,
   issueComments,
+  issueDocuments,
   issueReadStates,
+  issueRelations,
   issues,
   projects,
 } from "@paperclipai/db";
@@ -234,6 +239,56 @@ describeEmbeddedPostgres("cascade-delete service handlers (GH#7250)", () => {
       outputTokens: 5,
       costCents: 0,
       occurredAt: new Date(),
+    });
+    // Additional issue-child tables to verify full cascade coverage
+    // Need parent records for FK constraints
+    const documentId = randomUUID();
+    await db.insert(documents).values({
+      id: documentId,
+      companyId,
+      title: "Test document",
+      latestBody: "# Test",
+    });
+    await db.insert(issueDocuments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      documentId,
+      key: "test-key",
+    });
+    const assetId = randomUUID();
+    await db.insert(assets).values({
+      id: assetId,
+      companyId,
+      provider: "local",
+      objectKey: "test-asset.bin",
+      contentType: "application/octet-stream",
+      byteSize: 1024,
+      sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    });
+    await db.insert(issueAttachments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      assetId,
+    });
+    const relatedIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: relatedIssueId,
+      companyId,
+      projectId,
+      title: "Related issue",
+      status: "open",
+      priority: "low",
+      issueNumber: 2,
+      identifier: "PJC-2",
+    });
+    await db.insert(issueRelations).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      relatedIssueId,
+      type: "blocks",
     });
 
     const svc = projectService(db);

--- a/server/src/__tests__/cascade-delete-service.test.ts
+++ b/server/src/__tests__/cascade-delete-service.test.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentApiKeys,
+  agents,
+  companies,
+  costEvents,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueReadStates,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { companyService } from "../services/companies.js";
+import { agentService } from "../services/agents.js";
+import { projectService } from "../services/projects.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping cascade-delete tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("cascade-delete service handlers (GH#7250)", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cascade-delete-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("company remove() cascades all child rows without FK violation", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Cascade Test Co",
+      issuePrefix: "CAS",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Worker",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Do something",
+      status: "open",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: "CAS-1",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "succeeded",
+      invocationSource: "assignment",
+    });
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      body: "A comment",
+      authorAgentId: agentId,
+    });
+
+    const svc = companyService(db);
+    await expect(svc.remove(companyId)).resolves.not.toThrow();
+
+    const remaining = await db.select().from(companies).where(eq(companies.id, companyId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("agent remove() cascades agent-scoped child rows without FK violation", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Agent Cascade Co",
+      issuePrefix: "AGC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Write tests",
+      status: "open",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: "AGC-1",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "succeeded",
+      invocationSource: "assignment",
+    });
+    await db.insert(agentApiKeys).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      name: "test key",
+      keyHash: "deadbeef01",
+    });
+    await db.insert(costEvents).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      provider: "anthropic",
+      biller: "server",
+      billingType: "llm",
+      model: "claude-sonnet-4-6",
+      inputTokens: 100,
+      outputTokens: 50,
+      costCents: 1,
+      occurredAt: new Date(),
+    });
+
+    const svc = agentService(db);
+    await expect(svc.remove(agentId)).resolves.not.toThrow();
+
+    const remaining = await db.select().from(agents).where(eq(agents.id, agentId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("project remove() cascades project issues and their children without FK violation", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Project Cascade Co",
+      issuePrefix: "PJC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Dev",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "My Project",
+      color: "blue",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Project task",
+      status: "open",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: "PJC-1",
+    });
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      body: "Comment on project issue",
+      authorAgentId: agentId,
+    });
+    await db.insert(issueReadStates).values({
+      id: randomUUID(),
+      issueId,
+      companyId,
+      userId: randomUUID(),
+    });
+    await db.insert(costEvents).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      projectId,
+      provider: "anthropic",
+      biller: "server",
+      billingType: "llm",
+      model: "claude-sonnet-4-6",
+      inputTokens: 10,
+      outputTokens: 5,
+      costCents: 0,
+      occurredAt: new Date(),
+    });
+
+    const svc = projectService(db);
+    await expect(svc.remove(projectId)).resolves.not.toThrow();
+
+    const remaining = await db.select().from(projects).where(eq(projects.id, projectId));
+    expect(remaining).toHaveLength(0);
+    const remainingIssues = await db.select().from(issues).where(eq(issues.projectId, projectId));
+    expect(remainingIssues).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/cascade-delete-service.test.ts
+++ b/server/src/__tests__/cascade-delete-service.test.ts
@@ -4,7 +4,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agentApiKeys,
   agents,
+  approvals,
   assets,
+  budgetIncidents,
+  budgetPolicies,
   companies,
   costEvents,
   createDb,
@@ -298,5 +301,80 @@ describeEmbeddedPostgres("cascade-delete service handlers (GH#7250)", () => {
     expect(remaining).toHaveLength(0);
     const remainingIssues = await db.select().from(issues).where(eq(issues.projectId, projectId));
     expect(remainingIssues).toHaveLength(0);
+  });
+
+  it("agent remove() handles approval + budget incident FK without violation", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const approvalId = randomUUID();
+    const budgetIncidentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Approval Cascade Co",
+      issuePrefix: "APC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Approver",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // Create an approval requested by this agent
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "budget",
+      requestedByAgentId: agentId,
+      status: "approved",
+      payload: { amount: 1000 },
+    });
+    // Create a budget policy (required FK for budget incidents)
+    const policyId = randomUUID();
+    await db.insert(budgetPolicies).values({
+      id: policyId,
+      companyId,
+      scopeType: "company",
+      scopeId: companyId,
+      windowKind: "monthly",
+    });
+    // Create a budget incident linked to that approval (FK: budget_incidents.approvalId -> approvals.id)
+    await db.insert(budgetIncidents).values({
+      id: budgetIncidentId,
+      companyId,
+      policyId,
+      scopeType: "agent",
+      scopeId: agentId,
+      metric: "cost",
+      windowKind: "monthly",
+      windowStart: new Date(),
+      windowEnd: new Date(),
+      thresholdType: "hard",
+      amountLimit: 500,
+      amountObserved: 750,
+      status: "open",
+      approvalId,
+    });
+
+    const svc = agentService(db);
+    // This must not throw a FK constraint violation
+    await expect(svc.remove(agentId)).resolves.not.toThrow();
+
+    // Verify all related rows are deleted
+    const remainingAgent = await db.select().from(agents).where(eq(agents.id, agentId));
+    expect(remainingAgent).toHaveLength(0);
+    const remainingApproval = await db.select().from(approvals).where(eq(approvals.id, approvalId));
+    expect(remainingApproval).toHaveLength(0);
+    const remainingIncident = await db
+      .select()
+      .from(budgetIncidents)
+      .where(eq(budgetIncidents.id, budgetIncidentId));
+    expect(remainingIncident).toHaveLength(0);
   });
 });

--- a/server/src/__tests__/cascade-delete-service.test.ts
+++ b/server/src/__tests__/cascade-delete-service.test.ts
@@ -303,6 +303,88 @@ describeEmbeddedPostgres("cascade-delete service handlers (GH#7250)", () => {
     expect(remainingIssues).toHaveLength(0);
   });
 
+  it("project remove() handles cross-project issueRelations without FK violation", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const targetProjectId = randomUUID();
+    const otherProjectId = randomUUID();
+    const targetIssueId = randomUUID();
+    const otherIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Cross-Project Cascade Co",
+      issuePrefix: "CPC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cross-Project Dev",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: targetProjectId,
+      companyId,
+      name: "Target Project",
+      color: "red",
+    });
+    await db.insert(projects).values({
+      id: otherProjectId,
+      companyId,
+      name: "Other Project",
+      color: "green",
+    });
+    // Issue in target project
+    await db.insert(issues).values({
+      id: targetIssueId,
+      companyId,
+      projectId: targetProjectId,
+      title: "Target issue",
+      status: "open",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: "CPC-1",
+    });
+    // Issue in OTHER project
+    await db.insert(issues).values({
+      id: otherIssueId,
+      companyId,
+      projectId: otherProjectId,
+      title: "Other issue",
+      status: "open",
+      priority: "low",
+      issueNumber: 1,
+      identifier: "CPC-2",
+    });
+    // issueRelations: target issue blocks other issue (relatedIssueId points to other project)
+    await db.insert(issueRelations).values({
+      id: randomUUID(),
+      companyId,
+      issueId: targetIssueId,
+      relatedIssueId: otherIssueId,
+      type: "blocks",
+    });
+
+    const svc = projectService(db);
+    // This must not throw a FK violation on issueRelations.relatedIssueId → issues.id
+    await expect(svc.remove(targetProjectId)).resolves.not.toThrow();
+
+    // Verify target project and its issue are deleted
+    const remainingProject = await db.select().from(projects).where(eq(projects.id, targetProjectId));
+    expect(remainingProject).toHaveLength(0);
+    const remainingTargetIssue = await db.select().from(issues).where(eq(issues.id, targetIssueId));
+    expect(remainingTargetIssue).toHaveLength(0);
+    // Other project and its issue should still exist
+    const remainingOtherIssue = await db.select().from(issues).where(eq(issues.id, otherIssueId));
+    expect(remainingOtherIssue).toHaveLength(1);
+  });
+
   it("agent remove() handles approval + budget incident FK without violation", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -23,6 +23,7 @@ import {
   goals,
   routines,
   issueThreadInteractions,
+  budgetIncidents,
 } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -623,6 +624,12 @@ export function agentService(db: Db) {
           ),
         );
         await tx.delete(approvals).where(eq(approvals.requestedByAgentId, id));
+        await tx.delete(budgetIncidents).where(
+          inArray(
+            budgetIncidents.approvalId,
+            tx.select({ id: approvals.id }).from(approvals).where(eq(approvals.requestedByAgentId, id)),
+          ),
+        );
         await tx.delete(joinRequests).where(eq(joinRequests.createdAgentId, id));
         await tx.delete(assets).where(eq(assets.createdByAgentId, id));
         await tx.delete(goals).where(eq(goals.ownerAgentId, id));

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -623,13 +623,14 @@ export function agentService(db: Db) {
             tx.select({ id: approvals.id }).from(approvals).where(eq(approvals.requestedByAgentId, id)),
           ),
         );
-        await tx.delete(approvals).where(eq(approvals.requestedByAgentId, id));
+        // Delete budget incidents first — budget_incidents.approvalId FK has no ON DELETE CASCADE
         await tx.delete(budgetIncidents).where(
           inArray(
             budgetIncidents.approvalId,
             tx.select({ id: approvals.id }).from(approvals).where(eq(approvals.requestedByAgentId, id)),
           ),
         );
+        await tx.delete(approvals).where(eq(approvals.requestedByAgentId, id));
         await tx.delete(joinRequests).where(eq(joinRequests.createdAgentId, id));
         await tx.delete(assets).where(eq(assets.createdByAgentId, id));
         await tx.delete(goals).where(eq(goals.ownerAgentId, id));

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -613,7 +613,15 @@ export function agentService(db: Db) {
         // Agent-scoped tables with nullable agent FK (no cascade)
         await tx.delete(costEvents).where(eq(costEvents.agentId, id));
         await tx.delete(financeEvents).where(eq(financeEvents.agentId, id));
+        // Delete approval comments: first cover comments this agent authored on other agents' approvals,
+        // then cover comments on this agent's own approvals (by approvalId, not authorAgentId)
         await tx.delete(approvalComments).where(eq(approvalComments.authorAgentId, id));
+        await tx.delete(approvalComments).where(
+          inArray(
+            approvalComments.approvalId,
+            tx.select({ id: approvals.id }).from(approvals).where(eq(approvals.requestedByAgentId, id)),
+          ),
+        );
         await tx.delete(approvals).where(eq(approvals.requestedByAgentId, id));
         await tx.delete(joinRequests).where(eq(joinRequests.createdAgentId, id));
         await tx.delete(assets).where(eq(assets.createdByAgentId, id));

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -10,11 +10,19 @@ import {
   agentWakeupRequests,
   activityLog,
   costEvents,
+  financeEvents,
   heartbeatRunEvents,
   heartbeatRuns,
   issueExecutionDecisions,
   issues,
   issueComments,
+  approvalComments,
+  approvals,
+  joinRequests,
+  assets,
+  goals,
+  routines,
+  issueThreadInteractions,
 } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -601,6 +609,22 @@ export function agentService(db: Db) {
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.agentId, id));
+        await tx.delete(agentConfigRevisions).where(eq(agentConfigRevisions.agentId, id));
+        // Agent-scoped tables with nullable agent FK (no cascade)
+        await tx.delete(costEvents).where(eq(costEvents.agentId, id));
+        await tx.delete(financeEvents).where(eq(financeEvents.agentId, id));
+        await tx.delete(approvalComments).where(eq(approvalComments.authorAgentId, id));
+        await tx.delete(approvals).where(eq(approvals.requestedByAgentId, id));
+        await tx.delete(joinRequests).where(eq(joinRequests.createdAgentId, id));
+        await tx.delete(assets).where(eq(assets.createdByAgentId, id));
+        await tx.delete(goals).where(eq(goals.ownerAgentId, id));
+        await tx.delete(routines).where(eq(routines.assigneeAgentId, id));
+        await tx.delete(issueThreadInteractions).where(
+          or(
+            eq(issueThreadInteractions.createdByAgentId, id),
+            eq(issueThreadInteractions.resolvedByAgentId, id),
+          ),
+        );
         const deleted = await tx
           .delete(agents)
           .where(eq(agents.id, id))

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -28,6 +28,26 @@ import {
   companyMemberships,
   companySkills,
   documents,
+  issueRelations,
+  companySecretBindings,
+  budgetPolicies,
+  budgetIncidents,
+  inboxDismissals,
+  issueExecutionDecisions,
+  agentConfigRevisions,
+  issuePlanDecompositions,
+  heartbeatRunWatchdogDecisions,
+  secretAccessEvents,
+  issueDocuments,
+  issueWorkProducts,
+  projectGoals,
+  projectWorkspaces,
+  issueRecoveryActions,
+  issueAttachments,
+  feedbackVotes,
+  issueApprovals,
+  documentAnnotationComments,
+  issueReferenceMentions,
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { environmentService } from "./environments.js";
@@ -437,6 +457,7 @@ export function companyService(db: Db) {
         }
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
+        await tx.delete(heartbeatRunWatchdogDecisions).where(eq(heartbeatRunWatchdogDecisions.companyId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
@@ -447,18 +468,38 @@ export function companyService(db: Db) {
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
+        await tx.delete(companySecretBindings).where(eq(companySecretBindings.companyId, id));
         await tx.delete(joinRequests).where(eq(joinRequests.companyId, id));
         await tx.delete(invites).where(eq(invites.companyId, id));
         await tx.delete(principalPermissionGrants).where(eq(principalPermissionGrants.companyId, id));
         await tx.delete(companyMemberships).where(eq(companyMemberships.companyId, id));
         await tx.delete(companySkills).where(eq(companySkills.companyId, id));
         await tx.delete(issueReadStates).where(eq(issueReadStates.companyId, id));
+        // Issue child tables — must be deleted before issues (FK without cascade)
+        await tx.delete(issueRelations).where(eq(issueRelations.companyId, id));
+        await tx.delete(issueDocuments).where(eq(issueDocuments.companyId, id));
+        await tx.delete(issueWorkProducts).where(eq(issueWorkProducts.companyId, id));
+        await tx.delete(issueAttachments).where(eq(issueAttachments.companyId, id));
+        await tx.delete(issueApprovals).where(eq(issueApprovals.companyId, id));
+        await tx.delete(issueRecoveryActions).where(eq(issueRecoveryActions.companyId, id));
+        await tx.delete(issuePlanDecompositions).where(eq(issuePlanDecompositions.companyId, id));
+        await tx.delete(issueReferenceMentions).where(eq(issueReferenceMentions.companyId, id));
+        await tx.delete(documentAnnotationComments).where(eq(documentAnnotationComments.companyId, id));
+        await tx.delete(feedbackVotes).where(eq(feedbackVotes.companyId, id));
+        await tx.delete(inboxDismissals).where(eq(inboxDismissals.companyId, id));
+        await tx.delete(issueExecutionDecisions).where(eq(issueExecutionDecisions.companyId, id));
         await tx.delete(documents).where(eq(documents.companyId, id));
         await tx.delete(issues).where(eq(issues.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
+        await tx.delete(projectWorkspaces).where(eq(projectWorkspaces.companyId, id));
+        await tx.delete(projectGoals).where(eq(projectGoals.companyId, id));
         await tx.delete(goals).where(eq(goals.companyId, id));
         await tx.delete(projects).where(eq(projects.companyId, id));
+        await tx.delete(secretAccessEvents).where(eq(secretAccessEvents.companyId, id));
+        await tx.delete(budgetIncidents).where(eq(budgetIncidents.companyId, id));
+        await tx.delete(budgetPolicies).where(eq(budgetPolicies.companyId, id));
+        await tx.delete(agentConfigRevisions).where(eq(agentConfigRevisions.companyId, id));
         await tx.delete(agents).where(eq(agents.companyId, id));
         const rows = await tx
           .delete(companies)

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -466,6 +466,7 @@ export function companyService(db: Db) {
         await tx.delete(costEvents).where(eq(costEvents.companyId, id));
         await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
+        await tx.delete(budgetIncidents).where(eq(budgetIncidents.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
         await tx.delete(companySecretBindings).where(eq(companySecretBindings.companyId, id));
@@ -497,7 +498,6 @@ export function companyService(db: Db) {
         await tx.delete(goals).where(eq(goals.companyId, id));
         await tx.delete(projects).where(eq(projects.companyId, id));
         await tx.delete(secretAccessEvents).where(eq(secretAccessEvents.companyId, id));
-        await tx.delete(budgetIncidents).where(eq(budgetIncidents.companyId, id));
         await tx.delete(budgetPolicies).where(eq(budgetPolicies.companyId, id));
         await tx.delete(agentConfigRevisions).where(eq(agentConfigRevisions.companyId, id));
         await tx.delete(agents).where(eq(agents.companyId, id));

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -914,7 +914,12 @@ export function projectService(db: Db) {
           );
           // inboxDismissals has no issue reference — skip (deleted at company level)
           await tx.delete(issueExecutionDecisions).where(inArray(issueExecutionDecisions.issueId, issueIds));
-          await tx.delete(issueRelations).where(inArray(issueRelations.issueId, issueIds));
+          await tx.delete(issueRelations).where(
+            or(
+              inArray(issueRelations.issueId, issueIds),
+              inArray(issueRelations.relatedIssueId, issueIds),
+            ),
+          );
         }
         // Cost/finance events — reference project and/or issues (FK without cascade)
         await tx.delete(costEvents).where(

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -17,6 +17,17 @@ import {
   feedbackVotes,
   issueThreadInteractions,
   issueInboxArchives,
+  documentAnnotationComments,
+  issueDocuments,
+  issueWorkProducts,
+  issueAttachments,
+  issueApprovals,
+  issueRecoveryActions,
+  issuePlanDecompositions,
+  issueReferenceMentions,
+  inboxDismissals,
+  issueExecutionDecisions,
+  issueRelations,
 } from "@paperclipai/db";
 import {
   deriveProjectUrlKey,
@@ -884,6 +895,26 @@ export function projectService(db: Db) {
           await tx.delete(feedbackVotes).where(inArray(feedbackVotes.issueId, issueIds));
           await tx.delete(issueThreadInteractions).where(inArray(issueThreadInteractions.issueId, issueIds));
           await tx.delete(issueInboxArchives).where(inArray(issueInboxArchives.issueId, issueIds));
+          // Additional issue-child tables (companies.ts is the source of truth for ordering)
+          await tx.delete(documentAnnotationComments).where(inArray(documentAnnotationComments.issueId, issueIds));
+          await tx.delete(issueDocuments).where(inArray(issueDocuments.issueId, issueIds));
+          await tx.delete(issueWorkProducts).where(inArray(issueWorkProducts.issueId, issueIds));
+          await tx.delete(issueAttachments).where(inArray(issueAttachments.issueId, issueIds));
+          await tx.delete(issueApprovals).where(inArray(issueApprovals.issueId, issueIds));
+          // issueRecoveryActions uses sourceIssueId (FK to issues)
+          await tx.delete(issueRecoveryActions).where(inArray(issueRecoveryActions.sourceIssueId, issueIds));
+          // issuePlanDecompositions uses sourceIssueId (FK to issues)
+          await tx.delete(issuePlanDecompositions).where(inArray(issuePlanDecompositions.sourceIssueId, issueIds));
+          // issueReferenceMentions uses sourceIssueId and targetIssueId (both FK to issues)
+          await tx.delete(issueReferenceMentions).where(
+            or(
+              inArray(issueReferenceMentions.sourceIssueId, issueIds),
+              inArray(issueReferenceMentions.targetIssueId, issueIds),
+            ),
+          );
+          // inboxDismissals has no issue reference — skip (deleted at company level)
+          await tx.delete(issueExecutionDecisions).where(inArray(issueExecutionDecisions.issueId, issueIds));
+          await tx.delete(issueRelations).where(inArray(issueRelations.issueId, issueIds));
         }
         // Cost/finance events — reference project and/or issues (FK without cascade)
         await tx.delete(costEvents).where(

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -12,7 +12,6 @@ import {
   workspaceRuntimeServices,
   costEvents,
   financeEvents,
-  issues,
   issueComments,
   issueReadStates,
   feedbackVotes,
@@ -868,14 +867,16 @@ export function projectService(db: Db) {
       const existing = await getProjectById(id);
       if (!existing) return null;
 
-      // Get issue IDs for this project to cascade-delete issue children
-      const projectIssues = await db
-        .select({ id: issues.id })
-        .from(issues)
-        .where(eq(issues.projectId, id));
-      const issueIds = projectIssues.map((i) => i.id);
-
       return db.transaction(async (tx) => {
+        // Get issue IDs for this project to cascade-delete issue children
+        // (must be inside the transaction to avoid TOCTOU — a new issue created
+        // between the SELECT and the transaction could cause an FK violation)
+        const projectIssues = await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(eq(issues.projectId, id));
+        const issueIds = projectIssues.map((i) => i.id);
+
         // Issue child tables — must be deleted before issues (FK without cascade)
         if (issueIds.length > 0) {
           await tx.delete(issueComments).where(inArray(issueComments.issueId, issueIds));

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   projects,
@@ -10,6 +10,14 @@ import {
   plugins,
   projectWorkspaces,
   workspaceRuntimeServices,
+  costEvents,
+  financeEvents,
+  issues,
+  issueComments,
+  issueReadStates,
+  feedbackVotes,
+  issueThreadInteractions,
+  issueInboxArchives,
 } from "@paperclipai/db";
 import {
   deriveProjectUrlKey,
@@ -856,16 +864,45 @@ export function projectService(db: Db) {
       return cleared;
     },
 
-    remove: (id: string) =>
-      db
-        .delete(projects)
-        .where(eq(projects.id, id))
-        .returning()
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          if (!row) return null;
-          return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
-        }),
+    remove: async (id: string) => {
+      const existing = await getProjectById(id);
+      if (!existing) return null;
+
+      // Get issue IDs for this project to cascade-delete issue children
+      const projectIssues = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(eq(issues.projectId, id));
+      const issueIds = projectIssues.map((i) => i.id);
+
+      return db.transaction(async (tx) => {
+        // Issue child tables — must be deleted before issues (FK without cascade)
+        if (issueIds.length > 0) {
+          await tx.delete(issueComments).where(inArray(issueComments.issueId, issueIds));
+          await tx.delete(issueReadStates).where(inArray(issueReadStates.issueId, issueIds));
+          await tx.delete(feedbackVotes).where(inArray(feedbackVotes.issueId, issueIds));
+          await tx.delete(issueThreadInteractions).where(inArray(issueThreadInteractions.issueId, issueIds));
+          await tx.delete(issueInboxArchives).where(inArray(issueInboxArchives.issueId, issueIds));
+        }
+        // Cost/finance events — reference project and/or issues (FK without cascade)
+        await tx.delete(costEvents).where(
+          or(eq(costEvents.projectId, id), issueIds.length > 0 ? inArray(costEvents.issueId, issueIds) : sql`false`),
+        );
+        await tx.delete(financeEvents).where(
+          or(eq(financeEvents.projectId, id), issueIds.length > 0 ? inArray(financeEvents.issueId, issueIds) : sql`false`),
+        );
+        // Delete issues (FK to projects, no cascade)
+        await tx.delete(issues).where(eq(issues.projectId, id));
+        // Delete the project
+        const rows = await tx
+          .delete(projects)
+          .where(eq(projects.id, id))
+          .returning();
+        const row = rows[0] ?? null;
+        if (!row) return null;
+        return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
+      });
+    },
 
     listWorkspaces: async (projectId: string): Promise<ProjectWorkspace[]> => {
       const rows = await db


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server hard-delete handlers for companies, agents, and projects must cascade-delete all child rows before deleting the parent
> - The upstream PR #7349 that adds this logic was corrupted with node-compile-cache binary files, making it unmergeable
> - This PR cherry-picks the 4 clean commits from PR #7349 onto a fresh branch, excluding all binary cache junk
> - This pull request provides a clean, mergeable version of the cascade-delete fix
> - The benefit is that companies, agents, and projects can be safely hard-deleted without FK constraint violations

## Linked Issues or Issue Description

- Fixes: PAP-297

## What Changed

- Cherry-picked 4 clean commits from upstream PR #7349 (cascade-delete logic for companies, agents, projects, and FK ordering fix)
- Added proper cascade-delete in `companies.ts`: deletes all child tables (issues, comments, approvals, budget incidents, etc.) before deleting the company
- Added proper cascade-delete in `agents.ts`: deletes all agent-scoped children (cost events, approvals, budget incidents, etc.) before deleting the agent
- Added proper cascade-delete in `projects.ts`: deletes project issues and their children (comments, read states, feedback votes, etc.) before deleting the project
- Added integration tests in `cascade-delete-service.test.ts` for all three hard-delete handlers
- Fixed FK ordering: `budgetIncidents` deleted before `approvals` (FK: `budget_incidents.approvalId -> approvals.id` has no ON DELETE CASCADE)

## Verification

```bash
# Verify only cascade-delete related files are in the PR
git diff --stat upstream/master HEAD

# Run the integration tests
pnpm test -- cascade-delete-service

# Check no node-compile-cache files
git diff upstream/master HEAD | grep -c "node-compile-cache"
# Expected: 0
```

## Risks

- Low risk: This is a hard-delete handler change that only affects the DELETE code path
- The cascade-delete ordering must be correct to avoid FK violations — the integration tests verify this
- No schema changes, no migration needed

## Model Used

- Provider: Hermes (hermes_local)
- Model: Devstral-Small-2-24B
- Context window: 128K
- Reasoning: Extended thinking mode with tool use for git operations

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
