### PR TITLE
fix(recovery): cap terminal recovery retries with a durable attempt limit

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -83,6 +83,7 @@ import {
   redactDetectedSuccessfulRunProgressSummaryForBoard,
 } from "../services/heartbeat.ts";
 import {
+  STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS,
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
@@ -752,7 +753,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       returnOwnerAgentId: input.agentId,
       cause: input.cause ?? "stranded_assigned_issue",
       attemptCount: 1,
-      maxAttempts: null,
+      maxAttempts: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS,
     });
     expect(action.evidence).toMatchObject({
       sourceIssueId: input.issueId,

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -24,7 +24,7 @@ import {
 import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
-import { recoveryService } from "../services/recovery/service.js";
+import { recoveryService, STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS } from "../services/recovery/service.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -442,6 +442,131 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id));
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("Recovery action:");
+  });
+
+  it("caps recovery-owner wakeups at the stranded attempt limit and posts a single park notice", async () => {
+    const { coderId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    for (let cycle = 0; cycle < STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS + 2; cycle += 1) {
+      await db.update(issues).set({ status: "in_progress" }).where(eq(issues.id, sourceIssue.id));
+      const [current] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+      await recovery.escalateStrandedAssignedIssue({
+        issue: current!,
+        previousStatus: "in_progress",
+        latestRun: {
+          id: randomUUID(),
+          agentId: coderId,
+          status: "failed",
+          error: "adapter failed",
+          errorCode: "adapter_failed",
+          contextSnapshot: { retryReason: "issue_continuation_needed" },
+          livenessState: "needs_followup",
+        },
+        comment: "Automatic continuation recovery failed.",
+      });
+    }
+
+    expect(enqueueWakeup).toHaveBeenCalledTimes(STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS);
+
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actionRows).toHaveLength(1);
+    expect(actionRows[0]).toMatchObject({
+      status: "active",
+      attemptCount: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS + 2,
+      maxAttempts: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS,
+    });
+
+    const [parkedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(parkedIssue?.status).toBe("blocked");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id));
+    expect(comments).toHaveLength(2);
+    const parkNotices = comments.filter((comment) => comment.body?.includes("recovery attempt cap"));
+    expect(parkNotices).toHaveLength(1);
+  });
+
+  it("parks exhausted permanent failures instead of restarting continuation retries", async () => {
+    const { companyId, managerId, coderId, sourceIssueId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    // A failed run without a continuation retryReason resets the consecutive-retry
+    // counter; before the durable cap this restarted the transient retry cycle forever.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: coderId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "Process adapter missing command",
+      errorCode: "adapter_failed",
+      startedAt: new Date("2026-05-13T18:00:00.000Z"),
+      finishedAt: new Date("2026-05-13T18:00:05.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    await db.insert(issueRecoveryActions).values({
+      id: randomUUID(),
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "stranded_assigned_issue",
+      fingerprint: `source_scoped_recovery:${companyId}:${sourceIssueId}:stranded_assigned_issue`,
+      evidence: { latestRunErrorCode: "adapter_failed" },
+      nextAction: "Restore a live execution path.",
+      attemptCount: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS + 1,
+      maxAttempts: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS,
+      lastAttemptAt: new Date("2026-05-13T18:00:05.000Z"),
+    });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+
+    const [parkedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(parkedIssue?.status).toBe("blocked");
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssueId));
+    expect(actionRows).toHaveLength(1);
+    expect(actionRows[0]?.status).toBe("active");
+  });
+
+  it("still retries continuation while the stranded recovery action is under the attempt cap", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => ({ id: randomUUID() }) as never);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId: coderId,
+      invocationSource: "automation",
+      status: "failed",
+      error: "transient adapter failure",
+      errorCode: "adapter_failed",
+      startedAt: new Date("2026-05-13T18:00:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup.mock.calls[0]?.[1]?.reason).toBe("issue_continuation_needed");
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -29,6 +29,7 @@ export type {
   IssueLivenessState,
 } from "./issue-graph-liveness.js";
 export {
+  STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS,
   recoveryService,
 } from "./service.js";
 export {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -178,6 +178,23 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+export const STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS = 3;
+
+const STRANDED_RECOVERY_ACTION_KINDS = new Set<string>([
+  "stranded_assigned_issue",
+  "missing_disposition",
+]);
+
+function isExhaustedStrandedRecoveryAction(
+  action: { kind: string; attemptCount: number; maxAttempts: number | null } | null,
+) {
+  return Boolean(
+    action &&
+      STRANDED_RECOVERY_ACTION_KINDS.has(action.kind) &&
+      action.maxAttempts !== null &&
+      action.attemptCount > action.maxAttempts,
+  );
+}
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -2121,7 +2138,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           reason: "no_invokable_recovery_owner",
         },
       monitorPolicy: null,
-      maxAttempts: null,
+      maxAttempts: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS,
       lastAttemptAt: now,
     });
 
@@ -2135,6 +2152,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause: StrandedRecoveryCause;
   }) {
     if (!input.action.ownerAgentId) return;
+    if (isExhaustedStrandedRecoveryAction(input.action)) {
+      logger.info(
+        {
+          issueId: input.issue.id,
+          recoveryActionId: input.action.id,
+          attemptCount: input.action.attemptCount,
+          maxAttempts: input.action.maxAttempts,
+        },
+        "suppressed stranded recovery owner wakeup: attempt cap exhausted",
+      );
+      return;
+    }
     await deps.enqueueWakeup(input.action.ownerAgentId, {
       source: "assignment",
       triggerDetail: "system",
@@ -2369,6 +2398,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           });
         }
       }
+    }
+
+    if (
+      recoveryAction.maxAttempts !== null &&
+      recoveryAction.attemptCount === recoveryAction.maxAttempts + 1
+    ) {
+      await issuesSvc.addComment(
+        input.issue.id,
+        [
+          `Paperclip reached the automatic recovery attempt cap for this issue (recovery action \`${recoveryAction.id}\`, ` +
+            `${recoveryAction.maxAttempts}× attempts).`,
+          "",
+          "Automatic continuation retries and recovery-owner wakeups are parked so a deterministic failure cannot loop forever.",
+          "Fix the underlying runtime/adapter problem, then resolve the recovery action (restoring the issue to an executable status) to re-arm automatic recovery.",
+        ].join("\n"),
+        {},
+        { authorType: "system" },
+      );
     }
 
     await logActivity(db, {
@@ -2642,6 +2689,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
       if (isUnsuccessfulTerminalIssueRun(latestRun)) {
+        const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id);
+        if (isExhaustedStrandedRecoveryAction(activeRecoveryAction)) {
+          // Automatic recovery already exhausted its attempt cap for this issue and
+          // the active recovery action is still unresolved, so the failure is not
+          // healing on its own. Park the issue as blocked instead of restarting the
+          // transient retry cycle, which would otherwise loop forever whenever a
+          // non-continuation run resets the consecutive-retry counter.
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_progress",
+            latestRun,
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
         const classification = classifyContinuationFailure(latestRun);
 
         if (classification.kind === "non_retryable") {


### PR DESCRIPTION
Fixes #7535

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so stalled assigned work must be recovered without a human noticing first
> - The terminal-run recovery pipeline (`server/src/services/recovery/service.ts`) re-queues continuation runs for assigned `in_progress` issues whose latest run ended in a failed/cancelled/timed-out state
> - When the failure is deterministic (e.g. a permanently broken adapter config), every retry fails identically; #7535 reports the pipeline retrying forever — ~6 identical comments per hour, repeated `blocked` flips, and accumulating recovery artifacts
> - The in-place retry cap (3 per error code) counts only *consecutive* `issue_continuation_needed` runs, so the recovery-owner wake that escalation itself enqueues (whose checkout flips the issue back to `in_progress`, then fails) resets the counter and restarts the cycle; the persistent recovery action's `maxAttempts` column was always written `null` and never enforced
> - This pull request makes the attempt cap durable: the source-scoped recovery action now carries `maxAttempts = 3`, owner wakeups are suppressed once `attemptCount` exceeds it, and the reconciler parks (re-blocks) an issue whose active recovery action is exhausted instead of restarting transient retries
> - The benefit is that a deterministic failure converges to one escalation comment, one park notice, and a stable `blocked` state — and resolving the recovery action (the existing manual resolution route) re-arms automatic recovery after the config is fixed

## What Changed

- `ensureSourceScopedStrandedRecoveryAction` now writes `maxAttempts: STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS` (3) instead of `null` on the persistent `issue_recovery_actions` row
- `enqueueSourceScopedStrandedRecoveryWake` suppresses the recovery-owner wakeup (with a log line) once `attemptCount > maxAttempts`, breaking the mechanical wake → checkout → fail → escalate loop
- `reconcileStrandedAssignedIssues` checks the active recovery action before classifying an unsuccessful terminal run: if the action is exhausted, it parks the issue (re-blocks via the existing escalation path) instead of starting a fresh transient retry cycle — this is the guard that survives consecutive-counter resets
- `escalateStrandedAssignedIssue` posts exactly one park notice when the cap is crossed (`attemptCount === maxAttempts + 1`), telling operators to fix the underlying failure and resolve the recovery action to re-arm recovery
- Exported `STRANDED_RECOVERY_ACTION_MAX_ATTEMPTS` from the recovery barrel for tests

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean
- `pnpm --dir ui run build` — clean (no shared/UI types touched)
- `pnpm vitest run src/__tests__/issue-recovery-actions.test.ts` — 24/24, including three new tests:
  - repeated escalations stop waking the owner after 3 attempts and post exactly one park notice while the issue stays `blocked`
  - `reconcileStrandedAssignedIssues` parks an exhausted permanent failure with **zero** wakeups (the #7535 repro shape: failed `adapter_failed` run without a continuation retryReason, i.e. the counter-reset case)
  - under the cap, continuation retries still requeue normally (control)
- `pnpm vitest run src/__tests__/heartbeat-process-recovery.test.ts` — 49/49 (shared assertion helper updated for the new `maxAttempts` value)

## Risks

- Behavioral shift: issues whose recovery action has exhausted its attempts no longer retry automatically until the action is resolved — this is the intended give-up-and-park semantics from #7535; the existing recovery-action resolution route (which restores status and resolves the action) re-arms recovery, so intentional restarts still work
- The cap only applies to stranded-recovery action kinds (`stranded_assigned_issue`, `missing_disposition`); watchdog and monitor flows are untouched
- No migrations, no new dependencies, no shared-type changes

## Model Used

- Claude (Anthropic), model ID `claude-fable-5` (Fable 5), agentic coding session via Claude Code with tool use (file edits, vitest, embedded-Postgres test runs)

## Checklist

- [x] I searched for similar open/closed PRs and confirmed this is not a duplicate (only this PR references #7535)

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no UI changes)
- [x] I have updated relevant documentation to reflect my changes (no docs affected)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)