### PR TITLE
SPC-8449: allow creator agents to comment on reassigned issues

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1147,4 +1147,71 @@ describe("agent issue mutation checkout ownership", () => {
     }));
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
+
+  it("allows the agent that created an issue to post plain comments after it is reassigned", async () => {
+    // SentryBridge files the ticket, CTO picks it up. SentryBridge later wants
+    // to append per-event evidence.
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "in_progress",
+        assigneeAgentId: ownerAgentId,
+        createdByAgentId: peerAgentId,
+      }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "regression event #2" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("does NOT extend the creator bypass to reopen / resume / interrupt", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "in_progress",
+        assigneeAgentId: ownerAgentId,
+        createdByAgentId: peerAgentId,
+      }),
+    );
+
+    const reopen = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "bump", reopen: true });
+    expect(reopen.status, JSON.stringify(reopen.body)).toBe(409);
+    expect(reopen.body.error).toBe("Issue is checked out by another agent");
+
+    const resume = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "bump", resume: true });
+    expect(resume.status, JSON.stringify(resume.body)).toBe(409);
+
+    const interrupt = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "bump", interrupt: true });
+    expect(interrupt.status, JSON.stringify(interrupt.body)).toBe(409);
+
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("still rejects peer agents that did not create the issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "in_progress",
+        assigneeAgentId: ownerAgentId,
+        createdByAgentId: "99999999-9999-4999-8999-999999999999",
+      }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "unrelated peer noise" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/setup-supertest.ts
+++ b/server/src/__tests__/setup-supertest.ts
@@ -35,7 +35,7 @@ if (!SupertestTest.prototype.__paperclipLoopbackPatched) {
     }
 
     const host = listeningAddress.address === "::"
-      ? "[::1]"
+      ? "127.0.0.1"
       : listeningAddress.address === "0.0.0.0"
         ? "127.0.0.1"
         : listeningAddress.address;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6624,7 +6624,17 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    // Creator-can-comment: the agent that filed an issue may append plain
+    // comments after triage hands it off. Reopen/resume/interrupt still gated.
+    const actorAgentIdForCreatorBypass =
+      req.actor.type === "agent" ? req.actor.agentId ?? null : null;
+    const isPlainCreatorComment =
+      actorAgentIdForCreatorBypass !== null
+      && issue.createdByAgentId === actorAgentIdForCreatorBypass
+      && req.body.reopen !== true
+      && req.body.resume !== true
+      && req.body.interrupt !== true;
+    if (!isPlainCreatorComment && !(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,


### PR DESCRIPTION
## Summary

- Carve out a narrow creator-can-comment bypass in `POST /api/issues/:id/comments`: if the actor agent is the issue's `createdByAgentId` and the request is a plain comment (no `reopen` / `resume` / `interrupt`), skip the standard `assertAgentIssueMutationAllowed` gate. Otherwise the normal authz applies.
- Live verification on SPC-8439 surfaced that the SentryBridge dedup path was structurally broken: bridge files a ticket assigned to CTO triage, CTO picks it up, all subsequent `POST /comments` calls 403 with `Agent cannot mutate another agent's issue`. Per-event evidence comments lost, MVP fell back to a DynamoDB counter only.
- Pick option 1 from the issue ("Creator-can-comment authz") — smallest API surface, no new permission boundary, no new endpoint.
- Reopen / resume / interrupt remain fully gated by the existing mutation authz, so creators do **not** gain broader write rights.

## Side change

`server/src/__tests__/setup-supertest.ts` connects to `127.0.0.1` instead of `[::1]` when the test server binds to the dual-stack `::` address. Linux dual-stack listeners accept IPv4 traffic, so this works on CI and unblocks sandbox environments without IPv6 loopback connectivity. Strictly more portable.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 17/17 pass, including 3 new cases:
  - creator may post a plain comment on an in-progress peer-assigned issue
  - creator bypass does NOT extend to `reopen` / `resume` / `interrupt` (still 409)
  - non-creator peers still get 409 (no regression for the existing authz cohort)
- [x] Broader sweep across 11 issue-route test files (87/87 pass): mutation ownership, comment reopen, comment cancel, closed workspace, attachment, document restore, dependency wakeups, etc.
- [x] `pnpm exec tsc --noEmit` — no new errors (3 pre-existing errors in `plugin-host-services.ts` unrelated to this change).
- [ ] Live gamma verification on the SentryBridge Lambda (`/aws/lambda/sentry-paperclip-bridge-gamma`) once deployed — re-trigger an event and confirm the per-event comment lands on the existing CTO-assigned ticket.

## Optional follow-up (NOT in this PR)

The SPC-8449 issue body also mentions `originKind=sentry` silently downgrading to `manual`, `originId` / `originFingerprint` coercion, and `labels` array drop on create. These are separate, easier-to-isolate enum/persistence fixes — leaving them for a follow-up PR per the issue's "Optional" acceptance bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)