### PR TITLE
fix(ui): prevent stale service worker cache after deploy

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -356,7 +356,8 @@ export async function createApp(
         express.static(uiDist, {
           maxAge: "1h",
           setHeaders(res, filePath) {
-            if (path.basename(filePath) === "index.html") {
+            const baseName = path.basename(filePath);
+            if (baseName === "index.html" || baseName === "sw.js") {
               res.set("Cache-Control", "no-cache");
             }
           },


### PR DESCRIPTION
## Thinking Path

Paperclip serves the web UI for Stack. This PR updates static UI cache behavior to avoid stale client state after deploys.

- Paperclip subsystem: server static asset delivery (`server/src/app.ts`).
- Problem: `sw.js` was cached with `max-age`, which could keep an old service worker active and continue serving stale UI.
- Why address now: it caused UI regressions after deploy/fallback, including outdated screens appearing for users.
- This pull request changes static headers so both `index.html` and `sw.js` are served with `Cache-Control: no-cache`.
- Benefit: clients pick up the latest UI bundle and service worker reliably, reducing post-deploy stale UI incidents.

## Test plan

- [x] Build UI assets and restart Paperclip service.
- [x] Confirm `/` serves current hashed assets.
- [x] Confirm `/sw.js` is returned with `Cache-Control: no-cache`.
- [x] Validate login page renders correctly after reload.