### PR TITLE
fix(server): prefer loopback URL for agent env when bind is loopback (SAG-3617)

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../runtime-api.js";
 
 describe("runtime API discovery", () => {
-  it("prefers the explicit public base URL for the primary runtime URL", () => {
+  it("prefers the explicit public base URL for the primary runtime URL when bindHost is wildcard", () => {
     expect(
       choosePrimaryRuntimeApiUrl({
         authPublicBaseUrl: "https://paperclip.example.com/base/path",
@@ -15,6 +15,18 @@ describe("runtime API discovery", () => {
         port: 3102,
       }),
     ).toBe("https://paperclip.example.com");
+  });
+
+  it("prefers loopback URL over authPublicBaseUrl when bindHost is loopback", () => {
+    // Server bound to 127.0.0.1 only — agents must use loopback, not the Tailscale/auth URL.
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: "https://myhost.tail302fee.ts.net",
+        allowedHostnames: ["myhost.tail302fee.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("http://127.0.0.1:3100");
   });
 
   it("builds ordered callback candidates from explicit, allowed, bind, and interface hosts", () => {

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -52,6 +52,14 @@ export function choosePrimaryRuntimeApiUrl(input: {
   bindHost: string;
   port: number;
 }): string {
+  // When the server binds exclusively to loopback, agents on the same host must
+  // reach the API via loopback regardless of authPublicBaseUrl (which is for
+  // browser auth flows / reverse-proxy routing, not same-host agent-to-API calls).
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && isLoopbackHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const explicitPublicBaseUrl = input.authPublicBaseUrl?.trim();
   if (explicitPublicBaseUrl) {
     try {
@@ -68,7 +76,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }


### PR DESCRIPTION
## SAG-3617 — clean de-stacked replacement for #7886

Single-commit, off clean `origin/master`. Supersedes #7886, which was CONFLICTING and bundled 4 unrelated board-gated commits (SAG-3171, SAG-3376, SAG-3304 ×2). The fix commit here is **byte-identical** to the approved fix `42582622` (git diff empty).

### Root cause
`choosePrimaryRuntimeApiUrl` in `server/src/runtime-api.ts` unconditionally used `authPublicBaseUrl` (the Tailscale URL for browser auth) as `PAPERCLIP_RUNTIME_API_URL` / `PAPERCLIP_API_URL`. When the server binds to loopback only (`127.0.0.1`), same-host agents cannot reach that URL → silent API failures. This is the load-bearing reason SAG-2983 is blocked ("use localhost" memory).

### Fix (option (b) from the issue — lighter, bind unchanged)
Short-circuit at the top of `choosePrimaryRuntimeApiUrl`: when `bindHost` is a loopback address, return `http://<loopback>:<port>` immediately, skipping `authPublicBaseUrl`. `authPublicBaseUrl` is still used for browser-facing auth redirects. Server bind is unchanged.

Design note: if the server binds loopback-only, the *only* reachable path for any agent is loopback (remote agents can't reach it at all), so agents are necessarily same-host → the short-circuit is always correct.

### Verification
- `runtime-api.test.ts` 6/6 (new load-bearing case: Tailscale `authPublicBaseUrl` + `127.0.0.1` bind → `http://127.0.0.1:3100`)
- `paperclip-env.test.ts` 4/4
- 2 files changed, +21/-2

Closes SAG-3617 on merge → auto-unblocks SAG-2983 memory sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)