### PR TITLE
fix(issues): deduplicate retried/repeated agent issue creation (#7980)

### DIFF
--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ISSUE_CREATE_DEDUPLICATED } from "../services/issue-create-dedup.js";
 
 const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
 
@@ -332,6 +333,42 @@ describe("assigned backlog creation contract", () => {
           assignmentWakeSkipReason: "assigned_backlog",
         }),
       }),
+    );
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 (not 201) and skips create-only side effects when create is deduplicated (#7980/#8031)", async () => {
+    // Simulate the idempotent-create dedup path: issueService.create returns the
+    // already-created issue flagged via the non-enumerable ISSUE_CREATE_DEDUPLICATED
+    // marker. The route must detect that explicitly — not by comparing ids — and
+    // return 200 without a second issue.created activity or a duplicate wake.
+    mockIssueService.create.mockImplementationOnce(async (_companyId: string, data: Record<string, unknown>) => {
+      const existing = makeIssue({
+        id: "issue-1",
+        title: String(data.title),
+        status: String(data.status),
+        assigneeAgentId: data.assigneeAgentId as string | null | undefined,
+      });
+      Object.defineProperty(existing, ISSUE_CREATE_DEDUPLICATED, {
+        value: true,
+        enumerable: false,
+      });
+      return existing;
+    });
+
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Assigned executable work",
+        assigneeAgentId,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ id: "issue-1", assigneeAgentId }));
+    expect(res.body).not.toHaveProperty("issueCreateDeduplicated");
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.created" }),
     );
     expect(mockWakeup).not.toHaveBeenCalled();
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { sql } from "drizzle-orm";
 import {
@@ -222,6 +222,42 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         assigneeAgentId: terminatedAgentId,
       },
     });
+  });
+
+  it("deduplicates a retried create from the same agent instead of persisting a second issue (#7980)", async () => {
+    const companyId = await seedAssignableAgentCompany();
+    const agentId = randomUUID();
+    await db.insert(agents).values(agentRow(companyId, { id: agentId, name: "Creator" }));
+
+    const payload = {
+      title: "Implement the widget",
+      description: null,
+      status: "todo" as const,
+      priority: "medium" as const,
+      createdByAgentId: agentId,
+    };
+
+    const first = await svc.create(companyId, payload);
+    const second = await svc.create(companyId, payload);
+
+    // The retry returns the already-created issue, not a new one.
+    expect(second.id).toBe(first.id);
+
+    const sameTitleRows = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.title, "Implement the widget")));
+    expect(sameTitleRows).toHaveLength(1);
+
+    // A genuinely different issue (different title) from the same agent is NOT collapsed.
+    const distinct = await svc.create(companyId, { ...payload, title: "Implement the gadget" });
+    expect(distinct.id).not.toBe(first.id);
+
+    // A different creator with identical content is also NOT collapsed — scoped to createdByAgentId.
+    const otherAgentId = randomUUID();
+    await db.insert(agents).values(agentRow(companyId, { id: otherAgentId, name: "OtherCreator" }));
+    const otherCreator = await svc.create(companyId, { ...payload, createdByAgentId: otherAgentId });
+    expect(otherCreator.id).not.toBe(first.id);
   });
 
   it("rejects invalid ancestor-chain assignees and preserves the existing assignment", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -109,6 +109,7 @@ import { executionWorkspaceService as executionWorkspaceServiceDirect } from "..
 import { feedbackService } from "../services/feedback.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { readAcceptedPlanConfirmationTarget } from "../services/issues.js";
+import { wasDeduplicatedIssueCreate } from "../services/issue-create-dedup.js";
 import { environmentService } from "../services/environments.js";
 import { redactSensitiveText } from "../redaction.js";
 import {
@@ -4288,11 +4289,12 @@ export function issueRoutes(
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
     });
     // svc.create is idempotent per run+content (#7980): a retried/repeated create
-    // returns the already-created issue, whose id differs from the one we minted.
+    // returns the already-created issue and flags it via wasDeduplicatedIssueCreate.
     // On that dedup path, skip the create-only side effects (a second
     // "issue.created" activity entry and a duplicate assignment wake) and just
-    // return the existing issue so the retry is a clean no-op.
-    const createdNewIssue = issue.id === issueId;
+    // return the existing issue so the retry is a clean no-op. Genuine creates fall
+    // through to the 201 path with full create-time validation and side effects.
+    const createdNewIssue = !wasDeduplicatedIssueCreate(issue);
     if (!createdNewIssue) {
       const existingReferenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
       res.status(200).json({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4287,6 +4287,23 @@ export function issueRoutes(
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
     });
+    // svc.create is idempotent per run+content (#7980): a retried/repeated create
+    // returns the already-created issue, whose id differs from the one we minted.
+    // On that dedup path, skip the create-only side effects (a second
+    // "issue.created" activity entry and a duplicate assignment wake) and just
+    // return the existing issue so the retry is a clean no-op.
+    const createdNewIssue = issue.id === issueId;
+    if (!createdNewIssue) {
+      const existingReferenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
+      res.status(200).json({
+        ...issue,
+        relatedWork: existingReferenceSummary,
+        referencedIssueIdentifiers: existingReferenceSummary.outbound.map(
+          (item) => item.issue.identifier ?? item.issue.id,
+        ),
+      });
+      return;
+    }
     await issueReferencesSvc.syncIssue(issue.id);
     const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
     const referenceDiff = issueReferencesSvc.diffIssueReferenceSummary(

--- a/server/src/services/issue-create-dedup.ts
+++ b/server/src/services/issue-create-dedup.ts
@@ -1,0 +1,36 @@
+// Explicit, dependency-free signal that issueService.create collapsed a
+// retried/repeated create (#7980) into a pre-existing issue instead of inserting
+// a new row. The create route uses wasDeduplicatedIssueCreate() to detect that
+// branch reliably — rather than inferring it from whether the returned issue
+// echoes the route-minted id, which is brittle (a service mock or a future
+// id-normalizing path breaks that assumption).
+//
+// This lives in its own module — not services/issues.ts — on purpose: the create
+// route imports the detector here, while many route tests partially mock
+// "../services/issues.js" (exposing only issueService). Importing the detector
+// from issues.ts would resolve to `undefined` under those mocks and throw at
+// request time. Keeping it dependency-free here keeps both the route and those
+// tests working without each test having to re-stub the export.
+//
+// The marker is attached as a non-enumerable property so it never leaks into JSON
+// responses (JSON.stringify and object spread for the HTTP body both skip it) and
+// never affects the existing create callers that read normal issue fields.
+export const ISSUE_CREATE_DEDUPLICATED: unique symbol = Symbol("issueCreateDeduplicated");
+
+export function markDeduplicatedIssueCreate<T extends object>(issue: T): T {
+  Object.defineProperty(issue, ISSUE_CREATE_DEDUPLICATED, {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return issue;
+}
+
+export function wasDeduplicatedIssueCreate(issue: unknown): boolean {
+  return (
+    typeof issue === "object" &&
+    issue !== null &&
+    (issue as Record<symbol, unknown>)[ISSUE_CREATE_DEDUPLICATED] === true
+  );
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -69,6 +69,7 @@ import {
 } from "./execution-workspace-policy.js";
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+import { markDeduplicatedIssueCreate } from "./issue-create-dedup.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -4786,7 +4787,7 @@ export function issueService(db: Db) {
             .limit(1);
           if (duplicate) {
             const [enrichedDuplicate] = await withIssueLabels(tx, [duplicate]);
-            return enrichedDuplicate;
+            return markDeduplicatedIssueCreate(enrichedDuplicate);
           }
         }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -95,6 +95,10 @@ const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
 export const MAX_CHILD_ISSUES_CREATED_BY_HELPER = 25;
 const MAX_CHILD_COMPLETION_SUMMARIES = 20;
 const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
+// Window for collapsing a retried/repeated agent create into the already-created
+// issue (#7980). Long enough to absorb transport retries and an agent re-issuing
+// the same create, short enough that a deliberate later re-creation is not lost.
+const ISSUE_CREATE_DEDUPE_WINDOW_MS = 5 * 60 * 1000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_MAX_LOG_BYTES = 2_000_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_CHUNK_BYTES = 256_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS = 60_000;
@@ -4750,6 +4754,41 @@ export function issueService(db: Db) {
         throw unprocessable("in_progress issues require an assignee");
       }
       return db.transaction(async (tx) => {
+        // Idempotent create (#7980): a retried or repeated create request from the
+        // same agent with identical (parent, title, assignee) within a short
+        // window must not persist a second copy — return the already-created
+        // issue instead. Scoped to createdByAgentId AND a recency window so that
+        // legitimately-distinct issues (a different creator, or the same title
+        // revisited much later) are never collapsed.
+        const dedupeAgentId =
+          typeof issueData.createdByAgentId === "string" && issueData.createdByAgentId.length > 0
+            ? issueData.createdByAgentId
+            : null;
+        if (dedupeAgentId) {
+          const dedupeWindowStart = new Date(Date.now() - ISSUE_CREATE_DEDUPE_WINDOW_MS);
+          const [duplicate] = await tx
+            .select()
+            .from(issues)
+            .where(
+              and(
+                eq(issues.companyId, companyId),
+                eq(issues.createdByAgentId, dedupeAgentId),
+                eq(issues.title, issueData.title),
+                issueData.parentId
+                  ? eq(issues.parentId, issueData.parentId)
+                  : isNull(issues.parentId),
+                issueData.assigneeAgentId
+                  ? eq(issues.assigneeAgentId, issueData.assigneeAgentId)
+                  : isNull(issues.assigneeAgentId),
+                gt(issues.createdAt, dedupeWindowStart),
+              ),
+            )
+            .limit(1);
+          if (duplicate) {
+            const [enrichedDuplicate] = await withIssueLabels(tx, [duplicate]);
+            return enrichedDuplicate;
+          }
+        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
         let executionWorkspaceId = issueData.executionWorkspaceId ?? null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; agents create issues via the issue-creation API/tool.
> - Issue #7980 reports that a retried create (transport retry) or an agent re-issuing the same create persists a *second* identical issue, so the board shows duplicate tickets for one intended task.
> - `issueService.create` had no idempotency: each call inserts a new row. The issues table has no run/idempotency-key column wired for the manual agent-create path (origin_fingerprint dedup exists only for specific origin kinds via partial unique indexes, not for `manual`).
> - The expected behavior (per the issue) is that a repeated create with the same parent, title, and intended assignee returns the already-created issue rather than creating another.
> - This pull request makes `create` idempotent within a short window: same companyId + createdByAgentId + parentId + title + assigneeAgentId returns the existing issue.
> - The benefit is no more duplicate tickets from retries/re-issues, with no schema migration.

## What Changed

- `services/issues.ts`: at the start of `create`'s transaction, if `createdByAgentId` is set, look for an existing issue with the same `companyId`, `createdByAgentId`, `parentId`, `title`, and `assigneeAgentId` created within `ISSUE_CREATE_DEDUPE_WINDOW_MS` (5 min). If found, return it (enriched the same way as a fresh create) instead of inserting a duplicate.
- `routes/issues.ts`: the create handler detects the dedup (returned issue id ≠ the freshly-minted id) and responds `200` with the existing issue, skipping the create-only side effects (a second `issue.created` activity entry and a duplicate assignment wake).

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/issues-service.test.ts -t 'deduplicates a retried create'` — passes: a retried create returns the same issue id and only one row persists; a different title and a different creator are NOT collapsed.
- **Negative-verified:** the test fails against the code with the dedup guard disabled.

## Risks

Low. Scoped to `createdByAgentId` (agent-created issues) AND a 5-minute recency window, so a different creator or the same title legitimately revisited later is never collapsed. No schema/migration change — keys on existing columns. Window-based heuristic matches the issue's described "retried or repeated" semantics; window is a named constant if tuning is wanted.

## Model Used

Claude Fable 5 (`claude-fable-5`), Anthropic — extended reasoning, tool use / code execution via Claude Code harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
- [x] I searched the GitHub PR list for similar/duplicate PRs and found none addressing #7980.

Fixes #7980