### PR TITLE
feat(heartbeat): distinct heartbeat_idle wake reason for empty timer wakes (#8015)

### DIFF
--- a/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
+++ b/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
@@ -24,6 +24,19 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
     ).toBe(true);
   });
 
+  it("resets the session when wakeReason is heartbeat_idle (gh#8015)", () => {
+    // An idle timer wake (no standing work) is even more exploratory than a
+    // regular timer wake, so it must get the same fresh-session treatment.
+    expect(
+      shouldResetTaskSessionForWake({
+        source: "scheduler",
+        reason: "interval_elapsed_idle",
+        idle: true,
+        wakeReason: "heartbeat_idle",
+      }),
+    ).toBe(true);
+  });
+
   it("still resets for the existing reset reasons", () => {
     for (const wakeReason of [
       "issue_assigned",
@@ -65,6 +78,15 @@ describe("PF-4 describeSessionResetReason", () => {
     expect(reason).toBe("wake reason is heartbeat_timer (timer-driven wake starts fresh)");
   });
 
+  it("describes heartbeat_idle wakes explicitly (gh#8015)", () => {
+    const reason = describeSessionResetReason({
+      wakeReason: "heartbeat_idle",
+    });
+    expect(reason).toBe(
+      "wake reason is heartbeat_idle (idle timer wake with no standing work starts fresh)",
+    );
+  });
+
   it("returns the existing reasons for the existing reset triggers", () => {
     expect(describeSessionResetReason({ wakeReason: "issue_assigned" })).toBe(
       "wake reason is issue_assigned",
@@ -97,6 +119,7 @@ describe("PF-4 describeSessionResetReason", () => {
   it("agrees with shouldResetTaskSessionForWake on every input — non-null reason iff should reset", () => {
     const cases: Array<Record<string, unknown> | null | undefined> = [
       { wakeReason: "heartbeat_timer" },
+      { wakeReason: "heartbeat_idle" },
       { wakeReason: "issue_assigned" },
       { wakeReason: "execution_review_requested" },
       { wakeReason: "execution_approval_requested" },

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -216,6 +216,16 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+// Open/actionable issue statuses — an agent assigned at least one issue in this
+// set has standing work, so a timer-driven heartbeat is "real" rather than idle.
+// Mirrors the open-status set used by the issues partial indexes in the schema.
+const HEARTBEAT_ACTIONABLE_ISSUE_STATUSES = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "in_review",
+  "blocked",
+] as const;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -2041,7 +2051,10 @@ export function shouldResetTaskSessionForWake(
     // session toward the 64k compaction threshold (observed in CEO run
     // 292a5fd1, where timer wakes repeatedly bloated a long-lived manager
     // session). Reset on every timer wake so each interval starts fresh.
-    wakeReason === "heartbeat_timer"
+    // heartbeat_idle (gh#8015) is an even-more-exploratory timer wake with no
+    // standing work, so it gets the same fresh-session treatment.
+    wakeReason === "heartbeat_timer" ||
+    wakeReason === "heartbeat_idle"
   ) {
     return true;
   }
@@ -2119,6 +2132,7 @@ export function describeSessionResetReason(
   // PF-4: paired with shouldResetTaskSessionForWake — keep the reason wording
   // explicit so run logs make session reuse/reset behavior legible.
   if (wakeReason === "heartbeat_timer") return "wake reason is heartbeat_timer (timer-driven wake starts fresh)";
+  if (wakeReason === "heartbeat_idle") return "wake reason is heartbeat_idle (idle timer wake with no standing work starts fresh)";
   return null;
 }
 
@@ -11308,15 +11322,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
 
+        // Distinguish a timer wake with no standing work (gh#8015). When the
+        // agent has zero assigned issues in an actionable status, the run still
+        // fires (idle wakes may be a product requirement) but advertises a
+        // distinct reason so adapters/skills can treat it as an idle tick
+        // instead of "continue your work". Only runs for agents past the
+        // interval gate, so it adds at most one cheap indexed lookup per
+        // actually-due agent per tick.
+        const [actionableIssue] = await db
+          .select({ id: issues.id })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.assigneeAgentId, agent.id),
+              inArray(issues.status, [...HEARTBEAT_ACTIONABLE_ISSUE_STATUSES]),
+              isNull(issues.hiddenAt),
+            ),
+          )
+          .limit(1);
+        const isIdle = !actionableIssue;
+
         const run = await enqueueWakeup(agent.id, {
           source: "timer",
           triggerDetail: "system",
-          reason: "heartbeat_timer",
+          reason: isIdle ? "heartbeat_idle" : "heartbeat_timer",
           requestedByActorType: "system",
           requestedByActorId: "heartbeat_scheduler",
           contextSnapshot: {
             source: "scheduler",
-            reason: "interval_elapsed",
+            reason: isIdle ? "interval_elapsed_idle" : "interval_elapsed",
+            idle: isIdle,
             now: now.toISOString(),
           },
         });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; agents are woken on a schedule by `heartbeat_timer` so work keeps moving without humans.
> - Adapters and skills receive the wake reason and use it to decide how much work a wake should do.
> - When a timer fires for an agent with **zero assigned issues in an actionable status**, the wake looked identical to a real work wake (`heartbeat_timer`), so agents burned full sessions discovering there was nothing to do (#8015).
> - Skipping idle wakes entirely (option 1 in the issue) risks silently dropping wakes an operator expects; a distinct reason (option 2) is non-breaking and lets adapters/skills decide.
> - This PR emits a distinct **`heartbeat_idle`** wake reason for empty timer wakes and wires it through the context snapshot and the PF-4 fresh-session reset pair.
> - The benefit is adapters can branch on `PAPERCLIP_WAKE_REASON=heartbeat_idle` ("exit immediately unless standing orders") — cutting idle-wake token burn without changing scheduling behaviour.

## Linked Issues or Issue Description

Closes #8015.

Related: #6390 (circuit-breaker for *failing* heartbeats — complementary; this is about *empty* ones), #4399 (wake-reason observability — `contextSnapshot.idle` is also set for analytics).

**Duplicate/related PR search** — searched the PR list for `heartbeat`, `idle`, `wake reason`; no duplicate open PRs found besides the related issues linked above.

## What Changed

- `tickTimers` now does a single indexed lookup per *actually-due* agent (after the interval gate) to check for any assigned issue in an actionable status (`backlog`/`todo`/`in_progress`/`in_review`/`blocked`). If none, it emits `reason: "heartbeat_idle"` and `contextSnapshot.reason: "interval_elapsed_idle"` / `idle: true`.
- `reason` flows into `contextSnapshot.wakeReason` via the existing `enrichWakeContextSnapshot`, surfacing to adapters as `PAPERCLIP_WAKE_REASON=heartbeat_idle`.
- The actionable-status set mirrors the open-status set already used by the `issues` partial indexes in the schema.
- **PF-4 interaction:** `heartbeat_idle` is added to the fresh-session reset pair (`shouldResetTaskSessionForWake` / `describeSessionResetReason`) — an idle timer wake is even more exploratory than a regular one, so it must start a fresh task session. Omitting this would have regressed PF-4 (#4838).

## Verification

- Extended the existing PF-4 unit suite (`heartbeat-timer-wake-session-reset-pf4.test.ts`): `heartbeat_idle` resets the session like `heartbeat_timer` and gets an explicit reset-reason string; the invariant test ("non-null reason iff should reset") also covers it. 14 passed.

## Risks

- Low. No change to scheduling cadence — idle wakes still fire; only the advertised reason changes.
- Cost: one extra cheap `LIMIT 1` lookup per agent that is *already due* this tick (not per agent in the table).
- Adapters that switch on the literal string `heartbeat_timer` will see `heartbeat_idle` for empty wakes — that is the point of the issue's option 2, and unknown reasons fall through to default handling.

## Model Used

- Claude (Anthropic) via Claude Code CLI — implemented with `claude-opus-4-8` (Claude Opus 4.8, extended thinking + tool use, large context); PR description/template revision with `claude-fable-5` (Claude Fable 5, extended thinking + tool use).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no doc-facing surface changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
