### PR TITLE
fix(process-adapter): inject per-run PAPERCLIP_* env vars into spawned processes (#7899)

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -951,6 +951,64 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   return vars;
 }
 
+export function applyPaperclipRunContextEnv(
+  env: Record<string, string>,
+  input: { runId: string; context: Record<string, unknown> },
+): Record<string, string> {
+  const { runId, context } = input;
+  env.PAPERCLIP_RUN_ID = runId;
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  const issueWorkMode = readPaperclipIssueWorkModeFromContext(context);
+  if (wakeTaskId) {
+    env.PAPERCLIP_TASK_ID = wakeTaskId;
+  }
+  if (issueWorkMode) {
+    env.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
+  }
+  if (wakeReason) {
+    env.PAPERCLIP_WAKE_REASON = wakeReason;
+  }
+  if (wakeCommentId) {
+    env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  }
+  if (approvalId) {
+    env.PAPERCLIP_APPROVAL_ID = approvalId;
+  }
+  if (approvalStatus) {
+    env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  }
+  if (linkedIssueIds.length > 0) {
+    env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  }
+  if (wakePayloadJson) {
+    env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  }
+  return env;
+}
+
 export function applyPaperclipWorkspaceEnv(
   env: Record<string, string>,
   input: {

--- a/server/src/__tests__/process-adapter-execute.test.ts
+++ b/server/src/__tests__/process-adapter-execute.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "../adapters/process/execute.js";
+
+async function writeFakeProcessCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  paperclipRunId: process.env.PAPERCLIP_RUN_ID || null,
+  paperclipTaskId: process.env.PAPERCLIP_TASK_ID || null,
+  paperclipWakeReason: process.env.PAPERCLIP_WAKE_REASON || null,
+  paperclipWakeCommentId: process.env.PAPERCLIP_WAKE_COMMENT_ID || null,
+  paperclipApprovalId: process.env.PAPERCLIP_APPROVAL_ID || null,
+  paperclipApprovalStatus: process.env.PAPERCLIP_APPROVAL_STATUS || null,
+  staticEnvValue: process.env.STATIC_ADAPTER_ENV || null,
+  paperclipEnvKeys: Object.keys(process.env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort(),
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log("ok");
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+type CapturePayload = {
+  paperclipRunId: string | null;
+  paperclipTaskId: string | null;
+  paperclipWakeReason: string | null;
+  paperclipWakeCommentId: string | null;
+  paperclipApprovalId: string | null;
+  paperclipApprovalStatus: string | null;
+  staticEnvValue: string | null;
+  paperclipEnvKeys: string[];
+};
+
+describe("process adapter execute", () => {
+  it("injects per-run PAPERCLIP_* env vars alongside static adapterConfig.env", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-execute-env-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "fake-process");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeProcessCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-process-1",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Process Runner",
+          adapterType: "process",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            STATIC_ADAPTER_ENV: "static-value",
+          },
+        },
+        context: {
+          issueId: "issue-1",
+          taskId: "issue-1",
+          wakeReason: "issue_commented",
+          wakeCommentId: "comment-2",
+          approvalId: "approval-1",
+          approvalStatus: "approved",
+        },
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.paperclipRunId).toBe("run-process-1");
+      expect(capture.paperclipTaskId).toBe("issue-1");
+      expect(capture.paperclipWakeReason).toBe("issue_commented");
+      expect(capture.paperclipWakeCommentId).toBe("comment-2");
+      expect(capture.paperclipApprovalId).toBe("approval-1");
+      expect(capture.paperclipApprovalStatus).toBe("approved");
+      expect(capture.staticEnvValue).toBe("static-value");
+      expect(capture.paperclipEnvKeys).toEqual(
+        expect.arrayContaining([
+          "PAPERCLIP_AGENT_ID",
+          "PAPERCLIP_COMPANY_ID",
+          "PAPERCLIP_RUN_ID",
+          "PAPERCLIP_TASK_ID",
+          "PAPERCLIP_WAKE_REASON",
+        ]),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets static adapterConfig.env override per-run vars, matching local adapter precedence", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-execute-precedence-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "fake-process");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeProcessCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-process-2",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Process Runner",
+          adapterType: "process",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            PAPERCLIP_WAKE_REASON: "config-override",
+          },
+        },
+        context: {
+          taskId: "issue-2",
+          wakeReason: "issue_assigned",
+        },
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.paperclipTaskId).toBe("issue-2");
+      expect(capture.paperclipWakeReason).toBe("config-override");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -4,6 +4,7 @@ import {
   asNumber,
   asStringArray,
   parseObject,
+  applyPaperclipRunContextEnv,
   buildPaperclipEnv,
   buildInvocationEnvForLogs,
   ensurePathInEnv,
@@ -12,7 +13,7 @@ import {
 } from "../utils.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, agent, config, onLog, onMeta } = ctx;
+  const { runId, agent, config, context, onLog, onMeta } = ctx;
   const command = asString(config.command, "");
   if (!command) throw new Error("Process adapter missing command");
 
@@ -20,6 +21,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
   const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  applyPaperclipRunContextEnv(env, { runId, context });
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -29,6 +29,7 @@ export const resolvePathValue = serverUtils.resolvePathValue;
 export const renderTemplate = serverUtils.renderTemplate;
 export const redactEnvForLogs = serverUtils.redactEnvForLogs;
 export const buildPaperclipEnv = serverUtils.buildPaperclipEnv;
+export const applyPaperclipRunContextEnv = serverUtils.applyPaperclipRunContextEnv;
 export const defaultPathForPlatform = serverUtils.defaultPathForPlatform;
 export const ensurePathInEnv = serverUtils.ensurePathInEnv;
 export const ensureAbsoluteDirectory = serverUtils.ensureAbsoluteDirectory;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Adapters are how the server runs agent processes; the docs (reference/deploy/environment-variables.md, guides/org/agents.md, and the process adapter reference) promise that the server injects standard per-run `PAPERCLIP_*` variables into agent processes when a run starts
> - The `process` adapter's `execute()` only built `buildPaperclipEnv(agent)` (static identity vars) plus `adapterConfig.env`, dropping every per-run variable — `PAPERCLIP_RUN_ID`, `PAPERCLIP_TASK_ID`, `PAPERCLIP_WAKE_REASON`, and the comment/approval/wake-payload set — even though the resolved wake context is sitting in `ctx.context` at spawn time (#7899 shows `contextSnapshot` has it)
> - A wake-driven process agent therefore cannot know which issue woke it, which cascades into `successful_run_missing_state` escalations and corrective-wake loops on issues the agent never saw
> - This pull request extracts the per-run env block that claude-local/codex-local already build inline into a shared `applyPaperclipRunContextEnv()` helper in `@paperclipai/adapter-utils`, and calls it from the process adapter's spawn path
> - The benefit is the process adapter now honors the documented env contract, with identical semantics to the local adapters and a regression test pinning the injected variables and the precedence rules

## Linked Issues or Issue Description

Fixes #7899

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: new exported `applyPaperclipRunContextEnv(env, { runId, context })` — logic copied verbatim from the inline per-run blocks in `packages/adapters/claude-local/src/server/execute.ts` (and codex-local). Sets `PAPERCLIP_RUN_ID` always, and conditionally `PAPERCLIP_TASK_ID`, `PAPERCLIP_ISSUE_WORK_MODE`, `PAPERCLIP_WAKE_REASON`, `PAPERCLIP_WAKE_COMMENT_ID`, `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, `PAPERCLIP_LINKED_ISSUE_IDS`, `PAPERCLIP_WAKE_PAYLOAD_JSON`.
- `server/src/adapters/process/execute.ts`: call the helper after `buildPaperclipEnv(agent)` and **before** merging `adapterConfig.env`, so static config env can still override per-run vars — the same precedence the local adapters use (their config-env merge also runs after the per-run block).
- `server/src/adapters/utils.ts`: re-export the helper alongside the existing server-utils re-exports.
- `server/src/__tests__/process-adapter-execute.test.ts`: new test following the existing `codex-local-execute.test.ts` capture-script pattern; asserts (1) the spawned process receives the per-run vars alongside static `adapterConfig.env`, and (2) static config env overrides per-run vars.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck && pnpm --filter @paperclipai/server typecheck` → clean.
- The new test uses the same `#!/usr/bin/env node` + `chmod` fake-command pattern as the existing `codex-local-execute` / `gemini-local-execute` tests, which (like those tests) only runs on POSIX. On my Windows machine the pre-existing `codex-local-execute.test.ts` fails identically (13/13, spawn of shebang script), so CI (Linux) is the validating environment for this suite — same as for the existing adapter execute tests.
- claude-local/codex-local were intentionally **not** migrated to the shared helper to keep this diff surgical; a follow-up could dedupe their inline blocks.

## Risks

- Low risk for existing deployments: any process agent relying on `adapterConfig.env` keeps its values (config wins on conflict). The only change is that previously-absent `PAPERCLIP_*` per-run vars now appear in the spawned environment — which is exactly what the docs already promised.
- Helper is additive in adapter-utils; no existing callers changed.

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code, agentic mode with tool use (subagent implementation + independent adversarial review subagent), extended thinking enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found for #7899)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass (typechecks pass; the new execute test follows the repo's POSIX-only adapter-execute pattern — see Verification)
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A — docs already describe the intended behavior; this PR makes the code match them)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge
