### PR TITLE
fix: cross-replica coordination for migrations, backups, schedulers, and webhooks

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -657,8 +657,7 @@ export async function inspectMigrations(url: string): Promise<MigrationState> {
   }
 }
 
-// Keep in sync with PAPERCLIP_LOCK_NAMESPACE in server/src/services/advisory-locks.ts.
-const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
+export const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp" — namespaces Paperclip's advisory locks away from other tools' keys
 
 async function applyPendingMigrationsLocked(url: string): Promise<void> {
   const initialState = await inspectMigrations(url);

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -657,7 +657,10 @@ export async function inspectMigrations(url: string): Promise<MigrationState> {
   }
 }
 
-export async function applyPendingMigrations(url: string): Promise<void> {
+// Keep in sync with PAPERCLIP_LOCK_NAMESPACE in server/src/services/advisory-locks.ts.
+const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
+
+async function applyPendingMigrationsLocked(url: string): Promise<void> {
   const initialState = await inspectMigrations(url);
   if (initialState.status === "upToDate") return;
 
@@ -714,6 +717,20 @@ export async function applyPendingMigrations(url: string): Promise<void> {
     throw new Error(
       `Failed to apply pending migrations: ${finalState.pendingMigrations.join(", ")}`,
     );
+  }
+}
+
+export async function applyPendingMigrations(url: string): Promise<void> {
+  // Serialize concurrent migration attempts (N replicas booting after an
+  // upgrade). Session-scoped advisory lock on a dedicated connection: held
+  // across all migration transactions, released on sql.end() or if this
+  // process dies. Waiters block, then re-inspect and no-op.
+  const lockSql = createUtilitySql(url);
+  try {
+    await lockSql`SELECT pg_advisory_lock(${PAPERCLIP_LOCK_NAMESPACE}, hashtext('db-migrate'))`;
+    await applyPendingMigrationsLocked(url);
+  } finally {
+    await lockSql.end({ timeout: 5 });
   }
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,6 +2,7 @@
 // advisory locks) without declaring its own postgres dependency/version.
 export { default as postgres } from "postgres";
 export {
+  PAPERCLIP_LOCK_NAMESPACE,
   createDb,
   getPostgresDataDirectory,
   ensurePostgresDatabase,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
+export { default as postgres } from "postgres";
 export {
   createDb,
   getPostgresDataDirectory,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,5 @@
+// Re-exported so server code can open dedicated raw connections (session
+// advisory locks) without declaring its own postgres dependency/version.
 export { default as postgres } from "postgres";
 export {
   createDb,

--- a/packages/db/src/migration-lock.test.ts
+++ b/packages/db/src/migration-lock.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { applyPendingMigrations, ensurePostgresDatabase, inspectMigrations } from "./index.js";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./test-embedded-postgres.js";
+
+const support = await getEmbeddedPostgresTestSupport();
+const describeEmbedded = support.supported ? describe : describe.skip;
+
+describeEmbedded("concurrent migration application", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterAll(async () => {
+    for (const cleanup of cleanups) await cleanup();
+  });
+
+  it("N concurrent applyPendingMigrations calls race safely to an upToDate schema", async () => {
+    const seed = await startEmbeddedPostgresTestDatabase("paperclip-migration-lock-");
+    cleanups.push(seed.cleanup);
+    // Fresh empty sibling DB on the same cluster (no migrations applied yet).
+    const adminUrl = new URL(seed.connectionString);
+    adminUrl.pathname = "/postgres";
+    await ensurePostgresDatabase(adminUrl.toString(), "migration_race");
+    const targetUrl = new URL(seed.connectionString);
+    targetUrl.pathname = "/migration_race";
+    const url = targetUrl.toString();
+
+    const results = await Promise.allSettled([
+      applyPendingMigrations(url),
+      applyPendingMigrations(url),
+      applyPendingMigrations(url),
+    ]);
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+
+    const state = await inspectMigrations(url);
+    expect(state.status).toBe("upToDate");
+
+    // No duplicate journal entries.
+    const sql = postgres(url, { max: 1, onnotice: () => {} });
+    try {
+      const rows = await sql`SELECT hash, count(*) AS n FROM drizzle.__drizzle_migrations GROUP BY hash HAVING count(*) > 1`;
+      expect(rows.length).toBe(0);
+    } finally {
+      await sql.end();
+    }
+  });
+});

--- a/packages/db/src/migrations/0102_plugin_webhook_delivery_dedup.sql
+++ b/packages/db/src/migrations/0102_plugin_webhook_delivery_dedup.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "plugin_webhook_deliveries_external_id_unique"
+  ON "plugin_webhook_deliveries" ("plugin_id", "webhook_key", "external_id")
+  WHERE "external_id" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -715,6 +715,13 @@
       "when": 1781490000000,
       "tag": "0101_plugin_company_id_tenant_isolation",
       "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1781500000000,
+      "tag": "0102_plugin_webhook_delivery_dedup",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/plugin_webhooks.ts
+++ b/packages/db/src/schema/plugin_webhooks.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   pgTable,
   uuid,
@@ -6,6 +7,7 @@ import {
   timestamp,
   jsonb,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { plugins } from "./plugins.js";
@@ -65,5 +67,13 @@ export const pluginWebhookDeliveries = pgTable(
     companyIdx: index("plugin_webhook_deliveries_company_idx").on(table.companyId),
     statusIdx: index("plugin_webhook_deliveries_status_idx").on(table.status),
     keyIdx: index("plugin_webhook_deliveries_key_idx").on(table.webhookKey),
+    /**
+     * De-duplicates retried deliveries that carry a provider idempotency id
+     * (e.g. GitHub's `X-GitHub-Delivery` GUID). Partial: deliveries without
+     * an external id are never deduplicated.
+     */
+    externalIdUnique: uniqueIndex("plugin_webhook_deliveries_external_id_unique")
+      .on(table.pluginId, table.webhookKey, table.externalId)
+      .where(sql`external_id IS NOT NULL`),
   }),
 );

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -21,7 +21,9 @@ const nonServerProjects = [
   "paperclipai",
 ];
 const routeTestPattern = /[^/]*(?:route|routes|authz)[^/]*\.test\.ts$/;
+// Suites that boot an embedded Postgres are resource-heavy and belong in the serialized shards.
 const additionalSerializedServerTests = new Set([
+  "server/src/__tests__/advisory-locks.test.ts",
   "server/src/__tests__/approval-routes-idempotency.test.ts",
   "server/src/__tests__/assets.test.ts",
   "server/src/__tests__/authz-company-access.test.ts",
@@ -43,6 +45,8 @@ const additionalSerializedServerTests = new Set([
   "server/src/__tests__/issues-checkout-wakeup.test.ts",
   "server/src/__tests__/issues-service.test.ts",
   "server/src/__tests__/opencode-local-adapter-environment.test.ts",
+  "server/src/__tests__/plugin-job-scheduler-claim.test.ts",
+  "server/src/__tests__/plugin-webhook-dedup.test.ts",
   "server/src/__tests__/project-routes-env.test.ts",
   "server/src/__tests__/redaction.test.ts",
   "server/src/__tests__/routines-e2e.test.ts",

--- a/server/src/__tests__/advisory-locks.test.ts
+++ b/server/src/__tests__/advisory-locks.test.ts
@@ -33,12 +33,18 @@ describeEmbedded("advisory locks", () => {
 
   it("withAdvisoryXactLock serializes critical sections across two clients", async () => {
     const order: string[] = [];
+    // Deterministic latch: A's critical section resolves `aInside` as its
+    // first statement, and the test waits on it before starting B — A is
+    // guaranteed to hold the lock when B contends, with no timing sleep.
+    let aInsideResolve!: () => void;
+    const aInside = new Promise<void>((resolve) => (aInsideResolve = resolve));
     const first = withAdvisoryXactLock(dbA, "test-serialize", async () => {
+      aInsideResolve();
       order.push("a-start");
       await new Promise((resolve) => setTimeout(resolve, 150));
       order.push("a-end");
     });
-    await new Promise((resolve) => setTimeout(resolve, 50)); // let A acquire first
+    await aInside;
     const second = withAdvisoryXactLock(dbB, "test-serialize", async () => {
       order.push("b-start");
     });

--- a/server/src/__tests__/advisory-locks.test.ts
+++ b/server/src/__tests__/advisory-locks.test.ts
@@ -53,12 +53,19 @@ describeEmbedded("advisory locks", () => {
   });
 
   it("tryAdvisoryXactLock skips when another client holds the lock", async () => {
+    // Deterministic latch (same pattern as the serialization test): A's
+    // critical section resolves `aInside` as its first statement, and the
+    // test waits on it before B tries — A is guaranteed to hold the lock,
+    // with no timing sleep.
+    let aInsideResolve!: () => void;
+    const aInside = new Promise<void>((resolve) => (aInsideResolve = resolve));
     let releaseA: () => void = () => {};
     const held = new Promise<void>((resolve) => (releaseA = resolve));
     const first = withAdvisoryXactLock(dbA, "test-skip", async () => {
+      aInsideResolve();
       await held;
     });
-    await new Promise((resolve) => setTimeout(resolve, 100)); // ensure A holds it
+    await aInside;
     const result = await tryAdvisoryXactLock(dbB, "test-skip", async () => "ran");
     expect(result).toEqual({ acquired: false });
     releaseA();

--- a/server/src/__tests__/advisory-locks.test.ts
+++ b/server/src/__tests__/advisory-locks.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createDb, type Db } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import type { EmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+import {
+  tryAdvisoryXactLock,
+  trySessionAdvisoryLock,
+  withAdvisoryXactLock,
+} from "../services/advisory-locks.js";
+
+const support = await getEmbeddedPostgresTestSupport();
+const describeEmbedded = support.supported ? describe : describe.skip;
+
+describeEmbedded("advisory locks", () => {
+  let tempDb: EmbeddedPostgresTestDatabase | null = null;
+  let dbA: Db;
+  let dbB: Db;
+  let connectionString = "";
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-advisory-locks-");
+    connectionString = tempDb.connectionString;
+    dbA = createDb(connectionString);
+    dbB = createDb(connectionString);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("withAdvisoryXactLock serializes critical sections across two clients", async () => {
+    const order: string[] = [];
+    const first = withAdvisoryXactLock(dbA, "test-serialize", async () => {
+      order.push("a-start");
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      order.push("a-end");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50)); // let A acquire first
+    const second = withAdvisoryXactLock(dbB, "test-serialize", async () => {
+      order.push("b-start");
+    });
+    await Promise.all([first, second]);
+    expect(order).toEqual(["a-start", "a-end", "b-start"]);
+  });
+
+  it("tryAdvisoryXactLock skips when another client holds the lock", async () => {
+    let releaseA: () => void = () => {};
+    const held = new Promise<void>((resolve) => (releaseA = resolve));
+    const first = withAdvisoryXactLock(dbA, "test-skip", async () => {
+      await held;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100)); // ensure A holds it
+    const result = await tryAdvisoryXactLock(dbB, "test-skip", async () => "ran");
+    expect(result).toEqual({ acquired: false });
+    releaseA();
+    await first;
+    const after = await tryAdvisoryXactLock(dbB, "test-skip", async () => "ran");
+    expect(after).toEqual({ acquired: true, result: "ran" });
+  });
+
+  it("releases the lock when the critical section throws", async () => {
+    await expect(
+      withAdvisoryXactLock(dbA, "test-error", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    const after = await tryAdvisoryXactLock(dbB, "test-error", async () => "ran");
+    expect(after).toEqual({ acquired: true, result: "ran" });
+  });
+
+  it("different names do not contend", async () => {
+    const result = await withAdvisoryXactLock(dbA, "name-one", async () =>
+      tryAdvisoryXactLock(dbB, "name-two", async () => "ran"),
+    );
+    expect(result).toEqual({ acquired: true, result: "ran" });
+  });
+
+  it("trySessionAdvisoryLock holds across transactions until released", async () => {
+    const lock = await trySessionAdvisoryLock(connectionString, "test-session");
+    expect(lock.acquired).toBe(true);
+    const contender = await trySessionAdvisoryLock(connectionString, "test-session");
+    expect(contender.acquired).toBe(false);
+    if (lock.acquired) await lock.release();
+    const after = await trySessionAdvisoryLock(connectionString, "test-session");
+    expect(after.acquired).toBe(true);
+    if (after.acquired) await after.release();
+  });
+});

--- a/server/src/__tests__/plugin-job-scheduler-claim.test.ts
+++ b/server/src/__tests__/plugin-job-scheduler-claim.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Multi-replica dispatch tests for the plugin job scheduler.
+ *
+ * The scheduler's `tick()` loop runs on EVERY server replica. Without a
+ * DB-level guard, two replicas that tick concurrently both see the same due
+ * job (`status='active' AND next_run_at <= now`) and both dispatch it —
+ * duplicate webhooks / API calls from plugins.
+ *
+ * The fix under test: an atomic schedule-slot claim. Before dispatching,
+ * each replica CAS-advances `next_run_at` (`UPDATE ... WHERE id = $id AND
+ * next_run_at = $observed RETURNING id`). Exactly one replica's UPDATE
+ * matches; the others see zero rows and skip.
+ *
+ * These tests run two real scheduler instances against ONE embedded
+ * Postgres database (two separate connection pools) to reproduce the
+ * multi-replica race.
+ */
+
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { createDb, plugins, pluginJobs, pluginJobRuns, type Db } from "@paperclipai/db";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import type { EmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+import { createPluginJobScheduler } from "../services/plugin-job-scheduler.js";
+import { pluginJobStore } from "../services/plugin-job-store.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+
+const support = await getEmbeddedPostgresTestSupport();
+const describeEmbedded = support.supported ? describe : describe.skip;
+
+/**
+ * Minimal worker-manager stub: every plugin "runs", and `runJob` RPCs
+ * succeed after a short delay. The delay keeps both replicas' dispatches
+ * in flight at the same time so the race is exercised deterministically.
+ */
+function stubWorkerManager(callDelayMs = 50): PluginWorkerManager {
+  return {
+    isRunning: () => true,
+    call: async () => {
+      await new Promise((resolve) => setTimeout(resolve, callDelayMs));
+      return {};
+    },
+  } as unknown as PluginWorkerManager;
+}
+
+function testManifest(pluginKey: string): PaperclipPluginManifestV1 {
+  return {
+    id: pluginKey,
+    apiVersion: 1,
+    version: "1.0.0",
+    displayName: "Claim Test",
+    description: "Exercises the scheduler's atomic schedule-slot claim.",
+    author: "Paperclip",
+    categories: ["automation"],
+    capabilities: ["jobs.schedule"],
+    entrypoints: { worker: "./dist/worker.js" },
+  } as PaperclipPluginManifestV1;
+}
+
+describeEmbedded("plugin job scheduler — atomic schedule-slot claim", () => {
+  let tempDb: EmbeddedPostgresTestDatabase | null = null;
+  let dbA: Db;
+  let dbB: Db;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-job-claim-");
+    dbA = createDb(tempDb.connectionString);
+    dbB = createDb(tempDb.connectionString);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /** Seed one plugin + one active job whose nextRunAt is in the past. */
+  async function seedDueJob(): Promise<{ jobId: string; seededNextRunAt: Date }> {
+    const pluginId = randomUUID();
+    const pluginKey = `paperclip.claimtest-${pluginId.slice(0, 8)}`;
+    await dbA.insert(plugins).values({
+      id: pluginId,
+      pluginKey,
+      packageName: pluginKey,
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: testManifest(pluginKey),
+      status: "installed",
+      installOrder: 1,
+    });
+
+    const jobId = randomUUID();
+    const seededNextRunAt = new Date(Date.now() - 60_000);
+    await dbA.insert(pluginJobs).values({
+      id: jobId,
+      pluginId,
+      jobKey: "claim-test",
+      schedule: "* * * * *",
+      status: "active",
+      nextRunAt: seededNextRunAt,
+    });
+
+    return { jobId, seededNextRunAt };
+  }
+
+  it("dispatches exactly once when two replicas tick concurrently", async () => {
+    const { jobId, seededNextRunAt } = await seedDueJob();
+
+    const replicaA = createPluginJobScheduler({
+      db: dbA,
+      jobStore: pluginJobStore(dbA),
+      workerManager: stubWorkerManager(),
+    });
+    const replicaB = createPluginJobScheduler({
+      db: dbB,
+      jobStore: pluginJobStore(dbB),
+      workerManager: stubWorkerManager(),
+    });
+
+    await Promise.all([replicaA.tick(), replicaB.tick()]);
+
+    // Exactly ONE run row — the slot was claimed by exactly one replica.
+    const runs = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.trigger).toBe("schedule");
+    expect(runs[0]!.status).toBe("succeeded");
+
+    // The schedule pointer advanced past the seeded (due) value.
+    const [after] = await dbA
+      .select()
+      .from(pluginJobs)
+      .where(eq(pluginJobs.id, jobId));
+    expect(after!.nextRunAt).not.toBeNull();
+    expect(after!.nextRunAt!.getTime()).toBeGreaterThan(seededNextRunAt.getTime());
+    expect(after!.lastRunAt).not.toBeNull();
+  });
+
+  it("still dispatches normally with a single replica", async () => {
+    const { jobId, seededNextRunAt } = await seedDueJob();
+
+    const scheduler = createPluginJobScheduler({
+      db: dbA,
+      jobStore: pluginJobStore(dbA),
+      workerManager: stubWorkerManager(10),
+    });
+
+    await scheduler.tick();
+
+    const runs = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.status).toBe("succeeded");
+
+    const [after] = await dbA
+      .select()
+      .from(pluginJobs)
+      .where(eq(pluginJobs.id, jobId));
+    expect(after!.nextRunAt!.getTime()).toBeGreaterThan(seededNextRunAt.getTime());
+  });
+});

--- a/server/src/__tests__/plugin-job-scheduler-claim.test.ts
+++ b/server/src/__tests__/plugin-job-scheduler-claim.test.ts
@@ -18,7 +18,7 @@
 
 import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { createDb, plugins, pluginJobs, pluginJobRuns, type Db } from "@paperclipai/db";
 import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
 import {
@@ -184,6 +184,68 @@ describeEmbedded("plugin job scheduler — atomic schedule-slot claim", () => {
       .from(pluginJobs)
       .where(eq(pluginJobs.id, jobId));
     expect(after!.nextRunAt!.getTime()).toBeGreaterThan(seededNextRunAt.getTime());
+  });
+
+  it("caps a single tick at maxConcurrentJobs and dispatches deferred jobs on a later tick", async () => {
+    // Seed maxConcurrentJobs + 2 due jobs. A single tick must dispatch at
+    // most maxConcurrentJobs of them; the rest stay due and are picked up
+    // by a later tick. This only works if dispatchJob marks the job active
+    // SYNCHRONOUSLY (before its first await) — tick's loop pushes unawaited
+    // dispatch promises and checks `activeJobs.size` between iterations.
+    const maxConcurrentJobs = 2;
+    const seeded = [
+      await seedDueJob(),
+      await seedDueJob(),
+      await seedDueJob(),
+      await seedDueJob(),
+    ];
+    const jobIds = seeded.map((s) => s.jobId);
+
+    // All runJob RPCs hang on one controllable promise so the first
+    // tick's dispatches are still in-flight when we count run rows.
+    const hangingCall = makeControllableCall();
+    const worker: PluginWorkerManager = {
+      isRunning: () => true,
+      call: async () => {
+        await hangingCall.promise;
+        return {};
+      },
+    } as unknown as PluginWorkerManager;
+
+    const scheduler = createPluginJobScheduler({
+      db: dbA,
+      jobStore: pluginJobStore(dbA),
+      workerManager: worker,
+      maxConcurrentJobs,
+    });
+
+    const tickPromise = scheduler.tick();
+
+    // Give the admitted dispatches time to claim slots and create run rows.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const runsDuring = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(inArray(pluginJobRuns.jobId, jobIds));
+    expect(runsDuring.length).toBeLessThanOrEqual(maxConcurrentJobs);
+    expect(runsDuring).toHaveLength(maxConcurrentJobs);
+
+    // Release the hanging calls; the first tick completes.
+    hangingCall.resolve();
+    await tickPromise;
+
+    // The deferred jobs are still due (their nextRunAt was never claimed),
+    // so a later tick dispatches them.
+    await scheduler.tick();
+
+    const runsAfter = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(inArray(pluginJobRuns.jobId, jobIds));
+    expect(runsAfter).toHaveLength(jobIds.length);
+    expect(runsAfter.every((r) => r.status === "succeeded")).toBe(true);
+    expect(new Set(runsAfter.map((r) => r.jobId)).size).toBe(jobIds.length);
   });
 
   it("blocks cross-replica overlap when run outlasts its cron period (bounded guard)", async () => {

--- a/server/src/__tests__/plugin-job-scheduler-claim.test.ts
+++ b/server/src/__tests__/plugin-job-scheduler-claim.test.ts
@@ -30,6 +30,25 @@ import { createPluginJobScheduler } from "../services/plugin-job-scheduler.js";
 import { pluginJobStore } from "../services/plugin-job-store.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
+// ---------------------------------------------------------------------------
+// Helpers for the hanging-call stub
+// ---------------------------------------------------------------------------
+
+interface ControllableCall {
+  /** Resolves the hanging RPC call, causing the scheduler to mark run succeeded. */
+  resolve: () => void;
+  /** The promise that the stub's call() returns — awaited by the scheduler. */
+  promise: Promise<void>;
+}
+
+function makeControllableCall(): ControllableCall {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { resolve, promise };
+}
+
 const support = await getEmbeddedPostgresTestSupport();
 const describeEmbedded = support.supported ? describe : describe.skip;
 
@@ -165,5 +184,100 @@ describeEmbedded("plugin job scheduler — atomic schedule-slot claim", () => {
       .from(pluginJobs)
       .where(eq(pluginJobs.id, jobId));
     expect(after!.nextRunAt!.getTime()).toBeGreaterThan(seededNextRunAt.getTime());
+  });
+
+  it("blocks cross-replica overlap when run outlasts its cron period (bounded guard)", async () => {
+    // Scenario: replica A claims the slot and starts a long-running job (RPC
+    // call hangs). Before A finishes, the cron period elapses — we simulate
+    // this by moving next_run_at back to the past. Replica B (fresh instance,
+    // empty activeJobs) ticks and wins the CAS for that second slot. The
+    // bounded running-run guard must make B skip the fire.
+    //
+    // After A's call resolves we move next_run_at to the past once more; B
+    // ticks again — now no running row exists, so B SHOULD dispatch (row #2).
+
+    const { jobId } = await seedDueJob();
+
+    // Controllable hanging call for replica A
+    const hangingCall = makeControllableCall();
+
+    const workerA: PluginWorkerManager = {
+      isRunning: () => true,
+      call: async () => {
+        await hangingCall.promise;
+        return {};
+      },
+    } as unknown as PluginWorkerManager;
+
+    const replicaA = createPluginJobScheduler({
+      db: dbA,
+      jobStore: pluginJobStore(dbA),
+      workerManager: workerA,
+    });
+
+    // Replica B uses a fast-succeeding stub (empty activeJobs, different instance)
+    const replicaB = createPluginJobScheduler({
+      db: dbB,
+      jobStore: pluginJobStore(dbB),
+      workerManager: stubWorkerManager(5),
+    });
+
+    // Start A's tick — it will hang waiting for the call to resolve.
+    const tickAPromise = replicaA.tick();
+
+    // Give A time to claim the slot, create the run, and call markRunning.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Confirm A created exactly one run and it is in running state.
+    const runsBeforeB = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId));
+    expect(runsBeforeB).toHaveLength(1);
+    expect(runsBeforeB[0]!.status).toBe("running");
+
+    // Simulate the cron period elapsing: push next_run_at back to the past.
+    await dbA
+      .update(pluginJobs)
+      .set({ nextRunAt: new Date(Date.now() - 60_000) })
+      .where(eq(pluginJobs.id, jobId));
+
+    // Replica B ticks — it will win the CAS (slot is due again) but the
+    // running-run guard should make it skip the fire.
+    await replicaB.tick();
+
+    // Still exactly one run row — B skipped.
+    const runsAfterB = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId));
+    expect(runsAfterB).toHaveLength(1);
+
+    // Now release A's hanging call; A completes and marks the run succeeded.
+    hangingCall.resolve();
+    await tickAPromise;
+
+    const runsAfterADone = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId));
+    expect(runsAfterADone).toHaveLength(1);
+    expect(runsAfterADone[0]!.status).toBe("succeeded");
+
+    // Simulate the cron period elapsing again, after A has finished.
+    await dbA
+      .update(pluginJobs)
+      .set({ nextRunAt: new Date(Date.now() - 60_000) })
+      .where(eq(pluginJobs.id, jobId));
+
+    // B ticks once more — no running row now, so it SHOULD dispatch row #2.
+    await replicaB.tick();
+
+    const runsFinal = await dbA
+      .select()
+      .from(pluginJobRuns)
+      .where(eq(pluginJobRuns.jobId, jobId));
+    expect(runsFinal).toHaveLength(2);
+    expect(runsFinal.every((r) => r.status === "succeeded")).toBe(true);
   });
 });

--- a/server/src/__tests__/plugin-webhook-dedup.test.ts
+++ b/server/src/__tests__/plugin-webhook-dedup.test.ts
@@ -130,10 +130,26 @@ function createWebhookDb() {
   const update = vi.fn(() => ({
     set: vi.fn((v: Record<string, unknown>) => ({
       where: vi.fn(() => {
-        if (activeRow && typeof v.status === "string") {
-          activeRow.status = v.status;
-        }
-        return Promise.resolve([]);
+        const applyUnconditional = () => {
+          if (activeRow && typeof v.status === "string") {
+            activeRow.status = v.status;
+          }
+          return [] as unknown[];
+        };
+        return {
+          // Conditional reset path (`WHERE … AND status = 'failed'
+          // RETURNING id`): matches only while the row is still failed.
+          returning: vi.fn(() => {
+            if (activeRow && activeRow.status === "failed" && typeof v.status === "string") {
+              activeRow.status = v.status;
+              return Promise.resolve([{ id: activeRow.id }]);
+            }
+            return Promise.resolve([]);
+          }),
+          // Unconditional status updates are awaited directly (thenable).
+          then: (onFulfilled: (value: unknown[]) => unknown, onRejected?: (err: unknown) => unknown) =>
+            Promise.resolve(applyUnconditional()).then(onFulfilled, onRejected),
+        };
       }),
     })),
   }));

--- a/server/src/__tests__/plugin-webhook-dedup.test.ts
+++ b/server/src/__tests__/plugin-webhook-dedup.test.ts
@@ -77,10 +77,18 @@ const readyPlugin = {
  * triples; when an insert carries a non-null externalId AND uses
  * `onConflictDoNothing()`, a repeat triple yields an empty `returning` —
  * exactly what Postgres does with the partial unique index in place.
+ *
+ * It also tracks per-row `status` so the route's duplicate handling can
+ * distinguish failed deliveries (retried) from pending/successful ones
+ * (acknowledged as duplicates): `update().set({status})` is applied to the
+ * row last touched by insert, and `select()` resolves to the row matching
+ * the most recent conflicting insert's idempotency triple.
  */
 function createWebhookDb() {
-  const seen = new Set<string>();
+  const rowsByKey = new Map<string, { id: string; status: string }>();
   const insertedValues: Array<Record<string, unknown>> = [];
+  let lastConflictKey: string | null = null;
+  let activeRow: { id: string; status: string } | null = null;
 
   const insert = vi.fn(() => {
     let values: Record<string, unknown> = {};
@@ -99,22 +107,49 @@ function createWebhookDb() {
         const externalId = values.externalId as string | null | undefined;
         if (onConflict && externalId != null) {
           const key = `${values.pluginId}:${values.webhookKey}:${externalId}`;
-          if (seen.has(key)) return Promise.resolve([]);
-          seen.add(key);
+          const existing = rowsByKey.get(key);
+          if (existing) {
+            lastConflictKey = key;
+            activeRow = existing;
+            return Promise.resolve([]);
+          }
+          lastConflictKey = null;
+          const row = { id: randomUUID(), status: "pending" };
+          rowsByKey.set(key, row);
+          activeRow = row;
+          return Promise.resolve([{ id: row.id }]);
         }
-        return Promise.resolve([{ id: randomUUID() }]);
+        lastConflictKey = null;
+        activeRow = { id: randomUUID(), status: "pending" };
+        return Promise.resolve([{ id: activeRow.id }]);
       },
     };
     return chain;
   });
 
   const update = vi.fn(() => ({
-    set: vi.fn(() => ({
-      where: vi.fn(() => Promise.resolve([])),
+    set: vi.fn((v: Record<string, unknown>) => ({
+      where: vi.fn(() => {
+        if (activeRow && typeof v.status === "string") {
+          activeRow.status = v.status;
+        }
+        return Promise.resolve([]);
+      }),
     })),
   }));
 
-  return { db: { insert, update }, insertedValues };
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(() => {
+          const row = lastConflictKey ? rowsByKey.get(lastConflictKey) : undefined;
+          return Promise.resolve(row ? [{ id: row.id, status: row.status }] : []);
+        }),
+      })),
+    })),
+  }));
+
+  return { db: { insert, update, select }, insertedValues };
 }
 
 async function createApp() {
@@ -196,6 +231,54 @@ describe("plugin webhook delivery dedup (route)", () => {
     expect(second.status).toBe(202);
     expect(second.body.status).toBe("duplicate");
     expect(handleWebhookCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-dispatches a delivery whose previous attempt failed (provider retry after 5xx)", async () => {
+    // First POST: the worker RPC rejects, the route records the delivery as
+    // failed and answers 502 — providers retry exactly then. The retry with
+    // the same idempotency id must NOT be swallowed as a duplicate: it must
+    // re-dispatch and reuse the existing delivery row.
+    const { app, handleWebhookCall } = await createApp();
+    handleWebhookCall.mockRejectedValueOnce(new Error("worker crashed"));
+    const url = `/api/plugins/${PLUGIN_ID}/webhooks/${ENDPOINT_KEY}`;
+    const payload = { action: "opened" };
+
+    const first = await request(app)
+      .post(url)
+      .set("x-github-delivery", "guid-retry-1")
+      .send(payload);
+    expect(first.status).toBe(502);
+    expect(first.body.status).toBe("failed");
+    expect(handleWebhookCall).toHaveBeenCalledTimes(1);
+
+    const second = await request(app)
+      .post(url)
+      .set("x-github-delivery", "guid-retry-1")
+      .send(payload);
+    expect(second.status).toBe(200);
+    expect(second.body.status).toBe("success");
+    expect(second.body.deliveryId).toBe(first.body.deliveryId);
+    expect(handleWebhookCall).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not treat x-request-id as an idempotency id (tracing header, proxy-propagated)", async () => {
+    const { app, handleWebhookCall, insertedValues } = await createApp();
+    const url = `/api/plugins/${PLUGIN_ID}/webhooks/${ENDPOINT_KEY}`;
+
+    const first = await request(app)
+      .post(url)
+      .set("x-request-id", "trace-1")
+      .send({ n: 1 });
+    const second = await request(app)
+      .post(url)
+      .set("x-request-id", "trace-1")
+      .send({ n: 2 });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(handleWebhookCall).toHaveBeenCalledTimes(2);
+    expect(insertedValues[0]).toMatchObject({ externalId: null });
+    expect(insertedValues[1]).toMatchObject({ externalId: null });
   });
 
   it("dispatches every delivery when no idempotency header is present", async () => {

--- a/server/src/__tests__/plugin-webhook-dedup.test.ts
+++ b/server/src/__tests__/plugin-webhook-dedup.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for inbound plugin-webhook delivery de-duplication.
+ *
+ * Providers (GitHub, Stripe, ...) and load balancers retry webhook POSTs.
+ * When the provider supplies an idempotency id (e.g. `x-github-delivery`),
+ * the host must record the delivery once and acknowledge retries without
+ * re-dispatching `handleWebhook` to the plugin worker.
+ *
+ * Two layers are covered here:
+ * 1. Route-level behavior via supertest with a fake db that simulates the
+ *    partial unique index (`onConflictDoNothing` returns no rows for a
+ *    duplicate non-null external id).
+ * 2. The real partial unique index against embedded Postgres (migration
+ *    0099), asserting `onConflictDoNothing` yields an empty `returning`
+ *    for duplicate (plugin_id, webhook_key, external_id) and that NULL
+ *    external ids are never deduplicated.
+ */
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDb, type Db } from "@paperclipai/db";
+import { plugins, pluginWebhookDeliveries } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import type { EmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
+
+const mockRegistry = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByKey: vi.fn(),
+  upsertConfig: vi.fn(),
+  getCompanySettings: vi.fn(),
+  upsertCompanySettings: vi.fn(),
+}));
+
+const mockLifecycle = vi.hoisted(() => ({
+  load: vi.fn(),
+  upgrade: vi.fn(),
+  unload: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+}));
+
+vi.mock("../services/plugin-registry.js", () => ({
+  pluginRegistryService: () => mockRegistry,
+}));
+
+vi.mock("../services/plugin-lifecycle.js", () => ({
+  pluginLifecycleManager: () => mockLifecycle,
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: vi.fn(),
+}));
+
+vi.mock("../services/live-events.js", () => ({
+  publishGlobalLiveEvent: vi.fn(),
+}));
+
+const PLUGIN_ID = "11111111-1111-4111-8111-111111111111";
+const ENDPOINT_KEY = "gh-events";
+
+const readyPlugin = {
+  id: PLUGIN_ID,
+  pluginKey: "acme.github",
+  status: "ready",
+  manifestJson: {
+    capabilities: ["webhooks.receive"],
+    webhooks: [{ endpointKey: ENDPOINT_KEY }],
+  },
+};
+
+/**
+ * Fake db for the route harness. Tracks (pluginId, webhookKey, externalId)
+ * triples; when an insert carries a non-null externalId AND uses
+ * `onConflictDoNothing()`, a repeat triple yields an empty `returning` —
+ * exactly what Postgres does with the partial unique index in place.
+ */
+function createWebhookDb() {
+  const seen = new Set<string>();
+  const insertedValues: Array<Record<string, unknown>> = [];
+
+  const insert = vi.fn(() => {
+    let values: Record<string, unknown> = {};
+    let onConflict = false;
+    const chain = {
+      values(v: Record<string, unknown>) {
+        values = v;
+        insertedValues.push(v);
+        return chain;
+      },
+      onConflictDoNothing() {
+        onConflict = true;
+        return chain;
+      },
+      returning() {
+        const externalId = values.externalId as string | null | undefined;
+        if (onConflict && externalId != null) {
+          const key = `${values.pluginId}:${values.webhookKey}:${externalId}`;
+          if (seen.has(key)) return Promise.resolve([]);
+          seen.add(key);
+        }
+        return Promise.resolve([{ id: randomUUID() }]);
+      },
+    };
+    return chain;
+  });
+
+  const update = vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve([])),
+    })),
+  }));
+
+  return { db: { insert, update }, insertedValues };
+}
+
+async function createApp() {
+  const { pluginRoutes } = await import("../routes/plugins.js");
+  const { errorHandler } = await import("../middleware/index.js");
+
+  const { db, insertedValues } = createWebhookDb();
+  const handleWebhookCall = vi.fn(async () => ({}));
+  const webhookDeps = { workerManager: { call: handleWebhookCall } };
+  const loader = { installPlugin: vi.fn() };
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/api",
+    pluginRoutes(
+      db as never,
+      loader as never,
+      undefined,
+      webhookDeps as never,
+      undefined,
+      undefined,
+    ),
+  );
+  app.use(errorHandler);
+
+  return { app, handleWebhookCall, insertedValues };
+}
+
+describe("plugin webhook delivery dedup (route)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistry.getById.mockResolvedValue(readyPlugin);
+    mockRegistry.getByKey.mockResolvedValue(readyPlugin);
+  });
+
+  it("dispatches handleWebhook once for retries with the same provider idempotency id", async () => {
+    const { app, handleWebhookCall, insertedValues } = await createApp();
+    const url = `/api/plugins/${PLUGIN_ID}/webhooks/${ENDPOINT_KEY}`;
+    const payload = { action: "opened" };
+
+    const first = await request(app)
+      .post(url)
+      .set("x-github-delivery", "guid-1")
+      .send(payload);
+    expect(first.status).toBe(200);
+    expect(first.body.status).toBe("success");
+    expect(handleWebhookCall).toHaveBeenCalledTimes(1);
+    expect(handleWebhookCall).toHaveBeenCalledWith(
+      PLUGIN_ID,
+      "handleWebhook",
+      expect.objectContaining({ endpointKey: ENDPOINT_KEY }),
+    );
+    expect(insertedValues[0]).toMatchObject({ externalId: "guid-1" });
+
+    const second = await request(app)
+      .post(url)
+      .set("x-github-delivery", "guid-1")
+      .send(payload);
+    expect(second.status).toBe(202);
+    expect(second.body.status).toBe("duplicate");
+    expect(handleWebhookCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognizes alternate idempotency headers (idempotency-key)", async () => {
+    const { app, handleWebhookCall } = await createApp();
+    const url = `/api/plugins/${PLUGIN_ID}/webhooks/${ENDPOINT_KEY}`;
+
+    const first = await request(app)
+      .post(url)
+      .set("idempotency-key", "idem-1")
+      .send({});
+    expect(first.status).toBe(200);
+
+    const second = await request(app)
+      .post(url)
+      .set("idempotency-key", "idem-1")
+      .send({});
+    expect(second.status).toBe(202);
+    expect(second.body.status).toBe("duplicate");
+    expect(handleWebhookCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches every delivery when no idempotency header is present", async () => {
+    const { app, handleWebhookCall, insertedValues } = await createApp();
+    const url = `/api/plugins/${PLUGIN_ID}/webhooks/${ENDPOINT_KEY}`;
+
+    const first = await request(app).post(url).send({ n: 1 });
+    const second = await request(app).post(url).send({ n: 1 });
+
+    expect(first.status).toBe(200);
+    expect(first.body.status).toBe("success");
+    expect(second.status).toBe(200);
+    expect(second.body.status).toBe("success");
+    expect(handleWebhookCall).toHaveBeenCalledTimes(2);
+    expect(insertedValues).toHaveLength(2);
+    expect(insertedValues[0]).toMatchObject({ externalId: null });
+    expect(insertedValues[1]).toMatchObject({ externalId: null });
+  });
+});
+
+const support = await getEmbeddedPostgresTestSupport();
+const describeEmbedded = support.supported ? describe : describe.skip;
+
+describeEmbedded("plugin webhook delivery dedup (partial unique index)", () => {
+  let tempDb: EmbeddedPostgresTestDatabase | null = null;
+  let db: Db;
+  let pluginId = "";
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-webhook-dedup-");
+    db = createDb(tempDb.connectionString);
+    const [plugin] = await db
+      .insert(plugins)
+      .values({
+        pluginKey: "acme.github",
+        packageName: "@acme/github",
+        version: "1.0.0",
+        manifestJson: {
+          capabilities: ["webhooks.receive"],
+          webhooks: [{ endpointKey: ENDPOINT_KEY }],
+        } as never,
+        status: "ready",
+      })
+      .returning({ id: plugins.id });
+    pluginId = plugin.id;
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function insertDelivery(externalId: string | null, webhookKey = ENDPOINT_KEY) {
+    return db
+      .insert(pluginWebhookDeliveries)
+      .values({
+        pluginId,
+        webhookKey,
+        externalId,
+        status: "pending",
+        payload: {},
+        headers: {},
+      })
+      .onConflictDoNothing()
+      .returning({ id: pluginWebhookDeliveries.id });
+  }
+
+  it("returns no rows for a duplicate (plugin_id, webhook_key, external_id)", async () => {
+    const first = await insertDelivery("dup-guid-1");
+    expect(first).toHaveLength(1);
+
+    const second = await insertDelivery("dup-guid-1");
+    expect(second).toHaveLength(0);
+  });
+
+  it("allows the same external_id on a different webhook key", async () => {
+    const first = await insertDelivery("shared-guid", "gh-events-a");
+    const second = await insertDelivery("shared-guid", "gh-events-b");
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+  });
+
+  it("never deduplicates NULL external ids", async () => {
+    const first = await insertDelivery(null);
+    const second = await insertDelivery(null);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -603,7 +603,17 @@ export async function startServer(): Promise<StartedServer> {
     }
 
     databaseBackupInFlight = true;
-    const lock = await trySessionAdvisoryLock(activeDatabaseConnectionString, "database-backup");
+    // Acquire the cross-replica lock under an explicit catch: the main
+    // try/finally (which resets the flag) only starts below, so a throwing
+    // acquisition (e.g. connection failure) must reset the flag here or it
+    // would leak `true` and block all future backups on this replica.
+    let lock: Awaited<ReturnType<typeof trySessionAdvisoryLock>>;
+    try {
+      lock = await trySessionAdvisoryLock(activeDatabaseConnectionString, "database-backup");
+    } catch (err) {
+      databaseBackupInFlight = false;
+      throw err;
+    }
     if (!lock.acquired) {
       databaseBackupInFlight = false;
       const message = "Database backup already in progress on another replica";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -57,6 +57,7 @@ import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
+import { trySessionAdvisoryLock, withAdvisoryXactLock } from "./services/advisory-locks.js";
 import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
@@ -246,13 +247,21 @@ export async function startServer(): Promise<StartedServer> {
   const LOCAL_BOARD_USER_NAME = "Board";
   
   async function ensureLocalTrustedBoardPrincipal(db: any): Promise<void> {
+    // N replicas boot concurrently in local_trusted mode; the check-then-insert
+    // sequences below race without cross-replica mutual exclusion.
+    await withAdvisoryXactLock(db, "local-board-bootstrap", async () => {
+      await ensureLocalTrustedBoardPrincipalLocked(db);
+    });
+  }
+
+  async function ensureLocalTrustedBoardPrincipalLocked(db: any): Promise<void> {
     const now = new Date();
     const existingUser = await db
       .select({ id: authUsers.id })
       .from(authUsers)
       .where(eq(authUsers.id, LOCAL_BOARD_USER_ID))
       .then((rows: Array<{ id: string }>) => rows[0] ?? null);
-  
+
     if (!existingUser) {
       await db.insert(authUsers).values({
         id: LOCAL_BOARD_USER_ID,
@@ -264,7 +273,7 @@ export async function startServer(): Promise<StartedServer> {
         updatedAt: now,
       });
     }
-  
+
     const role = await db
       .select({ id: instanceUserRoles.id })
       .from(instanceUserRoles)
@@ -276,7 +285,7 @@ export async function startServer(): Promise<StartedServer> {
         role: "instance_admin",
       });
     }
-  
+
     const companyRows = await db.select({ id: companies.id }).from(companies);
     for (const company of companyRows) {
       const membership = await db
@@ -594,6 +603,16 @@ export async function startServer(): Promise<StartedServer> {
     }
 
     databaseBackupInFlight = true;
+    const lock = await trySessionAdvisoryLock(activeDatabaseConnectionString, "database-backup");
+    if (!lock.acquired) {
+      databaseBackupInFlight = false;
+      const message = "Database backup already in progress on another replica";
+      if (trigger === "scheduled") {
+        logger.warn("Skipping scheduled database backup because another replica is backing up");
+        return null;
+      }
+      throw conflict(message);
+    }
     const startedAt = new Date();
     const startedAtMs = Date.now();
     const label = trigger === "scheduled" ? "Automatic" : "Manual";
@@ -636,6 +655,7 @@ export async function startServer(): Promise<StartedServer> {
       logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
       throw err;
     } finally {
+      await lock.release().catch(() => {});
       databaseBackupInFlight = false;
     }
   };

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -2487,6 +2487,14 @@ export function pluginRoutes(
    * verification is the plugin's responsibility.
    *
    * Response: `{ deliveryId: string, status: string }`
+   *
+   * Deliveries carrying a recognized provider idempotency header are
+   * deduplicated: a retry of a pending or successful delivery is answered
+   * `202 { status: "duplicate", requestId }` (no `deliveryId`) without
+   * re-dispatching to the worker. A retry of a FAILED delivery (the
+   * provider retries exactly because we answered 5xx) resets the existing
+   * row to pending and re-dispatches, reusing its delivery id.
+   *
    * Errors:
    * - 404 if plugin not found or endpointKey not declared
    * - 400 if plugin is not in ready state or lacks webhooks.receive capability
@@ -2563,10 +2571,13 @@ export function pluginRoutes(
 
     // Provider-supplied idempotency id, when present. Covers provider and
     // load-balancer retries without guessing: no recognized header, no dedup.
+    // `x-request-id` is deliberately NOT in this chain — this codebase treats
+    // it as a tracing/correlation header (see sanitizePluginRequestHeaders),
+    // and proxies propagate one id across distinct calls, so keying dedup on
+    // it would swallow different events.
     const externalId =
       rawHeaders["x-github-delivery"] ??
       rawHeaders["x-delivery-id"] ??
-      rawHeaders["x-request-id"] ??
       rawHeaders["idempotency-key"] ??
       rawHeaders["x-idempotency-key"] ??
       null;
@@ -2589,12 +2600,47 @@ export function pluginRoutes(
       .onConflictDoNothing()
       .returning({ id: pluginWebhookDeliveries.id });
 
-    const delivery = inserted[0];
+    let delivery = inserted[0];
     if (!delivery) {
-      // Duplicate delivery (same provider idempotency id): acknowledge
-      // without re-dispatching to the worker.
-      res.status(202).json({ status: "duplicate", requestId });
-      return;
+      // Duplicate delivery (same provider idempotency id). Invariant:
+      // duplicates of pending/successful deliveries are acknowledged
+      // without re-dispatch; FAILED deliveries are retried. A failed
+      // delivery was answered with a 5xx, which is exactly when providers
+      // retry — swallowing that retry would lose the event forever.
+      const [existing] = externalId === null
+        ? []
+        : await db
+            .select({
+              id: pluginWebhookDeliveries.id,
+              status: pluginWebhookDeliveries.status,
+            })
+            .from(pluginWebhookDeliveries)
+            .where(
+              and(
+                eq(pluginWebhookDeliveries.pluginId, plugin.id),
+                eq(pluginWebhookDeliveries.webhookKey, endpointKey),
+                eq(pluginWebhookDeliveries.externalId, externalId),
+              ),
+            )
+            .limit(1);
+
+      if (!existing || existing.status !== "failed") {
+        res.status(202).json({ status: "duplicate", requestId });
+        return;
+      }
+
+      // Reset the failed row and fall through to the normal dispatch path,
+      // reusing its id as the delivery id.
+      await db
+        .update(pluginWebhookDeliveries)
+        .set({
+          status: "pending",
+          startedAt,
+          error: null,
+          finishedAt: null,
+        })
+        .where(eq(pluginWebhookDeliveries.id, existing.id));
+      delivery = { id: existing.id };
     }
 
     // Step 7: Dispatch to the worker via handleWebhook RPC

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -2630,8 +2630,11 @@ export function pluginRoutes(
       }
 
       // Reset the failed row and fall through to the normal dispatch path,
-      // reusing its id as the delivery id.
-      await db
+      // reusing its id as the delivery id. The reset is a conditional
+      // UPDATE: two replicas can race the same retry here, and only the
+      // one whose UPDATE matched the failed status may dispatch — the
+      // loser answers duplicate.
+      const reset = await db
         .update(pluginWebhookDeliveries)
         .set({
           status: "pending",
@@ -2639,7 +2642,17 @@ export function pluginRoutes(
           error: null,
           finishedAt: null,
         })
-        .where(eq(pluginWebhookDeliveries.id, existing.id));
+        .where(
+          and(
+            eq(pluginWebhookDeliveries.id, existing.id),
+            eq(pluginWebhookDeliveries.status, "failed"),
+          ),
+        )
+        .returning({ id: pluginWebhookDeliveries.id });
+      if (reset.length === 0) {
+        res.status(202).json({ status: "duplicate", requestId });
+        return;
+      }
       delivery = { id: existing.id };
     }
 

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -2561,19 +2561,41 @@ export function pluginRoutes(
     const parsedBody = req.body as unknown;
     const payload = (req.body as Record<string, unknown> | undefined) ?? {};
 
-    // Step 6: Record the delivery in the database
+    // Provider-supplied idempotency id, when present. Covers provider and
+    // load-balancer retries without guessing: no recognized header, no dedup.
+    const externalId =
+      rawHeaders["x-github-delivery"] ??
+      rawHeaders["x-delivery-id"] ??
+      rawHeaders["x-request-id"] ??
+      rawHeaders["idempotency-key"] ??
+      rawHeaders["x-idempotency-key"] ??
+      null;
+
+    // Step 6: Record the delivery in the database. The partial unique index
+    // on (plugin_id, webhook_key, external_id) makes retried deliveries with
+    // the same provider idempotency id a no-op insert (empty `returning`).
     const startedAt = new Date();
-    const [delivery] = await db
+    const inserted = await db
       .insert(pluginWebhookDeliveries)
       .values({
         pluginId: plugin.id,
         webhookKey: endpointKey,
+        externalId,
         status: "pending",
         payload,
         headers: rawHeaders,
         startedAt,
       })
+      .onConflictDoNothing()
       .returning({ id: pluginWebhookDeliveries.id });
+
+    const delivery = inserted[0];
+    if (!delivery) {
+      // Duplicate delivery (same provider idempotency id): acknowledge
+      // without re-dispatching to the worker.
+      res.status(202).json({ status: "duplicate", requestId });
+      return;
+    }
 
     // Step 7: Dispatch to the worker via handleWebhook RPC
     try {

--- a/server/src/services/advisory-locks.ts
+++ b/server/src/services/advisory-locks.ts
@@ -11,6 +11,7 @@ import type { Db } from "@paperclipai/db";
  * bounded by max_locks_per_transaction * max_connections) — lock names are
  * coordination points (a handful), never per-row keys.
  */
+// Keep in sync with PAPERCLIP_LOCK_NAMESPACE in packages/db/src/client.ts.
 const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
 
 /**

--- a/server/src/services/advisory-locks.ts
+++ b/server/src/services/advisory-locks.ts
@@ -7,9 +7,16 @@ import type { Db } from "@paperclipai/db";
  * tool that uses advisory locks (Rails migrations, job queues, …). The
  * two-int form with a fixed application namespace partitions Paperclip's
  * locks away from them, and `hashtext` collisions then require both ints
- * to match. Key cardinality must stay low (locks live in shared memory,
- * bounded by max_locks_per_transaction * max_connections) — lock names are
- * coordination points (a handful), never per-row keys.
+ * to match.
+ *
+ * Shared-memory footprint is bounded by locks HELD CONCURRENTLY (capped by
+ * max_locks_per_transaction * max_connections), not by the space of names:
+ * a transaction-scoped lock exists only while its transaction is open, and
+ * open transactions are bounded by the connection pool. Per-entity names
+ * (e.g. one per agent or company) are therefore fine for xact-scoped locks;
+ * what must stay bounded is the number of locks held at once — never take
+ * advisory locks in unbounded batches, and keep session-scoped locks
+ * (which outlive transactions) to a fixed handful.
  */
 // Keep in sync with PAPERCLIP_LOCK_NAMESPACE in packages/db/src/client.ts.
 const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
@@ -21,24 +28,33 @@ const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
  * the lock releases on commit OR rollback, with no manual unlock to lose.
  *
  * The transaction (and therefore one pooled connection) stays open for the
- * duration of `fn` — keep critical sections short; long-running work
- * (backups, migrations) belongs on `trySessionAdvisoryLock` instead.
+ * duration of `fn` — long-running callbacks hold that pooled connection for
+ * their entire duration, so keep critical sections bounded; at call sites
+ * where the protected work is heavier (e.g. skill refresh), state the bound
+ * in a comment. Truly long-running work (backups, migrations) belongs on
+ * `trySessionAdvisoryLock` instead.
+ *
+ * `fn` deliberately receives nothing: the lock's transaction is a mutex
+ * side-channel only, and the work inside `fn` runs its DB operations on the
+ * outer pool (its own connections), not inside the lock's transaction.
  */
-export async function withAdvisoryXactLock<T>(db: Db, name: string, fn: (tx: unknown) => Promise<T>): Promise<T> {
+export async function withAdvisoryXactLock<T>(db: Db, name: string, fn: () => Promise<T>): Promise<T> {
   return await db.transaction(async (tx) => {
     await tx.execute(sql`SELECT pg_advisory_xact_lock(${PAPERCLIP_LOCK_NAMESPACE}, hashtext(${name}))`);
-    return await fn(tx);
+    return await fn();
   });
 }
 
 /**
  * Non-blocking variant: if the lock is held elsewhere, returns
- * `{ acquired: false }` without running `fn`.
+ * `{ acquired: false }` without running `fn`. Like `withAdvisoryXactLock`,
+ * `fn` runs its DB work on the outer pool — the lock transaction is only a
+ * mutex side-channel.
  */
 export async function tryAdvisoryXactLock<T>(
   db: Db,
   name: string,
-  fn: (tx: unknown) => Promise<T>,
+  fn: () => Promise<T>,
 ): Promise<{ acquired: false } | { acquired: true; result: T }> {
   return await db.transaction(async (tx) => {
     const rows = await tx.execute(
@@ -46,7 +62,7 @@ export async function tryAdvisoryXactLock<T>(
     );
     const acquired = Boolean((rows as unknown as Array<{ acquired: boolean }>)[0]?.acquired);
     if (!acquired) return { acquired: false } as const;
-    return { acquired: true, result: await fn(tx) } as const;
+    return { acquired: true, result: await fn() } as const;
   });
 }
 

--- a/server/src/services/advisory-locks.ts
+++ b/server/src/services/advisory-locks.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { postgres } from "@paperclipai/db";
+import { PAPERCLIP_LOCK_NAMESPACE, postgres } from "@paperclipai/db";
 import type { Db } from "@paperclipai/db";
 
 /**
@@ -18,8 +18,6 @@ import type { Db } from "@paperclipai/db";
  * advisory locks in unbounded batches, and keep session-scoped locks
  * (which outlive transactions) to a fixed handful.
  */
-// Keep in sync with PAPERCLIP_LOCK_NAMESPACE in packages/db/src/client.ts.
-const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
 
 /**
  * Run `fn` inside a transaction holding `pg_advisory_xact_lock` on the

--- a/server/src/services/advisory-locks.ts
+++ b/server/src/services/advisory-locks.ts
@@ -43,7 +43,7 @@ export async function tryAdvisoryXactLock<T>(
     const rows = await tx.execute(
       sql`SELECT pg_try_advisory_xact_lock(${PAPERCLIP_LOCK_NAMESPACE}, hashtext(${name})) AS acquired`,
     );
-    const acquired = Boolean((rows as Array<{ acquired: boolean }>)[0]?.acquired);
+    const acquired = Boolean((rows as unknown as Array<{ acquired: boolean }>)[0]?.acquired);
     if (!acquired) return { acquired: false } as const;
     return { acquired: true, result: await fn(tx) } as const;
   });

--- a/server/src/services/advisory-locks.ts
+++ b/server/src/services/advisory-locks.ts
@@ -1,0 +1,83 @@
+import { sql } from "drizzle-orm";
+import { postgres } from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
+
+/**
+ * Advisory-lock keyspace is global per database and shared with every other
+ * tool that uses advisory locks (Rails migrations, job queues, …). The
+ * two-int form with a fixed application namespace partitions Paperclip's
+ * locks away from them, and `hashtext` collisions then require both ints
+ * to match. Key cardinality must stay low (locks live in shared memory,
+ * bounded by max_locks_per_transaction * max_connections) — lock names are
+ * coordination points (a handful), never per-row keys.
+ */
+const PAPERCLIP_LOCK_NAMESPACE = 0x70_63_6c_70; // "pclp"
+
+/**
+ * Run `fn` inside a transaction holding `pg_advisory_xact_lock` on the
+ * namespaced key. Blocks until the lock is granted. Transaction scope makes
+ * this safe under transaction-pooling poolers (PgBouncer) and leak-proof:
+ * the lock releases on commit OR rollback, with no manual unlock to lose.
+ *
+ * The transaction (and therefore one pooled connection) stays open for the
+ * duration of `fn` — keep critical sections short; long-running work
+ * (backups, migrations) belongs on `trySessionAdvisoryLock` instead.
+ */
+export async function withAdvisoryXactLock<T>(db: Db, name: string, fn: (tx: unknown) => Promise<T>): Promise<T> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(${PAPERCLIP_LOCK_NAMESPACE}, hashtext(${name}))`);
+    return await fn(tx);
+  });
+}
+
+/**
+ * Non-blocking variant: if the lock is held elsewhere, returns
+ * `{ acquired: false }` without running `fn`.
+ */
+export async function tryAdvisoryXactLock<T>(
+  db: Db,
+  name: string,
+  fn: (tx: unknown) => Promise<T>,
+): Promise<{ acquired: false } | { acquired: true; result: T }> {
+  return await db.transaction(async (tx) => {
+    const rows = await tx.execute(
+      sql`SELECT pg_try_advisory_xact_lock(${PAPERCLIP_LOCK_NAMESPACE}, hashtext(${name})) AS acquired`,
+    );
+    const acquired = Boolean((rows as Array<{ acquired: boolean }>)[0]?.acquired);
+    if (!acquired) return { acquired: false } as const;
+    return { acquired: true, result: await fn(tx) } as const;
+  });
+}
+
+/**
+ * Session-scoped lock on a DEDICATED direct connection, for operations that
+ * span multiple transactions or run external processes (migrations,
+ * pg_dump backups). The lock lives exactly as long as the connection:
+ * `release()` ends the connection (guaranteed release), and a crashed
+ * process releases implicitly when Postgres drops the socket.
+ *
+ * Caveat (documented, deliberate): session locks do not survive
+ * transaction-pooling poolers — this helper always dials the URL directly.
+ */
+export async function trySessionAdvisoryLock(
+  connectionString: string,
+  name: string,
+): Promise<{ acquired: false } | { acquired: true; release: () => Promise<void> }> {
+  const lockSql = postgres(connectionString, { max: 1, onnotice: () => {} });
+  try {
+    const rows = await lockSql`SELECT pg_try_advisory_lock(${PAPERCLIP_LOCK_NAMESPACE}, hashtext(${name})) AS acquired`;
+    if (!rows[0]?.acquired) {
+      await lockSql.end({ timeout: 5 });
+      return { acquired: false };
+    }
+    return {
+      acquired: true,
+      release: async () => {
+        await lockSql.end({ timeout: 5 });
+      },
+    };
+  } catch (err) {
+    await lockSql.end({ timeout: 5 }).catch(() => {});
+    throw err;
+  }
+}

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -48,6 +48,7 @@ import type {
 import { normalizeAgentUrlKey } from "@paperclipai/shared";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { withAdvisoryXactLock } from "./advisory-locks.js";
 import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import { agentService } from "./agents.js";
 import { projectService } from "./projects.js";
@@ -2326,7 +2327,11 @@ export function companySkillService(db: Db) {
       return;
     }
 
-    const refreshPromise = (async () => {
+    // Cross-replica: serialize concurrent refreshes of the same company so the
+    // ensure/reconcile writes don't interleave. A second replica blocks, then
+    // re-runs the idempotent refresh — duplicate work, never corrupted state.
+    // The in-process map above still dedupes callers within this process.
+    const refreshPromise = withAdvisoryXactLock(db, `skill-refresh:${companyId}`, async () => {
       const companyExists = await db
         .select({ id: companies.id })
         .from(companies)
@@ -2337,7 +2342,7 @@ export function companySkillService(db: Db) {
       }
       await ensureBundledSkills(companyId);
       await reconcileLocalPathSkillSources(companyId);
-    })();
+    });
 
     skillInventoryRefreshPromises.set(companyId, refreshPromise);
     try {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2331,6 +2331,12 @@ export function companySkillService(db: Db) {
     // ensure/reconcile writes don't interleave. A second replica blocks, then
     // re-runs the idempotent refresh — duplicate work, never corrupted state.
     // The in-process map above still dedupes callers within this process.
+    //
+    // Held-lock bound (see advisory-locks.ts): refreshes are operator-
+    // triggered and rare, the work is FS+DB-bounded (no network calls), and
+    // per-company concurrency is additionally capped by the in-process
+    // single-flight map above — so the count of concurrently held
+    // skill-refresh locks stays far below the connection-pool size.
     const refreshPromise = withAdvisoryXactLock(db, `skill-refresh:${companyId}`, async () => {
       const companyExists = await db
         .select({ id: companies.id })

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7747,7 +7747,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return claimedRuns;
       });
       if (!outcome.acquired) {
-        logger.info({ agentId }, "agent start skipped; another replica holds the start lock");
+        logger.debug({ agentId }, "agent start skipped; another replica holds the start lock");
         return [];
       }
       return outcome.result;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -159,6 +159,7 @@ import {
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
+import { tryAdvisoryXactLock } from "./advisory-locks.js";
 import {
   evaluateAgentInvokability,
   evaluateAgentInvokabilityFromDb,
@@ -7665,79 +7666,91 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function startNextQueuedRunForAgent(agentId: string) {
     return withAgentStartLock(agentId, async () => {
-      const agent = await getAgent(agentId);
-      if (!agent) return [];
-      const invokability = await getAgentInvokability(agent);
-      if (!invokability.invokable) {
-        if (shouldCancelRunsForNonInvokableAgent(invokability)) {
-          await cancelActiveForAgentInternal(agentId, `Cancelled because the agent is not invokable: ${invokability.reason}`);
+      // Cross-replica: if another replica is concurrently starting runs for
+      // this agent, skip — its pass will start what fits, and the next
+      // heartbeat tick (or API retry) covers anything left queued. Skipping
+      // beats blocking here: this section claims runs and counts slots, and
+      // two replicas doing that concurrently overrun per-agent concurrency.
+      const outcome = await tryAdvisoryXactLock(db, `agent-start:${agentId}`, async () => {
+        const agent = await getAgent(agentId);
+        if (!agent) return [];
+        const invokability = await getAgentInvokability(agent);
+        if (!invokability.invokable) {
+          if (shouldCancelRunsForNonInvokableAgent(invokability)) {
+            await cancelActiveForAgentInternal(agentId, `Cancelled because the agent is not invokable: ${invokability.reason}`);
+          }
+          return [];
         }
+        const policy = parseHeartbeatPolicy(agent);
+        const runningCount = await countRunningRunsForAgent(agentId);
+        const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+        if (availableSlots <= 0) return [];
+
+        const queuedRuns = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        if (queuedRuns.length === 0) return [];
+
+        const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, queuedRuns);
+        const queuedIssueIds = [...new Set(
+          queuedRuns
+            .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
+            .filter((issueId): issueId is string => Boolean(issueId)),
+        )];
+        const issueRows = await db
+          .select({
+            id: issues.id,
+            status: issues.status,
+            priority: issues.priority,
+          })
+          .from(issues)
+          .where(
+            queuedIssueIds.length > 0
+              ? and(eq(issues.companyId, agent.companyId), inArray(issues.id, queuedIssueIds))
+              : sql`false`,
+          );
+        const issueById = new Map(issueRows.map((row) => [row.id, row]));
+        const companyAgents = await listCompanyAgentOrgRows(agent.companyId);
+        const prioritizedRuns = [...queuedRuns].sort((left, right) => {
+          const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
+          const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
+          const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
+          const rightReadiness = rightIssueId ? dependencyReadiness.get(rightIssueId) : null;
+          const leftReady = leftIssueId ? (leftReadiness?.isDependencyReady ?? true) : true;
+          const rightReady = rightIssueId ? (rightReadiness?.isDependencyReady ?? true) : true;
+          const leftIssue = leftIssueId ? issueById.get(leftIssueId) : null;
+          const rightIssue = rightIssueId ? issueById.get(rightIssueId) : null;
+          const leftRank = leftIssueId ? (leftReady ? (leftIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
+          const rightRank = rightIssueId ? (rightReady ? (rightIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
+          if (leftRank !== rightRank) return leftRank - rightRank;
+          const leftPriorityRank = issueRunPriorityRank(leftIssue?.priority);
+          const rightPriorityRank = issueRunPriorityRank(rightIssue?.priority);
+          if (leftPriorityRank !== rightPriorityRank) return leftPriorityRank - rightPriorityRank;
+          return left.createdAt.getTime() - right.createdAt.getTime();
+        });
+
+        const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
+        for (const queuedRun of prioritizedRuns) {
+          if (claimedRuns.length >= availableSlots) break;
+          const claimed = await claimQueuedRun(queuedRun, companyAgents);
+          if (claimed) claimedRuns.push(claimed);
+        }
+        if (claimedRuns.length === 0) return [];
+
+        for (const claimedRun of claimedRuns) {
+          void executeRun(claimedRun.id).catch((err) => {
+            logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
+          });
+        }
+        return claimedRuns;
+      });
+      if (!outcome.acquired) {
+        logger.info({ agentId }, "agent start skipped; another replica holds the start lock");
         return [];
       }
-      const policy = parseHeartbeatPolicy(agent);
-      const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
-      if (availableSlots <= 0) return [];
-
-      const queuedRuns = await db
-        .select()
-        .from(heartbeatRuns)
-        .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
-        .orderBy(asc(heartbeatRuns.createdAt));
-      if (queuedRuns.length === 0) return [];
-
-      const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, queuedRuns);
-      const queuedIssueIds = [...new Set(
-        queuedRuns
-          .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
-          .filter((issueId): issueId is string => Boolean(issueId)),
-      )];
-      const issueRows = await db
-        .select({
-          id: issues.id,
-          status: issues.status,
-          priority: issues.priority,
-        })
-        .from(issues)
-        .where(
-          queuedIssueIds.length > 0
-            ? and(eq(issues.companyId, agent.companyId), inArray(issues.id, queuedIssueIds))
-            : sql`false`,
-        );
-      const issueById = new Map(issueRows.map((row) => [row.id, row]));
-      const companyAgents = await listCompanyAgentOrgRows(agent.companyId);
-      const prioritizedRuns = [...queuedRuns].sort((left, right) => {
-        const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
-        const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
-        const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
-        const rightReadiness = rightIssueId ? dependencyReadiness.get(rightIssueId) : null;
-        const leftReady = leftIssueId ? (leftReadiness?.isDependencyReady ?? true) : true;
-        const rightReady = rightIssueId ? (rightReadiness?.isDependencyReady ?? true) : true;
-        const leftIssue = leftIssueId ? issueById.get(leftIssueId) : null;
-        const rightIssue = rightIssueId ? issueById.get(rightIssueId) : null;
-        const leftRank = leftIssueId ? (leftReady ? (leftIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        const rightRank = rightIssueId ? (rightReady ? (rightIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        if (leftRank !== rightRank) return leftRank - rightRank;
-        const leftPriorityRank = issueRunPriorityRank(leftIssue?.priority);
-        const rightPriorityRank = issueRunPriorityRank(rightIssue?.priority);
-        if (leftPriorityRank !== rightPriorityRank) return leftPriorityRank - rightPriorityRank;
-        return left.createdAt.getTime() - right.createdAt.getTime();
-      });
-
-      const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
-      for (const queuedRun of prioritizedRuns) {
-        if (claimedRuns.length >= availableSlots) break;
-        const claimed = await claimQueuedRun(queuedRun, companyAgents);
-        if (claimed) claimedRuns.push(claimed);
-      }
-      if (claimedRuns.length === 0) return [];
-
-      for (const claimedRun of claimedRuns) {
-        void executeRun(claimedRun.id).catch((err) => {
-          logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
-        });
-      }
-      return claimedRuns;
+      return outcome.result;
     });
   }
 

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -31,16 +31,16 @@
  *       elapses mid-execution. Rows older than the guard window are treated as
  *       crashed-replica leftovers and do not block scheduling.
  *
- * 3b. **Multi-replica dedup** — Scheduled dispatches claim the schedule slot
- *     atomically (compare-and-swap on `nextRunAt`) BEFORE creating the run,
- *     so when N replicas tick concurrently exactly one wins the CAS; the
- *     cross-replica guard (§3b above) then covers the long-run overlap case.
+ * 4. **Multi-replica dedup** — Scheduled dispatches claim the schedule slot
+ *    atomically (compare-and-swap on `nextRunAt`) BEFORE creating the run,
+ *    so when N replicas tick concurrently exactly one wins the CAS; the
+ *    cross-replica guard (§3.b) then covers the long-run overlap case.
  *
- * 4. **Job run recording** — Every execution creates a `plugin_job_runs` row:
+ * 5. **Job run recording** — Every execution creates a `plugin_job_runs` row:
  *    `queued` → `running` → `succeeded` | `failed`. Duration and error are
  *    captured.
  *
- * 5. **Lifecycle integration** — The scheduler exposes `registerPlugin()` and
+ * 6. **Lifecycle integration** — The scheduler exposes `registerPlugin()` and
  *    `unregisterPlugin()` so the host lifecycle manager can wire up job
  *    scheduling when plugins start/stop. On registration, the scheduler
  *    computes `nextRunAt` for all active jobs that don't already have one.
@@ -373,57 +373,83 @@ export function createPluginJobScheduler(
   async function dispatchJob(
     job: typeof pluginJobs.$inferSelect,
   ): Promise<void> {
-    const { id: jobId, pluginId, jobKey, schedule } = job;
+    const { id: jobId, pluginId, jobKey } = job;
     const jobLog = log.child({ jobId, pluginId, jobKey });
 
-    // Atomic schedule-slot claim: advance next_run_at iff it still has the
-    // value this tick observed. With N replicas ticking concurrently, exactly
-    // one UPDATE matches; the rest see zero rows and skip. This is the
-    // multi-instance guard — the in-process activeJobs Set only bounds local
-    // concurrency.
-    const nextRunAt = computeNextRunAt(job);
-    const claimed = await db
-      .update(pluginJobs)
-      .set({ nextRunAt, updatedAt: new Date() })
-      .where(
-        and(
-          eq(pluginJobs.id, jobId),
-          job.nextRunAt === null
-            ? isNull(pluginJobs.nextRunAt)
-            : eq(pluginJobs.nextRunAt, job.nextRunAt),
-        ),
-      )
-      .returning({ id: pluginJobs.id });
-
-    if (claimed.length === 0) {
-      jobLog.debug("job slot claimed elsewhere; skipping");
-      return;
-    }
-
-    // A run longer than its cron period leaves the job due again mid-run;
-    // the CAS above means exactly one replica claims that next slot, and this
-    // guard makes that claimant skip the fire instead of overlapping the
-    // still-running execution (same invariant the manual path enforces).
-    // Stale running rows (crashed replica) are ignored past the guard window
-    // so they cannot park the schedule forever.
-    const overlapCutoff = new Date(Date.now() - RUNNING_RUN_OVERLAP_GUARD_MS);
-    const runningRuns = await db
-      .select({ id: pluginJobRuns.id })
-      .from(pluginJobRuns)
-      .where(
-        and(
-          eq(pluginJobRuns.jobId, jobId),
-          eq(pluginJobRuns.status, "running"),
-          gt(pluginJobRuns.startedAt, overlapCutoff),
-        ),
-      );
-    if (runningRuns.length > 0) {
-      jobLog.debug("skipping scheduled fire — a run is still in progress (slot already advanced)");
-      return;
-    }
-
-    // Mark as active (overlap prevention)
+    // Mark as active FIRST and synchronously — before the first await.
+    // tick() pushes dispatch promises without awaiting them and relies on
+    // `activeJobs.size >= maxConcurrentJobs` between loop iterations, so the
+    // add must happen in the synchronous prefix of this function or a burst
+    // of due jobs would all dispatch before the counter ever moves. The
+    // matching delete lives in the outer finally so EVERY exit (claim lost,
+    // overlap skip, success, failure) releases the slot.
     activeJobs.add(jobId);
+
+    try {
+      // Atomic schedule-slot claim: advance next_run_at iff it still has the
+      // value this tick observed. With N replicas ticking concurrently, exactly
+      // one UPDATE matches; the rest see zero rows and skip. This is the
+      // multi-instance guard — the in-process activeJobs Set only bounds local
+      // concurrency.
+      const nextRunAt = computeNextRunAt(job);
+      const claimed = await db
+        .update(pluginJobs)
+        .set({ nextRunAt, updatedAt: new Date() })
+        .where(
+          and(
+            eq(pluginJobs.id, jobId),
+            job.nextRunAt === null
+              ? // Defensive: tick never selects null-nextRunAt rows (its
+                // lte(nextRunAt, now) predicate cannot match NULL), so this
+                // branch is unreachable from the tick loop.
+                isNull(pluginJobs.nextRunAt)
+              : eq(pluginJobs.nextRunAt, job.nextRunAt),
+          ),
+        )
+        .returning({ id: pluginJobs.id });
+
+      if (claimed.length === 0) {
+        jobLog.debug("job slot claimed elsewhere; skipping");
+        return;
+      }
+
+      // A run longer than its cron period leaves the job due again mid-run;
+      // the CAS above means exactly one replica claims that next slot, and this
+      // guard makes that claimant skip the fire instead of overlapping the
+      // still-running execution (same invariant the manual path enforces).
+      // Stale running rows (crashed replica) are ignored past the guard window
+      // so they cannot park the schedule forever.
+      const overlapCutoff = new Date(Date.now() - RUNNING_RUN_OVERLAP_GUARD_MS);
+      const runningRuns = await db
+        .select({ id: pluginJobRuns.id })
+        .from(pluginJobRuns)
+        .where(
+          and(
+            eq(pluginJobRuns.jobId, jobId),
+            eq(pluginJobRuns.status, "running"),
+            gt(pluginJobRuns.startedAt, overlapCutoff),
+          ),
+        );
+      if (runningRuns.length > 0) {
+        jobLog.debug("skipping scheduled fire — a run is still in progress (slot already advanced)");
+        return;
+      }
+
+      await executeClaimedRun(job);
+    } finally {
+      activeJobs.delete(jobId);
+    }
+  }
+
+  /**
+   * Execute a scheduled run after the slot claim and overlap guard have
+   * passed: create the run record, call the worker, record the result.
+   */
+  async function executeClaimedRun(
+    job: typeof pluginJobs.$inferSelect,
+  ): Promise<void> {
+    const { id: jobId, pluginId, jobKey } = job;
+    const jobLog = log.child({ jobId, pluginId, jobKey });
 
     let runId: string | undefined;
     const startedAt = Date.now();
@@ -493,12 +519,10 @@ export function createPluginJobScheduler(
         }
       }
     } finally {
-      // Remove from active set
-      activeJobs.delete(jobId);
-
       // 5. Record lastRunAt (even on failure). nextRunAt is NOT touched
       //    here — it was already advanced by the atomic claim above, and
       //    re-advancing it after the run would re-open the slot to races.
+      //    (activeJobs release happens in dispatchJob's finally.)
       try {
         await db
           .update(pluginJobs)

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -431,7 +431,12 @@ export function createPluginJobScheduler(
           ),
         );
       if (runningRuns.length > 0) {
-        jobLog.debug("skipping scheduled fire — a run is still in progress (slot already advanced)");
+        // warn, not debug: a recurring overlap means the job outlasts its cron
+        // period and fires are being dropped — operators should see that.
+        jobLog.warn(
+          { jobId, jobKey, pluginId, nextRunAt },
+          "scheduled fire skipped: previous run still in progress; slot advanced — recurring overlap means the job outlasts its cron period",
+        );
         return;
       }
 

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -3,9 +3,10 @@
  *
  * The scheduler is the central coordinator for all plugin cron jobs. It
  * periodically ticks (default every 30 seconds), queries the `plugin_jobs`
- * table for jobs whose `nextRunAt` has passed, dispatches `runJob` RPC calls
- * to the appropriate worker processes, records each execution in the
- * `plugin_job_runs` table, and advances the scheduling pointer.
+ * table for jobs whose `nextRunAt` has passed, atomically claims each due
+ * schedule slot (advancing `nextRunAt`), dispatches `runJob` RPC calls to
+ * the appropriate worker processes, and records each execution in the
+ * `plugin_job_runs` table.
  *
  * ## Responsibilities
  *
@@ -14,11 +15,15 @@
  *
  * 2. **Cron parsing & next-run calculation** — Uses the lightweight built-in
  *    cron parser ({@link parseCron}, {@link nextCronTick}) to compute the
- *    `nextRunAt` timestamp after each run or when a new job is registered.
+ *    `nextRunAt` timestamp when a slot is claimed or a new job is registered.
  *
  * 3. **Overlap prevention** — Before dispatching a job, the scheduler checks
  *    for an existing `running` run for the same job. If one exists, the job
  *    is skipped for that tick.
+ *
+ * 3b. **Multi-replica dedup** — Scheduled dispatches claim the schedule slot
+ *     atomically (compare-and-swap on `nextRunAt`) BEFORE creating the run,
+ *     so when N replicas tick concurrently exactly one dispatches the job.
  *
  * 4. **Job run recording** — Every execution creates a `plugin_job_runs` row:
  *    `queued` → `running` → `succeeded` | `failed`. Duration and error are
@@ -34,7 +39,7 @@
  * @see ./cron.ts — Cron parsing utilities
  */
 
-import { and, eq, lte, or } from "drizzle-orm";
+import { and, eq, isNull, lte, or } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { pluginJobs, pluginJobRuns } from "@paperclipai/db";
 import type { PluginJobStore } from "./plugin-job-store.js";
@@ -337,14 +342,42 @@ export function createPluginJobScheduler(
   // -----------------------------------------------------------------------
 
   /**
-   * Dispatch a single job run — create the run record, call the worker,
-   * record the result, and advance the schedule pointer.
+   * Dispatch a single job run — atomically claim the schedule slot, create
+   * the run record, call the worker, and record the result.
+   *
+   * The schedule pointer (`nextRunAt`) is advanced by the claim itself,
+   * BEFORE the run is created, so it advances exactly once per scheduled
+   * fire regardless of how many replicas observed the job as due.
    */
   async function dispatchJob(
     job: typeof pluginJobs.$inferSelect,
   ): Promise<void> {
     const { id: jobId, pluginId, jobKey, schedule } = job;
     const jobLog = log.child({ jobId, pluginId, jobKey });
+
+    // Atomic schedule-slot claim: advance next_run_at iff it still has the
+    // value this tick observed. With N replicas ticking concurrently, exactly
+    // one UPDATE matches; the rest see zero rows and skip. This is the
+    // multi-instance guard — the in-process activeJobs Set only bounds local
+    // concurrency.
+    const nextRunAt = computeNextRunAt(job);
+    const claimed = await db
+      .update(pluginJobs)
+      .set({ nextRunAt, updatedAt: new Date() })
+      .where(
+        and(
+          eq(pluginJobs.id, jobId),
+          job.nextRunAt === null
+            ? isNull(pluginJobs.nextRunAt)
+            : eq(pluginJobs.nextRunAt, job.nextRunAt),
+        ),
+      )
+      .returning({ id: pluginJobs.id });
+
+    if (claimed.length === 0) {
+      jobLog.debug("job slot claimed elsewhere; skipping");
+      return;
+    }
 
     // Mark as active (overlap prevention)
     activeJobs.add(jobId);
@@ -420,13 +453,18 @@ export function createPluginJobScheduler(
       // Remove from active set
       activeJobs.delete(jobId);
 
-      // 5. Always advance the schedule pointer (even on failure)
+      // 5. Record lastRunAt (even on failure). nextRunAt is NOT touched
+      //    here — it was already advanced by the atomic claim above, and
+      //    re-advancing it after the run would re-open the slot to races.
       try {
-        await advanceSchedulePointer(job);
+        await db
+          .update(pluginJobs)
+          .set({ lastRunAt: new Date(), updatedAt: new Date() })
+          .where(eq(pluginJobs.id, jobId));
       } catch (err) {
         jobLog.error(
           { err: err instanceof Error ? err.message : String(err) },
-          "failed to advance schedule pointer",
+          "failed to record lastRunAt",
         );
       }
     }
@@ -562,28 +600,26 @@ export function createPluginJobScheduler(
   // -----------------------------------------------------------------------
 
   /**
-   * Advance the `lastRunAt` and `nextRunAt` timestamps on a job after a run.
+   * Compute the next occurrence of a job's cron schedule (after now).
+   *
+   * Returns `null` when the schedule is missing or invalid — claiming the
+   * slot with a null `nextRunAt` parks the job until it is re-registered.
    */
-  async function advanceSchedulePointer(
+  function computeNextRunAt(
     job: typeof pluginJobs.$inferSelect,
-  ): Promise<void> {
-    const now = new Date();
-    let nextRunAt: Date | null = null;
+  ): Date | null {
+    if (!job.schedule) return null;
 
-    if (job.schedule) {
-      const validationError = validateCron(job.schedule);
-      if (validationError) {
-        log.warn(
-          { jobId: job.id, schedule: job.schedule, error: validationError },
-          "invalid cron schedule — cannot compute next run",
-        );
-      } else {
-        const cron = parseCron(job.schedule);
-        nextRunAt = nextCronTick(cron, now);
-      }
+    const validationError = validateCron(job.schedule);
+    if (validationError) {
+      log.warn(
+        { jobId: job.id, schedule: job.schedule, error: validationError },
+        "invalid cron schedule — cannot compute next run",
+      );
+      return null;
     }
 
-    await jobStore.updateRunTimestamps(job.id, now, nextRunAt);
+    return nextCronTick(parseCron(job.schedule), new Date());
   }
 
   /**

--- a/server/src/services/plugin-job-scheduler.ts
+++ b/server/src/services/plugin-job-scheduler.ts
@@ -17,13 +17,24 @@
  *    cron parser ({@link parseCron}, {@link nextCronTick}) to compute the
  *    `nextRunAt` timestamp when a slot is claimed or a new job is registered.
  *
- * 3. **Overlap prevention** — Before dispatching a job, the scheduler checks
- *    for an existing `running` run for the same job. If one exists, the job
- *    is skipped for that tick.
+ * 3. **Overlap prevention** — Two layers prevent concurrent executions of the
+ *    same job:
+ *
+ *    a. **In-process guard** — The in-memory `activeJobs` set blocks a second
+ *       dispatch on the same replica within the same tick cycle.
+ *
+ *    b. **Cross-replica guard** — After winning the atomic CAS slot-claim, the
+ *       scheduler queries `plugin_job_runs` for any `running` row whose
+ *       `startedAt` is within the last {@link RUNNING_RUN_OVERLAP_GUARD_MS}
+ *       (6 h). If one exists, the claiming replica skips the fire, preventing
+ *       a long-running job from being double-dispatched when its cron period
+ *       elapses mid-execution. Rows older than the guard window are treated as
+ *       crashed-replica leftovers and do not block scheduling.
  *
  * 3b. **Multi-replica dedup** — Scheduled dispatches claim the schedule slot
  *     atomically (compare-and-swap on `nextRunAt`) BEFORE creating the run,
- *     so when N replicas tick concurrently exactly one dispatches the job.
+ *     so when N replicas tick concurrently exactly one wins the CAS; the
+ *     cross-replica guard (§3b above) then covers the long-run overlap case.
  *
  * 4. **Job run recording** — Every execution creates a `plugin_job_runs` row:
  *    `queued` → `running` → `succeeded` | `failed`. Duration and error are
@@ -39,7 +50,7 @@
  * @see ./cron.ts — Cron parsing utilities
  */
 
-import { and, eq, isNull, lte, or } from "drizzle-orm";
+import { and, eq, gt, isNull, lte, or } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { pluginJobs, pluginJobRuns } from "@paperclipai/db";
 import type { PluginJobStore } from "./plugin-job-store.js";
@@ -59,6 +70,15 @@ const DEFAULT_JOB_TIMEOUT_MS = 5 * 60 * 1_000;
 
 /** Maximum number of concurrent job executions across all plugins. */
 const DEFAULT_MAX_CONCURRENT_JOBS = 10;
+
+/**
+ * A run whose `startedAt` is older than this value is treated as a crashed-
+ * replica leftover and does NOT block the next scheduled dispatch. This
+ * prevents a permanently-`running` row (orphaned by a crashed replica) from
+ * parking the schedule forever, while still guarding against legitimate
+ * long-running executions within the window.
+ */
+const RUNNING_RUN_OVERLAP_GUARD_MS = 6 * 60 * 60 * 1_000; // 6 hours
 
 // ---------------------------------------------------------------------------
 // Types
@@ -263,8 +283,9 @@ export function createPluginJobScheduler(
       const now = new Date();
 
       // Query for jobs whose nextRunAt has passed and are active.
-      // We include jobs with null nextRunAt since they may have just been
-      // registered and need their first run calculated.
+      // Note: lte(nextRunAt, now) never matches NULL rows, so jobs with a
+      // null nextRunAt (e.g. missing or invalid schedule) are not included —
+      // they must be assigned a nextRunAt via registerPlugin / ensureNextRunTimestamps.
       const dueJobs = await db
         .select()
         .from(pluginJobs)
@@ -376,6 +397,28 @@ export function createPluginJobScheduler(
 
     if (claimed.length === 0) {
       jobLog.debug("job slot claimed elsewhere; skipping");
+      return;
+    }
+
+    // A run longer than its cron period leaves the job due again mid-run;
+    // the CAS above means exactly one replica claims that next slot, and this
+    // guard makes that claimant skip the fire instead of overlapping the
+    // still-running execution (same invariant the manual path enforces).
+    // Stale running rows (crashed replica) are ignored past the guard window
+    // so they cannot park the schedule forever.
+    const overlapCutoff = new Date(Date.now() - RUNNING_RUN_OVERLAP_GUARD_MS);
+    const runningRuns = await db
+      .select({ id: pluginJobRuns.id })
+      .from(pluginJobRuns)
+      .where(
+        and(
+          eq(pluginJobRuns.jobId, jobId),
+          eq(pluginJobRuns.status, "running"),
+          gt(pluginJobRuns.startedAt, overlapCutoff),
+        ),
+      );
+    if (runningRuns.length > 0) {
+      jobLog.debug("skipping scheduled fire — a run is still in progress (slot already advanced)");
       return;
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Deployments increasingly run `replicas > 1` behind load balancers (Kubernetes, ECS); the data layer is already multi-instance-safe (`FOR UPDATE` throughout, conflict-safe seeds), but several orchestration-layer mechanisms assume a single process
> - Concretely: N replicas booting after an upgrade race concurrent DDL in `applyPendingMigrations`; scheduled backups fire on every replica with only an in-memory in-flight flag; the plugin-job tick loop runs on every instance with TOCTOU-only dedup, so plugins double-fire webhooks/API calls; the agent-start lock is per-process; the local-trusted board bootstrap races; provider webhook retries re-dispatch `handleWebhook`; skill-inventory refreshes duplicate work
> - This PR adds Postgres-native coordination — no new infrastructure, consistent with the no-Redis stance and with #5875: a small namespaced advisory-lock helper (transaction-scoped for short critical sections, session-scoped on a dedicated connection for migrations/backups), atomic CAS claims where locks are the wrong tool, and a dedup unique index for webhooks
> - The benefit is that `replicas > 1` behaves like one logical instance for boot, backups, schedulers, bootstrap, and webhook ingestion — verified by multi-instance tests that run two clients against one real Postgres

## Linked Issues or Issue Description

Closes #7992 (multi-replica coordination gaps — filed first per CONTRIBUTING's coordination guidance; this PR is the first focused implementation step, after #5875's live-events transport).

## What Changed

- **`server/src/services/advisory-locks.ts`** (new) — namespaced advisory-lock helpers on the two-int keyspace `("pclp", hashtext(name))`: `withAdvisoryXactLock` / `tryAdvisoryXactLock` (transaction-scoped — safe under transaction-pooling poolers, auto-released on commit/rollback) and `trySessionAdvisoryLock` (dedicated direct connection for operations spanning transactions or running external processes).
- **`packages/db/src/client.ts`** — `applyPendingMigrations` now serializes cross-process via a session advisory lock on a dedicated connection; waiting replicas re-inspect and no-op. New race test proves three concurrent applies converge to one clean schema (failed deterministically before the lock).
- **`server/src/index.ts`** — local-trusted board principal bootstrap runs under an advisory lock (was unguarded check-then-insert); database backups take a session try-lock so a backup runs on exactly one replica (scheduled trigger skips, manual trigger 409s), with the in-memory fast-path kept and leak-windows closed.
- **`server/src/services/heartbeat.ts`** — `startNextQueuedRunForAgent` adds a cross-replica try-lock inside the existing in-process lock: concurrent starts for the same agent on another replica skip (the holder's pass starts what fits; the next tick covers the rest).
- **`server/src/services/plugin-job-scheduler.ts`** — scheduled dispatch now claims its slot atomically (CAS-advance of `next_run_at`); exactly one replica dispatches per cron fire. A bounded running-run guard (single checker per slot, 6h staleness window) prevents cross-replica overlap of runs that outlast their period, preserving the manual path's no-concurrent-runs invariant. In-process `activeJobs` throttle ordering preserved.
- **`server/src/routes/plugins.ts`** + migration `0099` — inbound webhook deliveries dedupe on provider idempotency ids (`x-github-delivery`, `x-delivery-id`, `idempotency-key`, `x-idempotency-key`) via a partial unique index; duplicates of pending/successful deliveries are acknowledged with `202 {status:"duplicate"}` without re-dispatch, while retries of FAILED deliveries conditionally reset the row (single winner across replicas) and re-dispatch — provider retry semantics keep working.
- **`server/src/services/company-skills.ts`** — company skill-inventory refresh serializes across replicas (idempotent re-run, no interleaved writes).
- **`packages/db/src/index.ts`** — re-exports `postgres` so server code can open dedicated raw connections (session locks) without declaring its own driver dependency/version.

## Verification

- New multi-instance tests run two clients/scheduler instances against one real (embedded) Postgres:
  - `server/src/__tests__/advisory-locks.test.ts` — mutual exclusion, try-skip, release-on-error, namespacing, session-lock lifecycle (5 tests)
  - `packages/db/src/migration-lock.test.ts` — 3 concurrent `applyPendingMigrations` on a fresh DB (failed 3/3 before the fix, passes 3/3 after)
  - `server/src/__tests__/plugin-job-scheduler-claim.test.ts` — concurrent ticks dispatch exactly one run (fail-first verified); long-run overlap guard; `maxConcurrentJobs` throttle under burst
  - `server/src/__tests__/plugin-webhook-dedup.test.ts` — duplicate suppressed / no-header unchanged / failed-retry re-dispatch / `x-request-id` not treated as idempotency id, plus a real-index integration test
- `pnpm --filter @paperclipai/db build` (incl. migration numbering check), `tsc --noEmit` clean, full server suite green modulo pre-existing flakes.

## Risks

- Advisory-lock keyspace is namespaced (`("pclp", hashtext(name))`) and key cardinality is bounded (a handful of coordination points) — no collision with the existing single-int `pg_advisory_xact_lock` use in `plugin-database.ts` (one-arg and two-arg forms use distinct keyspaces) or with other tools.
- Session locks require a direct (non-transaction-pooled) connection; both call sites (migrations, backups) dial the database URL directly, documented in the helper.
- Behavior changes, deliberate: concurrent cross-replica agent starts now skip instead of double-running; duplicate webhook deliveries with provider idempotency ids return `202 {status:"duplicate"}` (2xx, so providers don't re-retry); a plugin-job fire that would overlap a still-running execution is skipped (slot already advanced) — matching prior single-instance skip semantics.
- Single-replica deployments: every mechanism degrades to current behavior (locks always acquired immediately; PGlite single-session unaffected — in-process guards remain the active layer there).

## Model Used

Claude (Fable 5) with subagent-driven implementation and two-stage review per task.

## Related PRs

Searched the PR list for overlapping work: #5875 (live-events transport — complementary, same multi-replica umbrella), #3023 (advisory locks on issue checkout paths — different scope; this PR's namespaced two-int keyspace deliberately avoids its single-int `hashtext(issueId)` keys), #7852 (environment leases — composes), #60 (closed — superseded by the issue-first approach in #7992).

## Checklist

- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (it implements a step of the "Cloud deployments" direction, coordinated via #7992)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (no UI changes)
