### PR TITLE
fix(issues): resolve agent URL-key mentions to uuid before wake (PUL-3750)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -36,7 +36,11 @@ import {
   ISSUE_LIST_MAX_LIMIT,
   issueService,
 } from "../services/issues.ts";
-import { buildProjectMentionHref, MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
+import {
+  buildAgentMentionHref,
+  buildProjectMentionHref,
+  MAX_ISSUE_REQUEST_DEPTH,
+} from "@paperclipai/shared";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -3702,6 +3706,89 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
       titleProjectId,
       commentProjectId,
     ]);
+  });
+});
+
+describeEmbeddedPostgres("issueService.findMentionedAgents", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-mentioned-agents-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(companyId: string, name: string) {
+    const id = randomUUID();
+    await db.insert(agents).values({
+      id,
+      companyId,
+      name,
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return id;
+  }
+
+  it("resolves URL-key explicit mentions (e.g. board-liaison) to the agent uuid (PUL-3750)", async () => {
+    const companyId = await seedCompany();
+    const liaisonId = await seedAgent(companyId, "Board Liaison");
+
+    // The renderer/author may emit either the uuid or the URL key as the
+    // agent:// host. Before PUL-3750, the URL-key form was forwarded straight
+    // into enqueueWakeup -> agents.id (uuid) and Postgres rejected it.
+    const urlKeyBody = `Heads up [@Board Liaison](agent://board-liaison) — please relay.`;
+    const uuidBody = `Heads up [@Board Liaison](${buildAgentMentionHref(liaisonId)}) — please relay.`;
+
+    expect(await svc.findMentionedAgents(companyId, urlKeyBody)).toEqual([liaisonId]);
+    expect(await svc.findMentionedAgents(companyId, uuidBody)).toEqual([liaisonId]);
+  });
+
+  it("drops explicit mentions that match no agent in the company", async () => {
+    const companyId = await seedCompany();
+    await seedAgent(companyId, "Board Liaison");
+
+    const strangerUrlKey = "Mention [@Stranger](agent://stranger-agent)";
+    const strangerUuid = `Mention [@Stranger](${buildAgentMentionHref(randomUUID())})`;
+
+    expect(await svc.findMentionedAgents(companyId, strangerUrlKey)).toEqual([]);
+    expect(await svc.findMentionedAgents(companyId, strangerUuid)).toEqual([]);
+  });
+
+  it("still resolves bare @-name mentions against agent names", async () => {
+    const companyId = await seedCompany();
+    const liaisonId = await seedAgent(companyId, "BoardLiaison");
+
+    const body = "@BoardLiaison please relay this update";
+    expect(await svc.findMentionedAgents(companyId, body)).toEqual([liaisonId]);
   });
 });
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -55,6 +55,7 @@ import {
   issueCommentMetadataSchema,
   issueCommentPresentationSchema,
   isUuidLike,
+  normalizeAgentUrlKey,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
 import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
@@ -6071,12 +6072,41 @@ export function issueService(db: Db) {
         if (normalized) tokens.add(normalized.toLowerCase());
       }
 
-      const explicitAgentMentionIds = extractAgentMentionIds(body);
-      if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
+      // Explicit mentions (`agent://<id-or-url-key>`) may carry either an agent
+      // UUID or a URL key like `board-liaison`. Split them so we resolve each
+      // bucket against the agents table — passing a URL key straight through to
+      // enqueueWakeup hits the `agents.id` uuid column and blows up the wake.
+      const explicitMentionRefs = extractAgentMentionIds(body);
+      const explicitIdRefs = new Set<string>();
+      const explicitUrlKeyRefs = new Set<string>();
+      for (const ref of explicitMentionRefs) {
+        if (isUuidLike(ref)) {
+          explicitIdRefs.add(ref);
+        } else {
+          const urlKey = normalizeAgentUrlKey(ref);
+          if (urlKey) explicitUrlKeyRefs.add(urlKey);
+        }
+      }
+
+      if (
+        tokens.size === 0 &&
+        explicitIdRefs.size === 0 &&
+        explicitUrlKeyRefs.size === 0
+      )
+        return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      const resolved = new Set<string>(explicitAgentMentionIds);
+      const resolved = new Set<string>();
       for (const agent of rows) {
+        if (explicitIdRefs.has(agent.id)) {
+          resolved.add(agent.id);
+          continue;
+        }
+        const urlKey = normalizeAgentUrlKey(agent.name);
+        if (urlKey && explicitUrlKeyRefs.has(urlKey)) {
+          resolved.add(agent.id);
+          continue;
+        }
         if (tokens.has(agent.name.toLowerCase())) {
           resolved.add(agent.id);
         }


### PR DESCRIPTION
## Summary

`findMentionedAgents()` in `server/src/services/issues.ts` was forwarding the raw host of every `agent://` link straight into `addWakeup → enqueueWakeup`, which runs `SELECT FROM agents WHERE id = $1` against the `uuid` column. When the renderer emits the URL-key form (e.g. `agent://board-liaison`) instead of the uuid, Postgres throws:

> `PostgresError: invalid input syntax for type uuid: "board-liaison"`

The user-visible POST already succeeded, but the targeted wake was dropped silently — likely the cause of intermittent missed `@`-mentions of board-liaison-style agents.

## Fix

Split explicit mention refs into uuid-shaped vs url-key shaped buckets and resolve each against the company's `agents` table (normalising `agent.name → urlKey` for comparison via `normalizeAgentUrlKey`). Only real agent uuids reach the wake queue. Unknown refs are dropped instead of crashing.

## Test plan

- [x] New regression coverage in `server/src/__tests__/issues-service.test.ts` under `describeEmbeddedPostgres("issueService.findMentionedAgents", …)`:
  - resolves `agent://board-liaison` (URL-key form) to the seeded agent uuid — fails before this change
  - still resolves the uuid form
  - drops mentions (both URL-key and uuid) for agents not in the company
  - `@BoardLiaison` bare-token path still works
- [x] `npx vitest run src/__tests__/issues-service.test.ts -t "findMentionedAgents"` → 3 passed
- [x] `npx tsc --noEmit` clean

## Context

Surfaced while triaging the OpenClaw POST-500 incident — sibling issue [PUL-3749](https://paperclip.ing/PUL/issues/PUL-3749) fixed the foreground 500 in the same incident; this is the background-wake half. Background-wake only: no user-visible 500.