### PR TITLE
fix(server): normalize Intl h24 midnight hour so midnight cron routines fire (#7529)

### DIFF
--- a/server/src/services/routines-cron.test.ts
+++ b/server/src/services/routines-cron.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getZonedMinuteParts, nextCronTickInTimeZone } from "./routines.js";
+
+describe("nextCronTickInTimeZone", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the next UTC midnight for a midnight cron", () => {
+    const next = nextCronTickInTimeZone("0 0 * * *", "UTC", new Date("2026-06-10T12:30:45Z"));
+    expect(next).not.toBeNull();
+    expect(next!.toISOString()).toBe("2026-06-11T00:00:00.000Z");
+  });
+
+  it("normalizes hour 24 from h24-cycle locale data so midnight crons still fire", () => {
+    // Some ICU versions resolve `hour12: false` to the h24 cycle and format
+    // midnight as "24"; simulate that so the regression is covered everywhere.
+    const original = Intl.DateTimeFormat.prototype.formatToParts;
+    vi.spyOn(Intl.DateTimeFormat.prototype, "formatToParts").mockImplementation(function (
+      this: Intl.DateTimeFormat,
+      date,
+    ) {
+      return original.call(this, date).map((part) =>
+        part.type === "hour" && Number(part.value) === 0 ? { ...part, value: "24" } : part,
+      );
+    });
+
+    expect(getZonedMinuteParts(new Date("2026-06-11T00:05:00Z"), "UTC").hour).toBe(0);
+
+    const next = nextCronTickInTimeZone("0 0 * * *", "UTC", new Date("2026-06-10T12:30:45Z"));
+    expect(next).not.toBeNull();
+    expect(next!.toISOString()).toBe("2026-06-11T00:00:00.000Z");
+  });
+});

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -102,7 +102,7 @@ function floorToMinute(date: Date) {
   return copy;
 }
 
-function getZonedMinuteParts(date: Date, timeZone: string) {
+export function getZonedMinuteParts(date: Date, timeZone: string) {
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone,
     hour12: false,
@@ -123,7 +123,9 @@ function getZonedMinuteParts(date: Date, timeZone: string) {
     year: Number(map.year),
     month: Number(map.month),
     day: Number(map.day),
-    hour: Number(map.hour),
+    // Some ICU versions resolve `hour12: false` to the h24 cycle, formatting
+    // midnight as "24" instead of "0"; normalize so midnight crons match.
+    hour: Number(map.hour) % 24,
     minute: Number(map.minute),
     weekday,
   };
@@ -141,7 +143,7 @@ function matchesCronMinute(expression: string, timeZone: string, date: Date) {
   );
 }
 
-function nextCronTickInTimeZone(expression: string, timeZone: string, after: Date) {
+export function nextCronTickInTimeZone(expression: string, timeZone: string, after: Date) {
   const trimmed = expression.trim();
   assertTimeZone(timeZone);
   const error = validateCron(trimmed);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Routines are how agents get scheduled recurring work; their schedule triggers are driven by cron expressions evaluated by `nextCronTickInTimeZone` in `server/src/services/routines.ts`
> - `getZonedMinuteParts` formats the candidate time with `Intl.DateTimeFormat` using `hour12: false`, which some ICU versions resolve to the **h24** hour cycle — midnight is formatted as `"24"`, not `"0"`
> - `Number("24")` never matches `parseCron("0 0 * * *")`'s `hours: [0]`, so the search window is exhausted, `nextRunAt` stays `null`, and any routine whose cron targets local hour 0 silently never fires (#7529)
> - This pull request normalizes the parsed hour with `% 24`, mapping the h24 midnight representation back to `0`
> - The benefit is that midnight (and any local-hour-0) cron routines are scheduled correctly on every Node/ICU combination, with a regression test that covers the buggy formatter behavior even on ICUs where it doesn't reproduce naturally

## Linked Issues or Issue Description

Fixes #7529

## What Changed

- `server/src/services/routines.ts`: `getZonedMinuteParts` now computes `hour: Number(map.hour) % 24` (with a comment explaining the ICU h24 cycle), so `"24"` maps to `0`. `parseInt("24") % 24 === 0`, which is what `parseCron` expects.
- Exported `getZonedMinuteParts` and `nextCronTickInTimeZone` (previously module-private) solely as a test seam — no behavior change for existing callers.
- Added `server/src/services/routines-cron.test.ts` with two regression tests:
  1. `nextCronTickInTimeZone("0 0 * * *", "UTC", …)` returns the next UTC midnight (not `null`).
  2. A mocked `Intl.DateTimeFormat.prototype.formatToParts` that emits `"24"` at midnight (simulating the affected ICU behavior) still resolves hour `0` and returns the correct next tick. This test fails before the fix on **any** Node version.

## Verification

- `npx vitest run server/src/services/routines-cron.test.ts` → 2 passed.
- `pnpm --filter @paperclipai/server typecheck` → clean.
- Note: on Node v26 the formatter already returns `"00"` for midnight, so the bug is ICU-version dependent; the mocked test pins the regression regardless of the local ICU. The `% 24` normalization was chosen over switching the formatter to `hourCycle: 'h23'` because it is robust no matter how `hour12: false` resolves on a given ICU.

## Risks

- Low risk. `% 24` is a no-op for hours 0–23 and only remaps the out-of-range `24` produced by the h24 cycle. The only other change is exporting two pure helpers.

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code, agentic mode with tool use (subagent implementation + independent adversarial review subagent), extended thinking enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found for #7529)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A — no doc surface documents this internal behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge
