### PR TITLE
feat(adapter-utils): add ColdWakeBriefing shape to PaperclipWakePayload

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -929,6 +929,234 @@ describe("renderPaperclipWakePrompt", () => {
     expect(prompt).toContain("PAP-101 Implement helper (done)");
     expect(prompt).toContain("Added the helper route and tests.");
   });
+
+  it("round-trips a populated cold-wake briefing through normalize/stringify", () => {
+    const payload = {
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-9000",
+        title: "Cold wake target",
+        status: "in_progress",
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+      coldWakeBriefing: {
+        thresholdHours: 24,
+        hoursSinceLastRun: 48,
+        lastRunFinishedAt: "2026-06-09T10:15:00.000Z",
+        recentCommits: [
+          {
+            sha: "223740f",
+            subject: "Revert ALL-770 + ALL-777 bundled work",
+            author: "founder",
+            date: "2026-06-10T22:00:00.000Z",
+            touchedReferencedPath: true,
+          },
+        ],
+        recentCommitsTruncated: false,
+        recentlyClosedReferencedIssues: [
+          {
+            id: "issue-770",
+            identifier: "ALL-770",
+            title: "Calibration kill-prob",
+            status: "done",
+            closedAt: "2026-06-10T23:30:00.000Z",
+          },
+        ],
+        siblingInProgressIssues: [
+          {
+            id: "issue-779",
+            identifier: "ALL-779",
+            title: "Re-apply ALL-777",
+            assigneeAgentId: "agent-coder",
+            updatedAt: "2026-06-11T08:00:00.000Z",
+          },
+        ],
+        planDocument: { key: "plan", revisionId: "rev-3", updatedAt: "2026-06-11T09:00:00.000Z" },
+        pendingRequestConfirmation: {
+          interactionId: "int-1",
+          revisionId: "rev-3",
+          createdAt: "2026-06-11T09:05:00.000Z",
+        },
+        recentRelatedComments: [
+          {
+            issueId: "issue-770",
+            issueIdentifier: "ALL-770",
+            commentId: "c-7",
+            authorType: "user",
+            createdAt: "2026-06-11T08:45:00.000Z",
+            bodyPreview: "default-fawn-gamma.vercel.app alias is stuck on dangling commit",
+            bodyTruncated: false,
+          },
+        ],
+        sourcesIncluded: ["git", "closed_issues", "siblings", "plan", "interaction", "comments"],
+        budgetTokens: 1234,
+        budgetTokenCap: 8000,
+        truncated: false,
+        briefingError: null,
+      },
+    };
+
+    const serialized = stringifyPaperclipWakePayload(payload);
+    expect(serialized).not.toBeNull();
+    const roundTrip = JSON.parse(serialized ?? "{}");
+    expect(roundTrip).toMatchObject({
+      coldWakeBriefing: {
+        thresholdHours: 24,
+        hoursSinceLastRun: 48,
+        lastRunFinishedAt: "2026-06-09T10:15:00.000Z",
+        recentCommits: [{ sha: "223740f", touchedReferencedPath: true }],
+        recentlyClosedReferencedIssues: [{ identifier: "ALL-770" }],
+        siblingInProgressIssues: [{ identifier: "ALL-779", assigneeAgentId: "agent-coder" }],
+        planDocument: { key: "plan", revisionId: "rev-3" },
+        pendingRequestConfirmation: { interactionId: "int-1", revisionId: "rev-3" },
+        recentRelatedComments: [
+          {
+            issueIdentifier: "ALL-770",
+            bodyPreview: "default-fawn-gamma.vercel.app alias is stuck on dangling commit",
+          },
+        ],
+        sourcesIncluded: ["git", "closed_issues", "siblings", "plan", "interaction", "comments"],
+        budgetTokens: 1234,
+        budgetTokenCap: 8000,
+        truncated: false,
+        briefingError: null,
+      },
+    });
+  });
+
+  it("renders the cold-wake briefing section when coldWakeBriefing is populated", () => {
+    const prompt = renderPaperclipWakePrompt({
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-9000",
+        title: "Cold wake target",
+        status: "in_progress",
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+      coldWakeBriefing: {
+        thresholdHours: 24,
+        hoursSinceLastRun: 48,
+        lastRunFinishedAt: "2026-06-09T10:15:00.000Z",
+        recentCommits: [
+          {
+            sha: "223740f",
+            subject: "Revert ALL-770 + ALL-777 bundled work",
+            author: "founder",
+            date: "2026-06-10T22:00:00.000Z",
+            touchedReferencedPath: true,
+          },
+        ],
+        recentCommitsTruncated: false,
+        recentlyClosedReferencedIssues: [],
+        siblingInProgressIssues: [
+          {
+            id: "issue-779",
+            identifier: "ALL-779",
+            title: "Re-apply ALL-777",
+            assigneeAgentId: "agent-coder",
+            updatedAt: "2026-06-11T08:00:00.000Z",
+          },
+        ],
+        planDocument: { key: "plan", revisionId: "rev-3", updatedAt: "2026-06-11T09:00:00.000Z" },
+        pendingRequestConfirmation: {
+          interactionId: "int-1",
+          revisionId: "rev-3",
+          createdAt: "2026-06-11T09:05:00.000Z",
+        },
+        recentRelatedComments: [
+          {
+            issueId: "issue-770",
+            issueIdentifier: "ALL-770",
+            commentId: "c-7",
+            authorType: "user",
+            createdAt: "2026-06-11T08:45:00.000Z",
+            bodyPreview: "default-fawn-gamma.vercel.app alias is stuck",
+            bodyTruncated: false,
+          },
+        ],
+        sourcesIncluded: ["git", "siblings", "plan", "interaction", "comments"],
+        budgetTokens: 1234,
+        budgetTokenCap: 8000,
+        truncated: false,
+        briefingError: null,
+      },
+    });
+
+    expect(prompt).toContain("## Cold-wake briefing");
+    expect(prompt).toContain("Last successful run by this agent: 2026-06-09T10:15:00.000Z (48h ago; threshold 24h)");
+    expect(prompt).toContain("pending request_confirmation: interaction int-1");
+    expect(prompt).toContain("plan document: key=plan revision rev-3");
+    expect(prompt).toContain("- 223740f 2026-06-10T22:00:00.000Z founder: Revert ALL-770 + ALL-777 bundled work [touches referenced path]");
+    expect(prompt).toContain("ALL-779 Re-apply ALL-777 agent agent-coder (updated 2026-06-11T08:00:00.000Z)");
+    expect(prompt).toContain("ALL-770 comment c-7 at 2026-06-11T08:45:00.000Z by user: default-fawn-gamma.vercel.app alias is stuck");
+    expect(prompt).toContain("- briefing budget: 1234/8000 tokens");
+    expect(prompt).toContain("- sources included: git, siblings, plan, interaction, comments");
+    expect(prompt).not.toMatch(/^>\s*\[!WARNING\]/m);
+  });
+
+  it("prepends the BRIEFING FAILED banner when briefingError is set", () => {
+    const prompt = renderPaperclipWakePrompt({
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-9001",
+        title: "Briefing failed wake",
+        status: "in_progress",
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+      coldWakeBriefing: {
+        thresholdHours: 24,
+        hoursSinceLastRun: 72,
+        lastRunFinishedAt: "2026-06-08T10:00:00.000Z",
+        recentCommits: [],
+        recentCommitsTruncated: false,
+        recentlyClosedReferencedIssues: [],
+        siblingInProgressIssues: [],
+        planDocument: null,
+        pendingRequestConfirmation: null,
+        recentRelatedComments: [],
+        sourcesIncluded: [],
+        budgetTokens: 0,
+        budgetTokenCap: 8000,
+        truncated: false,
+        briefingError: { code: "git_unavailable", message: "simpleGit threw ENOENT on workspace cwd" },
+      },
+    });
+
+    const firstLine = prompt.split("\n")[0];
+    expect(firstLine).toBe(
+      "> [!WARNING] BRIEFING FAILED — agent is operating without context: git_unavailable — simpleGit threw ENOENT on workspace cwd",
+    );
+    expect(prompt).toContain("## Cold-wake briefing");
+    expect(prompt).toContain("## Paperclip Wake Payload");
+  });
+
+  it("does not regress existing wake prompts when coldWakeBriefing is absent", () => {
+    const prompt = renderPaperclipWakePrompt({
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-9002",
+        title: "Plain wake",
+        status: "in_progress",
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+    });
+
+    expect(prompt).toContain("## Paperclip Wake Payload");
+    expect(prompt).not.toContain("## Cold-wake briefing");
+    expect(prompt).not.toContain("BRIEFING FAILED");
+  });
 });
 
 describe("applyPaperclipWorkspaceEnv", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -424,6 +424,75 @@ type PaperclipWakeTreeHoldSummary = {
   reason: string | null;
 };
 
+type PaperclipColdWakeRecentCommit = {
+  sha: string;
+  subject: string;
+  author: string;
+  date: string;
+  touchedReferencedPath: boolean;
+};
+
+type PaperclipColdWakeClosedIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  closedAt: string;
+};
+
+type PaperclipColdWakeSiblingIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  assigneeAgentId: string | null;
+  updatedAt: string;
+};
+
+type PaperclipColdWakePlanDocument = {
+  key: string;
+  revisionId: string;
+  updatedAt: string;
+};
+
+type PaperclipColdWakePendingRequestConfirmation = {
+  interactionId: string;
+  revisionId: string | null;
+  createdAt: string;
+};
+
+type PaperclipColdWakeRelatedComment = {
+  issueId: string;
+  issueIdentifier: string | null;
+  commentId: string;
+  authorType: string;
+  createdAt: string;
+  bodyPreview: string;
+  bodyTruncated: boolean;
+};
+
+type PaperclipColdWakeBriefingError = {
+  code: string;
+  message: string;
+};
+
+type PaperclipColdWakeBriefing = {
+  thresholdHours: number;
+  hoursSinceLastRun: number | null;
+  lastRunFinishedAt: string | null;
+  recentCommits: PaperclipColdWakeRecentCommit[];
+  recentCommitsTruncated: boolean;
+  recentlyClosedReferencedIssues: PaperclipColdWakeClosedIssue[];
+  siblingInProgressIssues: PaperclipColdWakeSiblingIssue[];
+  planDocument: PaperclipColdWakePlanDocument | null;
+  pendingRequestConfirmation: PaperclipColdWakePendingRequestConfirmation | null;
+  recentRelatedComments: PaperclipColdWakeRelatedComment[];
+  sourcesIncluded: string[];
+  budgetTokens: number;
+  budgetTokenCap: number;
+  truncated: boolean;
+  briefingError: PaperclipColdWakeBriefingError | null;
+};
+
 type PaperclipWakePayload = {
   reason: string | null;
   issue: PaperclipWakeIssue | null;
@@ -448,6 +517,7 @@ type PaperclipWakePayload = {
   missingCount: number;
   truncated: boolean;
   fallbackFetchNeeded: boolean;
+  coldWakeBriefing: PaperclipColdWakeBriefing | null;
 };
 
 function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null {
@@ -598,6 +668,174 @@ function normalizePaperclipWakeExecutionStage(value: unknown): PaperclipWakeExec
   };
 }
 
+function normalizePaperclipColdWakeRecentCommit(value: unknown): PaperclipColdWakeRecentCommit | null {
+  const commit = parseObject(value);
+  const sha = asString(commit.sha, "").trim();
+  const subject = asString(commit.subject, "").trim();
+  if (!sha && !subject) return null;
+  return {
+    sha,
+    subject,
+    author: asString(commit.author, "").trim(),
+    date: asString(commit.date, "").trim(),
+    touchedReferencedPath: asBoolean(commit.touchedReferencedPath, false),
+  };
+}
+
+function normalizePaperclipColdWakeClosedIssue(value: unknown): PaperclipColdWakeClosedIssue | null {
+  const issue = parseObject(value);
+  const id = asString(issue.id, "").trim();
+  const title = asString(issue.title, "").trim();
+  if (!id && !title) return null;
+  return {
+    id,
+    identifier: asString(issue.identifier, "").trim() || null,
+    title,
+    status: asString(issue.status, "").trim(),
+    closedAt: asString(issue.closedAt, "").trim(),
+  };
+}
+
+function normalizePaperclipColdWakeSiblingIssue(value: unknown): PaperclipColdWakeSiblingIssue | null {
+  const issue = parseObject(value);
+  const id = asString(issue.id, "").trim();
+  const title = asString(issue.title, "").trim();
+  if (!id && !title) return null;
+  return {
+    id,
+    identifier: asString(issue.identifier, "").trim() || null,
+    title,
+    assigneeAgentId: asString(issue.assigneeAgentId, "").trim() || null,
+    updatedAt: asString(issue.updatedAt, "").trim(),
+  };
+}
+
+function normalizePaperclipColdWakePlanDocument(value: unknown): PaperclipColdWakePlanDocument | null {
+  const doc = parseObject(value);
+  const key = asString(doc.key, "").trim();
+  const revisionId = asString(doc.revisionId, "").trim();
+  if (!key && !revisionId) return null;
+  return {
+    key,
+    revisionId,
+    updatedAt: asString(doc.updatedAt, "").trim(),
+  };
+}
+
+function normalizePaperclipColdWakePendingRequestConfirmation(
+  value: unknown,
+): PaperclipColdWakePendingRequestConfirmation | null {
+  const interaction = parseObject(value);
+  const interactionId = asString(interaction.interactionId, "").trim();
+  if (!interactionId) return null;
+  return {
+    interactionId,
+    revisionId: asString(interaction.revisionId, "").trim() || null,
+    createdAt: asString(interaction.createdAt, "").trim(),
+  };
+}
+
+function normalizePaperclipColdWakeRelatedComment(value: unknown): PaperclipColdWakeRelatedComment | null {
+  const comment = parseObject(value);
+  const issueId = asString(comment.issueId, "").trim();
+  const commentId = asString(comment.commentId, "").trim();
+  const bodyPreview = asString(comment.bodyPreview, "");
+  if (!issueId && !commentId && !bodyPreview.trim()) return null;
+  return {
+    issueId,
+    issueIdentifier: asString(comment.issueIdentifier, "").trim() || null,
+    commentId,
+    authorType: asString(comment.authorType, "").trim(),
+    createdAt: asString(comment.createdAt, "").trim(),
+    bodyPreview,
+    bodyTruncated: asBoolean(comment.bodyTruncated, false),
+  };
+}
+
+function normalizePaperclipColdWakeBriefingError(value: unknown): PaperclipColdWakeBriefingError | null {
+  const error = parseObject(value);
+  const code = asString(error.code, "").trim();
+  const message = asString(error.message, "").trim();
+  if (!code && !message) return null;
+  return { code, message };
+}
+
+function normalizePaperclipColdWakeBriefing(value: unknown): PaperclipColdWakeBriefing | null {
+  if (value === null || value === undefined) return null;
+  const briefing = parseObject(value);
+  const recentCommits = Array.isArray(briefing.recentCommits)
+    ? briefing.recentCommits
+        .map((entry) => normalizePaperclipColdWakeRecentCommit(entry))
+        .filter((entry): entry is PaperclipColdWakeRecentCommit => Boolean(entry))
+    : [];
+  const recentlyClosedReferencedIssues = Array.isArray(briefing.recentlyClosedReferencedIssues)
+    ? briefing.recentlyClosedReferencedIssues
+        .map((entry) => normalizePaperclipColdWakeClosedIssue(entry))
+        .filter((entry): entry is PaperclipColdWakeClosedIssue => Boolean(entry))
+    : [];
+  const siblingInProgressIssues = Array.isArray(briefing.siblingInProgressIssues)
+    ? briefing.siblingInProgressIssues
+        .map((entry) => normalizePaperclipColdWakeSiblingIssue(entry))
+        .filter((entry): entry is PaperclipColdWakeSiblingIssue => Boolean(entry))
+    : [];
+  const recentRelatedComments = Array.isArray(briefing.recentRelatedComments)
+    ? briefing.recentRelatedComments
+        .map((entry) => normalizePaperclipColdWakeRelatedComment(entry))
+        .filter((entry): entry is PaperclipColdWakeRelatedComment => Boolean(entry))
+    : [];
+  const sourcesIncluded = Array.isArray(briefing.sourcesIncluded)
+    ? briefing.sourcesIncluded
+        .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+        .map((entry) => entry.trim())
+    : [];
+  const briefingError = normalizePaperclipColdWakeBriefingError(briefing.briefingError);
+  const planDocument = normalizePaperclipColdWakePlanDocument(briefing.planDocument);
+  const pendingRequestConfirmation = normalizePaperclipColdWakePendingRequestConfirmation(
+    briefing.pendingRequestConfirmation,
+  );
+
+  // A briefing that is entirely empty AND has no error is treated as absent so the field
+  // stays null on the wire instead of emitting an empty banner-less section.
+  if (
+    recentCommits.length === 0 &&
+    recentlyClosedReferencedIssues.length === 0 &&
+    siblingInProgressIssues.length === 0 &&
+    recentRelatedComments.length === 0 &&
+    sourcesIncluded.length === 0 &&
+    !planDocument &&
+    !pendingRequestConfirmation &&
+    !briefingError &&
+    asNumber(briefing.thresholdHours, 0) === 0 &&
+    briefing.hoursSinceLastRun === undefined &&
+    briefing.lastRunFinishedAt === undefined &&
+    asNumber(briefing.budgetTokens, 0) === 0 &&
+    asNumber(briefing.budgetTokenCap, 0) === 0
+  ) {
+    return null;
+  }
+
+  return {
+    thresholdHours: asNumber(briefing.thresholdHours, 0),
+    hoursSinceLastRun:
+      briefing.hoursSinceLastRun === null || briefing.hoursSinceLastRun === undefined
+        ? null
+        : asNumber(briefing.hoursSinceLastRun, 0),
+    lastRunFinishedAt: asString(briefing.lastRunFinishedAt, "").trim() || null,
+    recentCommits,
+    recentCommitsTruncated: asBoolean(briefing.recentCommitsTruncated, false),
+    recentlyClosedReferencedIssues,
+    siblingInProgressIssues,
+    planDocument,
+    pendingRequestConfirmation,
+    recentRelatedComments,
+    sourcesIncluded,
+    budgetTokens: asNumber(briefing.budgetTokens, 0),
+    budgetTokenCap: asNumber(briefing.budgetTokenCap, 0),
+    truncated: asBoolean(briefing.truncated, false),
+    briefingError,
+  };
+}
+
 export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayload | null {
   const payload = parseObject(value);
   const comments = Array.isArray(payload.comments)
@@ -631,7 +869,8 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     : [];
 
   const activeTreeHold = normalizePaperclipWakeTreeHoldSummary(payload.activeTreeHold);
-  if (comments.length === 0 && commentIds.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !livenessContinuation && !normalizePaperclipWakeIssue(payload.issue)) {
+  const coldWakeBriefing = normalizePaperclipColdWakeBriefing(payload.coldWakeBriefing);
+  if (comments.length === 0 && commentIds.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !livenessContinuation && !coldWakeBriefing && !normalizePaperclipWakeIssue(payload.issue)) {
     return null;
   }
 
@@ -659,6 +898,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     missingCount: asNumber(commentWindow.missingCount, 0),
     truncated: asBoolean(payload.truncated, false),
     fallbackFetchNeeded: asBoolean(payload.fallbackFetchNeeded, false),
+    coldWakeBriefing,
   };
 }
 
@@ -754,6 +994,78 @@ export function renderPaperclipWakePrompt(
       );
     }
   }
+
+  if (normalized.coldWakeBriefing) {
+    const briefing = normalized.coldWakeBriefing;
+    const hoursLabel =
+      briefing.hoursSinceLastRun === null ? "unknown" : `${briefing.hoursSinceLastRun}h`;
+    lines.push(
+      "",
+      "## Cold-wake briefing",
+      "",
+      `You are waking from hibernation. Last successful run by this agent: ${briefing.lastRunFinishedAt ?? "unknown"} (${hoursLabel} ago; threshold ${briefing.thresholdHours}h).`,
+      "Treat the sections below as authoritative context that landed while you were idle. Do not start work until you have reconciled the wake issue against this briefing.",
+    );
+    if (briefing.pendingRequestConfirmation) {
+      const pending = briefing.pendingRequestConfirmation;
+      lines.push(
+        "",
+        `- pending request_confirmation: interaction ${pending.interactionId}${pending.revisionId ? ` revision ${pending.revisionId}` : ""}${pending.createdAt ? ` opened ${pending.createdAt}` : ""}`,
+      );
+    }
+    if (briefing.planDocument) {
+      lines.push(
+        `- plan document: key=${briefing.planDocument.key} revision ${briefing.planDocument.revisionId}${briefing.planDocument.updatedAt ? ` updated ${briefing.planDocument.updatedAt}` : ""}`,
+      );
+    }
+    if (briefing.recentCommits.length > 0) {
+      lines.push("", "Recent commits:");
+      for (const commit of briefing.recentCommits) {
+        const flag = commit.touchedReferencedPath ? " [touches referenced path]" : "";
+        lines.push(`- ${commit.sha} ${commit.date} ${commit.author}: ${commit.subject}${flag}`);
+      }
+      if (briefing.recentCommitsTruncated) {
+        lines.push("[recent commits truncated]");
+      }
+    }
+    if (briefing.recentlyClosedReferencedIssues.length > 0) {
+      lines.push("", "Recently closed referenced issues:");
+      for (const issue of briefing.recentlyClosedReferencedIssues) {
+        const label = issue.identifier ?? issue.id;
+        lines.push(`- ${label} ${issue.title} (${issue.status}; closed ${issue.closedAt})`);
+      }
+    }
+    if (briefing.siblingInProgressIssues.length > 0) {
+      lines.push("", "Sibling issues currently in progress:");
+      for (const issue of briefing.siblingInProgressIssues) {
+        const label = issue.identifier ?? issue.id;
+        const owner = issue.assigneeAgentId ? ` agent ${issue.assigneeAgentId}` : "";
+        lines.push(`- ${label} ${issue.title}${owner} (updated ${issue.updatedAt})`);
+      }
+    }
+    if (briefing.recentRelatedComments.length > 0) {
+      lines.push("", "Recent comments across related-work graph (newest first):");
+      for (const comment of briefing.recentRelatedComments) {
+        const label = comment.issueIdentifier ?? comment.issueId;
+        lines.push(
+          `- ${label} comment ${comment.commentId} at ${comment.createdAt} by ${comment.authorType || "unknown"}: ${comment.bodyPreview}${comment.bodyTruncated ? " [truncated]" : ""}`,
+        );
+      }
+    }
+    const budgetLine = `- briefing budget: ${briefing.budgetTokens}/${briefing.budgetTokenCap} tokens`;
+    const sourcesLine =
+      briefing.sourcesIncluded.length > 0
+        ? `- sources included: ${briefing.sourcesIncluded.join(", ")}`
+        : null;
+    lines.push("", budgetLine);
+    if (sourcesLine) {
+      lines.push(sourcesLine);
+    }
+    if (briefing.truncated) {
+      lines.push("- briefing truncated to fit the token budget");
+    }
+  }
+
   if (normalized.checkedOutByHarness) {
     lines.push("- checkout: already claimed by the harness for this run");
   }
@@ -891,6 +1203,15 @@ export function renderPaperclipWakePrompt(
       lines.push("[comment body truncated]");
     }
     lines.push("");
+  }
+
+  const briefingError = normalized.coldWakeBriefing?.briefingError ?? null;
+  if (briefingError) {
+    const banner = [
+      `> [!WARNING] BRIEFING FAILED — agent is operating without context: ${briefingError.code}${briefingError.message ? ` — ${briefingError.message}` : ""}`,
+      "",
+    ];
+    return banner.concat(lines).join("\n").trim();
   }
 
   return lines.join("\n").trim();


### PR DESCRIPTION
Refs #8002 (step 2 in the same stack).

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The harness assembles a `PaperclipWakePayload` for every wake and ships it to the running adapter, which renders it into the agent's first prompt
> - When an agent has been hibernated for a while and is woken onto a fast-moving issue, it starts work without knowing what changed under it (reverts, parallel work by other agents, canonical URL drift). One real downstream incident: an agent was woken after multi-day idle and posted wrong deployment IDs because they didn't know a key commit had been reverted
> - The harness should inject a structured "what changed under you" briefing into the wake payload on cold wakes, so the agent has a deterministic context floor before its first model call
> - This pull request is **step 1 of a multi-PR stack**: it lands the shared contract — the `ColdWakeBriefing` type on `PaperclipWakePayload`, plus the normalize/stringify/render plumbing in `@paperclipai/adapter-utils`. No runtime behavior change; the field is optional and absent until the server-side assembler lands
> - The benefit is that follow-up PRs (detection helper, per-section assembler, budget guard, telemetry, wiring) can each ship as a focused, reviewable diff against a stable contract instead of a single mega-PR

## Linked Issues or Issue Description

No matching public Paperclip issue exists; describing inline per the feature-request template.

**Subsystem affected:** `packages/adapters` — specifically `@paperclipai/adapter-utils` shared payload contract that every local adapter consumes.

### Problem or motivation

When an agent has been hibernated past some threshold (typical: a working day or more) and is then woken onto an active issue, it has no built-in awareness of what has happened on or around that issue in its absence. Adapters render the wake payload as the agent's first prompt; today that prompt carries only the active wake stage, the issue summary, and any wake-targeted comments. It does not carry recent git activity, recently-closed referenced issues, sibling in-progress work by overlapping agents, plan-document or pending-`request_confirmation` pointers, or a deduped slice of the broader related-work comment graph. Agents in this state can start work from a stale mental model and ship visibly wrong actions.

### Proposed solution

Add a deterministic, no-LLM cold-wake briefing to the wake payload. The work is split into a multi-PR stack:

1. Shared contract — `ColdWakeBriefing` type + normalize/stringify/render plumbing in `adapter-utils` *(this PR)*
2. Staleness detection helper (`detectColdWake`) in `server/services`
3. Per-section assembler with `try/catch` partial-degrade behavior
4. Token-budget guard + eviction order (default 8k tokens; staleness header + active interaction pointer never dropped)
5. `PAPERCLIP_SKIP_COLD_WAKE_BRIEFING` bypass switch + `heartbeatRunEvents` telemetry
6. Wiring into `buildPaperclipWakePayload` via an adjacent `buildColdWakeBriefing()` assembler + renderer integration
7. Integration test: simulate 48h-hibernated agent woken on a hot issue; assert rendered prompt contains briefing block
8. Replay test against the motivating incident

### Alternatives considered

- *Inline LLM-summarized briefing:* faster to implement but adds non-determinism, latency, and cost to every cold wake. Rejected — start deterministic, layer summarization later if budget pressure justifies it.
- *Fold all sections into `buildPaperclipWakePayload`:* would inflate an already-large function. The adjacent-assembler approach (step 6) keeps cold-wake logic isolated.
- *Single mega-PR:* makes review prohibitive. Splitting is what enables the type-only first step to land risk-free.

### Roadmap alignment

Not currently in `ROADMAP.md`; this is a quality-of-implementation safety fix for the wake-payload pipeline, useful to every Paperclip user. Happy to add a roadmap note if maintainers prefer.

## What Changed

`packages/adapter-utils/src/server-utils.ts`:

- New `ColdWakeBriefing` type added to `PaperclipWakePayload` with:
  - Staleness header: `thresholdHours`, `hoursSinceLastRun`, `lastRunFinishedAt`
  - `recentCommits` (with `touchedReferencedPath` flag) + `recentCommitsTruncated`
  - `recentlyClosedReferencedIssues` from the related-work graph
  - `siblingInProgressIssues` — chain-of-command overlap
  - `planDocument` + `pendingRequestConfirmation` pointers
  - `recentRelatedComments` — deduped, newest-first, with `bodyPreview` + `bodyTruncated`
  - Hygiene fields: `sourcesIncluded`, `budgetTokens`, `budgetTokenCap`, `truncated`
  - `briefingError: { code, message } | null` for the explicit-banner failure path
- `normalizePaperclipWakePayload` accepts and echoes the new field.
- `stringifyPaperclipWakePayload` round-trips it.
- `renderPaperclipWakePrompt`:
  - Emits a `## Cold-wake briefing` section after the wake header bullets when populated.
  - Prepends `> [!WARNING] BRIEFING FAILED — agent is operating without context: <code> — <message>` at the very top when `briefingError` is set (explicit-banner over hard-fail: outage-time wakes still flow but the agent must acknowledge before acting).
  - Renders nothing extra when the field is absent — no regression on existing wakes.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` — clean
- `pnpm vitest run packages/adapter-utils/src/server-utils.test.ts` — 43/43 passed; four new cases added:
  - normalize/stringify round-trips a populated `coldWakeBriefing`
  - renderer emits the briefing section with staleness header, plan/interaction pointers, commits, siblings, comments, budget, sources
  - renderer prepends the `BRIEFING FAILED` warning banner at the very top when `briefingError` is set
  - renderer does not regress existing wakes when `coldWakeBriefing` is absent
- All in-tree adapter packages consume `PaperclipWakePayload` via `stringifyPaperclipWakePayload`; type addition is purely additive so no adapter changes are required.

### CI note

`General tests (server)` on this PR fails on `src/__tests__/environment-service.test.ts > environmentService leases > deduplicates concurrent managed Kubernetes environment creation` (`AssertionError: expected 2 to be 1`). This is a pre-existing flake on master unrelated to this PR — this PR touches zero environment-service code (only `packages/adapter-utils/src/server-utils.ts` + its test file). The `verify` check is the aggregator failing on that single test.

## Risks

- **Low risk.** Pure additive type + plumbing change, no behavior change. The field is optional and unset on every existing call path, so wakes serialize and render identically to before.
- The renderer change adds two gated branches (one for the briefing section, one for the failure banner). Both are gated on the field being present; existing tests pass without modification.
- Forward compatibility: in-tree adapters use the shared `normalizePaperclipWakePayload`, which tolerates unknown keys, so adapter packages that haven't yet bumped will still round-trip cleanly.

## Model Used

Provider: Anthropic. Model: **Claude Opus 4** (`claude-opus-4-7`). Capability details used here: extended thinking, tool use (file edits, shell), code execution via the host environment. No multi-modal input; this PR is text-only.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs (none found matching "cold wake briefing", "hibernated agent briefing", or "wake payload briefing")
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots *(N/A — server-side type plumbing)*
- [x] I have updated relevant documentation to reflect my changes *(N/A — internal contract only)*
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green *(in flight)*
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups *(in flight)*
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
