### PR TITLE
fix(recovery): skip orphan-blocker sweep when recovery action already active (FMA-3284)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2417,6 +2417,109 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("skips orphan-blocker assignment when an active recovery action already exists (FMA-3284)", async () => {
+    const companyId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const blockedAssigneeAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "SecurityEngineer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: blockedAssigneeAgentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Fix blocker",
+        status: "todo",
+        priority: "high",
+        createdByAgentId: creatorAgentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked work",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: blockedAssigneeAgentId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+      createdByAgentId: creatorAgentId,
+    });
+    // Seed an active recovery action — the stranded recovery system is already
+    // managing this issue; the orphan-blocker sweep should not interfere.
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: blockerIssueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: creatorAgentId,
+      cause: "stranded_assigned_issue",
+      fingerprint: `source_scoped_recovery:${companyId}:${blockerIssueId}:stranded_assigned_issue`,
+      evidence: {},
+      nextAction: "Restore a live execution path.",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // The orphan-blocker sweep must skip the blocker because a recovery action
+    // is already active — assigning it again would create a parallel wake loop.
+    expect(result.orphanBlockersAssigned).toBe(0);
+    expect(result.issueIds).not.toContain(blockerIssueId);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.assigneeAgentId).toBeNull();
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, creatorAgentId));
+    expect(wakeups).toHaveLength(0);
+  });
+
   it("re-enqueues continuation for stranded in-progress work with no active run", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -692,6 +692,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (seen.has(candidate.id)) continue;
       seen.add(candidate.id);
 
+      // If the stranded-recovery system already has an active action for this issue,
+      // adding an orphan-blocker assignment on top creates a parallel wake loop
+      // (agent wakes, finds nothing actionable, releases, sweep re-assigns, repeat).
+      // Let the recovery system drive resolution instead. (FMA-3284)
+      const existingRecoveryAction = await recoveryActionsSvc.getActiveForIssue(candidate.companyId, candidate.id);
+      if (existingRecoveryAction) {
+        skipped += 1;
+        continue;
+      }
+
       const creatorAgentId = candidate.createdByAgentId;
       if (!creatorAgentId) {
         skipped += 1;


### PR DESCRIPTION
## Summary

- **Root cause**: `reconcileUnassignedBlockingIssues()` assigned a creator-agent to blocking issues that already had an active stranded-recovery action, creating a parallel wake loop (4+ cycles in ~3 min, burning budget).
- **Fix**: Added `recoveryActionsSvc.getActiveForIssue()` check before assignment — if an active recovery action exists, skip the candidate and let the recovery system drive.
- **Test**: `"skips orphan-blocker assignment when an active recovery action already exists (FMA-3284)"` — PASS (351ms)

## Files changed

- `server/src/services/recovery/service.ts` — added active-recovery guard in orphan-blocker reconciliation loop

## Test plan

- [x] Unit test added and passing locally
- [ ] CI green on this branch

Co-Authored-By: Paperclip <noreply@paperclip.ing>