### PR TITLE
fix(CHRA-2541): raise opencode model-probe timeout 20s -> 60s with override

### DIFF
--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -124,6 +124,7 @@ Core fields:
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
 - graceSec (number, optional): SIGTERM grace period in seconds
+- modelsProbeTimeoutSec (number, optional): timeout in seconds for the \`opencode models\` availability probe; defaults to 60s
 
 Notes:
 - OpenCode supports multiple providers and models. Use \

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -89,6 +89,7 @@ export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
   env: Record<string, string>;
   timeoutSec: number;
   graceSec: number;
+  modelsProbeTimeoutSec?: unknown;
 }) {
   const model = requireOpenCodeModelId(input.model);
 
@@ -102,13 +103,19 @@ export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
     return;
   }
 
-  const defaultProbeTimeoutSec =
-    input.executionTarget.kind === "remote" && input.executionTarget.transport === "sandbox"
-      ? REMOTE_OPENCODE_MODELS_PROBE_SANDBOX_TIMEOUT_SEC
-      : REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC;
-  const probeTimeoutSec = input.timeoutSec > 0
-    ? Math.min(input.timeoutSec, defaultProbeTimeoutSec)
-    : defaultProbeTimeoutSec;
+  const overrideSec = asNumber(input.modelsProbeTimeoutSec, 0);
+  let probeTimeoutSec: number;
+  if (overrideSec > 0) {
+    probeTimeoutSec = input.timeoutSec > 0 ? Math.min(input.timeoutSec, overrideSec) : overrideSec;
+  } else {
+    const defaultProbeTimeoutSec =
+      input.executionTarget.kind === "remote" && input.executionTarget.transport === "sandbox"
+        ? REMOTE_OPENCODE_MODELS_PROBE_SANDBOX_TIMEOUT_SEC
+        : REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC;
+    probeTimeoutSec = input.timeoutSec > 0
+      ? Math.min(input.timeoutSec, defaultProbeTimeoutSec)
+      : defaultProbeTimeoutSec;
+  }
   const probe = await runAdapterExecutionTargetProcess(
     input.runId,
     input.executionTarget,
@@ -350,6 +357,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         command,
         cwd,
         env: runtimeEnv,
+        modelsProbeTimeoutSec: config.modelsProbeTimeoutSec,
       });
     }
 
@@ -441,6 +449,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         env: preparedRuntimeConfig.env,
         timeoutSec,
         graceSec,
+        modelsProbeTimeoutSec: config.modelsProbeTimeoutSec,
       });
     }
     const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -77,7 +77,7 @@ function resolveOpenCodeBiller(env: Record<string, string>, provider: string | n
   return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
 }
 
-const REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC = 20;
+const REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC = 60;
 const REMOTE_OPENCODE_MODELS_PROBE_SANDBOX_TIMEOUT_SEC = 120;
 
 export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
+  discoverOpenCodeModels,
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
   requireOpenCodeModelId,
@@ -73,5 +77,18 @@ describe("openCode models", () => {
         env: { OPENCODE_ALLOW_ALL_MODELS: "true" },
       }),
     ).rejects.toThrow("OpenCode requires `adapterConfig.model`");
+  });
+
+  it("honours modelsProbeTimeoutSec override and reports the actual timeout", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-timeout-test-"));
+    const slowScript = path.join(tmpDir, "slow-opencode-models.sh");
+    await fs.writeFile(slowScript, "#!/bin/sh\nsleep 5\n", { mode: 0o755 });
+    try {
+      await expect(
+        discoverOpenCodeModels({ command: slowScript, modelsProbeTimeoutSec: 1 }),
+      ).rejects.toThrow("`opencode models` timed out after 1s.");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import os from "node:os";
 import type { AdapterModel } from "@paperclipai/adapter-utils";
 import {
+  asNumber,
   asString,
   ensurePathInEnv,
   runChildProcess,
@@ -9,7 +10,13 @@ import {
 import { isValidOpenCodeModelId } from "../index.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
-const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const DEFAULT_MODELS_DISCOVERY_TIMEOUT_MS = 60_000;
+
+function resolveModelsDiscoveryTimeoutMs(modelsProbeTimeoutSec: unknown): number {
+  const overrideSec = asNumber(modelsProbeTimeoutSec, 0);
+  if (overrideSec > 0) return overrideSec * 1000;
+  return DEFAULT_MODELS_DISCOVERY_TIMEOUT_MS;
+}
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =
@@ -113,10 +120,12 @@ export async function discoverOpenCodeModels(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  modelsProbeTimeoutSec?: unknown;
 } = {}): Promise<AdapterModel[]> {
   const command = resolveOpenCodeCommand(input.command);
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
+  const timeoutMs = resolveModelsDiscoveryTimeoutMs(input.modelsProbeTimeoutSec);
   // Ensure HOME points to the actual running user's home directory.
   // When the server is started via `runuser -u <user>`, HOME may still
   // reflect the parent process (e.g. /root), causing OpenCode to miss
@@ -132,6 +141,7 @@ export async function discoverOpenCodeModels(input: {
   // Prevent OpenCode from writing an opencode.json into the working directory.
   const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}), OPENCODE_DISABLE_PROJECT_CONFIG: "true" }));
 
+  const timeoutSec = timeoutMs / 1000;
   const result = await runChildProcess(
     `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
     command,
@@ -139,14 +149,14 @@ export async function discoverOpenCodeModels(input: {
     {
       cwd,
       env: runtimeEnv,
-      timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
+      timeoutSec,
       graceSec: 3,
       onLog: async () => {},
     },
   );
 
   if (result.timedOut) {
-    throw new Error(`\`opencode models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    throw new Error(`\`opencode models\` timed out after ${timeoutSec}s.`);
   }
   if ((result.exitCode ?? 1) !== 0) {
     const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
@@ -160,6 +170,7 @@ export async function discoverOpenCodeModelsCached(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  modelsProbeTimeoutSec?: unknown;
 } = {}): Promise<AdapterModel[]> {
   const command = resolveOpenCodeCommand(input.command);
   const cwd = asString(input.cwd, process.cwd());
@@ -170,7 +181,7 @@ export async function discoverOpenCodeModelsCached(input: {
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
 
-  const models = await discoverOpenCodeModels({ command, cwd, env });
+  const models = await discoverOpenCodeModels({ command, cwd, env, modelsProbeTimeoutSec: input.modelsProbeTimeoutSec });
   discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
   return models;
 }
@@ -186,6 +197,7 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
+  modelsProbeTimeoutSec?: unknown;
 }): Promise<AdapterModel[]> {
   const model = requireOpenCodeModelId(input.model);
 
@@ -203,6 +215,7 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
     command: input.command,
     cwd: input.cwd,
     env: input.env,
+    modelsProbeTimeoutSec: input.modelsProbeTimeoutSec,
   });
 
   if (models.length === 0) {

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -101,13 +101,13 @@ function hashValue(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function discoveryCacheKey(command: string, cwd: string, env: Record<string, string>) {
+function discoveryCacheKey(command: string, cwd: string, env: Record<string, string>, timeoutMs: number) {
   const envKey = Object.entries(env)
     .filter(([key]) => !isVolatileEnvKey(key))
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `${key}=${hashValue(value)}`)
     .join("\n");
-  return `${command}\n${cwd}\n${envKey}`;
+  return `${command}\n${cwd}\n${timeoutMs}\n${envKey}`;
 }
 
 function pruneExpiredDiscoveryCache(now: number) {
@@ -175,7 +175,8 @@ export async function discoverOpenCodeModelsCached(input: {
   const command = resolveOpenCodeCommand(input.command);
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
-  const key = discoveryCacheKey(command, cwd, env);
+  const timeoutMs = resolveModelsDiscoveryTimeoutMs(input.modelsProbeTimeoutSec);
+  const key = discoveryCacheKey(command, cwd, env, timeoutMs);
   const now = Date.now();
   pruneExpiredDiscoveryCache(now);
   const cached = discoveryCache.get(key);

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -230,7 +230,7 @@ export async function testEnvironment(
       modelValidationPassed = true;
     } else if (canRunProbe && configuredModel) {
       try {
-        const discovered = await discoverOpenCodeModels({ command, cwd, env: runtimeEnv });
+        const discovered = await discoverOpenCodeModels({ command, cwd, env: runtimeEnv, modelsProbeTimeoutSec: config.modelsProbeTimeoutSec });
         if (discovered.length > 0) {
           checks.push({
             code: "opencode_models_discovered",
@@ -266,7 +266,7 @@ export async function testEnvironment(
       }
     } else if (!targetIsRemote && canRunProbe && !configuredModel) {
       try {
-        const discovered = await discoverOpenCodeModels({ command, cwd, env: runtimeEnv });
+        const discovered = await discoverOpenCodeModels({ command, cwd, env: runtimeEnv, modelsProbeTimeoutSec: config.modelsProbeTimeoutSec });
         if (discovered.length > 0) {
           checks.push({
             code: "opencode_models_discovered",
@@ -305,6 +305,7 @@ export async function testEnvironment(
           command,
           cwd,
           env: runtimeEnv,
+          modelsProbeTimeoutSec: config.modelsProbeTimeoutSec,
         });
         checks.push({
           code: "opencode_model_configured",


### PR DESCRIPTION
## Summary

- Raises the default `opencode models` probe timeout from 20s to 60s in both local and remote paths.
- Adds optional `adapter_config.modelsProbeTimeoutSec` override so per-agent/per-deployment tuning is possible without code changes.
- Rebased on current master (#4318 orphan lock cleanup retained); drops the out-of-scope `INSTANCE_MAX_CONCURRENT_RUNS` cap from the previous branch.

## What Changed

- `packages/adapters/opencode-local/src/server/models.ts`: bumped `DEFAULT_MODELS_DISCOVERY_TIMEOUT_MS` to 60s, added `resolveModelsDiscoveryTimeoutMs`, threaded `modelsProbeTimeoutSec` through discovery, and included the resolved timeout in the discovery cache key.
- `packages/adapters/opencode-local/src/server/execute.ts`: wired `modelsProbeTimeoutSec` into both local and remote model probes, and raised `REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC` to 60s.
- `packages/adapters/opencode-local/src/server/test.ts`: passed `modelsProbeTimeoutSec` to the three `discoverOpenCodeModels` call sites in environment tests.
- `packages/adapters/opencode-local/src/server/models.test.ts`: added a focused timeout-override integration test.
- `packages/adapters/opencode-local/src/index.ts`: documented `modelsProbeTimeoutSec` in the adapter configuration doc.

## Thinking Path

The original 20s default was too short for cold-start or remote/sandbox targets where `opencode models` can block on provider credential resolution. Rather than hard-code a larger one-size-fits-all value, the fix keeps a generous default (60s) and exposes an optional override in `adapter_config`. The remote path needed the same default bump so non-sandbox remote targets benefit from the longer probe window. Adding the timeout to the cache key prevents two callers with different overrides from colliding on a stale cached result, even though the returned model list would be identical.

## Risks

- Slightly longer worst-case wait during model discovery failures (now up to 60s instead of 20s), but this matches the intended behaviour and can be tuned down per-agent via `modelsProbeTimeoutSec`.
- Cache key now includes timeout, increasing cache fragmentation when many distinct timeout values are used; the TTL is short (60s) so impact is minimal.
- No breaking changes to existing configs: the override is optional and defaults to 60s.

## Model Used

- Code review feedback addressed by Engineer (`claude_local` / `claude-opus-4-8`).
- Original implementation authored on `claude-opus-4-8`.

## Verification

- `pnpm --filter @paperclipai/adapter-opencode-local typecheck` passes.
- `pnpm exec vitest run packages/adapters/opencode-local/src/server/models.test.ts packages/adapters/opencode-local/src/server/execute.test.ts` passes (12/12).

## Checklist

- [x] I searched existing PRs for similar changes (dedup-search).
- [x] I ran the relevant type checker.
- [x] I ran the relevant tests.
- [x] I updated the PR description to follow the template.

Relates to [CHRA-2541](/CHRA/issues/CHRA-2541).

---
Co-Authored-By: Paperclip <noreply@paperclip.ing>
