### PR TITLE
Block agent merge and deploy approval requests

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -347,4 +347,84 @@ describe("approval routes idempotent retries", () => {
       }),
     );
   });
+
+  it("blocks request_board_approval cards that authorize PR merge execution", async () => {
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: {
+          title: "Authorize merging #6907 and #6934 to rc",
+          summary: "Board approval requested so the agent can merge these PRs.",
+          recommendedAction: "Approve merge execution.",
+        },
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("WHA-1700");
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+    expect(mockIssueApprovalService.linkManyForApproval).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("blocks request_board_approval cards that authorize deploy execution", async () => {
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        payload: {
+          title: "Approve production deploy",
+          summary: "Authorize the agent to deploy to production now.",
+          recommendedAction: "Proceed with deployment to prod.",
+        },
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("agent-executed merge/deploy");
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows scope and plan board approvals that mention merge or deploy safety", async () => {
+    mockApprovalService.create.mockResolvedValue({
+      id: "approval-2",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: {
+        title: "Approve WHA-1700 prevention plan",
+        summary: "Scope approval for a merge-freeze guard and deploy policy tests.",
+        recommendedAction: "Approve the implementation plan; do not authorize any merge or deploy.",
+      },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-06-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-11T00:00:00.000Z"),
+    });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        payload: {
+          title: "Approve WHA-1700 prevention plan",
+          summary: "Scope approval for a merge-freeze guard and deploy policy tests.",
+          recommendedAction: "Approve the implementation plan; do not authorize any merge or deploy.",
+        },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockApprovalService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        type: "request_board_approval",
+        payload: expect.objectContaining({
+          title: "Approve WHA-1700 prevention plan",
+        }),
+      }),
+    );
+  });
 });

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -19,6 +19,7 @@ import {
 } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { redactEventPayload } from "../redaction.js";
+import { unprocessable } from "../errors.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(approval: T): T {
@@ -26,6 +27,41 @@ function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(a
     ...approval,
     payload: redactEventPayload(approval.payload) ?? {},
   };
+}
+
+function normalizeApprovalIntentText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.toLowerCase().replace(/[#/_.:-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function requestBoardApprovalHasMergeOrDeployExecutionIntent(payload: Record<string, unknown>) {
+  const rawText = ["title", "summary", "recommendedAction"]
+    .map((key) => normalizeApprovalIntentText(payload[key]))
+    .filter(Boolean)
+    .join(" ");
+  const text = rawText.replace(
+    /\b(do not|don't|does not|should not|must not|never)\b.{0,30}\b(authori[sz]e|approve|permit|execute|perform|run|proceed|ship|merge|deploy|release|promote|publish)\b.{0,60}\b(merge|merging|land|landing|rebase|rebasing|squash|squashing|cherry pick|cherry picking|deploy|deploying|deployment|release|releasing|promote|promoting|publish|publishing)\b/g,
+    " ",
+  );
+  if (!text) return false;
+
+  const hasPlanningContext = /\b(plan|planning|proposal|scope|design|budget|estimate|strategy|policy|guard|investigate|rca)\b/.test(text);
+  const directMergeExecution =
+    /\b(authori[sz]e|approve|permit|execute|perform|run|proceed|ship)\b.{0,40}\b(merge|merging|land|landing|rebase|rebasing|squash|squashing|cherry pick|cherry picking)\b/.test(text) ||
+    /\b(merge|merging|land|landing|rebase|rebasing|squash|squashing|cherry pick|cherry picking)\b.{0,40}\b(pr|pull request|\d{3,}|rc|prod|production|main|master)\b/.test(text);
+  const directDeployExecution =
+    /\b(authori[sz]e|approve|permit|execute|perform|run|proceed|ship)\b.{0,40}\b(deploy|deploying|deployment|release|releasing|promote|promoting|publish|publishing)\b.{0,60}\b(prod|production|rc|staging|live)\b/.test(text) ||
+    /\b(deploy|deploying|release|releasing|promote|promoting|publish|publishing)\b.{0,30}\b(to|into)\b.{0,20}\b(prod|production|rc|staging|live)\b/.test(text);
+
+  return directMergeExecution || (directDeployExecution && !hasPlanningContext);
+}
+
+function assertRequestBoardApprovalIntentAllowed(type: string, payload: Record<string, unknown>) {
+  if (type !== "request_board_approval") return;
+  if (!requestBoardApprovalHasMergeOrDeployExecutionIntent(payload)) return;
+  throw unprocessable(
+    "request_board_approval cannot request board authorization for agent-executed merge/deploy actions; use an issue-thread interaction or WorkflowHR escalation instead (WHA-1700).",
+  );
 }
 
 export function approvalRoutes(
@@ -101,6 +137,7 @@ export function approvalRoutes(
             { strictMode: strictSecretsMode },
           )
         : approvalInput.payload;
+    assertRequestBoardApprovalIntentAllowed(approvalInput.type, normalizedPayload);
 
     const actor = getActorInfo(req);
     const approval = await svc.create(companyId, {


### PR DESCRIPTION
## Summary
- Reject board approval requests that ask for agent-executed merge or deployment actions.
- Keep plan, scope, and policy approvals allowed when they mention merge or deploy safety without requesting execution.
- Add route coverage for merge execution, deployment execution, and allowed planning approval cases.

## Validation
- pnpm --filter @paperclipai/server exec vitest run src/__tests__/approval-routes-idempotency.test.ts
- pnpm --filter @paperclipai/server typecheck