### PR TITLE
fix(heartbeat): dedup issue_blockers_resolved wake re-fire on already-done blockers

### DIFF
--- a/server/src/__tests__/issue-blockers-resolved-wakes.test.ts
+++ b/server/src/__tests__/issue-blockers-resolved-wakes.test.ts
@@ -1,0 +1,200 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentWakeupRequests,
+  agents,
+  companies,
+  createDb,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  buildIssueBlockersResolvedIdempotencyKey,
+  findDeliveredIssueBlockersResolvedWake,
+} from "../services/issue-blockers-resolved-wakes.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue-blockers-resolved wake dedup tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue_blockers_resolved wake dedup", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-blockers-resolved-wakes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "DedupTester",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  it("builds a stable key per (dependent, blocker) pair", () => {
+    const key = buildIssueBlockersResolvedIdempotencyKey({
+      dependentIssueId: "dep-1",
+      resolvedBlockerIssueId: "blk-1",
+    });
+    expect(key).toBe("issue_blockers_resolved:dep-1:blk-1");
+    // A different blocker for the same dependent produces a different key, so
+    // the next blocker-done transition can still wake the dependent.
+    const otherBlockerKey = buildIssueBlockersResolvedIdempotencyKey({
+      dependentIssueId: "dep-1",
+      resolvedBlockerIssueId: "blk-2",
+    });
+    expect(otherBlockerKey).not.toBe(key);
+  });
+
+  it("returns a delivered wake row only when one already exists for the pair", async () => {
+    const { companyId, agentId } = await seedAgent();
+    const idempotencyKey = buildIssueBlockersResolvedIdempotencyKey({
+      dependentIssueId: "dependent-issue-id",
+      resolvedBlockerIssueId: "blocker-issue-id",
+    });
+
+    expect(
+      await findDeliveredIssueBlockersResolvedWake(db, { companyId, idempotencyKey }),
+    ).toBeNull();
+
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: "dependent-issue-id", resolvedBlockerIssueId: "blocker-issue-id" },
+      status: "completed",
+      idempotencyKey,
+      finishedAt: new Date(),
+    });
+
+    const delivered = await findDeliveredIssueBlockersResolvedWake(db, {
+      companyId,
+      idempotencyKey,
+    });
+    expect(delivered).not.toBeNull();
+    expect(delivered?.status).toBe("completed");
+  });
+
+  it("treats queued and deferred wakes as delivered so the re-fire skips them", async () => {
+    const { companyId, agentId } = await seedAgent();
+    const idempotencyKey = buildIssueBlockersResolvedIdempotencyKey({
+      dependentIssueId: "dep-q",
+      resolvedBlockerIssueId: "blk-q",
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: "dep-q", resolvedBlockerIssueId: "blk-q" },
+      status: "queued",
+      idempotencyKey,
+    });
+
+    const queued = await findDeliveredIssueBlockersResolvedWake(db, {
+      companyId,
+      idempotencyKey,
+    });
+    expect(queued?.status).toBe("queued");
+  });
+
+  it("does not treat skipped or cancelled wakes as delivered", async () => {
+    const { companyId, agentId } = await seedAgent();
+    const idempotencyKey = buildIssueBlockersResolvedIdempotencyKey({
+      dependentIssueId: "dep-s",
+      resolvedBlockerIssueId: "blk-s",
+    });
+
+    // Simulate a wake that was suppressed before delivery (e.g. by an active
+    // tree hold or a dependencies-still-blocked check). It must not block a
+    // legitimate later re-fire from completing the dependent's wake path.
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_tree_hold_active",
+      payload: { issueId: "dep-s", resolvedBlockerIssueId: "blk-s" },
+      status: "skipped",
+      idempotencyKey,
+      finishedAt: new Date(),
+    });
+
+    expect(
+      await findDeliveredIssueBlockersResolvedWake(db, { companyId, idempotencyKey }),
+    ).toBeNull();
+  });
+
+  it("scopes lookups to the requested company so cross-company wakes do not collide", async () => {
+    const first = await seedAgent();
+    const second = await seedAgent();
+    const idempotencyKey = buildIssueBlockersResolvedIdempotencyKey({
+      dependentIssueId: "shared-dependent-id",
+      resolvedBlockerIssueId: "shared-blocker-id",
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      companyId: first.companyId,
+      agentId: first.agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: "shared-dependent-id", resolvedBlockerIssueId: "shared-blocker-id" },
+      status: "completed",
+      idempotencyKey,
+      finishedAt: new Date(),
+    });
+
+    expect(
+      await findDeliveredIssueBlockersResolvedWake(db, {
+        companyId: second.companyId,
+        idempotencyKey,
+      }),
+    ).toBeNull();
+    expect(
+      await findDeliveredIssueBlockersResolvedWake(db, {
+        companyId: first.companyId,
+        idempotencyKey,
+      }),
+    ).not.toBeNull();
+  });
+});

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -176,6 +176,10 @@ describe("issue dependency wakeups in issue routes", () => {
         "agent-2",
         expect.objectContaining({
           reason: "issue_blockers_resolved",
+          // Per-pair idempotency key lets the workspace_finalize re-fire
+          // path suppress a duplicate wake on the same (dependent, blocker)
+          // pair (HMS-449 / paperclipai/paperclip#TBD).
+          idempotencyKey: "issue_blockers_resolved:issue-2:issue-1",
           payload: expect.objectContaining({
             issueId: "issue-2",
             resolvedBlockerIssueId: "issue-1",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -98,6 +98,7 @@ import {
   SVG_CONTENT_TYPE,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+import { buildIssueBlockersResolvedIdempotencyKey } from "../services/issue-blockers-resolved-wakes.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 import { executionWorkspaceService as executionWorkspaceServiceDirect } from "../services/execution-workspaces.js";
 import { feedbackService } from "../services/feedback.js";
@@ -4941,6 +4942,13 @@ export function issueRoutes(
             source: "automation",
             triggerDetail: "system",
             reason: "issue_blockers_resolved",
+            // Stamp a per-pair idempotency key so the workspace_finalize
+            // re-fire path can suppress a duplicate wake for a (dependent,
+            // blocker) pair that already received one at PATCH time.
+            idempotencyKey: buildIssueBlockersResolvedIdempotencyKey({
+              dependentIssueId: dependent.id,
+              resolvedBlockerIssueId: issue.id,
+            }),
             payload: {
               issueId: dependent.id,
               resolvedBlockerIssueId: issue.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -151,6 +151,10 @@ import {
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
 import { recoveryService } from "./recovery/service.js";
+import {
+  buildIssueBlockersResolvedIdempotencyKey,
+  findDeliveredIssueBlockersResolvedWake,
+} from "./issue-blockers-resolved-wakes.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
 import {
@@ -8338,20 +8342,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // mid-run (so the original `issue_blockers_resolved` wake was gated by
         // the readiness check waiting for workspace_finalize), the finalize
         // row we just recorded now lets dependents proceed. Fire wakes here.
+        //
+        // Dedup: every successful run on an already-`done` blocker would
+        // otherwise re-emit `issue_blockers_resolved` to ready dependents that
+        // received the wake at PATCH time, billing budget and producing noise
+        // heartbeats with no new context (HMS-449 / paperclipai/paperclip#TBD).
+        // We skip dependents whose (dependent, blocker) pair already has a
+        // delivered wake row stamped with the per-pair idempotency key.
         if (issueId && adapterFinalizeOutcome === "succeeded") {
           try {
             const blockerIssueStatus = await db
-              .select({ status: issues.status })
+              .select({ status: issues.status, companyId: issues.companyId })
               .from(issues)
               .where(eq(issues.id, issueId))
-              .then((rows) => rows[0]?.status ?? null);
-            if (blockerIssueStatus === "done") {
+              .then((rows) => rows[0] ?? null);
+            if (blockerIssueStatus?.status === "done") {
               const dependents = await issuesSvc.listWakeableBlockedDependents(issueId);
               for (const dependent of dependents) {
+                const idempotencyKey = buildIssueBlockersResolvedIdempotencyKey({
+                  dependentIssueId: dependent.id,
+                  resolvedBlockerIssueId: issueId,
+                });
+                const existingWake = await findDeliveredIssueBlockersResolvedWake(db, {
+                  companyId: blockerIssueStatus.companyId,
+                  idempotencyKey,
+                });
+                if (existingWake) continue;
                 await enqueueWakeup(dependent.assigneeAgentId, {
                   source: "automation",
                   triggerDetail: "system",
                   reason: "issue_blockers_resolved",
+                  idempotencyKey,
                   payload: {
                     issueId: dependent.id,
                     resolvedBlockerIssueId: issueId,

--- a/server/src/services/issue-blockers-resolved-wakes.ts
+++ b/server/src/services/issue-blockers-resolved-wakes.ts
@@ -1,0 +1,44 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agentWakeupRequests } from "@paperclipai/db";
+
+export const ISSUE_BLOCKERS_RESOLVED_REASON = "issue_blockers_resolved";
+
+// A wake row in any of these statuses counts as "already delivered" so we
+// suppress duplicate emits for the same (dependent, blocker) pair. `skipped`
+// and `cancelled` rows are intentionally excluded so a wake that was vetoed
+// (e.g. by a tree hold or a dependency-blocked check) does not permanently
+// mute the resolution path; the next legitimate transition can still fire.
+const DELIVERED_WAKE_STATUSES = ["queued", "deferred_issue_execution", "completed"];
+
+export function buildIssueBlockersResolvedIdempotencyKey(input: {
+  dependentIssueId: string;
+  resolvedBlockerIssueId: string;
+}) {
+  return [
+    ISSUE_BLOCKERS_RESOLVED_REASON,
+    input.dependentIssueId,
+    input.resolvedBlockerIssueId,
+  ].join(":");
+}
+
+export async function findDeliveredIssueBlockersResolvedWake(
+  db: Pick<Db, "select">,
+  input: {
+    companyId: string;
+    idempotencyKey: string;
+  },
+) {
+  return db
+    .select({ id: agentWakeupRequests.id, status: agentWakeupRequests.status })
+    .from(agentWakeupRequests)
+    .where(
+      and(
+        eq(agentWakeupRequests.companyId, input.companyId),
+        eq(agentWakeupRequests.idempotencyKey, input.idempotencyKey),
+        inArray(agentWakeupRequests.status, DELIVERED_WAKE_STATUSES),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}


### PR DESCRIPTION
## Why

`heartbeat.ts` re-emits `issue_blockers_resolved` for every ready dependent whenever a heartbeat run completes succeeded on a `done` blocker. The intent is to catch the race where the original PATCH wake was deferred behind a `workspace_finalize` barrier — but the current code does not check whether the dependent has already received a wake for this blocker. When the blocker is already `done` before the run starts (a post-completion synthesis run, a comment-mention wake, a routine touch, etc.), the original PATCH wake has already fired and the dependent is typically parked `in_review`. The re-fire produces a no-context wake heartbeat on the dependent that bills budget and posts noise commentary without progressing the deliverable.

Observed in a downstream company (HMS-440): `issue_blockers_resolved` fired three times after the only blocker reached `done`. Each wake produced no new comments, no blocker state change, and no interaction resolution.

## What changes

- Add a small helper module `server/src/services/issue-blockers-resolved-wakes.ts` exposing:
  - `buildIssueBlockersResolvedIdempotencyKey({ dependentIssueId, resolvedBlockerIssueId })` — deterministic per-pair key.
  - `findDeliveredIssueBlockersResolvedWake(db, { companyId, idempotencyKey })` — looks up a delivered wake (`queued`, `deferred_issue_execution`, or `completed`). `skipped` and `cancelled` rows are intentionally excluded so a wake suppressed by a tree hold or a still-blocked check does not permanently mute the resolution path.
- Stamp the key on both emit paths:
  - `routes/issues.ts` becameDone block — every PATCH-time wake gets the per-pair key.
  - `services/heartbeat.ts` workspace_finalize re-fire — checks the lookup before emitting; skips dependents that already have a delivered wake.

## Why this is safe

- The PATCH-time wake still fires immediately for every ready dependent (no behavior change there). The new key is just a stable marker.
- The workspace_finalize re-fire still catches the race where the original PATCH wake was deferred behind a finalize barrier. The dedup check only suppresses pairs that already received a wake; a dependent that was gated at PATCH time has no row in the delivered set and is emitted as before.
- Cancelled/skipped wakes are not treated as delivered, so a wake vetoed by an active tree hold can still be re-emitted after the hold lifts.
- Idempotency is per `(dependent, blocker)` pair. If a blocker were re-opened and re-completed (rare), no second wake would fire under this scheme — acceptable trade-off given how rare re-completion is.

## Tests

- `server/src/__tests__/issue-blockers-resolved-wakes.test.ts` (new) — embedded Postgres unit tests for the helper:
  - stable key shape per pair, distinct keys for different blockers
  - returns a delivered wake only when one already exists for the pair
  - treats `queued` / `deferred_issue_execution` / `completed` as delivered
  - does NOT treat `skipped` / `cancelled` as delivered
  - scopes lookups to the requested company
- `server/src/__tests__/issue-dependency-wakeups-routes.test.ts` (updated) — asserts the PATCH becameDone wake stamps the new idempotency key.

## Related

Filed by Hit Me SEO as a one-shot upstream contribution (sister to #7505) after the wake fired three times on an already-resolved dependent in our company runtime.
