### PR TITLE
fix: keep routine execution issues terminal after comments (FMA-3368)

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -833,6 +833,185 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
+  it("suppresses deferred comment wakes for terminal routine execution issues", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Routine execution should stay terminal",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+        originKind: "routine_execution",
+      });
+
+      const comment1 = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "First routine comment",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: comment1.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment1.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      const comment2 = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "This should stay history-only",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: comment2.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment2.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(deferredRun).toBeNull();
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select({
+            status: agentWakeupRequests.status,
+            error: agentWakeupRequests.error,
+          })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+            ),
+          )
+          .orderBy(asc(agentWakeupRequests.requestedAt))
+          .then((rows) =>
+            rows.find((row) => row.error?.includes("routine execution issue is terminal")) ?? null,
+          );
+        return deferred?.status === "cancelled" && deferred.error?.includes("routine execution issue is terminal");
+      });
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      });
+
+      const issue = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue?.status).toBe("done");
+      expect(issue?.completedAt).not.toBeNull();
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+      expect(runs).toHaveLength(1);
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("does not reopen a finished issue when the deferred comment wake came from another agent", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -30,6 +30,18 @@ async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
   await db?.$client?.end?.({ timeout: 0 });
 }
 
+async function waitForAgentIdle(db: ReturnType<typeof createDb>, agentId: string) {
+  await waitFor(async () => {
+    const agent = await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    return agent?.status !== "running";
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
 async function createControlledGatewayServer() {
   const server = createServer();
   const wss = new WebSocketServer({ server });
@@ -348,6 +360,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment1.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -395,6 +408,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment2.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -409,6 +423,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment3.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -463,6 +478,7 @@ describe("heartbeat comment wake batching", () => {
         const statusesByRunId = new Map(runs.map((run) => [run.id, run.status]));
         return statusesByRunId.get(firstRun!.id) === "succeeded" && statusesByRunId.get(secondRunId) === "succeeded";
       }, 90_000);
+      await waitForAgentIdle(db, agentId);
 
       expect(secondPayload.paperclip).toMatchObject({
         wake: {
@@ -547,6 +563,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment1.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -592,6 +609,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: queuedComment.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -629,12 +647,18 @@ describe("heartbeat comment wake batching", () => {
         },
       });
       expect(String(promotedPayload.message ?? "")).toContain("Queued follow-up");
+      const promotedRunId = typeof promotedPayload.idempotencyKey === "string" ? promotedPayload.idempotencyKey : null;
+      if (!promotedRunId) {
+        throw new Error("Expected promoted gateway payload to include an idempotencyKey run id");
+      }
 
       gateway.releaseFirstWait();
       await waitFor(async () => {
         const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
-        return runs.length === 2 && runs.every((run) => ["cancelled", "succeeded"].includes(run.status));
+        const statusesByRunId = new Map(runs.map((run) => [run.id, run.status]));
+        return statusesByRunId.get(firstRun!.id) === "cancelled" && statusesByRunId.get(promotedRunId) === "succeeded";
       }, 90_000);
+      await waitForAgentIdle(db, agentId);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -710,6 +734,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment1.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -746,6 +771,7 @@ describe("heartbeat comment wake batching", () => {
           taskId: issueId,
           commentId: comment2.id,
           wakeReason: "issue_commented",
+          skipIssueComment: true,
         },
         requestedByActorType: "user",
         requestedByActorId: "user-1",
@@ -987,6 +1013,7 @@ describe("heartbeat comment wake batching", () => {
           .then((rows) => rows[0] ?? null);
         return run?.status === "succeeded";
       });
+      await waitForAgentIdle(db, agentId);
 
       const issue = await db
         .select({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -600,6 +600,9 @@ describe.sequential("issue comment reopen routes", () => {
       expect.anything(),
       expect.objectContaining({ reason: "issue_reopened_via_comment" }),
     );
+    expect(mockRoutineService.syncRunStatusForIssue).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -195,7 +195,7 @@ async function normalizePolicy(input: {
   return normalizeIssueExecutionPolicy(input);
 }
 
-function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress") {
+function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progress", extra: Record<string, unknown> = {}) {
   return {
     id: "11111111-1111-4111-8111-111111111111",
     companyId: "company-1",
@@ -205,6 +205,7 @@ function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progr
     createdByUserId: "local-board",
     identifier: "PAP-580",
     title: "Comment reopen default",
+    ...extra,
   };
 }
 
@@ -520,6 +521,85 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     ));
+  });
+
+  it("does not implicitly reopen closed routine execution issues via POST comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", { originKind: "routine_execution" }),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "historical note" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
+
+  it("does not explicitly resume closed routine execution issues via POST comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", { originKind: "routine_execution" }),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "please resume this run", resume: true });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
+
+  it("does not explicitly reopen closed routine execution issues via the PATCH comment path", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", { originKind: "routine_execution" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", { originKind: "routine_execution" }),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "historical note",
+        reopen: true,
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.not.objectContaining({ status: "todo" }),
+    );
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.updated",
+        details: expect.objectContaining({ reopened: true }),
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -743,6 +743,13 @@ function isClosedIssueStatus(status: string | null | undefined): status is "done
   return status === "done" || status === "cancelled";
 }
 
+function isTerminalRoutineExecutionIssue(issue: {
+  status: string | null | undefined;
+  originKind?: string | null;
+}) {
+  return issue.originKind === "routine_execution" && isClosedIssueStatus(issue.status);
+}
+
 function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
@@ -4889,6 +4896,7 @@ export function issueRoutes(
       actorId: actor.actorId,
     });
     const effectiveMoveToTodoRequested =
+      !isTerminalRoutineExecutionIssue(existing) &&
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         (!!commentBody &&
@@ -6667,6 +6675,7 @@ export function issueRoutes(
       actorId: actor.actorId,
     });
     const effectiveMoveToTodoRequested =
+      !isTerminalRoutineExecutionIssue(issue) &&
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         shouldImplicitlyMoveCommentedIssueToTodo({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9769,7 +9769,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
+        const deferredCommentWakeId = deriveCommentId(deferredContextSeed, deferredPayload);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        if (
+          deferredCommentWakeId &&
+          issue.originKind === "routine_execution" &&
+          (issue.status === "done" || issue.status === "cancelled")
+        ) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: new Date(),
+              error: "Deferred comment wake suppressed because routine execution issue is terminal",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Routine executions create issue records that act as historical run records for recurring work.
> - Finished routine execution issues should stay terminal after `done` or `cancelled`.
> - The comment and deferred-comment wake paths were treating those historical records like ordinary reusable issues.
> - That let normal comments, explicit comment resume/reopen flags, and deferred comment wakes move a completed routine execution back to active work.
> - This pull request makes routine execution issues terminal at the route and heartbeat promotion boundaries.
> - The benefit is fewer routine/status loops and a cleaner invariant: follow-up execution happens through a new routine run or a new manual issue.

## Linked Issues or Issue Description

Bug report, in-PR issue description:

- **Summary:** Completed `routine_execution` issues can be reopened by comment and deferred-comment wake paths.
- **Expected behavior:** A completed routine execution issue remains `done` or `cancelled`; comments are retained as history/discussion only.
- **Actual behavior:** Comment-driven reopen paths can move the historical run issue back to `todo` and enqueue another run.
- **Impact:** Routine execution records can stop being terminal, which can keep routine/status loops alive and make historical run state misleading.
- **Scope:** FMA-3368 from the OpenSkills Paperclip board.
- **Related PR search:** `gh pr list --repo paperclipai/paperclip --state all --search "routine execution reopen comment wake" --limit 20` found adjacent lifecycle/deferred-wake PRs, including #4372, #7183, #6214, and #6300, but no exact PR for terminal `routine_execution` comment and deferred-wake suppression.

## What Changed

- Added a terminal routine execution guard in `server/src/routes/issues.ts` so closed routine execution issues do not move to `todo` from POST comments, PATCH-with-comment, `reopen: true`, or `resume: true` comment flows.
- Added deferred wake suppression in `server/src/services/heartbeat.ts` so terminal routine execution comment wakes are marked `cancelled` with `Deferred comment wake suppressed because routine execution issue is terminal` instead of promoting a new run.
- Added route regression tests for implicit comment reopen, explicit POST resume, and explicit PATCH reopen on closed routine execution issues.
- Added heartbeat regression coverage proving deferred routine comment wakes stay terminal while the issue remains `done`.

## Verification

- [x] `pnpm vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts`
- [x] `pnpm vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts -t "suppresses deferred comment wakes for terminal routine execution issues"`
- [x] `pnpm vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts -t "promotes deferred comment wakes with their comments after the active run is cancelled"`
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `git diff --check`

## Risks

- Low to medium. The route guard is scoped to `originKind === "routine_execution"` and closed statuses only, so manual issue reopen behavior remains unchanged.
- Deferred-wake suppression cancels comment wakes for terminal routine execution issues. If someone expected comments to resume historical routine runs, this intentionally changes that path; follow-up work should be a new routine run or manual issue.
- Full `heartbeat-comment-wake-batching.test.ts` still has an order-sensitive timeout in the existing `promotes deferred comment wakes with their comments after the active run is cancelled` test when run as a full file. That test passes isolated, and the new routine regression passes isolated.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, coding-agent mode with shell and git tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
