### PR TITLE
fix(ui): don't redirect to /auth on transient session-fetch failure (#7795)

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -202,6 +202,53 @@ describe("CloudAccessGate", () => {
     unmountRoot(root);
   });
 
+  it("redirects to /auth when the server confirms the user is signed out", async () => {
+    mockAuthApi.getSession.mockResolvedValue(null);
+
+    const root = renderGate(container);
+    await waitForText(container, "Navigate:/auth");
+
+    expect(container.textContent).toContain("Navigate:/auth?next=");
+    expect(container.textContent).not.toContain("Outlet content");
+
+    unmountRoot(root);
+  });
+
+  it("does not redirect to /auth when the session fetch fails transiently", async () => {
+    mockAuthApi.getSession.mockRejectedValueOnce(new Error("Failed to load session (503)"));
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+    });
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "user@example.com", name: "User", image: null },
+      userId: "user-1",
+      isInstanceAdmin: false,
+      companyIds: ["company-1"],
+      source: "session",
+      keyId: null,
+    });
+
+    const root = renderGate(container);
+    await waitForText(container, "Failed to load session (503)");
+
+    expect(container.textContent).not.toContain("Navigate:/auth");
+    expect(container.textContent).toContain("You have not been signed out");
+
+    const retry = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Retry"),
+    );
+    expect(retry).toBeTruthy();
+    flushSync(() => {
+      retry?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await waitForText(container, "Outlet content");
+
+    expect(container.textContent).toContain("Outlet content");
+
+    unmountRoot(root);
+  });
+
   it("keeps public bootstrap-pending instances invite-only", async () => {
     mockHealthApi.get.mockResolvedValue({
       status: "ok",

--- a/ui/src/components/CloudAccessGate.tsx
+++ b/ui/src/components/CloudAccessGate.tsx
@@ -6,6 +6,7 @@ import { authApi } from "@/api/auth";
 import { healthApi } from "@/api/health";
 import { queryKeys } from "@/lib/queryKeys";
 import { BootstrapPendingPage } from "@/components/BootstrapPendingPage";
+import { Button } from "@/components/ui/button";
 
 function NoBoardAccessPage() {
   return (
@@ -88,6 +89,23 @@ export function CloudAccessGate() {
     );
   }
 
+  if (isAuthenticatedMode && sessionQuery.error) {
+    return (
+      <div className="mx-auto max-w-xl py-10 text-sm">
+        <p className="text-destructive">
+          {sessionQuery.error instanceof Error ? sessionQuery.error.message : "Failed to load session"}
+        </p>
+        <p className="mt-2 text-muted-foreground">
+          Couldn&apos;t reach the server to confirm your session — it may still be starting up. You have not been
+          signed out.
+        </p>
+        <Button variant="outline" size="sm" className="mt-4" onClick={() => void sessionQuery.refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
   if (isBootstrapPending) {
     const health = healthQuery.data;
     if (!health) {
@@ -110,7 +128,10 @@ export function CloudAccessGate() {
     );
   }
 
-  if (isAuthenticatedMode && !sessionQuery.data) {
+  // Only bounce to /auth when the server actually confirmed signed-out (the
+  // 401 → null path in authApi.getSession). A failed fetch — cold-boot
+  // timeout, network error, 5xx — must not be treated as a sign-out.
+  if (isAuthenticatedMode && sessionQuery.isSuccess && !sessionQuery.data) {
     const next = encodeURIComponent(`${location.pathname}${location.search}`);
     return <Navigate to={`/auth?next=${next}`} replace />;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; humans reach the board through the web UI.
> - The web UI gates every authenticated route behind `CloudAccessGate`, which resolves the session via `/api/auth/get-session`.
> - On serverless cold boots (issue #7795) that request can hang, time out, or return 5xx while the function is still booting.
> - `CloudAccessGate` treated *any* missing session data as signed-out and redirected to `/auth` — so a slow boot looked like a logout and broke the login/navigation flow.
> - But `authApi.getSession()` already resolves `null` only on a real 401 and throws on every other failure; the gate just ignored that distinction.
> - This pull request makes the gate redirect only on a server-confirmed 401, and show a retryable error state on transient fetch failure.
> - The benefit is that cold-boot users stay on their page (with a Retry) instead of being bounced to login — directly addressing item 4 of the #7795 directive.

## What Changed

- `CloudAccessGate` now redirects to `/auth` only when the session query **succeeded with a null session** (`sessionQuery.isSuccess && !sessionQuery.data`), i.e. a real 401.
- On a failed session fetch (timeout / network / 5xx), the gate renders an explicit error state with a **Retry** button and the message "You have not been signed out", instead of redirecting.

## Verification

- `pnpm --filter @paperclipai/ui vitest run src/App.test.tsx` — 7/7 pass.
- Two new `CloudAccessGate` tests: (a) a server-confirmed null session still redirects to `/auth`; (b) a transient fetch failure shows Retry, does not redirect, and recovers to the board when Retry succeeds.
- **Negative-verified:** the transient-failure test fails against the unfixed component (it redirects) and passes with the fix.
- `tsc -b` clean. Edit region is identical between the PR base and current `master`, so it merges cleanly.

## Risks

Low risk. Single UI component; no API, schema, or behavioral change for the real-401 path (still redirects exactly as before). The only new path is the previously-unhandled fetch-error case, which now shows a Retry instead of a misleading redirect.

## Model Used

Claude Fable 5 (`claude-fable-5`), Anthropic — extended reasoning, tool use / code execution via Claude Code harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

<!-- dedup-search -->
- [x] I have searched the GitHub PR list for similar/duplicate PRs (companion to #7819; no existing PR covers the /auth redirect path).