### PR TITLE
fix(db): resolve migrations folder via @paperclipai/db module resolution when bundled (#7705)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./package.json": "./package.json",
     "./*": "./src/*.ts"
   },
   "publishConfig": {
@@ -23,6 +24,7 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
       },
+      "./package.json": "./package.json",
       "./*": {
         "types": "./dist/*.d.ts",
         "import": "./dist/*.js"

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -2,13 +2,13 @@ import { createHash } from "node:crypto";
 import { drizzle as drizzlePg } from "drizzle-orm/postgres-js";
 import { migrate as migratePg } from "drizzle-orm/postgres-js/migrator";
 import { readFile, readdir } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
 import postgres from "postgres";
+import { MIGRATIONS_FOLDER } from "./migrations-folder.js";
 import * as schema from "./schema/index.js";
 
-const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
-const MIGRATIONS_JOURNAL_JSON = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
+const MIGRATIONS_JOURNAL_JSON = path.join(MIGRATIONS_FOLDER, "meta", "_journal.json");
 
 function createUtilitySql(url: string) {
   return postgres(url, { max: 1, onnotice: () => {} });
@@ -107,7 +107,7 @@ async function listJournalMigrationFiles(): Promise<string[]> {
 }
 
 async function readMigrationFileContent(migrationFile: string): Promise<string> {
-  return readFile(new URL(`./migrations/${migrationFile}`, import.meta.url), "utf8");
+  return readFile(path.join(MIGRATIONS_FOLDER, migrationFile), "utf8");
 }
 
 async function orderMigrationsByJournal(migrationFiles: string[]): Promise<string[]> {

--- a/packages/db/src/migrations-folder.test.ts
+++ b/packages/db/src/migrations-folder.test.ts
@@ -1,0 +1,60 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { MIGRATIONS_FOLDER, resolveMigrationsFolder } from "./migrations-folder.js";
+
+const moduleDir = path.join("monorepo", "packages", "db", "src");
+const dbPackageRoot = path.join("npm", "node_modules", "@paperclipai", "db");
+const resolveDbPackageJson = () => path.join(dbPackageRoot, "package.json");
+
+describe("resolveMigrationsFolder", () => {
+  it("prefers the module-local migrations folder when it exists (monorepo and published db package)", () => {
+    const folder = resolveMigrationsFolder({
+      moduleDir,
+      resolveDbPackageJson,
+      exists: (candidate) => candidate === path.join(moduleDir, "migrations"),
+    });
+
+    expect(folder).toBe(path.join(moduleDir, "migrations"));
+  });
+
+  it("falls back to the installed @paperclipai/db dist migrations when bundled (npm-installed CLI)", () => {
+    const bundleDir = path.join("npm", "node_modules", "paperclipai", "dist");
+    const folder = resolveMigrationsFolder({
+      moduleDir: bundleDir,
+      resolveDbPackageJson,
+      exists: (candidate) => candidate === path.join(dbPackageRoot, "dist", "migrations"),
+    });
+
+    expect(folder).toBe(path.join(dbPackageRoot, "dist", "migrations"));
+  });
+
+  it("falls back to the resolved package src migrations when dist is not built (workspace link)", () => {
+    const folder = resolveMigrationsFolder({
+      moduleDir: path.join("somewhere", "else"),
+      resolveDbPackageJson,
+      exists: (candidate) => candidate === path.join(dbPackageRoot, "src", "migrations"),
+    });
+
+    expect(folder).toBe(path.join(dbPackageRoot, "src", "migrations"));
+  });
+
+  it("keeps the module-local path when @paperclipai/db is not resolvable", () => {
+    const folder = resolveMigrationsFolder({
+      moduleDir,
+      resolveDbPackageJson: () => {
+        throw new Error("Cannot find package '@paperclipai/db'");
+      },
+      exists: () => false,
+    });
+
+    expect(folder).toBe(path.join(moduleDir, "migrations"));
+  });
+});
+
+describe("MIGRATIONS_FOLDER", () => {
+  it("resolves to an existing migrations directory in this repo", () => {
+    expect(existsSync(MIGRATIONS_FOLDER)).toBe(true);
+    expect(existsSync(path.join(MIGRATIONS_FOLDER, "meta", "_journal.json"))).toBe(true);
+  });
+});

--- a/packages/db/src/migrations-folder.ts
+++ b/packages/db/src/migrations-folder.ts
@@ -1,0 +1,49 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+export type ResolveMigrationsFolderOptions = {
+  moduleDir: string;
+  resolveDbPackageJson: () => string;
+  exists?: (candidate: string) => boolean;
+};
+
+/**
+ * Resolve the directory containing the SQL migration files.
+ *
+ * In the monorepo (`src/`) and in the published `@paperclipai/db` package
+ * (`dist/`), the migrations live next to this module, so the module-relative
+ * folder wins. When this code is bundled into another package — the
+ * npm-published `paperclipai` CLI bundles `@paperclipai/db` into
+ * `paperclipai/dist/index.js` — the module-relative folder does not exist, so
+ * fall back to resolving the installed `@paperclipai/db` package, which ships
+ * its migrations in `dist/migrations`.
+ */
+export function resolveMigrationsFolder(options: ResolveMigrationsFolderOptions): string {
+  const exists = options.exists ?? existsSync;
+  const moduleLocalFolder = path.join(options.moduleDir, "migrations");
+  if (exists(moduleLocalFolder)) return moduleLocalFolder;
+
+  try {
+    const dbPackageRoot = path.dirname(options.resolveDbPackageJson());
+    const candidates = [
+      path.join(dbPackageRoot, "dist", "migrations"),
+      path.join(dbPackageRoot, "src", "migrations"),
+    ];
+    for (const candidate of candidates) {
+      if (exists(candidate)) return candidate;
+    }
+  } catch {
+    // @paperclipai/db is not resolvable from here. Fall through so downstream
+    // errors mention the module-local path that was actually probed.
+  }
+  return moduleLocalFolder;
+}
+
+export const MIGRATIONS_FOLDER = resolveMigrationsFolder({
+  moduleDir: path.dirname(fileURLToPath(import.meta.url)),
+  resolveDbPackageJson: () => require.resolve("@paperclipai/db/package.json"),
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The CLI's `worktree init` (seeded instance) applies DB migrations; `packages/db/src/client.ts` located them with `new URL("./migrations", import.meta.url)`
> - The npm-published `paperclipai` CLI bundles `packages/db` into its own `dist/index.js` (`cli/esbuild.config.mjs`), so that module-relative URL resolves to `paperclipai/dist/migrations` — a path that is never shipped; migrations actually ship in `@paperclipai/db/dist/migrations`
> - The monorepo layout masks this (the relative folder exists in dev), so the breakage only appears for npm/npx installs, where seeded worktree init fails with "migrations directory not found" (#7705)
> - This pull request resolves the migrations folder robustly: prefer the module-local folder (monorepo dev and the published `@paperclipai/db` package), and fall back to module resolution of `@paperclipai/db/package.json` via `createRequire`, joining `dist/migrations` (then `src/migrations`)
> - The benefit is `worktree init` works on npm-installed CLIs without symlink workarounds, while dev and the published db package keep their existing fast path — the same `createRequire` pattern already used in `cli/src/version.ts` and `packages/db/src/embedded-postgres-native.ts`, and the same "resolve via module resolution" approach as PR #7860 used for the skills-catalog manifest

## Linked Issues or Issue Description

Fixes #7705
Refs #7706 (a `plugin_state` anomaly observed on an instance seeded through the symlink workaround — worth re-checking once this lands, since seeds will then use the real migrations path)

## What Changed

- New `packages/db/src/migrations-folder.ts`: `resolveMigrationsFolder()` — module-local `./migrations` first; on miss, resolve `@paperclipai/db/package.json` with `createRequire(import.meta.url)` and probe `dist/migrations` then `src/migrations`; on total miss, return the module-local path so downstream errors mention the path that was actually probed. Exported `MIGRATIONS_FOLDER` constant evaluated once.
- `packages/db/src/client.ts`: use `MIGRATIONS_FOLDER` for the migrations folder, the journal JSON path, and per-file migration reads (previously three separate `import.meta.url`-relative lookups).
- `packages/db/package.json`: added `"./package.json": "./package.json"` to both the dev and `publishConfig` exports maps so the `createRequire` resolution is permitted under the package's exports restrictions.
- New `packages/db/src/migrations-folder.test.ts`: 5 unit tests covering monorepo layout, bundled-CLI layout (dist and src fallbacks), resolution failure, and no-candidate-exists behavior, using an injected `exists` predicate.

## Verification

- `npx vitest run packages/db/src/migrations-folder.test.ts` → 5 passed.
- `pnpm --filter @paperclipai/db typecheck` → clean.
- Layout reasoning: monorepo (`src/migrations` exists next to the module) → unchanged behavior; published `@paperclipai/db` (`dist/migrations` next to the module) → unchanged behavior; bundled `paperclipai` CLI (no module-local folder) → falls back to the installed `@paperclipai/db` package, which is a dependency of the CLI and ships the migrations.

## Risks

- Low risk. The module-local fast path preserves existing behavior in every layout that worked before; the fallback only activates where the previous code already failed.
- The `exports` map addition exposes `package.json` (metadata only) — a common, safe pattern.

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code, agentic mode with tool use (subagent implementation + independent adversarial review subagent), extended thinking enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (related pattern: PR #7860, skills-catalog manifest resolution; no PR addresses #7705 itself)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — db/CLI change)
- [x] I have updated relevant documentation to reflect my changes (N/A — no docs describe the internal migrations path)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review)
- [x] I will address all Greptile and reviewer comments before requesting merge
