### PR TITLE
Fix stranded recovery dispatch surge

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2178,6 +2178,71 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(0);
   });
 
+  it("caps stranded recovery dispatches per pass", async () => {
+    const previousCap = process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS;
+    process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS = "1";
+
+    try {
+      const first = await seedAssignedTodoNoRunFixture();
+      const second = await seedAssignedTodoNoRunFixture();
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+      expect(result.assignmentDispatched).toBe(1);
+      expect(result.dispatchRequeued).toBe(0);
+      expect(result.continuationRequeued).toBe(0);
+      expect(result.escalated).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.issueIds).toHaveLength(1);
+      expect([first.issueId, second.issueId]).toContain(result.issueIds[0]);
+
+      const runs = await db.select().from(heartbeatRuns);
+      expect(runs).toHaveLength(1);
+      if (runs[0]?.id) {
+        await waitForRunToSettle(heartbeat, runs[0].id);
+      }
+    } finally {
+      if (previousCap === undefined) {
+        delete process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS;
+      } else {
+        process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS = previousCap;
+      }
+    }
+  });
+
+  it("ignores nonpositive stranded recovery dispatch caps", async () => {
+    const previousCap = process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS;
+    process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS = "0";
+
+    try {
+      const first = await seedAssignedTodoNoRunFixture();
+      const second = await seedAssignedTodoNoRunFixture();
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+      expect(result.assignmentDispatched).toBe(2);
+      expect(result.dispatchRequeued).toBe(0);
+      expect(result.continuationRequeued).toBe(0);
+      expect(result.escalated).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.issueIds).toEqual(expect.arrayContaining([first.issueId, second.issueId]));
+
+      const runs = await db.select().from(heartbeatRuns);
+      expect(runs).toHaveLength(2);
+      for (const run of runs) {
+        if (run.id) {
+          await waitForRunToSettle(heartbeat, run.id);
+        }
+      }
+    } finally {
+      if (previousCap === undefined) {
+        delete process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS;
+      } else {
+        process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS = previousCap;
+      }
+    }
+  });
+
   it("re-enqueues assigned todo work when the last issue run died and no wake remains", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",
@@ -2260,6 +2325,39 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       }
     },
   );
+
+  it("does not retry stranded work while a pending issue interaction owns the next action", async () => {
+    const { agentId, companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+    });
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Confirm the next step before continuing.",
+      },
+      createdByAgentId: agentId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
 
   it("still re-enqueues stranded assigned todo recovery when an old queued wake exists", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -71,6 +71,7 @@ const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+const DEFAULT_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS = 4;
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -161,6 +162,29 @@ function didAutomaticRecoveryFail(
     UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
       latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
     );
+}
+
+function strandedRecoveryMaxDispatchesPerPass() {
+  const raw = readNonEmptyString(process.env.PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS);
+  const parsed = raw ? Number.parseInt(raw, 10) : DEFAULT_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS;
+}
+
+async function hasPendingIssueInteractionHold(db: Db, companyId: string, issueId: string) {
+  const rows = await db
+    .select({ id: issueThreadInteractions.id })
+    .from(issueThreadInteractions)
+    .where(
+      and(
+        eq(issueThreadInteractions.companyId, companyId),
+        eq(issueThreadInteractions.issueId, issueId),
+        eq(issueThreadInteractions.status, "pending"),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
 }
 
 const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
@@ -2479,7 +2503,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issueIds: [] as string[],
     };
 
+    const maxDispatches = strandedRecoveryMaxDispatchesPerPass();
+    const dispatchedCount = () =>
+      result.assignmentDispatched +
+      result.dispatchRequeued +
+      result.continuationRequeued +
+      result.successfulRunHandoffEscalated +
+      result.escalated;
+
     for (const issue of candidates) {
+      if (dispatchedCount() >= maxDispatches) {
+        result.skipped += 1;
+        continue;
+      }
+
       const agentId = issue.assigneeAgentId;
       if (!agentId) {
         result.skipped += 1;
@@ -2498,6 +2535,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasPendingIssueInteractionHold(db, issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat recovery service is responsible for finding assigned issues whose local process state was lost and getting them moving again.
> - Stranded assigned-issue recovery can currently dispatch or requeue every candidate found in a single reconciliation pass.
> - During gateway instability or after a process restart, that behavior can create a burst of retries and notifications instead of letting the system recover gradually.
> - Recovery also needs to respect pending issue-thread interactions, because those represent human or issue-thread state that should own the next action.
> - This pull request adds a bounded per-pass dispatch cap and skips stranded recovery when a pending issue interaction is already waiting.
> - The benefit is steadier recovery under failure conditions without suppressing legitimate future retries.

## Linked Issues or Issue Description

No existing issue was available for this incident.

Bug report fields:

- Pre-submission checklist: searched related Paperclip PRs and did not find a duplicate exact fix. Related recovery PRs found include #5106, #5282, #7709, #5648, #7359, and #7871, but none combine a per-pass stranded recovery dispatch cap with a pending issue-interaction hold.
- What happened: after gateway/process instability, stranded assigned-issue reconciliation could dispatch/requeue too many candidates in one pass and could retry work even when an issue-thread interaction was pending.
- Expected behavior: each recovery pass should make bounded progress and should leave issues alone when a pending issue interaction owns the next action.
- Steps to reproduce:
  1. Seed multiple assigned todo issues with no live prior run, or seed a stranded run with a pending issue-thread interaction.
  2. Run `heartbeat.reconcileStrandedAssignedIssues()`.
  3. Observe that the old behavior dispatches all candidates or retries despite the pending interaction.
- Paperclip version or commit: reproduced while auditing current `master` at `f3db7b88`.
- Deployment mode: local/global Paperclip server using the embedded database during incident audit; source tests use embedded Postgres fixtures.
- Installation method: npm/pnpm global install for runtime observation; built from source for the PR.
- Agent adapters involved: not adapter-specific; core heartbeat recovery bug.
- Database mode: embedded Postgres in tests.
- Access context: board/operator-triggered runtime observation; core service path.
- Node.js version: CI/local repo default.
- Operating system: macOS local audit; Linux GitHub Actions verification.
- Relevant logs or output: local runtime showed recovery reference errors before the installed hot patch and gateway timeout symptoms during restart pressure; no secrets are included here.
- Relevant config: `PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS` can override the per-pass cap. Nonpositive or invalid values now fall back to the default instead of disabling recovery.
- Additional context: this PR keeps recovery active but rate-limited; it is not a global kill switch.
- Privacy checklist: reviewed for secrets and PII; none included.

## What Changed

- Added `PAPERCLIP_STRANDED_RECOVERY_MAX_DISPATCHES_PER_PASS` support with a default cap of 4 dispatch/requeue/escalation actions per stranded-recovery pass.
- Made nonpositive/invalid cap values fall back to the default so `0` cannot silently disable recovery.
- Added a pending issue-interaction hold so stranded recovery skips issues with pending thread interactions.
- Added regression coverage for the per-pass cap, the nonpositive cap fallback, and the pending-interaction hold.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "caps stranded recovery dispatches per pass|ignores nonpositive stranded recovery dispatch caps|does not retry stranded work while a pending issue interaction owns the next action"`

Note: before this PR-body/code-review update, GitHub Actions passed server typecheck, build, server tests, e2e, and serialized server suites. The only failing general lane was an unrelated existing UI test: `src/components/IssueProperties.test.tsx > edits existing custom assignee model options from the properties pane`.

## Risks

- Low migration risk: no schema changes and no API contract changes.
- Behavioral risk: a large backlog of stranded issues may take more heartbeat passes to recover because dispatch/requeue/escalation work is capped per pass.
- Configuration risk: operators setting an invalid or nonpositive cap now get the default cap instead of a disabled recovery path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

GPT-5 Codex coding agent with terminal, git, GitHub CLI, and local test execution. Reasoning was used for code analysis and debugging; no private chain-of-thought is included.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
