### PR TITLE
fix(activity-log): degrade gracefully on unresolvable run_id (BLU-14531)

### DIFF
--- a/server/src/__tests__/activity-log-runid-fallback.test.ts
+++ b/server/src/__tests__/activity-log-runid-fallback.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { activityLog, agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { logActivity } from "../services/activity-log.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres activity-log run_id fallback tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("logActivity run_id graceful degradation", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  let companyId!: string;
+  let agentId!: string;
+  let registeredRunId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-activity-log-runid-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  beforeEach(async () => {
+    companyId = randomUUID();
+    agentId = randomUUID();
+    registeredRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: registeredRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "succeeded",
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function onlyActivityRow() {
+    const rows = await db.select().from(activityLog);
+    expect(rows).toHaveLength(1);
+    return rows[0];
+  }
+
+  it("writes a registered run_id unchanged", async () => {
+    await logActivity(db, {
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "issue.created",
+      entityType: "issue",
+      entityId: randomUUID(),
+      agentId,
+      runId: registeredRunId,
+    });
+
+    expect((await onlyActivityRow()).runId).toBe(registeredRunId);
+  });
+
+  it("substitutes NULL for a well-formed but unregistered run_id instead of throwing", async () => {
+    const unregisteredRunId = randomUUID();
+
+    await expect(
+      logActivity(db, {
+        companyId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "issue.created",
+        entityType: "issue",
+        entityId: randomUUID(),
+        agentId,
+        runId: unregisteredRunId,
+      }),
+    ).resolves.not.toThrow();
+
+    expect((await onlyActivityRow()).runId).toBeNull();
+  });
+
+  it("leaves a null run_id null (existing behavior unchanged)", async () => {
+    await logActivity(db, {
+      companyId,
+      actorType: "system",
+      actorId: "system",
+      action: "issue.created",
+      entityType: "issue",
+      entityId: randomUUID(),
+      runId: null,
+    });
+
+    expect((await onlyActivityRow()).runId).toBeNull();
+  });
+});

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog } from "@paperclipai/db";
+import { activityLog, heartbeatRuns } from "@paperclipai/db";
 import { PLUGIN_EVENT_TYPES, type PluginEventType } from "@paperclipai/shared";
 import type { PluginEvent } from "@paperclipai/plugin-sdk";
 import { publishLiveEvent } from "./live-events.js";
@@ -62,7 +63,34 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+/**
+ * Resolve a caller-supplied run_id against `heartbeat_runs` before it is written
+ * to the FK-constrained `activity_log.run_id` column. Process-adapter callers can
+ * self-mint a run_id that was never registered in `heartbeat_runs` (they did not go
+ * through the executor); writing it verbatim violates the FK and 500s an operation
+ * whose main row has already committed. When the run_id does not resolve we degrade
+ * gracefully to NULL — matching the existing behavior for null-run_id callers — and
+ * emit a warning for observability. The lookup runs on the same `db` handle (which
+ * may be a transaction), so the substitution happens before commit and the FK error
+ * is never triggered.
+ */
+async function resolveRunId(db: Db, runId: string | null | undefined): Promise<string | null> {
+  if (!runId) return null;
+  const [row] = await db
+    .select({ id: heartbeatRuns.id })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .limit(1);
+  if (row) return runId;
+  logger.warn(
+    { runId },
+    "activity-log: run_id not found in heartbeat_runs; writing activity_log with run_id=null",
+  );
+  return null;
+}
+
 export async function logActivity(db: Db, input: LogActivityInput) {
+  const resolvedRunId = await resolveRunId(db, input.runId);
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
   };
@@ -78,7 +106,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId: resolvedRunId,
     details: redactedDetails,
   });
 
@@ -92,7 +120,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       entityType: input.entityType,
       entityId: input.entityId,
       agentId: input.agentId ?? null,
-      runId: input.runId ?? null,
+      runId: resolvedRunId,
       details: redactedDetails,
     },
   });
@@ -111,7 +139,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       payload: {
         ...redactedDetails,
         agentId: input.agentId ?? null,
-        runId: input.runId ?? null,
+        runId: resolvedRunId,
       },
     };
     publishPluginDomainEvent(event);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Every `issue.created` / `comment.created` write fires an `activity_log` side-effect through the centralized `logActivity` writer
> - `logActivity` copies the caller's JWT `run_id` claim verbatim into the FK column `activity_log.run_id → heartbeat_runs(id)`
> - Process-adapter callers that self-mint a `run_id` (never registered in `heartbeat_runs` by the executor) violate `activity_log_run_id_heartbeat_runs_id_fk` and get a **500 — after the issue/comment row has already committed**, inviting duplicate-create retries
> - This pull request resolves the `run_id` against `heartbeat_runs` before the insert and substitutes `NULL` when it does not resolve (the same value ~5,100 rows/week already store successfully), emitting an observability warning
> - The benefit is that issue/comment creation can never 500 on an activity-log side-effect, the FK constraint stays intact, and the BLU-14518 pre-registration workaround becomes unnecessary

## Linked Issues or Issue Description

No public GitHub issue exists; the underlying defect is tracked internally as BLU-14531 (parent epic BLU-14530). Describing it inline per CONTRIBUTING.md path (B), following `bug_report.yml`:

**What happened?**
`activity_log` inserts on `issue.created` / `comment.created` copy the caller's JWT `run_id` claim straight into the FK column `run_id → heartbeat_runs(id)`. Any process-adapter caller that self-mints a `run_id` (does not go through the executor, which registers the row in `heartbeat_runs`) violates `activity_log_run_id_heartbeat_runs_id_fk` and receives a **500 on issue/comment creation** — even though the primary row has already committed.

**Expected behavior**
Issue/comment creation succeeds regardless of whether the caller's `run_id` is registered. An unresolvable `run_id` should not abort the write; the `activity_log` row should be written with `run_id = NULL` (consistent with the rows that already store NULL today).

**Steps to reproduce**
1. Create an issue/comment with a well-formed UUID `run_id` claim that has no matching `heartbeat_runs` row.
2. Observe a `23503` FK violation (`activity_log_run_id_heartbeat_runs_id_fk`) → 500, after the main row committed.

**Paperclip version or commit**
Reproduces on `bod/master` HEAD.

**Agent adapter(s) involved**
Not adapter-specific (core bug) — affects any process-adapter caller that self-mints a `run_id`.

## What Changed

- `server/src/services/activity-log.ts` — add `resolveRunId(db, runId)` helper; use the resolved value for the `activity_log` insert, the live event payload, and the plugin domain-event payload. Resolution runs on the same `db` handle (possibly the parent transaction) so the NULL substitution happens before commit and the FK error is never triggered. Centralized in `logActivity`, so all call sites are covered in one place.
- `server/src/__tests__/activity-log-runid-fallback.test.ts` — embedded-Postgres tests covering: registered `run_id` kept, unregistered → NULL + no throw, NULL → NULL.

The FK constraint is **kept in place** — we avoid triggering it by substituting NULL, not by weakening the constraint.

| Caller sends | Before | After |
|---|---|---|
| Registered `run_id` | written | written (unchanged) |
| Well-formed UUID, not in `heartbeat_runs` | **500 (FK violation)** | `NULL` written + warn |
| `run_id = NULL` | `NULL` | `NULL` (unchanged) |

## Verification

- New: `server/src/__tests__/activity-log-runid-fallback.test.ts` — 3 passing (registered → kept, unregistered → NULL + no throw, null → NULL). The unregistered-`run_id` test reproduces the exact `23503` FK violation against `bod/master` HEAD and goes green with the fix.
- Regression: existing `activity-service.test.ts` — 5 passing.
- Run locally: `npm test -- activity-log-runid-fallback activity-service` (server package).

## Risks

Low risk. The change only alters the value written to `activity_log.run_id` when that value would otherwise violate the FK (substituting NULL, which the column already accepts for ~5,100 rows/week). Registered `run_id`s are written unchanged. No schema/migration change; the FK constraint is preserved. A warning is emitted on substitution for observability.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have considered and documented any risks above

---

_Scope note for reviewer:_ This is a Paperclip control-plane change beyond Super Dev's original BLU-7088 carve-out. It is an explicitly-assigned platform ticket (parent epic BLU-14530) and requires human (Board / Head of Product) review before merge — flagging so the scope expansion is reviewed, not assumed. Refs: BLU-14531 (parent BLU-14530), supersedes BLU-14518 workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
