### PR TITLE
feat(server): add detectColdWake staleness helper for cold-wake briefing

### DIFF
--- a/server/src/__tests__/cold-wake-briefing-detection.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-detection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  detectColdWake,
+  resolveHibernationThresholdHours,
+} from "../services/cold-wake-briefing.ts";
+
+const NOW = new Date("2026-06-11T20:00:00Z");
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 3_600_000);
+
+describe("detectColdWake", () => {
+  it("flags the wake cold when there is no prior succeeded run", () => {
+    expect(detectColdWake({ lastRunFinishedAt: null, now: NOW })).toEqual({
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+    });
+  });
+
+  it("flags the wake warm when the last run is inside the threshold", () => {
+    const last = hoursAgo(2);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(2, 6);
+    expect(result.lastRunFinishedAt).toBe(last);
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("flags the wake cold when the last run is older than the threshold", () => {
+    const last = hoursAgo(48);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeCloseTo(48, 6);
+  });
+
+  it("respects an explicit thresholdHours override", () => {
+    const last = hoursAgo(6);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: 4 });
+    expect(result.isColdWake).toBe(true);
+    expect(result.thresholdHours).toBe(4);
+  });
+
+  it("treats exactly-at-threshold as warm (boundary is strict-greater)", () => {
+    const last = hoursAgo(24);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: 24 });
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(24, 6);
+  });
+
+  it("returns a Date for lastRunFinishedAt that round-trips through ISO", () => {
+    const last = hoursAgo(3);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.lastRunFinishedAt).toBeInstanceOf(Date);
+    expect(result.lastRunFinishedAt?.toISOString()).toBe(last.toISOString());
+  });
+
+  it("falls back to the env-resolved threshold when override is invalid", () => {
+    const last = hoursAgo(30);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: -1 });
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(result.isColdWake).toBe(true);
+  });
+});
+
+describe("resolveHibernationThresholdHours", () => {
+  it("returns the default when the env var is unset", () => {
+    expect(resolveHibernationThresholdHours({})).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("respects a valid numeric env var", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "12" }),
+    ).toBe(12);
+  });
+
+  it("falls back to the default when the env var is non-numeric", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "abc" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("falls back to the default when the env var is zero or negative", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "0" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "-5" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+});

--- a/server/src/services/cold-wake-briefing.ts
+++ b/server/src/services/cold-wake-briefing.ts
@@ -1,0 +1,117 @@
+// Cold-wake briefing assembler — step-by-step in service of the parent
+// initiative: when an agent has been hibernated past a threshold and is woken
+// onto an active issue, the harness prepends a "what changed under you"
+// briefing into the wake payload so the agent does not start work blind.
+//
+// This file holds the focused, adjacent assembler that the heartbeat service
+// calls right after `buildPaperclipWakePayload`. Each piece (detection,
+// section assembly, token-budget guard, telemetry) lands as a separate PR
+// against the parent tracker.
+//
+// **This PR — step 2 — only ships staleness detection.** Per-section
+// assembly, the budget guard, telemetry, and the call-site wiring all land
+// in follow-up PRs.
+
+import { and, desc, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+
+/** Default hibernation threshold. 24h ≈ one working day; gaps longer than
+ *  that are unambiguously stale from the agent's perspective. Tunable via
+ *  `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS` so operators can dial it down
+ *  once telemetry justifies a tighter value. */
+export const DEFAULT_HIBERNATION_THRESHOLD_HOURS = 24;
+
+const SUCCEEDED_RUN_STATUS = "succeeded";
+const MS_PER_HOUR = 3_600_000;
+
+export type ColdWakeDetectionInput = {
+  /** `null` when there is no prior succeeded run for the agent. */
+  lastRunFinishedAt: Date | null;
+  /** Override the default. Falsy values fall back to env / default. */
+  thresholdHours?: number;
+  /** Injectable clock for tests. Defaults to `new Date()`. */
+  now?: Date;
+};
+
+export type ColdWakeDetection = {
+  isColdWake: boolean;
+  hoursSinceLastRun: number | null;
+  lastRunFinishedAt: Date | null;
+  thresholdHours: number;
+};
+
+/** Resolve the hibernation threshold from the supplied env or `process.env`,
+ *  falling back to the default when unset, non-numeric, or non-positive. */
+export function resolveHibernationThresholdHours(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.PAPERCLIP_HIBERNATION_THRESHOLD_HOURS;
+  if (typeof raw !== "string" || raw.length === 0) {
+    return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+  }
+  return parsed;
+}
+
+/** Pure detection — given the last succeeded run's finish time, decide
+ *  whether this wake should be treated as a cold wake. No DB access.
+ *
+ *  Boundary rule: a gap **strictly greater than** the threshold is cold.
+ *  Exactly-at-threshold is warm; this keeps daily cron wakes (~24h apart)
+ *  from being flagged cold by default while still catching multi-day gaps
+ *  like the ALL-779 incident that motivated the briefing. */
+export function detectColdWake(input: ColdWakeDetectionInput): ColdWakeDetection {
+  const thresholdHours =
+    typeof input.thresholdHours === "number" && Number.isFinite(input.thresholdHours) && input.thresholdHours > 0
+      ? input.thresholdHours
+      : resolveHibernationThresholdHours();
+  const now = input.now ?? new Date();
+  const lastRunFinishedAt = input.lastRunFinishedAt;
+
+  if (!lastRunFinishedAt) {
+    return {
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours,
+    };
+  }
+
+  const hoursSinceLastRun = (now.getTime() - lastRunFinishedAt.getTime()) / MS_PER_HOUR;
+  return {
+    isColdWake: hoursSinceLastRun > thresholdHours,
+    hoursSinceLastRun,
+    lastRunFinishedAt,
+    thresholdHours,
+  };
+}
+
+/** Look up the most recent succeeded `heartbeat_runs.finished_at` for an
+ *  agent within a company. Returns `null` when no succeeded run is on
+ *  record. The query is covered by the existing
+ *  `heartbeat_runs_company_agent_started_idx` for filter selectivity; the
+ *  trailing `order by finished_at desc` falls back to a small in-memory
+ *  sort, which is acceptable for the per-wake call cadence. */
+export async function getLastSucceededRunFinishedAt(input: {
+  db: Db;
+  companyId: string;
+  agentId: string;
+}): Promise<Date | null> {
+  const rows = await input.db
+    .select({ finishedAt: heartbeatRuns.finishedAt })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.agentId, input.agentId),
+        eq(heartbeatRuns.status, SUCCEEDED_RUN_STATUS),
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.finishedAt))
+    .limit(1);
+  return rows[0]?.finishedAt ?? null;
+}


### PR DESCRIPTION
Refs #8001 (step 1 in the same stack).

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The harness builds a `PaperclipWakePayload` per wake and adapters render it as the agent's first prompt; on a cold wake (agent hibernated past a threshold) that prompt needs a deterministic "what changed under you" briefing — see the parent stack rationale on #8001
> - Before any of the briefing assembly runs, the harness needs to know *whether this wake is cold*. That's a pure decision over the agent's most recent succeeded heartbeat run vs. the configured hibernation threshold
> - This PR is **step 2 of the multi-PR stack**: server-side staleness detection. It adds `detectColdWake` (pure boundary logic), `resolveHibernationThresholdHours` (env reader with safe fallback), and `getLastSucceededRunFinishedAt` (the Drizzle query over `heartbeat_runs`). Separating the pure decision from the DB query gives cheap unit tests for the boundary choices without standing up an embedded Postgres
> - The benefit is the next PR (per-section assembler) has a stable detection primitive to call, and operators can already dial the threshold via `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS` once wiring lands

## Linked Issues or Issue Description

No matching public Paperclip issue exists; inline description per the feature-request template. Step 2 of the same initiative described on #8001.

**Subsystem affected:** `server/` — REST API & orchestration services. New module at `server/src/services/cold-wake-briefing.ts`.

### Problem or motivation

When an agent is woken after a long idle gap, the harness cannot currently distinguish "warm" wakes (a few minutes since the last successful run) from "cold" wakes (multiple days idle). Without that distinction it cannot conditionally inject a context briefing. A daily cron wake is also at the boundary of what should count as cold — without an explicit, tunable threshold the briefing risks firing on routine cadence and inflating prompt cost.

### Proposed solution

A small, focused server-side module that:

1. Resolves the hibernation threshold from `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS` (default 24h), with safe fallback on unset/non-numeric/zero/negative values.
2. Exposes a **pure** `detectColdWake({ lastRunFinishedAt, thresholdHours?, now? })` that returns the full struct the briefing assembler will need: `{ isColdWake, hoursSinceLastRun, lastRunFinishedAt, thresholdHours }`. Boundary is **strictly greater** than the threshold (exactly-24h = warm) so daily cron wakes don't routinely trigger the briefing path.
3. Exposes `getLastSucceededRunFinishedAt({ db, companyId, agentId })` that returns `Date | null` from the latest succeeded `heartbeat_runs` row for the agent.

No wiring into `buildPaperclipWakePayload` yet — that lands with the assembler PR in step 6 of the stack.

### Alternatives considered

- *Fold the query into `detectColdWake`:* would force every unit test to spin up an embedded Postgres. The pure-function + DB-helper split keeps boundary tests cheap.
- *Hard-coded 24h with no env override:* not workable — different installations will have different cadences (cron-wake-heavy vs. interactive); the env knob is the minimum operator surface.
- *Boundary as `>=`:* would flag every daily cron wake as cold, paying briefing-assembly cost on routine cadence. Rejected; strict-greater is the default, operators can tighten via env.

### Roadmap alignment

Same as #8001 — quality-of-implementation safety fix; not currently in `ROADMAP.md`.

## What Changed

- **`server/src/services/cold-wake-briefing.ts`** (new file):
  - `DEFAULT_HIBERNATION_THRESHOLD_HOURS = 24`
  - `resolveHibernationThresholdHours(env?)` — reads `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS`; falls back to default on unset / non-numeric / zero / negative
  - `detectColdWake({ lastRunFinishedAt, thresholdHours?, now? })` — pure function; returns `{ isColdWake, hoursSinceLastRun, lastRunFinishedAt, thresholdHours }`; injectable `now` for tests; safe fallback when `thresholdHours` override is non-positive
  - `getLastSucceededRunFinishedAt({ db, companyId, agentId })` — Drizzle query against `heartbeatRuns` filtered on `status='succeeded'` and the supplied agent + company, ordered by `finishedAt desc`, `limit 1`. Returns `Date | null`
- **`server/src/__tests__/cold-wake-briefing-detection.test.ts`** (new file): 11 vitest cases.

## Verification

- `pnpm vitest run src/__tests__/cold-wake-briefing-detection.test.ts` — **11/11 passed** locally:
  - `detectColdWake`: null last-run → cold (no hours); inside threshold → warm; beyond threshold → cold; explicit override respected; exactly-at-threshold → warm (strict-greater boundary); ISO round-trip on returned `lastRunFinishedAt`; invalid (negative) override falls back to default
  - `resolveHibernationThresholdHours`: env unset → default; valid numeric env → respected; non-numeric env → default; zero / negative env → default
- Regression sanity: `pnpm vitest run src/__tests__/heartbeat-model-profile.test.ts src/__tests__/heartbeat-run-summary.test.ts` — 13/13 passed.
- `tsc --noEmit` shows zero errors in the two new files. (Other workspace-level errors are pre-existing `@paperclipai/plugin-sdk` build-state issues unrelated to this PR.)

## Risks

- **Low risk** — pure additive module, no call-site wiring yet. Nothing imports it in `dist`, so runtime behavior is unchanged.
- DB query targets `heartbeatRuns(companyId, agentId, status, finishedAt)`. The existing `heartbeat_runs_company_agent_started_idx(companyId, agentId, startedAt)` covers the filter selectivity; the trailing `order by finished_at desc` falls back to an in-memory sort over a small filtered set. At the per-wake call cadence this is negligible. A future PR can add a `(companyId, agentId, status, finishedAt)` covering index if telemetry indicates.
- Boundary choice (`>` not `>=`) means a wake exactly 24h after a previous run is treated as warm. Intentional — keeps once-a-day cron wakes warm by default; operators wanting stricter behavior set `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS=12`.

## Model Used

Provider: Anthropic. Model: **Claude Opus 4** (`claude-opus-4-7`). Capability details used here: extended thinking, tool use (file edits, shell), code execution via the host environment. No multi-modal input; this PR is text-only.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs (none found matching "cold wake briefing", "detectColdWake", "hibernation threshold")
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots *(N/A — server-side helper)*
- [x] I have updated relevant documentation to reflect my changes *(N/A — internal helper)*
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green *(in flight)*
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups *(in flight)*
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
