### PR TITLE
fix: suppress stale routine recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ tests/release-smoke/playwright-report/
 .superpowers/
 .claude/worktrees/
 .herenow
+.go-output/

--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -194,6 +194,8 @@ GET /api/routines/{routineId}/runs?limit=50
 
 Returns recent run history for the routine. Defaults to 50 most recent runs.
 
+Historical failed routine executions may be marked `superseded` when a newer run for the same routine and dispatch fingerprint completes successfully. Superseded executions are retained in run history, but automatic stranded-work recovery is suppressed so stale failures do not trigger duplicate alerts or side effects after the operational obligation has already been satisfied.
+
 ## Agent Access Rules
 
 Agents can read all routines in their company but can only create and manage routines assigned to themselves:

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paperclipai/shared
 
+## Unreleased
+
+### Patch Changes
+
+- Add `superseded` to routine run statuses for historical executions replaced by newer completed runs.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -453,6 +453,7 @@ export const ROUTINE_RUN_STATUSES = [
   "issue_created",
   "completed",
   "failed",
+  "superseded",
  ] as const;
 export type RoutineRunStatus = (typeof ROUTINE_RUN_STATUSES)[number];
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paperclipai/server
 
+## Unreleased
+
+### Patch Changes
+
+- Suppress recovery for stale routine execution issues when a newer run with the same dispatch fingerprint has already completed, marking the old run superseded instead of waking recovery owners.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1023,8 +1023,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         })
     );
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
-    // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
-    expect(issue?.checkoutRunId).toBeNull();
+    // Terminal run cleanup releases the dead run's checkout lock. The retry may
+    // already be running by the time the assertion observes the issue, so the
+    // lock can be either free or owned by the live retry run — never the dead run.
+    expect(issue?.checkoutRunId).not.toBe(runId);
+    if (issue?.checkoutRunId) expect(issue.checkoutRunId).toBe(retryRun?.id);
   });
 
   it("releases active environment leases when an orphaned run is reaped", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -438,6 +438,79 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(comments[0]?.body).not.toContain("Recovery action:");
   });
 
+  it("does not suppress routine recovery using a run from another company", async () => {
+    const { companyId, managerId, coderId, sourceIssueId, sourceIssue } = await seedCompany();
+    const other = await seedCompany("OTHER");
+    const routineId = randomUUID();
+    const oldRunId = randomUUID();
+    const dispatchFingerprint = "routine:fingerprint:foreign";
+
+    await db.insert(routines).values({
+      id: routineId,
+      companyId: other.companyId,
+      title: "Foreign routine",
+      description: "Belongs to another company.",
+      assigneeAgentId: other.coderId,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+    });
+    await db.insert(routineRuns).values({
+      id: oldRunId,
+      companyId: other.companyId,
+      routineId,
+      source: "schedule",
+      status: "failed",
+      triggeredAt: new Date("2026-06-10T03:00:00.000Z"),
+      dispatchFingerprint,
+      completedAt: new Date("2026-06-10T03:05:00.000Z"),
+    });
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        originKind: "routine_execution",
+        originId: routineId,
+        originRunId: oldRunId,
+        originFingerprint: dispatchFingerprint,
+      })
+      .where(eq(issues.id, sourceIssueId));
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: {
+        ...sourceIssue,
+        status: "in_progress",
+        originKind: "routine_execution",
+        originId: routineId,
+        originRunId: oldRunId,
+        originFingerprint: dispatchFingerprint,
+      },
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue?.companyId).toBe(companyId);
+    expect(updatedIssue?.status).toBe("blocked");
+    await expect(db.select().from(issueRecoveryActions)).resolves.toHaveLength(1);
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({ payload: expect.objectContaining({ issueId: sourceIssueId }) }),
+    );
+  });
+
   it("reuses the same source-scoped action when latest run IDs change while the cause stays the same", async () => {
     const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
     const enqueueWakeup = vi.fn(async () => null);

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -16,6 +16,8 @@ import {
   issueRecoveryActions,
   issueRelations,
   issues,
+  routineRuns,
+  routines,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -136,6 +138,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.delete(issueComments);
     await db.delete(environmentLeases);
     await db.delete(activityLog);
+    await db.delete(routineRuns);
+    await db.delete(routines);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(environments);
@@ -322,6 +326,116 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       sourceIssueId: sourceIssue.id,
       recoveryCause: "stranded_assigned_issue",
     });
+  });
+
+  it("suppresses recovery for routine executions superseded by a newer completed run", async () => {
+    const { companyId, coderId, sourceIssueId, prefix, sourceIssue } = await seedCompany();
+    const routineId = randomUUID();
+    const oldRunId = randomUUID();
+    const newerRunId = randomUUID();
+    const newerIssueId = randomUUID();
+    const dispatchFingerprint = "routine:fingerprint:bobgo";
+
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "BobGo balance check",
+      description: "Check the courier wallet balance.",
+      assigneeAgentId: coderId,
+      priority: "medium",
+      status: "active",
+      concurrencyPolicy: "coalesce_if_active",
+      catchUpPolicy: "skip_missed",
+    });
+    await db
+      .update(issues)
+      .set({
+        title: "BobGo balance check",
+        status: "in_progress",
+        originKind: "routine_execution",
+        originId: routineId,
+        originRunId: oldRunId,
+        originFingerprint: dispatchFingerprint,
+      })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(issues).values({
+      id: newerIssueId,
+      companyId,
+      title: "BobGo balance check",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: coderId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+      originKind: "routine_execution",
+      originId: routineId,
+      originRunId: newerRunId,
+      originFingerprint: dispatchFingerprint,
+    });
+    await db.insert(routineRuns).values([
+      {
+        id: oldRunId,
+        companyId,
+        routineId,
+        source: "schedule",
+        status: "failed",
+        triggeredAt: new Date("2026-06-10T03:00:00.000Z"),
+        dispatchFingerprint,
+        linkedIssueId: sourceIssueId,
+        failureReason: "Execution issue moved to blocked",
+        completedAt: new Date("2026-06-10T03:05:00.000Z"),
+      },
+      {
+        id: newerRunId,
+        companyId,
+        routineId,
+        source: "schedule",
+        status: "completed",
+        triggeredAt: new Date("2026-06-11T03:00:00.000Z"),
+        dispatchFingerprint,
+        linkedIssueId: newerIssueId,
+        completedAt: new Date("2026-06-11T03:03:00.000Z"),
+      },
+    ]);
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: {
+        ...sourceIssue,
+        title: "BobGo balance check",
+        status: "in_progress",
+        originKind: "routine_execution",
+        originId: routineId,
+        originRunId: oldRunId,
+        originFingerprint: dispatchFingerprint,
+      },
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+    });
+
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+    await expect(db.select().from(issueRecoveryActions)).resolves.toHaveLength(0);
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue?.status).toBe("cancelled");
+    const [updatedRun] = await db.select().from(routineRuns).where(eq(routineRuns.id, oldRunId));
+    expect(updatedRun?.status).toBe("superseded");
+    expect(updatedRun?.coalescedIntoRunId).toBe(newerRunId);
+    expect(updatedRun?.failureReason).toContain(`${prefix}-2`);
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("superseded by a newer completed routine run");
+    expect(comments[0]?.body).toContain(`${prefix}-2`);
+    expect(comments[0]?.body).not.toContain("Recovery action:");
   });
 
   it("reuses the same source-scoped action when latest run IDs change while the cause stays the same", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2064,7 +2064,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const currentRun = await db
       .select()
       .from(routineRuns)
-      .where(eq(routineRuns.id, issue.originRunId))
+      .where(and(
+        eq(routineRuns.id, issue.originRunId),
+        eq(routineRuns.companyId, issue.companyId),
+      ))
       .limit(1)
       .then((rows) => rows[0] ?? null);
     if (!currentRun?.dispatchFingerprint) return null;
@@ -2097,40 +2100,57 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const message = `Routine execution superseded by a newer completed routine run (${newerIssueLabel}). Automatic recovery was suppressed to avoid acting on stale historical work.`;
 
     const now = new Date();
-    await db
-      .update(routineRuns)
-      .set({
-        status: "superseded",
-        coalescedIntoRunId: newerCompletedRun.id,
-        failureReason: message,
-        completedAt: now,
-        updatedAt: now,
-      })
-      .where(eq(routineRuns.id, currentRun.id));
+    const [updated] = await db.transaction(async (tx) => {
+      await tx
+        .update(routineRuns)
+        .set({
+          status: "superseded",
+          coalescedIntoRunId: newerCompletedRun.id,
+          failureReason: message,
+          completedAt: currentRun.completedAt ?? now,
+          updatedAt: now,
+        })
+        .where(eq(routineRuns.id, currentRun.id));
 
-    const updated = await issuesSvc.update(issue.id, { status: "cancelled" });
-    await issuesSvc.addComment(issue.id, message, {}, { authorType: "system" });
+      const [cancelledIssue] = await tx
+        .update(issues)
+        .set({ status: "cancelled", updatedAt: now })
+        .where(eq(issues.id, issue.id))
+        .returning();
 
-    await logActivity(db, {
-      companyId: issue.companyId,
-      actorType: "system",
-      actorId: "system",
-      agentId: null,
-      runId: null,
-      action: "issue.updated",
-      entityType: "issue",
-      entityId: issue.id,
-      details: {
-        identifier: issue.identifier,
-        status: "cancelled",
-        source: "recovery.suppress_superseded_routine_execution",
-        routineRunId: currentRun.id,
-        supersededByRunId: newerCompletedRun.id,
-        supersededByIssueId: newerCompletedRun.linkedIssueId,
-      },
+      await tx.insert(issueComments).values({
+        companyId: issue.companyId,
+        issueId: issue.id,
+        authorAgentId: null,
+        authorUserId: null,
+        authorType: "system",
+        createdByRunId: null,
+        body: message,
+      });
+
+      await tx.insert(activityLog).values({
+        companyId: issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          identifier: issue.identifier,
+          status: "cancelled",
+          source: "recovery.suppress_superseded_routine_execution",
+          routineRunId: currentRun.id,
+          supersededByRunId: newerCompletedRun.id,
+          supersededByIssueId: newerCompletedRun.linkedIssueId,
+        },
+      });
+
+      return [cancelledIssue];
     });
 
-    return updated;
+    return updated ?? null;
   }
 
   function buildStrandedRecoveryActionEvidence(input: {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -22,6 +22,7 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  routineRuns,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -2057,6 +2058,81 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ].join(":");
   }
 
+  async function suppressSupersededRoutineExecutionRecovery(issue: typeof issues.$inferSelect) {
+    if (issue.originKind !== "routine_execution" || !issue.originRunId) return null;
+
+    const currentRun = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.id, issue.originRunId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!currentRun?.dispatchFingerprint) return null;
+
+    const newerCompletedRun = await db
+      .select({
+        id: routineRuns.id,
+        linkedIssueId: routineRuns.linkedIssueId,
+        issueIdentifier: issues.identifier,
+        issueTitle: issues.title,
+      })
+      .from(routineRuns)
+      .leftJoin(issues, eq(issues.id, routineRuns.linkedIssueId))
+      .where(and(
+        eq(routineRuns.companyId, currentRun.companyId),
+        eq(routineRuns.routineId, currentRun.routineId),
+        eq(routineRuns.dispatchFingerprint, currentRun.dispatchFingerprint),
+        eq(routineRuns.status, "completed"),
+        gt(routineRuns.triggeredAt, currentRun.triggeredAt),
+      ))
+      .orderBy(desc(routineRuns.triggeredAt), desc(routineRuns.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!newerCompletedRun) return null;
+
+    const newerIssueLabel = newerCompletedRun.issueIdentifier ??
+      newerCompletedRun.issueTitle ??
+      newerCompletedRun.linkedIssueId ??
+      newerCompletedRun.id;
+    const message = `Routine execution superseded by a newer completed routine run (${newerIssueLabel}). Automatic recovery was suppressed to avoid acting on stale historical work.`;
+
+    const now = new Date();
+    await db
+      .update(routineRuns)
+      .set({
+        status: "superseded",
+        coalescedIntoRunId: newerCompletedRun.id,
+        failureReason: message,
+        completedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(routineRuns.id, currentRun.id));
+
+    const updated = await issuesSvc.update(issue.id, { status: "cancelled" });
+    await issuesSvc.addComment(issue.id, message, {}, { authorType: "system" });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        status: "cancelled",
+        source: "recovery.suppress_superseded_routine_execution",
+        routineRunId: currentRun.id,
+        supersededByRunId: newerCompletedRun.id,
+        supersededByIssueId: newerCompletedRun.linkedIssueId,
+      },
+    });
+
+    return updated;
+  }
+
   function buildStrandedRecoveryActionEvidence(input: {
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
@@ -2301,6 +2377,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         latestRun: input.latestRun,
       });
     }
+
+    const supersededRoutineExecution = await suppressSupersededRoutineExecutionRecovery(input.issue);
+    if (supersededRoutineExecution) return supersededRoutineExecution;
 
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -168,6 +168,7 @@ function nextResultText(status: string, issueId?: string | null) {
   if (status === "skipped") return "Skipped because a live execution issue already exists";
   if (status === "completed") return "Execution issue completed";
   if (status === "failed") return "Execution failed";
+  if (status === "superseded") return "Superseded by a newer completed routine run";
   return status;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Scheduled routines let a company keep recurring operational obligations moving without a human manually creating each issue.
> - Routine execution issues are individual attempts under one routine, not independent obligations forever.
> - A stale failed execution can become historical once a newer equivalent execution completes successfully.
> - Recovery currently can wake the stale failed execution later, which risks duplicate or false external side effects.
> - This pull request teaches recovery to suppress stale routine executions that have already been superseded by a newer completed run.
> - The benefit is quieter, more consistent routine operations: old failures stay in history instead of re-alerting after the routine has already succeeded.

## Linked Issues or Issue Description

No GitHub issue exists for this exact bug.

Bug description:

- **What happened:** A recurring routine execution that had failed earlier could be recovered later even after a newer execution with the same routine dispatch fingerprint completed successfully. Recovery then treated the stale execution as active work.
- **Expected behavior:** Once a newer equivalent routine execution completes, older failed executions should be retained as history and marked superseded rather than being recovered or escalated.
- **Steps to reproduce:**
  1. Create a routine using `coalesce_if_active`.
  2. Create an older routine execution issue/run with a dispatch fingerprint and mark it failed or blocked.
  3. Create a newer routine execution issue/run with the same dispatch fingerprint and mark it completed.
  4. Invoke stranded assigned issue recovery for the older execution.
  5. Observe that recovery should suppress the stale execution instead of enqueuing a wake.
- **Paperclip version/commit:** Reproduced against current `master` before this PR.
- **Deployment mode:** Server-side routine/recovery services; no external adapter or production credential required for the regression test.

Related PRs found during duplicate search:

- Refs #5211 — related recovery guard work, but this PR is narrower: routine execution supersession after newer completed equivalent runs.

## What Changed

- Added a recovery guard for `routine_execution` issues that detects newer completed runs with the same routine and dispatch fingerprint.
- Marks the older routine run as `superseded`, links it via `coalescedIntoRunId`, cancels the stale execution issue, and writes a system comment instead of enqueueing recovery.
- Added `superseded` to the shared routine run status list and server-side status label handling.
- Added regression coverage for stale routine recovery suppression.
- Updated routine API docs and changelogs.
- Adjusted one heartbeat recovery assertion to be Vitest v4-safe: the dead run must not keep the checkout lock, while a live retry may acquire it before the assertion observes the issue.

## Verification

- `pnpm --dir server exec vitest run src/__tests__/issue-recovery-actions.test.ts src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/routines-service.test.ts` — 3 files passed, 110 tests passed
- `pnpm --filter @paperclipai/server typecheck && pnpm --filter @paperclipai/shared typecheck` — passed
- `git diff --check` — passed

## Risks

- Low-to-moderate behavior change for recovery: stale routine execution issues can now be cancelled and their runs marked `superseded` instead of being recovered.
- The new `superseded` status is added to the shared status constants and documented; consumers that assumed only the previous run statuses should render it as historical terminal state.
- No DB migration or production data mutation is included.
- Follow-up still needed: enforce `status_only` recovery as a hard side-effect boundary, not only model-profile context.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Pi coding-agent session using a frontier coding model with tool use for repository inspection, tests, git, and GitHub operations. The harness did not expose a stable provider model identifier in-session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
