### PR TITLE
feat(server): split issue:comment authorization from issue:mutate (WKP-118)

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -912,4 +912,185 @@ describeEmbeddedPostgres("authorization service", () => {
       grant: { permissionKey: "tasks:assign" },
     });
   });
+
+  it("lets a manager comment on a child issue assigned to a report", async () => {
+    const company = await createCompany(db, "CommentManagerDown");
+    const ceo = await createAgent(db, company.id, { role: "ceo" });
+    const report = await createAgent(db, company.id, { reportsTo: ceo.id });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: report.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: ceo.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: issue.assigneeAgentId,
+        status: issue.status,
+      },
+    });
+
+    expect(decision).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+  });
+
+  it("lets a parent-issue assignee comment on a child assigned to another agent", async () => {
+    const company = await createCompany(db, "CommentParentDown");
+    const parentAssignee = await createAgent(db, company.id);
+    const childAssignee = await createAgent(db, company.id);
+    const parentIssue = await createIssue(db, company.id, { assigneeAgentId: parentAssignee.id });
+    const childIssue = await createIssue(db, company.id, {
+      parentId: parentIssue.id,
+      assigneeAgentId: childAssignee.id,
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: parentAssignee.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: childIssue.id,
+        parentIssueId: childIssue.parentId,
+        assigneeAgentId: childIssue.assigneeAgentId,
+        status: childIssue.status,
+      },
+    });
+
+    expect(decision).toMatchObject({ allowed: true, reason: "allow_parent_assignee" });
+  });
+
+  it("lets a mentioned thread participant comment on the mentioning issue", async () => {
+    const company = await createCompany(db, "CommentMentionUp");
+    const assignee = await createAgent(db, company.id);
+    const mentioned = await createAgent(db, company.id);
+    const issue = await createIssue(db, company.id, { assigneeAgentId: assignee.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: mentioned.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: issue.assigneeAgentId,
+        status: issue.status,
+        threadParticipantAgentIds: [mentioned.id],
+      },
+    });
+
+    expect(decision).toMatchObject({ allowed: true, reason: "allow_thread_participant" });
+  });
+
+  it("denies comments from an unrelated agent that is not assignee, manager, parent, or participant", async () => {
+    const company = await createCompany(db, "CommentUnrelatedDenied");
+    const assignee = await createAgent(db, company.id);
+    const unrelated = await createAgent(db, company.id);
+    const issue = await createIssue(db, company.id, { assigneeAgentId: assignee.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: unrelated.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        parentIssueId: issue.parentId,
+        assigneeAgentId: issue.assigneeAgentId,
+        status: issue.status,
+        threadParticipantAgentIds: [],
+      },
+    });
+
+    expect(decision).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+  });
+
+  it("keeps issue:mutate strictly assignee-only for managers, parents, and participants", async () => {
+    const company = await createCompany(db, "MutateRegression");
+    const ceo = await createAgent(db, company.id, { role: "ceo" });
+    const report = await createAgent(db, company.id, { reportsTo: ceo.id });
+    const parentAssignee = await createAgent(db, company.id);
+    const mentioned = await createAgent(db, company.id);
+    const parentIssue = await createIssue(db, company.id, { assigneeAgentId: parentAssignee.id });
+    const issue = await createIssue(db, company.id, {
+      parentId: parentIssue.id,
+      assigneeAgentId: report.id,
+    });
+
+    const authorization = authorizationService(db);
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: issue.id,
+      parentIssueId: issue.parentId,
+      assigneeAgentId: issue.assigneeAgentId,
+      status: issue.status,
+      // Even if a participant set were supplied, mutate must ignore it.
+      threadParticipantAgentIds: [mentioned.id],
+    };
+
+    const managerMutate = await authorization.decide({
+      actor: { type: "agent", agentId: ceo.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource,
+    });
+    const parentMutate = await authorization.decide({
+      actor: { type: "agent", agentId: parentAssignee.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource,
+    });
+    const mentionedMutate = await authorization.decide({
+      actor: { type: "agent", agentId: mentioned.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource,
+    });
+
+    expect(managerMutate).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    expect(parentMutate).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    expect(mentionedMutate).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+  });
+
+  it("denies comments from a low-trust agent outside its boundary", async () => {
+    const company = await createCompany(db, "CommentLowTrustOutside");
+    const project = await createProject(db, company.id, "Allowed");
+    const otherProject = await createProject(db, company.id, "Denied");
+    const rootIssueId = randomUUID();
+    const actorAgent = await createAgent(db, company.id, {
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            projectIds: [project.id],
+            rootIssueId,
+          },
+        },
+      },
+    });
+    await createIssue(db, company.id, {
+      id: rootIssueId,
+      projectId: project.id,
+      assigneeAgentId: actorAgent.id,
+    });
+    const outsideIssue = await createIssue(db, company.id, { projectId: otherProject.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: outsideIssue.id,
+        projectId: outsideIssue.projectId,
+        parentIssueId: outsideIssue.parentId,
+        status: outsideIssue.status,
+        // Participation must not override the low-trust boundary.
+        threadParticipantAgentIds: [actorAgent.id],
+      },
+    });
+
+    expect(decision).toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+  });
 });

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -27,6 +27,7 @@ const mockIssueService = vi.hoisted(() => ({
   removeAttachment: vi.fn(),
   update: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
@@ -318,12 +319,14 @@ describe("agent issue mutation checkout ownership", () => {
         input.action === "tasks:assign" ||
         input.action === "issue:read" ||
         input.action === "issue:mutate" ||
+        input.action === "issue:comment" ||
         input.action === "company_scope:read",
       action: input.action,
       reason:
         input.action === "tasks:assign" ||
           input.action === "issue:read" ||
           input.action === "issue:mutate" ||
+          input.action === "issue:comment" ||
           input.action === "company_scope:read"
           ? "allow_explicit_grant"
           : "deny_missing_grant",
@@ -331,6 +334,7 @@ describe("agent issue mutation checkout ownership", () => {
         input.action === "tasks:assign" ||
           input.action === "issue:read" ||
           input.action === "issue:mutate" ||
+          input.action === "issue:comment" ||
           input.action === "company_scope:read"
           ? "Allowed by test default."
           : "Missing permission.",
@@ -568,7 +572,9 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
+    // NOTE: "comment" intentionally omitted here — WKP-118 decoupled commenting
+    // from issue:mutate, so comments are NOT blocked by another agent's active
+    // checkout. That behavior is covered by the dedicated comment test below.
     [
       "document upsert",
       (app: express.Express) =>
@@ -606,6 +612,24 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("allows a boundary-authorized peer agent to comment on another agent's active checkout", async () => {
+    // WKP-118: commenting is a coordination primitive (issue:comment), decoupled
+    // from issue:mutate. A peer who passes the issue:comment boundary (e.g. a
+    // manager, parent-issue assignee, or thread participant) may comment even
+    // though another agent holds the in_progress checkout — no 409 checkout gate.
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "coordination note" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "issue:comment" }),
+    );
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("rejects the checked-out owner without a run id on attachment upload (401)", async () => {
@@ -975,7 +999,7 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
+    // "comment" omitted — comments are decoupled from issue:mutate (WKP-118).
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   getDependencyReadiness: vi.fn(),
   getCurrentScheduledRetry: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
 }));
@@ -522,8 +523,20 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
-  it("rejects non-assignee agent POST comments on closed issues", async () => {
+  it("rejects unauthorized (non-participant) agent POST comments on closed issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    // WKP-118: commenting is gated by issue:comment, not issue:mutate. An agent
+    // that is not the assignee, manager, parent assignee, or thread participant
+    // fails the issue:comment boundary decision and is rejected.
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => {
+      const allowed = input.action !== "issue:comment" && input.action !== "tasks:manage_active_checkouts";
+      return {
+        allowed,
+        action: input.action,
+        reason: allowed ? "allow_explicit_grant" : "deny_missing_grant",
+        explanation: allowed ? "Allowed by test grant." : "Outside comment authorization boundary.",
+      };
+    });
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -546,7 +559,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "hello" });
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
@@ -1493,8 +1506,11 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "restart someone else's work", resume: true });
 
+    // Commenting itself is now decoupled from issue:mutate (WKP-118), but the
+    // explicit resume/follow-up intent is still gated to the assignee, so a
+    // non-assignee resume request is rejected by the resume-intent guard.
     expect(res.status).toBe(403);
-    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(res.body.error).toBe("Agent cannot request follow-up for another agent's issue");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   createChild: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),

--- a/server/src/__tests__/issue-feedback-routes.test.ts
+++ b/server/src/__tests__/issue-feedback-routes.test.ts
@@ -16,6 +16,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
 }));
 
 const mockFeedbackExportService = vi.hoisted(() => ({

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),

--- a/server/src/__tests__/issue-workspace-command-authz.test.ts
+++ b/server/src/__tests__/issue-workspace-command-authz.test.ts
@@ -7,6 +7,7 @@ const mockIssueService = vi.hoisted(() => ({
   assertCheckoutOwner: vi.fn(),
   create: vi.fn(),
   findMentionedAgents: vi.fn(),
+  findThreadParticipantAgentIds: vi.fn(async () => []),
   getByIdentifier: vi.fn(),
   getById: vi.fn(),
   getRelationSummaries: vi.fn(),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1775,7 +1775,8 @@ export function issueRoutes(
       assigneeUserId: string | null;
       status: string;
     },
-    action: "issue:read" | "issue:mutate",
+    action: "issue:read" | "issue:mutate" | "issue:comment",
+    extra?: { threadParticipantAgentIds?: string[] | null },
   ) {
     return access.decide({
       actor: req.actor,
@@ -1789,6 +1790,9 @@ export function issueRoutes(
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
         status: issue.status,
+        ...(extra?.threadParticipantAgentIds
+          ? { threadParticipantAgentIds: extra.threadParticipantAgentIds }
+          : {}),
       },
       scope: {
         issueId: issue.id,
@@ -1919,6 +1923,47 @@ export function issueRoutes(
           reason: "stale_checkout_run",
         },
       });
+    }
+    return true;
+  }
+
+  /**
+   * Authorization guard for posting comments. Commenting is a coordination
+   * primitive (`issue:comment`), decoupled from state/field mutation
+   * (`issue:mutate`). An agent may comment when it is the assignee, the issue
+   * has no agent assignee, it manages the assignee, it is assigned the parent
+   * issue, or it participates in / was @-mentioned on the thread — resolved by
+   * `access.decide` against the `issue:comment` action. Low-trust boundary
+   * scoping still applies inside `decide`.
+   *
+   * Unlike mutation, comments are allowed even while another agent holds the
+   * checkout of an `in_progress` issue, so there is intentionally no 409/owner
+   * gate here: the boundary decision is the complete check.
+   */
+  async function assertAgentIssueCommentAllowed(
+    req: Request,
+    res: Response,
+    issue: {
+      id: string;
+      companyId: string;
+      projectId: string | null;
+      parentId: string | null;
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+    },
+  ) {
+    if (req.actor.type !== "agent") return true;
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) {
+      res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+    const threadParticipantAgentIds = await svc.findThreadParticipantAgentIds(issue.id);
+    const decision = await decideIssueAccess(req, issue, "issue:comment", { threadParticipantAgentIds });
+    if (!decision.allowed) {
+      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      return false;
     }
     return true;
   }
@@ -6624,7 +6669,7 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(await assertAgentIssueCommentAllowed(req, res, issue))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -46,6 +46,7 @@ export type AuthorizationAction =
   | "agent:wake"
   | "company_scope:read"
   | "issue:mutate"
+  | "issue:comment"
   | "issue:read"
   | "project:read"
   | "runtime:manage"
@@ -64,6 +65,13 @@ export type AuthorizationResource =
       assigneeAgentId?: string | null;
       assigneeUserId?: string | null;
       status?: string | null;
+      /**
+       * Agents who participate in the issue thread (comment authors) or were
+       * @-mentioned anywhere on it. Used only by `issue:comment` decisions so
+       * coordination participants may comment without `issue:mutate` rights.
+       * Resolved by the route layer via the issues service.
+       */
+      threadParticipantAgentIds?: string[] | null;
     };
 
 export type AuthorizationDecision = {
@@ -81,6 +89,8 @@ export type AuthorizationDecision = {
     | "allow_company_member"
     | "allow_simple_company_member"
     | "allow_manager_chain"
+    | "allow_parent_assignee"
+    | "allow_thread_participant"
     | "deny_unauthenticated"
     | "deny_company_boundary"
     | "deny_missing_membership"
@@ -118,7 +128,7 @@ function permissionForAction(action: AuthorizationAction): PermissionKey | null 
   ) {
     return null;
   }
-  if (action === "issue:mutate") return null;
+  if (action === "issue:mutate" || action === "issue:comment") return null;
   return action;
 }
 
@@ -753,7 +763,11 @@ export function authorizationService(db: Db) {
         : lowTrustDeny("Project is outside this low-trust boundary.");
     }
 
-    if (input.action === "issue:read" || input.action === "issue:mutate") {
+    if (
+      input.action === "issue:read" ||
+      input.action === "issue:mutate" ||
+      input.action === "issue:comment"
+    ) {
       if (input.resource.type !== "issue") {
         return lowTrustDeny("Low-trust issue access is missing an issue resource.");
       }
@@ -1168,6 +1182,54 @@ export function authorizationService(db: Db) {
           action: input.action,
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
+        });
+      }
+    }
+    if (input.action === "issue:comment") {
+      const resource = input.resource.type === "issue" ? input.resource : null;
+      // 1. The actor is the assignee of the issue being commented on.
+      if (resource?.assigneeAgentId === actorAgentId) {
+        return allow({
+          action: input.action,
+          reason: "allow_self",
+          explanation: "Allowed because the actor owns the assigned issue.",
+        });
+      }
+      // 2. The issue has no agent assignee (company-wide coordination surface).
+      if (resource && !resource.assigneeAgentId) {
+        return allow({
+          action: input.action,
+          reason: "allow_company_agent",
+          explanation: "Allowed because the issue has no agent assignee.",
+        });
+      }
+      if (resource?.assigneeAgentId) {
+        // 3. The actor manages the assignee in the reporting chain.
+        if (await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId)) {
+          return allow({
+            action: input.action,
+            reason: "allow_manager_chain",
+            explanation: "Allowed because the actor manages the issue assignee in the reporting chain.",
+          });
+        }
+      }
+      // 4. The actor is the assignee of the parent issue.
+      if (resource?.parentIssueId) {
+        const parent = await loadIssue(resource.parentIssueId);
+        if (parent && parent.assigneeAgentId === actorAgentId) {
+          return allow({
+            action: input.action,
+            reason: "allow_parent_assignee",
+            explanation: "Allowed because the actor is assigned the parent issue.",
+          });
+        }
+      }
+      // 5. The actor was @-mentioned on the thread or authored a comment on it.
+      if (resource?.threadParticipantAgentIds?.includes(actorAgentId)) {
+        return allow({
+          action: input.action,
+          reason: "allow_thread_participant",
+          explanation: "Allowed because the actor participates in or was mentioned on the issue thread.",
         });
       }
     }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6343,6 +6343,49 @@ export function issueService(db: Db) {
       return explicitAgentMentionIds.filter((agentId) => companyAgentIds.has(agentId));
     },
 
+    /**
+     * Resolve the set of agents that "participate" in an issue thread: agents
+     * who authored a (non-deleted) comment on it, plus agents @-mentioned
+     * anywhere on the thread (title, description, or comment bodies). Used by
+     * the comment-authorization guard so coordination participants may comment
+     * on an issue assigned to someone else without holding `issue:mutate`.
+     */
+    findThreadParticipantAgentIds: async (issueId: string): Promise<string[]> => {
+      const issue = await db
+        .select({
+          companyId: issues.companyId,
+          title: issues.title,
+          description: issues.description,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      if (!issue) return [];
+
+      const comments = await db
+        .select({ body: issueComments.body, authorAgentId: issueComments.authorAgentId })
+        .from(issueComments)
+        .where(and(eq(issueComments.issueId, issueId), isNull(issueComments.deletedAt)));
+
+      const candidateIds = new Set<string>();
+      for (const source of [issue.title, issue.description ?? ""]) {
+        for (const agentId of extractAgentMentionIds(source)) candidateIds.add(agentId);
+      }
+      for (const comment of comments) {
+        if (comment.authorAgentId) candidateIds.add(comment.authorAgentId);
+        for (const agentId of extractAgentMentionIds(comment.body)) candidateIds.add(agentId);
+      }
+
+      if (candidateIds.size === 0) return [];
+
+      const rows = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.companyId, issue.companyId), inArray(agents.id, [...candidateIds])));
+      const valid = new Set(rows.map((row) => row.id));
+      return [...candidateIds].filter((agentId) => valid.has(agentId));
+    },
+
     findMentionedProjectIds: async (
       issueId: string,
       opts?: { includeCommentBodies?: boolean },


### PR DESCRIPTION
## Summary

Splits a new authorization action `issue:comment` out of `issue:mutate` so commenting is a **coordination primitive**, while state/field mutation stays strictly assignee-only. Implements the board-accepted fix from WKP-116.

## Changes
- **`server/src/services/authorization.ts`** — new `issue:comment` action (`permissionForAction` → `null`); new `decide()` branch allowing **assignee · unassigned · manager-of-assignee · parent-issue assignee · thread participant/@-mention**, routed through `decideLowTrustAccess` so low-trust scoping still applies. The `issue:mutate` branch is unchanged.
- **`server/src/services/issues.ts`** — `findThreadParticipantAgentIds(issueId)` resolving comment authors + @-mentions across title/description/comments, company-scoped, excluding deleted comments.
- **`server/src/routes/issues.ts`** — `assertAgentIssueCommentAllowed`; **only** `POST /issues/:id/comments` repointed to it. All other `assertAgentIssueMutationAllowed` call sites stay on `issue:mutate`. Comments are allowed even when another agent holds the checkout (no 409 gate); the existing resume-intent guard still blocks non-assignee reopen.

## Security notes
- `issue:mutate` decision path is byte-for-byte unchanged; cross-agent `PATCH`/`DELETE`/document/work-product writes still return `403`/`409`.
- Comment allow-set is exactly the five conditions above — unrelated agents are denied.
- Low-trust boundary is evaluated in front of `issue:comment`; participation cannot override the boundary.

## Tests
- `authorization-service.test.ts`: **28 passed** (6 new — manager-down, parent-down, mention-up, unrelated-deny, **mutate regression**, low-trust-deny).
- `issue-agent-mutation-ownership-routes` + `issue-comment-reopen-routes`: **107 passed** (updated for decoupled comments; added "comment allowed on another agent's active checkout").
- Full server suite: **2510 passed**; the only failures are pre-existing env issues (unbuilt `@paperclipai/plugin-sdk`, worktree git/seed), unrelated to this change.
- `tsc --noEmit`: 0 errors in changed files.

## Review
Independent security-focused review completed and **approved** (Paperclip WKP-121) — no required changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)