### PR TITLE
perf(server): cache Intl.DateTimeFormat per timezone in routine scheduler (#8033)

### DIFF
--- a/server/src/__tests__/routines-cron-tz.test.ts
+++ b/server/src/__tests__/routines-cron-tz.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { nextCronTickInTimeZone } from "../services/routines.ts";
+
+describe("nextCronTickInTimeZone", () => {
+  it("finds the next hourly tick in UTC", () => {
+    // 2026-01-01 00:30 UTC — next tick for "0 * * * *" is 01:00 UTC
+    const after = new Date("2026-01-01T00:30:00.000Z");
+    const result = nextCronTickInTimeZone("0 * * * *", "UTC", after);
+    expect(result).not.toBeNull();
+    expect(result?.toISOString()).toBe("2026-01-01T01:00:00.000Z");
+  });
+
+  it("finds the next daily tick in a non-UTC timezone (America/New_York)", () => {
+    // 2026-06-01 14:00 UTC = 10:00 EDT; next midnight NY = 04:00 UTC the next day
+    const after = new Date("2026-06-01T14:00:00.000Z");
+    const result = nextCronTickInTimeZone("0 0 * * *", "America/New_York", after);
+    expect(result).not.toBeNull();
+    // midnight NY on 2026-06-02 = 04:00 UTC (EDT = UTC-4)
+    expect(result?.toISOString()).toBe("2026-06-02T04:00:00.000Z");
+  });
+
+  it("returns the same result when called repeatedly for the same timezone (formatter cache)", () => {
+    const after = new Date("2026-03-15T08:00:00.000Z");
+    const first = nextCronTickInTimeZone("30 9 * * *", "Asia/Tokyo", after);
+    const second = nextCronTickInTimeZone("30 9 * * *", "Asia/Tokyo", after);
+    // Determinism proves the cached formatter produces the same result as a fresh one.
+    expect(first?.toISOString()).toBe(second?.toISOString());
+  });
+
+  it("throws for an invalid cron expression", () => {
+    const after = new Date("2026-01-01T00:00:00.000Z");
+    expect(() => nextCronTickInTimeZone("99 * * * *", "UTC", after)).toThrow();
+  });
+});

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -88,9 +88,31 @@ function routineWebhookSecretConfigPath(secretId: string) {
   return `webhookSecret:${secretId}`;
 }
 
+// Intl.DateTimeFormat construction is ~1ms of ICU work per call. Cache formatters by timezone
+// so the per-minute-step cost is ~1µs (formatToParts on an existing instance) rather than ~1ms.
+const ZONED_MINUTE_FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
+
+function getOrCreateZonedMinuteFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = ZONED_MINUTE_FORMATTER_CACHE.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      weekday: "short",
+    });
+    ZONED_MINUTE_FORMATTER_CACHE.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
 function assertTimeZone(timeZone: string) {
   try {
-    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
+    getOrCreateZonedMinuteFormatter(timeZone).format(new Date());
   } catch {
     throw unprocessable(`Invalid timezone: ${timeZone}`);
   }
@@ -103,16 +125,7 @@ function floorToMinute(date: Date) {
 }
 
 function getZonedMinuteParts(date: Date, timeZone: string) {
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour12: false,
-    year: "numeric",
-    month: "numeric",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    weekday: "short",
-  });
+  const formatter = getOrCreateZonedMinuteFormatter(timeZone);
   const parts = formatter.formatToParts(date);
   const map = Object.fromEntries(parts.map((part) => [part.type, part.value]));
   const weekday = WEEKDAY_INDEX[map.weekday ?? ""];
@@ -141,7 +154,7 @@ function matchesCronMinute(expression: string, timeZone: string, date: Date) {
   );
 }
 
-function nextCronTickInTimeZone(expression: string, timeZone: string, after: Date) {
+export function nextCronTickInTimeZone(expression: string, timeZone: string, after: Date) {
   const trimmed = expression.trim();
   assertTimeZone(timeZone);
   const error = validateCron(trimmed);


### PR DESCRIPTION
Fixes #8033.

## Thinking Path
- Profiling showed 74% of CPU samples in `v8::internal::Builtin_DateTimeFormatConstructor` during a scheduler hang. The call site is `getZonedMinuteParts`, which constructs a new `Intl.DateTimeFormat` on every minute-step iteration inside `nextCronTickInTimeZone`.
- `Intl.DateTimeFormat` construction involves ICU locale data load + pattern resolution, costing ~1ms each. With up to 2,632,320 iterations for a sparse schedule, a single scheduler tick can block the event loop for ~45 minutes. Formatter instances themselves are immutable and safe to reuse across calls.
- Caching by timezone string (a module-level `Map`) reduces the per-iteration cost from ~1ms to ~1µs (`formatToParts` on an existing instance), making the loop cost negligible regardless of schedule sparsity. The cache is module-scoped and never invalidated — timezone definitions don't change at runtime.

## What Changed
- `server/src/services/routines.ts` — added `ZONED_MINUTE_FORMATTER_CACHE: Map<string, Intl.DateTimeFormat>` and `getOrCreateZonedMinuteFormatter(timeZone)` helper. Replaced the inline `new Intl.DateTimeFormat(...)` in `getZonedMinuteParts` and `assertTimeZone` with calls to this helper. Also exported `nextCronTickInTimeZone` for testability.
- `server/src/__tests__/routines-cron-tz.test.ts` — new unit-test file with four tests: next UTC hourly tick, next daily tick in America/New_York (DST aware), formatter-cache determinism (same result on repeated calls), and invalid-cron rejection.

## Verification
- `server $ vitest run routines-cron-tz` → 4 passed.
- Manual reasoning: formatter options are identical across all calls for a given timezone (same locale, same fields), so caching is correct. A formatter instance holds no per-date state; only `formatToParts(date)` is date-sensitive.

## Risks
- Low. The cache holds at most one entry per distinct timezone string seen at runtime (IANA tz database has ~500 zones; most deployments use 1–5). Memory impact is negligible. The only behavioral change is that the first call for a timezone pays the construction cost; all subsequent calls are free.

## Model Used
claude-sonnet-4-6

---

- [x] I searched the GitHub PRs for similar or duplicate PRs and confirmed this is not a duplicate.
