### PR TITLE
fix(ui): register project plugin operations route

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { readFile } from "node:fs/promises";
 import type { ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
@@ -96,6 +97,16 @@ describe("CloudAccessGate", () => {
     container.remove();
     document.body.innerHTML = "";
     vi.clearAllMocks();
+  });
+
+  it("keeps plugin operations routes registered in App", async () => {
+    const uiRoot = process.cwd().endsWith("/ui") ? process.cwd() : `${process.cwd()}/ui`;
+    const appSource = await readFile(`${uiRoot}/src/App.tsx`, "utf8");
+
+    expect(appSource).toContain('<Route path="projects/:projectId/plugin-operations" element={<ProjectDetail />} />');
+    expect(appSource).toContain(
+      '<Route path="projects/:projectId/plugin-operations" element={<UnprefixedBoardRedirect />} />',
+    );
   });
 
   it("shows a no-access message for signed-in users without org access", async () => {

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ts from "typescript";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudAccessGate } from "./components/CloudAccessGate";
 
@@ -79,6 +80,60 @@ function unmountRoot(root: ReturnType<typeof createRoot>) {
   });
 }
 
+async function collectPluginOperationsRoutes() {
+  const uiRoot = process.cwd().endsWith("/ui") ? process.cwd() : `${process.cwd()}/ui`;
+  const appSource = await readFile(`${uiRoot}/src/App.tsx`, "utf8");
+  const sourceFile = ts.createSourceFile("App.tsx", appSource, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const routes: Array<{ path: string; element: string }> = [];
+
+  function visit(node: ts.Node) {
+    if (ts.isJsxSelfClosingElement(node) && node.tagName.getText(sourceFile) === "Route") {
+      let path: string | null = null;
+      let element: string | null = null;
+
+      for (const attribute of node.attributes.properties) {
+        if (!ts.isJsxAttribute(attribute) || !attribute.initializer) continue;
+        const attributeName = attribute.name.getText(sourceFile);
+        if (attributeName === "path" && ts.isStringLiteral(attribute.initializer)) {
+          path = attribute.initializer.text;
+          continue;
+        }
+        if (
+          attributeName === "element" &&
+          ts.isJsxExpression(attribute.initializer) &&
+          attribute.initializer.expression
+        ) {
+          element = attribute.initializer.expression.getText(sourceFile);
+        }
+      }
+
+      if (path && element) {
+        routes.push({ path, element });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return routes;
+}
+
+describe("Route registration", () => {
+  it("keeps plugin operations routes registered in App", async () => {
+    const routes = await collectPluginOperationsRoutes();
+
+    expect(routes).toContainEqual({
+      path: "projects/:projectId/plugin-operations",
+      element: "<ProjectDetail />",
+    });
+    expect(routes).toContainEqual({
+      path: "projects/:projectId/plugin-operations",
+      element: "<UnprefixedBoardRedirect />",
+    });
+  });
+});
+
 describe("CloudAccessGate", () => {
   let container: HTMLDivElement;
 
@@ -97,16 +152,6 @@ describe("CloudAccessGate", () => {
     container.remove();
     document.body.innerHTML = "";
     vi.clearAllMocks();
-  });
-
-  it("keeps plugin operations routes registered in App", async () => {
-    const uiRoot = process.cwd().endsWith("/ui") ? process.cwd() : `${process.cwd()}/ui`;
-    const appSource = await readFile(`${uiRoot}/src/App.tsx`, "utf8");
-
-    expect(appSource).toContain('<Route path="projects/:projectId/plugin-operations" element={<ProjectDetail />} />');
-    expect(appSource).toContain(
-      '<Route path="projects/:projectId/plugin-operations" element={<UnprefixedBoardRedirect />} />',
-    );
   });
 
   it("shows a no-access message for signed-in users without org access", async () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -116,6 +116,7 @@ function boardRoutes() {
       <Route path="projects/:projectId/workspaces" element={<ProjectDetail />} />
       <Route path="projects/:projectId/configuration" element={<ProjectDetail />} />
       <Route path="projects/:projectId/budget" element={<ProjectDetail />} />
+      <Route path="projects/:projectId/plugin-operations" element={<ProjectDetail />} />
       <Route path="workspaces" element={<Workspaces />} />
       <Route path="issues" element={<Issues />} />
       <Route path="search" element={<Search />} />
@@ -365,6 +366,7 @@ export function App() {
           <Route path="projects/:projectId/workspaces" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
           <Route path="projects/:projectId/configuration" element={<UnprefixedBoardRedirect />} />
+          <Route path="projects/:projectId/plugin-operations" element={<UnprefixedBoardRedirect />} />
           <Route path="workspaces" element={<UnprefixedBoardRedirect />} />
           <Route path="execution-workspaces/:workspaceId" element={<UnprefixedBoardRedirect />} />
           <Route path="execution-workspaces/:workspaceId/services" element={<UnprefixedBoardRedirect />} />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source control plane for AI-agent companies, with the board UI exposing company-scoped project and plugin operations.
> - The UI route map in `ui/src/App.tsx` is the source of truth for which board URLs resolve.
> - `ProjectDetail` already navigates the user to `/projects/:projectId/plugin-operations` from the Plugin operations tab.
> - That navigation path was not registered in the route table, so valid in-app navigation could land on a Not Found page.
> - This is a host UI routing bug rather than a plugin-manifest bug.
> - This pull request adds the missing registered routes and a regression test that checks the route definitions stay present.
> - The benefit is that managed plugin project tabs no longer navigate users into a dead route.

## Linked Issues or Issue Description

_No existing matching issue found after GitHub search; describing the bug inline using the bug-report fields._

### Pre-submission checklist
- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration.

### What happened?
Clicking a project's `Plugin operations` tab navigates to `/projects/<projectId>/plugin-operations`, but the route is missing and the UI returns Not Found.

### Expected behavior
The route should render `ProjectDetail` like the other project tabs.

### Steps to reproduce
1. Open a managed plugin project.
2. Click `Plugin operations`.
3. Observe navigation to `/projects/<projectId>/plugin-operations`.
4. Observe the resulting 404 / Not Found state.

### Paperclip version or commit
Reproduced against `master` base `f3db7b88`; PR head `fcf69799`.

### Deployment mode
Local dev (pnpm dev)

### Installation method
Built from source (pnpm dev / pnpm build)

### Agent adapter(s) involved
- [x] Not adapter-specific (core bug)

### Database mode
Not database-related

### Access context
Board (human operator)

### Node.js version
`v24.10.0`

### Operating system
macOS / Darwin arm64

### Relevant logs or output
```text
Navigating to /projects/<projectId>/plugin-operations lands on the Not Found screen because the route is unregistered.
```

### Relevant config (if applicable)
Not config-specific.

### Additional context
`ProjectDetail` already links to this path from the Plugin operations tab, so the bug is in route registration rather than project data or plugin manifests.

### Privacy checklist
- [x] I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.

## What Changed

- Added `projects/:projectId/plugin-operations` to the board route table in `ui/src/App.tsx`.
- Added the matching unprefixed redirect route in `ui/src/App.tsx`.
- Added a regression test in `ui/src/App.test.tsx` that verifies both route registrations are present.

## Verification

- `cd ui && pnpm exec vitest run src/App.test.tsx`
- `cd ui && pnpm build`

## Risks

- Low risk.
- The change only registers a route that `ProjectDetail` already navigates to and adds a regression test around that route definition.

## Model Used

- OpenAI `gpt-5.4` via Hermes Agent tool-assisted workflow.
- Capabilities used: repository inspection, file editing, test/build execution, git, and GitHub CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
