### PR TITLE
fix(security): block invite-based privilege escalation above actor role (#7786)

### DIFF
--- a/server/src/__tests__/invite-create-route.test.ts
+++ b/server/src/__tests__/invite-create-route.test.ts
@@ -135,3 +135,98 @@ describe("POST /companies/:companyId/invites", () => {
     expect(res.body.inviteUrl).toMatch(/^https:\/\/paperclip\.example\/invite\/pcp_invite_/);
   });
 });
+
+describe("POST /companies/:companyId/invites role-escalation guard (#7786)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/access.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.clearAllMocks();
+    logActivityMock.mockReset();
+  });
+
+  async function createAppWithMembershipRole(actorMembershipRole: string) {
+    vi.doMock("../services/index.js", () => ({
+      accessService: () => ({
+        isInstanceAdmin: vi.fn(async () => false),
+        canUser: vi.fn(async () => true),
+        hasPermission: vi.fn(async () => true),
+        getMembership: vi.fn(async () => ({
+          status: "active",
+          membershipRole: actorMembershipRole,
+        })),
+      }),
+      agentService: () => ({ getById: vi.fn() }),
+      boardAuthService: () => ({
+        createChallenge: vi.fn(),
+        resolveBoardAccess: vi.fn(),
+        assertCurrentBoardKey: vi.fn(),
+        revokeBoardApiKey: vi.fn(),
+      }),
+      deduplicateAgentName: vi.fn(),
+      logActivity: (...args: unknown[]) => logActivityMock(...args),
+      notifyHireApproved: vi.fn(),
+    }));
+    const [{ accessRoutes }, { errorHandler }] = await Promise.all([
+      import("../routes/access.js"),
+      import("../middleware/index.js"),
+    ]);
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        source: "api_key",
+        userId: "user-actor",
+        isInstanceAdmin: false,
+        companyIds: ["company-1"],
+      };
+      next();
+    });
+    app.use(
+      "/api",
+      accessRoutes(createDbStub() as any, {
+        deploymentMode: "managed",
+        deploymentExposure: "private",
+        bindHost: "127.0.0.1",
+        allowedHostnames: [],
+      }),
+    );
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("rejects an admin minting an owner invite with 403", async () => {
+    const app = await createAppWithMembershipRole("admin");
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "human", humanRole: "owner" });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects an operator minting an admin invite with 403", async () => {
+    const app = await createAppWithMembershipRole("operator");
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "human", humanRole: "admin" });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows an admin to invite at or below their own role", async () => {
+    const app = await createAppWithMembershipRole("admin");
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "human", humanRole: "admin" });
+    expect(res.status).toBe(201);
+  });
+
+  it("still allows a default (no humanRole) human invite from an operator", async () => {
+    const app = await createAppWithMembershipRole("operator");
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      .send({ allowedJoinTypes: "human" });
+    expect(res.status).toBe(201);
+  });
+});

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -3068,6 +3068,25 @@ export function accessRoutes(
     async (req, res) => {
       const companyId = req.params.companyId as string;
       await assertCompanyPermission(req, companyId, "users:invite");
+      // GH #7786: users:invite alone must not allow granting a role above the
+      // actor's own — an admin could otherwise mint owner invites and escalate.
+      // Human invites default to "operator" when no role is requested, so guard
+      // the effective role. Non-board actors (agents) have no membership role;
+      // cap them at the legacy default ("operator") so they can still create
+      // ordinary invites but never privileged ones.
+      const requestedHumanRole =
+        req.body.allowedJoinTypes === "agent"
+          ? null
+          : normalizeHumanRole(req.body.humanRole ?? "operator", "operator");
+      if (requestedHumanRole) {
+        const actorRole = await resolveActorHumanRole(req, access, companyId);
+        const grantableRank = actorRole ? humanRoleRank[actorRole] : humanRoleRank.operator;
+        if (humanRoleRank[requestedHumanRole] > grantableRank) {
+          throw forbidden(
+            "You can only create invites for roles at or below your own company role",
+          );
+        }
+      }
       const { token, created, normalizedAgentMessage } =
         await createCompanyInviteForCompany({
           req,


### PR DESCRIPTION
## Thinking Path

> - Paperclip companies have a human role hierarchy (viewer < operator < admin < owner) enforced by `humanRoleRank` for member management.
> - #7786: `POST /companies/:companyId/invites` only checks the `users:invite` permission and accepts any `humanRole` — so an admin can mint an **owner** invite and escalate themselves or others (verified repro in the issue).
> - The member-removal path already guards with `humanRoleRank` ("you can only remove users below your role"); the invite path simply never got the equivalent guard.
> - This PR validates the **effective** invite role (human invites default to `operator` when no role is requested) against the actor's resolved company role.
> - Non-board actors (agents) have no membership role; they are capped at the legacy default (`operator`) so ordinary agent-created invites keep working while privileged grants are blocked.
> - The benefit is the role hierarchy can no longer be bypassed via invites.

## What Changed

- `server/src/routes/access.ts` (invite creation route): compute the effective human role; resolve the actor's role via the existing `resolveActorHumanRole`; reject with **403** when `humanRoleRank[requested] > humanRoleRank[actor]` (agents capped at operator). Local-implicit/instance-admin actors resolve to owner as before.
- `server/src/__tests__/invite-create-route.test.ts`: 4 new route tests — admin→owner **403**, operator→admin **403**, admin→admin **201**, operator default-role invite **201**; the existing local-implicit test still passes.

## Verification

- `npx vitest run src/__tests__/invite-create-route.test.ts` → 5/5 pass.
- Server `tsc --noEmit` clean.

## Risks

- Low risk: reuses the established `humanRoleRank`/`resolveActorHumanRole` primitives. Owners and local-implicit/instance-admin actors are unaffected (rank 4 grants everything). The one behavior change beyond the vuln: agents can no longer mint admin/owner invites — they keep the operator-default path, which matches the hierarchy intent. Agent-only invites (`allowedJoinTypes: "agent"`) carry no human role and are untouched.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended reasoning, via Claude Code (tool use + local test execution).

Closes #7786. Related contributions: #7864 (#7840), #7865 (#7656), #7819 (#7795), #7814 (#7790), #7809 (#7685).

## Dedup search

- [x] I searched the open and recently-closed GitHub PRs for similar or duplicate PRs (invite role validation / privilege escalation) and found none addressing this.
