### PR TITLE
feat(approvals): wake requesting agent on board replies (GH #7784)

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -348,3 +348,164 @@ describe("approval routes idempotent retries", () => {
     );
   });
 });
+
+// TON-2324 / GH #7784: board replies (decisions + comments) must wake the
+// requesting agent with the reply text in context.
+describe("approval reply wakes the requesting agent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/approvals.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockApprovalService.getById.mockReset();
+    mockApprovalService.approve.mockReset();
+    mockApprovalService.reject.mockReset();
+    mockApprovalService.requestRevision.mockReset();
+    mockApprovalService.addComment.mockReset();
+    mockHeartbeatService.wakeup.mockReset();
+    mockIssueApprovalService.listIssuesForApproval.mockReset();
+    mockLogActivity.mockReset();
+    mockHeartbeatService.wakeup.mockResolvedValue({ id: "wake-1" });
+    mockIssueApprovalService.listIssuesForApproval.mockResolvedValue([{ id: "issue-1" }]);
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("forwards the decision note into the wake context on approve", async () => {
+    const approval = {
+      id: "approval-1",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "approved",
+      payload: {},
+      requestedByAgentId: "agent-1",
+      decisionNote: "Looks good — ship it",
+    };
+    mockApprovalService.getById.mockResolvedValue({ ...approval, status: "pending" });
+    mockApprovalService.approve.mockResolvedValue({ approval, applied: true });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-1/approve")
+      .send({ decisionNote: "Looks good — ship it" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({
+        reason: "approval_approved",
+        payload: expect.objectContaining({ note: "Looks good — ship it", approvalId: "approval-1" }),
+        contextSnapshot: expect.objectContaining({
+          wakeReason: "approval_approved",
+          note: "Looks good — ship it",
+        }),
+      }),
+    );
+  });
+
+  it("wakes the requester with the note on reject", async () => {
+    const approval = {
+      id: "approval-2",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "rejected",
+      payload: {},
+      requestedByAgentId: "agent-1",
+      decisionNote: "Not now — revisit next sprint",
+    };
+    mockApprovalService.getById.mockResolvedValue({ ...approval, status: "pending" });
+    mockApprovalService.reject.mockResolvedValue({ approval, applied: true });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-2/reject")
+      .send({ decisionNote: "Not now — revisit next sprint" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({
+        reason: "approval_rejected",
+        contextSnapshot: expect.objectContaining({
+          wakeReason: "approval_rejected",
+          note: "Not now — revisit next sprint",
+        }),
+      }),
+    );
+  });
+
+  it("wakes the requester on request-revision", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-3",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-1",
+    });
+    mockApprovalService.requestRevision.mockResolvedValue({
+      id: "approval-3",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "revision_requested",
+      payload: {},
+      requestedByAgentId: "agent-1",
+      decisionNote: "Tighten the scope",
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-3/request-revision")
+      .send({ decisionNote: "Tighten the scope" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({ reason: "approval_revision_requested" }),
+    );
+  });
+
+  it("wakes the requester when the board comments", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-4",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-1",
+    });
+    mockApprovalService.addComment.mockResolvedValue({ id: "comment-9", body: "Can you clarify the cost?" });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-4/comments")
+      .send({ body: "Can you clarify the cost?" });
+
+    expect(res.status).toBe(201);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({
+        reason: "approval_commented",
+        payload: expect.objectContaining({ commentId: "comment-9", note: "Can you clarify the cost?" }),
+      }),
+    );
+  });
+
+  it("does not wake the requester on its own comment", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-5",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-1",
+    });
+    mockApprovalService.addComment.mockResolvedValue({ id: "comment-10", body: "Following up here." });
+
+    const res = await request(await createAgentApp())
+      .post("/api/approvals/approval-5/comments")
+      .send({ body: "Following up here." });
+
+    expect(res.status).toBe(201);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -62,6 +62,109 @@ export function approvalRoutes(
     return false;
   }
 
+  // TON-2324 / GH #7784: enqueue a wake for the agent that requested an approval
+  // whenever the board replies — a decision (approve/reject/request-revision) or a
+  // free-form comment. The reply text (`note`) is threaded into both the wake
+  // payload and the context snapshot so the woken agent resumes with the board's
+  // answer in hand instead of having to re-fetch the approval. Best-effort: a wake
+  // failure is logged but never blocks the decision/comment response.
+  async function wakeApprovalRequester(
+    approval: {
+      id: string;
+      companyId: string;
+      status: string;
+      type: string;
+      requestedByAgentId: string | null;
+    },
+    opts: {
+      reason: string;
+      source: string;
+      note?: string | null;
+      commentId?: string | null;
+      requestedByActorType: "user" | "agent" | "system";
+      requestedByActorId: string | null;
+    },
+  ) {
+    if (!approval.requestedByAgentId) return;
+
+    const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
+    const linkedIssueIds = linkedIssues.map((issue) => issue.id);
+    const primaryIssueId = linkedIssueIds[0] ?? null;
+    const note = opts.note?.trim() ? opts.note.trim() : null;
+
+    try {
+      const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: opts.reason,
+        payload: {
+          approvalId: approval.id,
+          approvalStatus: approval.status,
+          approvalType: approval.type,
+          issueId: primaryIssueId,
+          issueIds: linkedIssueIds,
+          ...(note ? { note } : {}),
+          ...(opts.commentId ? { commentId: opts.commentId } : {}),
+        },
+        requestedByActorType: opts.requestedByActorType,
+        requestedByActorId: opts.requestedByActorId,
+        contextSnapshot: {
+          source: opts.source,
+          approvalId: approval.id,
+          approvalStatus: approval.status,
+          approvalType: approval.type,
+          issueId: primaryIssueId,
+          issueIds: linkedIssueIds,
+          taskId: primaryIssueId,
+          wakeReason: opts.reason,
+          ...(note ? { note } : {}),
+          ...(opts.commentId ? { commentId: opts.commentId } : {}),
+        },
+      });
+
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: "user",
+        actorId: opts.requestedByActorId ?? "board",
+        action: "approval.requester_wakeup_queued",
+        entityType: "approval",
+        entityId: approval.id,
+        details: {
+          requesterAgentId: approval.requestedByAgentId,
+          wakeRunId: wakeRun?.id ?? null,
+          reason: opts.reason,
+          commentId: opts.commentId ?? null,
+          linkedIssueIds,
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          approvalId: approval.id,
+          requestedByAgentId: approval.requestedByAgentId,
+          reason: opts.reason,
+        },
+        "failed to queue requester wakeup after approval reply",
+      );
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: "user",
+        actorId: opts.requestedByActorId ?? "board",
+        action: "approval.requester_wakeup_failed",
+        entityType: "approval",
+        entityId: approval.id,
+        details: {
+          requesterAgentId: approval.requestedByAgentId,
+          reason: opts.reason,
+          commentId: opts.commentId ?? null,
+          linkedIssueIds,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+
   router.get("/companies/:companyId/approvals", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -163,7 +266,6 @@ export function approvalRoutes(
     if (applied) {
       const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
       const linkedIssueIds = linkedIssues.map((issue) => issue.id);
-      const primaryIssueId = linkedIssueIds[0] ?? null;
 
       await logActivity(db, {
         companyId: approval.companyId,
@@ -179,68 +281,13 @@ export function approvalRoutes(
         },
       });
 
-      if (approval.requestedByAgentId) {
-        try {
-          const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "approval_approved",
-            payload: {
-              approvalId: approval.id,
-              approvalStatus: approval.status,
-              issueId: primaryIssueId,
-              issueIds: linkedIssueIds,
-            },
-            requestedByActorType: "user",
-            requestedByActorId: req.actor.userId ?? "board",
-            contextSnapshot: {
-              source: "approval.approved",
-              approvalId: approval.id,
-              approvalStatus: approval.status,
-              issueId: primaryIssueId,
-              issueIds: linkedIssueIds,
-              taskId: primaryIssueId,
-              wakeReason: "approval_approved",
-            },
-          });
-
-          await logActivity(db, {
-            companyId: approval.companyId,
-            actorType: "user",
-            actorId: req.actor.userId ?? "board",
-            action: "approval.requester_wakeup_queued",
-            entityType: "approval",
-            entityId: approval.id,
-            details: {
-              requesterAgentId: approval.requestedByAgentId,
-              wakeRunId: wakeRun?.id ?? null,
-              linkedIssueIds,
-            },
-          });
-        } catch (err) {
-          logger.warn(
-            {
-              err,
-              approvalId: approval.id,
-              requestedByAgentId: approval.requestedByAgentId,
-            },
-            "failed to queue requester wakeup after approval",
-          );
-          await logActivity(db, {
-            companyId: approval.companyId,
-            actorType: "user",
-            actorId: req.actor.userId ?? "board",
-            action: "approval.requester_wakeup_failed",
-            entityType: "approval",
-            entityId: approval.id,
-            details: {
-              requesterAgentId: approval.requestedByAgentId,
-              linkedIssueIds,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
-      }
+      await wakeApprovalRequester(approval, {
+        reason: "approval_approved",
+        source: "approval.approved",
+        note: approval.decisionNote,
+        requestedByActorType: "user",
+        requestedByActorId: req.actor.userId ?? "board",
+      });
     }
 
     res.json(redactApprovalPayload(approval));
@@ -265,6 +312,14 @@ export function approvalRoutes(
         entityType: "approval",
         entityId: approval.id,
         details: { type: approval.type },
+      });
+
+      await wakeApprovalRequester(approval, {
+        reason: "approval_rejected",
+        source: "approval.rejected",
+        note: approval.decisionNote,
+        requestedByActorType: "user",
+        requestedByActorId: req.actor.userId ?? "board",
       });
     }
 
@@ -292,6 +347,14 @@ export function approvalRoutes(
         entityType: "approval",
         entityId: approval.id,
         details: { type: approval.type },
+      });
+
+      await wakeApprovalRequester(approval, {
+        reason: "approval_revision_requested",
+        source: "approval.revision_requested",
+        note: approval.decisionNote,
+        requestedByActorType: "user",
+        requestedByActorId: req.actor.userId ?? "board",
       });
 
       res.json(redactApprovalPayload(approval));
@@ -372,6 +435,19 @@ export function approvalRoutes(
       entityId: approval.id,
       details: { commentId: comment.id },
     });
+
+    // Wake the requesting agent on a board/peer reply — but never on the agent's
+    // own comment (that would self-trigger an idle loop).
+    if (approval.requestedByAgentId && actor.agentId !== approval.requestedByAgentId) {
+      await wakeApprovalRequester(approval, {
+        reason: "approval_commented",
+        source: "approval.comment_added",
+        note: req.body.body,
+        commentId: comment.id,
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
 
     res.status(201).json(comment);
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -367,7 +367,15 @@ function mergeAdapterRecoveryMetadata(input: {
       : {}),
   };
 }
-const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved"]);
+const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
+  "approval_approved",
+  // TON-2324 / GH #7784: board replies must survive a mid-run wake — if the
+  // requesting agent is already executing when the board rejects, requests a
+  // revision, or comments, queue a follow-up so the reply is not dropped.
+  "approval_rejected",
+  "approval_revision_requested",
+  "approval_commented",
+]);
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",

--- a/ui/src/pages/ApprovalDetail.tsx
+++ b/ui/src/pages/ApprovalDetail.tsx
@@ -24,6 +24,7 @@ export function ApprovalDetail() {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [commentBody, setCommentBody] = useState("");
+  const [decisionNote, setDecisionNote] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [showRawPayload, setShowRawPayload] = useState(false);
 
@@ -84,10 +85,18 @@ export function ApprovalDetail() {
     }
   };
 
+  // TON-2324 / GH #7784: decision buttons carry an optional note that is woken
+  // back to the requesting agent as the board's reply in context.
+  const decisionNoteArg = () => {
+    const trimmed = decisionNote.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  };
+
   const approveMutation = useMutation({
-    mutationFn: () => approvalsApi.approve(approvalId!),
+    mutationFn: () => approvalsApi.approve(approvalId!, decisionNoteArg()),
     onSuccess: () => {
       setError(null);
+      setDecisionNote("");
       refresh();
       navigate(`/approvals/${approvalId}?resolved=approved`, { replace: true });
     },
@@ -95,18 +104,20 @@ export function ApprovalDetail() {
   });
 
   const rejectMutation = useMutation({
-    mutationFn: () => approvalsApi.reject(approvalId!),
+    mutationFn: () => approvalsApi.reject(approvalId!, decisionNoteArg()),
     onSuccess: () => {
       setError(null);
+      setDecisionNote("");
       refresh();
     },
     onError: (err) => setError(err instanceof Error ? err.message : "Reject failed"),
   });
 
   const revisionMutation = useMutation({
-    mutationFn: () => approvalsApi.requestRevision(approvalId!),
+    mutationFn: () => approvalsApi.requestRevision(approvalId!, decisionNoteArg()),
     onSuccess: () => {
       setError(null);
+      setDecisionNote("");
       refresh();
     },
     onError: (err) => setError(err instanceof Error ? err.message : "Revision request failed"),
@@ -257,6 +268,19 @@ export function ApprovalDetail() {
             </div>
             <p className="text-[11px] text-muted-foreground mt-2">
               Linked tasks remain open until the requesting agent follows up and closes them.
+            </p>
+          </div>
+        )}
+        {isActionable && !isBudgetApproval && (
+          <div className="space-y-1">
+            <Textarea
+              value={decisionNote}
+              onChange={(e) => setDecisionNote(e.target.value)}
+              placeholder="Optional note for the requesting agent (sent with your decision)…"
+              rows={2}
+            />
+            <p className="text-[11px] text-muted-foreground">
+              The agent that requested this approval is woken with your decision and this note in context.
             </p>
           </div>
         )}


### PR DESCRIPTION
Fixes #7784

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, where a human board approves high-stakes agent actions (hires, budget overrides, board-approval requests).
> - The **approvals subsystem** (`server/src/routes/approvals.ts` + `approvalService`) lets an agent request a decision and the board approve/reject/request-revision or leave free-form comments on the approval thread.
> - The gap: this reply channel was **one-way**. Only `approve` enqueued a wake for the requesting agent, and even that wake dropped the board's `decisionNote`. `reject` and `request-revision` were silent, and the **approval comment box never woke anyone** — a board member could type "can you clarify the cost?" and the agent would never see it.
> - It needs addressing because an approval the agent never hears back about stalls the whole zero-human loop: the agent sits idle waiting on a decision that was already made.
> - This pull request adds a single shared wake path (`wakeApprovalRequester`) that fires on every board reply — decision or comment — and threads the reply text into the agent's wake context so it resumes with the answer in hand.
> - It guards against a self-trigger loop (an agent commenting on its own approval does not wake itself) and registers the new wake reasons as follow-up-requiring, so a reply is queued rather than dropped when the requester is already mid-run.
> - The benefit is a closed-loop approval conversation: the board's decision **and** its note/comment reach the requesting agent every time.

## What Changed

- **New wake path (`server/src/routes/approvals.ts`):** added a shared `wakeApprovalRequester(approval, opts)` helper that lists the approval's linked issues, builds a wake payload + context snapshot carrying the reply text (`note`) and any `commentId`, calls `heartbeat.wakeup`, and logs `approval.requester_wakeup_queued` / `_failed`. Best-effort — a wake failure never blocks the decision/comment HTTP response.
- Wired the helper into **approve** (now forwarding `decisionNote`, previously dropped), **reject** and **request-revision** (previously no wake at all), and the **comment** endpoint.
- The comment wake fires only when the commenter is **not** the requesting agent (`actor.agentId !== approval.requestedByAgentId`), preventing an idle self-trigger loop.
- **`server/src/services/heartbeat.ts`:** added `approval_rejected`, `approval_revision_requested`, `approval_commented` to `RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP` so a reply that arrives while the requester is executing is queued as a follow-up instead of being lost.
- **UI (`ui/src/pages/ApprovalDetail.tsx`):** added an optional decision-note textarea to the decision panel; the Approve / Reject / Request-revision buttons now carry that note (cleared on success), with a hint explaining it is sent to the requesting agent.
- **Tests:** extended `approval-routes-idempotency.test.ts` with note-forwarding on approve, wake-on-reject/revision/comment, and the no-self-wake guard.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passes.
- `pnpm --filter @paperclipai/ui typecheck` and `pnpm --filter @paperclipai/ui build` — pass (the separate `ui build` tsc gate is green).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/approval-routes-idempotency.test.ts` — 13/13 pass (8 existing + 5 new).
- Manual: open an approval, type a note, click Approve/Reject/Request-revision, or post a comment as the board → the requesting agent receives a wake with `reason` of `approval_{approved,rejected,revision_requested,commented}` and the note/comment in `payload.note` + `contextSnapshot.note`.

## Risks

- **Low risk.** No DB migration, no new dependency, no `.github/workflows` changes. The wake reason field is a free `string` (not a narrowed union), so no UI consumers break.
- New behavior is additive: previously-silent paths now wake the requester. The self-comment guard prevents an agent from waking itself in a loop. Wake failures are caught and logged, so they cannot fail the board's decision/comment request.

## Model Used

- Claude (Anthropic), model ID `claude-opus-4-8`, extended-thinking + tool-use, used for design and implementation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
- [x] I searched for similar open/closed PRs and confirmed this is not a duplicate
