### PR TITLE
Add relation-only duplicate issue convention

### DIFF
--- a/packages/db/src/schema/issue_relations.ts
+++ b/packages/db/src/schema/issue_relations.ts
@@ -1,7 +1,11 @@
+import { sql } from "drizzle-orm";
 import { index, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { companies } from "./companies.js";
 import { issues } from "./issues.js";
+
+export const ISSUE_RELATION_TYPES = ["blocks", "duplicate_of"] as const;
+export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 
 export const issueRelations = pgTable(
   "issue_relations",
@@ -10,7 +14,7 @@ export const issueRelations = pgTable(
     companyId: uuid("company_id").notNull().references(() => companies.id),
     issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
     relatedIssueId: uuid("related_issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
-    type: text("type").$type<"blocks">().notNull(),
+    type: text("type").$type<IssueRelationType>().notNull(),
     createdByAgentId: uuid("created_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
     createdByUserId: text("created_by_user_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -26,5 +30,11 @@ export const issueRelations = pgTable(
       table.relatedIssueId,
       table.type,
     ),
+    duplicateOfIssueUq: uniqueIndex("issue_relations_duplicate_of_issue_uq")
+      .on(table.companyId, table.issueId, table.type)
+      .where(sql`${table.type} = 'duplicate_of'`),
+    duplicateOfCanonicalIdx: index("issue_relations_duplicate_of_canonical_idx")
+      .on(table.companyId, table.relatedIssueId)
+      .where(sql`${table.type} = 'duplicate_of'`),
   }),
 );

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -126,6 +126,15 @@ async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
       "updated_at" timestamptz NOT NULL DEFAULT now()
     );
   `));
+  await db.execute(sql.raw(`
+    ALTER TABLE "issue_relations"
+      DROP CONSTRAINT IF EXISTS "issue_relations_type_check";
+  `));
+  await db.execute(sql.raw(`
+    ALTER TABLE "issue_relations"
+      ADD CONSTRAINT "issue_relations_type_check"
+      CHECK ("type" IN ('blocks', 'duplicate_of'));
+  `));
 }
 
 if (!embeddedPostgresSupport.supported) {
@@ -2675,6 +2684,419 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
 
     expect(blockerRelations.blocks.map((relation) => relation.id)).toEqual([blockedId]);
     expect(blockedRelations.blockedBy.map((relation) => relation.id)).toEqual([blockerId]);
+  });
+
+  it("resolves a duplicate issue through a relation-only duplicate_of edge", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const duplicateIssueId = randomUUID();
+    const canonicalIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: duplicateIssueId,
+        companyId,
+        title: "Duplicate marker source",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: canonicalIssueId,
+        companyId,
+        title: "Canonical marker target",
+        status: "blocked",
+        priority: "high",
+      },
+    ]);
+
+    const duplicateBefore = await db
+      .select({
+        status: issues.status,
+        hiddenAt: issues.hiddenAt,
+        title: issues.title,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issues)
+      .where(eq(issues.id, duplicateIssueId))
+      .then((rows) => rows[0]);
+    const canonicalBefore = await db
+      .select({
+        status: issues.status,
+        hiddenAt: issues.hiddenAt,
+        title: issues.title,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issues)
+      .where(eq(issues.id, canonicalIssueId))
+      .then((rows) => rows[0]);
+
+    const result = await svc.resolveDuplicateIssue({
+      companyId,
+      duplicateIssueId,
+      canonicalIssueId,
+      reasonCode: "routine_execution_duplicate_cleanup",
+      source: "manual_admin",
+      idempotencyKey: "duplicate-relation-only-test",
+    });
+
+    expect(result).toMatchObject({
+      status: "applied",
+      duplicateIssueId,
+      canonicalIssueId,
+      previousDuplicateStatus: "todo",
+      newDuplicateStatus: "todo",
+      changedFields: ["issue_relations"],
+    });
+    expect(result.relationId).toEqual(expect.any(String));
+    expect(result.auditEventId).toEqual(expect.any(String));
+
+    const relationRows = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.issueId, duplicateIssueId));
+    expect(relationRows).toHaveLength(1);
+    expect(relationRows[0]).toMatchObject({
+      companyId,
+      issueId: duplicateIssueId,
+      relatedIssueId: canonicalIssueId,
+      type: "duplicate_of",
+    });
+
+    const duplicateAfter = await db
+      .select({
+        status: issues.status,
+        hiddenAt: issues.hiddenAt,
+        title: issues.title,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issues)
+      .where(eq(issues.id, duplicateIssueId))
+      .then((rows) => rows[0]);
+    const canonicalAfter = await db
+      .select({
+        status: issues.status,
+        hiddenAt: issues.hiddenAt,
+        title: issues.title,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issues)
+      .where(eq(issues.id, canonicalIssueId))
+      .then((rows) => rows[0]);
+    expect(duplicateAfter).toEqual(duplicateBefore);
+    expect(canonicalAfter).toEqual(canonicalBefore);
+
+    const audit = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.id, result.auditEventId!))
+      .then((rows) => rows[0]);
+    expect(audit.action).toBe("issue.duplicate_resolved");
+    expect(Object.keys(audit.details as Record<string, unknown>).sort()).toEqual([
+      "canonicalIssueId",
+      "canonicalMutated",
+      "changedFields",
+      "duplicateIssueId",
+      "idempotencyKey",
+      "newDuplicateStatus",
+      "previousDuplicateStatus",
+      "reasonCode",
+      "relationId",
+      "source",
+      "sourceBatch",
+    ]);
+    expect(audit.details).toMatchObject({
+      duplicateIssueId,
+      canonicalIssueId,
+      relationId: result.relationId,
+      canonicalMutated: false,
+      changedFields: ["issue_relations"],
+    });
+  });
+
+  it("keeps duplicate resolution idempotent for the same canonical and rejects a different canonical", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const duplicateIssueId = randomUUID();
+    const canonicalIssueId = randomUUID();
+    const otherCanonicalIssueId = randomUUID();
+    await db.insert(issues).values([
+      { id: duplicateIssueId, companyId, title: "Duplicate", status: "todo", priority: "medium" },
+      { id: canonicalIssueId, companyId, title: "Canonical", status: "todo", priority: "medium" },
+      { id: otherCanonicalIssueId, companyId, title: "Other canonical", status: "todo", priority: "medium" },
+    ]);
+
+    const input = {
+      companyId,
+      duplicateIssueId,
+      canonicalIssueId,
+      reasonCode: "routine_execution_duplicate_cleanup" as const,
+      source: "manual_admin" as const,
+      idempotencyKey: "same-canonical",
+    };
+    const first = await svc.resolveDuplicateIssue(input);
+    const second = await svc.resolveDuplicateIssue(input);
+
+    expect(second).toMatchObject({
+      status: "already_applied",
+      relationId: first.relationId,
+      auditEventId: null,
+    });
+
+    await expect(
+      svc.resolveDuplicateIssue({
+        ...input,
+        canonicalIssueId: otherCanonicalIssueId,
+        idempotencyKey: "different-canonical",
+      }),
+    ).rejects.toThrow(/different canonical/i);
+
+    const relationRows = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.issueId, duplicateIssueId));
+    expect(relationRows).toHaveLength(1);
+  });
+
+  it("allows many duplicate issues to point to one canonical issue", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const canonicalIssueId = randomUUID();
+    const duplicateIssueIds = [randomUUID(), randomUUID()];
+    await db.insert(issues).values([
+      { id: canonicalIssueId, companyId, title: "Canonical", status: "todo", priority: "medium" },
+      ...duplicateIssueIds.map((id, index) => ({
+        id,
+        companyId,
+        title: `Duplicate ${index}`,
+        status: "todo",
+        priority: "medium",
+      })),
+    ]);
+
+    for (const [index, duplicateIssueId] of duplicateIssueIds.entries()) {
+      await svc.resolveDuplicateIssue({
+        companyId,
+        duplicateIssueId,
+        canonicalIssueId,
+        reasonCode: "routine_execution_duplicate_cleanup",
+        source: "manual_admin",
+        idempotencyKey: `many-to-one-${index}`,
+      });
+    }
+
+    const relationRows = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.relatedIssueId, canonicalIssueId));
+    expect(relationRows.map((row) => row.issueId).sort()).toEqual([...duplicateIssueIds].sort());
+    expect(relationRows.every((row) => row.type === "duplicate_of")).toBe(true);
+  });
+
+  it("rejects self, cross-company, canonical-duplicate, and duplicate cycle requests", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Other",
+        issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    const issueA = randomUUID();
+    const issueB = randomUUID();
+    const issueC = randomUUID();
+    const otherCompanyIssue = randomUUID();
+    await db.insert(issues).values([
+      { id: issueA, companyId, title: "Issue A", status: "todo", priority: "medium" },
+      { id: issueB, companyId, title: "Issue B", status: "todo", priority: "medium" },
+      { id: issueC, companyId, title: "Issue C", status: "todo", priority: "medium" },
+      { id: otherCompanyIssue, companyId: otherCompanyId, title: "Other issue", status: "todo", priority: "medium" },
+    ]);
+
+    const base = {
+      companyId,
+      reasonCode: "routine_execution_duplicate_cleanup" as const,
+      source: "manual_admin" as const,
+    };
+
+    await expect(
+      svc.resolveDuplicateIssue({
+        ...base,
+        duplicateIssueId: issueA,
+        canonicalIssueId: issueA,
+        idempotencyKey: "self",
+      }),
+    ).rejects.toThrow(/itself/i);
+
+    await expect(
+      svc.resolveDuplicateIssue({
+        ...base,
+        duplicateIssueId: issueA,
+        canonicalIssueId: otherCompanyIssue,
+        idempotencyKey: "cross-company",
+      }),
+    ).rejects.toThrow(/same company/i);
+
+    await svc.resolveDuplicateIssue({
+      ...base,
+      duplicateIssueId: issueB,
+      canonicalIssueId: issueA,
+      idempotencyKey: "canonical-is-duplicate-setup",
+    });
+    await expect(
+      svc.resolveDuplicateIssue({
+        ...base,
+        duplicateIssueId: issueC,
+        canonicalIssueId: issueB,
+        idempotencyKey: "canonical-is-duplicate",
+      }),
+    ).rejects.toThrow(/canonical issue is already marked as a duplicate/i);
+
+    await expect(
+      svc.resolveDuplicateIssue({
+        ...base,
+        duplicateIssueId: issueA,
+        canonicalIssueId: issueB,
+        idempotencyKey: "cycle",
+      }),
+    ).rejects.toThrow(/cycles/i);
+  });
+
+  it("rolls back only the duplicate relation and metadata-only audit state", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const duplicateIssueId = randomUUID();
+    const canonicalIssueId = randomUUID();
+    await db.insert(issues).values([
+      { id: duplicateIssueId, companyId, title: "Duplicate", status: "todo", priority: "medium" },
+      { id: canonicalIssueId, companyId, title: "Canonical", status: "todo", priority: "medium" },
+    ]);
+
+    const resolved = await svc.resolveDuplicateIssue({
+      companyId,
+      duplicateIssueId,
+      canonicalIssueId,
+      reasonCode: "routine_execution_duplicate_cleanup",
+      source: "manual_admin",
+      idempotencyKey: "rollback-setup",
+    });
+
+    const rolledBack = await svc.rollbackDuplicateResolution({
+      companyId,
+      duplicateIssueId,
+      canonicalIssueId,
+      relationId: resolved.relationId!,
+      reasonCode: "routine_execution_duplicate_cleanup_rollback",
+      source: "manual_admin",
+      idempotencyKey: "rollback",
+      rollbackCorrelationId: randomUUID(),
+      expectedPreviousStatus: "todo",
+    });
+
+    expect(rolledBack).toMatchObject({
+      status: "rolled_back",
+      duplicateIssueId,
+      canonicalIssueId,
+      relationId: resolved.relationId,
+      restoredFields: ["issue_relations"],
+    });
+    expect(rolledBack.auditEventId).toEqual(expect.any(String));
+
+    const remainingRelations = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.issueId, duplicateIssueId));
+    expect(remainingRelations).toEqual([]);
+
+    const rollbackAudit = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.id, rolledBack.auditEventId!))
+      .then((rows) => rows[0]);
+    expect(rollbackAudit.action).toBe("issue.duplicate_resolution_rolled_back");
+    expect(Object.keys(rollbackAudit.details as Record<string, unknown>).sort()).toEqual([
+      "canonicalIssueId",
+      "canonicalMutated",
+      "duplicateIssueId",
+      "idempotencyKey",
+      "reasonCode",
+      "relationId",
+      "restoredFields",
+      "rollbackCorrelationId",
+      "source",
+      "sourceBatch",
+    ]);
+    expect(rollbackAudit.details).toMatchObject({
+      duplicateIssueId,
+      canonicalIssueId,
+      relationId: resolved.relationId,
+      restoredFields: ["issue_relations"],
+      canonicalMutated: false,
+    });
+  });
+
+  it("does not treat duplicate_of relations as blocker summaries", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const duplicateIssueId = randomUUID();
+    const canonicalIssueId = randomUUID();
+    await db.insert(issues).values([
+      { id: duplicateIssueId, companyId, title: "Duplicate", status: "todo", priority: "medium" },
+      { id: canonicalIssueId, companyId, title: "Canonical", status: "todo", priority: "medium" },
+    ]);
+
+    await svc.resolveDuplicateIssue({
+      companyId,
+      duplicateIssueId,
+      canonicalIssueId,
+      reasonCode: "routine_execution_duplicate_cleanup",
+      source: "manual_admin",
+      idempotencyKey: "blocker-summary-isolation",
+    });
+
+    await expect(svc.getRelationSummaries(duplicateIssueId)).resolves.toEqual({ blockedBy: [], blocks: [] });
+    await expect(svc.getRelationSummaries(canonicalIssueId)).resolves.toEqual({ blockedBy: [], blocks: [] });
   });
 
   it("adds terminal blockers to immediate blocked-by summaries", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -353,6 +353,59 @@ type IssueRelationSummaryMap = {
   blockedBy: IssueRelationIssueSummary[];
   blocks: IssueRelationIssueSummary[];
 };
+type DuplicateResolutionReasonCode = "routine_execution_duplicate_cleanup";
+type DuplicateRollbackReasonCode = "routine_execution_duplicate_cleanup_rollback";
+type DuplicateResolutionActor = {
+  agentId?: string | null;
+  userId?: string | null;
+  runId?: string | null;
+  actorType?: "agent" | "user" | "system" | "board";
+  actorId?: string | null;
+};
+type ResolveDuplicateIssueInput = {
+  companyId: string;
+  duplicateIssueId: string;
+  canonicalIssueId: string;
+  actor?: DuplicateResolutionActor;
+  reasonCode: DuplicateResolutionReasonCode;
+  source: "phase_0_4_batch_a_pilot" | "manual_admin";
+  sourceBatch?: string | null;
+  idempotencyKey: string;
+  dryRun?: boolean;
+};
+type RollbackDuplicateIssueInput = {
+  companyId: string;
+  duplicateIssueId: string;
+  canonicalIssueId: string;
+  relationId: string;
+  actor?: DuplicateResolutionActor;
+  reasonCode: DuplicateRollbackReasonCode;
+  source: "phase_0_4_batch_a_pilot_rollback" | "manual_admin";
+  sourceBatch?: string | null;
+  idempotencyKey: string;
+  rollbackCorrelationId: string;
+  expectedPreviousStatus: string;
+  expectedResolutionAuditEventId?: string | null;
+  dryRun?: boolean;
+};
+type DuplicateResolutionResult = {
+  status: "applied" | "already_applied" | "dry_run";
+  duplicateIssueId: string;
+  canonicalIssueId: string;
+  relationId: string | null;
+  auditEventId: string | null;
+  previousDuplicateStatus: string;
+  newDuplicateStatus: string;
+  changedFields: string[];
+};
+type DuplicateRollbackResult = {
+  status: "rolled_back" | "already_rolled_back" | "dry_run";
+  duplicateIssueId: string;
+  canonicalIssueId: string;
+  relationId: string;
+  auditEventId: string | null;
+  restoredFields: string[];
+};
 export type IssueDependencyReadiness = {
   issueId: string;
   blockerIssueIds: string[];
@@ -3824,9 +3877,358 @@ export function issueService(db: Db) {
     });
   }
 
+  function validateDuplicateResolutionInput(input: ResolveDuplicateIssueInput) {
+    if (!input.companyId || !input.duplicateIssueId || !input.canonicalIssueId) {
+      throw unprocessable("Duplicate resolution requires company, duplicate issue, and canonical issue ids");
+    }
+    if (input.duplicateIssueId === input.canonicalIssueId) {
+      throw unprocessable("Issue cannot be marked as a duplicate of itself");
+    }
+    if (input.reasonCode !== "routine_execution_duplicate_cleanup") {
+      throw unprocessable("Unsupported duplicate resolution reason");
+    }
+    if (!input.idempotencyKey?.trim()) {
+      throw unprocessable("Duplicate resolution requires an idempotency key");
+    }
+  }
+
+  function validateDuplicateRollbackInput(input: RollbackDuplicateIssueInput) {
+    if (!input.companyId || !input.duplicateIssueId || !input.canonicalIssueId || !input.relationId) {
+      throw unprocessable("Duplicate rollback requires company, issue, canonical, and relation ids");
+    }
+    if (input.duplicateIssueId === input.canonicalIssueId) {
+      throw unprocessable("Issue cannot be marked as a duplicate of itself");
+    }
+    if (input.reasonCode !== "routine_execution_duplicate_cleanup_rollback") {
+      throw unprocessable("Unsupported duplicate rollback reason");
+    }
+    if (!input.idempotencyKey?.trim()) {
+      throw unprocessable("Duplicate rollback requires an idempotency key");
+    }
+    if (!input.rollbackCorrelationId?.trim()) {
+      throw unprocessable("Duplicate rollback requires a rollback correlation id");
+    }
+  }
+
+  function duplicateActivityActor(actor: DuplicateResolutionActor | undefined) {
+    const actorType: "agent" | "user" | "system" | "board" =
+      actor?.actorType ?? (actor?.agentId ? "agent" : actor?.userId ? "user" : "system");
+    return {
+      actorType,
+      actorId: actor?.actorId ?? actor?.agentId ?? actor?.userId ?? "system",
+      agentId: actor?.agentId ?? null,
+      runId: actor?.runId ?? null,
+    };
+  }
+
+  async function assertNoDuplicateRelationCycle(
+    companyId: string,
+    duplicateIssueId: string,
+    canonicalIssueId: string,
+    dbOrTx: DbReader = db,
+  ) {
+    const rows = await dbOrTx
+      .select({
+        duplicateIssueId: issueRelations.issueId,
+        canonicalIssueId: issueRelations.relatedIssueId,
+      })
+      .from(issueRelations)
+      .where(and(eq(issueRelations.companyId, companyId), eq(issueRelations.type, "duplicate_of")));
+
+    const canonicalByDuplicate = new Map(rows.map((row) => [row.duplicateIssueId, row.canonicalIssueId]));
+    canonicalByDuplicate.set(duplicateIssueId, canonicalIssueId);
+
+    const visited = new Set<string>();
+    let current: string | undefined = canonicalIssueId;
+    while (current) {
+      if (current === duplicateIssueId) {
+        throw unprocessable("Duplicate relations cannot contain cycles");
+      }
+      if (visited.has(current)) return;
+      visited.add(current);
+      current = canonicalByDuplicate.get(current);
+    }
+  }
+
   return {
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
+
+    resolveDuplicateIssue: async (
+      input: ResolveDuplicateIssueInput,
+      dbOrTx: any = db,
+    ): Promise<DuplicateResolutionResult> => {
+      validateDuplicateResolutionInput(input);
+
+      const runResolve = async (tx: any): Promise<DuplicateResolutionResult> => {
+        const lockedIssueIds = [input.duplicateIssueId, input.canonicalIssueId].sort();
+        await tx.execute(
+          sql`SELECT ${issues.id} FROM ${issues}
+              WHERE ${and(eq(issues.companyId, input.companyId), inArray(issues.id, lockedIssueIds))}
+              ORDER BY ${issues.id}
+              FOR UPDATE`,
+        );
+
+        const issueRows = await tx
+          .select({
+            id: issues.id,
+            companyId: issues.companyId,
+            status: issues.status,
+          })
+          .from(issues)
+          .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, lockedIssueIds)));
+        const duplicateIssue = issueRows.find((row: typeof issueRows[number]) => row.id === input.duplicateIssueId);
+        const canonicalIssue = issueRows.find((row: typeof issueRows[number]) => row.id === input.canonicalIssueId);
+        if (!duplicateIssue || !canonicalIssue) {
+          throw unprocessable("Duplicate and canonical issues must belong to the same company");
+        }
+
+        const existingDuplicateRelations = await tx
+          .select({
+            id: issueRelations.id,
+            relatedIssueId: issueRelations.relatedIssueId,
+          })
+          .from(issueRelations)
+          .where(
+            and(
+              eq(issueRelations.companyId, input.companyId),
+              eq(issueRelations.issueId, input.duplicateIssueId),
+              eq(issueRelations.type, "duplicate_of"),
+            ),
+          );
+
+        const matchingRelation = existingDuplicateRelations.find(
+          (row: typeof existingDuplicateRelations[number]) => row.relatedIssueId === input.canonicalIssueId,
+        );
+        if (matchingRelation) {
+          return {
+            status: "already_applied",
+            duplicateIssueId: input.duplicateIssueId,
+            canonicalIssueId: input.canonicalIssueId,
+            relationId: matchingRelation.id,
+            auditEventId: null,
+            previousDuplicateStatus: duplicateIssue.status,
+            newDuplicateStatus: duplicateIssue.status,
+            changedFields: ["issue_relations"],
+          };
+        }
+        if (existingDuplicateRelations.length > 0) {
+          throw conflict("Issue is already marked as a duplicate of a different canonical issue");
+        }
+
+        await assertNoDuplicateRelationCycle(input.companyId, input.duplicateIssueId, input.canonicalIssueId, tx);
+
+        const canonicalDuplicateRelation = await tx
+          .select({ id: issueRelations.id })
+          .from(issueRelations)
+          .where(
+            and(
+              eq(issueRelations.companyId, input.companyId),
+              eq(issueRelations.issueId, input.canonicalIssueId),
+              eq(issueRelations.type, "duplicate_of"),
+            ),
+          )
+          .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+        if (canonicalDuplicateRelation) {
+          throw conflict("Canonical issue is already marked as a duplicate");
+        }
+
+        if (input.dryRun) {
+          return {
+            status: "dry_run",
+            duplicateIssueId: input.duplicateIssueId,
+            canonicalIssueId: input.canonicalIssueId,
+            relationId: null,
+            auditEventId: null,
+            previousDuplicateStatus: duplicateIssue.status,
+            newDuplicateStatus: duplicateIssue.status,
+            changedFields: ["issue_relations"],
+          };
+        }
+
+        const [relation] = await tx
+          .insert(issueRelations)
+          .values({
+            companyId: input.companyId,
+            issueId: input.duplicateIssueId,
+            relatedIssueId: input.canonicalIssueId,
+            type: "duplicate_of",
+            createdByAgentId: input.actor?.agentId ?? null,
+            createdByUserId: input.actor?.userId ?? null,
+          })
+          .returning({ id: issueRelations.id });
+
+        const actor = duplicateActivityActor(input.actor);
+        const [auditEvent] = await tx
+          .insert(activityLog)
+          .values({
+            companyId: input.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "issue.duplicate_resolved",
+            entityType: "issue",
+            entityId: input.duplicateIssueId,
+            details: {
+              duplicateIssueId: input.duplicateIssueId,
+              canonicalIssueId: input.canonicalIssueId,
+              relationId: relation.id,
+              reasonCode: input.reasonCode,
+              source: input.source,
+              sourceBatch: input.sourceBatch ?? null,
+              idempotencyKey: input.idempotencyKey,
+              previousDuplicateStatus: duplicateIssue.status,
+              newDuplicateStatus: duplicateIssue.status,
+              changedFields: ["issue_relations"],
+              canonicalMutated: false,
+            },
+          })
+          .returning({ id: activityLog.id });
+
+        return {
+          status: "applied",
+          duplicateIssueId: input.duplicateIssueId,
+          canonicalIssueId: input.canonicalIssueId,
+          relationId: relation.id,
+          auditEventId: auditEvent.id,
+          previousDuplicateStatus: duplicateIssue.status,
+          newDuplicateStatus: duplicateIssue.status,
+          changedFields: ["issue_relations"],
+        };
+      };
+
+      return dbOrTx === db ? db.transaction(runResolve) : runResolve(dbOrTx);
+    },
+
+    rollbackDuplicateResolution: async (
+      input: RollbackDuplicateIssueInput,
+      dbOrTx: any = db,
+    ): Promise<DuplicateRollbackResult> => {
+      validateDuplicateRollbackInput(input);
+
+      const runRollback = async (tx: any): Promise<DuplicateRollbackResult> => {
+        const lockedIssueIds = [input.duplicateIssueId, input.canonicalIssueId].sort();
+        await tx.execute(
+          sql`SELECT ${issues.id} FROM ${issues}
+              WHERE ${and(eq(issues.companyId, input.companyId), inArray(issues.id, lockedIssueIds))}
+              ORDER BY ${issues.id}
+              FOR UPDATE`,
+        );
+        const issueRows = await tx
+          .select({ id: issues.id, companyId: issues.companyId, status: issues.status })
+          .from(issues)
+          .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, lockedIssueIds)));
+        const duplicateIssue = issueRows.find((row: typeof issueRows[number]) => row.id === input.duplicateIssueId);
+        const canonicalIssue = issueRows.find((row: typeof issueRows[number]) => row.id === input.canonicalIssueId);
+        if (!duplicateIssue || !canonicalIssue) {
+          throw unprocessable("Duplicate and canonical issues must belong to the same company");
+        }
+        if (duplicateIssue.status !== input.expectedPreviousStatus) {
+          throw conflict("Duplicate issue status does not match rollback manifest");
+        }
+
+        const relation = await tx
+          .select({
+            id: issueRelations.id,
+            companyId: issueRelations.companyId,
+            issueId: issueRelations.issueId,
+            relatedIssueId: issueRelations.relatedIssueId,
+            type: issueRelations.type,
+          })
+          .from(issueRelations)
+          .where(eq(issueRelations.id, input.relationId))
+          .then((rows: Array<typeof issueRelations.$inferSelect>) => rows[0] ?? null);
+
+        if (!relation) {
+          const rollbackEvent = await tx
+            .select({ id: activityLog.id })
+            .from(activityLog)
+            .where(
+              and(
+                eq(activityLog.companyId, input.companyId),
+                eq(activityLog.action, "issue.duplicate_resolution_rolled_back"),
+                eq(activityLog.entityType, "issue"),
+                eq(activityLog.entityId, input.duplicateIssueId),
+                sql`${activityLog.details}->>'relationId' = ${input.relationId}`,
+                sql`${activityLog.details}->>'rollbackCorrelationId' = ${input.rollbackCorrelationId}`,
+              ),
+            )
+            .then((rows: Array<{ id: string }>) => rows[0] ?? null);
+          if (!rollbackEvent) {
+            throw conflict("Duplicate relation is missing without matching rollback audit");
+          }
+          return {
+            status: "already_rolled_back",
+            duplicateIssueId: input.duplicateIssueId,
+            canonicalIssueId: input.canonicalIssueId,
+            relationId: input.relationId,
+            auditEventId: rollbackEvent.id,
+            restoredFields: ["issue_relations"],
+          };
+        }
+
+        if (
+          relation.companyId !== input.companyId ||
+          relation.issueId !== input.duplicateIssueId ||
+          relation.relatedIssueId !== input.canonicalIssueId ||
+          relation.type !== "duplicate_of"
+        ) {
+          throw conflict("Duplicate relation does not match rollback manifest");
+        }
+
+        if (input.dryRun) {
+          return {
+            status: "dry_run",
+            duplicateIssueId: input.duplicateIssueId,
+            canonicalIssueId: input.canonicalIssueId,
+            relationId: input.relationId,
+            auditEventId: null,
+            restoredFields: ["issue_relations"],
+          };
+        }
+
+        await tx.delete(issueRelations).where(eq(issueRelations.id, input.relationId));
+
+        const actor = duplicateActivityActor(input.actor);
+        const [auditEvent] = await tx
+          .insert(activityLog)
+          .values({
+            companyId: input.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            action: "issue.duplicate_resolution_rolled_back",
+            entityType: "issue",
+            entityId: input.duplicateIssueId,
+            details: {
+              duplicateIssueId: input.duplicateIssueId,
+              canonicalIssueId: input.canonicalIssueId,
+              relationId: input.relationId,
+              rollbackCorrelationId: input.rollbackCorrelationId,
+              reasonCode: input.reasonCode,
+              source: input.source,
+              sourceBatch: input.sourceBatch ?? null,
+              idempotencyKey: input.idempotencyKey,
+              restoredFields: ["issue_relations"],
+              canonicalMutated: false,
+            },
+          })
+          .returning({ id: activityLog.id });
+
+        return {
+          status: "rolled_back",
+          duplicateIssueId: input.duplicateIssueId,
+          canonicalIssueId: input.canonicalIssueId,
+          relationId: input.relationId,
+          auditEventId: auditEvent.id,
+          restoredFields: ["issue_relations"],
+        };
+      };
+
+      return dbOrTx === db ? db.transaction(runRollback) : runRollback(dbOrTx);
+    },
 
     list: async (companyId: string, filters?: IssueFilters) => {
       if (filters?.attention === "blocked") {


### PR DESCRIPTION
Refs #7986

## Thinking Path

- Paperclip is the open source app people use to manage AI agents for work.
- The issue service already models relationships between issues, including blocker relationships.
- Duplicate issue cleanup needs a first-class convention before any historical cleanup, migration, or production data mutation is safe.
- This pull request adds a focused duplicate_of relation convention plus service-owned resolution and rollback behavior.
- Cleanup execution, migrations, SQL, routes, and production changes are intentionally out of scope.

## Linked Issues or Issue Description

Refs #7986

This PR is an external-contributor draft and does not claim maintainer authority.

### Problem

Paperclip needs a first-class, auditable way to represent duplicate issues before any future duplicate cleanup, migration-blocker remediation, or historical data mutation is considered. Existing generic outcomes such as done, cancelled, hidden issues, or ad hoc cleanup do not safely express that one issue is a duplicate of another canonical issue.

### Expected behavior

The service should be able to record that one issue is a duplicate of another issue using an explicit relationship, while preserving the original issue rows and avoiding cleanup, status changes, route/API exposure, or migration execution in this PR.

### Actual behavior

Before this change, there was no dedicated duplicate_of issue relation convention enforced by the issue service. That made future duplicate cleanup work riskier because the relationship intent was not represented as a first-class service-owned invariant.

### Proposed fix

Add a relation-only duplicate_of convention in the issue service with validation and rollback behavior. This creates the service-level foundation for future cleanup work without performing cleanup now.

### Dedup search

I searched GitHub issues and pull requests for similar work before opening this PR. Adjacent issue-relations and dedup-related work was found, but I did not find an obvious duplicate PR for this narrow relation-only duplicate_of service convention.

## What Changed

- Extended packages/db/src/schema/issue_relations.ts so issue relations support duplicate_of alongside existing blocks relations.
- Added service-owned duplicate resolution and rollback behavior in server/src/services/issues.ts.
- Enforced same-company, non-self, no canonical-already-duplicate, no cycle, same-pair idempotency, different-canonical conflict, and many-duplicates-to-one-canonical behavior.
- Recorded metadata-only audit details for duplicate resolution and rollback.
- Kept blocker relation summaries scoped to blocks; duplicate_of relations are not exposed as blockers.
- Added targeted tests in server/src/__tests__/issues-service.test.ts.
- Did not add migrations, cleanup execution, SQL execution, DB queries, ticket mutation, status duplicate, routes/API, Group 1/4 work, or production/runtime changes.

## Verification

Targeted normal-shell validation was run: pnpm --dir server exec vitest run src/__tests__/issues-service.test.ts -t duplicate

Result: 1 test file passed; 7 tests passed; 72 skipped.

Full local test suite was not run in this gate. CI is pending on this draft PR. Greptile review is pending.

## Risks

- Schema migration is still needed in a separate PR/gate before this relation type can be used against a production database.
- No historical duplicate cleanup is included.
- Future duplicate cleanup execution must go through the service path so service-level validation and rollback behavior are preserved.
- This relation-only convention does not add status duplicate; future status, route/API, migration, or cleanup behavior needs separate design and review.
- Direct DB writes outside the service path would bypass service-level duplicate invariants and should remain prohibited.

## Model Used

- GPT-5.5 Thinking / Codex CLI assistance for implementation, validation packaging, and external-contributor PR preparation.
- Grok review assistance for independent read-only implementation review.
- Human operator Grant reviewed and approved the bounded gates that authorized local commit preparation and draft external-contributor PR preparation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub issues and pull requests for similar work before opening this PR
- [x] I have either linked existing issues with Fixes # / Closes # / Refs # OR described the issue in-PR following the relevant issue template
- [x] I have run targeted tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] This change does not affect the UI, so screenshots are not applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
