### PR TITLE
test(ui): de-flake IssueProperties custom-model edit test

### DIFF
--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -936,9 +936,16 @@ describe("IssueProperties", () => {
     expect(container.textContent).toContain("Custom · gpt-5.4 · high");
     expect(container.textContent).toContain("Model lane");
 
-    const modelButton = Array.from(container.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("GPT-5.5"));
-    expect(modelButton).not.toBeUndefined();
+    // The adapter model options load asynchronously (mockAgentsApi.adapterModels),
+    // so two fixed flushes can race under CI load and leave the button unrendered.
+    // Poll until it appears instead of asserting on a fixed tick (matches the
+    // waitForAssertion pattern used elsewhere in this file).
+    let modelButton: HTMLButtonElement | undefined;
+    await waitForAssertion(() => {
+      modelButton = Array.from(container.querySelectorAll("button"))
+        .find((button) => button.textContent?.includes("GPT-5.5"));
+      expect(modelButton).not.toBeUndefined();
+    });
 
     await act(async () => {
       modelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; the web UI is how humans review and steer work.
> - The UI test suite runs in CI as "General tests (workspaces-a)" and gates every PR (and the downstream `verify` aggregator).
> - One UI test — `IssueProperties.test.tsx > edits existing custom assignee model options from the properties pane` — has been failing intermittently with `expected undefined not to be undefined`.
> - Root cause: the adapter model options render asynchronously from `mockAgentsApi.adapterModels`, but the test asserts the "GPT-5.5" button exists after exactly two fixed `await flush()` ticks. Under CI load those two ticks can resolve before the button mounts, so the lookup returns `undefined` and the assertion throws.
> - This is a pure test-timing flake (the component is fine) — but it has been red-herring-blocking unrelated PRs (#7869 and #7898 both hit it; #7898 only went green on a re-run).
> - This pull request makes the test poll for the button via the file's existing `waitForAssertion` helper instead of asserting on a fixed tick.
> - The benefit is a stable CI signal so real failures are not masked by this flake and PRs stop needing re-runs.

## What Changed

- In `IssueProperties.test.tsx`, the custom-model-edit test now wraps the "GPT-5.5" button lookup + presence assertion in `waitForAssertion(...)` (the helper already defined in this file and used at two other call sites), instead of relying on two fixed `await flush()` ticks.

## Verification

- `pnpm --filter @paperclipai/ui vitest run src/components/IssueProperties.test.tsx` — full file green, run 5× consecutively with no failures (and 3× again from the PR base).
- Test-only change; no production code touched.

## Risks

Very low. Single test file, one assertion site, no source/behavior change. `waitForAssertion` has a bounded 20-attempt cap so it cannot hang; if the button genuinely never renders the test still fails (correctly) with the same assertion error.

## Model Used

Claude Fable 5 (`claude-fable-5`), Anthropic — extended reasoning, tool use / code execution via Claude Code harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
- [x] I searched the GitHub PR list for similar/duplicate PRs and found none addressing this flaky test.