### PR TITLE
fix: prefer loopback api for local agents

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -935,6 +935,22 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) return `[${host}]`;
     return host;
   };
+  const isLoopbackHost = (rawHost: string): boolean => {
+    const host = rawHost.trim().toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+  };
+  const resolveAgentApiUrl = (runtimeHost: string, runtimePort: string): string => {
+    const loopbackUrl = `http://${runtimeHost}:${runtimePort}`;
+    const explicitApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL ?? process.env.PAPERCLIP_API_URL;
+    if (!explicitApiUrl) return loopbackUrl;
+    if (!isLoopbackHost(runtimeHost)) return explicitApiUrl;
+    try {
+      const explicitHost = new URL(explicitApiUrl).hostname;
+      return isLoopbackHost(explicitHost) ? explicitApiUrl : loopbackUrl;
+    } catch {
+      return explicitApiUrl;
+    }
+  };
   const vars: Record<string, string> = {
     PAPERCLIP_AGENT_ID: agent.id,
     PAPERCLIP_COMPANY_ID: agent.companyId,
@@ -943,10 +959,7 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
-  const apiUrl =
-    process.env.PAPERCLIP_RUNTIME_API_URL ??
-    process.env.PAPERCLIP_API_URL ??
-    `http://${runtimeHost}:${runtimePort}`;
+  const apiUrl = resolveAgentApiUrl(runtimeHost, runtimePort);
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
 }

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -29,15 +29,26 @@ afterEach(() => {
 });
 
 describe("buildPaperclipEnv", () => {
-  it("prefers an explicit PAPERCLIP_RUNTIME_API_URL", () => {
+  it("prefers an explicit PAPERCLIP_RUNTIME_API_URL when the runtime bind is not loopback", () => {
     process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
     process.env.PAPERCLIP_API_URL = "http://localhost:4100";
-    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_HOST = "192.0.2.10";
     process.env.PAPERCLIP_LISTEN_PORT = "3101";
 
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
     expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
+  });
+
+  it("prefers the runtime loopback URL over a stale explicit non-loopback URL", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://mac-mini-anton.taildf2cae.ts.net:3100";
+    process.env.PAPERCLIP_API_URL = "http://203.0.113.42:4100";
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3101");
   });
 
   it("falls back to PAPERCLIP_API_URL when no runtime URL is configured", () => {


### PR DESCRIPTION
## Summary
- prefer loopback `PAPERCLIP_API_URL` for local agents when the runtime bind is loopback
- keep explicit runtime API URLs for non-loopback binds
- add regression coverage for stale tailnet DNS versus loopback binds

## Verification
- `pnpm --dir /Users/tommy/paperclip/main --filter @paperclipai/server exec vitest run src/__tests__/paperclip-env.test.ts`
- Manual reviewer verification issue `OFM-1044`: `PAPERCLIP_API_URL=http://127.0.0.1:3100`, `curl $PAPERCLIP_API_URL/api/agents/me` succeeded

## Context
- Fixes OFM-1036
