### PR TITLE
fix(server): delete issue_comments before issue row in issues.remove() (#7991)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4734,3 +4734,73 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     expect(record?.childIssues.every((child) => typeof child.title === "string")).toBe(true);
   });
 });
+
+describeEmbeddedPostgres("issueService.remove", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-remove-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueDocuments);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(documents);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("deletes an issue that has comments without a FK constraint violation (#7991)", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue with a comment",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      body: "A comment that used to prevent deletion",
+    });
+
+    const removed = await svc.remove(issueId);
+
+    expect(removed).not.toBeNull();
+    expect(removed?.id).toBe(issueId);
+
+    const remaining = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5328,6 +5328,8 @@ export function issueService(db: Db) {
           .from(issueDocuments)
           .where(eq(issueDocuments.issueId, id));
 
+        await tx.delete(issueComments).where(eq(issueComments.issueId, id));
+
         const removedIssue = await tx
           .delete(issues)
           .where(eq(issues.id, id))


### PR DESCRIPTION
Fixes #7991.

## Thinking Path
- `DELETE /api/issues/:id` runs inside a transaction in `issues.remove()`; it deletes `issueAttachments` asset rows and `issueDocuments` document rows before calling `tx.delete(issues)`, but never removes `issueComments` first.
- The `issue_comments` table has a non-cascaded FK `issue_comments_issue_id_issues_id_fk` on `issue_id`, so Postgres rejects the parent row deletion with a 23503 constraint violation any time at least one comment exists.
- The minimal fix is a single `tx.delete(issueComments).where(eq(issueComments.issueId, id))` call before the `tx.delete(issues)` inside the existing transaction — no migration needed, no cascade change to the schema.

## What Changed
- `server/src/services/issues.ts` — added `await tx.delete(issueComments).where(eq(issueComments.issueId, id));` before the `tx.delete(issues)` call in `remove()`.
- `server/src/__tests__/issues-service.test.ts` — new `issueService.remove` embedded-Postgres suite with one test: creates an issue, inserts a comment, calls `svc.remove()`, and asserts both that the call succeeds (no constraint error) and that the comment row is gone.

## Verification
- `server $ vitest run -t "issueService.remove"` → 1 passed.
- Confirmed that without the fix the same test fails with `PostgresError: update or delete on table \issues\ violates foreign key constraint`.

## Risks
- Low. The deleted comments belong to the deleted issue and have no other references; cleaning them inside the same transaction keeps the operation atomic. Soft-delete strategies are not in use for comments.

## Model Used
claude-sonnet-4-6

---

- [x] I searched the GitHub PRs for similar or duplicate PRs and confirmed this is not a duplicate.
