### PR TITLE
feat(server): token-budget guard + eviction for cold-wake briefing

### DIFF
--- a/server/src/__tests__/cold-wake-briefing-assembly.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-assembly.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ColdWakeBriefing,
+  ColdWakeClosedIssue,
+  ColdWakeContextSnapshot,
+  ColdWakePendingRequestConfirmation,
+  ColdWakePlanDocument,
+  ColdWakeRelatedComment,
+  ColdWakeSectionRunners,
+  ColdWakeSiblingIssue,
+  RawGitCommit,
+} from "../services/cold-wake-briefing.ts";
+import {
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  buildColdWakeBriefing,
+} from "../services/cold-wake-briefing.ts";
+
+// Centralised deterministic values. `now` and `lastRunFinishedAt` straddle
+// the default 24h threshold so the detection result is unambiguously cold
+// (or warm) without depending on the real clock.
+const NOW = new Date("2026-06-11T20:00:00Z");
+const HOT_LAST_RUN = new Date("2026-06-11T18:00:00Z"); // 2h ago — warm
+const COLD_LAST_RUN = new Date("2026-06-08T20:00:00Z"); // 72h ago — cold
+
+const COMPANY_ID = "00000000-0000-0000-0000-0000000000aa";
+const AGENT_ID = "00000000-0000-0000-0000-0000000000bb";
+const ISSUE_ID = "00000000-0000-0000-0000-0000000000cc";
+
+const FAKE_COMMITS: RawGitCommit[] = [
+  {
+    sha: "deadbeef1111111111111111111111111111aaaa",
+    subject: "feat(harness): touched referenced path",
+    author: "Harness Engineer",
+    date: "2026-06-10T12:00:00Z",
+    files: ["server/src/services/cold-wake-briefing.ts"],
+  },
+  {
+    sha: "deadbeef2222222222222222222222222222bbbb",
+    subject: "chore: unrelated commit",
+    author: "Other Agent",
+    date: "2026-06-09T12:00:00Z",
+    files: ["docs/README.md"],
+  },
+];
+
+const FAKE_CLOSED_ISSUE: ColdWakeClosedIssue = {
+  id: "00000000-0000-0000-0000-0000000000d1",
+  identifier: "ALL-700",
+  title: "Closed dependency",
+  status: "done",
+  closedAt: "2026-06-09T10:00:00Z",
+};
+
+const FAKE_SIBLING: ColdWakeSiblingIssue = {
+  id: "00000000-0000-0000-0000-0000000000e1",
+  identifier: "ALL-781",
+  title: "Parent tracker",
+  assigneeAgentId: AGENT_ID,
+  updatedAt: "2026-06-11T19:30:00Z",
+};
+
+const FAKE_PLAN: ColdWakePlanDocument = {
+  key: "plan",
+  revisionId: "00000000-0000-0000-0000-0000000000f1",
+  updatedAt: "2026-06-11T18:00:00Z",
+};
+
+const FAKE_INTERACTION: ColdWakePendingRequestConfirmation = {
+  interactionId: "00000000-0000-0000-0000-00000000a111",
+  revisionId: "00000000-0000-0000-0000-0000000000f1",
+  createdAt: "2026-06-11T18:05:00Z",
+};
+
+const FAKE_COMMENT: ColdWakeRelatedComment = {
+  issueId: "00000000-0000-0000-0000-0000000000d1",
+  issueIdentifier: "ALL-700",
+  commentId: "00000000-0000-0000-0000-00000000c111",
+  authorType: "board_user",
+  createdAt: "2026-06-11T17:00:00Z",
+  bodyPreview: "Please pick up the next step.",
+  bodyTruncated: false,
+};
+
+/** Defaults that pass through the input shape but return canned populated
+ *  data when arguments imply a populated case. Tests compose against this
+ *  by spreading and overriding individual runners. */
+function populatedRunners(): Partial<ColdWakeSectionRunners> {
+  return {
+    detectColdWake: () => ({
+      isColdWake: true,
+      hoursSinceLastRun: 72,
+      lastRunFinishedAt: COLD_LAST_RUN,
+      thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+    }),
+    getLastSucceededRunFinishedAt: async () => COLD_LAST_RUN,
+    readRecentCommits: async () => FAKE_COMMITS,
+    loadClosedReferencedIssues: async ({ issueIds }) =>
+      issueIds.length === 0 ? [] : [FAKE_CLOSED_ISSUE],
+    loadSiblingInProgressIssues: async ({ assigneeAgentIds }) =>
+      assigneeAgentIds.length === 0 ? [] : [FAKE_SIBLING],
+    loadPlanDocument: async () => FAKE_PLAN,
+    loadPendingRequestConfirmation: async () => FAKE_INTERACTION,
+    loadRecentRelatedComments: async ({ outbound }) =>
+      outbound.length === 0 ? [] : [FAKE_COMMENT],
+  };
+}
+
+const REFERENCED_PATH = "server/src/services/cold-wake-briefing.ts";
+
+const FULL_SNAPSHOT: ColdWakeContextSnapshot = {
+  referencedIssueIdentifiers: [REFERENCED_PATH],
+  relatedWork: {
+    outbound: [
+      { issue: { id: FAKE_CLOSED_ISSUE.id, identifier: FAKE_CLOSED_ISSUE.identifier } },
+    ],
+  },
+  issueAncestry: {
+    chainOfCommand: ["00000000-0000-0000-0000-000000000099"],
+    ancestorIssueIds: ["00000000-0000-0000-0000-0000000000aa"],
+  },
+};
+
+// The `db` field is unused when every section runner is overridden — pass a
+// typed sentinel so the test does not have to spin up an embedded Postgres.
+const FAKE_DB = {} as unknown as Parameters<typeof buildColdWakeBriefing>[0]["db"];
+
+async function callBuild(
+  overrides: Partial<ColdWakeSectionRunners>,
+  opts: { snapshot?: ColdWakeContextSnapshot; workspaceCwd?: string | null } = {},
+): Promise<ColdWakeBriefing | null> {
+  return buildColdWakeBriefing({
+    db: FAKE_DB,
+    companyId: COMPANY_ID,
+    agentId: AGENT_ID,
+    issueId: ISSUE_ID,
+    contextSnapshot: opts.snapshot ?? FULL_SNAPSHOT,
+    workspaceCwd: opts.workspaceCwd === undefined ? "/tmp/workspace" : opts.workspaceCwd,
+    now: NOW,
+    __overrides: overrides,
+  });
+}
+
+describe("buildColdWakeBriefing", () => {
+  it("returns null on a warm wake (detectColdWake → isColdWake: false)", async () => {
+    const result = await callBuild({
+      // Warm — the assembler should short-circuit before any section runs.
+      detectColdWake: () => ({
+        isColdWake: false,
+        hoursSinceLastRun: 2,
+        lastRunFinishedAt: HOT_LAST_RUN,
+        thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+      }),
+      getLastSucceededRunFinishedAt: async () => HOT_LAST_RUN,
+      // If any of the section runners were invoked, the test would fail at
+      // this rejection; their non-invocation proves the short-circuit.
+      readRecentCommits: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadClosedReferencedIssues: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadSiblingInProgressIssues: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadPlanDocument: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadPendingRequestConfirmation: async () => {
+        throw new Error("section ran on warm wake");
+      },
+      loadRecentRelatedComments: async () => {
+        throw new Error("section ran on warm wake");
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("populates all five sections on a cold wake with every source present", async () => {
+    const briefing = await callBuild(populatedRunners());
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    // Detection metadata round-trips through the briefing.
+    expect(b.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(b.hoursSinceLastRun).toBe(72);
+    expect(b.lastRunFinishedAt).toBe(COLD_LAST_RUN.toISOString());
+
+    // Section 1 — recent commits, with touchedReferencedPath set on the
+    // commit that touched the referenced path.
+    expect(b.recentCommits).toHaveLength(2);
+    expect(b.recentCommits[0]).toMatchObject({
+      sha: FAKE_COMMITS[0]!.sha,
+      touchedReferencedPath: true,
+    });
+    expect(b.recentCommits[1]).toMatchObject({
+      sha: FAKE_COMMITS[1]!.sha,
+      touchedReferencedPath: false,
+    });
+    expect(b.recentCommitsTruncated).toBe(false);
+
+    // Sections 2–5 round-trip the canned values.
+    expect(b.recentlyClosedReferencedIssues).toEqual([FAKE_CLOSED_ISSUE]);
+    expect(b.siblingInProgressIssues).toEqual([FAKE_SIBLING]);
+    expect(b.planDocument).toEqual(FAKE_PLAN);
+    expect(b.pendingRequestConfirmation).toEqual(FAKE_INTERACTION);
+    expect(b.recentRelatedComments).toEqual([FAKE_COMMENT]);
+
+    // sourcesIncluded covers all six keys (six because plan + interaction
+    // are tracked separately even though §3.2 groups them under "section 4").
+    expect(new Set(b.sourcesIncluded)).toEqual(
+      new Set(["git", "closed_issues", "siblings", "plan", "interaction", "comments"]),
+    );
+
+    expect(b.briefingError).toBeNull();
+    // Placeholders for step 4's budget guard.
+    expect(b.budgetTokens).toBe(0);
+    expect(b.budgetTokenCap).toBeGreaterThan(0);
+    expect(b.truncated).toBe(false);
+  });
+
+  it("degrades the git section when simpleGit throws (workspace not cloned)", async () => {
+    const briefing = await callBuild({
+      ...populatedRunners(),
+      readRecentCommits: async () => {
+        throw new Error("ENOENT: no .git directory");
+      },
+    });
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    expect(b.recentCommits).toEqual([]);
+    expect(b.recentCommitsTruncated).toBe(false);
+    expect(b.sourcesIncluded).not.toContain("git");
+    // The other sections still populated normally.
+    expect(b.sourcesIncluded).toEqual(
+      expect.arrayContaining([
+        "closed_issues",
+        "siblings",
+        "plan",
+        "interaction",
+        "comments",
+      ]),
+    );
+    expect(b.recentlyClosedReferencedIssues).toEqual([FAKE_CLOSED_ISSUE]);
+    expect(b.recentRelatedComments).toEqual([FAKE_COMMENT]);
+    // Per-section catch absorbs the failure — top-level error stays null.
+    expect(b.briefingError).toBeNull();
+  });
+
+  it("returns empty section 2 and 5 when contextSnapshot has no relatedWork.outbound", async () => {
+    const snapshot: ColdWakeContextSnapshot = {
+      referencedIssueIdentifiers: [REFERENCED_PATH],
+      relatedWork: { outbound: [] },
+      issueAncestry: { chainOfCommand: [], ancestorIssueIds: [] },
+    };
+
+    const briefing = await callBuild(populatedRunners(), { snapshot });
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    expect(b.recentlyClosedReferencedIssues).toEqual([]);
+    expect(b.recentRelatedComments).toEqual([]);
+    // Both sections succeeded with empty output — keep them in sourcesIncluded
+    // so downstream renderers can distinguish "no data" from "errored".
+    expect(b.sourcesIncluded).toEqual(
+      expect.arrayContaining(["closed_issues", "comments"]),
+    );
+    // Sections 1, 3, 4 unaffected.
+    expect(b.recentCommits).toHaveLength(2);
+    expect(b.siblingInProgressIssues).toEqual([FAKE_SIBLING]);
+    expect(b.planDocument).toEqual(FAKE_PLAN);
+    expect(b.pendingRequestConfirmation).toEqual(FAKE_INTERACTION);
+    expect(b.briefingError).toBeNull();
+  });
+
+  it("marks briefingError.code='all_sections_failed' when every section throws", async () => {
+    const throwingRunners: Partial<ColdWakeSectionRunners> = {
+      detectColdWake: populatedRunners().detectColdWake,
+      getLastSucceededRunFinishedAt: populatedRunners().getLastSucceededRunFinishedAt,
+      readRecentCommits: async () => {
+        throw new Error("git boom");
+      },
+      loadClosedReferencedIssues: async () => {
+        throw new Error("closed boom");
+      },
+      loadSiblingInProgressIssues: async () => {
+        throw new Error("siblings boom");
+      },
+      loadPlanDocument: async () => {
+        throw new Error("plan boom");
+      },
+      loadPendingRequestConfirmation: async () => {
+        throw new Error("interaction boom");
+      },
+      loadRecentRelatedComments: async () => {
+        throw new Error("comments boom");
+      },
+    };
+
+    const briefing = await callBuild(throwingRunners);
+
+    expect(briefing).not.toBeNull();
+    const b = briefing as ColdWakeBriefing;
+
+    // Every section degrades to its empty default.
+    expect(b.recentCommits).toEqual([]);
+    expect(b.recentlyClosedReferencedIssues).toEqual([]);
+    expect(b.siblingInProgressIssues).toEqual([]);
+    expect(b.planDocument).toBeNull();
+    expect(b.pendingRequestConfirmation).toBeNull();
+    expect(b.recentRelatedComments).toEqual([]);
+    expect(b.sourcesIncluded).toEqual([]);
+
+    expect(b.briefingError).not.toBeNull();
+    expect(b.briefingError?.code).toBe("all_sections_failed");
+    expect(b.briefingError?.message.length).toBeGreaterThan(0);
+    // The aggregated message should reference each failing section by key
+    // so the operator can trace which section blew up.
+    expect(b.briefingError?.message).toContain("git");
+    expect(b.briefingError?.message).toContain("comments");
+  });
+});

--- a/server/src/__tests__/cold-wake-briefing-assembly.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-assembly.test.ts
@@ -214,9 +214,13 @@ describe("buildColdWakeBriefing", () => {
     );
 
     expect(b.briefingError).toBeNull();
-    // Placeholders for step 4's budget guard.
-    expect(b.budgetTokens).toBe(0);
+    // Step 4's budget guard runs at the end of buildColdWakeBriefing — the
+    // populated briefing is well under the default 8000-token cap so it
+    // round-trips unmodified, but `budgetTokens` now reflects the real
+    // estimate rather than the step-3 placeholder zero.
+    expect(b.budgetTokens).toBeGreaterThan(0);
     expect(b.budgetTokenCap).toBeGreaterThan(0);
+    expect(b.budgetTokens).toBeLessThanOrEqual(b.budgetTokenCap);
     expect(b.truncated).toBe(false);
   });
 

--- a/server/src/__tests__/cold-wake-briefing-budget.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-budget.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ColdWakeBriefing,
+  ColdWakeClosedIssue,
+  ColdWakeRecentCommit,
+  ColdWakeRelatedComment,
+  ColdWakeSiblingIssue,
+} from "../services/cold-wake-briefing.ts";
+import {
+  DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP,
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  enforceBriefingBudget,
+  estimateBriefingTokens,
+  resolveColdWakeBriefingTokenCap,
+} from "../services/cold-wake-briefing.ts";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const COLD_LAST_RUN_ISO = "2026-06-08T20:00:00Z";
+
+/** Build a small "base" briefing whose protected fields exercise the
+ *  acceptance criterion that the staleness header, planDocument, and
+ *  pendingRequestConfirmation are never mutated. */
+function baseBriefing(): ColdWakeBriefing {
+  return {
+    thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+    hoursSinceLastRun: 72,
+    lastRunFinishedAt: COLD_LAST_RUN_ISO,
+    recentCommits: [],
+    recentCommitsTruncated: false,
+    recentlyClosedReferencedIssues: [],
+    siblingInProgressIssues: [],
+    planDocument: {
+      key: "plan",
+      revisionId: "00000000-0000-0000-0000-0000000000f1",
+      updatedAt: "2026-06-11T18:00:00Z",
+    },
+    pendingRequestConfirmation: {
+      interactionId: "00000000-0000-0000-0000-00000000a111",
+      revisionId: "00000000-0000-0000-0000-0000000000f1",
+      createdAt: "2026-06-11T18:05:00Z",
+    },
+    recentRelatedComments: [],
+    sourcesIncluded: ["git", "closed_issues", "siblings", "plan", "interaction", "comments"],
+    budgetTokens: 0,
+    budgetTokenCap: DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP,
+    truncated: false,
+    briefingError: null,
+  };
+}
+
+/** Helper to build a commit with controllable size. `bodyChars` pads the
+ *  subject so we can drive the estimator over the cap deterministically. */
+function makeCommit(opts: {
+  date: string;
+  sha?: string;
+  bodyChars?: number;
+  touchedReferencedPath?: boolean;
+}): ColdWakeRecentCommit {
+  const pad = "x".repeat(opts.bodyChars ?? 0);
+  return {
+    sha: opts.sha ?? `c${opts.date.replace(/[^0-9]/g, "")}`,
+    subject: `commit ${opts.date} ${pad}`,
+    author: "Test Author",
+    date: opts.date,
+    touchedReferencedPath: opts.touchedReferencedPath ?? false,
+  };
+}
+
+function makeComment(opts: {
+  createdAt: string;
+  id?: string;
+  bodyChars?: number;
+}): ColdWakeRelatedComment {
+  const pad = "x".repeat(opts.bodyChars ?? 0);
+  return {
+    issueId: "00000000-0000-0000-0000-0000000000d1",
+    issueIdentifier: "ALL-700",
+    commentId: opts.id ?? `comment-${opts.createdAt}`,
+    authorType: "board_user",
+    createdAt: opts.createdAt,
+    bodyPreview: `preview ${pad}`,
+    bodyTruncated: false,
+  };
+}
+
+function makeSibling(opts: { updatedAt: string; id?: string }): ColdWakeSiblingIssue {
+  return {
+    id: opts.id ?? `sib-${opts.updatedAt}`,
+    identifier: `SIB-${opts.updatedAt}`,
+    title: `Sibling ${opts.updatedAt}`,
+    assigneeAgentId: "00000000-0000-0000-0000-0000000000bb",
+    updatedAt: opts.updatedAt,
+  };
+}
+
+function makeClosed(opts: { closedAt: string; id?: string }): ColdWakeClosedIssue {
+  return {
+    id: opts.id ?? `cls-${opts.closedAt}`,
+    identifier: `CLS-${opts.closedAt}`,
+    title: `Closed ${opts.closedAt}`,
+    status: "done",
+    closedAt: opts.closedAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveColdWakeBriefingTokenCap
+// ---------------------------------------------------------------------------
+
+describe("resolveColdWakeBriefingTokenCap", () => {
+  it("falls back to the default when the env var is unset", () => {
+    expect(resolveColdWakeBriefingTokenCap({})).toBe(
+      DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP,
+    );
+  });
+
+  it("respects a valid numeric override", () => {
+    expect(
+      resolveColdWakeBriefingTokenCap({
+        PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP: "12345",
+      }),
+    ).toBe(12345);
+  });
+
+  it("falls back to the default when the env var is non-numeric", () => {
+    expect(
+      resolveColdWakeBriefingTokenCap({
+        PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP: "not-a-number",
+      }),
+    ).toBe(DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP);
+  });
+
+  it("falls back to the default when the env var is zero or negative", () => {
+    expect(
+      resolveColdWakeBriefingTokenCap({
+        PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP: "0",
+      }),
+    ).toBe(DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP);
+    expect(
+      resolveColdWakeBriefingTokenCap({
+        PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP: "-500",
+      }),
+    ).toBe(DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// estimateBriefingTokens
+// ---------------------------------------------------------------------------
+
+describe("estimateBriefingTokens", () => {
+  it("returns a deterministic, positive token count for a fixture briefing", () => {
+    const b = baseBriefing();
+    const first = estimateBriefingTokens(b);
+    const second = estimateBriefingTokens(b);
+    expect(first).toBe(second);
+    expect(first).toBeGreaterThan(0);
+  });
+
+  it("is monotonic in section size — adding content never lowers the estimate", () => {
+    const small = baseBriefing();
+    const big: ColdWakeBriefing = {
+      ...small,
+      recentRelatedComments: [
+        makeComment({ createdAt: "2026-06-10T10:00:00Z", bodyChars: 200 }),
+        makeComment({ createdAt: "2026-06-10T11:00:00Z", bodyChars: 200 }),
+      ],
+    };
+    expect(estimateBriefingTokens(big)).toBeGreaterThan(
+      estimateBriefingTokens(small),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceBriefingBudget
+// ---------------------------------------------------------------------------
+
+describe("enforceBriefingBudget — under cap", () => {
+  it("does not evict and reports truncated:false when the briefing already fits", () => {
+    const briefing = baseBriefing();
+    const sourcesBefore = [...briefing.sourcesIncluded];
+
+    const out = enforceBriefingBudget(briefing);
+
+    expect(out.truncated).toBe(false);
+    expect(out.recentRelatedComments).toEqual(briefing.recentRelatedComments);
+    expect(out.recentCommits).toEqual(briefing.recentCommits);
+    expect(out.siblingInProgressIssues).toEqual(briefing.siblingInProgressIssues);
+    expect(out.recentlyClosedReferencedIssues).toEqual(
+      briefing.recentlyClosedReferencedIssues,
+    );
+    expect(out.sourcesIncluded).toEqual(sourcesBefore);
+    expect(out.budgetTokenCap).toBe(DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP);
+    expect(out.budgetTokens).toBeGreaterThan(0);
+    expect(out.budgetTokens).toBeLessThanOrEqual(out.budgetTokenCap);
+  });
+});
+
+describe("enforceBriefingBudget — eviction order", () => {
+  it("drops oldest comments first when only comments push us over cap", () => {
+    // 5 comments × ~1100 chars body each (~ 1375 tokens of comments at /4) —
+    // pushing the JSON over a small 600-token cap. Other sections stay tiny.
+    const comments: ColdWakeRelatedComment[] = [
+      makeComment({ createdAt: "2026-06-08T10:00:00Z", id: "oldest", bodyChars: 1100 }),
+      makeComment({ createdAt: "2026-06-09T10:00:00Z", id: "older", bodyChars: 1100 }),
+      makeComment({ createdAt: "2026-06-10T10:00:00Z", id: "mid", bodyChars: 1100 }),
+      makeComment({ createdAt: "2026-06-11T10:00:00Z", id: "newer", bodyChars: 1100 }),
+      makeComment({ createdAt: "2026-06-11T18:00:00Z", id: "newest", bodyChars: 1100 }),
+    ];
+    const briefing: ColdWakeBriefing = {
+      ...baseBriefing(),
+      recentRelatedComments: comments,
+    };
+
+    const cap = 600;
+    const out = enforceBriefingBudget(briefing, { tokenCap: cap });
+
+    expect(out.truncated).toBe(true);
+    // The newest comment must still be present; the oldest must be gone.
+    const survivingIds = out.recentRelatedComments.map((c) => c.commentId);
+    expect(survivingIds).toContain("newest");
+    expect(survivingIds).not.toContain("oldest");
+    // sourcesIncluded marks comments as truncated; other sections untouched.
+    expect(out.sourcesIncluded).toContain("comments:truncated");
+    expect(out.sourcesIncluded).toContain("git");
+    expect(out.sourcesIncluded).toContain("siblings");
+    expect(out.sourcesIncluded).toContain("plan");
+    expect(out.sourcesIncluded).toContain("interaction");
+    expect(out.sourcesIncluded).toContain("closed_issues");
+    // Protected fields untouched.
+    expect(out.planDocument).toEqual(briefing.planDocument);
+    expect(out.pendingRequestConfirmation).toEqual(briefing.pendingRequestConfirmation);
+    expect(out.thresholdHours).toBe(briefing.thresholdHours);
+    expect(out.hoursSinceLastRun).toBe(briefing.hoursSinceLastRun);
+    expect(out.lastRunFinishedAt).toBe(briefing.lastRunFinishedAt);
+    // Other content sections are untouched.
+    expect(out.recentCommits).toEqual(briefing.recentCommits);
+    expect(out.siblingInProgressIssues).toEqual(briefing.siblingInProgressIssues);
+    expect(out.recentlyClosedReferencedIssues).toEqual(
+      briefing.recentlyClosedReferencedIssues,
+    );
+  });
+
+  it("cascades comments → commits → siblings → closed-issues in order", () => {
+    // Roughly 10× cap: ~700 chars of padding per item across many items in
+    // every section. Cap is tiny so even after evicting comments+commits we
+    // still drop siblings down to top-3 and then closed-issues down to top-3.
+    const comments: ColdWakeRelatedComment[] = Array.from({ length: 6 }, (_, i) =>
+      makeComment({
+        createdAt: `2026-06-0${i + 1}T10:00:00Z`,
+        id: `cmt-${i}`,
+        bodyChars: 600,
+      }),
+    );
+    const commits: ColdWakeRecentCommit[] = Array.from({ length: 6 }, (_, i) =>
+      makeCommit({
+        date: `2026-06-0${i + 1}T12:00:00Z`,
+        sha: `commit-${i}`,
+        bodyChars: 600,
+      }),
+    );
+    // 7 siblings — we expect 4 to be dropped down to top-3 by updatedAt DESC.
+    const siblings: ColdWakeSiblingIssue[] = Array.from({ length: 7 }, (_, i) =>
+      makeSibling({
+        updatedAt: `2026-06-0${i + 1}T15:00:00Z`,
+        id: `sib-${i}`,
+      }),
+    );
+    // 7 closed — top 3 by closedAt DESC must survive.
+    const closed: ColdWakeClosedIssue[] = Array.from({ length: 7 }, (_, i) =>
+      makeClosed({
+        closedAt: `2026-06-0${i + 1}T20:00:00Z`,
+        id: `cls-${i}`,
+      }),
+    );
+
+    const briefing: ColdWakeBriefing = {
+      ...baseBriefing(),
+      recentRelatedComments: comments,
+      recentCommits: commits,
+      siblingInProgressIssues: siblings,
+      recentlyClosedReferencedIssues: closed,
+    };
+
+    // Aggressive cap — small enough that the cascade fully exhausts comments
+    // and commits, and trims siblings + closed-issues down to top-3.
+    const cap = 100;
+    const out = enforceBriefingBudget(briefing, { tokenCap: cap });
+
+    expect(out.truncated).toBe(true);
+
+    // Comments and commits drain entirely; siblings and closed land on their
+    // top-3 floor with the newest entries (sort by *At DESC) surviving.
+    expect(out.recentRelatedComments).toEqual([]);
+    expect(out.recentCommits).toEqual([]);
+
+    expect(out.siblingInProgressIssues).toHaveLength(3);
+    const siblingUpdates = out.siblingInProgressIssues
+      .map((s) => s.updatedAt)
+      .sort();
+    // Top-3 by updatedAt DESC are 06-07, 06-06, 06-05; sorted ASC the first
+    // entry is exactly the 3rd-newest input.
+    expect(siblingUpdates[0]).toBe("2026-06-05T15:00:00Z");
+    expect(siblingUpdates[2]).toBe("2026-06-07T15:00:00Z");
+
+    expect(out.recentlyClosedReferencedIssues).toHaveLength(3);
+    const closedAts = out.recentlyClosedReferencedIssues
+      .map((c) => c.closedAt)
+      .sort();
+    expect(closedAts[0]).toBe("2026-06-05T20:00:00Z");
+    expect(closedAts[2]).toBe("2026-06-07T20:00:00Z");
+
+    // sourcesIncluded gets `:truncated` markers on every reduced section.
+    const sources = new Set(out.sourcesIncluded);
+    expect(sources.has("comments:truncated")).toBe(true);
+    expect(sources.has("git:truncated")).toBe(true);
+    expect(sources.has("siblings:truncated")).toBe(true);
+    expect(sources.has("closed_issues:truncated")).toBe(true);
+    // Protected sections are still listed plainly.
+    expect(sources.has("plan")).toBe(true);
+    expect(sources.has("interaction")).toBe(true);
+
+    // Protected fields are byte-identical to input.
+    expect(out.planDocument).toEqual(briefing.planDocument);
+    expect(out.pendingRequestConfirmation).toEqual(briefing.pendingRequestConfirmation);
+    expect(out.thresholdHours).toBe(briefing.thresholdHours);
+    expect(out.hoursSinceLastRun).toBe(briefing.hoursSinceLastRun);
+    expect(out.lastRunFinishedAt).toBe(briefing.lastRunFinishedAt);
+  });
+});
+
+describe("enforceBriefingBudget — protected fields", () => {
+  it("never mutates the staleness header, planDocument, or pendingRequestConfirmation", () => {
+    // Pump the briefing past cap with a single huge comment so the eviction
+    // loops have somewhere to chew, then verify the protected fields are
+    // untouched.
+    const briefing: ColdWakeBriefing = {
+      ...baseBriefing(),
+      recentRelatedComments: [
+        makeComment({ createdAt: "2026-06-08T10:00:00Z", bodyChars: 10_000 }),
+      ],
+    };
+    const out = enforceBriefingBudget(briefing, { tokenCap: 200 });
+
+    expect(out.thresholdHours).toBe(briefing.thresholdHours);
+    expect(out.hoursSinceLastRun).toBe(briefing.hoursSinceLastRun);
+    expect(out.lastRunFinishedAt).toBe(briefing.lastRunFinishedAt);
+    expect(out.planDocument).toEqual(briefing.planDocument);
+    expect(out.pendingRequestConfirmation).toEqual(briefing.pendingRequestConfirmation);
+    expect(out.truncated).toBe(true);
+  });
+
+  it("returns the briefing (not null) and sets truncated:true when only protected fields remain", () => {
+    // Cap is impossibly small (10 tokens ≈ 40 chars) — well under even the
+    // bare protected fields. Eviction empties every droppable section and we
+    // still cannot fit; the guard must flag truncated:true but not throw.
+    const briefing: ColdWakeBriefing = {
+      ...baseBriefing(),
+      recentRelatedComments: [
+        makeComment({ createdAt: "2026-06-09T10:00:00Z", bodyChars: 50 }),
+      ],
+      recentCommits: [makeCommit({ date: "2026-06-09T12:00:00Z", bodyChars: 50 })],
+      siblingInProgressIssues: [makeSibling({ updatedAt: "2026-06-10T15:00:00Z" })],
+      recentlyClosedReferencedIssues: [makeClosed({ closedAt: "2026-06-10T20:00:00Z" })],
+    };
+
+    const out = enforceBriefingBudget(briefing, { tokenCap: 10 });
+
+    expect(out).not.toBeNull();
+    expect(out.truncated).toBe(true);
+    // Protected fields survive.
+    expect(out.planDocument).toEqual(briefing.planDocument);
+    expect(out.pendingRequestConfirmation).toEqual(briefing.pendingRequestConfirmation);
+    expect(out.thresholdHours).toBe(briefing.thresholdHours);
+    expect(out.hoursSinceLastRun).toBe(briefing.hoursSinceLastRun);
+    expect(out.lastRunFinishedAt).toBe(briefing.lastRunFinishedAt);
+    // Comments and commits drained entirely; siblings/closed kept top-3 floor
+    // (which equals the 1 input each, so they survive). The budget is still
+    // over cap, but the briefing is returned intact.
+    expect(out.recentRelatedComments).toEqual([]);
+    expect(out.recentCommits).toEqual([]);
+    expect(out.budgetTokens).toBeGreaterThan(out.budgetTokenCap);
+  });
+});

--- a/server/src/__tests__/cold-wake-briefing-detection.test.ts
+++ b/server/src/__tests__/cold-wake-briefing-detection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+  detectColdWake,
+  resolveHibernationThresholdHours,
+} from "../services/cold-wake-briefing.ts";
+
+const NOW = new Date("2026-06-11T20:00:00Z");
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 3_600_000);
+
+describe("detectColdWake", () => {
+  it("flags the wake cold when there is no prior succeeded run", () => {
+    expect(detectColdWake({ lastRunFinishedAt: null, now: NOW })).toEqual({
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours: DEFAULT_HIBERNATION_THRESHOLD_HOURS,
+    });
+  });
+
+  it("flags the wake warm when the last run is inside the threshold", () => {
+    const last = hoursAgo(2);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(2, 6);
+    expect(result.lastRunFinishedAt).toBe(last);
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("flags the wake cold when the last run is older than the threshold", () => {
+    const last = hoursAgo(48);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.isColdWake).toBe(true);
+    expect(result.hoursSinceLastRun).toBeCloseTo(48, 6);
+  });
+
+  it("respects an explicit thresholdHours override", () => {
+    const last = hoursAgo(6);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: 4 });
+    expect(result.isColdWake).toBe(true);
+    expect(result.thresholdHours).toBe(4);
+  });
+
+  it("treats exactly-at-threshold as warm (boundary is strict-greater)", () => {
+    const last = hoursAgo(24);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: 24 });
+    expect(result.isColdWake).toBe(false);
+    expect(result.hoursSinceLastRun).toBeCloseTo(24, 6);
+  });
+
+  it("returns a Date for lastRunFinishedAt that round-trips through ISO", () => {
+    const last = hoursAgo(3);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW });
+    expect(result.lastRunFinishedAt).toBeInstanceOf(Date);
+    expect(result.lastRunFinishedAt?.toISOString()).toBe(last.toISOString());
+  });
+
+  it("falls back to the env-resolved threshold when override is invalid", () => {
+    const last = hoursAgo(30);
+    const result = detectColdWake({ lastRunFinishedAt: last, now: NOW, thresholdHours: -1 });
+    expect(result.thresholdHours).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(result.isColdWake).toBe(true);
+  });
+});
+
+describe("resolveHibernationThresholdHours", () => {
+  it("returns the default when the env var is unset", () => {
+    expect(resolveHibernationThresholdHours({})).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("respects a valid numeric env var", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "12" }),
+    ).toBe(12);
+  });
+
+  it("falls back to the default when the env var is non-numeric", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "abc" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+
+  it("falls back to the default when the env var is zero or negative", () => {
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "0" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+    expect(
+      resolveHibernationThresholdHours({ PAPERCLIP_HIBERNATION_THRESHOLD_HOURS: "-5" }),
+    ).toBe(DEFAULT_HIBERNATION_THRESHOLD_HOURS);
+  });
+});

--- a/server/src/services/cold-wake-briefing.ts
+++ b/server/src/services/cold-wake-briefing.ts
@@ -8,13 +8,30 @@
 // section assembly, token-budget guard, telemetry) lands as a separate PR
 // against the parent tracker.
 //
-// **This PR — step 2 — only ships staleness detection.** Per-section
-// assembly, the budget guard, telemetry, and the call-site wiring all land
-// in follow-up PRs.
+// **Steps shipped:**
+// - Step 2 (detection): `detectColdWake`, `resolveHibernationThresholdHours`,
+//   `getLastSucceededRunFinishedAt`.
+// - Step 3 (per-section assembler): `buildColdWakeBriefing` — collects the
+//   five sections from §3.2 of the parent plan (recent commits, recently
+//   closed referenced issues, sibling in-progress issues, plan document +
+//   pending request_confirmation, recent related comments). Each section is
+//   wrapped in a try/catch so a single failure degrades the briefing rather
+//   than failing the wake.
+//
+// The token-budget guard, bypass switch, telemetry, and the call-site wiring
+// land in follow-up PRs (steps 4–6).
 
-import { and, desc, eq } from "drizzle-orm";
+import { execFile } from "node:child_process";
+import { and, desc, eq, gte, inArray, isNull, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { heartbeatRuns } from "@paperclipai/db";
+import {
+  documents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issueThreadInteractions,
+  issues,
+} from "@paperclipai/db";
 
 /** Default hibernation threshold. 24h ≈ one working day; gaps longer than
  *  that are unambiguously stale from the agent's perspective. Tunable via
@@ -114,4 +131,720 @@ export async function getLastSucceededRunFinishedAt(input: {
     .orderBy(desc(heartbeatRuns.finishedAt))
     .limit(1);
   return rows[0]?.finishedAt ?? null;
+}
+
+// =============================================================================
+// Step 3 — per-section assembler.
+// =============================================================================
+
+const RECENT_COMMITS_MAX = 20;
+const SIBLING_LIMIT = 10;
+const COMMENT_LIMIT_PER_ISSUE = 3;
+const COMMENT_TOTAL_LIMIT = 25;
+const COMMENT_PREVIEW_LIMIT = 280;
+const CLOSED_ISSUE_LOOKBACK_DAYS = 14;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+/** Placeholder token-budget cap. Step 4 wires up the real guard and eviction
+ *  policy; the field is populated here so the briefing shape round-trips. */
+const DEFAULT_BUDGET_TOKEN_CAP = 8000;
+
+export type ColdWakeRecentCommit = {
+  sha: string;
+  subject: string;
+  author: string;
+  date: string;
+  touchedReferencedPath: boolean;
+};
+
+export type ColdWakeClosedIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  closedAt: string;
+};
+
+export type ColdWakeSiblingIssue = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  assigneeAgentId: string | null;
+  updatedAt: string;
+};
+
+export type ColdWakePlanDocument = {
+  key: string;
+  revisionId: string;
+  updatedAt: string;
+};
+
+export type ColdWakePendingRequestConfirmation = {
+  interactionId: string;
+  revisionId: string | null;
+  createdAt: string;
+};
+
+export type ColdWakeRelatedComment = {
+  issueId: string;
+  issueIdentifier: string | null;
+  commentId: string;
+  authorType: string;
+  createdAt: string;
+  bodyPreview: string;
+  bodyTruncated: boolean;
+};
+
+export type ColdWakeBriefingError = {
+  code: string;
+  message: string;
+};
+
+/** The assembled briefing. Shape mirrors `PaperclipColdWakeBriefing` on
+ *  `PaperclipWakePayload` (step 1) — `normalizePaperclipColdWakeBriefing`
+ *  in `@paperclipai/adapter-utils` accepts this object verbatim. */
+export type ColdWakeBriefing = {
+  thresholdHours: number;
+  hoursSinceLastRun: number | null;
+  lastRunFinishedAt: string | null;
+  recentCommits: ColdWakeRecentCommit[];
+  recentCommitsTruncated: boolean;
+  recentlyClosedReferencedIssues: ColdWakeClosedIssue[];
+  siblingInProgressIssues: ColdWakeSiblingIssue[];
+  planDocument: ColdWakePlanDocument | null;
+  pendingRequestConfirmation: ColdWakePendingRequestConfirmation | null;
+  recentRelatedComments: ColdWakeRelatedComment[];
+  /** Section keys actually populated — matches the §3.2 source list:
+   *  `"git" | "closed_issues" | "siblings" | "plan" | "interaction" | "comments"`.
+   *  Sections that failed are omitted. */
+  sourcesIncluded: string[];
+  /** Placeholder until step 4 implements the budget guard. */
+  budgetTokens: number;
+  /** Placeholder until step 4 implements the budget guard. */
+  budgetTokenCap: number;
+  /** Placeholder until step 4 implements eviction. */
+  truncated: boolean;
+  briefingError: ColdWakeBriefingError | null;
+};
+
+/** Minimal context the assembler needs from the wake payload context
+ *  snapshot. The wiring layer (step 6) maps the existing snapshot onto
+ *  this shape; deliberately permissive so it can absorb upstream changes
+ *  without ripping through every test. */
+export type ColdWakeContextSnapshot = {
+  /** Paths that the recent-commits section should flag as
+   *  `touchedReferencedPath: true` when a commit touches them. Despite the
+   *  legacy field name, this is consumed as a list of path fragments
+   *  matched by substring against each commit's touched files. */
+  referencedIssueIdentifiers?: string[] | null;
+  /** Related work summary as produced by `listIssueReferenceSummary`. Only
+   *  `outbound[*].issue.{id,identifier}` is consulted here. */
+  relatedWork?: {
+    outbound?: Array<
+      | {
+          issue?: {
+            id?: string | null;
+            identifier?: string | null;
+          } | null;
+        }
+      | null
+    > | null;
+  } | null;
+  /** Optional ancestor metadata. `chainOfCommand` widens the sibling-issue
+   *  search to peers and supervisors; `ancestorIssueIds` widens the
+   *  pending-request_confirmation search to plan reviews living on parents. */
+  issueAncestry?: {
+    chainOfCommand?: string[] | null;
+    ancestorIssueIds?: string[] | null;
+  } | null;
+};
+
+/** Raw commit shape returned by the git reader. Keeps the I/O concern
+ *  (simple-git vs. `execFile('git', …)`) behind a single seam so tests can
+ *  substitute a deterministic implementation. */
+export type RawGitCommit = {
+  sha: string;
+  subject: string;
+  author: string;
+  date: string;
+  files: string[];
+};
+
+/** Per-section runners. Default implementations hit the DB / filesystem;
+ *  callers (tests) can override any subset to inject deterministic values
+ *  or simulate failures. */
+export type ColdWakeSectionRunners = {
+  detectColdWake: typeof detectColdWake;
+  getLastSucceededRunFinishedAt: typeof getLastSucceededRunFinishedAt;
+  readRecentCommits: (
+    workspaceCwd: string,
+    maxCount: number,
+  ) => Promise<RawGitCommit[]>;
+  loadClosedReferencedIssues: (args: {
+    db: Db;
+    companyId: string;
+    issueIds: string[];
+    since: Date;
+  }) => Promise<ColdWakeClosedIssue[]>;
+  loadSiblingInProgressIssues: (args: {
+    db: Db;
+    companyId: string;
+    assigneeAgentIds: string[];
+    excludeIssueId: string;
+    limit: number;
+  }) => Promise<ColdWakeSiblingIssue[]>;
+  loadPlanDocument: (args: {
+    db: Db;
+    companyId: string;
+    issueId: string;
+  }) => Promise<ColdWakePlanDocument | null>;
+  loadPendingRequestConfirmation: (args: {
+    db: Db;
+    companyId: string;
+    issueIds: string[];
+  }) => Promise<ColdWakePendingRequestConfirmation | null>;
+  loadRecentRelatedComments: (args: {
+    db: Db;
+    companyId: string;
+    outbound: Array<{ id: string; identifier: string | null }>;
+    perIssue: number;
+    total: number;
+    previewLimit: number;
+  }) => Promise<ColdWakeRelatedComment[]>;
+};
+
+export type BuildColdWakeBriefingInput = {
+  db: Db;
+  companyId: string;
+  agentId: string;
+  issueId: string;
+  contextSnapshot: ColdWakeContextSnapshot;
+  /** Absolute path to the git workspace whose history the section 1 reader
+   *  should walk. `null` (or unset) means the agent has no checked-out
+   *  workspace and the git section degrades gracefully. */
+  workspaceCwd?: string | null;
+  /** Injectable clock for tests. Defaults to `new Date()`. */
+  now?: Date;
+  /** Test seam — override any subset of section runners. Defaults to the
+   *  real DB / filesystem-backed implementations. */
+  __overrides?: Partial<ColdWakeSectionRunners>;
+};
+
+/** Default git-log reader. Shells out to the system `git` binary to avoid a
+ *  new runtime dependency; output is parsed via record/field separators
+ *  (`%x1e` between commits, `%x1f` between header fields) so commit
+ *  subjects with newlines do not split a record. */
+async function defaultReadRecentCommits(
+  workspaceCwd: string,
+  maxCount: number,
+): Promise<RawGitCommit[]> {
+  return new Promise<RawGitCommit[]>((resolve, reject) => {
+    execFile(
+      "git",
+      [
+        "log",
+        `--max-count=${maxCount}`,
+        "--pretty=format:%x1e%H%x1f%s%x1f%an%x1f%aI",
+        "--name-only",
+      ],
+      { cwd: workspaceCwd, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        const commits: RawGitCommit[] = [];
+        const records = stdout.split("\x1e");
+        for (const rec of records) {
+          const trimmed = rec.replace(/^\n+/, "");
+          if (!trimmed) continue;
+          const lines = trimmed.split("\n");
+          const headerLine = lines[0] ?? "";
+          const fileLines = lines.slice(1).filter((l) => l.length > 0);
+          const [sha, subject, author, date] = headerLine.split("\x1f");
+          if (!sha) continue;
+          commits.push({
+            sha,
+            subject: subject ?? "",
+            author: author ?? "",
+            date: date ?? "",
+            files: fileLines,
+          });
+        }
+        resolve(commits);
+      },
+    );
+  });
+}
+
+async function defaultLoadClosedReferencedIssues(args: {
+  db: Db;
+  companyId: string;
+  issueIds: string[];
+  since: Date;
+}): Promise<ColdWakeClosedIssue[]> {
+  if (args.issueIds.length === 0) return [];
+  const rows = await args.db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      status: issues.status,
+      updatedAt: issues.updatedAt,
+    })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, args.companyId),
+        inArray(issues.id, args.issueIds),
+        inArray(issues.status, ["done", "cancelled"]),
+        gte(issues.updatedAt, args.since),
+      ),
+    )
+    .orderBy(desc(issues.updatedAt));
+  return rows.map((row) => ({
+    id: row.id,
+    identifier: row.identifier ?? null,
+    title: row.title,
+    status: row.status,
+    closedAt: row.updatedAt.toISOString(),
+  }));
+}
+
+async function defaultLoadSiblingInProgressIssues(args: {
+  db: Db;
+  companyId: string;
+  assigneeAgentIds: string[];
+  excludeIssueId: string;
+  limit: number;
+}): Promise<ColdWakeSiblingIssue[]> {
+  if (args.assigneeAgentIds.length === 0) return [];
+  const rows = await args.db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      assigneeAgentId: issues.assigneeAgentId,
+      updatedAt: issues.updatedAt,
+    })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, args.companyId),
+        eq(issues.status, "in_progress"),
+        inArray(issues.assigneeAgentId, args.assigneeAgentIds),
+        ne(issues.id, args.excludeIssueId),
+      ),
+    )
+    .orderBy(desc(issues.updatedAt))
+    .limit(args.limit);
+  return rows.map((row) => ({
+    id: row.id,
+    identifier: row.identifier ?? null,
+    title: row.title,
+    assigneeAgentId: row.assigneeAgentId,
+    updatedAt: row.updatedAt.toISOString(),
+  }));
+}
+
+async function defaultLoadPlanDocument(args: {
+  db: Db;
+  companyId: string;
+  issueId: string;
+}): Promise<ColdWakePlanDocument | null> {
+  const rows = await args.db
+    .select({
+      key: issueDocuments.key,
+      updatedAt: issueDocuments.updatedAt,
+      latestRevisionId: documents.latestRevisionId,
+      documentId: documents.id,
+    })
+    .from(issueDocuments)
+    .innerJoin(documents, eq(documents.id, issueDocuments.documentId))
+    .where(
+      and(
+        eq(issueDocuments.companyId, args.companyId),
+        eq(issueDocuments.issueId, args.issueId),
+        eq(issueDocuments.key, "plan"),
+      ),
+    )
+    .orderBy(desc(issueDocuments.updatedAt))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    key: row.key,
+    // `latestRevisionId` is the canonical pointer; fall back to the document
+    // id when the column is null (older rows seeded before revisions landed).
+    revisionId: row.latestRevisionId ?? row.documentId,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+async function defaultLoadPendingRequestConfirmation(args: {
+  db: Db;
+  companyId: string;
+  issueIds: string[];
+}): Promise<ColdWakePendingRequestConfirmation | null> {
+  if (args.issueIds.length === 0) return null;
+  const rows = await args.db
+    .select({
+      id: issueThreadInteractions.id,
+      payload: issueThreadInteractions.payload,
+      createdAt: issueThreadInteractions.createdAt,
+    })
+    .from(issueThreadInteractions)
+    .where(
+      and(
+        eq(issueThreadInteractions.companyId, args.companyId),
+        inArray(issueThreadInteractions.issueId, args.issueIds),
+        eq(issueThreadInteractions.kind, "request_confirmation"),
+        eq(issueThreadInteractions.status, "pending"),
+      ),
+    )
+    .orderBy(desc(issueThreadInteractions.createdAt))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    interactionId: row.id,
+    revisionId: extractTargetRevisionId(row.payload),
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function extractTargetRevisionId(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const target = (payload as Record<string, unknown>).target;
+  if (!target || typeof target !== "object") return null;
+  const revisionId = (target as Record<string, unknown>).revisionId;
+  return typeof revisionId === "string" && revisionId.length > 0 ? revisionId : null;
+}
+
+async function defaultLoadRecentRelatedComments(args: {
+  db: Db;
+  companyId: string;
+  outbound: Array<{ id: string; identifier: string | null }>;
+  perIssue: number;
+  total: number;
+  previewLimit: number;
+}): Promise<ColdWakeRelatedComment[]> {
+  if (args.outbound.length === 0) return [];
+  const issueIds = args.outbound.map((item) => item.id);
+  const identifierMap = new Map(args.outbound.map((item) => [item.id, item.identifier]));
+  const rows = await args.db
+    .select({
+      id: issueComments.id,
+      issueId: issueComments.issueId,
+      authorType: issueComments.authorType,
+      body: issueComments.body,
+      createdAt: issueComments.createdAt,
+    })
+    .from(issueComments)
+    .where(
+      and(
+        eq(issueComments.companyId, args.companyId),
+        inArray(issueComments.issueId, issueIds),
+        isNull(issueComments.deletedAt),
+      ),
+    )
+    .orderBy(desc(issueComments.createdAt));
+
+  const perIssueCount = new Map<string, number>();
+  const seen = new Set<string>();
+  const collected: ColdWakeRelatedComment[] = [];
+  for (const row of rows) {
+    if (seen.has(row.id)) continue;
+    const taken = perIssueCount.get(row.issueId) ?? 0;
+    if (taken >= args.perIssue) continue;
+    const body = row.body ?? "";
+    const truncated = body.length > args.previewLimit;
+    collected.push({
+      issueId: row.issueId,
+      issueIdentifier: identifierMap.get(row.issueId) ?? null,
+      commentId: row.id,
+      authorType: row.authorType ?? "agent",
+      createdAt: row.createdAt.toISOString(),
+      bodyPreview: truncated ? body.slice(0, args.previewLimit) : body,
+      bodyTruncated: truncated,
+    });
+    seen.add(row.id);
+    perIssueCount.set(row.issueId, taken + 1);
+    if (collected.length >= args.total) break;
+  }
+  return collected;
+}
+
+function defaultSectionRunners(): ColdWakeSectionRunners {
+  return {
+    detectColdWake,
+    getLastSucceededRunFinishedAt,
+    readRecentCommits: defaultReadRecentCommits,
+    loadClosedReferencedIssues: defaultLoadClosedReferencedIssues,
+    loadSiblingInProgressIssues: defaultLoadSiblingInProgressIssues,
+    loadPlanDocument: defaultLoadPlanDocument,
+    loadPendingRequestConfirmation: defaultLoadPendingRequestConfirmation,
+    loadRecentRelatedComments: defaultLoadRecentRelatedComments,
+  };
+}
+
+function collectOutboundIssues(
+  snapshot: ColdWakeContextSnapshot,
+): Array<{ id: string; identifier: string | null }> {
+  const items = snapshot.relatedWork?.outbound ?? [];
+  const out: Array<{ id: string; identifier: string | null }> = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const id = item?.issue?.id ?? null;
+    if (typeof id !== "string" || id.length === 0) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, identifier: item?.issue?.identifier ?? null });
+  }
+  return out;
+}
+
+function collectAssigneeAgentIds(
+  snapshot: ColdWakeContextSnapshot,
+  selfAgentId: string,
+): string[] {
+  const chain = snapshot.issueAncestry?.chainOfCommand ?? [];
+  const ids = new Set<string>([selfAgentId]);
+  for (const id of chain) {
+    if (typeof id === "string" && id.length > 0) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+function collectIssueAncestryIds(
+  snapshot: ColdWakeContextSnapshot,
+  selfIssueId: string,
+): string[] {
+  const ancestors = snapshot.issueAncestry?.ancestorIssueIds ?? [];
+  const ids = new Set<string>([selfIssueId]);
+  for (const id of ancestors) {
+    if (typeof id === "string" && id.length > 0) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+function describeSectionError(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name || "unknown error";
+  if (typeof err === "string") return err;
+  return "unknown error";
+}
+
+/** Assemble the cold-wake briefing. Calls `detectColdWake` first and returns
+ *  `null` on a warm wake (no briefing). On a cold wake, runs each section in
+ *  parallel — each behind its own try/catch so a single failure degrades the
+ *  briefing rather than failing the wake. `briefingError` is null on partial
+ *  success; only set when *every* section throws.
+ *
+ *  The token-budget guard, eviction policy, and call-site wiring land in
+ *  follow-up PRs; `budgetTokens` / `budgetTokenCap` / `truncated` are
+ *  populated with safe placeholders so the shape round-trips through the
+ *  step-1 normalizer. */
+export async function buildColdWakeBriefing(
+  input: BuildColdWakeBriefingInput,
+): Promise<ColdWakeBriefing | null> {
+  const runners: ColdWakeSectionRunners = {
+    ...defaultSectionRunners(),
+    ...(input.__overrides ?? {}),
+  };
+  const now = input.now ?? new Date();
+
+  // Detection — failure to read the last-succeeded run is treated as "no
+  // prior run" (i.e. cold). Detection itself is a pure function and is not
+  // wrapped because the briefing shape needs `thresholdHours`.
+  let lastRunFinishedAt: Date | null = null;
+  try {
+    lastRunFinishedAt = await runners.getLastSucceededRunFinishedAt({
+      db: input.db,
+      companyId: input.companyId,
+      agentId: input.agentId,
+    });
+  } catch {
+    lastRunFinishedAt = null;
+  }
+  const detection = runners.detectColdWake({ lastRunFinishedAt, now });
+  if (!detection.isColdWake) return null;
+
+  const referencedPaths = (input.contextSnapshot.referencedIssueIdentifiers ?? []).filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+  const outboundIssues = collectOutboundIssues(input.contextSnapshot);
+  const outboundIds = outboundIssues.map((item) => item.id);
+  const assigneeAgentIds = collectAssigneeAgentIds(input.contextSnapshot, input.agentId);
+  const ancestryIssueIds = collectIssueAncestryIds(input.contextSnapshot, input.issueId);
+  const closedSince = new Date(now.getTime() - CLOSED_ISSUE_LOOKBACK_DAYS * MS_PER_DAY);
+
+  // Section 1 — recent git commits, with the touched-referenced-path flag
+  // tagged in-process so this is the only section that talks to the
+  // filesystem.
+  const gitSection = (async (): Promise<{
+    recentCommits: ColdWakeRecentCommit[];
+    recentCommitsTruncated: boolean;
+  }> => {
+    if (!input.workspaceCwd) {
+      throw new Error("no_workspace_cwd");
+    }
+    const raw = await runners.readRecentCommits(input.workspaceCwd, RECENT_COMMITS_MAX);
+    const recentCommits = raw.slice(0, RECENT_COMMITS_MAX).map((c) => ({
+      sha: c.sha,
+      subject: c.subject,
+      author: c.author,
+      date: c.date,
+      touchedReferencedPath:
+        referencedPaths.length > 0 &&
+        c.files.some((f) => referencedPaths.some((p) => f === p || f.includes(p))),
+    }));
+    return {
+      recentCommits,
+      recentCommitsTruncated: raw.length > RECENT_COMMITS_MAX,
+    };
+  })();
+
+  const closedIssuesSection = runners.loadClosedReferencedIssues({
+    db: input.db,
+    companyId: input.companyId,
+    issueIds: outboundIds,
+    since: closedSince,
+  });
+
+  const siblingsSection = runners.loadSiblingInProgressIssues({
+    db: input.db,
+    companyId: input.companyId,
+    assigneeAgentIds,
+    excludeIssueId: input.issueId,
+    limit: SIBLING_LIMIT,
+  });
+
+  const planSection = runners.loadPlanDocument({
+    db: input.db,
+    companyId: input.companyId,
+    issueId: input.issueId,
+  });
+
+  const interactionSection = runners.loadPendingRequestConfirmation({
+    db: input.db,
+    companyId: input.companyId,
+    issueIds: ancestryIssueIds,
+  });
+
+  const commentsSection = runners.loadRecentRelatedComments({
+    db: input.db,
+    companyId: input.companyId,
+    outbound: outboundIssues,
+    perIssue: COMMENT_LIMIT_PER_ISSUE,
+    total: COMMENT_TOTAL_LIMIT,
+    previewLimit: COMMENT_PREVIEW_LIMIT,
+  });
+
+  // `Promise.allSettled` lets every section run in parallel and report its
+  // own outcome, so one failure does not poison the whole briefing.
+  const [
+    gitResult,
+    closedIssuesResult,
+    siblingsResult,
+    planResult,
+    interactionResult,
+    commentsResult,
+  ] = await Promise.allSettled([
+    gitSection,
+    closedIssuesSection,
+    siblingsSection,
+    planSection,
+    interactionSection,
+    commentsSection,
+  ]);
+
+  const sourcesIncluded: string[] = [];
+  const sectionErrors: string[] = [];
+  let succeededAny = false;
+
+  let recentCommits: ColdWakeRecentCommit[] = [];
+  let recentCommitsTruncated = false;
+  if (gitResult.status === "fulfilled") {
+    recentCommits = gitResult.value.recentCommits;
+    recentCommitsTruncated = gitResult.value.recentCommitsTruncated;
+    sourcesIncluded.push("git");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`git:${describeSectionError(gitResult.reason)}`);
+  }
+
+  let recentlyClosedReferencedIssues: ColdWakeClosedIssue[] = [];
+  if (closedIssuesResult.status === "fulfilled") {
+    recentlyClosedReferencedIssues = closedIssuesResult.value;
+    sourcesIncluded.push("closed_issues");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`closed_issues:${describeSectionError(closedIssuesResult.reason)}`);
+  }
+
+  let siblingInProgressIssues: ColdWakeSiblingIssue[] = [];
+  if (siblingsResult.status === "fulfilled") {
+    siblingInProgressIssues = siblingsResult.value;
+    sourcesIncluded.push("siblings");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`siblings:${describeSectionError(siblingsResult.reason)}`);
+  }
+
+  let planDocument: ColdWakePlanDocument | null = null;
+  if (planResult.status === "fulfilled") {
+    planDocument = planResult.value;
+    sourcesIncluded.push("plan");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`plan:${describeSectionError(planResult.reason)}`);
+  }
+
+  let pendingRequestConfirmation: ColdWakePendingRequestConfirmation | null = null;
+  if (interactionResult.status === "fulfilled") {
+    pendingRequestConfirmation = interactionResult.value;
+    sourcesIncluded.push("interaction");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`interaction:${describeSectionError(interactionResult.reason)}`);
+  }
+
+  let recentRelatedComments: ColdWakeRelatedComment[] = [];
+  if (commentsResult.status === "fulfilled") {
+    recentRelatedComments = commentsResult.value;
+    sourcesIncluded.push("comments");
+    succeededAny = true;
+  } else {
+    sectionErrors.push(`comments:${describeSectionError(commentsResult.reason)}`);
+  }
+
+  const briefingError: ColdWakeBriefingError | null = succeededAny
+    ? null
+    : {
+        code: "all_sections_failed",
+        message:
+          sectionErrors.length > 0
+            ? sectionErrors.join("; ")
+            : "All briefing sections failed",
+      };
+
+  return {
+    thresholdHours: detection.thresholdHours,
+    hoursSinceLastRun: detection.hoursSinceLastRun,
+    lastRunFinishedAt: detection.lastRunFinishedAt
+      ? detection.lastRunFinishedAt.toISOString()
+      : null,
+    recentCommits,
+    recentCommitsTruncated,
+    recentlyClosedReferencedIssues,
+    siblingInProgressIssues,
+    planDocument,
+    pendingRequestConfirmation,
+    recentRelatedComments,
+    sourcesIncluded,
+    budgetTokens: 0,
+    budgetTokenCap: DEFAULT_BUDGET_TOKEN_CAP,
+    truncated: false,
+    briefingError,
+  };
 }

--- a/server/src/services/cold-wake-briefing.ts
+++ b/server/src/services/cold-wake-briefing.ts
@@ -1,0 +1,117 @@
+// Cold-wake briefing assembler — step-by-step in service of the parent
+// initiative: when an agent has been hibernated past a threshold and is woken
+// onto an active issue, the harness prepends a "what changed under you"
+// briefing into the wake payload so the agent does not start work blind.
+//
+// This file holds the focused, adjacent assembler that the heartbeat service
+// calls right after `buildPaperclipWakePayload`. Each piece (detection,
+// section assembly, token-budget guard, telemetry) lands as a separate PR
+// against the parent tracker.
+//
+// **This PR — step 2 — only ships staleness detection.** Per-section
+// assembly, the budget guard, telemetry, and the call-site wiring all land
+// in follow-up PRs.
+
+import { and, desc, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+
+/** Default hibernation threshold. 24h ≈ one working day; gaps longer than
+ *  that are unambiguously stale from the agent's perspective. Tunable via
+ *  `PAPERCLIP_HIBERNATION_THRESHOLD_HOURS` so operators can dial it down
+ *  once telemetry justifies a tighter value. */
+export const DEFAULT_HIBERNATION_THRESHOLD_HOURS = 24;
+
+const SUCCEEDED_RUN_STATUS = "succeeded";
+const MS_PER_HOUR = 3_600_000;
+
+export type ColdWakeDetectionInput = {
+  /** `null` when there is no prior succeeded run for the agent. */
+  lastRunFinishedAt: Date | null;
+  /** Override the default. Falsy values fall back to env / default. */
+  thresholdHours?: number;
+  /** Injectable clock for tests. Defaults to `new Date()`. */
+  now?: Date;
+};
+
+export type ColdWakeDetection = {
+  isColdWake: boolean;
+  hoursSinceLastRun: number | null;
+  lastRunFinishedAt: Date | null;
+  thresholdHours: number;
+};
+
+/** Resolve the hibernation threshold from the supplied env or `process.env`,
+ *  falling back to the default when unset, non-numeric, or non-positive. */
+export function resolveHibernationThresholdHours(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.PAPERCLIP_HIBERNATION_THRESHOLD_HOURS;
+  if (typeof raw !== "string" || raw.length === 0) {
+    return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_HIBERNATION_THRESHOLD_HOURS;
+  }
+  return parsed;
+}
+
+/** Pure detection — given the last succeeded run's finish time, decide
+ *  whether this wake should be treated as a cold wake. No DB access.
+ *
+ *  Boundary rule: a gap **strictly greater than** the threshold is cold.
+ *  Exactly-at-threshold is warm; this keeps daily cron wakes (~24h apart)
+ *  from being flagged cold by default while still catching multi-day gaps
+ *  like the ALL-779 incident that motivated the briefing. */
+export function detectColdWake(input: ColdWakeDetectionInput): ColdWakeDetection {
+  const thresholdHours =
+    typeof input.thresholdHours === "number" && Number.isFinite(input.thresholdHours) && input.thresholdHours > 0
+      ? input.thresholdHours
+      : resolveHibernationThresholdHours();
+  const now = input.now ?? new Date();
+  const lastRunFinishedAt = input.lastRunFinishedAt;
+
+  if (!lastRunFinishedAt) {
+    return {
+      isColdWake: true,
+      hoursSinceLastRun: null,
+      lastRunFinishedAt: null,
+      thresholdHours,
+    };
+  }
+
+  const hoursSinceLastRun = (now.getTime() - lastRunFinishedAt.getTime()) / MS_PER_HOUR;
+  return {
+    isColdWake: hoursSinceLastRun > thresholdHours,
+    hoursSinceLastRun,
+    lastRunFinishedAt,
+    thresholdHours,
+  };
+}
+
+/** Look up the most recent succeeded `heartbeat_runs.finished_at` for an
+ *  agent within a company. Returns `null` when no succeeded run is on
+ *  record. The query is covered by the existing
+ *  `heartbeat_runs_company_agent_started_idx` for filter selectivity; the
+ *  trailing `order by finished_at desc` falls back to a small in-memory
+ *  sort, which is acceptable for the per-wake call cadence. */
+export async function getLastSucceededRunFinishedAt(input: {
+  db: Db;
+  companyId: string;
+  agentId: string;
+}): Promise<Date | null> {
+  const rows = await input.db
+    .select({ finishedAt: heartbeatRuns.finishedAt })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.agentId, input.agentId),
+        eq(heartbeatRuns.status, SUCCEEDED_RUN_STATUS),
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.finishedAt))
+    .limit(1);
+  return rows[0]?.finishedAt ?? null;
+}

--- a/server/src/services/cold-wake-briefing.ts
+++ b/server/src/services/cold-wake-briefing.ts
@@ -17,9 +17,15 @@
 //   pending request_confirmation, recent related comments). Each section is
 //   wrapped in a try/catch so a single failure degrades the briefing rather
 //   than failing the wake.
+// - Step 4 (token-budget guard): `DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP`,
+//   `resolveColdWakeBriefingTokenCap`, `estimateBriefingTokens`,
+//   `enforceBriefingBudget`. Deterministic eviction order per parent plan
+//   §3.3: oldest comments → oldest commits → siblings beyond top-3 →
+//   closed-issues beyond top-3 → set `truncated: true`. Staleness header,
+//   `planDocument`, and `pendingRequestConfirmation` are never dropped.
 //
-// The token-budget guard, bypass switch, telemetry, and the call-site wiring
-// land in follow-up PRs (steps 4–6).
+// The bypass switch, telemetry, and the call-site wiring land in follow-up
+// PRs (steps 5–6).
 
 import { execFile } from "node:child_process";
 import { and, desc, eq, gte, inArray, isNull, ne } from "drizzle-orm";
@@ -145,9 +151,11 @@ const COMMENT_PREVIEW_LIMIT = 280;
 const CLOSED_ISSUE_LOOKBACK_DAYS = 14;
 const MS_PER_DAY = 24 * MS_PER_HOUR;
 
-/** Placeholder token-budget cap. Step 4 wires up the real guard and eviction
- *  policy; the field is populated here so the briefing shape round-trips. */
-const DEFAULT_BUDGET_TOKEN_CAP = 8000;
+/** Default cap for the assembled cold-wake briefing, in estimated tokens.
+ *  8000 is the parent plan §3.3 target: room for a meaningful briefing
+ *  without crowding the wake payload itself. Tunable via
+ *  `PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP`. */
+export const DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP = 8000;
 
 export type ColdWakeRecentCommit = {
   sha: string;
@@ -216,13 +224,17 @@ export type ColdWakeBriefing = {
   recentRelatedComments: ColdWakeRelatedComment[];
   /** Section keys actually populated — matches the §3.2 source list:
    *  `"git" | "closed_issues" | "siblings" | "plan" | "interaction" | "comments"`.
-   *  Sections that failed are omitted. */
+   *  Sections that failed are omitted. When `enforceBriefingBudget` evicts
+   *  items from a section, the entry is rewritten as `"<key>:truncated"`. */
   sourcesIncluded: string[];
-  /** Placeholder until step 4 implements the budget guard. */
+  /** Estimated tokens after the budget guard runs. See
+   *  `estimateBriefingTokens`. */
   budgetTokens: number;
-  /** Placeholder until step 4 implements the budget guard. */
+  /** Cap the guard ran against. See `resolveColdWakeBriefingTokenCap`. */
   budgetTokenCap: number;
-  /** Placeholder until step 4 implements eviction. */
+  /** True when any section was reduced by `enforceBriefingBudget`, or when
+   *  the budget could not be hit even after evicting every droppable
+   *  section. */
   truncated: boolean;
   briefingError: ColdWakeBriefingError | null;
 };
@@ -640,10 +652,10 @@ function describeSectionError(err: unknown): string {
  *  briefing rather than failing the wake. `briefingError` is null on partial
  *  success; only set when *every* section throws.
  *
- *  The token-budget guard, eviction policy, and call-site wiring land in
- *  follow-up PRs; `budgetTokens` / `budgetTokenCap` / `truncated` are
- *  populated with safe placeholders so the shape round-trips through the
- *  step-1 normalizer. */
+ *  Step 4: the assembled briefing is passed through `enforceBriefingBudget`
+ *  before return, populating `budgetTokens` / `budgetTokenCap` / `truncated`
+ *  per parent plan §3.3 and updating `sourcesIncluded` with `:truncated`
+ *  markers when a section was evicted. */
 export async function buildColdWakeBriefing(
   input: BuildColdWakeBriefingInput,
 ): Promise<ColdWakeBriefing | null> {
@@ -828,7 +840,8 @@ export async function buildColdWakeBriefing(
             : "All briefing sections failed",
       };
 
-  return {
+  const tokenCap = resolveColdWakeBriefingTokenCap();
+  const assembled: ColdWakeBriefing = {
     thresholdHours: detection.thresholdHours,
     hoursSinceLastRun: detection.hoursSinceLastRun,
     lastRunFinishedAt: detection.lastRunFinishedAt
@@ -843,8 +856,184 @@ export async function buildColdWakeBriefing(
     recentRelatedComments,
     sourcesIncluded,
     budgetTokens: 0,
-    budgetTokenCap: DEFAULT_BUDGET_TOKEN_CAP,
+    budgetTokenCap: tokenCap,
     truncated: false,
     briefingError,
   };
+  return enforceBriefingBudget(assembled, { tokenCap, now });
+}
+
+// =============================================================================
+// Step 4 — token-budget guard + deterministic eviction order.
+//
+// The guard is a pure function: it does not read the env, the DB, or the
+// filesystem. Env resolution lives in `resolveColdWakeBriefingTokenCap`, and
+// `buildColdWakeBriefing` calls that resolver to obtain the cap that gets
+// passed in here. This keeps `enforceBriefingBudget` trivially testable while
+// still picking up operator overrides at the call site.
+// =============================================================================
+
+const BRIEFING_SECTIONS_KEEP_TOP_N = 3;
+
+/** Resolve the cold-wake briefing token cap from the supplied env or
+ *  `process.env`, falling back to the default when unset, non-numeric, zero,
+ *  or negative. Mirrors `resolveHibernationThresholdHours` so operators have
+ *  a single mental model for both knobs. */
+export function resolveColdWakeBriefingTokenCap(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP;
+  if (typeof raw !== "string" || raw.length === 0) {
+    return DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP;
+  }
+  return parsed;
+}
+
+/** Cheap, deterministic token estimator. Serializes the briefing to JSON and
+ *  divides the character count by 4 — the well-known rule-of-thumb for
+ *  English text token density. This is intentionally approximate; the guard
+ *  only needs ordering monotonicity to decide whether to keep evicting.
+ *
+ *  Pure function: same input → same output. Unit-testable without a real
+ *  tokenizer. */
+export function estimateBriefingTokens(briefing: ColdWakeBriefing): number {
+  const json = JSON.stringify(briefing) ?? "";
+  return Math.ceil(json.length / 4);
+}
+
+/** Update `sourcesIncluded`, rewriting `"<key>"` as `"<key>:truncated"` for
+ *  every section that lost items. Sections that were not present originally
+ *  are not added — eviction can only mark a section the assembler already
+ *  populated. */
+function markSourcesTruncated(
+  current: ReadonlyArray<string>,
+  truncatedSections: ReadonlySet<string>,
+): string[] {
+  if (truncatedSections.size === 0) return [...current];
+  return current.map((src) => {
+    const baseKey = src.split(":")[0] ?? src;
+    return truncatedSections.has(baseKey) ? `${baseKey}:truncated` : src;
+  });
+}
+
+export type EnforceBriefingBudgetOptions = {
+  /** Override the resolved cap. Falsy / non-finite / non-positive values
+   *  fall back to `DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP`. */
+  tokenCap?: number;
+  /** Reserved for symmetry with the rest of the assembler call shape. The
+   *  guard itself does not depend on the clock; accepting `now` keeps the
+   *  signature stable if a future eviction policy needs it (e.g., age-based
+   *  drop of "recent" entries that have since aged out). */
+  now?: Date;
+};
+
+/** Enforce the cold-wake briefing token budget. Pure function: same input →
+ *  same output, no side effects. Returns a new briefing object with
+ *  `budgetTokens`, `budgetTokenCap`, `truncated`, and `sourcesIncluded`
+ *  updated; the input briefing is not mutated.
+ *
+ *  Eviction order (parent plan §3.3, acceptance criterion 5). Drop in this
+ *  order until under budget; re-estimate after every drop so we short-circuit
+ *  as soon as the briefing falls under cap:
+ *
+ *  1. Oldest `recentRelatedComments` (sort by `createdAt`, drop oldest).
+ *  2. Oldest `recentCommits` (sort by `date`, drop oldest).
+ *  3. `siblingInProgressIssues` items beyond top 3 (sort by `updatedAt`
+ *     DESC, keep top 3, drop the rest).
+ *  4. `recentlyClosedReferencedIssues` items beyond top 3 (sort by
+ *     `closedAt` DESC, keep top 3, drop the rest).
+ *  5. If still over budget, set `truncated: true` and stop. The staleness
+ *     header, `planDocument`, and `pendingRequestConfirmation` are NEVER
+ *     mutated, even when the rest of the briefing is empty after eviction. */
+export function enforceBriefingBudget(
+  briefing: ColdWakeBriefing,
+  options: EnforceBriefingBudgetOptions = {},
+): ColdWakeBriefing {
+  const tokenCap =
+    typeof options.tokenCap === "number" &&
+    Number.isFinite(options.tokenCap) &&
+    options.tokenCap > 0
+      ? options.tokenCap
+      : DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP;
+
+  let working: ColdWakeBriefing = {
+    ...briefing,
+    budgetTokens: 0,
+    budgetTokenCap: tokenCap,
+    truncated: false,
+  };
+
+  // Short-circuit when already under cap. We still rewrite the budget fields
+  // so callers can rely on `budgetTokens` reflecting the actual estimate.
+  if (estimateBriefingTokens(working) <= tokenCap) {
+    return { ...working, budgetTokens: estimateBriefingTokens(working) };
+  }
+
+  const truncatedSections = new Set<string>();
+
+  // Step 1 — drop oldest comments first. Sort DESC so `pop()` removes the
+  // oldest item; this preserves the original "newest-first" presentation
+  // order for the survivors.
+  let comments = [...working.recentRelatedComments].sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
+  while (estimateBriefingTokens(working) > tokenCap && comments.length > 0) {
+    comments.pop();
+    truncatedSections.add("comments");
+    working = { ...working, recentRelatedComments: comments };
+  }
+
+  // Step 2 — drop oldest commits next, same DESC-then-pop pattern.
+  let commits = [...working.recentCommits].sort((a, b) =>
+    b.date.localeCompare(a.date),
+  );
+  while (estimateBriefingTokens(working) > tokenCap && commits.length > 0) {
+    commits.pop();
+    truncatedSections.add("git");
+    working = { ...working, recentCommits: commits };
+  }
+
+  // Step 3 — siblings beyond top-3. Sort DESC by updatedAt and pop the
+  // back until we hit the top-3 floor or the budget.
+  let siblings = [...working.siblingInProgressIssues].sort((a, b) =>
+    b.updatedAt.localeCompare(a.updatedAt),
+  );
+  while (
+    estimateBriefingTokens(working) > tokenCap &&
+    siblings.length > BRIEFING_SECTIONS_KEEP_TOP_N
+  ) {
+    siblings.pop();
+    truncatedSections.add("siblings");
+    working = { ...working, siblingInProgressIssues: siblings };
+  }
+
+  // Step 4 — closed-issue references beyond top-3. Same shape as step 3.
+  let closed = [...working.recentlyClosedReferencedIssues].sort((a, b) =>
+    b.closedAt.localeCompare(a.closedAt),
+  );
+  while (
+    estimateBriefingTokens(working) > tokenCap &&
+    closed.length > BRIEFING_SECTIONS_KEEP_TOP_N
+  ) {
+    closed.pop();
+    truncatedSections.add("closed_issues");
+    working = { ...working, recentlyClosedReferencedIssues: closed };
+  }
+
+  // Step 5 — still over budget. Per §3.3 we never drop the staleness header
+  // or section 4 (plan / interaction); flag truncated and return what we
+  // have. The briefing is always returned, never nulled out.
+  const overBudgetAfterEvict = estimateBriefingTokens(working) > tokenCap;
+  const sourcesIncluded = markSourcesTruncated(working.sourcesIncluded, truncatedSections);
+  const truncated = truncatedSections.size > 0 || overBudgetAfterEvict;
+  const finalWorking: ColdWakeBriefing = {
+    ...working,
+    sourcesIncluded,
+    truncated,
+  };
+  return { ...finalWorking, budgetTokens: estimateBriefingTokens(finalWorking) };
 }


### PR DESCRIPTION
## Summary

Step 4 of the cold-wake briefing stack (parent: [ALL-781]; this PR closes [ALL-898]). Stacked on **#8006** (step 3, the per-section assembler).

Adds the token-budget guard and deterministic eviction policy that the step-3 assembler was leaving as placeholders. All work lives in the same `server/src/services/cold-wake-briefing.ts` module per CTO's adjacent-assembler sign-off on ALL-782.

### New exports

- `DEFAULT_COLD_WAKE_BRIEFING_TOKEN_CAP = 8000`
- `resolveColdWakeBriefingTokenCap(env?)` — reads `PAPERCLIP_COLD_WAKE_BRIEFING_TOKEN_CAP`, falls back to the default on unset / non-numeric / zero / negative (mirrors `resolveHibernationThresholdHours`).
- `estimateBriefingTokens(briefing)` — cheap, deterministic `Math.ceil(JSON.stringify(briefing).length / 4)`. Pure.
- `enforceBriefingBudget(briefing, { tokenCap?, now? })` — pure function. Returns a new briefing with budget fields populated and sections evicted per parent plan §3.3.

### Eviction order (plan §3.3, AC 5)

Drop one item at a time, re-estimating after each drop, until under cap:

1. Oldest `recentRelatedComments` (sort by `createdAt` DESC, pop the back so the newest survivors keep their presentation order).
2. Oldest `recentCommits` (same shape).
3. `siblingInProgressIssues` beyond top-3 by `updatedAt` DESC.
4. `recentlyClosedReferencedIssues` beyond top-3 by `closedAt` DESC.
5. If still over cap: set `truncated: true` and return. **Never** mutate the staleness header, `planDocument`, or `pendingRequestConfirmation`.

`sourcesIncluded` entries are rewritten as `"<key>:truncated"` for any section that lost items. `truncated: true` is set whenever any section was reduced OR the briefing is still over cap after every droppable section was emptied.

### Assembler wiring

`buildColdWakeBriefing` now calls `enforceBriefingBudget` on its assembled return value, replacing the step-3 placeholder `budgetTokens: 0, budgetTokenCap: 8000, truncated: false` with real values driven by the env-resolved cap.

## Test plan

New `server/src/__tests__/cold-wake-briefing-budget.test.ts`:

- [x] `resolveColdWakeBriefingTokenCap`: unset → default; valid numeric → respected; non-numeric → default; zero / negative → default.
- [x] `estimateBriefingTokens`: deterministic for a fixture briefing; monotonic — adding section content never lowers the estimate.
- [x] `enforceBriefingBudget` under cap: no eviction, `truncated: false`, `sourcesIncluded` unchanged, `budgetTokens` populated with the real estimate.
- [x] 2× over cap from comments alone: evicts oldest comments first, `comments:truncated` appears in `sourcesIncluded`, other sections untouched, `truncated: true`, protected fields byte-identical.
- [x] Cascading eviction: tiny cap forces comments → commits → siblings → closed-issues in that exact order; siblings + closed land on their top-3 floor with the newest-by-sort-key survivors; all four `:truncated` markers present.
- [x] Staleness header + `pendingRequestConfirmation` + `planDocument` NEVER mutated even when the rest of the briefing has been chewed down by an aggressive cap.
- [x] Final fallback: impossibly small cap (still over cap after every droppable section is emptied) → `truncated: true`, briefing returned (not nulled), protected fields intact.

Updated `cold-wake-briefing-assembly.test.ts`: the existing "all five sections populated" case now asserts `budgetTokens > 0` and `budgetTokens <= budgetTokenCap` instead of the step-3 placeholder zero. Detection + assembly + budget test files together: 27 passing.

```
$ node_modules/.bin/vitest run server/src/__tests__/cold-wake-briefing-budget.test.ts \
                               server/src/__tests__/cold-wake-briefing-assembly.test.ts \
                               server/src/__tests__/cold-wake-briefing-detection.test.ts
 Test Files  3 passed (3)
      Tests  27 passed (27)
```

## What is NOT in this PR (per parent plan)

- Bypass switch + `heartbeatRunEvents` telemetry → step 5.
- Wiring into `buildPaperclipWakePayload` + renderer integration → step 6.
- Integration / replay tests → steps 7, 8.

## Stacking note

Branches off `feat/cold-wake-briefing-assembler` (#8006). When that lands on `master`, this PR's diff against `master` will be the changes shown here. If GitHub initially compares against `master` directly, the noise is the step-3 commit on top of which this builds; please review against the **stacked** parent.

[ALL-781]: https://app.paperclip.ai/ALL/issues/ALL-781
[ALL-898]: https://app.paperclip.ai/ALL/issues/ALL-898
