### PR TITLE
fix(heartbeat): suppress background wakes for terminal-status issues (#7841)

### DIFF
--- a/server/src/__tests__/heartbeat-terminal-issue-wake-guard.test.ts
+++ b/server/src/__tests__/heartbeat-terminal-issue-wake-guard.test.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentRuntimeState,
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres terminal-issue wake guard tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat terminal-issue wake guard (#7841)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-terminal-issue-wake-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function insertAgentWithIssue(issueStatus: "done" | "cancelled" | "todo") {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Wake Guard Co",
+      status: "active",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Wake Guard Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 60,
+          wakeOnDemand: true,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: `Wake guard issue (${issueStatus})`,
+      status: issueStatus,
+      assigneeAgentId: agentId,
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  async function findWakeupRequest(agentId: string) {
+    return db
+      .select({
+        agentId: agentWakeupRequests.agentId,
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        error: agentWakeupRequests.error,
+      })
+      .from(agentWakeupRequests)
+      .then((rows) => rows.find((row) => row.agentId === agentId) ?? null);
+  }
+
+  it("skips background wakes for a done issue with an issue.terminal_status reason", async () => {
+    const { agentId, issueId } = await insertAgentWithIssue("done");
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "missing_issue_comment",
+      payload: { issueId, retryReason: "missing_issue_comment" },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+
+    expect(run).toBeNull();
+    expect(await findWakeupRequest(agentId)).toMatchObject({
+      status: "skipped",
+      reason: "issue.terminal_status",
+      error: "Wake suppressed because issue status is done",
+    });
+  });
+
+  it("skips background wakes for a cancelled issue", async () => {
+    const { agentId, issueId } = await insertAgentWithIssue("cancelled");
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: randomUUID() },
+      requestedByActorType: "system",
+      requestedByActorId: "comment_wake",
+    });
+
+    expect(run).toBeNull();
+    expect(await findWakeupRequest(agentId)).toMatchObject({
+      status: "skipped",
+      reason: "issue.terminal_status",
+      error: "Wake suppressed because issue status is cancelled",
+    });
+  });
+
+  it("still enqueues background wakes for an open issue", async () => {
+    const { agentId, issueId } = await insertAgentWithIssue("todo");
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: randomUUID() },
+      requestedByActorType: "system",
+      requestedByActorId: "comment_wake",
+    });
+
+    expect(run).not.toBeNull();
+    const request = await findWakeupRequest(agentId);
+    expect(request?.reason).not.toBe("issue.terminal_status");
+    expect(request?.status).not.toBe("skipped");
+  });
+
+  it("does not intercept user-requested wakes at enqueue time", async () => {
+    const { agentId, issueId } = await insertAgentWithIssue("done");
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "user",
+      reason: "follow_up_question",
+      payload: { issueId },
+      requestedByActorType: "user",
+      requestedByActorId: randomUUID(),
+    });
+
+    // The new guard only suppresses background wakes: the user wake is
+    // enqueued normally. The pre-existing claim-time semantics then decide
+    // what happens to the queued run (today: cancelled at claim because the
+    // issue is terminal) — the guard adds no new restriction for users.
+    expect(run).not.toBeNull();
+    const request = await findWakeupRequest(agentId);
+    expect(request?.reason).not.toBe("issue.terminal_status");
+    expect(request?.error).toContain("terminal status");
+  });
+});

--- a/server/src/__tests__/heartbeat-terminal-issue-wake-guard.test.ts
+++ b/server/src/__tests__/heartbeat-terminal-issue-wake-guard.test.ts
@@ -59,6 +59,7 @@ describeEmbeddedPostgres("heartbeat terminal-issue wake guard (#7841)", () => {
       status: "active",
       issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
       requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
     });
 
     await db.insert(agents).values({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13397,7 +13397,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const continuationAttempt = readContinuationAttempt(enrichedContextSnapshot.livenessContinuationAttempt);
 
     let projectId = readNonEmptyString(enrichedContextSnapshot.projectId);
-    if (!projectId && issueId) {
+    let resolvedIssueStatus: string | null = null;
+    if (issueId) {
       // Look up by either UUID or identifier (e.g. "ENV-13"), but always scope
       // by companyId so a row from another tenant can never be returned even
       // when identifiers collide across companies. Guard the UUID arm because
@@ -13409,12 +13410,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? or(eq(issues.id, issueId), eq(issues.identifier, issueId.toUpperCase()))
         : eq(issues.identifier, issueId.toUpperCase());
       const resolvedIssue = await db
-        .select({ id: issues.id, projectId: issues.projectId })
+        .select({ id: issues.id, projectId: issues.projectId, status: issues.status })
         .from(issues)
         .where(and(eq(issues.companyId, agent.companyId), idMatch))
         .then((rows) => rows[0] ?? null);
       if (resolvedIssue) {
-        projectId = resolvedIssue.projectId ?? null;
+        resolvedIssueStatus = resolvedIssue.status ?? null;
+        if (!projectId) projectId = resolvedIssue.projectId ?? null;
         // Canonicalize context to the UUID so downstream lookups always use UUID
         if (resolvedIssue.id !== issueId) {
           issueId = resolvedIssue.id;
@@ -13467,22 +13469,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // work that is already over, and combined with #7840 can pull a
     // completed issue back into execution. Humans can still wake an agent
     // about a closed issue explicitly (requestedByActorType === "user").
-    if (issueId && opts.requestedByActorType !== "user") {
-      const issueIdIsUuid = isUuidLike(issueId);
-      const terminalMatch = issueIdIsUuid
-        ? or(eq(issues.id, issueId), eq(issues.identifier, issueId.toUpperCase()))
-        : eq(issues.identifier, issueId.toUpperCase());
-      const issueStatusRow = await db
-        .select({ status: issues.status })
-        .from(issues)
-        .where(and(eq(issues.companyId, agent.companyId), terminalMatch))
-        .then((rows) => rows[0] ?? null);
-      if (issueStatusRow && (issueStatusRow.status === "done" || issueStatusRow.status === "cancelled")) {
-        await writeSkippedRequest("issue.terminal_status", {
-          error: `Wake suppressed because issue status is ${issueStatusRow.status}`,
-        });
-        return null;
-      }
+    // Status comes from the canonicalization lookup above — no extra query.
+    if (
+      opts.requestedByActorType !== "user" &&
+      (resolvedIssueStatus === "done" || resolvedIssueStatus === "cancelled")
+    ) {
+      await writeSkippedRequest("issue.terminal_status", {
+        error: `Wake suppressed because issue status is ${resolvedIssueStatus}`,
+      });
+      return null;
     }
 
     const budgetBlock = await budgets.getInvocationBlock(agent.companyId, agentId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13461,6 +13461,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return queuedResponsibleUserIdPromise;
     };
 
+    // Background wakes must not target finished work (#7841). Stale wakes for
+    // a done/cancelled issue — comment retries, recovery sweeps, re-queues
+    // after a governor-driven cancellation — make the system busy-loop on
+    // work that is already over, and combined with #7840 can pull a
+    // completed issue back into execution. Humans can still wake an agent
+    // about a closed issue explicitly (requestedByActorType === "user").
+    if (issueId && opts.requestedByActorType !== "user") {
+      const issueIdIsUuid = isUuidLike(issueId);
+      const terminalMatch = issueIdIsUuid
+        ? or(eq(issues.id, issueId), eq(issues.identifier, issueId.toUpperCase()))
+        : eq(issues.identifier, issueId.toUpperCase());
+      const issueStatusRow = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.companyId, agent.companyId), terminalMatch))
+        .then((rows) => rows[0] ?? null);
+      if (issueStatusRow && (issueStatusRow.status === "done" || issueStatusRow.status === "cancelled")) {
+        await writeSkippedRequest("issue.terminal_status", {
+          error: `Wake suppressed because issue status is ${issueStatusRow.status}`,
+        });
+        return null;
+      }
+    }
+
     const budgetBlock = await budgets.getInvocationBlock(agent.companyId, agentId, {
       issueId,
       projectId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat subsystem wakes agents via `agentWakeupRequests` — timers, assignments, comment wakes, recovery sweeps, and automation re-queues all funnel through `enqueueWakeup`
> - #7841: background wakes keep targeting issues that are already `done`/`cancelled` (comment retries, recovery sweeps, re-queues after a governor-driven cancellation), so the system busy-loops on finished work — we observed ~50 created-and-cancelled runs across two production episodes
> - Each of those wakes is enqueued, becomes a queued run, and is only stopped at claim time — and the cancellation itself can re-queue, which is the loop's fuel
> - This PR suppresses non-user wakes for terminal-status issues at enqueue time, using the same skip convention as `company.inactive` / `issue_tree_hold_active`, with an auditable skipped request row
> - The benefit is that every variant of the completed-issue wake loop dies at a single chokepoint, with zero queued-run churn, while user-initiated wakes keep their existing semantics

## Linked Issues or Issue Description

Closes #7841
Refs #7840

## What Changed

- `server/src/services/heartbeat.ts`: the issue canonicalization lookup in `enqueueWakeup` now runs whenever an `issueId` is present (previously only when `projectId` was missing) and additionally selects `status`; `projectId` assignment keeps its original precedence
- `server/src/services/heartbeat.ts`: new guard after canonicalization — when the wake is **not** user-requested and the resolved issue status is `done` or `cancelled`, write a skipped wakeup request with reason `issue.terminal_status` and return `null` (no extra query; status comes from the canonicalization lookup)
- `server/src/__tests__/heartbeat-terminal-issue-wake-guard.test.ts`: new embedded-Postgres suite (4 cases) modeled on `heartbeat-archived-company-guard.test.ts` — done/cancelled suppression, open-issue pass-through, and the user-wake exemption (asserting the pre-existing claim-time terminal check still governs the queued run)

## Verification

- `npx vitest run src/__tests__/heartbeat-terminal-issue-wake-guard.test.ts` — 4/4 pass
- `npx vitest run src/__tests__/heartbeat-archived-company-guard.test.ts` — 8/8 pass (nearest-neighbor guard suite, unaffected)
- `pnpm typecheck` (server) — clean
- Note: `heartbeat-comment-wake-batching.test.ts` has 1 failing test **on unmodified master** in my environment (verified via `git stash`); unrelated to this change

## Related PRs (dedup search)

Searched open/closed PRs for wake/terminal/completed-issue work. Adjacent but non-overlapping — none adds an enqueue-time terminal skip for all background wakes:

- #6675 — gates **comment-reopen intent** and suppresses **scheduled retries** for terminal issues (different entry points; complementary)
- #6871 — prevents comment-path/deferred-wake from **promoting** done/cancelled issues' status (status mutation, not wake suppression; complementary)
- #7864 — companion fix for #7840 (recovery escalation must not regress terminal status)
- #6657, #5616 — related wake-hygiene work (stale closeout comment wakes; zombie queue reaping)

## Risks

- Background wakes for terminal issues are now skipped at enqueue (with an auditable request row) instead of enqueued-then-cancelled at claim. Anything that intended to wake an agent about a closed issue must be user-initiated — matching the claim-time semantics that would have cancelled the run anyway.
- Behavioral note: the canonicalization lookup now also runs when `projectId` was already supplied (one indexed single-row SELECT per issue-bound wake); `projectId` precedence is unchanged.
- Scope is deliberately narrow: the broader cancellation-retry asymmetry for *open* issues is left to the maintainers' design (flagged in #7841 comments).

## Model Used

Claude (model id `claude-fable-5`, Anthropic) via Claude Code CLI with tool use and local code execution; operated and reviewed by @ianbruton.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-only)
- [x] I have updated relevant documentation to reflect my changes (N/A — no doc surface for this internal guard; skip reason is self-describing in the wakeup request row)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (re-running after the review-feedback commit)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (4/5 on first pass; the flagged duplicate query is removed in the latest commit — awaiting re-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)