### PR TITLE
fix(adapter-claude-local): honor runtimeConfig.mcpServers via --mcp-config

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -89,6 +90,7 @@ interface ClaudeRuntimeConfig {
   timeoutSec: number;
   graceSec: number;
   extraArgs: string[];
+  mcpConfigPath: string | null;
 }
 
 export function claudeSessionCwdMatchesExecutionTarget(input: {
@@ -177,6 +179,22 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     executionCwd: effectiveExecutionCwd,
   });
   await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const mcpServersConfig = parseObject(config.mcpServers);
+  let mcpConfigPath: string | null = null;
+  if (Object.keys(mcpServersConfig).length > 0) {
+    const tmpRoot = path.join(os.tmpdir(), "paperclip-mcp");
+    await fs.mkdir(tmpRoot, { recursive: true });
+    mcpConfigPath = path.join(tmpRoot, `mcp-${runId}.json`);
+    await fs.writeFile(
+      mcpConfigPath,
+      JSON.stringify({ mcpServers: mcpServersConfig }, null, 2),
+    );
+    await onLog(
+      "stdout",
+      `[paperclip] Materialized ${Object.keys(mcpServersConfig).length} MCP server config(s) at ${mcpConfigPath} (via --mcp-config).\n`,
+    );
+  }
 
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
@@ -321,6 +339,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     timeoutSec,
     graceSec,
     extraArgs,
+    mcpConfigPath,
   };
 }
 
@@ -421,6 +440,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     timeoutSec,
     graceSec,
     extraArgs,
+    mcpConfigPath,
   } = runtimeConfig;
   let loggedEnv = initialLoggedEnv;
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
@@ -710,6 +730,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
+    if (mcpConfigPath) {
+      args.push("--mcp-config", mcpConfigPath);
+    }
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };


### PR DESCRIPTION
## Summary

The `@paperclipai/adapter-claude-local` adapter silently dropped the `runtimeConfig.mcpServers` field set on agents. As a result, any MCP server an operator configured on a Paperclip agent was never loaded by Claude Code — `tools/list` would only show the default tools.

A `grep -rE "mcpServers|\.mcp\.json|--mcp-config" packages/` over the repo confirms zero handling existed.

## Change

In `buildClaudeRuntimeConfig`:
- Parse `config.mcpServers` as an object.
- If non-empty, materialize a per-run JSON file at `${os.tmpdir()}/paperclip-mcp/mcp-${runId}.json` containing `{ "mcpServers": ... }`.
- Thread the resulting path through `ClaudeRuntimeConfig.mcpConfigPath`.

In `execute`:
- When `mcpConfigPath` is set, pass `--mcp-config <path>` to the Claude CLI alongside `--add-dir`.

### Why `--mcp-config` (option B) instead of writing `.mcp.json` into the workspace cwd (option A)

Both approaches were considered. `--mcp-config`:
- Doesn't pollute the agent workspace (which is often a git repo).
- Bypasses Claude's project-level MCP approval prompt without needing a `enabledMcpjsonServers` whitelist hack in `~/.claude.json`.
- Works identically whether or not the agent has `dangerouslySkipPermissions`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec vitest run` — 28/28 passing
- [ ] Manual: run a Paperclip agent whose runtime config sets `mcpServers`, verify `tools/list` exposes the configured tools (e.g. `mcp__google-ads__*`) and that no `.mcp.json` appears in the workspace cwd.

🤖 Filed from the GrowthLead/WBS-239 thread, where the missing MCP plumbing was blocking the Google Ads MCP rollout.