### PR TITLE
feat(server): provider-agnostic "sandbox" execution mode (closes #7988)

### DIFF
--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -25,12 +25,17 @@ export const DEFAULT_BACKUP_RETENTION: BackupRetentionPolicy = {
  * - `"any"` (default / absent): unrestricted — any environment driver (local,
  *   ssh, sandbox) may run agents. Preserves single-tenant / local-trusted
  *   behavior.
- * - `"kubernetes"`: force ALL agent execution onto the Kubernetes
- *   sandbox-provider environment and REFUSE local/in-process execution. Used by
- *   shared cloud (cloud_tenant) instances so untrusted tenant agents can never
- *   run in the server process or on an unsandboxed local/ssh adapter.
+ * - `"sandbox"`: force ALL agent execution onto *some* sandbox-provider
+ *   environment (any provider — Kubernetes, Daytona, E2B, Modal, …) and REFUSE
+ *   local/ssh/in-process execution. Provider-agnostic; for shared cloud
+ *   instances whose sandbox is not Kubernetes.
+ * - `"kubernetes"`: stricter, provider-pinned variant of `"sandbox"` — force the
+ *   Kubernetes sandbox provider specifically and REFUSE every other driver
+ *   (including non-Kubernetes sandbox providers). Used by shared cloud
+ *   (cloud_tenant) instances so untrusted tenant agents can never run in the
+ *   server process or on an unsandboxed local/ssh adapter.
  */
-export type InstanceExecutionMode = "kubernetes" | "any";
+export type InstanceExecutionMode = "kubernetes" | "sandbox" | "any";
 
 export interface InstanceGeneralSettings {
   censorUsernameInLogs: boolean;
@@ -38,8 +43,9 @@ export interface InstanceGeneralSettings {
   feedbackDataSharingPreference: FeedbackDataSharingPreference;
   backupRetention: BackupRetentionPolicy;
   /**
-   * Execution policy. Absent/`"any"` = unrestricted; `"kubernetes"` forces the
-   * Kubernetes sandbox provider and denies local/ssh execution.
+   * Execution policy. Absent/`"any"` = unrestricted; `"sandbox"` forces some
+   * sandbox provider (any) and denies local/ssh; `"kubernetes"` forces the
+   * Kubernetes provider specifically.
    */
   executionMode?: InstanceExecutionMode;
 }

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -31,9 +31,10 @@ export const instanceGeneralSettingsSchema = z.object({
     DEFAULT_FEEDBACK_DATA_SHARING_PREFERENCE,
   ),
   backupRetention: backupRetentionPolicySchema.default(DEFAULT_BACKUP_RETENTION),
-  // Execution policy. Absent/"any" = unrestricted; "kubernetes" forces the
-  // Kubernetes sandbox provider and denies local/ssh execution (cloud_tenant).
-  executionMode: z.enum(["kubernetes", "any"]).optional(),
+  // Execution policy. Absent/"any" = unrestricted; "sandbox" forces some
+  // sandbox provider (any) and denies local/ssh; "kubernetes" pins the
+  // Kubernetes provider specifically (cloud_tenant).
+  executionMode: z.enum(["kubernetes", "sandbox", "any"]).optional(),
 }).strict();
 
 export const patchInstanceGeneralSettingsSchema = instanceGeneralSettingsSchema.partial();

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -343,6 +343,28 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect((await svc.findManagedSandboxEnvironment(companyId))?.id).toBe(fake.id);
   });
 
+  it("findManagedSandboxEnvironment ignores a provider-less sandbox env (treated as unconfigured)", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // A sandbox row without a provider key is a misconfiguration; the lookup
+    // must return null so the heartbeat raises the actionable
+    // "configure a sandbox provider" error instead of pinning onto it.
+    await svc.create(companyId, {
+      name: "Provider-less Sandbox",
+      driver: "sandbox",
+      config: { reuseLease: false },
+    });
+
+    expect(await svc.findManagedSandboxEnvironment(companyId)).toBeNull();
+  });
+
   it("findManagedSandboxEnvironment prefers a Paperclip-managed sandbox when several exist", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -318,6 +318,54 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
   });
 
+  it("findManagedSandboxEnvironment returns any active sandbox provider, unlike findKubernetesEnvironment", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // No sandbox configured yet → both lookups null.
+    expect(await svc.findManagedSandboxEnvironment(companyId)).toBeNull();
+
+    // A non-Kubernetes sandbox (e.g. Daytona/E2B stand-in): findKubernetes
+    // ignores it, but the provider-agnostic lookup returns it so
+    // executionMode="sandbox" can pin onto it.
+    const fake = await svc.create(companyId, {
+      name: "Fake Sandbox",
+      driver: "sandbox",
+      config: { provider: "fake", image: "busybox", reuseLease: false },
+    });
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+    expect((await svc.findManagedSandboxEnvironment(companyId))?.id).toBe(fake.id);
+  });
+
+  it("findManagedSandboxEnvironment prefers a Paperclip-managed sandbox when several exist", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await svc.create(companyId, {
+      name: "Tenant Sandbox",
+      driver: "sandbox",
+      config: { provider: "fake", image: "busybox", reuseLease: false },
+    });
+    const managed = await svc.ensureKubernetesEnvironment(companyId, {
+      backend: "job",
+      inCluster: true,
+    });
+
+    expect((await svc.findManagedSandboxEnvironment(companyId))?.id).toBe(managed.id);
+  });
+
   it("ignores a config.provider=kubernetes sandbox env without the managed marker", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -343,6 +343,46 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect((await svc.findManagedSandboxEnvironment(companyId))?.id).toBe(fake.id);
   });
 
+  it("ensureManagedSandboxEnvironment auto-provisions a generic sandbox and is idempotent", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const created = await svc.ensureManagedSandboxEnvironment(companyId, {
+      provider: "daytona",
+      config: { apiUrl: "https://daytona.example", target: "eu" },
+    });
+    expect(created.driver).toBe("sandbox");
+    expect(created.config.provider).toBe("daytona");
+    expect(created.config.apiUrl).toBe("https://daytona.example");
+    expect(created.metadata?.managedByPaperclip).toBe(true);
+    expect(created.metadata?.managedSandbox).toBe(true);
+
+    // Idempotent: second call refreshes config in place, no new row.
+    const refreshed = await svc.ensureManagedSandboxEnvironment(companyId, {
+      provider: "daytona",
+      config: { apiUrl: "https://daytona.example", target: "us" },
+    });
+    expect(refreshed.id).toBe(created.id);
+    expect(refreshed.config.target).toBe("us");
+
+    // It is the env the provider-agnostic lookup pins onto, and is NOT mistaken
+    // for the managed Kubernetes env.
+    expect((await svc.findManagedSandboxEnvironment(companyId))?.id).toBe(created.id);
+    expect(await svc.findKubernetesEnvironment(companyId)).toBeNull();
+
+    const rows = await db
+      .select()
+      .from(environments)
+      .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")));
+    expect(rows).toHaveLength(1);
+  });
+
   it("findManagedSandboxEnvironment ignores a provider-less sandbox env (treated as unconfigured)", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -308,6 +308,30 @@ export function environmentService(db: Db) {
       return match ? toEnvironment(match) : null;
     },
 
+    // Provider-agnostic counterpart of findKubernetesEnvironment: the company's
+    // active sandbox environment regardless of which provider backs it. Used by
+    // executionMode="sandbox" to pin runs onto whatever sandbox the operator
+    // configured (Daytona, E2B, Modal, Kubernetes, …). Prefers a Paperclip-
+    // managed environment when several exist, else the most recently updated.
+    findManagedSandboxEnvironment: async (companyId: string): Promise<Environment | null> => {
+      const rows = await db
+        .select()
+        .from(environments)
+        .where(
+          and(
+            eq(environments.companyId, companyId),
+            eq(environments.driver, "sandbox"),
+            eq(environments.status, "active"),
+          ),
+        )
+        .orderBy(desc(environments.updatedAt));
+      if (rows.length === 0) return null;
+      const managed = rows.find(
+        (row) => (row.metadata as Record<string, unknown> | null)?.managedByPaperclip === true,
+      );
+      return toEnvironment(managed ?? rows[0]!);
+    },
+
     create: async (companyId: string, input: CreateEnvironment): Promise<Environment> => {
       const now = new Date();
       const row = await db

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -29,6 +29,8 @@ const DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION =
 const KUBERNETES_PROVIDER_KEY = "kubernetes";
 /** Metadata marker for the company's managed-by-config Kubernetes sandbox environment. */
 const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
+/** Metadata marker for any Paperclip-managed environment (set on managed sandbox envs). */
+const PAPERCLIP_MANAGED_MARKER = "managedByPaperclip";
 
 /**
  * Configuration accepted by `ensureKubernetesEnvironment`. Mirrors the keys of
@@ -204,7 +206,7 @@ export function environmentService(db: Db) {
         provider: KUBERNETES_PROVIDER_KEY,
       };
       const desiredMetadata: Record<string, unknown> = {
-        managedByPaperclip: true,
+        [PAPERCLIP_MANAGED_MARKER]: true,
         [KUBERNETES_MANAGED_MARKER]: true,
       };
 
@@ -313,6 +315,11 @@ export function environmentService(db: Db) {
     // executionMode="sandbox" to pin runs onto whatever sandbox the operator
     // configured (Daytona, E2B, Modal, Kubernetes, …). Prefers a Paperclip-
     // managed environment when several exist, else the most recently updated.
+    //
+    // Only environments with a configured provider count: a provider-less
+    // sandbox row is treated as "no sandbox configured", so the heartbeat
+    // surfaces the actionable "configure a sandbox provider" error rather than
+    // pinning onto it and tripping the allowlist backstop later.
     findManagedSandboxEnvironment: async (companyId: string): Promise<Environment | null> => {
       const rows = await db
         .select()
@@ -325,11 +332,15 @@ export function environmentService(db: Db) {
           ),
         )
         .orderBy(desc(environments.updatedAt));
-      if (rows.length === 0) return null;
-      const managed = rows.find(
-        (row) => (row.metadata as Record<string, unknown> | null)?.managedByPaperclip === true,
+      const providerRows = rows.filter((row) => {
+        const provider = (row.config as Record<string, unknown> | null)?.provider;
+        return typeof provider === "string" && provider.length > 0;
+      });
+      if (providerRows.length === 0) return null;
+      const managed = providerRows.find(
+        (row) => (row.metadata as Record<string, unknown> | null)?.[PAPERCLIP_MANAGED_MARKER] === true,
       );
-      return toEnvironment(managed ?? rows[0]!);
+      return toEnvironment(managed ?? providerRows[0]!);
     },
 
     create: async (companyId: string, input: CreateEnvironment): Promise<Environment> => {

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -31,6 +31,11 @@ const KUBERNETES_PROVIDER_KEY = "kubernetes";
 const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
 /** Metadata marker for any Paperclip-managed environment (set on managed sandbox envs). */
 const PAPERCLIP_MANAGED_MARKER = "managedByPaperclip";
+/** Metadata marker for a company's managed-by-config generic (non-k8s) sandbox environment. */
+const MANAGED_SANDBOX_MARKER = "managedSandbox";
+const DEFAULT_MANAGED_SANDBOX_ENVIRONMENT_NAME = "Sandbox";
+const DEFAULT_MANAGED_SANDBOX_ENVIRONMENT_DESCRIPTION =
+  "Auto-provisioned sandbox environment for the instance execution policy (executionMode=sandbox).";
 
 /**
  * Configuration accepted by `ensureKubernetesEnvironment`. Mirrors the keys of
@@ -277,6 +282,95 @@ export function environmentService(db: Db) {
                 (candidate.metadata as Record<string, unknown> | null)?.[
                   KUBERNETES_MANAGED_MARKER
                 ] === true,
+            ) ?? null,
+        );
+      if (winner && winner.id !== row.id) {
+        await db.delete(environments).where(eq(environments.id, row.id));
+        return toEnvironment(winner);
+      }
+      return toEnvironment(row);
+    },
+
+    /**
+     * Provider-agnostic counterpart of `ensureKubernetesEnvironment`: ensure the
+     * company's managed sandbox environment for an arbitrary provider (Daytona,
+     * E2B, Modal, …), idempotently. Used by `executionMode=sandbox` so an
+     * uploaded/synced company auto-gets the operator's configured sandbox on
+     * first heartbeat — the tenant never configures cloud details. Config is
+     * refreshed in place on repeat calls (gitops-friendly). The provider plugin
+     * validates the config blob at run time.
+     */
+    ensureManagedSandboxEnvironment: async (
+      companyId: string,
+      input: { provider: string; config?: Record<string, unknown> },
+    ): Promise<Environment> => {
+      const desiredConfig: Record<string, unknown> = {
+        ...(input.config ?? {}),
+        provider: input.provider,
+      };
+      const desiredMetadata: Record<string, unknown> = {
+        [PAPERCLIP_MANAGED_MARKER]: true,
+        [MANAGED_SANDBOX_MARKER]: true,
+      };
+
+      const existing = await db
+        .select()
+        .from(environments)
+        .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+        .then((rows) =>
+          rows.find(
+            (row) => (row.metadata as Record<string, unknown> | null)?.[MANAGED_SANDBOX_MARKER] === true,
+          ) ?? null,
+        );
+
+      const now = new Date();
+      if (existing) {
+        const updated = await db
+          .update(environments)
+          .set({
+            config: desiredConfig,
+            metadata: { ...(existing.metadata ?? {}), ...desiredMetadata },
+            status: "active",
+            updatedAt: now,
+          })
+          .where(eq(environments.id, existing.id))
+          .returning()
+          .then((rows) => rows[0] ?? existing);
+        return toEnvironment(updated);
+      }
+
+      const row = await db
+        .insert(environments)
+        .values({
+          companyId,
+          name: DEFAULT_MANAGED_SANDBOX_ENVIRONMENT_NAME,
+          description: DEFAULT_MANAGED_SANDBOX_ENVIRONMENT_DESCRIPTION,
+          driver: "sandbox",
+          status: "active",
+          config: desiredConfig,
+          metadata: desiredMetadata,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!row) {
+        throw new Error("Failed to ensure managed sandbox environment");
+      }
+
+      // Same race convergence as ensureKubernetesEnvironment (no partial unique
+      // index on managed sandbox rows yet): prefer the oldest managed row,
+      // delete our own insert if it lost.
+      const winner = await db
+        .select()
+        .from(environments)
+        .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+        .orderBy(asc(environments.createdAt), asc(environments.id))
+        .then(
+          (rows) =>
+            rows.find(
+              (candidate) =>
+                (candidate.metadata as Record<string, unknown> | null)?.[MANAGED_SANDBOX_MARKER] === true,
             ) ?? null,
         );
       if (winner && winner.id !== row.id) {

--- a/server/src/services/execution-allowlist.test.ts
+++ b/server/src/services/execution-allowlist.test.ts
@@ -110,12 +110,15 @@ describe("evaluateExecutionAllowlist", () => {
       expect(result.allowed).toBe(false);
     });
 
-    it("DENIES a sandbox driver with no provider", () => {
+    it("DENIES a sandbox driver with no provider, naming the missing provider", () => {
       const result = evaluateExecutionAllowlist(
         { executionMode: "sandbox" },
         { driver: "sandbox", provider: null },
       );
       expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.reason).toMatch(/no configured provider/);
+      }
     });
   });
 

--- a/server/src/services/execution-allowlist.test.ts
+++ b/server/src/services/execution-allowlist.test.ts
@@ -85,12 +85,63 @@ describe("evaluateExecutionAllowlist", () => {
     });
   });
 
-  describe("isExecutionForcedToKubernetes helper", () => {
-    it("reflects the policy", async () => {
+  describe('executionMode "sandbox" (forced any-provider sandbox)', () => {
+    it("allows the kubernetes sandbox provider", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "sandbox" }, kubernetesEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows a non-kubernetes sandbox provider (e.g. fake/Daytona/E2B)", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "sandbox" }, fakeSandboxEnv);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("DENIES the local environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "sandbox" }, localEnv);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.deniedDriver).toBe("local");
+        expect(result.reason).toMatch(/executionMode=sandbox/);
+      }
+    });
+
+    it("DENIES an ssh environment", () => {
+      const result = evaluateExecutionAllowlist({ executionMode: "sandbox" }, sshEnv);
+      expect(result.allowed).toBe(false);
+    });
+
+    it("DENIES a sandbox driver with no provider", () => {
+      const result = evaluateExecutionAllowlist(
+        { executionMode: "sandbox" },
+        { driver: "sandbox", provider: null },
+      );
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("forcing helpers", () => {
+    it("isExecutionForcedToKubernetes reflects only the kubernetes mode", async () => {
       const { isExecutionForcedToKubernetes } = await import("./execution-allowlist.js");
       expect(isExecutionForcedToKubernetes({ executionMode: "kubernetes" })).toBe(true);
+      expect(isExecutionForcedToKubernetes({ executionMode: "sandbox" })).toBe(false);
       expect(isExecutionForcedToKubernetes({ executionMode: "any" })).toBe(false);
       expect(isExecutionForcedToKubernetes({})).toBe(false);
+    });
+
+    it("isExecutionForcedToSandbox reflects only the provider-agnostic mode", async () => {
+      const { isExecutionForcedToSandbox } = await import("./execution-allowlist.js");
+      expect(isExecutionForcedToSandbox({ executionMode: "sandbox" })).toBe(true);
+      expect(isExecutionForcedToSandbox({ executionMode: "kubernetes" })).toBe(false);
+      expect(isExecutionForcedToSandbox({ executionMode: "any" })).toBe(false);
+      expect(isExecutionForcedToSandbox({})).toBe(false);
+    });
+
+    it("isExecutionForcedToSandboxTier covers both forcing modes", async () => {
+      const { isExecutionForcedToSandboxTier } = await import("./execution-allowlist.js");
+      expect(isExecutionForcedToSandboxTier({ executionMode: "kubernetes" })).toBe(true);
+      expect(isExecutionForcedToSandboxTier({ executionMode: "sandbox" })).toBe(true);
+      expect(isExecutionForcedToSandboxTier({ executionMode: "any" })).toBe(false);
+      expect(isExecutionForcedToSandboxTier({})).toBe(false);
     });
   });
 });

--- a/server/src/services/execution-allowlist.ts
+++ b/server/src/services/execution-allowlist.ts
@@ -135,11 +135,17 @@ export function evaluateExecutionAllowlist(
     return { allowed: true };
   }
 
+  // A `sandbox` driver with no provider is the likeliest misconfiguration, so
+  // name that distinctly instead of blaming the (correct) driver.
+  const target =
+    candidate.driver === "sandbox"
+      ? `sandbox driver with no configured provider`
+      : `"${candidate.driver}" driver`;
   return {
     allowed: false,
     reason:
       `Instance execution policy requires a sandbox-provider environment ` +
-      `(executionMode=sandbox), but the resolved environment uses the "${candidate.driver}" driver. ` +
+      `(executionMode=sandbox), but the resolved environment uses the ${target}. ` +
       `Untrusted execution outside a sandbox is refused.`,
     deniedDriver: candidate.driver,
     deniedProvider: provider,

--- a/server/src/services/execution-allowlist.ts
+++ b/server/src/services/execution-allowlist.ts
@@ -24,11 +24,16 @@ export const KUBERNETES_PROVIDER_KEY = "kubernetes" as const;
  *
  * - `"any"` / absent: unrestricted — any environment driver is allowed (the
  *   default, preserves single-tenant / local-trusted behavior).
- * - `"kubernetes"`: force the Kubernetes sandbox provider; deny local, ssh, and
- *   any non-kubernetes sandbox provider.
+ * - `"sandbox"`: force *some* sandbox-provider environment (any provider —
+ *   Kubernetes, Daytona, E2B, Modal, …); deny local, ssh, and in-process
+ *   execution. Provider-agnostic, for cloud instances whose sandbox is not
+ *   Kubernetes.
+ * - `"kubernetes"`: stricter, provider-pinned variant of `"sandbox"` — force
+ *   the Kubernetes sandbox provider specifically and deny every other driver,
+ *   including non-Kubernetes sandbox providers.
  */
 export interface ExecutionPolicy {
-  executionMode?: "kubernetes" | "any";
+  executionMode?: "kubernetes" | "sandbox" | "any";
 }
 
 /**
@@ -50,9 +55,30 @@ export type ExecutionAllowlistDecision =
       deniedProvider: string | null;
     };
 
-/** True when the policy forces all execution onto the Kubernetes sandbox. */
+/** True when the policy pins all execution to the Kubernetes sandbox provider specifically. */
 export function isExecutionForcedToKubernetes(policy: ExecutionPolicy | null | undefined): boolean {
   return policy?.executionMode === "kubernetes";
+}
+
+/** True when the policy forces some (provider-agnostic) sandbox provider, but not a specific one. */
+export function isExecutionForcedToSandbox(policy: ExecutionPolicy | null | undefined): boolean {
+  return policy?.executionMode === "sandbox";
+}
+
+/**
+ * True when the policy forces a sandbox tier of any kind (`"sandbox"` or the
+ * provider-pinned `"kubernetes"`) — i.e. local/ssh/in-process execution is
+ * refused. Use this to decide whether the heartbeat should override selection
+ * onto a sandbox environment; use the more specific predicates above to pick
+ * *which* environment to pin to.
+ */
+export function isExecutionForcedToSandboxTier(policy: ExecutionPolicy | null | undefined): boolean {
+  return isExecutionForcedToSandbox(policy) || isExecutionForcedToKubernetes(policy);
+}
+
+/** True iff the candidate is any core `sandbox` driver backed by a provider. */
+export function isSandboxProviderEnvironment(candidate: ExecutionEnvironmentCandidate): boolean {
+  return candidate.driver === "sandbox" && typeof candidate.provider === "string" && candidate.provider.length > 0;
 }
 
 /**
@@ -68,35 +94,53 @@ export function isKubernetesSandboxEnvironment(
 /**
  * Decide whether the candidate environment may run under the given policy.
  *
- * When `executionMode === "kubernetes"`, ONLY a `sandbox_provider` driver with
- * provider/driverKey "kubernetes" is allowed; a `local` driver (or any non-k8s
- * sandbox provider, or ssh, or plugin) is DENIED. Otherwise everything is
- * allowed.
+ * - `executionMode === "kubernetes"`: ONLY a `sandbox` driver with provider
+ *   "kubernetes" is allowed; everything else (local, ssh, plugin, or any
+ *   non-Kubernetes sandbox provider) is DENIED.
+ * - `executionMode === "sandbox"`: ANY `sandbox` driver backed by a provider is
+ *   allowed; local, ssh, and in-process execution are DENIED.
+ * - otherwise: everything is allowed.
  */
 export function evaluateExecutionAllowlist(
   policy: ExecutionPolicy | null | undefined,
   candidate: ExecutionEnvironmentCandidate,
 ): ExecutionAllowlistDecision {
-  if (!isExecutionForcedToKubernetes(policy)) {
-    return { allowed: true };
-  }
-
-  if (isKubernetesSandboxEnvironment(candidate)) {
+  if (!isExecutionForcedToSandboxTier(policy)) {
     return { allowed: true };
   }
 
   const provider = candidate.provider ?? null;
-  const target =
-    candidate.driver === "sandbox"
-      ? `sandbox provider "${provider ?? "(none)"}"`
-      : `"${candidate.driver}" driver`;
+
+  if (isExecutionForcedToKubernetes(policy)) {
+    if (isKubernetesSandboxEnvironment(candidate)) {
+      return { allowed: true };
+    }
+    const target =
+      candidate.driver === "sandbox"
+        ? `sandbox provider "${provider ?? "(none)"}"`
+        : `"${candidate.driver}" driver`;
+    return {
+      allowed: false,
+      reason:
+        `Instance execution policy requires the Kubernetes sandbox provider ` +
+        `(executionMode=kubernetes), but the resolved environment uses the ${target}. ` +
+        `Untrusted execution on a non-Kubernetes environment is refused.`,
+      deniedDriver: candidate.driver,
+      deniedProvider: provider,
+    };
+  }
+
+  // executionMode === "sandbox": any sandbox provider is acceptable.
+  if (isSandboxProviderEnvironment(candidate)) {
+    return { allowed: true };
+  }
 
   return {
     allowed: false,
     reason:
-      `Instance execution policy requires the Kubernetes sandbox provider ` +
-      `(executionMode=kubernetes), but the resolved environment uses the ${target}. ` +
-      `Untrusted execution on a non-Kubernetes environment is refused.`,
+      `Instance execution policy requires a sandbox-provider environment ` +
+      `(executionMode=sandbox), but the resolved environment uses the "${candidate.driver}" driver. ` +
+      `Untrusted execution outside a sandbox is refused.`,
     deniedDriver: candidate.driver,
     deniedProvider: provider,
   };

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -28,6 +28,17 @@ function env(overrides: Record<string, string | undefined>): ExecutionPolicyBoot
   return overrides;
 }
 
+// Narrow a parsed bootstrap to the Kubernetes variant (the union now also has a
+// provider-agnostic `sandbox` variant with no kubernetesConfig).
+function asKubernetes(
+  parsed: ReturnType<typeof parseExecutionPolicyBootstrapEnv>,
+): Extract<ExecutionPolicyBootstrap, { executionMode: "kubernetes" }> {
+  if (!parsed || parsed.executionMode !== "kubernetes") {
+    throw new Error(`expected a kubernetes bootstrap, got ${parsed?.executionMode ?? "null"}`);
+  }
+  return parsed;
+}
+
 const bootstrap: ExecutionPolicyBootstrap = {
   executionMode: "kubernetes",
   kubernetesConfig: { inCluster: true, backend: "job" },
@@ -62,7 +73,7 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     );
     expect(parsed).not.toBeNull();
     expect(parsed?.executionMode).toBe("kubernetes");
-    expect(parsed?.kubernetesConfig).toMatchObject({
+    expect(asKubernetes(parsed).kubernetesConfig).toMatchObject({
       backend: "job",
       inCluster: true,
       runtimeClassName: "gvisor",
@@ -76,15 +87,20 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     const parsed = parseExecutionPolicyBootstrapEnv(
       env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }),
     );
-    expect(parsed?.kubernetesConfig.inCluster).toBe(false);
-    expect(parsed?.kubernetesConfig.runtimeClassName).toBeUndefined();
-    expect(parsed?.kubernetesConfig.egressAllowFqdns).toBeUndefined();
+    expect(asKubernetes(parsed).kubernetesConfig.inCluster).toBe(false);
+    expect(asKubernetes(parsed).kubernetesConfig.runtimeClassName).toBeUndefined();
+    expect(asKubernetes(parsed).kubernetesConfig.egressAllowFqdns).toBeUndefined();
   });
 
   it("throws on an unknown execution mode", () => {
     expect(() =>
       parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "vm" })),
     ).toThrow(/PAPERCLIP_EXECUTION_MODE/);
+  });
+
+  it("parses sandbox mode as a provider-agnostic bootstrap with no kubernetes config", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "sandbox" }));
+    expect(parsed).toEqual({ executionMode: "sandbox" });
   });
 
   it("attaches the declared adapter registry to the kubernetes config", () => {
@@ -96,13 +112,13 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
         ]),
       }),
     );
-    expect(parsed?.kubernetesConfig.adapters).toHaveLength(1);
-    expect(parsed?.kubernetesConfig.adapters?.[0].adapterType).toBe("opencode_local");
+    expect(asKubernetes(parsed).kubernetesConfig.adapters).toHaveLength(1);
+    expect(asKubernetes(parsed).kubernetesConfig.adapters?.[0].adapterType).toBe("opencode_local");
   });
 
   it("leaves adapters undefined when PAPERCLIP_ADAPTERS is absent", () => {
     const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }));
-    expect(parsed?.kubernetesConfig.adapters).toBeUndefined();
+    expect(asKubernetes(parsed).kubernetesConfig.adapters).toBeUndefined();
   });
 
   it("reads PAPERCLIP_K8S_RPC_TIMEOUT_MS into kubernetesConfig.timeoutMs", () => {
@@ -112,12 +128,12 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
         PAPERCLIP_K8S_RPC_TIMEOUT_MS: "600000",
       }),
     );
-    expect(parsed?.kubernetesConfig.timeoutMs).toBe(600000);
+    expect(asKubernetes(parsed).kubernetesConfig.timeoutMs).toBe(600000);
   });
 
   it("omits timeoutMs when PAPERCLIP_K8S_RPC_TIMEOUT_MS is absent", () => {
     const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }));
-    expect(parsed?.kubernetesConfig.timeoutMs).toBeUndefined();
+    expect(asKubernetes(parsed).kubernetesConfig.timeoutMs).toBeUndefined();
   });
 
   it("throws when PAPERCLIP_K8S_RPC_TIMEOUT_MS is not a positive integer", () => {
@@ -164,5 +180,15 @@ describe("applyExecutionPolicyBootstrap", () => {
 
     // It keeps going past the failure (attempts all three companies).
     expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(3);
+  });
+
+  it("persists sandbox mode without provisioning any managed environment", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2"]);
+
+    const result = await applyExecutionPolicyBootstrap(fakeDb, { executionMode: "sandbox" });
+
+    expect(result).toEqual({ executionMode: "sandbox", companiesConfigured: 0 });
+    expect(updateGeneral).toHaveBeenCalledWith({ executionMode: "sandbox" });
+    expect(ensureKubernetesEnvironment).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const updateGeneral = vi.fn();
 const listCompanyIds = vi.fn();
 const ensureKubernetesEnvironment = vi.fn();
+const ensureManagedSandboxEnvironment = vi.fn();
 
 vi.mock("./instance-settings.js", () => ({
   instanceSettingsService: () => ({
@@ -14,6 +15,7 @@ vi.mock("./instance-settings.js", () => ({
 vi.mock("./environments.js", () => ({
   environmentService: () => ({
     ensureKubernetesEnvironment,
+    ensureManagedSandboxEnvironment,
   }),
 }));
 
@@ -98,9 +100,54 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     ).toThrow(/PAPERCLIP_EXECUTION_MODE/);
   });
 
-  it("parses sandbox mode as a provider-agnostic bootstrap with no kubernetes config", () => {
+  it("parses sandbox mode with no provider as a persist-only bootstrap", () => {
     const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "sandbox" }));
     expect(parsed).toEqual({ executionMode: "sandbox" });
+  });
+
+  it("parses sandbox mode with a default provider + config for auto-provisioning", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({
+        PAPERCLIP_EXECUTION_MODE: "sandbox",
+        PAPERCLIP_SANDBOX_PROVIDER: "daytona",
+        PAPERCLIP_SANDBOX_CONFIG: JSON.stringify({ apiUrl: "https://daytona.example", target: "eu" }),
+      }),
+    );
+    expect(parsed).toEqual({
+      executionMode: "sandbox",
+      sandbox: { provider: "daytona", config: { apiUrl: "https://daytona.example", target: "eu" } },
+    });
+  });
+
+  it("defaults sandbox config to an empty object when only a provider is given", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({ PAPERCLIP_EXECUTION_MODE: "sandbox", PAPERCLIP_SANDBOX_PROVIDER: "e2b" }),
+    );
+    expect(parsed).toEqual({ executionMode: "sandbox", sandbox: { provider: "e2b", config: {} } });
+  });
+
+  it("throws when PAPERCLIP_SANDBOX_CONFIG is not valid JSON", () => {
+    expect(() =>
+      parseExecutionPolicyBootstrapEnv(
+        env({
+          PAPERCLIP_EXECUTION_MODE: "sandbox",
+          PAPERCLIP_SANDBOX_PROVIDER: "daytona",
+          PAPERCLIP_SANDBOX_CONFIG: "{not json",
+        }),
+      ),
+    ).toThrow(/PAPERCLIP_SANDBOX_CONFIG must be valid JSON/);
+  });
+
+  it("throws when PAPERCLIP_SANDBOX_CONFIG is a JSON non-object", () => {
+    expect(() =>
+      parseExecutionPolicyBootstrapEnv(
+        env({
+          PAPERCLIP_EXECUTION_MODE: "sandbox",
+          PAPERCLIP_SANDBOX_PROVIDER: "daytona",
+          PAPERCLIP_SANDBOX_CONFIG: "[1,2,3]",
+        }),
+      ),
+    ).toThrow(/PAPERCLIP_SANDBOX_CONFIG must be a JSON object/);
   });
 
   it("attaches the declared adapter registry to the kubernetes config", () => {
@@ -155,6 +202,7 @@ describe("applyExecutionPolicyBootstrap", () => {
     updateGeneral.mockReset().mockResolvedValue(undefined);
     listCompanyIds.mockReset();
     ensureKubernetesEnvironment.mockReset();
+    ensureManagedSandboxEnvironment.mockReset();
   });
 
   it("does not throw when every company gets a managed environment", async () => {
@@ -182,7 +230,7 @@ describe("applyExecutionPolicyBootstrap", () => {
     expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(3);
   });
 
-  it("persists sandbox mode without provisioning any managed environment", async () => {
+  it("persists sandbox mode (no default provider) without provisioning any environment", async () => {
     listCompanyIds.mockResolvedValue(["c1", "c2"]);
 
     const result = await applyExecutionPolicyBootstrap(fakeDb, { executionMode: "sandbox" });
@@ -190,5 +238,40 @@ describe("applyExecutionPolicyBootstrap", () => {
     expect(result).toEqual({ executionMode: "sandbox", companiesConfigured: 0 });
     expect(updateGeneral).toHaveBeenCalledWith({ executionMode: "sandbox" });
     expect(ensureKubernetesEnvironment).not.toHaveBeenCalled();
+    expect(ensureManagedSandboxEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("auto-provisions the default sandbox for every company when a provider is set", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2", "c3"]);
+    ensureManagedSandboxEnvironment.mockResolvedValue({ id: "sbx" });
+
+    const result = await applyExecutionPolicyBootstrap(fakeDb, {
+      executionMode: "sandbox",
+      sandbox: { provider: "daytona", config: { target: "eu" } },
+    });
+
+    expect(result).toEqual({ executionMode: "sandbox", companiesConfigured: 3 });
+    expect(ensureManagedSandboxEnvironment).toHaveBeenCalledTimes(3);
+    expect(ensureManagedSandboxEnvironment).toHaveBeenCalledWith("c1", {
+      provider: "daytona",
+      config: { target: "eu" },
+    });
+    expect(ensureKubernetesEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("throws when a company fails to get its managed sandbox, after attempting all", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2", "c3"]);
+    ensureManagedSandboxEnvironment.mockImplementation(async (companyId: string) => {
+      if (companyId === "c2") throw new Error("provider unreachable");
+      return { id: `sbx-${companyId}` };
+    });
+
+    await expect(
+      applyExecutionPolicyBootstrap(fakeDb, {
+        executionMode: "sandbox",
+        sandbox: { provider: "daytona", config: {} },
+      }),
+    ).rejects.toThrow(/1 of 3 companies failed to get a managed sandbox.*c2/);
+    expect(ensureManagedSandboxEnvironment).toHaveBeenCalledTimes(3);
   });
 });

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -42,6 +42,11 @@ export type ExecutionPolicyBootstrap =
     }
   | {
       executionMode: Extract<InstanceExecutionMode, "sandbox">;
+      // When set, a managed sandbox environment is auto-provisioned per company
+      // (mirrors the Kubernetes path) so uploaded/synced companies just work.
+      // When absent, the operator manages sandbox environments manually and the
+      // setting is merely persisted.
+      sandbox?: { provider: string; config: Record<string, unknown> };
     };
 
 function parseBool(value: string | undefined): boolean | undefined {
@@ -86,9 +91,32 @@ export function parseExecutionPolicyBootstrapEnv(
   const raw = env.PAPERCLIP_EXECUTION_MODE?.trim();
   if (!raw || raw === "any") return null;
   if (raw === "sandbox") {
-    // Provider-agnostic: the operator configures their sandbox provider via the
-    // normal environment flow; the boot hook only persists the setting.
-    return { executionMode: "sandbox" };
+    // Provider-agnostic. If the operator names a default provider, every company
+    // auto-provisions that sandbox on first heartbeat (mirrors the Kubernetes
+    // path) so an uploaded/synced tenant just works without knowing cloud
+    // details. Without a provider, the setting is persisted and operators manage
+    // sandbox environments themselves.
+    const provider = env.PAPERCLIP_SANDBOX_PROVIDER?.trim();
+    if (!provider) return { executionMode: "sandbox" };
+    let config: Record<string, unknown> = {};
+    const rawConfig = env.PAPERCLIP_SANDBOX_CONFIG?.trim();
+    if (rawConfig) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawConfig);
+      } catch (err) {
+        throw new Error(
+          `PAPERCLIP_SANDBOX_CONFIG must be valid JSON (got a parse error: ${
+            err instanceof Error ? err.message : String(err)
+          }).`,
+        );
+      }
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error("PAPERCLIP_SANDBOX_CONFIG must be a JSON object.");
+      }
+      config = parsed as Record<string, unknown>;
+    }
+    return { executionMode: "sandbox", sandbox: { provider, config } };
   }
   if (raw !== "kubernetes") {
     throw new Error(
@@ -169,11 +197,42 @@ export async function applyExecutionPolicyBootstrap(
   await instanceSettings.updateGeneral({ executionMode: bootstrap.executionMode });
 
   if (bootstrap.executionMode === "sandbox") {
+    if (!bootstrap.sandbox) {
+      logger.info(
+        { executionMode: bootstrap.executionMode },
+        "applied provider-agnostic sandbox execution policy (no default provider; configure a sandbox environment per company)",
+      );
+      return { executionMode: bootstrap.executionMode, companiesConfigured: 0 };
+    }
+    const sandboxCompanyIds = await instanceSettings.listCompanyIds();
+    let sandboxConfigured = 0;
+    const sandboxFailedCompanyIds: string[] = [];
+    for (const companyId of sandboxCompanyIds) {
+      try {
+        await environments.ensureManagedSandboxEnvironment(companyId, bootstrap.sandbox);
+        sandboxConfigured += 1;
+      } catch (err) {
+        logger.error(
+          { err, companyId, provider: bootstrap.sandbox.provider },
+          "failed to ensure managed sandbox environment during execution-policy bootstrap",
+        );
+        sandboxFailedCompanyIds.push(companyId);
+      }
+    }
     logger.info(
-      { executionMode: bootstrap.executionMode },
-      "applied provider-agnostic sandbox execution policy (no managed environment provisioned; configure a sandbox provider per company)",
+      {
+        executionMode: bootstrap.executionMode,
+        provider: bootstrap.sandbox.provider,
+        companiesConfigured: sandboxConfigured,
+      },
+      "applied forced sandbox execution policy",
     );
-    return { executionMode: bootstrap.executionMode, companiesConfigured: 0 };
+    if (sandboxFailedCompanyIds.length > 0) {
+      throw new Error(
+        `execution-policy bootstrap: ${sandboxFailedCompanyIds.length} of ${sandboxCompanyIds.length} companies failed to get a managed sandbox environment under executionMode=sandbox (provider=${bootstrap.sandbox.provider}); refusing to start (companies: ${sandboxFailedCompanyIds.join(", ")})`,
+      );
+    }
+    return { executionMode: bootstrap.executionMode, companiesConfigured: sandboxConfigured };
   }
 
   const companyIds = await instanceSettings.listCompanyIds();

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -26,10 +26,23 @@ import { parseAdapterRegistryEnv } from "./adapter-registry-bootstrap.js";
 
 export type ExecutionPolicyBootstrapEnv = Record<string, string | undefined>;
 
-export interface ExecutionPolicyBootstrap {
-  executionMode: Extract<InstanceExecutionMode, "kubernetes">;
-  kubernetesConfig: KubernetesEnvironmentConfigInput;
-}
+/**
+ * Parsed forced-execution bootstrap.
+ *
+ * - `kubernetes`: provider-pinned; carries the managed Kubernetes config so the
+ *   boot hook can provision a k8s environment per company.
+ * - `sandbox`: provider-agnostic; the operator configures their sandbox provider
+ *   through the normal environment flow, so the boot hook only persists the
+ *   setting and provisions nothing.
+ */
+export type ExecutionPolicyBootstrap =
+  | {
+      executionMode: Extract<InstanceExecutionMode, "kubernetes">;
+      kubernetesConfig: KubernetesEnvironmentConfigInput;
+    }
+  | {
+      executionMode: Extract<InstanceExecutionMode, "sandbox">;
+    };
 
 function parseBool(value: string | undefined): boolean | undefined {
   if (value === undefined) return undefined;
@@ -72,9 +85,14 @@ export function parseExecutionPolicyBootstrapEnv(
 ): ExecutionPolicyBootstrap | null {
   const raw = env.PAPERCLIP_EXECUTION_MODE?.trim();
   if (!raw || raw === "any") return null;
+  if (raw === "sandbox") {
+    // Provider-agnostic: the operator configures their sandbox provider via the
+    // normal environment flow; the boot hook only persists the setting.
+    return { executionMode: "sandbox" };
+  }
   if (raw !== "kubernetes") {
     throw new Error(
-      `PAPERCLIP_EXECUTION_MODE must be "kubernetes" or "any" (got "${raw}").`,
+      `PAPERCLIP_EXECUTION_MODE must be "kubernetes", "sandbox", or "any" (got "${raw}").`,
     );
   }
 
@@ -133,8 +151,13 @@ export function parseExecutionPolicyBootstrapEnv(
 
 /**
  * Apply the parsed bootstrap to the database: persist `executionMode` into
- * instance settings and ensure a configured Kubernetes environment for every
- * company. Idempotent; safe to call on every boot.
+ * instance settings and, for the Kubernetes mode, ensure a configured
+ * Kubernetes environment for every company. Idempotent; safe to call on every
+ * boot.
+ *
+ * For `executionMode=sandbox` there is nothing to provision — the operator
+ * configures their sandbox provider through the normal environment flow — so we
+ * only persist the setting and the per-run heartbeat guard enforces it.
  */
 export async function applyExecutionPolicyBootstrap(
   db: Db,
@@ -144,6 +167,14 @@ export async function applyExecutionPolicyBootstrap(
   const environments = environmentService(db);
 
   await instanceSettings.updateGeneral({ executionMode: bootstrap.executionMode });
+
+  if (bootstrap.executionMode === "sandbox") {
+    logger.info(
+      { executionMode: bootstrap.executionMode },
+      "applied provider-agnostic sandbox execution policy (no managed environment provisioned; configure a sandbox provider per company)",
+    );
+    return { executionMode: bootstrap.executionMode, companiesConfigured: 0 };
+  }
 
   const companyIds = await instanceSettings.listCompanyIds();
   let configured = 0;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8157,20 +8157,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       selectedEnvironmentId = kubernetesEnvironment.id;
     } else if (isExecutionForcedToSandbox(executionPolicy)) {
-      // Provider-agnostic sandbox forcing: pin the run onto whatever sandbox
-      // environment the operator configured for this company (Daytona, E2B,
-      // Modal, …). Unlike the Kubernetes path we cannot lazily provision one —
-      // the provider and its config are operator-specific — so a missing
-      // sandbox environment fails the run with an explicit error rather than
-      // silently falling back to local execution. The allowlist guard below is
-      // the backstop if selection were somehow bypassed.
-      const sandboxEnvironment = await environmentsSvc.findManagedSandboxEnvironment(agent.companyId);
+      // Provider-agnostic sandbox forcing: pin the run onto the sandbox
+      // environment configured for this company (Daytona, E2B, Modal, …).
+      let sandboxEnvironment = await environmentsSvc.findManagedSandboxEnvironment(agent.companyId);
+      if (!sandboxEnvironment) {
+        // Lazily auto-provision from the operator's default sandbox config —
+        // mirrors the Kubernetes path so an uploaded/synced company just works
+        // on first heartbeat without the tenant configuring cloud details.
+        // Only possible when the operator set PAPERCLIP_SANDBOX_PROVIDER; if not
+        // (config drift / manual-env operators), fail loudly below instead of
+        // falling back to local. The allowlist guard after acquisition is the
+        // backstop if selection were somehow bypassed.
+        let sandboxBootstrap: ReturnType<typeof parseExecutionPolicyBootstrapEnv> = null;
+        try {
+          sandboxBootstrap = parseExecutionPolicyBootstrapEnv(process.env);
+        } catch (err) {
+          logger.warn(
+            { runId: run.id, agentId: agent.id, companyId: agent.companyId, err },
+            "executionMode=sandbox is persisted but PAPERCLIP_SANDBOX_* bootstrap env failed to parse; cannot lazily provision",
+          );
+        }
+        if (
+          sandboxBootstrap &&
+          sandboxBootstrap.executionMode === "sandbox" &&
+          sandboxBootstrap.sandbox
+        ) {
+          await environmentsSvc.ensureManagedSandboxEnvironment(
+            agent.companyId,
+            sandboxBootstrap.sandbox,
+          );
+          sandboxEnvironment = await environmentsSvc.findManagedSandboxEnvironment(agent.companyId);
+        }
+      }
       if (!sandboxEnvironment) {
         throw new Error(
           "Instance execution policy requires a sandbox-provider environment " +
             "(executionMode=sandbox) but no active sandbox environment is configured " +
-            "for this company. Configure a sandbox provider (e.g. Kubernetes, Daytona, " +
-            "E2B, Modal) before running agents; refusing to fall back to local execution.",
+            "for this company and no default provider (PAPERCLIP_SANDBOX_PROVIDER) is set " +
+            "to auto-provision one. Configure a sandbox provider before running agents; " +
+            "refusing to fall back to local execution.",
         );
       }
       if (sandboxEnvironment.id !== selectedEnvironmentId) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -135,6 +135,8 @@ import { instanceSettingsService } from "./instance-settings.js";
 import {
   evaluateExecutionAllowlist,
   isExecutionForcedToKubernetes,
+  isExecutionForcedToSandbox,
+  isExecutionForcedToSandboxTier,
 } from "./execution-allowlist.js";
 import {
   RECOVERY_ORIGIN_KINDS,
@@ -8106,13 +8108,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (!bootstrap) {
             bootstrapSkipReason =
               'PAPERCLIP_EXECUTION_MODE bootstrap env is not kubernetes-forced (absent or "any")';
+          } else if (bootstrap.executionMode !== "kubernetes") {
+            bootstrapSkipReason =
+              `PAPERCLIP_EXECUTION_MODE bootstrap env is "${bootstrap.executionMode}", not "kubernetes"; cannot derive a managed Kubernetes config`;
           }
         } catch (err) {
           bootstrapSkipReason = `PAPERCLIP_EXECUTION_MODE bootstrap env failed to parse: ${
             err instanceof Error ? err.message : String(err)
           }`;
         }
-        if (bootstrap) {
+        if (bootstrap && bootstrap.executionMode === "kubernetes") {
           await environmentsSvc.ensureKubernetesEnvironment(
             agent.companyId,
             bootstrap.kubernetesConfig,
@@ -8151,6 +8156,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
       }
       selectedEnvironmentId = kubernetesEnvironment.id;
+    } else if (isExecutionForcedToSandbox(executionPolicy)) {
+      // Provider-agnostic sandbox forcing: pin the run onto whatever sandbox
+      // environment the operator configured for this company (Daytona, E2B,
+      // Modal, …). Unlike the Kubernetes path we cannot lazily provision one —
+      // the provider and its config are operator-specific — so a missing
+      // sandbox environment fails the run with an explicit error rather than
+      // silently falling back to local execution. The allowlist guard below is
+      // the backstop if selection were somehow bypassed.
+      const sandboxEnvironment = await environmentsSvc.findManagedSandboxEnvironment(agent.companyId);
+      if (!sandboxEnvironment) {
+        throw new Error(
+          "Instance execution policy requires a sandbox-provider environment " +
+            "(executionMode=sandbox) but no active sandbox environment is configured " +
+            "for this company. Configure a sandbox provider (e.g. Kubernetes, Daytona, " +
+            "E2B, Modal) before running agents; refusing to fall back to local execution.",
+        );
+      }
+      if (sandboxEnvironment.id !== selectedEnvironmentId) {
+        logger.info(
+          {
+            runId: run.id,
+            issueId,
+            agentId: agent.id,
+            resolvedEnvironmentId: selectedEnvironmentId,
+            forcedSandboxEnvironmentId: sandboxEnvironment.id,
+            sandboxProvider:
+              typeof sandboxEnvironment.config?.provider === "string"
+                ? sandboxEnvironment.config.provider
+                : null,
+          },
+          "Forcing run onto the configured sandbox environment (executionMode=sandbox)",
+        );
+      }
+      selectedEnvironmentId = sandboxEnvironment.id;
     }
     const {
       selectedEnvironmentDriver: lowTrustPreflightEnvironmentDriver,
@@ -8472,11 +8511,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         })
         .where(eq(heartbeatRuns.id, run.id));
     }
-    // When execution is forced to Kubernetes, `selectedEnvironmentId` is already
-    // pinned to the managed k8s environment above; ignore any persisted workspace
-    // environmentId (which could point at a stale local/ssh env) so a reused
-    // workspace can never downgrade us off the sandbox.
-    const persistedEnvironmentId = isExecutionForcedToKubernetes(executionPolicy)
+    // When execution is forced to a sandbox tier (kubernetes or sandbox),
+    // `selectedEnvironmentId` is already pinned to the sandbox environment above;
+    // ignore any persisted workspace environmentId (which could point at a stale
+    // local/ssh env) so a reused workspace can never downgrade us off the sandbox.
+    const persistedEnvironmentId = isExecutionForcedToSandboxTier(executionPolicy)
       ? selectedEnvironmentId
       : persistedExecutionWorkspace?.config?.environmentId ?? selectedEnvironmentId;
     const acquiredEnvironment = await envOrchestrator.acquireForRun({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; on a shared cloud instance, untrusted tenant agents must be confined to a sandbox and never run in the server process or on a local/ssh adapter.
> - The Kubernetes sandbox integration (#5790 / #7938 / #7934) added an instance `executionMode` to force exactly that — but it hardwired the forcing to the **`kubernetes`** provider specifically, at four layers (enum, allowlist guard, heartbeat selection, bootstrap).
> - Paperclip already ships six sandbox providers (`kubernetes`, `daytona`, `e2b`, `modal`, `cloudflare`, `exe-dev`). An operator whose cloud sandbox is not Kubernetes has no safe setting: `"kubernetes"` denies their provider outright (every run fails), and `"any"` allows local/in-process execution — reopening the tenant-isolation hole the feature exists to close.
> - This PR generalizes the policy from a provider toggle to a sandbox tier: a new provider-agnostic `"sandbox"` mode forces *some* sandbox provider and denies local/ssh/in-process, while `"kubernetes"` remains the stricter provider-pinned variant. Backward-compatible and additive.

## Linked Issues or Issue Description

Closes #7988 (full problem statement and evidence). In short: execution forcing was Kubernetes-specific rather than sandbox-generic, so non-k8s cloud sandboxes could not enforce isolation.

## What Changed

A new `executionMode: "sandbox"` value, threaded through the same four layers the k8s forcing already used:

- **`packages/shared` (types + validator)** — `InstanceExecutionMode` becomes `"kubernetes" | "sandbox" | "any"`; settings validator accepts `"sandbox"`.
- **`execution-allowlist.ts`** (the security gate) — adds `isExecutionForcedToSandbox`, `isExecutionForcedToSandboxTier`, and `isSandboxProviderEnvironment`. `evaluateExecutionAllowlist`:
  - `"kubernetes"` → allow only the kubernetes provider (unchanged).
  - `"sandbox"` → allow **any** `driver:"sandbox"` backed by a provider; deny local/ssh/in-process.
  - `"any"`/absent → allow all (unchanged).
- **`environments.ts`** — adds `findManagedSandboxEnvironment(companyId)` (provider-agnostic counterpart of `findKubernetesEnvironment`; returns the company's active sandbox env regardless of provider, ignoring provider-less rows, preferring a Paperclip-managed one) and `ensureManagedSandboxEnvironment(companyId, {provider, config})` (provider-agnostic counterpart of `ensureKubernetesEnvironment`: idempotent, race-converging, `managedSandbox` marker).
- **`heartbeat.ts`** — adds a `"sandbox"` branch to the selection override: pin the run onto the company's configured sandbox env. If none exists, **lazily auto-provision** the operator's default sandbox (from `PAPERCLIP_SANDBOX_PROVIDER`/`PAPERCLIP_SANDBOX_CONFIG`) — mirroring the k8s lazy path so an uploaded/synced company just works on first heartbeat without the tenant configuring anything. Only when no default provider is set does it **fail the run with an explicit error** (no silent local fallback). The defense-in-depth allowlist check after acquisition covers both modes. The "ignore stale persisted workspace env" guard now triggers for the whole sandbox tier (`isExecutionForcedToSandboxTier`) so a reused workspace can't downgrade either mode off the sandbox.
- **`execution-policy-bootstrap.ts`** — `PAPERCLIP_EXECUTION_MODE=sandbox` with `PAPERCLIP_SANDBOX_PROVIDER` (+ optional `PAPERCLIP_SANDBOX_CONFIG` JSON) auto-provisions the managed sandbox per company at boot, exactly like the k8s bootstrap. With no provider it stays persist-only. The bootstrap type is a discriminated union (`{kubernetes, kubernetesConfig}` | `{sandbox, sandbox?: {provider, config}}`).

`"kubernetes"` and `"any"` are byte-for-byte unchanged in behavior.

## Verification

- `pnpm run typecheck` — clean.
- New/updated unit tests, all green locally:
  - `execution-allowlist.test.ts` — `"sandbox"` allows k8s + non-k8s providers, denies local/ssh/provider-less sandbox; the three forcing helpers reflect the right modes.
  - `execution-policy-bootstrap.test.ts` — `"sandbox"` parses to `{executionMode:"sandbox"}` and applies without provisioning or calling `ensureKubernetesEnvironment`.
  - `environment-service.test.ts` — `findManagedSandboxEnvironment` returns a non-k8s sandbox (where `findKubernetesEnvironment` returns null) and prefers a managed env when several exist.
- Full server vitest suite — green (modulo the known macOS-flaky `heartbeat-process-recovery`, tracked in #4328).

## Risks

- **Additive and backward-compatible.** No existing `executionMode` value changes behavior; `"sandbox"` is opt-in.
- **Auto-provision parity with k8s.** When the operator sets a default `PAPERCLIP_SANDBOX_PROVIDER`, every company (including uploaded/synced ones) auto-gets that sandbox on first heartbeat — the tenant configures nothing, matching the Kubernetes ergonomics. Operators who'd rather manage envs by hand omit the provider, and the mode then fails loud on a missing sandbox rather than degrading to local.
- **No new required env vars.** Single-tenant/local-first deploys (`"any"`/absent) are untouched.
- **Security gate unchanged in spirit** — the allowlist still denies local/ssh/in-process under any forcing mode; `"sandbox"` only widens *which* sandbox providers count as compliant.

## Model Used

Claude Fable 5 (1M context), extended thinking mode.

## Checklist

- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] Thinking path traces from project context to this change
- [x] Model used specified
- [x] Checked ROADMAP.md — extends the multi-tenant sandbox-forcing initiative (#5790/#7938/#7934)
- [x] Tests run locally and pass
- [x] No UI changes (executionMode has no UI surface; set via settings API / `PAPERCLIP_EXECUTION_MODE`)
- [x] Documented risks above
- [x] Will address all Greptile and reviewer comments before merge

Extends the multi-tenant hardening initiative — see also #3967 (cross-tenant 404 oracle), #5864 (per-company JWT keys), #5865 (plugin tables `company_id`).

