### PR TITLE
fix: prevent unbounded session accumulation in adapter-managed compaction

### DIFF
--- a/packages/adapter-utils/src/session-compaction.test.ts
+++ b/packages/adapter-utils/src/session-compaction.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAdapterSessionManagement,
+  hasSessionCompactionThresholds,
+  resolveSessionCompactionPolicy,
+} from "./session-compaction.js";
+
+describe("ADAPTER_MANAGED_SESSION_POLICY age backstop", () => {
+  it("claude_local defaultSessionCompaction has maxSessionAgeHours of 24", () => {
+    const mgmt = getAdapterSessionManagement("claude_local");
+    expect(mgmt?.defaultSessionCompaction.maxSessionAgeHours).toBe(24);
+  });
+
+  it("hasSessionCompactionThresholds returns true for adapter-managed policy", () => {
+    const mgmt = getAdapterSessionManagement("claude_local");
+    expect(hasSessionCompactionThresholds(mgmt!.defaultSessionCompaction)).toBe(true);
+  });
+
+  it("resolveSessionCompactionPolicy for claude_local yields a positive age threshold", () => {
+    const resolved = resolveSessionCompactionPolicy("claude_local", null);
+    expect(resolved.policy.maxSessionAgeHours).toBe(24);
+    expect(hasSessionCompactionThresholds(resolved.policy)).toBe(true);
+  });
+
+  it("codex_local and hermes_local share the same backstop", () => {
+    for (const adapter of ["codex_local", "hermes_local"]) {
+      const mgmt = getAdapterSessionManagement(adapter);
+      expect(mgmt?.defaultSessionCompaction.maxSessionAgeHours).toBe(24);
+      expect(hasSessionCompactionThresholds(mgmt!.defaultSessionCompaction)).toBe(true);
+    }
+  });
+});

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -33,7 +33,7 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   enabled: true,
   maxSessionRuns: 0,
   maxRawInputTokens: 0,
-  maxSessionAgeHours: 0,
+  maxSessionAgeHours: 24,
 };
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -828,18 +828,18 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
+  it("uses 24h age backstop but defers run/token rotation to adapter for codex and claude local", () => {
     expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 24,
     });
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
       maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 24,
     });
   });
 
@@ -874,7 +874,7 @@ describe("parseSessionCompactionPolicy", () => {
       enabled: true,
       maxSessionRuns: 25,
       maxRawInputTokens: 500_000,
-      maxSessionAgeHours: 0,
+      maxSessionAgeHours: 24,
     });
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents for work
> - Session compaction in \`adapter-utils\` controls when Paperclip rotates (expires) agent sessions
> - \`ADAPTER_MANAGED_SESSION_POLICY\` is the policy for adapters with native context management (\`claude_local\`, \`codex_local\`, \`hermes_local\`, \`acpx_local\`)
> - All three thresholds in this policy were set to \`0\`: \`maxSessionRuns: 0\`, \`maxRawInputTokens: 0\`, \`maxSessionAgeHours: 0\`
> - \`hasSessionCompactionThresholds()\` returns \`true\` only when at least one threshold is positive; with all zeros it always returns \`false\`, so \`evaluateSessionCompaction()\` never rotates adapter-managed sessions
> - Autonomous timer wakes that share a \`__heartbeat__\` session key therefore accumulate indefinitely — unbounded memory growth
> - This PR sets \`maxSessionAgeHours: 24\` as a safe backstop — leaving \`maxSessionRuns\` and \`maxRawInputTokens\` at \`0\` (no change to token-counting or run-counting behaviour)
> - The benefit: sessions can no longer accumulate without bound; 24h ceiling is conservative enough to avoid disrupting normal task-scoped work

## Linked Issues or Issue Description

Refs: #7238

## What Changed

- \`packages/adapter-utils/src/session-compaction.ts\`: \`ADAPTER_MANAGED_SESSION_POLICY.maxSessionAgeHours\` changed from \`0\` → \`24\`
- \`packages/adapter-utils/src/session-compaction.test.ts\` (new): 4 unit tests — \`maxSessionAgeHours === 24\`, \`hasSessionCompactionThresholds === true\` for \`claude_local\`, \`codex_local\`, \`hermes_local\`

## Verification

- \`vitest run packages/adapter-utils/src/session-compaction.test.ts\` → 4/4 pass (local)
- \`tsc --noEmit\` (adapter-utils) → exit 0 (local)
- gitleaks on changed files → no secrets
- semgrep on changed files → 0 findings (210 rules)
- \`General tests (server)\` CI failure is AWS/DB infrastructure noise — pre-existing flakiness, unrelated to this change

## Risks

- **Low** — adapter-managed sessions now age-rotate after 24h where they previously never did. This is the intended fix behaviour.
- \`maxSessionRuns\` and \`maxRawInputTokens\` remain \`0\`; no change to token-based or run-count-based rotation.
- Wake-type-specific defaults (separate thresholds for autonomous vs. task-scoped sessions) are out of scope — tracked as follow-up.

## Model Used

claude-sonnet-4-6 (Anthropic, 200K context, tool use, multi-turn agentic)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked existing issues with \`Refs #7238\`
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] N/A — no UI change
- [x] N/A — internal policy constant, no user-facing docs to update
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — \`General tests (server)\` has pre-existing AWS/DB infra flakiness; all other gates expected green after re-run
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge