### PR TITLE
fix(server): split issue:comment from issue:mutate so mention-woken agents can reply on issue threads

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -248,6 +248,123 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("simple mode");
   });
 
+  it("splits same-company comment access from mutation on another agent's issue", async () => {
+    const company = await createCompany(db, "CommentSplit");
+    const otherCompany = await createCompany(db, "CommentSplitOther");
+    const owner = await createAgent(db, company.id);
+    const peer = await createAgent(db, company.id);
+    const outsider = await createAgent(db, otherCompany.id);
+    const issue = await createIssue(db, company.id, { assigneeAgentId: owner.id });
+
+    const authorization = authorizationService(db);
+    const issueResource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      parentIssueId: issue.parentId,
+      assigneeAgentId: issue.assigneeAgentId,
+      status: issue.status,
+    };
+    const peerActor = {
+      type: "agent" as const,
+      agentId: peer.id,
+      companyId: company.id,
+      source: "agent_key" as const,
+    };
+
+    const mutateDecision = await authorization.decide({
+      actor: peerActor,
+      action: "issue:mutate",
+      resource: issueResource,
+    });
+    const commentDecision = await authorization.decide({
+      actor: peerActor,
+      action: "issue:comment",
+      resource: issueResource,
+    });
+    const outsiderDecision = await authorization.decide({
+      actor: {
+        type: "agent" as const,
+        agentId: outsider.id,
+        companyId: otherCompany.id,
+        source: "agent_key" as const,
+      },
+      action: "issue:comment",
+      resource: issueResource,
+    });
+
+    expect(mutateDecision).toMatchObject({ allowed: false });
+    expect(commentDecision).toMatchObject({ allowed: true, reason: "allow_company_agent" });
+    expect(outsiderDecision).toMatchObject({ allowed: false, reason: "deny_company_boundary" });
+  });
+
+  it("limits low-trust comment access to the configured issue boundary", async () => {
+    const company = await createCompany(db, "LowTrustComments");
+    const project = await createProject(db, company.id, "Allowed");
+    const otherProject = await createProject(db, company.id, "Denied");
+    const rootIssueId = randomUUID();
+    const actorAgent = await createAgent(db, company.id, {
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            projectIds: [project.id],
+            rootIssueId,
+          },
+        },
+      },
+    });
+    const owner = await createAgent(db, company.id);
+    const rootIssue = await createIssue(db, company.id, {
+      id: rootIssueId,
+      projectId: project.id,
+      assigneeAgentId: owner.id,
+    });
+    const unrelatedIssue = await createIssue(db, company.id, {
+      projectId: otherProject.id,
+      assigneeAgentId: owner.id,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = {
+      type: "agent" as const,
+      agentId: actorAgent.id,
+      companyId: company.id,
+      source: "agent_key" as const,
+    };
+    const insideDecision = await authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: rootIssue.id,
+        projectId: rootIssue.projectId,
+        parentIssueId: rootIssue.parentId,
+        assigneeAgentId: rootIssue.assigneeAgentId,
+        status: rootIssue.status,
+      },
+    });
+    const outsideDecision = await authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: unrelatedIssue.id,
+        projectId: unrelatedIssue.projectId,
+        parentIssueId: unrelatedIssue.parentId,
+        assigneeAgentId: unrelatedIssue.assigneeAgentId,
+        status: unrelatedIssue.status,
+      },
+    });
+
+    expect(insideDecision).toMatchObject({ allowed: true });
+    expect(outsideDecision).toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+  });
+
   it("limits low-trust issue reads to the configured project and root issue boundary", async () => {
     const company = await createCompany(db, "LowTrustIssueReads");
     const project = await createProject(db, company.id, "Allowed");

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -361,7 +361,7 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     });
 
-    expect(insideDecision).toMatchObject({ allowed: true });
+    expect(insideDecision).toMatchObject({ allowed: true, reason: "allow_low_trust_boundary" });
     expect(outsideDecision).toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -318,12 +318,14 @@ describe("agent issue mutation checkout ownership", () => {
         input.action === "tasks:assign" ||
         input.action === "issue:read" ||
         input.action === "issue:mutate" ||
+        input.action === "issue:comment" ||
         input.action === "company_scope:read",
       action: input.action,
       reason:
         input.action === "tasks:assign" ||
           input.action === "issue:read" ||
           input.action === "issue:mutate" ||
+          input.action === "issue:comment" ||
           input.action === "company_scope:read"
           ? "allow_explicit_grant"
           : "deny_missing_grant",
@@ -331,6 +333,7 @@ describe("agent issue mutation checkout ownership", () => {
         input.action === "tasks:assign" ||
           input.action === "issue:read" ||
           input.action === "issue:mutate" ||
+          input.action === "issue:comment" ||
           input.action === "company_scope:read"
           ? "Allowed by test default."
           : "Missing permission.",
@@ -568,7 +571,16 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
+    [
+      "reopen comment",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/comments`).send({ body: "reopen it", reopen: true }),
+    ],
+    [
+      "resume comment",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/comments`).send({ body: "resume it", resume: true }),
+    ],
     [
       "document upsert",
       (app: express.Express) =>
@@ -606,6 +618,43 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["in_progress"],
+    ["todo"],
+  ])("allows peer agent thread comments on another agent's %s issue", async (status) => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status, assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "mention reply" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:comment",
+      resource: expect.objectContaining({ type: "issue", issueId }),
+    }));
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects peer agent comments outside the issue:comment authorization boundary", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action !== "issue:comment",
+      action: input.action,
+      reason: input.action !== "issue:comment" ? "allow_explicit_grant" : "deny_company_boundary",
+      explanation: input.action !== "issue:comment" ? "Allowed by test default." : "Denied by test boundary.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "blocked reply" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects the checked-out owner without a run id on attachment upload (401)", async () => {
@@ -975,7 +1024,12 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
+    [
+      "todo",
+      "reopen comment",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo reopen", reopen: true }),
+    ],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -522,7 +522,9 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  it("allows non-assignee agent POST comments on closed issues without reopening", async () => {
+    // issue:comment split: plain comments by same-company agents are
+    // communicative and inert — the issue stays closed and nothing wakes.
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
@@ -545,10 +547,9 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "hello" });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1739,7 +1739,7 @@ export function issueRoutes(
       assigneeUserId: string | null;
       status: string;
     },
-    action: "issue:read" | "issue:mutate",
+    action: "issue:read" | "issue:mutate" | "issue:comment",
   ) {
     return access.decide({
       actor: req.actor,
@@ -1883,6 +1883,36 @@ export function issueRoutes(
           reason: "stale_checkout_run",
         },
       });
+    }
+    return true;
+  }
+
+  // Comment-only writes are communicative and do not contend for checkout
+  // ownership: any same-company agent (e.g. one woken by an @-mention) may
+  // reply on the thread. Status-changing comment flags (reopen/resume) still
+  // go through assertAgentIssueMutationAllowed.
+  async function assertAgentIssueCommentAllowed(
+    req: Request,
+    res: Response,
+    issue: {
+      id: string;
+      companyId: string;
+      projectId: string | null;
+      parentId: string | null;
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+    },
+  ) {
+    if (req.actor.type !== "agent") return true;
+    if (!req.actor.agentId) {
+      res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+    const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
+    if (!boundaryDecision.allowed) {
+      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      return false;
     }
     return true;
   }
@@ -6557,7 +6587,14 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    const reopenRequested = req.body.reopen === true;
+    const resumeRequested = req.body.resume === true;
+    const interruptRequested = req.body.interrupt === true;
+    if (reopenRequested || resumeRequested) {
+      if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    } else if (!(await assertAgentIssueCommentAllowed(req, res, issue))) {
+      return;
+    }
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,
@@ -6569,9 +6606,6 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
-    const reopenRequested = req.body.reopen === true;
-    const resumeRequested = req.body.resume === true;
-    const interruptRequested = req.body.interrupt === true;
     if (resumeRequested === true && !(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     if (resumeRequested !== true && reopenRequested === true && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, issue))) return;

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1097,6 +1097,11 @@ export function authorizationService(db: Db) {
         input.action === "agent:read" ||
         input.action === "agent:wake" ||
         input.action === "company_scope:read" ||
+        // issue:comment ends in an allow either way; returning here keeps
+        // allow_low_trust_boundary as the audit reason instead of the
+        // standard allow_company_agent. issue:mutate must NOT early-return —
+        // its assignee/ownership checks below still apply inside the boundary.
+        input.action === "issue:comment" ||
         input.action === "issue:read" ||
         input.action === "project:read" ||
         input.action === "runtime:manage" ||

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -45,6 +45,7 @@ export type AuthorizationAction =
   | "agent:read"
   | "agent:wake"
   | "company_scope:read"
+  | "issue:comment"
   | "issue:mutate"
   | "issue:read"
   | "project:read"
@@ -118,7 +119,7 @@ function permissionForAction(action: AuthorizationAction): PermissionKey | null 
   ) {
     return null;
   }
-  if (action === "issue:mutate") return null;
+  if (action === "issue:mutate" || action === "issue:comment") return null;
   return action;
 }
 
@@ -753,7 +754,11 @@ export function authorizationService(db: Db) {
         : lowTrustDeny("Project is outside this low-trust boundary.");
     }
 
-    if (input.action === "issue:read" || input.action === "issue:mutate") {
+    if (
+      input.action === "issue:read" ||
+      input.action === "issue:mutate" ||
+      input.action === "issue:comment"
+    ) {
       if (input.resource.type !== "issue") {
         return lowTrustDeny("Low-trust issue access is missing an issue resource.");
       }
@@ -1151,6 +1156,24 @@ export function authorizationService(db: Db) {
         action: input.action,
         reason: "allow_simple_company_member",
         explanation: "Allowed by simple mode company-wide task assignment default.",
+      });
+    }
+
+    if (input.action === "issue:comment") {
+      if (input.resource.type !== "issue") {
+        return deny({
+          action: input.action,
+          reason: "deny_scope",
+          explanation: "Issue comment access requires an issue resource.",
+        });
+      }
+      // Comments are communicative, not state-changing: any same-company agent
+      // may reply on an issue thread (e.g. after an @-mention wake), while
+      // reassignment, status changes, and cancellation stay on issue:mutate.
+      return allow({
+        action: input.action,
+        reason: "allow_company_agent",
+        explanation: "Allowed because same-company agents can comment on issue threads.",
       });
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents coordinate through issue threads: the authorization service (`server/src/services/authorization.ts`) decides what each actor may read or mutate, and @-mentions wake other agents to come look at a thread
> - The comments route (`POST /api/issues/:id/comments`) rides the `issue:mutate` action, whose agent branch only allows the assignee or unassigned issues — and there is no grant escape hatch, because `permissionForAction("issue:mutate")` returns `null`, so `principalPermissionGrants` is never consulted
> - As a result, any agent woken by an @-mention on another agent's issue gets 403 on every reply path, contradicting the platform's own mention-wake contract ("acknowledge the latest comment") in its most common case — the mentioning issue is, almost by definition, assigned to someone else
> - This pull request splits a dedicated `issue:comment` action out of `issue:mutate`, so same-company agents can post plain thread comments while every state-changing path keeps the strict ownership rules
> - The benefit is working cross-agent conversation — mention replies, reviewer ccs, chain-of-command pings — without widening reassign/cancel/status authority

## Linked Issues or Issue Description

No existing upstream issue (searched open and closed issues for `mention comment 403`, `agent cannot comment`, `authorization boundary comment` — no matches). Described inline per `bug_report.yml`:

**What happened?** An agent woken with reason `issue_comment_mentioned` cannot reply on the issue it was mentioned on. `POST /api/issues/{id}/comments` returns `403 {"error": "Issue is outside this actor's authorization boundary"}` whenever the issue is assigned to a different agent (tried by UUID and by identifier; comment-only `PATCH /api/issues/{id}` fails the same way). Reads succeed; commenting on the agent's own assigned issues succeeds. The run-id header was present in all attempts.

**Expected behavior** A mentioned agent can post a plain comment on the thread where it was mentioned — the wake payload itself instructs the agent to "acknowledge the latest comment".

**Steps to reproduce**
1. Create two agents A and B in one company; assign issue X to agent A.
2. As agent B (agent JWT or key, run-id header set), `POST /api/issues/{X}/comments` with `{"body": "ack"}`.
3. Observe `403 "Issue is outside this actor's authorization boundary"` (route: `assertAgentIssueMutationAllowed` → `issue:mutate` boundary).
4. For the wake-contract contradiction: have A post a comment @-mentioning B, let B's `issue_comment_mentioned` heartbeat try to acknowledge on X — same 403.

**Paperclip version or commit** Reproduced on stable `2026.609.0`; the code path is unchanged through current `master` (verified at `70357b96`).

**Deployment mode** Local instance, `authenticated` mode, private exposure.

**Agent adapter(s) involved** Claude Code (`claude_local`) and OpenCode (`opencode_local`) — adapter-independent; the boundary is server-side.

## What Changed

- `services/authorization.ts`: new `issue:comment` authorization action. Same-company agents are allowed (`allow_company_agent`); cross-company stays denied; low-trust presets gate it with the same issue-boundary check as `issue:read`/`issue:mutate`; `permissionForAction` maps it to `null` like `issue:mutate`.
- `routes/issues.ts`: new `assertAgentIssueCommentAllowed` helper (boundary check only — comments do not contend for checkout ownership). `POST /issues/:id/comments` uses it for plain comments; requests with `reopen`/`resume` flags keep the full `assertAgentIssueMutationAllowed` path.
- Tests: route-level coverage in `issue-agent-mutation-ownership-routes.test.ts` (peer comments allowed, boundary denial, reopen/resume still ownership-gated) and service-level coverage in `authorization-service.test.ts` (mutate-vs-comment split, cross-company, low-trust in/out of boundary).

## Verification

- `cd server && pnpm exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/authorization-service.test.ts src/__tests__/issue-execution-policy-routes.test.ts src/__tests__/issue-telemetry-routes.test.ts` — 79/79 pass on this branch (authorization-service runs against embedded Postgres, i.e. the real service, not mocks)
- `cd server && pnpm exec tsc --noEmit` — clean
- Manual: repro steps above flip from 403 to 201 for plain comments, while step-2 with `{"reopen": true}` still returns the ownership 409/403

## Risks

- Deliberate behavioral shift: agent comment visibility widens from assignee-only to same-company on the issue-thread comment route. State-changing paths (PATCH, delete, reassign, cancel, checkout, documents, work products, attachments, `reopen`/`resume` comment flags) are unchanged. Implicit reopen-on-comment was already human-only; structured presentation/metadata stays board-only.
- Interaction with review auto-approval (`isApprovalReviewComment`) checked: it remains gated on `actorMatchesExecutionParticipant`, so the comment path does not widen who can trigger an execution-policy transition.
- Assignee's own plain comments no longer require checkout run-lock adoption (they are comment-only writes); lock adoption still happens on all mutating routes.
- Alternative narrower shapes (mentioned-agents-only, manager-chain-only) were considered; same-company matches the existing simple-mode company defaults (e.g. `tasks:assign`). Happy to rework if maintainers prefer narrower.

## Model Used

Anthropic Claude — **Fable 5** (`claude-fable-5`), extended thinking enabled, agentic tool use via Claude Code (Agent SDK), running as a Paperclip `claude_local` agent (headless heartbeats). No other models involved.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (nearest item is first-class review/approval stages — adjacent subsystem, different problem)
- [x] I have searched GitHub for duplicate or related PRs and linked them above (no related PRs found; closest textual match #403 is an unrelated plugin-SDK feature)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A — no existing docs describe the internal authorization actions; happy to add one if maintainers point me at the right home)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first Greptile pass)
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

