### PR TITLE
fix(server): emit documented cost_event.created plugin event

### DIFF
--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -16,6 +16,8 @@ import {
 } from "@paperclipai/db";
 import { costService } from "../services/costs.ts";
 import { financeService } from "../services/finance.ts";
+import { setPluginEventBus } from "../services/activity-log.ts";
+import type { PluginEventBus } from "../services/plugin-event-bus.ts";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -806,6 +808,74 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     // 120s + 30s = 150s + ~5s live run
     expect(descendantsOnly.runtimeMs).toBeGreaterThanOrEqual(150_000 + 4_000);
     expect(descendantsOnly.runtimeMs).toBeLessThan(150_000 + 60_000);
+  });
+
+  it("emits a cost_event.created plugin domain event when a cost event is created", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const emitted: any[] = [];
+    let resolveEmit: () => void;
+    const emittedOnce = new Promise<void>((resolve) => {
+      resolveEmit = resolve;
+    });
+    const fakeBus: Pick<PluginEventBus, "emit"> = {
+      async emit(event) {
+        emitted.push(event);
+        resolveEmit();
+        return { errors: [] };
+      },
+    };
+    setPluginEventBus(fakeBus as PluginEventBus);
+
+    const created = await costs.createEvent(companyId, {
+      agentId,
+      provider: "aws_bedrock",
+      biller: "aws_bedrock",
+      billingType: "metered_api",
+      model: "claude-opus-4-8",
+      inputTokens: 1200,
+      cachedInputTokens: 0,
+      outputTokens: 800,
+      costCents: 4242,
+      occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+    } as any);
+
+    // Emission is fire-and-forget; wait for the bus to receive it.
+    await emittedOnce;
+
+    const costEvent = emitted.find((e) => e.eventType === "cost_event.created");
+    expect(costEvent).toBeDefined();
+    expect(costEvent.companyId).toBe(companyId);
+    expect(costEvent.entityType).toBe("cost_event");
+    expect(costEvent.entityId).toBe(created.id);
+    expect(costEvent.payload).toMatchObject({
+      companyId,
+      agentId,
+      provider: "aws_bedrock",
+      model: "claude-opus-4-8",
+      inputTokens: 1200,
+      outputTokens: 800,
+      costCents: 4242,
+    });
   });
 
   it("aggregates finance event sums above int32 without raising Postgres integer overflow", async () => {

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -2,8 +2,10 @@ import { and, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from "drizzle-orm
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
+import { randomUUID } from "node:crypto";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
+import { publishPluginDomainEvent } from "./activity-log.js";
 
 export interface CostDateRange {
   from?: Date;
@@ -97,6 +99,41 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .where(eq(companies.id, companyId));
 
       await budgets.evaluateCostEvent(event);
+
+      // Forward to plugins as a first-class domain event. `cost_event.created`
+      // is a declared PluginEventType but had no host producer; emit it here so
+      // observability plugins receive cost signal as it flows.
+      publishPluginDomainEvent({
+        eventId: randomUUID(),
+        eventType: "cost_event.created",
+        occurredAt: new Date().toISOString(),
+        actorId: event.agentId,
+        actorType: "agent",
+        entityId: event.id,
+        entityType: "cost_event",
+        companyId: event.companyId,
+        payload: {
+          id: event.id,
+          companyId: event.companyId,
+          agentId: event.agentId,
+          issueId: event.issueId ?? null,
+          projectId: event.projectId ?? null,
+          goalId: event.goalId ?? null,
+          heartbeatRunId: event.heartbeatRunId ?? null,
+          billingCode: event.billingCode ?? null,
+          provider: event.provider,
+          biller: event.biller,
+          billingType: event.billingType,
+          model: event.model,
+          inputTokens: event.inputTokens,
+          cachedInputTokens: event.cachedInputTokens,
+          outputTokens: event.outputTokens,
+          costCents: event.costCents,
+          occurredAt: event.occurredAt instanceof Date
+            ? event.occurredAt.toISOString()
+            : event.occurredAt,
+        },
+      });
 
       return event;
     },


### PR DESCRIPTION
# PR A — Emit `cost_event.created` as a plugin domain event

**Branch suggestion:** `fix/emit-cost-event-created-plugin-event`
**Files:** `server/src/services/costs.ts`
**Patch:** `PR-A-emit-cost-event-created.patch`

---

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Plugins extend it through a typed domain-event stream; the set of event types is `PLUGIN_EVENT_TYPES` in `packages/shared/src/constants.ts`, and the SDK README documents each one plugins can subscribe to.
> - `cost_event.created` is listed in `PLUGIN_EVENT_TYPES` **and** documented in `packages/plugins/sdk/README.md` as a subscribable event — but no server code path actually publishes it. The cost route logs a `cost.reported` activity, which is not in the `activity-log.ts` activity→plugin-event map, and heartbeat only emits `agent.run.*`.
> - So an observability plugin that subscribes to `cost_event.created` (exactly as documented) silently receives nothing, with no error to indicate why.
> - This pull request emits `cost_event.created` from `costService.createEvent`, right after the cost row is persisted and budgets are evaluated, using the existing `publishPluginDomainEvent` bus.
> - The benefit is that the documented event now fires, so cost-observability plugins work as advertised — and every cost event (route-driven or heartbeat-driven) is covered because emission lives at the service layer.

## Linked Issues or Issue Description

**Related prior work (searched & reviewed):** `Refs #3750` — *"server infrastructure for observability plugin"* already moves `cost_event.created` emission into `costService.createEvent`. That PR has been **stale since 2026-04-16, is merge-conflicting (DIRTY), has unaddressed review comments, and bundles four unrelated concerns** (run-lifecycle events, agent-delegation events, the orphaned-run reaper threshold, and a shared-package export cleanup). Per CONTRIBUTING's guidance on effectively-dead PRs, this is a fresh, **minimal** PR that does only the cost-event emission — independently mergeable and conflict-free. Happy to instead help rebase #3750 if maintainers prefer; calling it out so the reviewer has full context.

No existing issue for the bug itself. Describing it here per the bug template:

- **What happens:** Subscribing a plugin to `cost_event.created` (a declared `PluginEventType`, documented in the SDK README) never delivers any events.
- **Expected:** The host emits `cost_event.created` when a cost event is created, like other documented domain events.
- **Repro:** Install any plugin with `ctx.events.on("cost_event.created", …)`, then `POST /api/companies/:id/cost-events`. The handler is never invoked. (Confirmed against commit currently checked out.)
- **Root cause:** No producer. `costService.createEvent` persists the row and evaluates budgets but never publishes the plugin event; the cost route's `cost.reported` activity action is not in `ACTIVITY_ACTION_TO_PLUGIN_EVENT`.
- **Deployment mode:** all (embedded-postgres local_trusted reproduced).

## What Changed

- `costService.createEvent` now calls `publishPluginDomainEvent({ eventType: "cost_event.created", … })` after the cost row is written and `budgets.evaluateCostEvent` runs.
- The payload mirrors the `cost_events` schema (`packages/db/src/schema/cost_events.ts`): `id, companyId, agentId, issueId, projectId, goalId, heartbeatRunId, billingCode, provider, biller, billingType, model, inputTokens, cachedInputTokens, outputTokens, costCents, occurredAt`.
- Emission is at the service layer so both API-route and heartbeat-originated cost events are covered.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- Manual, against a local embedded-postgres instance:
  1. Install a plugin subscribing to `cost_event.created`.
  2. `POST /api/companies/:id/cost-events`.
  3. The plugin handler now fires with the full payload. (Verified live with the Cost Clipper plugin — see PR B — which raised an anomaly and posted an issue comment as a result.)
- No new tests are strictly required for the one-line emission, but a service-level test asserting the event fires can be added on request.

## Risks

- **Low.** Additive only — emits an already-declared event that nothing currently produces. No schema, API, or behavioral change to cost recording itself; emission happens after persistence and budget evaluation, and `publishPluginDomainEvent` is fire-and-forget (handler errors are logged, not thrown), so a misbehaving plugin cannot break cost recording.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking + tool use (ran the server locally, traced the event bus, verified end-to-end).

## Checklist

- [x] Thinking path from project context to this change
- [x] Model specified
- [x] Checked ROADMAP.md — aligns with "Better Budgeting" spend-visibility direction; not duplicating planned core work
- [x] Searched GitHub for duplicate/related PRs and linked them (#3750 — stale predecessor, referenced above)
- [x] Described the issue in-PR following the bug template
- [x] Ran typecheck locally (clean)
- [ ] Added/updated tests where applicable <!-- optional service-level test on request -->
- [ ] N/A — no UI change
- [x] Documented risks
- [ ] CI gates green <!-- after push -->
- [ ] Greptile 5/5
