### PR TITLE
Bound heartbeat recovery queue resume

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -996,6 +996,96 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(result.skipped).toBe(6);
   });
 
+  it("skips stranded issue recovery when company active run cap is reached", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const now = new Date("2026-03-19T00:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values(
+      Array.from({ length: 8 }, (_, index) => ({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "queued" as const,
+        contextSnapshot: {
+          wakeReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+        },
+        createdAt: now,
+        updatedAt: now,
+        sequence: index + 1,
+      })),
+    );
+    const strandedRows = Array.from({ length: 10 }, (_, index) => {
+      const issueId = randomUUID();
+      const runId = randomUUID();
+      return {
+        issue: {
+          id: issueId,
+          companyId,
+          title: `Recover stranded work ${index + 1}`,
+          status: "in_progress" as const,
+          priority: "medium" as const,
+          assigneeAgentId: agentId,
+          checkoutRunId: runId,
+          issueNumber: index + 1,
+          identifier: `${issuePrefix}-${index + 1}`,
+          startedAt: now,
+        },
+        run: {
+          id: runId,
+          companyId,
+          agentId,
+          invocationSource: "assignment" as const,
+          triggerDetail: "system" as const,
+          status: "failed" as const,
+          contextSnapshot: {
+            issueId,
+            taskId: issueId,
+            wakeReason: "issue_assigned",
+          },
+          errorCode: "process_lost",
+          error: "run failed before issue advanced",
+          startedAt: now,
+          finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+          createdAt: now,
+          updatedAt: new Date("2026-03-19T00:05:00.000Z"),
+        },
+      };
+    });
+    await db.insert(heartbeatRuns).values(strandedRows.map((row) => row.run));
+    await db.insert(issues).values(strandedRows.map((row) => row.issue));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues({
+      maxRecoveries: 4,
+      maxActiveRunsPerCompany: 8,
+    });
+
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toHaveLength(0);
+    expect(result.skipped).toBe(10);
+  });
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -944,6 +944,58 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     return { companyId, agentId, runId, wakeupRequestId, issueId };
   }
 
+  it("bounds queued run resumption across agents during recovery sweeps", async () => {
+    const pendingExecutions: Array<() => void> = [];
+    mockAdapterExecute.mockImplementation(async () => {
+      await new Promise<void>((resolve) => pendingExecutions.push(resolve));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Recovered queued work.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+    const fixtures = [];
+    for (let i = 0; i < 10; i += 1) {
+      fixtures.push(await seedQueuedIssueRunFixture());
+    }
+    const heartbeat = heartbeatService(db);
+
+    const resumed = await heartbeat.resumeQueuedRuns({ maxAgents: 4, maxRunsPerAgent: 1 });
+
+    expect(resumed).toEqual({ agentsScanned: 4, agentsStarted: 4, runsStarted: 4 });
+    await waitForValue(async () => (mockAdapterExecute.mock.calls.length === 4 ? true : null));
+    const rows = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.id, fixtures.map((fixture) => fixture.runId)));
+    expect(rows.filter((row) => row.status === "running")).toHaveLength(4);
+    expect(rows.filter((row) => row.status === "queued")).toHaveLength(6);
+
+    for (const resolve of pendingExecutions) resolve();
+    await waitForHeartbeatIdle(db);
+  });
+
+  it("bounds stranded issue recovery enqueueing during recovery sweeps", async () => {
+    for (let i = 0; i < 10; i += 1) {
+      await seedStrandedIssueFixture({
+        status: "in_progress",
+        runStatus: "failed",
+        runErrorCode: "process_lost",
+      });
+    }
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues({ maxRecoveries: 4 });
+
+    expect(result.continuationRequeued).toBe(4);
+    expect(result.issueIds).toHaveLength(4);
+    expect(result.skipped).toBe(6);
+  });
+
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -85,6 +85,9 @@ type EmbeddedPostgresCtor = new (opts: {
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;
 
+const RECOVERY_QUEUE_RESUME_MAX_AGENTS = 4;
+const RECOVERY_QUEUE_RESUME_MAX_RUNS_PER_AGENT = 1;
+const RECOVERY_STRANDED_ISSUE_MAX_RECOVERIES = 4;
 
 export interface StartedServer {
   server: ReturnType<typeof createServer>;
@@ -770,8 +773,16 @@ export async function startServer(): Promise<StartedServer> {
       }
 
       const promotion = await heartbeat.promoteDueScheduledRetries();
-      await heartbeat.resumeQueuedRuns();
-      const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+      const resumed = await heartbeat.resumeQueuedRuns({
+        maxAgents: RECOVERY_QUEUE_RESUME_MAX_AGENTS,
+        maxRunsPerAgent: RECOVERY_QUEUE_RESUME_MAX_RUNS_PER_AGENT,
+      });
+      if (resumed.runsStarted > 0) {
+        logger.warn({ ...resumed }, "startup heartbeat recovery resumed queued runs with bounded concurrency");
+      }
+      const reconciled = await heartbeat.reconcileStrandedAssignedIssues({
+        maxRecoveries: RECOVERY_STRANDED_ISSUE_MAX_RECOVERIES,
+      });
       if (
         promotion.promoted > 0 ||
         reconciled.assignmentDispatched > 0 ||
@@ -841,8 +852,16 @@ export async function startServer(): Promise<StartedServer> {
         .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
         .then(() => heartbeat.promoteDueScheduledRetries())
         .then(async (promotion) => {
-          await heartbeat.resumeQueuedRuns();
-          const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+          const resumed = await heartbeat.resumeQueuedRuns({
+            maxAgents: RECOVERY_QUEUE_RESUME_MAX_AGENTS,
+            maxRunsPerAgent: RECOVERY_QUEUE_RESUME_MAX_RUNS_PER_AGENT,
+          });
+          if (resumed.runsStarted > 0) {
+            logger.warn({ ...resumed }, "periodic heartbeat recovery resumed queued runs with bounded concurrency");
+          }
+          const reconciled = await heartbeat.reconcileStrandedAssignedIssues({
+            maxRecoveries: RECOVERY_STRANDED_ISSUE_MAX_RECOVERIES,
+          });
           if (
             promotion.promoted > 0 ||
             reconciled.assignmentDispatched > 0 ||

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -88,6 +88,7 @@ type EmbeddedPostgresCtor = new (opts: {
 const RECOVERY_QUEUE_RESUME_MAX_AGENTS = 4;
 const RECOVERY_QUEUE_RESUME_MAX_RUNS_PER_AGENT = 1;
 const RECOVERY_STRANDED_ISSUE_MAX_RECOVERIES = 4;
+const RECOVERY_STRANDED_ISSUE_MAX_ACTIVE_RUNS_PER_COMPANY = 8;
 
 export interface StartedServer {
   server: ReturnType<typeof createServer>;
@@ -782,6 +783,7 @@ export async function startServer(): Promise<StartedServer> {
       }
       const reconciled = await heartbeat.reconcileStrandedAssignedIssues({
         maxRecoveries: RECOVERY_STRANDED_ISSUE_MAX_RECOVERIES,
+        maxActiveRunsPerCompany: RECOVERY_STRANDED_ISSUE_MAX_ACTIVE_RUNS_PER_COMPANY,
       });
       if (
         promotion.promoted > 0 ||
@@ -861,6 +863,7 @@ export async function startServer(): Promise<StartedServer> {
           }
           const reconciled = await heartbeat.reconcileStrandedAssignedIssues({
             maxRecoveries: RECOVERY_STRANDED_ISSUE_MAX_RECOVERIES,
+            maxActiveRunsPerCompany: RECOVERY_STRANDED_ISSUE_MAX_ACTIVE_RUNS_PER_COMPANY,
           });
           if (
             promotion.promoted > 0 ||

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7541,7 +7541,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { reaped: reaped.length, runIds: reaped };
   }
 
-  async function resumeQueuedRuns() {
+  async function resumeQueuedRuns(opts?: { maxAgents?: number; maxRunsPerAgent?: number }) {
+    const maxAgents = opts?.maxAgents === undefined
+      ? Number.POSITIVE_INFINITY
+      : Math.max(0, Math.floor(opts.maxAgents));
+    const maxRunsPerAgent = opts?.maxRunsPerAgent === undefined
+      ? undefined
+      : Math.max(0, Math.floor(opts.maxRunsPerAgent));
+    if (maxAgents <= 0 || maxRunsPerAgent === 0) return { agentsScanned: 0, agentsStarted: 0, runsStarted: 0 };
+
     const queuedRuns = await db
       .select({ agentId: heartbeatRuns.agentId })
       .from(heartbeatRuns)
@@ -7551,14 +7559,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         eq(companies.status, "active"),
       ));
 
-    const agentIds = [...new Set(queuedRuns.map((r) => r.agentId))];
+    const agentIds = [...new Set(queuedRuns.map((r) => r.agentId))].slice(0, maxAgents);
+    let agentsStarted = 0;
+    let runsStarted = 0;
     for (const agentId of agentIds) {
-      await startNextQueuedRunForAgent(agentId);
+      const started = await startNextQueuedRunForAgent(agentId, { maxStarts: maxRunsPerAgent });
+      if (started.length > 0) {
+        agentsStarted += 1;
+        runsStarted += started.length;
+      }
     }
+
+    return { agentsScanned: agentIds.length, agentsStarted, runsStarted };
   }
 
-  async function reconcileStrandedAssignedIssues() {
-    return recovery.reconcileStrandedAssignedIssues();
+  async function reconcileStrandedAssignedIssues(opts?: { maxRecoveries?: number }) {
+    return recovery.reconcileStrandedAssignedIssues(opts);
   }
 
   async function sweepStaleIssueLocks() {
@@ -7663,7 +7679,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
   }
 
-  async function startNextQueuedRunForAgent(agentId: string) {
+  async function startNextQueuedRunForAgent(agentId: string, opts?: { maxStarts?: number }) {
     return withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
@@ -7676,7 +7692,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      const requestedSlots = opts?.maxStarts === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, Math.floor(opts.maxStarts));
+      const availableSlots = Math.min(Math.max(0, policy.maxConcurrentRuns - runningCount), requestedSlots);
       if (availableSlots <= 0) return [];
 
       const queuedRuns = await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7573,7 +7573,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { agentsScanned: agentIds.length, agentsStarted, runsStarted };
   }
 
-  async function reconcileStrandedAssignedIssues(opts?: { maxRecoveries?: number }) {
+  async function reconcileStrandedAssignedIssues(opts?: {
+    maxRecoveries?: number;
+    maxActiveRunsPerCompany?: number;
+  }) {
     return recovery.reconcileStrandedAssignedIssues(opts);
   }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2643,7 +2643,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return updated;
   }
 
-  async function reconcileStrandedAssignedIssues(opts?: { maxRecoveries?: number }) {
+  async function reconcileStrandedAssignedIssues(opts?: {
+    maxRecoveries?: number;
+    maxActiveRunsPerCompany?: number;
+  }) {
     const candidates = await db
       .select()
       .from(issues)
@@ -2671,9 +2674,43 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const maxRecoveries = opts?.maxRecoveries === undefined
       ? Number.POSITIVE_INFINITY
       : Math.max(0, Math.floor(opts.maxRecoveries));
+    const maxActiveRunsPerCompany = opts?.maxActiveRunsPerCompany === undefined
+      ? undefined
+      : Math.max(0, Math.floor(opts.maxActiveRunsPerCompany));
+    const activeRunCountsByCompany = new Map<string, number>();
+    const getActiveRunCount = async (companyId: string) => {
+      const cached = activeRunCountsByCompany.get(companyId);
+      if (cached !== undefined) return cached;
+      const [row] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.companyId, companyId),
+          inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+        ));
+      const count = Number(row?.count ?? 0);
+      activeRunCountsByCompany.set(companyId, count);
+      return count;
+    };
+    const canEnqueueRecoveryForCompany = async (companyId: string) => {
+      if (maxActiveRunsPerCompany === undefined) return true;
+      return (await getActiveRunCount(companyId)) < maxActiveRunsPerCompany;
+    };
+    const noteEnqueuedRecoveryForCompany = (companyId: string) => {
+      if (maxActiveRunsPerCompany === undefined) return;
+      activeRunCountsByCompany.set(
+        companyId,
+        (activeRunCountsByCompany.get(companyId) ?? 0) + 1,
+      );
+    };
 
     for (const issue of candidates) {
       if (result.issueIds.length >= maxRecoveries) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (!(await canEnqueueRecoveryForCompany(issue.companyId))) {
         result.skipped += 1;
         continue;
       }
@@ -2737,6 +2774,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           if (queued) {
             result.assignmentDispatched += 1;
             result.issueIds.push(issue.id);
+            noteEnqueuedRecoveryForCompany(issue.companyId);
           } else {
             result.skipped += 1;
           }
@@ -2784,6 +2822,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         if (queued) {
           result.dispatchRequeued += 1;
           result.issueIds.push(issue.id);
+          noteEnqueuedRecoveryForCompany(issue.companyId);
         } else {
           result.skipped += 1;
         }
@@ -2872,6 +2911,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         if (queued) {
           result.continuationRequeued += 1;
           result.issueIds.push(issue.id);
+          noteEnqueuedRecoveryForCompany(issue.companyId);
         } else {
           result.skipped += 1;
         }
@@ -2958,6 +2998,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (queued) {
         result.continuationRequeued += 1;
         result.issueIds.push(issue.id);
+        noteEnqueuedRecoveryForCompany(issue.companyId);
       } else {
         result.skipped += 1;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2643,7 +2643,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return updated;
   }
 
-  async function reconcileStrandedAssignedIssues() {
+  async function reconcileStrandedAssignedIssues(opts?: { maxRecoveries?: number }) {
     const candidates = await db
       .select()
       .from(issues)
@@ -2668,8 +2668,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       skipped: 0,
       issueIds: [] as string[],
     };
+    const maxRecoveries = opts?.maxRecoveries === undefined
+      ? Number.POSITIVE_INFINITY
+      : Math.max(0, Math.floor(opts.maxRecoveries));
 
     for (const issue of candidates) {
+      if (result.issueIds.length >= maxRecoveries) {
+        result.skipped += 1;
+        continue;
+      }
+
       const agentId = issue.assigneeAgentId;
       if (!agentId) {
         result.skipped += 1;
@@ -2955,10 +2963,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
     }
 
-    const orphanBlockerRecovery = await reconcileUnassignedBlockingIssues();
-    result.orphanBlockersAssigned = orphanBlockerRecovery.assigned;
-    result.skipped += orphanBlockerRecovery.skipped;
-    result.issueIds.push(...orphanBlockerRecovery.issueIds);
+    if (result.issueIds.length < maxRecoveries) {
+      const orphanBlockerRecovery = await reconcileUnassignedBlockingIssues();
+      result.orphanBlockersAssigned = orphanBlockerRecovery.assigned;
+      result.skipped += orphanBlockerRecovery.skipped;
+      result.issueIds.push(...orphanBlockerRecovery.issueIds);
+    }
 
     return result;
   }


### PR DESCRIPTION
## Summary
- add bounded resume options for queued heartbeat runs
- add bounded stranded-issue reconciliation options so automatic recovery cannot enqueue a large live-run backlog in one sweep
- use bounded startup and periodic recovery: max 4 agents, 1 resumed run per agent, 4 stranded recoveries per sweep
- add regression coverage for both a 10-agent queued backlog and a 10-issue stranded recovery backlog

## Incident context
A local Paperclip restart had hundreds of persisted queued/running heartbeat rows. Startup recovery attempted to resume/recover work across many agents, producing a large live-agent burst even after per-agent scheduled heartbeats were disabled.

This keeps direct/manual `resumeQueuedRuns()` and `reconcileStrandedAssignedIssues()` behavior unbounded by default, but applies conservative caps to automatic startup/periodic recovery.

## Verification
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

Note: `pnpm install` populated dependencies in the fresh worktree but exited non-zero due an existing plugin-sdk symlink in plugin postinstall; the targeted tests and server typecheck passed afterward.