### PR TITLE
fix(ui): remove non-functional start/due date buttons from New Issue overflow menu (#7862)

### DIFF
--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -789,6 +789,19 @@ describe("NewIssueDialog", () => {
     act(() => root.unmount());
   });
 
+  it("does not offer non-functional start/due date options in the overflow menu", async () => {
+    const { root } = renderDialog(container);
+    await flush();
+
+    const moreTrigger = container.querySelector('[data-testid="new-issue-more-menu-trigger"]');
+    expect(moreTrigger?.className).toContain("sm:hidden");
+
+    expect(container.textContent).not.toContain("Start date");
+    expect(container.textContent).not.toContain("Due date");
+
+    act(() => root.unmount());
+  });
+
   it("allows editor autocomplete portal pointer events inside the modal", async () => {
     const { root } = renderDialog(container);
     await flush();

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -51,7 +51,6 @@ import {
   ArrowDown,
   AlertTriangle,
   Tag,
-  Calendar,
   Paperclip,
   FileText,
   Flag,
@@ -1976,50 +1975,39 @@ export function NewIssueDialog() {
             </PopoverContent>
           </Popover>
 
-          {/* More */}
+          {/* More — mobile-only overflow for the priority options */}
           <Popover open={moreOpen} onOpenChange={setMoreOpen}>
             <PopoverTrigger asChild>
               <button
                 type="button"
                 data-testid="new-issue-more-menu-trigger"
-                className="inline-flex items-center justify-center rounded-md border border-border p-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50"
+                className="inline-flex items-center justify-center rounded-md border border-border p-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 sm:hidden"
               >
                 <MoreHorizontal className="h-3 w-3" />
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-44 p-1" align="start" data-testid="new-issue-more-menu">
-              <div className="sm:hidden">
-                <div className="px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
-                  Priority
-                </div>
-                {priorities.map((p) => (
-                  <button
-                    type="button"
-                    key={p.value}
-                    data-testid={`new-issue-more-priority-${p.value}`}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent/50",
-                      p.value === priority && "bg-accent",
-                    )}
-                    onClick={() => {
-                      setPriority(p.value);
-                      setMoreOpen(false);
-                    }}
-                  >
-                    <p.icon className={cn("h-3 w-3", p.color)} />
-                    {p.label}
-                  </button>
-                ))}
-                <div className="my-1 border-t border-border" />
+              <div className="px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+                Priority
               </div>
-              <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
-                <Calendar className="h-3 w-3" />
-                Start date
-              </button>
-              <button className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-muted-foreground">
-                <Calendar className="h-3 w-3" />
-                Due date
-              </button>
+              {priorities.map((p) => (
+                <button
+                  type="button"
+                  key={p.value}
+                  data-testid={`new-issue-more-priority-${p.value}`}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent/50",
+                    p.value === priority && "bg-accent",
+                  )}
+                  onClick={() => {
+                    setPriority(p.value);
+                    setMoreOpen(false);
+                  }}
+                >
+                  <p.icon className={cn("h-3 w-3", p.color)} />
+                  {p.label}
+                </button>
+              ))}
             </PopoverContent>
           </Popover>
         </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The New Issue dialog (`ui/src/components/NewIssueDialog.tsx`) is the primary surface for creating work items, with a bottom-bar "..." overflow menu
> - That menu rendered "Start date" and "Due date" buttons with **no `onClick` handler** — clicking them did nothing, which reads as broken UI (#7862, triaged as a launch-blocking UX regression)
> - Wiring a real picker is not a surgical fix: the issues table has no `start_date`/`due_date` columns, the shared create/update validators accept no such fields, the server has zero `startDate`/`dueDate` references, and no date-picker component exists anywhere in `ui/` (the only date input in the app is a native `<input type="date">` in NewProjectDialog) — full date support is a feature, not a bug fix
> - This pull request takes the fallback explicitly accepted in the issue thread: remove the dead buttons so users no longer see controls that do nothing
> - The benefit is no more visibly broken UI in the New Issue modal; date support can land later as a proper end-to-end feature (DB migration + validators + API + picker)

## Linked Issues or Issue Description

Fixes #7862

The issue author: "or (b) hide the buttons until the picker component lands, so they don't look broken to users." The CTO comment in-thread: "Either fix is acceptable."

## What Changed

- `ui/src/components/NewIssueDialog.tsx`:
  - Removed the two dead "Start date" / "Due date" buttons from the "..." overflow popover.
  - The only remaining content of that popover was the **mobile-only** priority section, so the "..." trigger itself is now `sm:hidden` (mobile-only); the redundant inner `sm:hidden` wrapper and divider were unwrapped accordingly. Desktop loses nothing — the priority options are already available via the desktop priority chip.
  - Dropped the now-unused `Calendar` lucide import.
- `ui/src/components/NewIssueDialog.test.tsx`: added a regression test asserting the overflow trigger is mobile-only and that "Start date" / "Due date" no longer render, following the file's existing `renderDialog`/`flush` patterns.

## Verification

- `npx vitest run src/components/NewIssueDialog.test.tsx` (in `ui/`) → 13 passed (12 pre-existing + 1 new).
- `pnpm --filter @paperclipai/ui typecheck` → clean.
- Before/after screenshots at desktop and mobile widths are in the PR comment below (captured from a live dev instance via Playwright). Summary: **Before** — desktop and mobile show a "..." button whose menu contains two dead buttons (desktop menu contains *only* the two dead buttons). **After** — desktop has no "..." button (nothing functional remains in it); mobile "..." shows only the working priority list.

## Risks

- Low risk, removal-only. The one behavioral consideration: desktop users lose the "..." button entirely. That button's desktop content consisted *exclusively* of the two broken buttons, so nothing functional is removed.
- When real start/due date support lands, the buttons can be restored wired to actual state (the work-mode buttons in the same bar are the template).

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code, agentic mode with tool use (subagent implementation + independent adversarial review subagent), extended thinking enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (PRs #5577/#5138 match the "7862" search by SHA only — unrelated; no PR addresses this issue)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (see screenshots comment)
- [x] I have updated relevant documentation to reflect my changes (N/A — no docs reference these buttons)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge

