### PR TITLE
feat(auth): add issue:mutate permission and allow Merger explicit-grant mutations

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -730,6 +730,7 @@ export const PERMISSION_KEYS = [
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",
   "joins:approve",
+  "issue:mutate",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];
 

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -10,7 +10,7 @@ import {
   principalPermissionGrants,
   projects,
 } from "@paperclipai/db";
-import { LOW_TRUST_REVIEW_PRESET } from "@paperclipai/shared";
+import { LOW_TRUST_REVIEW_PRESET, type PermissionKey } from "@paperclipai/shared";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -94,7 +94,7 @@ async function grantAgentPermission(
   db: ReturnType<typeof createDb>,
   companyId: string,
   agentId: string,
-  permissionKey: "tasks:assign" | "tasks:assign_scope",
+  permissionKey: PermissionKey,
   scope: Record<string, unknown> | null = null,
 ) {
   await db.insert(companyMemberships).values({
@@ -707,6 +707,75 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision).toMatchObject({
       allowed: true,
       grant: { permissionKey: "tasks:assign" },
+    });
+  });
+
+  it("allows an agent with an issue:mutate grant to mutate another agent's non-in-progress issue", async () => {
+    const company = await createCompany(db, "IssueMutateGrant");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      assigneeAgentId: targetAgent.id,
+      status: "todo",
+    });
+    await grantAgentPermission(db, company.id, actorAgent.id, "issue:mutate");
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: issue.assigneeAgentId,
+        assigneeUserId: issue.assigneeUserId,
+        status: issue.status,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_explicit_grant",
+      grant: { permissionKey: "issue:mutate" },
+    });
+  });
+
+  it("denies issue:mutate to an agent without the grant when the issue is assigned to another agent", async () => {
+    const company = await createCompany(db, "IssueMutateDenied");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      assigneeAgentId: targetAgent.id,
+      status: "todo",
+    });
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "agent",
+      principalId: actorAgent.id,
+      status: "active",
+      membershipRole: "member",
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: issue.assigneeAgentId,
+        assigneeUserId: issue.assigneeUserId,
+        status: issue.status,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
     });
   });
 });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -313,28 +313,27 @@ describe("agent issue mutation checkout ownership", () => {
     vi.clearAllMocks();
     mockAccessService.canUser.mockReset();
     mockAccessService.decide.mockReset();
-    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
-      allowed:
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => {
+      const allowed =
         input.action === "tasks:assign" ||
         input.action === "issue:read" ||
         input.action === "issue:mutate" ||
-        input.action === "company_scope:read",
-      action: input.action,
-      reason:
-        input.action === "tasks:assign" ||
-          input.action === "issue:read" ||
-          input.action === "issue:mutate" ||
-          input.action === "company_scope:read"
-          ? "allow_explicit_grant"
-          : "deny_missing_grant",
-      explanation:
-        input.action === "tasks:assign" ||
-          input.action === "issue:read" ||
-          input.action === "issue:mutate" ||
-          input.action === "company_scope:read"
-          ? "Allowed by test default."
-          : "Missing permission.",
-    }));
+        input.action === "company_scope:read";
+      if (input.action === "issue:mutate") {
+        return {
+          allowed: true,
+          action: input.action,
+          reason: "allow_company_agent",
+          explanation: "Allowed by test default company-agent visibility.",
+        };
+      }
+      return {
+        allowed,
+        action: input.action,
+        reason: allowed ? "allow_explicit_grant" : "deny_missing_grant",
+        explanation: allowed ? "Allowed by test default." : "Missing permission.",
+      };
+    });
     mockAccessService.hasPermission.mockReset();
     mockAgentService.getById.mockReset();
     mockAgentService.list.mockReset();
@@ -971,6 +970,66 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status).toBe(200);
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows an agent with an issue:mutate explicit grant to mutate another agent's non-in-progress issue", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => {
+      if (input.action === "issue:mutate") {
+        return {
+          allowed: true,
+          action: input.action,
+          reason: "allow_explicit_grant",
+          explanation: "Allowed by issue:mutate grant.",
+        };
+      }
+      return {
+        allowed: true,
+        action: input.action,
+        reason: "allow_test_default",
+        explanation: "Allowed by test default.",
+      };
+    });
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor())).patch(`/api/issues/${issueId}`).send({ title: "Granted update" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("blocks an agent with only an issue:mutate explicit grant from mutating another agent's in-progress checkout", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => {
+      if (input.action === "issue:mutate") {
+        return {
+          allowed: true,
+          action: input.action,
+          reason: "allow_explicit_grant",
+          explanation: "Allowed by issue:mutate grant.",
+        };
+      }
+      if (input.action === "tasks:manage_active_checkouts") {
+        return {
+          allowed: false,
+          action: input.action,
+          reason: "deny_missing_grant",
+          explanation: "Missing permission.",
+        };
+      }
+      return {
+        allowed: true,
+        action: input.action,
+        reason: "allow_test_default",
+        explanation: "Allowed by test default.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor())).patch(`/api/issues/${issueId}`).send({ title: "Blocked grant update" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue is checked out by another agent");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1789,6 +1789,9 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
+      if (boundaryDecision.reason === "allow_explicit_grant") {
+        return true;
+      }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1789,7 +1789,10 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
-      if (boundaryDecision.reason === "allow_explicit_grant") {
+      if (
+        boundaryDecision.reason === "allow_explicit_grant" &&
+        issue.status !== "in_progress"
+      ) {
         return true;
       }
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -117,7 +117,7 @@ function permissionForAction(action: AuthorizationAction): PermissionKey | null 
   ) {
     return null;
   }
-  if (action === "issue:mutate") return null;
+  if (action === "issue:mutate") return "issue:mutate";
   return action;
 }
 


### PR DESCRIPTION
Register a new `issue:mutate` PermissionKey and wire it through the authorization service and issue mutation route so that agents granted the permission (e.g., Merger) can mutate issues assigned to other agents.

Changes:
- `packages/shared/src/constants.ts`: add `issue:mutate` to `PERMISSION_KEYS`.
- `server/src/services/authorization.ts`: return `issue:mutate` from `permissionForAction`.
- `server/src/routes/issues.ts`: honor an explicit `allow_explicit_grant` boundary decision in `assertAgentIssueMutationAllowed`.
- `server/src/__tests__/authorization-service.test.ts`: add granted/denied coverage for the new permission.

Verification:
- `pnpm run typecheck` passes.
- Targeted tests pass: `pnpm vitest run server/src/__tests__/authorization-service.test.ts server/src/__tests__/agent-permissions-service.test.ts` (21 passed).

Closes CHRA-2640.