### PR TITLE
feat(heartbeat): detectColdWake() staleness helper (ALL-781 step 2)

### DIFF
--- a/server/src/__tests__/heartbeat-detect-cold-wake.test.ts
+++ b/server/src/__tests__/heartbeat-detect-cold-wake.test.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  HIBERNATION_THRESHOLD_ENV_VAR,
+  detectColdWake,
+  resolveHibernationThresholdHours,
+} from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres detectColdWake tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("detectColdWake", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-detect-cold-wake-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+    delete process.env[HIBERNATION_THRESHOLD_ENV_VAR];
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  async function insertSucceededRun(
+    companyId: string,
+    agentId: string,
+    finishedAt: Date | null,
+  ) {
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "succeeded",
+      startedAt: finishedAt
+        ? new Date(finishedAt.getTime() - 60_000)
+        : null,
+      finishedAt,
+    });
+  }
+
+  it("returns cold + null lastRunFinishedAt when the agent has no prior succeeded run", async () => {
+    const { agentId } = await seedCompanyAndAgent();
+
+    const result = await detectColdWake(db, agentId);
+
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeNull();
+    expect(result.lastRunFinishedAt).toBeNull();
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("returns warm when the most recent succeeded run is within threshold", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const now = new Date("2026-06-11T12:00:00Z");
+    const finishedAt = new Date(now.getTime() - 2 * 60 * 60 * 1000); // 2h ago
+    await insertSucceededRun(companyId, agentId, finishedAt);
+
+    const result = await detectColdWake(db, agentId, undefined, { now });
+
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(2, 5);
+    expect(result.lastRunFinishedAt).toBe("2026-06-11T10:00:00.000Z");
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("returns cold when the most recent succeeded run exceeds the threshold", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const now = new Date("2026-06-11T12:00:00Z");
+    const finishedAt = new Date(now.getTime() - 48 * 60 * 60 * 1000); // 48h ago
+    await insertSucceededRun(companyId, agentId, finishedAt);
+
+    const result = await detectColdWake(db, agentId, undefined, { now });
+
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeCloseTo(48, 5);
+    expect(result.lastRunFinishedAt).toBe(finishedAt.toISOString());
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("picks the most recent succeeded run when multiple exist and ignores non-succeeded runs", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const now = new Date("2026-06-11T12:00:00Z");
+    // Older succeeded run, 30h ago.
+    await insertSucceededRun(companyId, agentId, new Date(now.getTime() - 30 * 60 * 60 * 1000));
+    // More recent succeeded run, 3h ago — must win.
+    await insertSucceededRun(companyId, agentId, new Date(now.getTime() - 3 * 60 * 60 * 1000));
+    // A failed run that finished 1h ago — must NOT win.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      startedAt: new Date(now.getTime() - 60 * 60 * 1000 - 60_000),
+      finishedAt: new Date(now.getTime() - 60 * 60 * 1000),
+    });
+
+    const result = await detectColdWake(db, agentId, undefined, { now });
+
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(3, 5);
+    expect(result.lastRunFinishedAt).toBe(new Date(now.getTime() - 3 * 60 * 60 * 1000).toISOString());
+  });
+
+  it("ignores runs from other agents", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const otherAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherAgent",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const now = new Date("2026-06-11T12:00:00Z");
+    // Other agent ran 1h ago; should not count for our agent.
+    await insertSucceededRun(companyId, otherAgentId, new Date(now.getTime() - 60 * 60 * 1000));
+
+    const result = await detectColdWake(db, agentId, undefined, { now });
+
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeNull();
+    expect(result.lastRunFinishedAt).toBeNull();
+  });
+
+  it("honors the explicit thresholdHours argument over default and env", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const now = new Date("2026-06-11T12:00:00Z");
+    const finishedAt = new Date(now.getTime() - 5 * 60 * 60 * 1000); // 5h ago
+    await insertSucceededRun(companyId, agentId, finishedAt);
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "1"; // would force cold via env
+    // Param of 12 must win: 5h < 12h ⇒ warm.
+    const result = await detectColdWake(db, agentId, 12, { now });
+
+    expect(result.thresholdHours).toBe(12);
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(5, 5);
+  });
+
+  it("honors PAPERCLIP_HIBERNATION_THRESHOLD_HOURS env override when no param is passed", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const now = new Date("2026-06-11T12:00:00Z");
+    const finishedAt = new Date(now.getTime() - 5 * 60 * 60 * 1000); // 5h ago
+    await insertSucceededRun(companyId, agentId, finishedAt);
+
+    // Default 24h would say warm; env tightens to 2h ⇒ cold.
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "2";
+    const result = await detectColdWake(db, agentId, undefined, { now });
+
+    expect(result.thresholdHours).toBe(2);
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeCloseTo(5, 5);
+  });
+
+  it("returns an ISO-8601 lastRunFinishedAt string", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const now = new Date("2026-06-11T12:00:00Z");
+    const finishedAt = new Date("2026-06-09T09:34:21Z");
+    await insertSucceededRun(companyId, agentId, finishedAt);
+
+    const result = await detectColdWake(db, agentId, undefined, { now });
+
+    expect(result.lastRunFinishedAt).toBe("2026-06-09T09:34:21.000Z");
+    expect(() => new Date(result.lastRunFinishedAt as string).toISOString()).not.toThrow();
+  });
+});
+
+describe("resolveHibernationThresholdHours", () => {
+  beforeEach(() => {
+    delete process.env[HIBERNATION_THRESHOLD_ENV_VAR];
+  });
+
+  afterAll(() => {
+    delete process.env[HIBERNATION_THRESHOLD_ENV_VAR];
+  });
+
+  it("returns the default when no override is set", () => {
+    expect(resolveHibernationThresholdHours()).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("prefers the positive finite override argument", () => {
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "8";
+    expect(resolveHibernationThresholdHours(48)).toBe(48);
+  });
+
+  it("falls back to env when the override is invalid", () => {
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "8";
+    expect(resolveHibernationThresholdHours(undefined)).toBe(8);
+    expect(resolveHibernationThresholdHours(0)).toBe(8);
+    expect(resolveHibernationThresholdHours(-3)).toBe(8);
+    expect(resolveHibernationThresholdHours(Number.NaN)).toBe(8);
+    expect(resolveHibernationThresholdHours(Number.POSITIVE_INFINITY)).toBe(8);
+  });
+
+  it("falls back to the default when env is invalid", () => {
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "not-a-number";
+    expect(resolveHibernationThresholdHours()).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "-1";
+    expect(resolveHibernationThresholdHours()).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "0";
+    expect(resolveHibernationThresholdHours()).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    process.env[HIBERNATION_THRESHOLD_ENV_VAR] = "   ";
+    expect(resolveHibernationThresholdHours()).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -236,6 +236,130 @@ const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_r
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+
+/**
+ * Default hibernation threshold for cold-wake detection.
+ *
+ * If an agent's most recent succeeded heartbeat finished more than this many
+ * hours before the current wake, the wake is considered a "cold wake" and
+ * downstream callers may attach a pre-wake context briefing to the run.
+ *
+ * 24h is the lower bound the board set on ALL-781: shorter than the longest
+ * weekend gap (so a Monday wake on Friday's work still gets briefed), longer
+ * than a normal active session (so back-to-back heartbeats don't burn budget
+ * on briefings nobody needs).
+ */
+export const DEFAULT_HIBERNATION_THRESHOLD_HOURS = 24;
+
+/**
+ * Environment variable that overrides {@link DEFAULT_HIBERNATION_THRESHOLD_HOURS}
+ * at runtime. Per-call `thresholdHours` (when passed) takes precedence over the
+ * env var. Non-numeric, non-finite, zero, or negative values are ignored.
+ */
+export const HIBERNATION_THRESHOLD_ENV_VAR = "PAPERCLIP_HIBERNATION_THRESHOLD_HOURS";
+
+const MILLIS_PER_HOUR = 60 * 60 * 1000;
+
+export interface ColdWakeDetectionResult {
+  /** True when no prior succeeded run exists, or the gap exceeds `thresholdHours`. */
+  isColdWake: boolean;
+  /** Hours between the most recent succeeded run's `finishedAt` and `now`. Null when no prior run. */
+  hoursSinceLastRun: number | null;
+  /** ISO-8601 timestamp of the most recent succeeded run's `finishedAt`. Null when no prior run. */
+  lastRunFinishedAt: string | null;
+  /** Resolved threshold actually used for this check (param > env > default). */
+  thresholdHours: number;
+}
+
+export interface DetectColdWakeOptions {
+  /** Optional override for the wall-clock reference; defaults to `new Date()`. Test-only. */
+  now?: Date;
+}
+
+/**
+ * Resolve the active hibernation threshold using the param > env > default
+ * precedence. Exported for tests and for callers that need to log the value
+ * separately from a detection result.
+ */
+export function resolveHibernationThresholdHours(thresholdHoursOverride?: number): number {
+  if (
+    typeof thresholdHoursOverride === "number" &&
+    Number.isFinite(thresholdHoursOverride) &&
+    thresholdHoursOverride > 0
+  ) {
+    return thresholdHoursOverride;
+  }
+  const raw = process.env[HIBERNATION_THRESHOLD_ENV_VAR];
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+}
+
+/**
+ * Detect whether the next wake for `agentId` should be treated as a cold wake.
+ *
+ * Looks up the most recent `heartbeatRuns` row for the agent whose status is
+ * `"succeeded"` and whose `finishedAt` is non-null. Compares that to `now`
+ * (default: `new Date()`). If no such row exists, the wake is cold. Otherwise
+ * the wake is cold when the gap meets-or-exceeds the resolved threshold.
+ *
+ * Threshold resolution order: explicit `thresholdHours` argument (when
+ * positive and finite) > {@link HIBERNATION_THRESHOLD_ENV_VAR} > {@link DEFAULT_HIBERNATION_THRESHOLD_HOURS}.
+ *
+ * Pure read; no DB writes, no telemetry side effects. Briefing assembly,
+ * logging, and bypass-switch handling are owned by follow-up steps of
+ * ALL-781.
+ *
+ * @param db - Drizzle DB handle (Postgres).
+ * @param agentId - UUID of the agent being woken.
+ * @param thresholdHours - Optional per-call override in hours.
+ * @param options - Optional injection point for `now` (test-only).
+ */
+export async function detectColdWake(
+  db: Db,
+  agentId: string,
+  thresholdHours?: number,
+  options: DetectColdWakeOptions = {},
+): Promise<ColdWakeDetectionResult> {
+  const resolvedThresholdHours = resolveHibernationThresholdHours(thresholdHours);
+  const now = options.now ?? new Date();
+
+  const [latest] = await db
+    .select({ finishedAt: heartbeatRuns.finishedAt })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.agentId, agentId),
+        eq(heartbeatRuns.status, "succeeded"),
+        sql`${heartbeatRuns.finishedAt} IS NOT NULL`,
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.finishedAt))
+    .limit(1);
+
+  if (!latest || !latest.finishedAt) {
+    return {
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours: resolvedThresholdHours,
+    };
+  }
+
+  const finishedAt =
+    latest.finishedAt instanceof Date ? latest.finishedAt : new Date(latest.finishedAt);
+  const hoursSinceLastRun = (now.getTime() - finishedAt.getTime()) / MILLIS_PER_HOUR;
+  return {
+    isColdWake: hoursSinceLastRun >= resolvedThresholdHours,
+    hoursSinceLastRun,
+    lastRunFinishedAt: finishedAt.toISOString(),
+    thresholdHours: resolvedThresholdHours,
+  };
+}
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,


### PR DESCRIPTION
## Summary

Step 2 of a multi-PR change adding a pre-wake context briefing for hibernated agents (parent issue: ALL-781). Step 1 (PR #7956, type plumbing) is already merged.

This PR adds a focused, read-only **staleness helper** in `server/src/services/heartbeat.ts`:

```ts
detectColdWake(
  db: Db,
  agentId: string,
  thresholdHours?: number,
  options?: { now?: Date },
): Promise<ColdWakeDetectionResult>
```

Return shape:

```ts
{
  isColdWake: boolean,
  hoursSinceLastRun: number | null,
  lastRunFinishedAt: string | null,  // ISO-8601
  thresholdHours: number,            // resolved threshold actually used
}
```

The next PR in this series wires this into `buildPaperclipWakePayload` and builds the briefing block; this PR is intentionally just the detection primitive, so it can land independently and earn its own test surface.

## Behavior

- Reads the most recent `heartbeatRuns` row for the agent with `status = 'succeeded'` and a non-null `finishedAt`, ordered desc.
- Cold when no prior succeeded run exists, OR when the gap meets-or-exceeds the resolved threshold.
- Threshold precedence: explicit `thresholdHours` arg > `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS` env > `DEFAULT_HIBERNATION_THRESHOLD_HOURS` (24h). Non-finite, zero, or negative overrides fall through to the next level.
- `resolveHibernationThresholdHours()` is exported separately so callers that only want to log the threshold (without running the query) don't have to duplicate the precedence logic.
- `lastRunFinishedAt` is normalized to an ISO-8601 string.
- `options.now` is injectable for deterministic tests; production callers omit it.

Pure read; no writes, no telemetry side effects. Briefing assembly, bypass switch, and telemetry land in the follow-up PR.

## Threshold default rationale

24h is the floor from the board direction on ALL-781:

- Long enough that an actively iterating agent (back-to-back heartbeats inside an hour) doesn't pay the briefing cost every wake.
- Short enough that a weekend gap (Friday EOD -> Monday AM) still triggers a briefing, which is the originating ALL-779 / CTO-regression incident the parent issue calls out as the golden test case.

Operators can override per-instance via the env var without a code change.

## Test plan

`server/src/__tests__/heartbeat-detect-cold-wake.test.ts` runs against embedded Postgres (matching the pattern in `heartbeat-list.test.ts`) and covers:

- [x] No prior run -> cold + `null` `lastRunFinishedAt` + `null` `hoursSinceLastRun`.
- [x] Under threshold -> warm.
- [x] Over threshold -> cold.
- [x] Multiple succeeded runs -> picks the most recent.
- [x] Failed/cancelled/timed-out runs are ignored even when more recent.
- [x] Runs from other agents are ignored.
- [x] Explicit param overrides the env override (precedence proof).
- [x] Env override applies when no param is passed.
- [x] `lastRunFinishedAt` is ISO-8601 and `Date`-round-trippable.
- [x] `resolveHibernationThresholdHours` unit tests for default, valid override, valid env, and invalid (NaN / negative / zero / whitespace / non-numeric) values.

Targeted run: `pnpm exec vitest run server/src/__tests__/heartbeat-detect-cold-wake.test.ts` -> 12/12 pass.

Repo-wide `tsc --noEmit` error count is unchanged (pre-existing errors in `plugin-host-services.ts` / plugin-sdk are not introduced by this PR).

## Out of scope (follow-up PRs on ALL-781)

- Briefing payload assembly (recent git activity, related-work comment graph, plan + interaction pointers).
- Wiring `detectColdWake` into `buildPaperclipWakePayload`.
- Telemetry (run id, agent id, issue id, briefing token count, sources included).
- `PAPERCLIP_SKIP_COLD_WAKE_BRIEFING` bypass switch.

Refs: ALL-896 (this PR), ALL-781 (parent).
