### PR TITLE
fix(claude-local): prevent false-positive claude_auth_required on successful runs

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -832,7 +832,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             errorMessage: fallbackErrorMessage,
           })
         : null;
-      const errorCode = loginMeta.requiresLogin
+      const errorCode = (proc.exitCode ?? 0) !== 0 && loginMeta.requiresLogin
         ? "claude_auth_required"
         : transientUpstream
         ? "claude_transient_upstream"
@@ -925,7 +925,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           errorMessage,
         })
       : null;
-    const resolvedErrorCode = loginMeta.requiresLogin
+    const resolvedErrorCode = failed && loginMeta.requiresLogin
       ? "claude_auth_required"
       : failed && clearSessionForMaxTurns
       ? "max_turns_exhausted"

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
   isClaudePoisonedPreviousMessageIdError,
@@ -253,5 +254,60 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+});
+
+describe("detectClaudeLoginRequired", () => {
+  it("does not detect login required when 'unauthorized' appears in successful stdout content", () => {
+    // Regression test for AEO-199: paper abstracts and other content in stdout
+    // should never trigger false-positive auth failures on successful runs.
+    const result = detectClaudeLoginRequired({
+      parsed: {
+        subtype: "success",
+        is_error: false,
+        result: "Here is the analysis...",
+      },
+      stdout: 'type: "assistant"\nmessage: "canary tokens to detect unauthorized use..."',
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(false);
+  });
+
+  it("detects login required when 'unauthorized' appears in stderr", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: null,
+      stdout: "",
+      stderr: "Error: unauthorized",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("detects login required when error messages contain login-related text", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: {
+        subtype: "error",
+        is_error: true,
+        result: "Please log in with `claude login` first.",
+        errors: [],
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("does not detect login required when 'login' is just part of normal content", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: {
+        subtype: "success",
+        is_error: false,
+        result: "The user needs to login to the website.",
+        errors: [],
+      },
+      stdout: "",
+      stderr: "",
+    });
+    // "login" appears in result but with no regex match (needs "required" or similar phrase)
+    expect(result.requiresLogin).toBe(false);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -135,7 +135,10 @@ export function detectClaudeLoginRequired(input: {
   stderr: string;
 }): { requiresLogin: boolean; loginUrl: string | null } {
   const resultText = asString(input.parsed?.result, "").trim();
-  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+  const errorMessages = extractClaudeErrorMessages(input.parsed ?? {});
+  // Only scan stderr + parsed error messages for login detection.
+  // Never scan full stdout as it contains the entire transcript including assistant responses.
+  const messages = [resultText, ...errorMessages, input.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The claude_local adapter detects when users need to re-authenticate via login detection
> - But the login detection was scanning the entire stdout transcript, including all assistant responses and tool content
> - This caused false positives when research content (like paper abstracts) contained keywords like "unauthorized" or "authentication required"
> - Even though the run completed successfully with `subtype=success, is_error=false, exit=0`, it would be incorrectly marked as `failed("claude_auth_required")`
> - This pull request fixes login detection to only scan stderr + parsed error messages, and only sets `claude_auth_required` when the run actually failed
> - The benefit is that research/security digests and other legitimate content can quote auth-related text without breaking runs

## Linked Issues

Fixes: #199 (internal Paperclip instance issue AEO-199)

Real incident (2026-06-11): Run 9a86a326-1c25-4ed4-a8d4-8c83f4052c6d completed successfully but was incorrectly marked failed because the transcript quoted "unauthorized" from a paper abstract.

## What Changed

- **parse.ts**: Modified `detectClaudeLoginRequired()` to only scan stderr + parsed error messages for login detection keywords. Removed full stdout scanning which was the source of false positives.
- **execute.ts**: Added guards so that `claude_auth_required` is only set when the run actually failed (`exitCode != 0`). Never set it for successful runs.
- **parse.test.ts**: Added comprehensive regression tests covering:
  - Successful runs with auth keywords in content don't trigger false positives
  - Login detection still works for actual stderr failures
  - Error messages are properly detected
  - False positive prevention for incidental "login" mentions

## Verification

Run the test suite:
\`\`\`bash
cd packages/adapters/claude-local
pnpm test
\`\`\`

The new tests specifically verify:
1. \`detectClaudeLoginRequired\` returns false for successful runs with "unauthorized" in stdout
2. Login detection still works when "unauthorized" appears in stderr
3. Login detection works for error messages in parsed.result
4. Incidental "login" text in successful content doesn't trigger false positives

## Risks

Low risk:
- Changes are scoped to login detection only
- Behavior for actual authentication failures is preserved
- Only prevents false positives on successful runs
- Comprehensive test coverage prevents regression
- No changes to public API or data structures

## Model Used

Claude Haiku 4.5 — analyzed the bug, designed the fix, wrote tests, and generated this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have searched GitHub for duplicate or related PRs
- [x] I have described the issue in-PR with full context
- [x] I have written comprehensive tests
- [x] Tests pass locally
- [x] Changes are minimal and focused
- [ ] All Paperclip CI gates are green (pending merge)
- [ ] Greptile review (pending)