### PR TITLE
Fix dev watch loops from Drizzle schema edits

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -39,6 +39,8 @@ This starts:
 
 `pnpm dev` runs the server in watch mode and restarts on changes from workspace packages (including adapter packages). Use `pnpm dev:once` to run without file watching.
 
+Drizzle schema edits under `packages/db/src/schema/` are intentionally excluded from the watch trigger. Generate a migration (`pnpm db:generate`) after schema changes; the resulting migration/meta write is what restarts dev so startup can apply or reconcile the new schema safely.
+
 `pnpm dev:once` auto-applies pending local migrations by default before starting the dev server.
 
 `pnpm dev` and `pnpm dev:once` are now idempotent for the current repo and instance: if the matching Paperclip dev runner is already alive, Paperclip reports the existing process instead of starting a duplicate.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,8 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/skills-catalog: {}
+
   server:
     dependencies:
       '@aws-sdk/client-s3':

--- a/server/src/__tests__/dev-watch-ignore.test.ts
+++ b/server/src/__tests__/dev-watch-ignore.test.ts
@@ -8,19 +8,24 @@ describe("resolveServerDevWatchIgnorePaths", () => {
   it("includes both the worktree UI paths and their real shared targets", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-dev-watch-"));
     const sharedUiRoot = path.join(tempRoot, "shared-ui");
+    const sharedDbSchemaRoot = path.join(tempRoot, "shared-db-schema");
     const worktreeRoot = path.join(tempRoot, "repo", ".paperclip", "worktrees", "PAP-884");
     const serverRoot = path.join(worktreeRoot, "server");
     const worktreeUiRoot = path.join(worktreeRoot, "ui");
+    const worktreeDbSchemaRoot = path.join(worktreeRoot, "packages", "db", "src", "schema");
 
     fs.mkdirSync(path.join(sharedUiRoot, "node_modules"), { recursive: true });
     fs.mkdirSync(path.join(sharedUiRoot, ".vite"), { recursive: true });
     fs.mkdirSync(path.join(sharedUiRoot, "dist"), { recursive: true });
     fs.mkdirSync(serverRoot, { recursive: true });
     fs.mkdirSync(worktreeUiRoot, { recursive: true });
+    fs.mkdirSync(sharedDbSchemaRoot, { recursive: true });
+    fs.mkdirSync(path.dirname(worktreeDbSchemaRoot), { recursive: true });
 
     fs.symlinkSync(path.join(sharedUiRoot, "node_modules"), path.join(worktreeUiRoot, "node_modules"));
     fs.symlinkSync(path.join(sharedUiRoot, ".vite"), path.join(worktreeUiRoot, ".vite"));
     fs.symlinkSync(path.join(sharedUiRoot, "dist"), path.join(worktreeUiRoot, "dist"));
+    fs.symlinkSync(sharedDbSchemaRoot, worktreeDbSchemaRoot);
 
     const ignorePaths = resolveServerDevWatchIgnorePaths(serverRoot);
 
@@ -36,6 +41,10 @@ describe("resolveServerDevWatchIgnorePaths", () => {
     expect(ignorePaths).toContain(fs.realpathSync(path.join(sharedUiRoot, ".vite")));
     expect(ignorePaths).toContain(path.join(worktreeUiRoot, "dist"));
     expect(ignorePaths).toContain(fs.realpathSync(path.join(sharedUiRoot, "dist")));
+    expect(ignorePaths).toContain(worktreeDbSchemaRoot);
+    expect(ignorePaths).toContain(`${worktreeDbSchemaRoot.replaceAll(path.sep, "/")}/**`);
+    expect(ignorePaths).toContain(fs.realpathSync(sharedDbSchemaRoot));
+    expect(ignorePaths).toContain(`${fs.realpathSync(sharedDbSchemaRoot).replaceAll(path.sep, "/")}/**`);
     expect(ignorePaths).toContain("**/{node_modules,bower_components,vendor}/**");
     expect(ignorePaths).toContain("**/.vite-temp/**");
   });

--- a/server/src/dev-watch-ignore.ts
+++ b/server/src/dev-watch-ignore.ts
@@ -28,6 +28,10 @@ export function resolveServerDevWatchIgnorePaths(serverRoot: string): string[] {
     "../ui/node_modules/.vite-temp",
     "../ui/.vite",
     "../ui/dist",
+    // Drizzle schema edits must not hot-reload the server until a migration is
+    // generated. The subsequent migration/meta write is what should trigger the
+    // restart so startup can reconcile/apply the new schema safely.
+    "../packages/db/src/schema",
     // npm install during reinstall would trigger a restart mid-request
     // if tsx watch sees the new files. Exclude the managed plugins dir.
     process.env.HOME + "/.paperclip/adapter-plugins",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and local dev instances across the main repo and repo-linked worktrees
> - Local development depends on the managed `pnpm dev` watcher restarting the server only for changes that are safe to reconcile during startup
> - Drizzle schema edits under `packages/db/src/schema/` change source-of-truth metadata before a migration exists
> - Restarting immediately on raw schema edits can bounce the dev server into noisy loops instead of waiting for the migration/meta write that actually makes the schema change actionable
> - Worktree-linked paths are often symlinked, so the ignore list has to cover both the visible worktree path and the resolved real path target
> - This pull request adds the Drizzle schema directory to the server dev-watch ignore set, extends the test to cover symlinked schema roots, and documents the intended workflow
> - The benefit is that local dev waits for `pnpm db:generate` before restarting, which avoids spurious restarts and reduces timer-wake churn caused by pure wait-state loops

## What Changed

- Added `../packages/db/src/schema` to the server dev-watch ignore list
- Extended `resolveServerDevWatchIgnorePaths` coverage to assert both worktree and realpath ignore entries for symlinked Drizzle schema directories
- Documented that schema edits do not restart `pnpm dev` until a migration/meta write happens via `pnpm db:generate`

## Verification

- `pnpm exec vitest run server/src/__tests__/dev-watch-ignore.test.ts`

## Risks

- Low risk: raw schema-file edits no longer trigger an immediate dev-server restart, so developers must follow the documented `pnpm db:generate` step to get the expected restart/apply behavior

## Model Used

- OpenAI Codex, GPT-5.5-class coding agent in Codex CLI with tool use, shell execution, and patch-based editing capabilities

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
