### PR TITLE
feat(server): assemble per-section cold-wake briefing

### DIFF
--- a/server/src/__tests__/cold-wake-briefing-assembly.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-assembly.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ColdWakeBriefing,
+  ColdWakeClosedIssue,
+  ColdWakeContextSnapshot,
+  ColdWakePendingRequestConfirmation,
+  ColdWakePlanDocument,
+  ColdWakeRelatedComment,
+  ColdWakeSectionRunners,
+  ColdWakeSiblingIssue,
+  RawGitCommit,
+} from "../services/cold-wake-briefing.ts";
+import {
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  buildColdWakeBriefing,
+} from "../services/cold-wake-briefing.ts";
+
+// Centralised deterministic values. `now` and `lastRunFinishedAt` straddle
+// the default 24h threshold so the detection result is unambiguously cold
+// (or warm) without depending on the real clock.
+const NOW = new Date("2026-06-11T20:00:00Z");
+const HOT_LAST_RUN = new Date("2026-06-11T18:00:00Z"); // 2h ago — warm
+const COLD_LAST_RUN = new Date("2026-06-08T20:00:00Z"); // 72h ago — cold
+
+const COMPANY_ID = "00000000-0000-0000-0000-0000000000aa";
+const AGENT_ID = "00000000-0000-0000-0000-0000000000bb";
+const ISSUE_ID = "00000000-0000-0000-0000-0000000000cc";
+
+const FAKE_COMMITS: RawGitCommit[] = [
+  {
+    sha: "deadbeef1111111111111111111111111111aaaa",
+    subject: "feat(harness): touched referenced path",
+    author: "Harness Engineer",
+    date: "2026-06-10T12:00:00Z",
+    files: ["server/src/services/cold-wake-briefing.ts"],
+  },
+  {
+    sha: "deadbeef2222222222222222222222222222bbbb",
+    subject: "chore: unrelated commit",
+    author: "Other Agent",
+    date: "2026-06-09T12:00:00Z",
+    files: ["docs/README.md"],
+  },
+];
+
+const FAKE_CLOSED_ISSUE: ColdWakeClosedIssue = {
+  id: "00000000-0000-0000-0000-0000000000d1",
+  identifier: "ALL-700",
+  title: "Closed dependency",
+  status: "done",
+  closedAt: "2026-06-09T10:00:00Z",
+};
+
+const FAKE_SIBLING: ColdWakeSiblingIssue = {
+  id: "00000000-0000-0000-0000-0000000000e1",
+  identifier: "ALL-781",
+  title: "Parent tracker",
+  assigneeAgentId: AGENT_ID,
+  updatedAt: "2026-06-11T19:30:00Z",
+};
+
+const FAKE_PLAN: ColdWakePlanDocument = {
+  key: "plan",
+  revisionId: "00000000-0000-0000-0000-0000000000f1",
+  updatedAt: "2026-06-11T18:00:00Z",
+};
+
+const FAKE_INTERACTION: ColdWakePendingRequestConfirmation = {
+  interactionId: "00000000-0000-0000-0000-00000000a111",
+  revisionId: "00000000-0000-0000-0000-0000000000f1",
+  createdAt: "2026-06-11T18:05:00Z",
+};
+
+const FAKE_COMMENT: ColdWakeRelatedComment = {
+  issueId: "00000000-0000-0000-0000-0000000000d1",
+  issueIdentifier: "ALL-700",
+  commentId: "00000000-0000-0000-0000-00000000c111",
+  authorType: "board_user",
+  createdAt: "2026-06-11T17:00:00Z",
+  bodyPreview: "Please pick up the next step.",
+  bodyTruncated: false,
+};
+
+/** Defaults that pass through the input shape but return canned populated
+ *  data when arguments imply a populated case. Tests compose against this
+ *  by spreading and overriding individual runners. */
+function populatedRunners(): Partial<ColdWakeSectionRunners> {
+  return {
+    detectColdWake: () => ({
+      isColdWake: true,
+      hoursSinceLastRun: 72,
+      lastRunFinishedAt: COLD_LAST_RUN,
+      thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+    }),
+    getLastSucceededRunFinishedAt: async () => COLD_LAST_RUN,
+    readRecentCommits: async () => FAKE_COMMITS,
+    loadClosedReferencedIssues: async ({ issueIds }) =>
+      issueIds.length === 0 ? [] : [FAKE_CLOSED_ISSUE],
+    loadSiblingInProgressIssues: async ({ assigneeAgentIds }) =>
+      assigneeAgentIds.length === 0 ? [] : [FAKE_SIBLING],
+    loadPlanDocument: async () => FAKE_PLAN,
+    loadPendingRequestConfirmation: async () => FAKE_INTERACTION,
+    loadRecentRelatedComments: async ({ outbound }) =>
+      outbound.length === 0 ? [] : [FAKE_COMMENT],
+  };
+}
+
+const REFERENCED_PATH = "server/src/services/cold-wake-briefing.ts";
+
+const FULL_SNAPSHOT: ColdWakeContextSnapshot = {
+  referencedIssueIdentifiers: [REFERENCED_PATH],
+  relatedWork: {
+    outbound: [
+      { issue: { id: FAKE_CLOSED_ISSUE.id, identifier: FAKE_CLOSED_ISSUE.identifier } },
+    ],
+  },
+  issueAncestry: {
+    chainOfCommand: ["00000000-0000-0000-0000-000000000099"],
+    ancestorIssueIds: ["00000000-0000-0000-0000-0000000000aa"],
+  },
+};
+
+// The `db` field is unused when every section runner is overridden — pass a
+// typed sentinel so the test does not have to spin up an embedded Postgres.
+const FAKE_DB = {} as unknown as Parameters<typeof buildColdWakeBriefing>[0]["db"];
+
+async function callBuild(
+  overrides: Partial<ColdWakeSectionRunners>,
+  opts: { snapshot?: ColdWakeContextSnapshot; workspaceCwd?: string | null } = {},
+): Promise<ColdWakeBriefing | null> {
+  return buildColdWakeBriefing({
+    db: FAKE_DB,
+    companyId: COMPANY_ID,
+    agentId: AGENT_ID,
+    issueId: ISSUE_ID,
+    contextSnapshot: opts.snapshot ?? FULL_SNAPSHOT,
+    workspaceCwd: opts.workspaceCwd === undefined ? "/tmp/workspace" : opts.workspaceCwd,
+    now: NOW,
+    __overrides: overrides,
+  });
+}
+
+describe("buildColdWakeBriefing", () => {
+  it("returns null on a warm wake (detectColdWake → isColdWake: false)", async () => {
+    const result = await callBuild({
+      // Warm — the assembler should short-circuit before any section runs.
+      detectColdWake: () => ({
+        isColdWake: false,
+        hoursSinceLastRun: 2,
+        lastRunFinishedAt: HOT_LAST_RUN,
+        thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+      }),
+      getLastSucceededRunFinishedAt: async () => HOT_LAST_RUN,
+      // If any of the section runners were invoked, the test would fail at
+      // this rejection; their non-invocation proves the short-circuit.
+      readRecentCommits: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadClosedReferencedIssues: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadSiblingInProgressIssues: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadPlanDocument: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadPendingRequestConfirmation: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadRecentRelatedComments: async () => {
+        throw new Error("section ran on warm wake");
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("populates all five sections on a cold wake with every source present", async () => {
+    const briefing = await callBuild(populatedRunners());
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    // Detection metadata round-trips through the briefing.
+    expect(b.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(b.hoursSinceLastRun).toBe(72);
+    expect(b.lastRunFinishedAt).toBe(COLD_LAST_RUN.toISOString());
+
+    // Section 1 — recent commits, with touchedReferencedPath set on the
+    // commit that touched the referenced path.
+    expect(b.recentCommits).toHaveLength(2);
+    expect(b.recentCommits[0]).toMatchObject({
+      sha: FAKE_COMMITS[0]!.sha,
+      touchedReferencedPath: true,
+    });
+    expect(b.recentCommits[1]).toMatchObject({
+      sha: FAKE_COMMITS[1]!.sha,
+      touchedReferencedPath: false,
+    });
+    expect(b.recentCommitsTruncated).toBe(false);
+
+    // Sections 2–5 round-trip the canned values.
+    expect(b.recentlyClosedReferencedIssues).toEqual([FAKE_CLOSED_ISSUE]);
+    expect(b.siblingInProgressIssues).toEqual([FAKE_SIBLING]);
+    expect(b.planDocument).toEqual(FAKE_PLAN);
+    expect(b.pendingRequestConfirmation).toEqual(FAKE_INTERACTION);
+    expect(b.recentRelatedComments).toEqual([FAKE_COMMENT]);
+
+    // sourcesIncluded covers all six keys (six because plan + interaction
+    // are tracked separately even though §3.2 groups them under "section 4").
+    expect(new Set(b.sourcesIncluded)).toEqual(
+      new Set(["git", "closed_issues", "siblings", "plan", "interaction", "comments"]),
+    );
+
+    expect(b.briefingError).toBeNull();
+    // Placeholders for step 4's budget guard.
+    expect(b.budgetTokens).toBe(0);
+    expect(b.budgetTokenCap).toBeGreaterThan(0);
+    expect(b.truncated).toBe(false);
+  });
+
+  it("degrades the git section when simpleGit throws (workspace not cloned)", async () => {
+    const briefing = await callBuild({
+      ...populatedRunners(),
+      readRecentCommits: async () => {
+        throw new Error("ENOENT: no .git directory");
+      },
+    });
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    expect(b.recentCommits).toEqual([]);
+    expect(b.recentCommitsTruncated).toBe(false);
+    expect(b.sourcesIncluded).not.toContain("git");
+    // The other sections still populated normally.
+    expect(b.sourcesIncluded).toEqual(
+      expect.arrayContaining([
+        "closed_issues",
+        "siblings",
+        "plan",
+        "interaction",
+        "comments",
+      ]),
+    );
+    expect(b.recentlyClosedReferencedIssues).toEqual([FAKE_CLOSED_ISSUE]);
+    expect(b.recentRelatedComments).toEqual([FAKE_COMMENT]);
+    // Per-section catch absorbs the failure — top-level error stays null.
+    expect(b.briefingError).toBeNull();
+  });
+
+  it("returns empty section 2 and 5 when contextSnapshot has no relatedWork.outbound", async () => {
+    const snapshot: ColdWakeContextSnapshot = {
+      referencedIssueIdentifiers: [REFERENCED_PATH],
+      relatedWork: { outbound: [] },
+      issueAncestry: { chainOfCommand: [], ancestorIssueIds: [] },
+    };
+
+    const briefing = await callBuild(populatedRunners(), { snapshot });
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    expect(b.recentlyClosedReferencedIssues).toEqual([]);
+    expect(b.recentRelatedComments).toEqual([]);
+    // Both sections succeeded with empty output — keep them in sourcesIncluded
+    // so downstream renderers can distinguish "no data" from "errored".
+    expect(b.sourcesIncluded).toEqual(
+      expect.arrayContaining(["closed_issues", "comments"]),
+    );
+    // Sections 1, 3, 4 unaffected.
+    expect(b.recentCommits).toHaveLength(2);
+    expect(b.siblingInProgressIssues).toEqual([FAKE_SIBLING]);
+    expect(b.planDocument).toEqual(FAKE_PLAN);
+    expect(b.pendingRequestConfirmation).toEqual(FAKE_INTERACTION);
+    expect(b.briefingError).toBeNull();
+  });
+
+  it("marks briefingError.code='all_sections_failed' when every section throws", async () => {
+    const throwingRunners: Partial<ColdWakeSectionRunners> = {
+      detectColdWake: populatedRunners().detectColdWake,
+      getLastSucceededRunFinishedAt: populatedRunners().getLastSucceededRunFinishedAt,
+      readRecentCommits: async () => {
+        throw new Error("git boom");
+      },
+      loadClosedReferencedIssues: async () => {
+        throw new Error("closed boom");
+      },
+      loadSiblingInProgressIssues: async () => {
+        throw new Error("siblings boom");
+      },
+      loadPlanDocument: async () => {
+        throw new Error("plan boom");
+      },
+      loadPendingRequestConfirmation: async () => {
+        throw new Error("interaction boom");
+      },
+      loadRecentRelatedComments: async () => {
+        throw new Error("comments boom");
+      },
+    };
+
+    const briefing = await callBuild(throwingRunners);
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    // Every section degrades to its empty default.
+    expect(b.recentCommits).toEqual([]);
+    expect(b.recentlyClosedReferencedIssues).toEqual([]);
+    expect(b.siblingInProgressIssues).toEqual([]);
+    expect(b.planDocument).toBeNull();
+    expect(b.pendingRequestConfirmation).toBeNull();
+    expect(b.recentRelatedComments).toEqual([]);
+    expect(b.sourcesIncluded).toEqual([]);
+
+    expect(b.briefingError).not.toBeNull();
+    expect(b.briefingError?.code).toBe("all_sections_failed");
+    expect(b.briefingError?.message.length).toBeGreaterThan(0);
+    // The aggregated message should reference each failing section by key
+    // so the operator can trace which section blew up.
+    expect(b.briefingError?.message).toContain("git");
+    expect(b.briefingError?.message).toContain("comments");
+  });
+});

--- a/server/src/__tests__/cold-wake-briefing-detection.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-detection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  detectColdWake,
+  resolveHibernationThresholdHours,
+} from "../services/cold-wake-briefing.ts";
+
+const NOW = new Date("2026-06-11T20:00:00Z");
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 3_600_000);
+
+describe("detectColdWake", () => {
+  it("flags the wake cold when there is no prior succeeded run", () => {
+    expect(detectColdWake({ lastRunFinishedAt: null, now: NOW })).toEqual({
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+    });
+  });
+
+  it("flags the wake warm when the last run is inside the threshold", () => {
+    const last = hoursAgo(2);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(2, 6);
+    expect(result.lastRunFinishedAt).toBe(last);
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("flags the wake cold when the last run is older than the threshold", () => {
+    const last = hoursAgo(48);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeCloseTo(48, 6);
+  });
+
+  it("respects an explicit thresholdHours override", () => {
+    const last = hoursAgo(6);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: 4 });
+    expect(result.isColdWake).toBe(true);
+    expect(result.thresholdHours).toBe(4);
+  });
+
+  it("treats exactly-at-threshold as warm (boundary is strict-greater)", () => {
+    const last = hoursAgo(24);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: 24 });
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(24, 6);
+  });
+
+  it("returns a Date for lastRunFinishedAt that round-trips through ISO", () => {
+    const last = hoursAgo(3);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.lastRunFinishedAt).toBeInstanceOf(Date);
+    expect(result.lastRunFinishedAt?.toISOString()).toBe(last.toISOString());
+  });
+
+  it("falls back to the env-resolved threshold when override is invalid", () => {
+    const last = hoursAgo(30);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: -1 });
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(result.isColdWake).toBe(true);
+  });
+});
+
+describe("resolveHibernationThresholdHours", () => {
+  it("returns the default when the env var is unset", () => {
+    expect(resolveHibernationThresholdHours({})).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("respects a valid numeric env var", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "12" }),
+    ).toBe(12);
+  });
+
+  it("falls back to the default when the env var is non-numeric", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "abc" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("falls back to the default when the env var is zero or negative", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "0" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "-5" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+});

--- a/server/src/services/cold-wake-briefing.ts
+++ b/server/src/services/cold-wake-briefing.ts
@@ -8,13 +8,30 @@
 // section assembly, token-budget guard, telemetry) lands as a separate PR
 // against the parent tracker.
 //
-// **This PR — step 2 — only ships staleness detection.** Per-section
-// assembly, the budget guard, telemetry, and the call-site wiring all land
-// in follow-up PRs.
+// **Steps shipped:**
+// - Step 2 (detection): `detectColdWake`, `resolveHibernationThresholdHours`,
+//   `getLastSucceededRunFinishedAt`.
+// - Step 3 (per-section assembler): `buildColdWakeBriefing` — collects the
+//   five sections from §3.2 of the parent plan (recent commits, recently
+//   closed referenced issues, sibling in-progress issues, plan document +
+//   pending request_confirmation, recent related comments). Each section is
+//   wrapped in a try/catch so a single failure degrades the briefing rather
+//   than failing the wake.
+//
+// The token-budget guard, bypass switch, telemetry, and the call-site wiring
+// land in follow-up PRs (steps 4–6).
 
-import { and, desc, eq } from "drizzle-orm";
+import { execFile } from "node:child_process";
+import { and, desc, eq, gte, inArray, isNull, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { heartbeatRuns } from "@paperclipai/db";
+import {
+  documents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issueThreadInteractions,
+  issues,
+} from "@paperclipai/db";
 
 /** Default hibernation threshold. 24h ≈ one working day; gaps longer than
  *  that are unambiguously stale from the agent's perspective. Tunable via
@@ -114,4 +131,720 @@ export async function getLastSucceededRunFinishedAt(input: {
     .orderBy(desc(heartbeatRuns.finishedAt))
     .limit(1);
   return rows[0]?.finishedAt ?? null;
+}
+
+// =============================================================================
+// Step 3 — per-section assembler.
+// =============================================================================
+
+const RECENT_COMMITS_MAX = 20;
+const SIBLING_LIMIT = 10;
+const COMMENT_LIMIT_PER_ISSUE = 3;
+const COMMENT_TOTAL_LIMIT = 25;
+const COMMENT_PREVIEW_LIMIT = 280;
+const CLOSED_ISSUE_LOOKBACK_DAYS = 14;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+/** Placeholder token-budget cap. Step 4 wires up the real guard and eviction
+ *  policy; the field is populated here so the briefing shape round-trips. */
+const DEFAULT_BUDGET_TOKEN_CAP = 8000;
+
+export type ColdWakeRecentCommit = {
+  sha: string;
+  subject: string;
+  author: string;
+  date: string;
+  touchedReferencedPath: boolean;
+};
+
+export type ColdWakeClosedIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  closedAt: string;
+};
+
+export type ColdWakeSiblingIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  assigneeAgentId: string | null;
+  updatedAt: string;
+};
+
+export type ColdWakePlanDocument = {
+  key: string;
+  revisionId: string;
+  updatedAt: string;
+};
+
+export type ColdWakePendingRequestConfirmation = {
+  interactionId: string;
+  revisionId: string | null;
+  createdAt: string;
+};
+
+export type ColdWakeRelatedComment = {
+  issueId: string;
+  issueIdentifier: string | null;
+  commentId: string;
+  authorType: string;
+  createdAt: string;
+  bodyPreview: string;
+  bodyTruncated: boolean;
+};
+
+export type ColdWakeBriefingError = {
+  code: string;
+  message: string;
+};
+
+/** The assembled briefing. Shape mirrors `PaperclipColdWakeBriefing` on
+ *  `PaperclipWakePayload` (step 1) — `normalizePaperclipColdWakeBriefing`
+ *  in `@paperclipai/adapter-utils` accepts this object verbatim. */
+export type ColdWakeBriefing = {
+  thresholdHours: number;
+  hoursSinceLastRun: number | null;
+  lastRunFinishedAt: string | null;
+  recentCommits: ColdWakeRecentCommit[];
+  recentCommitsTruncated: boolean;
+  recentlyClosedReferencedIssues: ColdWakeClosedIssue[];
+  siblingInProgressIssues: ColdWakeSiblingIssue[];
+  planDocument: ColdWakePlanDocument | null;
+  pendingRequestConfirmation: ColdWakePendingRequestConfirmation | null;
+  recentRelatedComments: ColdWakeRelatedComment[];
+  /** Section keys actually populated — matches the §3.2 source list:
+   *  `"git" | "closed_issues" | "siblings" | "plan" | "interaction" | "comments"`.
+   *  Sections that failed are omitted. */
+  sourcesIncluded: string[];
+  /** Placeholder until step 4 implements the budget guard. */
+  budgetTokens: number;
+  /** Placeholder until step 4 implements the budget guard. */
+  budgetTokenCap: number;
+  /** Placeholder until step 4 implements eviction. */
+  truncated: boolean;
+  briefingError: ColdWakeBriefingError | null;
+};
+
+/** Minimal context the assembler needs from the wake payload context
+ *  snapshot. The wiring layer (step 6) maps the existing snapshot onto
+ *  this shape; deliberately permissive so it can absorb upstream changes
+ *  without ripping through every test. */
+export type ColdWakeContextSnapshot = {
+  /** Paths that the recent-commits section should flag as
+   *  `touchedReferencedPath: true` when a commit touches them. Despite the
+   *  legacy field name, this is consumed as a list of path fragments
+   *  matched by substring against each commit's touched files. */
+  referencedIssueIdentifiers?: string[] | null;
+  /** Related work summary as produced by `listIssueReferenceSummary`. Only
+   *  `outbound[*].issue.{id,identifier}` is consulted here. */
+  relatedWork?: {
+    outbound?: Array<
+      | {
+          issue?: {
+            id?: string | null;
+            identifier?: string | null;
+          } | null;
+        }
+      | null
+    > | null;
+  } | null;
+  /** Optional ancestor metadata. `chainOfCommand` widens the sibling-issue
+   *  search to peers and supervisors; `ancestorIssueIds` widens the
+   *  pending-request_confirmation search to plan reviews living on parents. */
+  issueAncestry?: {
+    chainOfCommand?: string[] | null;
+    ancestorIssueIds?: string[] | null;
+  } | null;
+};
+
+/** Raw commit shape returned by the git reader. Keeps the I/O concern
+ *  (simple-git vs. `execFile('git', …)`) behind a single seam so tests can
+ *  substitute a deterministic implementation. */
+export type RawGitCommit = {
+  sha: string;
+  subject: string;
+  author: string;
+  date: string;
+  files: string[];
+};
+
+/** Per-section runners. Default implementations hit the DB / filesystem;
+ *  callers (tests) can override any subset to inject deterministic values
+ *  or simulate failures. */
+export type ColdWakeSectionRunners = {
+  detectColdWake: typeof detectColdWake;
+  getLastSucceededRunFinishedAt: typeof getLastSucceededRunFinishedAt;
+  readRecentCommits: (
+    workspaceCwd: string,
+    maxCount: number,
+  ) => Promise<RawGitCommit[]>;
+  loadClosedReferencedIssues: (args: {
+    db: Db;
+    companyId: string;
+    issueIds: string[];
+    since: Date;
+  }) => Promise<ColdWakeClosedIssue[]>;
+  loadSiblingInProgressIssues: (args: {
+    db: Db;
+    companyId: string;
+    assigneeAgentIds: string[];
+    excludeIssueId: string;
+    limit: number;
+  }) => Promise<ColdWakeSiblingIssue[]>;
+  loadPlanDocument: (args: {
+    db: Db;
+    companyId: string;
+    issueId: string;
+  }) => Promise<ColdWakePlanDocument | null>;
+  loadPendingRequestConfirmation: (args: {
+    db: Db;
+    companyId: string;
+    issueIds: string[];
+  }) => Promise<ColdWakePendingRequestConfirmation | null>;
+  loadRecentRelatedComments: (args: {
+    db: Db;
+    companyId: string;
+    outbound: Array<{ id: string; identifier: string | null }>;
+    perIssue: number;
+    total: number;
+    previewLimit: number;
+  }) => Promise<ColdWakeRelatedComment[]>;
+};
+
+export type BuildColdWakeBriefingInput = {
+  db: Db;
+  companyId: string;
+  agentId: string;
+  issueId: string;
+  contextSnapshot: ColdWakeContextSnapshot;
+  /** Absolute path to the git workspace whose history the section 1 reader
+   *  should walk. `null` (or unset) means the agent has no checked-out
+   *  workspace and the git section degrades gracefully. */
+  workspaceCwd?: string | null;
+  /** Injectable clock for tests. Defaults to `new Date()`. */
+  now?: Date;
+  /** Test seam — override any subset of section runners. Defaults to the
+   *  real DB / filesystem-backed implementations. */
+  __overrides?: Partial<ColdWakeSectionRunners>;
+};
+
+/** Default git-log reader. Shells out to the system `git` binary to avoid a
+ *  new runtime dependency; output is parsed via record/field separators
+ *  (`%x1e` between commits, `%x1f` between header fields) so commit
+ *  subjects with newlines do not split a record. */
+async function defaultReadRecentCommits(
+  workspaceCwd: string,
+  maxCount: number,
+): Promise<RawGitCommit[]> {
+  return new Promise<RawGitCommit[]>((resolve, reject) => {
+    execFile(
+      "git",
+      [
+        "log",
+        `--max-count=${maxCount}`,
+        "--pretty=format:%x1e%H%x1f%s%x1f%an%x1f%aI",
+        "--name-only",
+      ],
+      { cwd: workspaceCwd, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        const commits: RawGitCommit[] = [];
+        const records = stdout.split("\x1e");
+        for (const rec of records) {
+          const trimmed = rec.replace(/^\n+/, "");
+          if (!trimmed) continue;
+          const lines = trimmed.split("\n");
+          const headerLine = lines[0] ?? "";
+          const fileLines = lines.slice(1).filter((l) => l.length > 0);
+          const [sha, subject, author, date] = headerLine.split("\x1f");
+          if (!sha) continue;
+          commits.push({
+            sha,
+            subject: subject ?? "",
+            author: author ?? "",
+            date: date ?? "",
+            files: fileLines,
+          });
+        }
+        resolve(commits);
+      },
+    );
+  });
+}
+
+async function defaultLoadClosedReferencedIssues(args: {
+  db: Db;
+  companyId: string;
+  issueIds: string[];
+  since: Date;
+}): Promise<ColdWakeClosedIssue[]> {
+  if (args.issueIds.length === 0) return [];
+  const rows = await args.db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      status: issues.status,
+      updatedAt: issues.updatedAt,
+    })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, args.companyId),
+        inArray(issues.id, args.issueIds),
+        inArray(issues.status, ["done", "cancelled"]),
+        gte(issues.updatedAt, args.since),
+      ),
+    )
+    .orderBy(desc(issues.updatedAt));
+  return rows.map((row) => ({
+    id: row.id,
+    identifier: row.identifier ?? null,
+    title: row.title,
+    status: row.status,
+    closedAt: row.updatedAt.toISOString(),
+  }));
+}
+
+async function defaultLoadSiblingInProgressIssues(args: {
+  db: Db;
+  companyId: string;
+  assigneeAgentIds: string[];
+  excludeIssueId: string;
+  limit: number;
+}): Promise<ColdWakeSiblingIssue[]> {
+  if (args.assigneeAgentIds.length === 0) return [];
+  const rows = await args.db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      assigneeAgentId: issues.assigneeAgentId,
+      updatedAt: issues.updatedAt,
+    })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, args.companyId),
+        eq(issues.status, "in_progress"),
+        inArray(issues.assigneeAgentId, args.assigneeAgentIds),
+        ne(issues.id, args.excludeIssueId),
+      ),
+    )
+    .orderBy(desc(issues.updatedAt))
+    .limit(args.limit);
+  return rows.map((row) => ({
+    id: row.id,
+    identifier: row.identifier ?? null,
+    title: row.title,
+    assigneeAgentId: row.assigneeAgentId,
+    updatedAt: row.updatedAt.toISOString(),
+  }));
+}
+
+async function defaultLoadPlanDocument(args: {
+  db: Db;
+  companyId: string;
+  issueId: string;
+}): Promise<ColdWakePlanDocument | null> {
+  const rows = await args.db
+    .select({
+      key: issueDocuments.key,
+      updatedAt: issueDocuments.updatedAt,
+      latestRevisionId: documents.latestRevisionId,
+      documentId: documents.id,
+    })
+    .from(issueDocuments)
+    .innerJoin(documents, eq(documents.id, issueDocuments.documentId))
+    .where(
+      and(
+        eq(issueDocuments.companyId, args.companyId),
+        eq(issueDocuments.issueId, args.issueId),
+        eq(issueDocuments.key, "plan"),
+      ),
+    )
+    .orderBy(desc(issueDocuments.updatedAt))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    key: row.key,
+    // `latestRevisionId` is the canonical pointer; fall back to the document
+    // id when the column is null (older rows seeded before revisions landed).
+    revisionId: row.latestRevisionId ?? row.documentId,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+async function defaultLoadPendingRequestConfirmation(args: {
+  db: Db;
+  companyId: string;
+  issueIds: string[];
+}): Promise<ColdWakePendingRequestConfirmation | null> {
+  if (args.issueIds.length === 0) return null;
+  const rows = await args.db
+    .select({
+      id: issueThreadInteractions.id,
+      payload: issueThreadInteractions.payload,
+      createdAt: issueThreadInteractions.createdAt,
+    })
+    .from(issueThreadInteractions)
+    .where(
+      and(
+        eq(issueThreadInteractions.companyId, args.companyId),
+        inArray(issueThreadInteractions.issueId, args.issueIds),
+        eq(issueThreadInteractions.kind, "request_confirmation"),
+        eq(issueThreadInteractions.status, "pending"),
+      ),
+    )
+    .orderBy(desc(issueThreadInteractions.createdAt))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    interactionId: row.id,
+    revisionId: extractTargetRevisionId(row.payload),
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function extractTargetRevisionId(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const target = (payload as Record<string, unknown>).target;
+  if (!target || typeof target !== "object") return null;
+  const revisionId = (target as Record<string, unknown>).revisionId;
+  return typeof revisionId === "string" && revisionId.length > 0 ? revisionId : null;
+}
+
+async function defaultLoadRecentRelatedComments(args: {
+  db: Db;
+  companyId: string;
+  outbound: Array<{ id: string; identifier: string | null }>;
+  perIssue: number;
+  total: number;
+  previewLimit: number;
+}): Promise<ColdWakeRelatedComment[]> {
+  if (args.outbound.length === 0) return [];
+  const issueIds = args.outbound.map((item) => item.id);
+  const identifierMap = new Map(args.outbound.map((item) => [item.id, item.identifier]));
+  const rows = await args.db
+    .select({
+      id: issueComments.id,
+      issueId: issueComments.issueId,
+      authorType: issueComments.authorType,
+      body: issueComments.body,
+      createdAt: issueComments.createdAt,
+    })
+    .from(issueComments)
+    .where(
+      and(
+        eq(issueComments.companyId, args.companyId),
+        inArray(issueComments.issueId, issueIds),
+        isNull(issueComments.deletedAt),
+      ),
+    )
+    .orderBy(desc(issueComments.createdAt));
+
+  const perIssueCount = new Map<string, number>();
+  const seen = new Set<string>();
+  const collected: ColdWakeRelatedComment[] = [];
+  for (const row of rows) {
+    if (seen.has(row.id)) continue;
+    const taken = perIssueCount.get(row.issueId) ?? 0;
+    if (taken >= args.perIssue) continue;
+    const body = row.body ?? "";
+    const truncated = body.length > args.previewLimit;
+    collected.push({
+      issueId: row.issueId,
+      issueIdentifier: identifierMap.get(row.issueId) ?? null,
+      commentId: row.id,
+      authorType: row.authorType ?? "agent",
+      createdAt: row.createdAt.toISOString(),
+      bodyPreview: truncated ? body.slice(0, args.previewLimit) : body,
+      bodyTruncated: truncated,
+    });
+    seen.add(row.id);
+    perIssueCount.set(row.issueId, taken + 1);
+    if (collected.length >= args.total) break;
+  }
+  return collected;
+}
+
+function defaultSectionRunners(): ColdWakeSectionRunners {
+  return {
+    detectColdWake,
+    getLastSucceededRunFinishedAt,
+    readRecentCommits: defaultReadRecentCommits,
+    loadClosedReferencedIssues: defaultLoadClosedReferencedIssues,
+    loadSiblingInProgressIssues: defaultLoadSiblingInProgressIssues,
+    loadPlanDocument: defaultLoadPlanDocument,
+    loadPendingRequestConfirmation: defaultLoadPendingRequestConfirmation,
+    loadRecentRelatedComments: defaultLoadRecentRelatedComments,
+  };
+}
+
+function collectOutboundIssues(
+  snapshot: ColdWakeContextSnapshot,
+): Array<{ id: string; identifier: string | null }> {
+  const items = snapshot.relatedWork?.outbound ?? [];
+  const out: Array<{ id: string; identifier: string | null }> = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const id = item?.issue?.id ?? null;
+    if (typeof id !== "string" || id.length === 0) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, identifier: item?.issue?.identifier ?? null });
+  }
+  return out;
+}
+
+function collectAssigneeAgentIds(
+  snapshot: ColdWakeContextSnapshot,
+  selfAgentId: string,
+): string[] {
+  const chain = snapshot.issueAncestry?.chainOfCommand ?? [];
+  const ids = new Set<string>([selfAgentId]);
+  for (const id of chain) {
+    if (typeof id === "string" && id.length > 0) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+function collectIssueAncestryIds(
+  snapshot: ColdWakeContextSnapshot,
+  selfIssueId: string,
+): string[] {
+  const ancestors = snapshot.issueAncestry?.ancestorIssueIds ?? [];
+  const ids = new Set<string>([selfIssueId]);
+  for (const id of ancestors) {
+    if (typeof id === "string" && id.length > 0) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+function describeSectionError(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name || "unknown error";
+  if (typeof err === "string") return err;
+  return "unknown error";
+}
+
+/** Assemble the cold-wake briefing. Calls `detectColdWake` first and returns
+ *  `null` on a warm wake (no briefing). On a cold wake, runs each section in
+ *  parallel — each behind its own try/catch so a single failure degrades the
+ *  briefing rather than failing the wake. `briefingError` is null on partial
+ *  success; only set when *every* section throws.
+ *
+ *  The token-budget guard, eviction policy, and call-site wiring land in
+ *  follow-up PRs; `budgetTokens` / `budgetTokenCap` / `truncated` are
+ *  populated with safe placeholders so the shape round-trips through the
+ *  step-1 normalizer. */
+export async function buildColdWakeBriefing(
+  input: BuildColdWakeBriefingInput,
+): Promise<ColdWakeBriefing | null> {
+  const runners: ColdWakeSectionRunners = {
+    ...defaultSectionRunners(),
+    ...(input.__overrides ?? {}),
+  };
+  const now = input.now ?? new Date();
+
+  // Detection — failure to read the last-succeeded run is treated as "no
+  // prior run" (i.e. cold). Detection itself is a pure function and is not
+  // wrapped because the briefing shape needs `thresholdHours`.
+  let lastRunFinishedAt: Date | null = null;
+  try {
+    lastRunFinishedAt = await runners.getLastSucceededRunFinishedAt({
+      db: input.db,
+      companyId: input.companyId,
+      agentId: input.agentId,
+    });
+  } catch {
+    lastRunFinishedAt = null;
+  }
+  const detection = runners.detectColdWake({ lastRunFinishedAt, now });
+  if (!detection.isColdWake) return null;
+
+  const referencedPaths = (input.contextSnapshot.referencedIssueIdentifiers ?? []).filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+  const outboundIssues = collectOutboundIssues(input.contextSnapshot);
+  const outboundIds = outboundIssues.map((item) => item.id);
+  const assigneeAgentIds = collectAssigneeAgentIds(input.contextSnapshot, input.agentId);
+  const ancestryIssueIds = collectIssueAncestryIds(input.contextSnapshot, input.issueId);
+  const closedSince = new Date(now.getTime() - CLOSED_ISSUE_LOOKBACK_DAYS * MS_PER_DAY);
+
+  // Section 1 — recent git commits, with the touched-referenced-path flag
+  // tagged in-process so this is the only section that talks to the
+  // filesystem.
+  const gitSection = (async (): Promise<{
+    recentCommits: ColdWakeRecentCommit[];
+    recentCommitsTruncated: boolean;
+  }> => {
+    if (!input.workspaceCwd) {
+      throw new Error("no_workspace_cwd");
+    }
+    const raw = await runners.readRecentCommits(input.workspaceCwd, RECENT_COMMITS_MAX);
+    const recentCommits = raw.slice(0, RECENT_COMMITS_MAX).map((c) => ({
+      sha: c.sha,
+      subject: c.subject,
+      author: c.author,
+      date: c.date,
+      touchedReferencedPath:
+        referencedPaths.length > 0 &&
+        c.files.some((f) => referencedPaths.some((p) => f === p || f.includes(p))),
+    }));
+    return {
+      recentCommits,
+      recentCommitsTruncated: raw.length > RECENT_COMMITS_MAX,
+    };
+  })();
+
+  const closedIssuesSection = runners.loadClosedReferencedIssues({
+    db: input.db,
+    companyId: input.companyId,
+    issueIds: outboundIds,
+    since: closedSince,
+  });
+
+  const siblingsSection = runners.loadSiblingInProgressIssues({
+    db: input.db,
+    companyId: input.companyId,
+    assigneeAgentIds,
+    excludeIssueId: input.issueId,
+    limit: SIBLING_LIMIT,
+  });
+
+  const planSection = runners.loadPlanDocument({
+    db: input.db,
+    companyId: input.companyId,
+    issueId: input.issueId,
+  });
+
+  const interactionSection = runners.loadPendingRequestConfirmation({
+    db: input.db,
+    companyId: input.companyId,
+    issueIds: ancestryIssueIds,
+  });
+
+  const commentsSection = runners.loadRecentRelatedComments({
+    db: input.db,
+    companyId: input.companyId,
+    outbound: outboundIssues,
+    perIssue: COMMENT_LIMIT_PER_ISSUE,
+    total: COMMENT_TOTAL_LIMIT,
+    previewLimit: COMMENT_PREVIEW_LIMIT,
+  });
+
+  // `Promise.allSettled` lets every section run in parallel and report its
+  // own outcome, so one failure does not poison the whole briefing.
+  const [
+    gitResult,
+    closedIssuesResult,
+    siblingsResult,
+    planResult,
+    interactionResult,
+    commentsResult,
+  ] = await Promise.allSettled([
+    gitSection,
+    closedIssuesSection,
+    siblingsSection,
+    planSection,
+    interactionSection,
+    commentsSection,
+  ]);
+
+  const sourcesIncluded: string[] = [];
+  const sectionErrors: string[] = [];
+  let succeededAny = false;
+
+  let recentCommits: ColdWakeRecentCommit[] = [];
+  let recentCommitsTruncated = false;
+  if (gitResult.status === "fulfilled") {
+    recentCommits = gitResult.value.recentCommits;
+    recentCommitsTruncated = gitResult.value.recentCommitsTruncated;
+    sourcesIncluded.push("git");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`git:${describeSectionError(gitResult.reason)}`);
+  }
+
+  let recentlyClosedReferencedIssues: ColdWakeClosedIssue[] = [];
+  if (closedIssuesResult.status === "fulfilled") {
+    recentlyClosedReferencedIssues = closedIssuesResult.value;
+    sourcesIncluded.push("closed_issues");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`closed_issues:${describeSectionError(closedIssuesResult.reason)}`);
+  }
+
+  let siblingInProgressIssues: ColdWakeSiblingIssue[] = [];
+  if (siblingsResult.status === "fulfilled") {
+    siblingInProgressIssues = siblingsResult.value;
+    sourcesIncluded.push("siblings");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`siblings:${describeSectionError(siblingsResult.reason)}`);
+  }
+
+  let planDocument: ColdWakePlanDocument | null = null;
+  if (planResult.status === "fulfilled") {
+    planDocument = planResult.value;
+    sourcesIncluded.push("plan");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`plan:${describeSectionError(planResult.reason)}`);
+  }
+
+  let pendingRequestConfirmation: ColdWakePendingRequestConfirmation | null = null;
+  if (interactionResult.status === "fulfilled") {
+    pendingRequestConfirmation = interactionResult.value;
+    sourcesIncluded.push("interaction");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`interaction:${describeSectionError(interactionResult.reason)}`);
+  }
+
+  let recentRelatedComments: ColdWakeRelatedComment[] = [];
+  if (commentsResult.status === "fulfilled") {
+    recentRelatedComments = commentsResult.value;
+    sourcesIncluded.push("comments");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`comments:${describeSectionError(commentsResult.reason)}`);
+  }
+
+  const briefingError: ColdWakeBriefingError | null = succeededAny
+    ? null
+    : {
+        code: "all_sections_failed",
+        message:
+          sectionErrors.length > 0
+            ? sectionErrors.join("; ")
+            : "All briefing sections failed",
+      };
+
+  return {
+    thresholdHours: detection.thresholdHours,
+    hoursSinceLastRun: detection.hoursSinceLastRun,
+    lastRunFinishedAt: detection.lastRunFinishedAt
+      ? detection.lastRunFinishedAt.toISOString()
+      : null,
+    recentCommits,
+    recentCommitsTruncated,
+    recentlyClosedReferencedIssues,
+    siblingInProgressIssues,
+    planDocument,
+    pendingRequestConfirmation,
+    recentRelatedComments,
+    sourcesIncluded,
+    budgetTokens: 0,
+    budgetTokenCap: DEFAULT_BUDGET_TOKEN_CAP,
+    truncated: false,
+    briefingError,
+  };
 }

--- a/server/src/services/cold-wake-briefing.ts
+++ b/server/src/services/cold-wake-briefing.ts
@@ -1,0 +1,117 @@
+// Cold-wake briefing assembler — step-by-step in service of the parent
+// initiative: when an agent has been hibernated past a threshold and is woken
+// onto an active issue, the harness prepends a "what changed under you"
+// briefing into the wake payload so the agent does not start work blind.
+//
+// This file holds the focused, adjacent assembler that the heartbeat service
+// calls right after `buildPaperclipWakePayload`. Each piece (detection,
+// section assembly, token-budget guard, telemetry) lands as a separate PR
+// against the parent tracker.
+//
+// **This PR — step 2 — only ships staleness detection.** Per-section
+// assembly, the budget guard, telemetry, and the call-site wiring all land
+// in follow-up PRs.
+
+import { and, desc, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+
+/** Default hibernation threshold. 24h ≈ one working day; gaps longer than
+ *  that are unambiguously stale from the agent's perspective. Tunable via
+ *  `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS` so operators can dial it down
+ *  once telemetry justifies a tighter value. */
+export const DEFAULT_HIBERNATION_THRESHOLD_HOURS = 24;
+
+const SUCCEEDED_RUN_STATUS = "succeeded";
+const MS_PER_HOUR = 3_600_000;
+
+export type ColdWakeDetectionInput = {
+  /** `null` when there is no prior succeeded run for the agent. */
+  lastRunFinishedAt: Date | null;
+  /** Override the default. Falsy values fall back to env / default. */
+  thresholdHours?: number;
+  /** Injectable clock for tests. Defaults to `new Date()`. */
+  now?: Date;
+};
+
+export type ColdWakeDetection = {
+  isColdWake: boolean;
+  hoursSinceLastRun: number | null;
+  lastRunFinishedAt: Date | null;
+  thresholdHours: number;
+};
+
+/** Resolve the hibernation threshold from the supplied env or `process.env`,
+ *  falling back to the default when unset, non-numeric, or non-positive. */
+export function resolveHibernationThresholdHours(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.PAPERCLIP_HIBERNATION_THRESHOLD_HOURS;
+  if (typeof raw !== "string" || raw.length === 0) {
+    return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+  }
+  return parsed;
+}
+
+/** Pure detection — given the last succeeded run's finish time, decide
+ *  whether this wake should be treated as a cold wake. No DB access.
+ *
+ *  Boundary rule: a gap **strictly greater than** the threshold is cold.
+ *  Exactly-at-threshold is warm; this keeps daily cron wakes (~24h apart)
+ *  from being flagged cold by default while still catching multi-day gaps
+ *  like the ALL-779 incident that motivated the briefing. */
+export function detectColdWake(input: ColdWakeDetectionInput): ColdWakeDetection {
+  const thresholdHours =
+    typeof input.thresholdHours === "number" && Number.isFinite(input.thresholdHours) && input.thresholdHours > 0
+      ? input.thresholdHours
+      : resolveHibernationThresholdHours();
+  const now = input.now ?? new Date();
+  const lastRunFinishedAt = input.lastRunFinishedAt;
+
+  if (!lastRunFinishedAt) {
+    return {
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours,
+    };
+  }
+
+  const hoursSinceLastRun = (now.getTime() - lastRunFinishedAt.getTime()) / MS_PER_HOUR;
+  return {
+    isColdWake: hoursSinceLastRun > thresholdHours,
+    hoursSinceLastRun,
+    lastRunFinishedAt,
+    thresholdHours,
+  };
+}
+
+/** Look up the most recent succeeded `heartbeat_runs.finished_at` for an
+ *  agent within a company. Returns `null` when no succeeded run is on
+ *  record. The query is covered by the existing
+ *  `heartbeat_runs_company_agent_started_idx` for filter selectivity; the
+ *  trailing `order by finished_at desc` falls back to a small in-memory
+ *  sort, which is acceptable for the per-wake call cadence. */
+export async function getLastSucceededRunFinishedAt(input: {
+  db: Db;
+  companyId: string;
+  agentId: string;
+}): Promise<Date | null> {
+  const rows = await input.db
+    .select({ finishedAt: heartbeatRuns.finishedAt })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.agentId, input.agentId),
+        eq(heartbeatRuns.status, SUCCEEDED_RUN_STATUS),
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.finishedAt))
+    .limit(1);
+  return rows[0]?.finishedAt ?? null;
+}


### PR DESCRIPTION
Step 3 of the cold-wake briefing stack, behind #8001 (types) and #8002 (detection).

## Thinking Path

> - Paperclip is the open-source app people use to manage AI agents for work.
> - The harness builds a `PaperclipWakePayload` per wake and adapters render it as the agent's first prompt; on a cold wake (agent hibernated past a threshold) that prompt needs a deterministic "what changed under you" briefing — see #8001 for the parent-stack rationale.
> - Step 1 (#8001) added the `PaperclipColdWakeBriefing` shape on the wake payload and its normalize/render plumbing.
> - Step 2 (#8002) added the detection primitive (`detectColdWake` + `getLastSucceededRunFinishedAt`).
> - This PR — step 3 — assembles the five-section briefing from §3.2 of the parent plan. It calls detection first and short-circuits warm wakes, then runs each section concurrently with per-section error isolation so one broken source degrades the briefing instead of failing the wake.
> - Token-budget guard (step 4), bypass + telemetry (step 5), call-site wiring (step 6), and replay tests (steps 7–8) land separately.

## Linked Issues or Issue Description

No matching public Paperclip issue — inline description per the feature-request template; this is step 3 of the same initiative described on #8001 / #8002.

**Subsystem affected:** `server/` — REST API & orchestration services. Extends the module from #8002 at `server/src/services/cold-wake-briefing.ts`.

### Problem or motivation

`detectColdWake` (step 2) tells the harness *whether* this wake is cold. It does not produce the briefing the agent should read before its first model call. Without an assembler, step 6 cannot wire anything into `buildPaperclipWakePayload` — the briefing field on the payload (step 1) would always be `null`.

### Proposed solution

Add `buildColdWakeBriefing(input)` to the same module. It:

1. Looks up the agent's last succeeded run (via the step-2 helper) and calls `detectColdWake`. Warm wake → returns `null` and **no section runs** (verified by test 1).
2. Cold wake → runs five sections concurrently via `Promise.allSettled`, each wrapped per-section. `briefingError` stays `null` on partial success and is only set to `{ code: "all_sections_failed", message }` when *every* section throws.
3. Returns a value whose shape matches the type that `normalizePaperclipColdWakeBriefing` (step 1) already accepts. No cross-PR import needed — the round-trip is by-shape, which lets the three PRs be merged in any order without a hard ordering constraint between #8001 and #8002/#8003.

Section runners are exposed through an internal `__overrides` test seam (typed `Partial<ColdWakeSectionRunners>`). Production callers do not pass `__overrides`; it exists so the assembly test cases can simulate per-section failure without an embedded Postgres or a real git checkout.

### Alternatives considered

- **Embed Postgres for assembly tests.** Heavy and slow for what these tests actually verify (graceful degradation per section). Rejected in favour of the runner-injection seam — defaults still execute the real Drizzle queries in production, and step 7 will add the embedded-Postgres integration test against the real defaults.
- **Add `simple-git` as a runtime dep.** The parent plan named `simpleGit(...).log(...)`; I implemented the same behaviour with `execFile('git', ['log', ...])` to avoid a new dep. Tests stub the reader entirely. If telemetry shows we want richer commit metadata later, swapping to `simple-git` is a one-function change.
- **Fail the whole briefing on any section error.** Rejected — the whole point of the briefing is to be a best-effort, additive context block. Per-section catch is the only way to keep one DB-driver hiccup from blacking out the briefing in production.

### Roadmap alignment

Same as #8001 / #8002 — quality-of-implementation safety fix; not currently in `ROADMAP.md`.

## What Changed

- **`server/src/services/cold-wake-briefing.ts`** (extended): added the assembler, type shapes (`ColdWakeBriefing`, per-section types, `ColdWakeContextSnapshot`, `ColdWakeSectionRunners`, `RawGitCommit`), default DB-backed section runners, and the `execFile`-based git-log reader.
- **`server/src/__tests__/cold-wake-briefing-assembly.test.ts`** (new): five vitest cases matching the parent issue's test plan.

## Verification

- `pnpm vitest run src/__tests__/cold-wake-briefing-assembly.test.ts` — **5/5 passed** locally.
- `pnpm vitest run src/__tests__/cold-wake-briefing-detection.test.ts` — **11/11 still passed** (no regression on step 2).
- `pnpm tsc --noEmit` shows zero new errors in `cold-wake-briefing.ts` or its test. The pre-existing `@paperclipai/plugin-sdk` build-state errors flagged on #8002's verification are still present and unrelated to this PR.

## Risks

- **Low risk** — pure additive symbol on a module that has no call sites yet (`buildPaperclipWakePayload` does not import it until step 6). Runtime behaviour is unchanged.
- The `execFile('git', ['log', ...])` reader inherits the host's `git` binary. In the wiring step we will guard against missing `git` (step 6 also picks the right workspace cwd). The current per-section catch already prevents a missing binary from failing the wake.
- DB queries fan out to `issues`, `issue_documents`, `documents`, `issue_thread_interactions`, and `issue_comments`. All filter on `companyId` first and are bounded (`limit 1` for plan/interaction, `limit 10` for siblings, full scan capped at 14d × outbound count for closed-issues, 25 total for comments). The per-wake call cadence is low; existing indexes cover the filters. A future PR can add a covering index if telemetry shows the comments query is hot.
- The `__overrides` test seam is opt-in; production callers should never set it. Documented as such in the type and the source comment.

## Model Used

Provider: Anthropic. Model: **Claude Opus 4** (`claude-opus-4-7`). Capability details used here: extended thinking, tool use (file edits, shell, git). No multi-modal input; this PR is text-only.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs (#8001, #8002 are the prior steps; no duplicate assembler)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots *(N/A — server-side assembler)*
- [x] I have updated relevant documentation to reflect my changes *(N/A — internal helper)*
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green *(in flight)*
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups *(in flight)*
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
