### PR TITLE
fix(server): resolve environment env bindings at heartbeat runtime

### DIFF
--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -67,6 +67,24 @@ describe("resolveExecutionRunAdapterConfig", () => {
             outcome: "success",
           },
         ],
+      })
+      .mockResolvedValueOnce({
+        env: {
+          SHARED_KEY: "environment",
+          ENV_ONLY: "env-only",
+        },
+        secretKeys: new Set(["ENV_SECRET"]),
+        manifest: [
+          {
+            configPath: "env.ENV_SECRET",
+            envKey: "ENV_SECRET",
+            secretId: "secret-environment",
+            secretKey: "environment-secret",
+            version: 1,
+            provider: "local_encrypted",
+            outcome: "success",
+          },
+        ],
       });
 
     const result = await resolveExecutionRunAdapterConfig({
@@ -75,6 +93,8 @@ describe("resolveExecutionRunAdapterConfig", () => {
       projectEnv: { SHARED_KEY: "project" },
       routineEnv: { SHARED_KEY: "routine" },
       routineId: "routine-1",
+      environmentEnv: { SHARED_KEY: "environment" },
+      environmentId: "environment-1",
       secretsSvc: {
         resolveAdapterConfigForRuntime,
         resolveEnvBindings,
@@ -84,15 +104,22 @@ describe("resolveExecutionRunAdapterConfig", () => {
     expect(result.resolvedConfig).toMatchObject({
       other: "value",
       env: {
-        SHARED_KEY: "routine",
+        SHARED_KEY: "environment",
         AGENT_ONLY: "agent-only",
         PROJECT_ONLY: "project-only",
         ROUTINE_ONLY: "routine-only",
+        ENV_ONLY: "env-only",
       },
     });
-    expect(Array.from(result.secretKeys).sort()).toEqual(["AGENT_SECRET", "PROJECT_SECRET", "ROUTINE_SECRET"]);
+    expect(Array.from(result.secretKeys).sort()).toEqual([
+      "AGENT_SECRET",
+      "ENV_SECRET",
+      "PROJECT_SECRET",
+      "ROUTINE_SECRET",
+    ]);
     expect(result.secretManifest.map((entry) => entry.secretId).sort()).toEqual([
       "secret-agent",
+      "secret-environment",
       "secret-project",
       "secret-routine",
     ]);
@@ -102,6 +129,10 @@ describe("resolveExecutionRunAdapterConfig", () => {
     expect(resolveEnvBindings.mock.calls[1]?.[2]).toMatchObject({
       consumerType: "routine",
       consumerId: "routine-1",
+    });
+    expect(resolveEnvBindings.mock.calls[2]?.[2]).toMatchObject({
+      consumerType: "environment",
+      consumerId: "environment-1",
     });
   });
 
@@ -213,6 +244,8 @@ describe("resolveExecutionRunAdapterConfig", () => {
       executionRunConfig: { env: {} },
       projectEnv: { PROJECT_FLAG: "plain" },
       routineEnv: { ROUTINE_FLAG: "plain" },
+      environmentEnv: { ENV_FLAG: "plain" },
+      environmentId: "environment-1",
       trustPreset: {
         kind: "low_trust_review",
         preset: LOW_TRUST_REVIEW_PRESET,
@@ -239,6 +272,76 @@ describe("resolveExecutionRunAdapterConfig", () => {
     expect(resolveEnvBindings.mock.calls[1]?.[2]).toMatchObject({
       allowedBindingIds: ["binding-1"],
     });
+    expect(resolveEnvBindings.mock.calls[2]?.[2]).toMatchObject({
+      allowedBindingIds: ["binding-1"],
+    });
+  });
+
+  it("resolves environment env bindings with consumerType environment", async () => {
+    const resolveAdapterConfigForRuntime = vi.fn().mockResolvedValue({
+      config: { env: { AGENT_ONLY: "agent-only" } },
+      secretKeys: new Set<string>(),
+      manifest: [],
+    });
+    const resolveEnvBindings = vi.fn().mockResolvedValue({
+      env: { CURSOR_API_KEY: "resolved-cursor-key" },
+      secretKeys: new Set(["CURSOR_API_KEY"]),
+      manifest: [
+        {
+          configPath: "env.CURSOR_API_KEY",
+          envKey: "CURSOR_API_KEY",
+          secretId: "secret-cursor",
+          secretKey: "cursor-key",
+          version: 1,
+          provider: "local_encrypted",
+          outcome: "success",
+        },
+      ],
+    });
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      heartbeatRunId: "run-1",
+      environmentId: "environment-1",
+      executionRunConfig: { env: { AGENT_ONLY: "agent-only" } },
+      projectEnv: null,
+      environmentEnv: {
+        CURSOR_API_KEY: {
+          type: "secret_ref",
+          secretId: "secret-cursor",
+          version: "latest",
+        },
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime,
+        resolveEnvBindings,
+      } as any,
+    });
+
+    expect(result.resolvedConfig.env).toEqual({
+      AGENT_ONLY: "agent-only",
+      CURSOR_API_KEY: "resolved-cursor-key",
+    });
+    expect(resolveEnvBindings).toHaveBeenCalledWith(
+      "company-1",
+      {
+        CURSOR_API_KEY: {
+          type: "secret_ref",
+          secretId: "secret-cursor",
+          version: "latest",
+        },
+      },
+      expect.objectContaining({
+        consumerType: "environment",
+        consumerId: "environment-1",
+        actorType: "agent",
+        actorId: "agent-1",
+        issueId: "issue-1",
+        heartbeatRunId: "run-1",
+      }),
+    );
   });
 
   it("rejects inline sensitive env values for low-trust runs", async () => {

--- a/server/src/routes/environments.ts
+++ b/server/src/routes/environments.ts
@@ -225,6 +225,11 @@ export function environmentRoutes(
       { targetType: "environment", targetId: environment.id },
       await collectEnvironmentSecretRefs({ db, environment }),
     );
+    await secrets.syncEnvBindingsForTarget?.(
+      companyId,
+      { targetType: "environment", targetId: environment.id },
+      parseObject(environment.config).env,
+    );
     await logActivity(db, {
       companyId,
       actorType: actor.actorType,
@@ -340,6 +345,11 @@ export function environmentRoutes(
         environment.companyId,
         { targetType: "environment", targetId: environment.id },
         await collectEnvironmentSecretRefs({ db, environment }),
+      );
+      await secrets.syncEnvBindingsForTarget?.(
+        environment.companyId,
+        { targetType: "environment", targetId: environment.id },
+        parseObject(environment.config).env,
       );
     }
     await logActivity(db, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -434,6 +434,8 @@ export async function resolveExecutionRunAdapterConfig(input: {
   executionRunConfig: Record<string, unknown>;
   projectEnv: unknown;
   routineEnv?: unknown;
+  environmentId?: string | null;
+  environmentEnv?: unknown;
   secretsSvc: RuntimeConfigSecretResolver;
   trustPreset?: TrustPresetResolution;
 }) {
@@ -447,6 +449,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
     assertLowTrustEnvConfigAllowed(executionRunConfig.env, "agent.env");
     assertLowTrustEnvConfigAllowed(projectEnv, "project.env");
     assertLowTrustEnvConfigAllowed(routineEnv, "routine.env");
+    assertLowTrustEnvConfigAllowed(input.environmentEnv, "environment.env");
   }
   const { config: resolvedConfig, secretKeys, manifest } = await input.secretsSvc.resolveAdapterConfigForRuntime(
     input.companyId,
@@ -515,6 +518,33 @@ export async function resolveExecutionRunAdapterConfig(input: {
       secretKeys.add(key);
     }
   }
+  const environmentEnv = stripPaperclipRuntimeEnvBindings(input.environmentEnv);
+  const environmentEnvResolution = environmentEnv
+    ? await input.secretsSvc.resolveEnvBindings(
+        input.companyId,
+        environmentEnv,
+        input.environmentId
+          ? {
+              consumerType: "environment",
+              consumerId: input.environmentId,
+              actorType: "agent",
+              actorId: input.agentId ?? null,
+              issueId: input.issueId ?? null,
+              heartbeatRunId: input.heartbeatRunId ?? null,
+              ...(lowTrustAllowedBindingIds !== undefined ? { allowedBindingIds: lowTrustAllowedBindingIds } : {}),
+            }
+          : undefined,
+      )
+    : { env: {}, secretKeys: new Set<string>(), manifest: [] };
+  if (Object.keys(environmentEnvResolution.env).length > 0) {
+    resolvedConfig.env = {
+      ...parseObject(resolvedConfig.env),
+      ...environmentEnvResolution.env,
+    };
+    for (const key of environmentEnvResolution.secretKeys) {
+      secretKeys.add(key);
+    }
+  }
   return {
     resolvedConfig,
     secretKeys,
@@ -522,6 +552,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
       ...(manifest ?? []),
       ...(projectEnvResolution.manifest ?? []),
       ...(routineEnvResolution.manifest ?? []),
+      ...(environmentEnvResolution.manifest ?? []),
     ],
   };
 }
@@ -8235,6 +8266,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
     const configSnapshot = buildExecutionWorkspaceConfigSnapshot(mergedConfig, selectedEnvironmentId);
     const executionRunConfig = stripWorkspaceRuntimeFromExecutionRunConfig(mergedConfig);
+    const selectedEnvironmentRecord = selectedEnvironmentId
+      ? await environmentsSvc.getById(selectedEnvironmentId)
+      : null;
+    const selectedEnvironmentEnv = selectedEnvironmentRecord
+      ? parseObject(parseObject(selectedEnvironmentRecord.config).env)
+      : null;
     const { resolvedConfig, secretKeys, secretManifest } = await resolveExecutionRunAdapterConfig({
       companyId: agent.companyId,
       agentId: agent.id,
@@ -8245,6 +8282,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       executionRunConfig,
       projectEnv: projectContext?.env ?? null,
       routineEnv: routineEnvContext.env,
+      environmentId: selectedEnvironmentId,
+      environmentEnv: selectedEnvironmentEnv,
       secretsSvc,
       trustPreset,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Heartbeat execution resolves adapter config and overlays env from agent, project, routine, and environment bindings before spawning adapter processes
> - Agents with `defaultEnvironmentId` could store secrets on `environment.config.env` but those bindings were not resolved into the adapter runtime shell
> - Project and routine env overlays already worked; environment env was missing from `resolveExecutionRunAdapterConfig`, and environment create/update did not sync `config.env` into `company_secret_bindings`
> - This pull request adds environment env resolution at heartbeat runtime and syncs env bindings on environment create/update
> - The benefit is adapter heartbeats (e.g. cursor) receive secrets like `CURSOR_API_KEY` from the agent's default environment without manual dist patching

## Linked Issues or Issue Description

Refs #6128

External consumer tracking: Managing MAN-71 (local dist patch to drop after merge).

## What happened?

Cursor adapter heartbeats ran with empty `CURSOR_API_KEY` even when the agent's `defaultEnvironmentId` Local environment had `config.env.CURSOR_API_KEY` stored as a `secret_ref`. Project/routine env overlays resolved correctly; environment env did not.

## Expected behavior

Environment `config.env` `secret_ref` bindings should resolve into adapter runtime env at heartbeat time (`consumerType: environment`), matching project/routine overlay behavior. Environment create/update should sync `config.env` into `company_secret_bindings`.

## Steps to reproduce

1. Create a Local environment with `config.env.CURSOR_API_KEY` as `secret_ref`.
2. Assign an agent `defaultEnvironmentId` to that environment and use the `cursor` adapter.
3. Trigger a heartbeat and inspect adapter shell env (or run a script that reads `process.env.CURSOR_API_KEY`).
4. Before fix: key is empty. After fix: key is present.

## Paperclip version

v2026.529.0 (local dist patch); fix targets `master`.

## Deployment mode

Local (`paperclipai run`).

## What Changed

- `server/src/services/heartbeat.ts`: in `resolveExecutionRunAdapterConfig`, resolve `environment.config.env` bindings (`consumerType: environment`) and merge into adapter runtime env (mirror project/routine).
- `server/src/routes/environments.ts`: on environment create/update, call `syncEnvBindingsForTarget` for `config.env`.
- `server/src/__tests__/heartbeat-project-env.test.ts`: extend unit test to cover environment env overlay and `consumerType: environment` resolution.

## Verification

```bash
cd server && npx vitest run src/__tests__/heartbeat-project-env.test.ts
# 9 passed

cd managing/lab
echo '{"decision":"hold","studyName":"smoke-test","topCandidates":[]}' \
  | CURSOR_MODEL_ID=gpt-5.3-codex-spark node cursor-sdk/summarize.mjs
# exit 0
```

## Risks

Low risk. Mirrors existing project/routine env overlay pattern. No schema migration. Environment env still passes through `stripPaperclipRuntimeEnvBindings` and low-trust checks.

## Model Used

Claude (Cursor agent Composer) — assisted implementation and test extension from local dist patch spec.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge