### PR TITLE
feat(authz): decouple agent_config:read from agents:create (canReadAgentConfig)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -723,6 +723,7 @@ export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
   "agents:create",
+  "agent_config:read",
   "environments:manage",
   "users:invite",
   "users:manage_permissions",

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -162,6 +162,7 @@ export type TestAdapterEnvironment = z.infer<typeof testAdapterEnvironmentSchema
 export const updateAgentPermissionsSchema = z.object({
   canCreateAgents: z.boolean(),
   canAssignTasks: z.boolean(),
+  canReadAgentConfig: z.boolean().optional(),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),
 });

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -12,6 +12,7 @@ vi.mock("acpx/runtime", () => ({
 }));
 
 const agentId = "11111111-1111-4111-8111-111111111111";
+const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
 const companyId = "22222222-2222-4222-8222-222222222222";
 
 const baseAgent = {
@@ -46,6 +47,12 @@ const mockAgentService = vi.hoisted(() => ({
   activatePendingApproval: vi.fn(),
   update: vi.fn(),
   updatePermissions: vi.fn(),
+  listConfigRevisions: vi.fn(),
+  getConfigRevision: vi.fn(),
+  rollbackConfigRevision: vi.fn(),
+  createApiKey: vi.fn(),
+  listKeys: vi.fn(),
+  getKeyById: vi.fn(),
   getChainOfCommand: vi.fn(),
   resolveByReference: vi.fn(),
 }));
@@ -301,6 +308,12 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.activatePendingApproval.mockReset();
     mockAgentService.update.mockReset();
     mockAgentService.updatePermissions.mockReset();
+    mockAgentService.listConfigRevisions.mockReset();
+    mockAgentService.getConfigRevision.mockReset();
+    mockAgentService.rollbackConfigRevision.mockReset();
+    mockAgentService.createApiKey.mockReset();
+    mockAgentService.listKeys.mockReset();
+    mockAgentService.getKeyById.mockReset();
     mockAgentService.getChainOfCommand.mockReset();
     mockAgentService.resolveByReference.mockReset();
     mockAccessService.canUser.mockReset();
@@ -344,6 +357,12 @@ describe.sequential("agent permission routes", () => {
     });
     mockAgentService.update.mockResolvedValue(baseAgent);
     mockAgentService.updatePermissions.mockResolvedValue(baseAgent);
+    mockAgentService.listConfigRevisions.mockResolvedValue([]);
+    mockAgentService.getConfigRevision.mockResolvedValue(null);
+    mockAgentService.rollbackConfigRevision.mockResolvedValue(baseAgent);
+    mockAgentService.createApiKey.mockResolvedValue({ id: "key-1", name: "default", token: "test-token" });
+    mockAgentService.listKeys.mockResolvedValue([]);
+    mockAgentService.getKeyById.mockResolvedValue(null);
     mockAccessService.canUser.mockResolvedValue(true);
     mockAccessService.decide.mockImplementation(async (input: { action?: string }) => {
       const allowed = Boolean(await mockAccessService.canUser());
@@ -540,6 +559,130 @@ describe.sequential("agent permission routes", () => {
 
     expect(res.status).toBe(403);
   });
+
+  it("allows read-only agent config reviewers to read redacted config and revisions without mutation authority", async () => {
+    const targetAgent = {
+      ...baseAgent,
+      adapterConfig: {
+        apiUrl: "https://api.example.test/v1",
+        headers: { Authorization: "Bearer adapter-header-token" },
+        env: {
+          PAPERCLIP_API_KEY: "paperclip-key",
+          SAFE_VALUE: "visible",
+        },
+        privateKey: "private-key-value",
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          cheap: {
+            adapterConfig: {
+              endpoint: "https://runtime.example.test",
+              authHeader: "Bearer runtime-header-token",
+            },
+          },
+        },
+      },
+    };
+    const reviewerAgent = {
+      ...baseAgent,
+      id: reviewerAgentId,
+      name: "Reviewer",
+      role: "cto",
+      permissions: { canCreateAgents: false },
+    };
+    const revision = {
+      id: "revision-1",
+      agentId,
+      beforeConfig: {
+        adapterConfig: { token: "before-token", safe: "before" },
+        runtimeConfig: { endpoint: "https://before.example.test?access_token=before-query-token" },
+      },
+      afterConfig: {
+        adapterConfig: targetAgent.adapterConfig,
+        runtimeConfig: targetAgent.runtimeConfig,
+        metadata: { privateKey: "revision-private-key", safe: "revision" },
+      },
+      createdAt: new Date("2026-03-19T00:00:00.000Z"),
+    };
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === reviewerAgentId) return reviewerAgent;
+      if (id === agentId) return targetAgent;
+      return null;
+    });
+    mockAgentService.list.mockResolvedValue([targetAgent]);
+    mockAgentService.listConfigRevisions.mockResolvedValue([revision]);
+    mockAgentService.getConfigRevision.mockResolvedValue(revision);
+    // The reviewer holds only the dedicated agent_config:read grant — no
+    // agents:create grant and canCreateAgents:false on its own record. Reads
+    // gate on hasPermission(agent_config:read); mutations gate on decide
+    // (agents:create / agent:update), which must deny.
+    mockAccessService.hasPermission.mockImplementation(
+      async (_companyId: string, _principalType: string, principalId: string, key: string) =>
+        principalId === reviewerAgentId && key === "agent_config:read",
+    );
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+      allowed: false,
+      reason: "deny_missing_grant",
+      explanation: `Missing permission: ${input.action}.`,
+      grant: undefined,
+    }));
+
+    const app = await createApp({
+      type: "agent",
+      agentId: reviewerAgentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const listRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/${companyId}/agent-configurations`)
+    );
+    const configRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/configuration`)
+    );
+    const revisionsRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/config-revisions`)
+    );
+    const revisionRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/config-revisions/revision-1`)
+    );
+    const createAgentRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post(`/api/companies/${companyId}/agents`)
+        .send({ name: "Backdoor", role: "engineer", adapterType: "process", adapterConfig: {} })
+    );
+    const updateRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).patch(`/api/agents/${agentId}`).send({ title: "Mutated" })
+    );
+    const keyRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/keys`).send({ name: "reviewer-key" })
+    );
+    const rollbackRes = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/config-revisions/revision-1/rollback`).send({})
+    );
+
+    expect(listRes.status, JSON.stringify(listRes.body)).toBe(200);
+    expect(configRes.status, JSON.stringify(configRes.body)).toBe(200);
+    expect(revisionsRes.status, JSON.stringify(revisionsRes.body)).toBe(200);
+    expect(revisionRes.status, JSON.stringify(revisionRes.body)).toBe(200);
+    expect(configRes.body.adapterConfig.env).toEqual({
+      PAPERCLIP_API_KEY: "***REDACTED***",
+      SAFE_VALUE: "visible",
+    });
+    expect(configRes.body.adapterConfig.headers.Authorization).toBe("***REDACTED***");
+    expect(configRes.body.adapterConfig.privateKey).toBe("***REDACTED***");
+    expect(revisionsRes.body[0].beforeConfig.adapterConfig.token).toBe("***REDACTED***");
+    expect(revisionRes.body.afterConfig.metadata.privateKey).toBe("***REDACTED***");
+    expect(createAgentRes.status).toBe(403);
+    expect(updateRes.status).toBe(403);
+    expect(keyRes.status).toBe(403);
+    expect(rollbackRes.status).toBe(403);
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockAgentService.createApiKey).not.toHaveBeenCalled();
+    expect(mockAgentService.rollbackConfigRevision).not.toHaveBeenCalled();
+  }, 20_000);
 
   it("blocks agent-authenticated self-updates that set host-executed workspace commands", async () => {
     const app = await createApp({
@@ -1451,6 +1594,47 @@ describe.sequential("agent permission routes", () => {
     );
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
+  });
+
+  it("sets explicit config-read grants without requiring agent creation privilege", async () => {
+    mockAgentService.updatePermissions.mockResolvedValue({
+      ...baseAgent,
+      permissions: { canCreateAgents: false, canAssignTasks: true },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}/permissions`)
+      .send({ canCreateAgents: false, canAssignTasks: true, canReadAgentConfig: true }));
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.updatePermissions).toHaveBeenCalledWith(agentId, {
+      canCreateAgents: false,
+      canAssignTasks: true,
+    });
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "tasks:assign",
+      true,
+      "board-user",
+    );
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "agent_config:read",
+      true,
+      "board-user",
+    );
   });
 
   it("exposes a dedicated agent route for the inbox mine view", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -94,7 +94,7 @@ async function grantAgentPermission(
   db: ReturnType<typeof createDb>,
   companyId: string,
   agentId: string,
-  permissionKey: "tasks:assign" | "tasks:assign_scope",
+  permissionKey: "agent_config:read" | "agents:create" | "tasks:assign" | "tasks:assign_scope",
   scope: Record<string, unknown> | null = null,
 ) {
   await db.insert(companyMemberships).values({
@@ -175,24 +175,27 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("Allowed by explicit grant tasks:assign");
   });
 
-  it("allows agent grants for agent configuration decisions", async () => {
-    const company = await createCompany(db, "AgentGrant");
+  it("allows read-only agent config grants for agent configuration reads", async () => {
+    const company = await createCompany(db, "AgentConfigReadGrant");
     const actorAgent = await createAgent(db, company.id);
     const targetAgent = await createAgent(db, company.id);
-    await db.insert(companyMemberships).values({
-      companyId: company.id,
-      principalType: "agent",
-      principalId: actorAgent.id,
-      status: "active",
-      membershipRole: "member",
+    await grantAgentPermission(db, company.id, actorAgent.id, "agent_config:read");
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "agent_config:read",
+      resource: { type: "agent", companyId: company.id, agentId: targetAgent.id },
     });
-    await db.insert(principalPermissionGrants).values({
-      companyId: company.id,
-      principalType: "agent",
-      principalId: actorAgent.id,
-      permissionKey: "agents:create",
-      grantedByUserId: null,
-    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.grant?.permissionKey).toBe("agent_config:read");
+  });
+
+  it("keeps agent create grants compatible with agent configuration reads", async () => {
+    const company = await createCompany(db, "AgentCreateReadCompat");
+    const actorAgent = await createAgent(db, company.id);
+    const targetAgent = await createAgent(db, company.id);
+    await grantAgentPermission(db, company.id, actorAgent.id, "agents:create");
 
     const decision = await authorizationService(db).decide({
       actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -690,11 +690,13 @@ export function agentRoutes(
     // are never exposed. Mutations and environment probes still gate on
     // agents:create via assertCanCreateAgentsForCompany / assertCanUpdateAgent.
     //
-    // For AGENT actors we keep the previous, stricter gate: an agent must
-    // either have an explicit `agents:create` grant or the legacy
-    // `canCreateAgents` permission on its own record. Agents are
-    // non-human principals — they should not be able to introspect peer
-    // agents' configurations just by virtue of being in the same company.
+    // For AGENT actors the read is gated on the dedicated `agent_config:read`
+    // grant — decoupled from agent-creation authority (WKP-103). An explicit
+    // `agents:create` grant or the legacy `canCreateAgents` record permission
+    // still satisfy the gate for backwards compatibility, so existing
+    // agent-creators keep their access. Agents are non-human principals — they
+    // should not be able to introspect peer agents' configurations just by
+    // virtue of being in the same company.
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "agent") {
       if (!req.actor.agentId) throw forbidden("Agent authentication required");
@@ -702,14 +704,11 @@ export function agentRoutes(
       if (!actorAgent || actorAgent.companyId !== companyId) {
         throw forbidden("Agent key cannot access another company");
       }
-      const allowedByGrant = await access.hasPermission(
-        companyId,
-        "agent",
-        actorAgent.id,
-        "agents:create",
-      );
+      const allowedByGrant =
+        (await access.hasPermission(companyId, "agent", actorAgent.id, "agent_config:read")) ||
+        (await access.hasPermission(companyId, "agent", actorAgent.id, "agents:create"));
       if (!allowedByGrant && !canCreateAgents(actorAgent)) {
-        throw forbidden("Missing permission: can create agents");
+        throw forbidden("Missing permission: agent_config:read");
       }
       return actorAgent;
     }
@@ -731,10 +730,10 @@ export function agentRoutes(
 
   async function actorCanReadConfigurationsForCompany(req: Request, companyId: string) {
     // Mirrors assertCanReadConfigurations but returns a boolean instead of
-    // throwing. Board actors only need company access; agent actors must
-    // still pass the agents:create gate (explicit grant or canCreateAgents
-    // on their own record) so peer agents cannot snoop each others'
-    // configurations.
+    // throwing. Board actors only need company access; agent actors must hold
+    // the dedicated agent_config:read grant (or, for backwards compatibility,
+    // an agents:create grant / canCreateAgents on their own record) so peer
+    // agents cannot snoop each others' configurations.
     try {
       assertCompanyAccess(req, companyId);
     } catch {
@@ -744,12 +743,9 @@ export function agentRoutes(
     if (!req.actor.agentId) return false;
     const actorAgent = await svc.getById(req.actor.agentId);
     if (!actorAgent || actorAgent.companyId !== companyId) return false;
-    const allowedByGrant = await access.hasPermission(
-      companyId,
-      "agent",
-      actorAgent.id,
-      "agents:create",
-    );
+    const allowedByGrant =
+      (await access.hasPermission(companyId, "agent", actorAgent.id, "agent_config:read")) ||
+      (await access.hasPermission(companyId, "agent", actorAgent.id, "agents:create"));
     return allowedByGrant || canCreateAgents(actorAgent);
   }
 
@@ -2455,7 +2451,8 @@ export function agentRoutes(
       await assertBoardCanManageAgentsForCompany(req, existing.companyId);
     }
 
-    const agent = await svc.updatePermissions(id, req.body);
+    const { canReadAgentConfig, ...permissionPatch } = req.body;
+    const agent = await svc.updatePermissions(id, permissionPatch);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
       return;
@@ -2472,6 +2469,16 @@ export function agentRoutes(
       effectiveCanAssignTasks,
       req.actor.type === "board" ? (req.actor.userId ?? null) : null,
     );
+    if (typeof canReadAgentConfig === "boolean") {
+      await access.setPrincipalPermission(
+        agent.companyId,
+        "agent",
+        agent.id,
+        "agent_config:read",
+        canReadAgentConfig,
+        req.actor.type === "board" ? (req.actor.userId ?? null) : null,
+      );
+    }
 
     const actor = getActorInfo(req);
     await logActivity(db, {
@@ -2486,6 +2493,7 @@ export function agentRoutes(
       details: {
         canCreateAgents: agent.permissions?.canCreateAgents ?? false,
         canAssignTasks: effectiveCanAssignTasks,
+        ...(typeof canReadAgentConfig === "boolean" ? { canReadAgentConfig } : {}),
         trustPreset: agent.permissions?.trustPreset ?? "standard",
       },
     });

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -106,7 +106,8 @@ function companyIdForResource(resource: AuthorizationResource) {
 }
 
 function permissionForAction(action: AuthorizationAction): PermissionKey | null {
-  if (action === "agent_config:read" || action === "agent_config:update") return "agents:create";
+  if (action === "agent_config:read") return "agent_config:read";
+  if (action === "agent_config:update") return "agents:create";
   if (
     action === "agent:read" ||
     action === "agent:wake" ||
@@ -884,6 +885,32 @@ export function authorizationService(db: Db) {
       return broadDecision;
     }
 
+    async function decideWithAgentConfigReadGrants(
+      principalType: PrincipalType,
+      principalId: string,
+    ): Promise<AuthorizationDecision> {
+      const readDecision = await decidePrincipalGrant({
+        companyId,
+        principalType,
+        principalId,
+        action: input.action,
+        permissionKey: "agent_config:read",
+        scope: input.scope,
+      });
+      if (readDecision.allowed || readDecision.reason === "deny_missing_membership") return readDecision;
+
+      const createDecision = await decidePrincipalGrant({
+        companyId,
+        principalType,
+        principalId,
+        action: input.action,
+        permissionKey: "agents:create",
+        scope: input.scope,
+      });
+      if (createDecision.allowed) return createDecision;
+      return readDecision;
+    }
+
     async function denyForAssignmentPolicyIfNeeded(
       policyEffect: AssignmentPolicyEffect,
     ): Promise<AuthorizationDecision | null> {
@@ -1040,6 +1067,9 @@ export function authorizationService(db: Db) {
         if (policyEffect.kind === "restricted") return denyRestrictedAssignmentPolicy(policyEffect);
         return grantDecision;
       }
+      if (input.action === "agent_config:read") {
+        return decideWithAgentConfigReadGrants("user", input.actor.userId);
+      }
       return decidePrincipalGrant({
         companyId,
         principalType: "user",
@@ -1184,15 +1214,20 @@ export function authorizationService(db: Db) {
     }
 
     if (permissionKey) {
-      const grantDecision = await decidePrincipalGrant({
-        companyId,
-        principalType: "agent",
-        principalId: actorAgentId,
-        action: input.action,
-        permissionKey,
-        scope: input.scope,
-      });
-      if (grantDecision.allowed) return grantDecision;
+      if (input.action === "agent_config:read") {
+        const grantDecision = await decideWithAgentConfigReadGrants("agent", actorAgentId);
+        if (grantDecision.allowed) return grantDecision;
+      } else {
+        const grantDecision = await decidePrincipalGrant({
+          companyId,
+          principalType: "agent",
+          principalId: actorAgentId,
+          action: input.action,
+          permissionKey,
+          scope: input.scope,
+        });
+        if (grantDecision.allowed) return grantDecision;
+      }
     }
 
     if (


### PR DESCRIPTION
## Summary
Give agent configuration reads their own first-class permission grant — `agent_config:read` / `canReadAgentConfig` — instead of piggybacking on `agents:create`. A least-privilege principal (e.g. a CTO that should *read* agent config without being able to *create* agents) can now read redacted agent configuration and config revisions without holding agent-creation authority.

Re-lands the WKP-103 decoupling, isolated to a clean, single-purpose changeset (no commingled in-flight edits).

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent configuration (adapter config, env, keys, config revisions) is read/written through the agents routes, gated by the authorization service's permission grants
> - The "read agent config" capability was piggybacked on the `agents:create` permission — so any principal that should merely *read* redacted config was forced to also hold *agent-creation* authority
> - That violates least privilege: a CTO-role agent that needs to inspect peer agent configuration had to be granted the power to create agents, which is a much broader and riskier grant
> - This pull request gives `agent_config:read` its own first-class permission key (`canReadAgentConfig`), decoupled from `agents:create`, while keeping `agents:create` (and the legacy `canCreateAgents` record flag, via the existing route helpers) as a backward-compatible fallback so no existing access is lost
> - The benefit is true least-privilege config-read: read access can be granted independently, without handing out agent-creation authority

## Linked Issues or Issue Description

No public GitHub issue. Tracked internally as Paperclip issues WKP-103 (original decoupling) / WKP-119 (clean re-land) under parent WKP-117.

In-PR description (feature): The authorization model conflated two distinct capabilities — reading agent configuration and creating agents — by routing `agent_config:read` through the `agents:create` permission key. This forced an over-broad grant on any principal that only needed read access. This PR introduces a dedicated `agent_config:read` permission key so config-read can be granted on its own, preserving all existing access through explicit fallbacks.

## What Changed
- **`packages/shared/src/constants.ts`** — add `agent_config:read` to `PERMISSION_KEYS` (makes the new grant a first-class permission key; required for type-safety).
- **`packages/shared/src/validators/agent.ts`** — accept optional `canReadAgentConfig` in `updateAgentPermissionsSchema`.
- **`server/src/services/authorization.ts`** — map `agent_config:read` to its own permission key (previously mapped to `agents:create`); add `decideWithAgentConfigReadGrants` which tries the dedicated `agent_config:read` grant first, then falls back to `agents:create` for backward compatibility. Wired into both the user and agent decision paths.
- **`server/src/routes/agents.ts`** — gate the agent config-read path on `agent_config:read` (or `agents:create` / legacy `canCreateAgents`) instead of `agents:create` only; **board-member read access is unchanged** (preserves #3725). Accept + persist `canReadAgentConfig` in `PATCH /api/agents/:id/permissions` via a dedicated `setPrincipalPermission` call.

## Reconciliation with #3725
#3725 loosened config-read so any board member can read, while agents still needed `agents:create`. This PR keeps that board-open behavior intact and only decouples the **agent** path — agents now pass with a dedicated `agent_config:read` grant. Existing agents holding `agents:create` / `canCreateAgents` keep their access via the fallback.

## Verification
- `pnpm --filter @paperclipai/server test agent-permissions-routes` — 50 passed, including a reviewer with `canReadAgentConfig:true` + `canCreateAgents:false`: reads redacted config + config revisions (200), but create / update / mint-keys / rollback all denied (403).
- `pnpm --filter @paperclipai/server test authorization-service` — 23 passed, including: `agent_config:read` satisfied by a dedicated `agent_config:read` grant, and `agents:create` remains compatible.
- `tsc --noEmit` clean for `server`; `@paperclipai/shared` builds.
- Redaction of secrets (env keys, `Authorization` headers, `privateKey`, query-param tokens within revisions) asserted in the reviewer-read test.

## Risks
Low risk. Backward-compatible by construction: existing `agents:create` grants and the legacy `canCreateAgents` record flag continue to satisfy config-read through explicit fallbacks, so no principal loses access. The new key only *adds* a narrower way to grant read. Board-member read access is unchanged (#3725 preserved). No schema migration. Change is reversible (revert restores the `agents:create` mapping).

Known non-blocking observations (Greptile): (1) `decideWithAgentConfigReadGrants` does not consult the legacy `canCreateAgents` *record flag* — this is pre-existing, fail-closed behavior: the `decide()` path for `agent_config:read` only ever checked grants (the record flag is honored by the route helpers, which gate the actual endpoints), so no regression. (2) The `PATCH .../permissions` response body does not echo the freshly-set `canReadAgentConfig`; the grant is recorded in the activity log. Both are tracked as optional follow-ups.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR.

## Model Used
Claude — `claude-opus-4-8` (Opus 4.8, 1M-context variant), extended-thinking / agentic tool-use mode, via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have considered and documented any risks above
- [ ] I have updated relevant documentation to reflect my changes (no doc changes required for this internal permission key)
- [ ] All Paperclip CI gates are green (re-running after this description update)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (the only open P2 was this missing description; re-running)
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>
