### PR TITLE
[codex] Keep agent-created follow-ups in run workspace

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -818,6 +818,67 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("defaults agent-created root follow-up issues to inherit the current run workspace", async () => {
+    const app = await createApp(
+      ownerActor(),
+      createRunContextDb({
+        issueId,
+        executionWorkspaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+    );
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Follow-up in same worktree",
+        projectId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({
+        title: "Follow-up in same worktree",
+        inheritExecutionWorkspaceFromIssueId: issueId,
+      }),
+    );
+  });
+
+  it("preserves explicit workspace choices on agent-created root issues", async () => {
+    const app = await createApp(
+      ownerActor(),
+      createRunContextDb({
+        issueId,
+        executionWorkspaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+    );
+
+    const explicitExecutionWorkspaceId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Explicit different workspace",
+        executionWorkspaceId: explicitExecutionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({
+        title: "Explicit different workspace",
+        executionWorkspaceId: explicitExecutionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+      }),
+    );
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.not.objectContaining({
+        inheritExecutionWorkspaceFromIssueId: issueId,
+      }),
+    );
+  });
+
   it("allows board users to set explicit cheap issue assignee profile overrides", async () => {
     const app = await createApp(boardActor());
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -984,6 +984,42 @@ export function issueRoutes(
     return resolveActorSourceTrustForIssue({ db, issue, actor });
   }
 
+  function hasExplicitIssueWorkspaceCreateSelection(input: Record<string, unknown>) {
+    return input.parentId !== undefined ||
+      input.inheritExecutionWorkspaceFromIssueId !== undefined ||
+      input.projectWorkspaceId !== undefined ||
+      input.executionWorkspaceId !== undefined ||
+      input.executionWorkspacePreference !== undefined ||
+      input.executionWorkspaceSettings !== undefined;
+  }
+
+  async function resolveRunIssueWorkspaceInheritanceSource(
+    companyId: string,
+    actor: ReturnType<typeof getActorInfo>,
+  ): Promise<string | null> {
+    if (actor.actorType !== "agent" || !actor.agentId || !actor.runId) return null;
+    const run = await db
+      .select({
+        agentId: heartbeatRuns.agentId,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.id, actor.runId),
+        eq(heartbeatRuns.companyId, companyId),
+      ))
+      .then((rows) => rows[0] ?? null);
+    if (!run || run.agentId !== actor.agentId) return null;
+    const context = run.contextSnapshot && typeof run.contextSnapshot === "object"
+      ? run.contextSnapshot as Record<string, unknown>
+      : null;
+    if (!context || !readNonEmptyString(context.executionWorkspaceId)) return null;
+    const paperclipIssue = context.paperclipIssue && typeof context.paperclipIssue === "object"
+      ? context.paperclipIssue as Record<string, unknown>
+      : null;
+    return readNonEmptyString(context.issueId) ?? readNonEmptyString(paperclipIssue?.id);
+  }
+
   async function resolveAgentTrustForIssue(
     input: {
       agentId: string | null | undefined;
@@ -4205,9 +4241,16 @@ export function issueRoutes(
       companyId,
       req.body.assigneeAgentId as string | null | undefined,
     );
+    const actor = getActorInfo(req);
+    const runWorkspaceInheritanceSourceIssueId = hasExplicitIssueWorkspaceCreateSelection(req.body)
+      ? null
+      : await resolveRunIssueWorkspaceInheritanceSource(companyId, actor);
     const createBody = {
       ...req.body,
       ...(normalizedAssigneeAgentId !== undefined ? { assigneeAgentId: normalizedAssigneeAgentId } : {}),
+      ...(runWorkspaceInheritanceSourceIssueId
+        ? { inheritExecutionWorkspaceFromIssueId: runWorkspaceInheritanceSourceIssueId }
+        : {}),
     };
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, { companyId }, createBody))) return;
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
@@ -4224,7 +4267,6 @@ export function issueRoutes(
     }
     await assertIssueEnvironmentSelection(companyId, createBody.executionWorkspaceSettings?.environmentId);
 
-    const actor = getActorInfo(req);
     const executionPolicy = applyActorMonitorScheduledBy(
       normalizeIssueExecutionPolicy(createBody.executionPolicy),
       actor.actorType,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent runs can execute inside issue-specific worktrees so follow-up work stays attached to the right checkout and context.
> - The issue creation route currently falls back to the project default workspace when an agent creates a top-level follow-up without explicit workspace fields.
> - That fallback can move newly created follow-ups from the run worktree back into the shared master checkout.
> - The original prevention fix landed inside the broader pipelines/tutorial branch, but master needs the focused guard independently.
> - This pull request ports that guard so implicit agent-created follow-ups inherit the creating run issue workspace.
> - The benefit is that agents can create follow-up tasks mid-run without accidentally escaping their active worktree.

## Linked Issues or Issue Description

No public GitHub issue tracks this exact incident. Internal issue: [PAP-10871](/PAP/issues/PAP-10871).

Related PR: Refs #7907, which contains the original commit (`289d934bf`) inside a broader branch.

Bug context:
- What happened: agent-authenticated top-level issue creation during a run with no workspace fields silently used the project default workspace.
- Expected behavior: if the creating run has an execution workspace and the request did not explicitly select workspace behavior, the new issue should inherit from the run's issue.
- Reproduction shape: start from an agent run whose issue is bound to a worktree, then create a top-level issue with no `parentId`, `inheritExecutionWorkspaceFromIssueId`, `projectWorkspaceId`, `executionWorkspaceId`, `executionWorkspacePreference`, or `executionWorkspaceSettings`.
- Deployment mode: local Paperclip control-plane route behavior.

## What Changed

- Added create-route detection for explicit issue workspace selections.
- When an agent request is tied to a heartbeat run and has no explicit workspace selection, defaulted `inheritExecutionWorkspaceFromIssueId` to the current run issue.
- Preserved existing behavior for explicit workspace selections, explicit parents, explicit inheritance, and non-agent issue creation.
- Added focused route coverage for implicit inheritance and explicit workspace override behavior.

## Verification

- `pnpm vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` passed: 39 tests.
- `git diff --check origin/master...HEAD` passed.

## Risks

Low risk. The new default only applies when all of these are true: the actor is an agent, the request is tied to that agent's heartbeat run, the run context has an execution workspace, and the create body did not explicitly select any workspace or parent behavior. Explicit request fields continue to win.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex coding agent based on GPT-5, with repository tool use and shell execution. Context window size was session-managed by the hosted Codex environment and not directly exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

