### PR TITLE
fix(plugins): plugin-key UI lookups fall back instead of 500ing on wrapped 22P02 (#7639)

### DIFF
--- a/server/src/__tests__/plugin-ui-static-pg-code.test.ts
+++ b/server/src/__tests__/plugin-ui-static-pg-code.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { errorChainHasPgCode } from "../routes/plugin-ui-static.js";
+
+describe("errorChainHasPgCode (#7639)", () => {
+  it("matches a code on the error itself (raw driver error)", () => {
+    const raw = Object.assign(new Error("invalid input syntax for type uuid"), { code: "22P02" });
+    expect(errorChainHasPgCode(raw, "22P02")).toBe(true);
+  });
+
+  it("matches a code on error.cause (DrizzleQueryError wrapping)", () => {
+    const pg = Object.assign(new Error("invalid input syntax for type uuid"), { code: "22P02" });
+    const wrapped = new Error("Failed query: select ...", { cause: pg });
+    expect(errorChainHasPgCode(wrapped, "22P02")).toBe(true);
+  });
+
+  it("matches a code nested two causes deep", () => {
+    const pg = Object.assign(new Error("boom"), { code: "22P02" });
+    const mid = new Error("mid", { cause: pg });
+    const outer = new Error("outer", { cause: mid });
+    expect(errorChainHasPgCode(outer, "22P02")).toBe(true);
+  });
+
+  it("does not match a different code or non-error values", () => {
+    const pg = Object.assign(new Error("fk"), { code: "23503" });
+    expect(errorChainHasPgCode(new Error("x", { cause: pg }), "22P02")).toBe(false);
+    expect(errorChainHasPgCode(new Error("plain"), "22P02")).toBe(false);
+    expect(errorChainHasPgCode(null, "22P02")).toBe(false);
+    expect(errorChainHasPgCode("22P02", "22P02")).toBe(false);
+  });
+
+  it("terminates on a self-referential cause chain", () => {
+    const cyclic: Record<string, unknown> = { code: "XXXXX" };
+    cyclic.cause = cyclic;
+    expect(errorChainHasPgCode(cyclic, "22P02")).toBe(false);
+  });
+});

--- a/server/src/routes/plugin-ui-static.ts
+++ b/server/src/routes/plugin-ui-static.ts
@@ -176,6 +176,21 @@ function computeETag(size: number, mtimeMs: number): string {
   return `"${hash}"`;
 }
 
+/**
+ * True when the error — or anything in its `cause` chain — carries the given
+ * Postgres error code. drizzle-orm wraps driver errors in DrizzleQueryError,
+ * so codes like 22P02 (invalid uuid input) live on `error.cause.code`, not
+ * `error.code` (GH #7639). Exported for unit testing.
+ */
+export function errorChainHasPgCode(error: unknown, pgCode: string): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && typeof current === "object" && current !== null; depth += 1) {
+    if ((current as { code?: unknown }).code === pgCode) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Route factory
 // ---------------------------------------------------------------------------
@@ -246,11 +261,11 @@ export function pluginUiStaticRoutes(db: Db, options: PluginUiStaticRouteOptions
     try {
       plugin = await registry.getById(pluginId);
     } catch (error) {
-      const maybeCode =
-        typeof error === "object" && error !== null && "code" in error
-          ? (error as { code?: unknown }).code
-          : undefined;
-      if (maybeCode !== "22P02") {
+      // GH #7639: when :pluginId is a manifest key (not a UUID), Postgres raises
+      // 22P02 — but drizzle wraps the driver error in DrizzleQueryError, so the
+      // code lives on error.cause.code. Check the error AND its cause chain so
+      // the key fallback below actually triggers instead of re-throwing a 500.
+      if (!errorChainHasPgCode(error, "22P02")) {
         throw error;
       }
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip plugins ship UI bundles served by `GET /_plugins/:pluginId/ui/*`, which is documented to accept either the plugin's DB UUID or its manifest key (e.g. `agent-pixels.camera`).
> - #7639: every plugin-key URL returns 500 — the host's own plugin UI loading breaks, not just direct key access.
> - The route has a UUID-vs-key fallback that swallows Postgres `22P02` (invalid uuid input) and retries `getByKey` — but it reads `error.code`, while drizzle-orm wraps driver errors in `DrizzleQueryError`, putting the code on `error.cause.code`.
> - So the condition never matched, the wrapped error re-threw as a 500, and `getByKey` was unreachable on that path.
> - This PR adds a small, bounded cause-chain walker and uses it for the 22P02 check so the documented fallback actually triggers.
> - The benefit is plugin UI assets load by key again, matching the documented contract.

## What Changed

- `server/src/routes/plugin-ui-static.ts`: new exported `errorChainHasPgCode(error, code)` — walks `error.cause` up to 5 levels (cycle-safe) looking for the Postgres code; the lookup's 22P02 check now uses it. (Only occurrence of this pattern in the repo — verified by grep.)
- `server/src/__tests__/plugin-ui-static-pg-code.test.ts`: 5 unit tests — raw driver error, drizzle-wrapped cause, double-wrapped, non-matching code, non-object inputs, and a self-referential cause chain.

## Verification

- `npx vitest run src/__tests__/plugin-ui-static-pg-code.test.ts` → 5/5 pass.
- Server `tsc --noEmit` clean.

## Risks

- Low risk: strictly widens the swallowed-error match from `error.code === '22P02'` to "22P02 anywhere in the cause chain"; all other errors still re-throw. UUID lookups are unaffected.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended reasoning, via Claude Code (tool use + local test execution).

Closes #7639. Related contributions: #7867, #7866, #7864, #7865, #7819, #7814, #7809.

## Dedup search

- [x] I searched the open and recently-closed GitHub PRs for similar or duplicate PRs (plugin UI 500 / 22P02 / DrizzleQueryError) and found none addressing this.
