### PR TITLE
fix(claude-local): self-heal failed session resumes instead of poisoning task sessions

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -887,7 +887,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // sessionId is dropped server-side. Drop here so resolveNextSessionState
     // calls clearTaskSessions on the next heartbeat. See RED-978 / RED-976.
     const shouldDropSessionForPoison = poisonedPreviousMessageId;
-    const resolvedSessionId = shouldDropSessionForPoison ? null : rawResolvedSessionId;
+    // Verified-session guard (SUP-2320): on a failed run with no assistant
+    // turn, the CLI may emit a freshly minted session id in stream events
+    // without ever writing the conversation to disk (e.g. a failed
+    // `--resume`). Persisting that id poisons every subsequent resume. Only
+    // trust a stream-derived id when the run succeeded or an assistant turn
+    // proves the conversation exists; otherwise keep the previous known
+    // session (fallbackSessionId) or clear.
+    const sessionVerified = !failed || parsedStream.sawAssistantEvent;
+    const resolvedSessionId = shouldDropSessionForPoison
+      ? null
+      : sessionVerified
+      ? rawResolvedSessionId
+      : opts.fallbackSessionId ?? null;
     const resolvedSessionParams = resolvedSessionId
       ? ({
         sessionId: resolvedSessionId,
@@ -975,10 +987,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
+    // A failed resume is not always a non-zero exit: the CLI can exit 0 while
+    // the stream-json result carries `is_error: true` (e.g. subtype
+    // error_during_execution for "No conversation found with session ID").
+    // Treat both shapes as failures so the fresh-session retry fires. SUP-2320.
+    const initialFailed =
+      (initial.proc.exitCode ?? 0) !== 0 ||
+      (initial.parsed ? asBoolean(initial.parsed.is_error, false) : false);
     const sessionErrorKind =
       sessionId &&
       !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
+      initialFailed &&
       initial.parsed
         ? isClaudeUnknownSessionError(initial.parsed)
           ? "unknown"

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -18,6 +18,7 @@ export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
   let model = "";
   let finalResult: Record<string, unknown> | null = null;
+  let sawAssistantEvent = false;
   const assistantTexts: string[] = [];
 
   for (const rawLine of stdout.split(/\r?\n/)) {
@@ -34,6 +35,7 @@ export function parseClaudeStreamJson(stdout: string) {
     }
 
     if (type === "assistant") {
+      sawAssistantEvent = true;
       sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
       const message = parseObject(event.message);
       const content = Array.isArray(message.content) ? message.content : [];
@@ -62,6 +64,7 @@ export function parseClaudeStreamJson(stdout: string) {
       usage: null as UsageSummary | null,
       summary: assistantTexts.join("\n\n").trim(),
       resultJson: null as Record<string, unknown> | null,
+      sawAssistantEvent,
     };
   }
 
@@ -82,6 +85,7 @@ export function parseClaudeStreamJson(stdout: string) {
     usage,
     summary,
     resultJson: finalResult,
+    sawAssistantEvent,
   };
 }
 

--- a/packages/db/src/migrations/0099_agent_task_session_failure_count.sql
+++ b/packages/db/src/migrations/0099_agent_task_session_failure_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_task_sessions" ADD COLUMN "consecutive_failure_count" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -694,6 +694,13 @@
       "when": 1780534200000,
       "tag": "0098_project_icon",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1781500000000,
+      "tag": "0099_agent_task_session_failure_count",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_task_sessions.ts
+++ b/packages/db/src/schema/agent_task_sessions.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, jsonb, integer, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
 import { heartbeatRuns } from "./heartbeat_runs.js";
@@ -15,6 +15,7 @@ export const agentTaskSessions = pgTable(
     sessionDisplayId: text("session_display_id"),
     lastRunId: uuid("last_run_id").references(() => heartbeatRuns.id),
     lastError: text("last_error"),
+    consecutiveFailureCount: integer("consecutive_failure_count").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, lstatSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, lstatSync, symlinkSync, unlinkSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,7 +20,9 @@ mkdirSync(scopeDir, { recursive: true });
 try {
   const stat = lstatSync(linkTarget);
   if (stat.isSymbolicLink()) {
-    rmSync(linkTarget, { force: true });
+    // unlinkSync, not rmSync: on Node >=24 rmSync refuses symlinks that point
+    // at directories (ERR_FS_EISDIR), which made every fresh install fail.
+    unlinkSync(linkTarget);
   } else {
     console.log("  i Keeping existing installed @paperclipai/plugin-sdk directory in place");
     process.exit(0);

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -197,6 +197,67 @@ console.log(JSON.stringify({ type: "result", session_id: "22222222-2222-4222-822
   await fs.chmod(commandPath, 0o755);
 }
 
+// Reproduces the SUP-2320 live failure shape: a failed `--resume` where the
+// CLI exits 0 but the stream-json result carries is_error: true
+// (subtype error_during_execution), and the stream mints a NEW session id
+// that is never written to disk. A fresh (non-resume) attempt succeeds.
+async function writeExitZeroResumeFailThenSucceedClaudeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const statePath = process.env.PAPERCLIP_TEST_STATE_PATH;
+const payload = {
+  argv: process.argv.slice(2),
+  prompt: fs.readFileSync(0, "utf8"),
+};
+if (capturePath) {
+  const entries = fs.existsSync(capturePath) ? JSON.parse(fs.readFileSync(capturePath, "utf8")) : [];
+  entries.push(payload);
+  fs.writeFileSync(capturePath, JSON.stringify(entries), "utf8");
+}
+const resumed = process.argv.includes("--resume");
+const shouldFailResume = resumed && statePath && !fs.existsSync(statePath);
+if (shouldFailResume) {
+  fs.writeFileSync(statePath, "retried", "utf8");
+  console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", model: "claude-sonnet" }));
+  console.log(JSON.stringify({
+    type: "result",
+    subtype: "error_during_execution",
+    session_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    is_error: true,
+    result: "No conversation found with session ID: 11111111-1111-4111-8111-111111111111",
+  }));
+  process.exit(0);
+}
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "22222222-2222-4222-8222-222222222222", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "assistant", session_id: "22222222-2222-4222-8222-222222222222", message: { content: [{ type: "text", text: "hello" }] } }));
+console.log(JSON.stringify({ type: "result", session_id: "22222222-2222-4222-8222-222222222222", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+// A run that fails (exit 0 + is_error) with an error that is NOT a session
+// error, after minting a new session id in the init event but before any
+// assistant turn. The minted id was never written to disk, so it must not be
+// persisted; the previous known session id should be kept instead.
+async function writeUnverifiedSessionFailureClaudeCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd", model: "claude-sonnet" }));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "error_during_execution",
+  session_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  is_error: true,
+  result: "Internal error: something unrelated to sessions failed",
+}));
+process.exit(0);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 async function setupExecuteEnv(
   root: string,
   options?: { commandWriter?: (commandPath: string) => Promise<void> },
@@ -450,6 +511,100 @@ describe("claude execute", () => {
       expect(metaEvents[1]?.commandNotes.some((note) => note.includes("--append-system-prompt-file"))).toBe(true);
       expect(result.sessionId).toBe("22222222-2222-4222-8222-222222222222");
       expect(result.clearSession).toBe(false);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries with a fresh session when a failed resume exits 0 with an is_error result (SUP-2320)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-exit0-resume-fail-"));
+    const { workspace, commandPath, capturePath, statePath, restore } = await setupExecuteEnv(root, {
+      commandWriter: writeExitZeroResumeFailThenSucceedClaudeCommand,
+    });
+    try {
+      const result = await execute({
+        runId: "run-exit0-resume-fail",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: "11111111-1111-4111-8111-111111111111", sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+            PAPERCLIP_TEST_STATE_PATH: statePath,
+          },
+          promptTemplate: "Do work.",
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf-8")) as Array<{ argv: string[] }>;
+      expect(captured).toHaveLength(2);
+      expect(captured[0]?.argv).toContain("--resume");
+      expect(captured[1]?.argv).not.toContain("--resume");
+      expect(result.errorMessage).toBeNull();
+      expect(result.sessionId).toBe("22222222-2222-4222-8222-222222222222");
+      expect(result.clearSession).toBe(false);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not persist a session id minted by a failed run with no assistant turn (SUP-2320)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-unverified-session-"));
+    const { workspace, commandPath, restore } = await setupExecuteEnv(root, {
+      commandWriter: writeUnverifiedSessionFailureClaudeCommand,
+    });
+    try {
+      const result = await execute({
+        runId: "run-unverified-session",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: "11111111-1111-4111-8111-111111111111", sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Do work.",
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+      });
+      // The failed run minted dddddddd-... in stream events but never produced
+      // an assistant turn, so the conversation may not exist on disk. Keep the
+      // previous known session instead of adopting the unverified id.
+      expect(result.errorMessage).toContain("Internal error");
+      expect(result.sessionId).toBe("11111111-1111-4111-8111-111111111111");
+      expect(result.sessionParams).toMatchObject({ sessionId: "11111111-1111-4111-8111-111111111111" });
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns no session id when a fresh run fails before any assistant turn (SUP-2320)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-unverified-fresh-"));
+    const { workspace, commandPath, restore } = await setupExecuteEnv(root, {
+      commandWriter: writeUnverifiedSessionFailureClaudeCommand,
+    });
+    try {
+      const result = await execute({
+        runId: "run-unverified-fresh",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Do work.",
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+      });
+      expect(result.sessionId).toBeNull();
+      expect(result.sessionParams).toBeNull();
     } finally {
       restore();
       await fs.rm(root, { recursive: true, force: true });

--- a/server/src/__tests__/heartbeat-task-session-failure-reset.test.ts
+++ b/server/src/__tests__/heartbeat-task-session-failure-reset.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { shouldResetTaskSessionForConsecutiveFailures } from "../services/heartbeat.ts";
+
+// SUP-2320: a task session whose runs keep failing (e.g. a poisoned resume id
+// the adapter never classifies as a session error) must be auto-abandoned
+// after a threshold of consecutive failures so the agent self-heals instead
+// of failing every wake forever. A successful run resets the counter to 0 in
+// upsertTaskSession, so reuse resumes normally after recovery.
+
+describe("shouldResetTaskSessionForConsecutiveFailures", () => {
+  it("does not reset below the threshold", () => {
+    expect(shouldResetTaskSessionForConsecutiveFailures(0)).toBe(false);
+    expect(shouldResetTaskSessionForConsecutiveFailures(1)).toBe(false);
+    expect(shouldResetTaskSessionForConsecutiveFailures(2)).toBe(false);
+  });
+
+  it("resets at and above the threshold", () => {
+    expect(shouldResetTaskSessionForConsecutiveFailures(3)).toBe(true);
+    expect(shouldResetTaskSessionForConsecutiveFailures(26)).toBe(true);
+  });
+
+  it("treats missing counters as healthy", () => {
+    expect(shouldResetTaskSessionForConsecutiveFailures(null)).toBe(false);
+    expect(shouldResetTaskSessionForConsecutiveFailures(undefined)).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -216,6 +216,10 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+// After this many consecutive failed runs against the same task session,
+// stop resuming it and start a fresh session (self-heal for poisoned
+// session ids that fail every resume). SUP-2320.
+const MAX_TASK_SESSION_CONSECUTIVE_FAILURES = 3;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -2168,6 +2172,15 @@ export function shouldResetTaskSessionForModelChange(input: {
   if (!configuredModel || !taskSessionParams) return false;
   const sessionModel = readConfiguredModelFromSessionParams(taskSessionParams);
   return !!sessionModel && sessionModel !== configuredModel;
+}
+
+// SUP-2320 belt-and-braces: a persisted task session that keeps failing run
+// after run (e.g. a poisoned resume id the adapter never recognizes as a
+// session error) must eventually be abandoned so the agent self-heals.
+export function shouldResetTaskSessionForConsecutiveFailures(
+  consecutiveFailureCount: number | null | undefined,
+) {
+  return (consecutiveFailureCount ?? 0) >= MAX_TASK_SESSION_CONSECUTIVE_FAILURES;
 }
 
 export function stripConfiguredModelFromSessionParams(
@@ -4489,6 +4502,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     sessionDisplayId: string | null;
     lastRunId: string | null;
     lastError: string | null;
+    runFailed: boolean;
   }) {
     const existing = await getTaskSession(
       input.companyId,
@@ -4496,6 +4510,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       input.adapterType,
       input.taskKey,
     );
+    // Track consecutive failed runs so a session that keeps failing (e.g. a
+    // poisoned resume id) can be auto-reset after a threshold. SUP-2320.
+    const consecutiveFailureCount = input.runFailed
+      ? (existing?.consecutiveFailureCount ?? 0) + 1
+      : 0;
     if (existing) {
       return db
         .update(agentTaskSessions)
@@ -4504,6 +4523,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           sessionDisplayId: input.sessionDisplayId,
           lastRunId: input.lastRunId,
           lastError: input.lastError,
+          consecutiveFailureCount,
           updatedAt: new Date(),
         })
         .where(eq(agentTaskSessions.id, existing.id))
@@ -4522,6 +4542,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         sessionDisplayId: input.sessionDisplayId,
         lastRunId: input.lastRunId,
         lastError: input.lastError,
+        consecutiveFailureCount,
       })
       .returning()
       .then((rows) => rows[0] ?? null);
@@ -7893,13 +7914,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       configuredModel,
       taskSessionParams: taskSessionDecodedParams,
     });
-    const resetTaskSession = shouldResetTaskSessionForWake(context) || modelChangedSinceTaskSession;
+    // Belt-and-braces self-heal (SUP-2320): if the persisted session has
+    // produced N consecutive failed runs, stop resuming it and start fresh.
+    // A successful run resets the counter in upsertTaskSession.
+    const taskSessionFailureResetTriggered =
+      shouldResetTaskSessionForConsecutiveFailures(taskSession?.consecutiveFailureCount);
+    const resetTaskSession =
+      shouldResetTaskSessionForWake(context) ||
+      modelChangedSinceTaskSession ||
+      taskSessionFailureResetTriggered;
     const wakeSessionResetReason = describeSessionResetReason(context);
     const taskSessionConfiguredModel = readConfiguredModelFromSessionParams(taskSessionDecodedParams);
     const modelSessionResetReason = modelChangedSinceTaskSession && taskSessionConfiguredModel
       ? `configured model changed from "${taskSessionConfiguredModel}" to "${configuredModel}"`
       : null;
-    const sessionResetReason = [modelSessionResetReason, wakeSessionResetReason]
+    const failureSessionResetReason = taskSessionFailureResetTriggered
+      ? `session failed ${taskSession?.consecutiveFailureCount ?? 0} consecutive runs (threshold ${MAX_TASK_SESSION_CONSECUTIVE_FAILURES})`
+      : null;
+    const sessionResetReason = [modelSessionResetReason, failureSessionResetReason, wakeSessionResetReason]
       .filter((value): value is string => Boolean(value))
       .join("; ") || null;
     const taskSessionForRun = resetTaskSession ? null : taskSession;
@@ -9325,6 +9357,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               sessionDisplayId: nextSessionState.displayId,
               lastRunId: finalizedRun.id,
               lastError: outcome === "succeeded" ? null : (adapterResult.errorMessage ?? "run_failed"),
+              runFailed: outcome !== "succeeded",
             });
           }
         }
@@ -9408,6 +9441,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             sessionDisplayId: previousSessionDisplayId,
             lastRunId: failedRun.id,
             lastError: message,
+            runFailed: true,
           });
         }
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run on adapters (claude_local et al.) and resume per-task conversations via persisted session ids in agentTaskSessions
> - When `claude --resume <id>` targets a session that does not exist on disk, the CLI exits 0 but emits a stream-json result with `is_error: true` (subtype `error_during_execution`, "No conversation found with session ID: …")
> - The adapter's retry-on-unknown-session gate only fired on non-zero exits, so this shape failed the run — and worse, the adapter persisted a freshly minted session id from the failed stream even though that conversation was never created
> - The next wake resumed that nonexistent id and failed identically, forever: a live incident produced ~26 consecutive failed 5-minute heartbeat runs over 2.5h with no self-healing
> - This pull request makes the failed resume retry once with a fresh session in the same run, refuses to persist session ids that were never verifiably created, and auto-resets a task session after 3 consecutive failed runs
> - The benefit is that a transient session loss costs one degraded run instead of permanently bricking an agent's heartbeat until an operator intervenes

## Linked Issues or Issue Description

No GitHub issue exists; tracked internally as SUP-2320.

Related PRs found during dedup search: Refs #6396 (open: quarantines poisoned session jsonl + fresh-session retry — its merged predecessor added the poisoned/image session-error retry kinds this PR builds on), Refs #658 (open: clears stale task sessions after a failed run — broader/staler approach; this PR's consecutive-failure counter is narrower and keeps valid continuation context), Refs #2361 (closed: retry on stale session with no parsed output). None of them handle the exit-0 `is_error` resume failure or the unverified-session-id persistence that caused this incident.

Bug summary per the bug-report template:

- **What happened:** A heartbeat run resumed a session id that was not on disk. The run failed with `error_during_execution: No conversation found with session ID: <id>` (process exit 0), and the adapter persisted a NEW session id from the failed run's stream events into `agent_task_sessions` — an id whose conversation was never created. Every subsequent 5-minute heartbeat wake resumed the poisoned id and failed the same way (~26 consecutive failures over 2.5h) until an operator manually reset the session row.
- **Expected behavior:** A failed resume should fall back to a fresh session within the same run; a session id should never be persisted unless the conversation verifiably exists; repeated failures on the same task session should eventually self-heal.
- **Steps to reproduce:** Persist a claude_local task session id, delete the corresponding `~/.claude/projects/<cwd>/<id>.jsonl`, trigger a wake. Before this fix: run fails and the poisoned cycle begins. After: the run retries fresh and succeeds.
- **Version/commit:** master @ 69a368ed5; deployment mode: local.

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts`: the fresh-session retry gate now also fires when the failed attempt exits 0 with `is_error: true` in the parsed result (previously only non-zero exits qualified).
- `packages/adapters/claude-local/src/server/execute.ts` + `parse.ts`: verified-session guard — `parseClaudeStreamJson` now reports `sawAssistantEvent`; `toAdapterResult` only adopts a stream-derived session id when the run succeeded or an assistant turn proves the conversation exists. Otherwise it keeps the previous known session id (fallback) or returns none, mirroring the existing poisoned-message-id drop guard.
- `server/src/services/heartbeat.ts` + `packages/db` (schema + migration `0099`): new `consecutive_failure_count` column on `agent_task_sessions`, incremented on failed runs and zeroed on success by `upsertTaskSession`; at session selection, `shouldResetTaskSessionForConsecutiveFailures` abandons the stored session after 3 consecutive failures so unrecognized failure shapes still self-heal.
- `scripts/link-plugin-dev-sdk.mjs` (separate commit): use `unlinkSync` instead of `rmSync` for the plugin SDK symlink — on Node >= 24 `rmSync` throws `ERR_FS_EISDIR` on directory symlinks, which broke every fresh `pnpm install`.
- Tests: three new execute-level regression tests reproducing the incident shape (exit-0 `is_error` resume failure retries fresh; failed runs do not persist unverified minted ids, with and without a prior session) and unit tests for the consecutive-failure threshold.

## Verification

- `cd server && pnpm vitest run src/__tests__/claude-local-execute.test.ts` — 22 passed (3 new SUP-2320 regression tests; the first fails on master).
- `cd server && pnpm vitest run src/__tests__/heartbeat-task-session-failure-reset.test.ts src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts src/__tests__/heartbeat-workspace-session.test.ts` — 100 passed.
- `pnpm typecheck` clean for `@paperclipai/adapter-claude-local`, `@paperclipai/db`, and `@paperclipai/server`.
- `pnpm db:migrate` applied migration `0099_agent_task_session_failure_count` successfully against a fresh embedded-postgres instance.
- Note: migration `0099` is hand-written (SQL + journal entry) because `drizzle-kit generate` is currently broken on master — `0097` has no snapshot and `0098`'s snapshot collides on its parent (`0095`/`0098` both point at the same parent snapshot). Same approach as the most recent migrations.

## Risks

- New non-null column with default 0 on `agent_task_sessions` — additive, safe for existing rows; migration is a single `ALTER TABLE ... ADD COLUMN`.
- Behavioral shift: failed runs that previously (incorrectly) adopted a newly minted session id now keep the prior session id instead. That prior id was the last verifiably good session, so this strictly reduces poisoning risk; worst case a continuation re-resumes the pre-failure conversation.
- The consecutive-failure auto-reset (threshold 3) discards conversation context after persistent failures — intentional, since a session failing 3 runs in a row was previously a permanent outage.
- The retry-once gate broadening could, in principle, retry a non-session `is_error` failure — but the retry still requires a positive session-error classification (`unknown`/`poisoned`/`image`), unchanged from before.

## Model Used

- Claude Opus 4.6 (`claude-opus-4-6`, Anthropic) via Claude Code / Paperclip claude_local adapter agent harness, with extended thinking and tool use (code reading, editing, vitest execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes (code-level comments; no doc pages affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending — will confirm after CI runs)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
