### PR TITLE
BRO-520: implicit in_progress re-confirmation for no-op succeeded heartbeats

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1616,6 +1616,61 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(activity.some((event) => event.action === "issue.successful_run_handoff_required")).toBe(true);
   });
 
+  it("treats an engaged successful run with no PATCH as an implicit in_progress re-confirmation and queues no handoff", async () => {
+    const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
+    // Record the run actually engaging (checking out) the issue. This is the
+    // durable signal the handoff gate reads to tell a clean in_progress
+    // re-confirmation apart from an issue that was never picked up.
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.checked_out",
+      entityType: "issue",
+      entityId: issueId,
+      details: { agentId },
+    });
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { runId: string }) => {
+      // Productive work (a comment + summary) but no disposition-bearing PATCH:
+      // the run leaves the issue in_progress on purpose.
+      await db.insert(issueComments).values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: ctx.runId,
+        body: "Monitored the live signal; nothing to change, still in progress.",
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Monitored the live signal; nothing to change, still in progress.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.filter((wakeup) => wakeup.reason === "finish_successful_run_handoff")).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments.find((comment) => comment.body === SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY)).toBeUndefined();
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("requeues a missing-disposition handoff when the previous corrective wake was cancelled", async () => {
     const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
     const idempotencyKey = `finish_successful_run_handoff:${issueId}:${runId}:1`;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5077,6 +5077,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       budgetBlock,
       pauseHold,
       activeRoutineContinuation,
+      runCheckoutActivity,
+      runPatchActivity,
     ] = await Promise.all([
       issue
         ? db
@@ -5216,6 +5218,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .limit(1)
           .then((rows) => rows[0] ?? null)
         : Promise.resolve(null),
+      issue
+        ? db
+          .select({ id: activityLog.id })
+          .from(activityLog)
+          .where(
+            and(
+              eq(activityLog.companyId, run.companyId),
+              eq(activityLog.runId, run.id),
+              eq(activityLog.entityType, "issue"),
+              eq(activityLog.entityId, issue.id),
+              inArray(activityLog.action, ["issue.checked_out", "issue.checkout_lock_adopted"]),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
+      issue
+        ? db
+          .select({ id: activityLog.id })
+          .from(activityLog)
+          .where(
+            and(
+              eq(activityLog.companyId, run.companyId),
+              eq(activityLog.runId, run.id),
+              eq(activityLog.entityType, "issue"),
+              eq(activityLog.entityId, issue.id),
+              eq(activityLog.action, "issue.updated"),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
     ]);
 
     const decision = decideSuccessfulRunHandoff({
@@ -5234,6 +5268,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       hasActiveRoutineContinuation: Boolean(activeRoutineContinuation),
       budgetBlocked: Boolean(budgetBlock),
       idempotentWakeExists: Boolean(existingWake),
+      runEngagedIssue: Boolean(runCheckoutActivity),
+      runEmittedIssuePatch: Boolean(runPatchActivity),
     });
 
     if (decision.kind !== "enqueue" || !issue) return;

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -55,6 +55,8 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     hasActiveRoutineContinuation: false,
     budgetBlocked: false,
     idempotentWakeExists: false,
+    runEngagedIssue: false,
+    runEmittedIssuePatch: false,
     ...overrides,
   });
 }
@@ -152,6 +154,23 @@ describe("successful run handoff decision", () => {
       kind: "skip",
       reason: "active routine continuation owns the next action",
     });
+  });
+
+  it("treats an engaged run with no PATCH or blocker as an implicit in_progress re-confirmation", () => {
+    expect(decide({ runEngagedIssue: true, runEmittedIssuePatch: false })).toEqual({
+      kind: "skip",
+      reason: "succeeded run engaged the issue with no PATCH or blocker — implicit in_progress re-confirmation",
+    });
+  });
+
+  it("still queues a handoff when an engaged run emitted a PATCH but left the issue in_progress", () => {
+    const decision = decide({ runEngagedIssue: true, runEmittedIssuePatch: true });
+    expect(decision.kind).toBe("enqueue");
+  });
+
+  it("does not suppress recovery for a productive run that never engaged the issue", () => {
+    const decision = decide({ runEngagedIssue: false, runEmittedIssuePatch: false });
+    expect(decision.kind).toBe("enqueue");
   });
 
   it("does not queue when a successful run has no progress signal", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -353,6 +353,20 @@ export function decideSuccessfulRunHandoff(input: {
   hasActiveRoutineContinuation: boolean;
   budgetBlocked: boolean;
   idempotentWakeExists: boolean;
+  // True when this run actually engaged the issue (checked it out / adopted its
+  // checkout lock). Used to scope the implicit in_progress re-confirmation so we
+  // never suppress recovery for issues a run never picked up.
+  runEngagedIssue: boolean;
+  // True when this run emitted ANY issue PATCH that logged an `issue.updated`
+  // activity row attributed to the run. This is deliberately broad: it includes
+  // disposition-bearing writes (status / blocker changes) but ALSO non-disposition
+  // edits (title, description, labels). We intentionally do not try to distinguish
+  // them — any issue write by an engaged run counts as "the agent acted on the
+  // issue", so the implicit in_progress re-confirmation below is suppressed only
+  // for runs that engaged the issue and wrote nothing at all. This errs toward
+  // letting recovery proceed rather than silently skipping it after a partial
+  // (non-disposition) write.
+  runEmittedIssuePatch: boolean;
 }): SuccessfulRunHandoffDecision {
   const { run, issue, agent } = input;
 
@@ -382,6 +396,18 @@ export function decideSuccessfulRunHandoff(input: {
   }
   if (!isProductiveSuccessfulRun(input)) {
     return { kind: "skip", reason: "successful run did not produce handoff-relevant progress" };
+  }
+  // A succeeded run that engaged the issue (checked it out) and exited without a
+  // disposition-bearing PATCH or blocker is an implicit `in_progress`
+  // re-confirmation — the agent is saying "still in progress, nothing to change".
+  // Treat that as a valid disposition instead of a missing one. Scoped to engaged
+  // runs so issues that were never picked up still flow to recovery, and to
+  // no-PATCH runs so an explicit status/blocker PATCH keeps existing handling.
+  if (input.runEngagedIssue && !input.runEmittedIssuePatch) {
+    return {
+      kind: "skip",
+      reason: "succeeded run engaged the issue with no PATCH or blocker — implicit in_progress re-confirmation",
+    };
   }
   if (input.hasActiveExecutionPath) return { kind: "skip", reason: "issue already has an active execution path" };
   if (input.hasQueuedWake) return { kind: "skip", reason: "issue already has a queued or deferred wake" };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; agents run in periodic **heartbeats** and report a disposition each run.
> - The **recovery subsystem** decides what happens after a run finishes. `decideSuccessfulRunHandoff` inspects a `succeeded` run and, if it sees no disposition, can trigger `source_scoped_recovery_action` and wake a manager (CEO) to recover the issue.
> - The gap: a run that **engaged** an issue (checked it out / adopted the checkout lock) and then exited with **no disposition-bearing PATCH** and no blocker was being read as a *missing disposition* — even for a legitimate no-op heartbeat ("nothing to change, routine still live").
> - That false positive drops the issue to `blocked` and fires a CEO recovery wake on every quiet heartbeat, producing recovery loops and wasted manager runs.
> - This PR treats an engaged, no-PATCH, no-blocker `succeeded` run as an **implicit `in_progress` re-confirmation** and skips the handoff in exactly that case.
> - The benefit is the elimination of a whole class of false-positive recovery wakes for all agents, while leaving genuine missing-disposition, failed, cancelled, and terminal/blocked handling untouched.

## Linked Issues or Issue Description

No public `paperclipai/paperclip` issue tracks this; describing in-PR (bug):

- **Problem:** `decideSuccessfulRunHandoff` classifies an engaged `succeeded` run that emits no PATCH/blocker as `missing_disposition`, triggering `source_scoped_recovery_action` + a manager recovery wake.
- **Expected:** a no-op engaged heartbeat that issues no PATCH and no blocker should leave the issue `in_progress` (no drop to `blocked`, no recovery wake).
- **Actual:** the issue is dropped to `blocked` and the CEO is woken to "recover" a perfectly healthy routine.

**Searched for duplicate/related PRs (dedup):** this subsystem has substantial parallel work; the closest related upstream PRs:
- #6008 — Clear stale `checkoutRunId` on run finalization (adjacent lifecycle fix; this PR is complementary, see Risks).
- #7718 — resolve `missing_disposition` recovery loop for blocked issues with active blockers.
- #6093 — Resolve stale missing-disposition recovery actions.
- #7495 — Bound missing-disposition recovery refires.
- #6616 — Bound `missing_disposition` recovery to maxAttempts with auto-escalation.
- #7635 / #7636 — sweep active recoveries with out-of-band dispositions / routine-as-liveness caps.
- #7539 — issue disposition endpoint to clear the missing-disposition flag.

This PR is **narrower and distinct**: it targets the single false-positive case of an *engaged no-op `succeeded` run*, rather than bounding/iterating on recovery refires. It composes with the above rather than superseding them.

## What Changed

- `server/src/services/recovery/successful-run-handoff.ts` — `decideSuccessfulRunHandoff` skips the handoff when `runEngagedIssue && !runEmittedIssuePatch` (implicit `in_progress` re-confirmation).
- `server/src/services/heartbeat.ts` — derives `runEngagedIssue` (`issue.checked_out` / `issue.checkout_lock_adopted`) and `runEmittedIssuePatch` (`issue.updated`) from durable `activity_log` rows attributed to the run, so the signals survive the `checkoutRunId` clear that runs before the handoff during finalization.
- Tests: 3 new unit cases in `successful-run-handoff.test.ts`; 1 new integration test in `heartbeat-process-recovery.test.ts`.

### Guardrails preserved
- `failed`/`cancelled` runs unchanged (`status != succeeded` skip stays first).
- Terminal/blocked dispositions still honored (`status != in_progress` skip).
- Runs that never engaged/checked out the issue still flow to recovery.
- A run that **did** emit a PATCH but left the issue `in_progress` still hands off.

## Verification

Run from a fresh install of this branch (on top of current `master`, `f3db7b8`, post-#6008):

```bash
corepack pnpm install --frozen-lockfile
cd server
NODE_ENV=test corepack pnpm exec vitest run src/services/recovery/successful-run-handoff.test.ts
# → Test Files 1 passed, Tests 17 passed
NODE_ENV=test corepack pnpm exec vitest run src/__tests__/heartbeat-process-recovery.test.ts -t "implicit in_progress re-confirmation"
# → Test Files 1 passed, Tests 1 passed
```

- Patch applies cleanly on `master` (pure additions, +130 across 4 files).

## Risks

- **Low risk.** Pure addition of a single skip condition gated on `runEngagedIssue && !runEmittedIssuePatch`; all other recovery paths are unchanged and covered by existing + new tests.
- **No conflict with #6008.** #6008 reworks `checkoutRunId` finalization/cleanup; this change deliberately reads durable `activity_log` rows rather than `checkoutRunId`, so it is robust against #6008's more aggressive lock-clearing. Branch cherry-picks cleanly onto post-#6008 `master`.
- Behavioral shift is intentional and scoped: engaged no-op `succeeded` heartbeats no longer trigger recovery. Genuine missing-disposition (never-engaged) cases are unaffected.

## Model Used

- **Claude Opus 4.8** (`claude-opus-4-8`), Anthropic. Extended thinking + tool use (code edit, shell, git, GitHub API). Change authored and verified by the agent; tests run locally as shown above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [ ] I have updated relevant documentation to reflect my changes (N/A — no doc surface affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (re-running after this description update)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (review in progress)
- [x] I will address all Greptile and reviewer comments before requesting merge

---
Co-authored-by: BRO CTO Agent <noreply@paperclip.ing>
