### PR TITLE
fix: classify empty/malformed API response and socket closure as transient upstream errors

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -90,6 +90,30 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(false);
   });
 
+  it("classifies 'empty or malformed response' as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          subtype: "success",
+          is_error: true,
+          result: "API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("classifies 'socket connection was closed unexpectedly' as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          subtype: "success",
+          is_error: true,
+          result: "API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument",
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("does not classify deterministic validation errors as transient", () => {
     expect(
       isClaudeTransientUpstreamError({

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -90,13 +90,25 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(false);
   });
 
-  it("classifies 'empty or malformed response' as transient", () => {
+  it("classifies 'API returned an empty or malformed response (HTTP 200)' as transient", () => {
     expect(
       isClaudeTransientUpstreamError({
         parsed: {
           subtype: "success",
           is_error: true,
           result: "API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("classifies 'API returned a empty or malformed response, HTTP 200' variant as transient", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          subtype: "success",
+          is_error: true,
+          result: "API Error: API returned a empty or malformed response, HTTP 200",
         },
       }),
     ).toBe(true);

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,7 +10,7 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|api\s+returned\s+an?\s+empty\s+or\s+malformed\s+response[^,\n]*\bHTTP\s+200\b|socket\s+connection\s+was\s+closed\s+unexpectedly)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|api\s+returned\s+an?\s+empty\s+or\s+malformed\s+response[\s\S]{0,48}?\bHTTP\s+200\b|socket\s+connection\s+was\s+closed\s+unexpectedly)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,7 +10,7 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|empty\s+or\s+malformed\s+response|socket\s+connection\s+was\s+closed\s+unexpectedly)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|api\s+returned\s+an?\s+empty\s+or\s+malformed\s+response[^,\n]*\bHTTP\s+200\b|socket\s+connection\s+was\s+closed\s+unexpectedly)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,7 +10,7 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|empty\s+or\s+malformed\s+response|socket\s+connection\s+was\s+closed\s+unexpectedly)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -1130,6 +1130,64 @@ describe("claude execute", () => {
     }
   });
 
+  it("classifies malformed HTTP 200 Claude API responses as transient", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-malformed-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(commandPath, {
+      resultEvent: {
+        type: "result",
+        subtype: "success",
+        session_id: "abababab-abab-4aba-8aba-abababababab",
+        is_error: true,
+        result:
+          "API Error: API returned an empty or malformed response (HTTP 200) - check for a proxy or gateway intercepting the request.",
+      },
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-malformed-http-200",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("claude_transient_upstream");
+      expect(result.errorFamily).toBe("transient_upstream");
+      expect(result.retryNotBefore ?? null).toBeNull();
+      expect(result.resultJson?.retryNotBefore ?? null).toBeNull();
+      expect(result.errorMessage ?? "").toContain("malformed response");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not reclassify deterministic Claude failures (auth, max turns) as transient", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-max-turns-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents connect to LLM runtimes through adapters like `claude_local`
> - When an adapter run fails, Paperclip must decide whether the failure is transient (worth retrying with backoff) or permanent (give up)
> - The `claude_local` adapter classifies transient errors using `isClaudeTransientUpstreamError()` which matches against `CLAUDE_TRANSIENT_UPSTREAM_RE`
> - But two common transient error patterns are missing from that regex: "API returned an empty or malformed response (HTTP 200)" and "The socket connection was closed unexpectedly"
> - These errors occur when a proxy/gateway returns HTTP 200 with an empty body, or when a network connection drops mid-stream — both are clearly transient infrastructure issues
> - This PR adds both patterns to `CLAUDE_TRANSIENT_UPSTREAM_RE` so the heartbeat engine automatically retries these transient errors
> - The benefit is that agents no longer permanently fail on recoverable network/proxy errors

## Linked Issues or Issue Description

Closes #7978

Related: #1389 (original transient retry feature), #5221 (independent fix for the same HTTP 200 empty-body pattern plus concurrency gate and session checkpointing — Fix 1 overlaps with this PR; Fixes 3 and 4 are orthogonal), #6849 (ConnectionRefused transient classification), #6855 (session limit transient classification)

## What Changed

- **`packages/adapters/claude-local/src/server/parse.ts`**: Added `api\s+returned\s+an?\s+empty\s+or\s+malformed\s+response[^,\n]*\bHTTP\s+200\b` to `CLAUDE_TRANSIENT_UPSTREAM_RE` — matches the Claude Code error "API returned an empty or malformed response (HTTP 200)" with indefinite article alternation. Added `socket\s+connection\s+was\s+closed\s+unexpectedly` to match socket closure errors.
- **`packages/adapters/claude-local/src/server/parse.test.ts`**: Added three test cases: (1) the canonical "empty or malformed response (HTTP 200)" error, (2) the "a empty" variant form, (3) "socket connection was closed unexpectedly" — all with `subtype=success + is_error=true`.
- **`server/src/__tests__/claude-local-execute.test.ts`**: Added an execute-path integration test asserting `claude_transient_upstream` / `transient_upstream` for malformed HTTP 200 failures.

## Verification

```bash
cd packages/adapters/claude-local
pnpm vitest run src/server/parse.test.ts

cd server
npx vitest run src/__tests__/claude-local-execute.test.ts -t "malformed HTTP 200"
```

## Risks

**Low risk.** Both patterns are clearly transient in nature (network/infrastructure issues that resolve on retry). Safety guarantees:

- Existing deterministic-error classifiers (`isClaudeMaxTurnsResult`, `isClaudeUnknownSessionError`, `isClaudePoisonedPreviousMessageIdError`, `isClaudeImageProcessingError`) are checked **before** the transient regex in `isClaudeTransientUpstreamError()`, so no deterministic failure can be misclassified as transient.
- The HTTP 200 pattern is scoped to `api\s+returned\s+an?\s+empty\s+or\s+malformed\s+response` followed by `HTTP 200`, avoiding false positives on unrelated messages.
- Retries are bounded by the heartbeat engine's own max-retry limits.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

None — human-authored

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (N/A — no docs changes needed for a regex fix)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups