### PR TITLE
fix(recovery): run cancellation no longer auto-queues a retry wake (#7841)

### DIFF
--- a/server/src/__tests__/heartbeat-cancel-no-retry.test.ts
+++ b/server/src/__tests__/heartbeat-cancel-no-retry.test.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentRuntimeState,
+  agentWakeupRequests,
+  agents,
+  companies,
+  createDb,
+  environmentLeases,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("heartbeat run cancellation does not auto-retry (#7841)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-cancel-no-retry-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRunEvents);
+    await db.delete(environmentLeases);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Work",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+    });
+    return { companyId, agentId, issueId, runId };
+  }
+
+  it("cancelling a run releases the issue lock without queuing a retry or blocking", async () => {
+    const { issueId, runId } = await seed();
+
+    await heartbeat.cancelRun(runId);
+
+    // The cancelled run must not spawn an automatic retry run.
+    const retryRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId));
+    expect(retryRuns).toHaveLength(0);
+
+    const allRuns = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+    expect(allRuns).toHaveLength(1);
+    expect(allRuns[0]?.status).toBe("cancelled");
+
+    // The issue is released (lock cleared) but NOT regressed to blocked.
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.executionRunId).toBeNull();
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10533,11 +10533,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
 
+      // GH #7841: a cancellation is a deliberate veto (e.g. a budget/volume
+      // governor cancelling over-quota runs), not a failure to recover from.
+      // Auto-retrying it re-queued another run that got cancelled again, which
+      // re-queued another retry — a self-sustaining loop. Only failed/timed_out
+      // runs warrant automatic immediate recovery; cancelled runs just release
+      // the execution lock (deferred human/mention wakes above still promote).
       const issueNeedsImmediateRecovery =
         (issue.status === "todo" || issue.status === "in_progress") &&
         !issue.assigneeUserId &&
         issue.assigneeAgentId === run.agentId &&
-        (run.status === "failed" || run.status === "timed_out" || run.status === "cancelled");
+        (run.status === "failed" || run.status === "timed_out");
 
       if (!issueNeedsImmediateRecovery) {
         return { kind: "released" as const };


### PR DESCRIPTION
## Thinking Path

> - Paperclip's heartbeat service auto-recovers assigned issues: when a run ends without a live execution path, it queues a retry.
> - #7841: an external governor that cancels over-budget runs via `POST /heartbeat-runs/:id/cancel` triggered a self-sustaining loop — each cancellation queued another retry run, which the governor cancelled again (~20 runs in ~15 min on one ticket), compounded by recovery issues.
> - Root cause: `releaseIssueExecutionAndPromote` treats `cancelled` the same as `failed`/`timed_out` in its `issueNeedsImmediateRecovery` trigger — but a cancellation is a deliberate veto, not a failure to recover from.
> - Per the issue, the real fix is to not auto-retry cancellations.
> - This drops `cancelled` from the trigger; cancelled runs still release the lock and still promote deferred human/mention wakes (that runs earlier in the function).
> - The benefit is that deliberate cancellations stop the work instead of feeding an infinite retry loop.

## What Changed

- `server/src/services/heartbeat.ts`: `issueNeedsImmediateRecovery` now triggers on `failed`/`timed_out` only, not `cancelled`. A cancelled run returns `released` (no retry run, no blocked flip, no recovery issue); deferred-wake promotion above is unchanged.
- `server/src/__tests__/heartbeat-cancel-no-retry.test.ts`: embedded-Postgres test — cancelling a running run on an in_progress assigned issue creates **no** retry run and leaves the issue in_progress with the lock cleared.

## Verification

- `npx vitest run src/__tests__/heartbeat-cancel-no-retry.test.ts` → passes. Confirmed it **fails before the fix** (a retry run is queued).
- Server `tsc --noEmit` clean.

## Risks

- Low risk: narrows an auto-retry trigger; failed/timed_out recovery is unchanged. Cancelled runs already release the lock + promote legitimate deferred wakes, so human/mention-driven continuation is unaffected — only the automatic system retry on a deliberate cancel is removed. Pairs with #7864 (terminal-status regression guard); together they close the #7841 loop.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended reasoning, via Claude Code (tool use + local embedded-Postgres test, incl. negative verification).

Closes #7841. Related: #7864 (#7840), #7867 (#7450), #7869 (#7639), #7866 (#7786), #7819 (#7795), #7814 (#7790), #7809 (#7685).

## Dedup search

- [x] I searched the open and recently-closed GitHub PRs for similar or duplicate PRs (cancellation retry loop / immediate recovery) and found none addressing this.
