### PR TITLE
fix(opencode_local): preserve custom providers by parsing runtime config as JSONC

### DIFF
--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "json5": "^2.2.3",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -30,6 +30,17 @@ async function makeConfigHome(initialConfig?: Record<string, unknown>) {
   return root;
 }
 
+// Writes opencode.json verbatim so tests can exercise *raw* JSONC bytes (comments,
+// trailing commas) that `JSON.stringify` would never produce.
+async function makeConfigHomeRaw(rawConfig: string) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-opencode-test-"));
+  cleanupPaths.add(root);
+  const configDir = path.join(root, "opencode");
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.writeFile(path.join(configDir, "opencode.json"), rawConfig, "utf8");
+  return root;
+}
+
 describe("prepareOpenCodeRuntimeConfig", () => {
   it("injects an external_directory allow rule by default", async () => {
     const configHome = await makeConfigHome({
@@ -63,6 +74,80 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     await prepared.cleanup();
     cleanupPaths.delete(prepared.env.XDG_CONFIG_HOME);
     await expect(fs.access(prepared.env.XDG_CONFIG_HOME)).rejects.toThrow();
+  });
+
+  it("preserves custom providers from a JSONC opencode.json (comments + trailing commas) without corrupting http:// URLs", async () => {
+    // A *raw* JSONC config: line + inline comments and trailing commas -- exactly
+    // the kind of valid OpenCode config that strict JSON.parse rejects. The
+    // provider baseURL is an http:// URL to prove the tolerant parser does not
+    // treat the `//` inside the string as a comment.
+    const rawJsonc = [
+      "{",
+      "  // local gateway provider",
+      '  "provider": {',
+      '    "ollama": {',
+      '      "npm": "@ai-sdk/openai-compatible",',
+      '      "options": {',
+      '        "baseURL": "http://localhost:11434/v1", // talk to the local server',
+      "      },",
+      '      "models": {',
+      '        "qwen2.5-coder": { "name": "Qwen 2.5 Coder" },',
+      "      },",
+      "    },",
+      "  },",
+      '  "theme": "system",',
+      "}",
+      "",
+    ].join("\n");
+    const configHome = await makeConfigHomeRaw(rawJsonc);
+
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {},
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as {
+      provider?: {
+        ollama?: { options?: { baseURL?: string }; models?: Record<string, unknown> };
+      };
+      permission?: Record<string, unknown>;
+      theme?: string;
+    };
+
+    // The custom provider survived the permission merge, with the http:// URL intact.
+    expect(runtimeConfig.provider?.ollama?.options?.baseURL).toBe("http://localhost:11434/v1");
+    expect(runtimeConfig.provider?.ollama?.models).toMatchObject({
+      "qwen2.5-coder": { name: "Qwen 2.5 Coder" },
+    });
+    expect(runtimeConfig.theme).toBe("system");
+    // ...and the permission injection still happened.
+    expect(runtimeConfig.permission).toMatchObject({ external_directory: "allow" });
+
+    await prepared.cleanup();
+  });
+
+  it("does not destroy a copied opencode.json that cannot be parsed even as JSONC", async () => {
+    const garbage = "{ this is : definitely <<< not valid json or jsonc at all";
+    const configHome = await makeConfigHomeRaw(garbage);
+
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {},
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimePath = path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json");
+    // Fail-open: preserve the file verbatim rather than overwrite it with a stub.
+    expect(await fs.readFile(runtimePath, "utf8")).toBe(garbage);
+    expect(prepared.notes.some((n) => n.includes("left it intact"))).toBe(true);
+
+    await prepared.cleanup();
   });
 
   it("merges custom providers from PAPERCLIP_OPENCODE_PROVIDERS into the config", async () => {

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
+import JSON5 from "json5";
 
 type PreparedOpenCodeRuntimeConfig = {
   env: Record<string, string>;
@@ -84,13 +85,42 @@ function parseProviderConfig(
   return Object.keys(providers).length > 0 ? providers : null;
 }
 
-async function readJsonObject(filepath: string): Promise<Record<string, unknown>> {
+type RuntimeConfigRead =
+  | { status: "parsed"; config: Record<string, unknown> }
+  | { status: "missing" }
+  | { status: "unparseable" };
+
+// OpenCode's `opencode.json` is JSONC: it tolerates `//` / `/* */` comments and
+// trailing commas. We copy the user's config into a temp runtime dir and then
+// re-read it here to merge in `permission.external_directory: "allow"`. Re-reading
+// with strict `JSON.parse` throws on any JSONC, which previously collapsed the
+// config to `{}` and overwrote the runtime file with a permission-only stub --
+// silently deleting every custom provider the user had defined.
+//
+// JSON5 is a strict superset of JSONC, so any valid OpenCode config round-trips.
+// Critically, unlike a hand-rolled `//` comment stripper, it never mangles
+// in-string values such as `"baseURL": "http://host:11434/v1"` because `//`
+// inside a string literal is not a comment.
+async function readRuntimeConfigObject(filepath: string): Promise<RuntimeConfigRead> {
+  let raw: string;
   try {
-    const raw = await fs.readFile(filepath, "utf8");
-    const parsed = JSON.parse(raw);
-    return isPlainObject(parsed) ? parsed : {};
+    raw = await fs.readFile(filepath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      return { status: "missing" };
+    }
+    // The file exists but is unreadable -- treat it like an unparseable config so
+    // we fail open (preserve it) instead of clobbering it below.
+    return { status: "unparseable" };
+  }
+  if (raw.trim().length === 0) {
+    return { status: "parsed", config: {} };
+  }
+  try {
+    const parsed = JSON5.parse(raw);
+    return { status: "parsed", config: isPlainObject(parsed) ? parsed : {} };
   } catch {
-    return {};
+    return { status: "unparseable" };
   }
 }
 
@@ -140,7 +170,31 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     }
   }
 
-  const existingConfig = await readJsonObject(runtimeConfigPath);
+  const configRead = await readRuntimeConfigObject(runtimeConfigPath);
+
+  // Defensive fail-open: a copied config exists but could not be parsed even as
+  // JSONC/JSON5. Overwriting it with a permission-only stub would delete the
+  // user's custom providers, so instead leave the copied file untouched (OpenCode
+  // parses it itself) and skip permission injection for this run. "Providers
+  // preserved, permission maybe not injected" is a strictly safer failure than
+  // "providers deleted".
+  if (configRead.status === "unparseable") {
+    return {
+      env: {
+        ...input.env,
+        XDG_CONFIG_HOME: runtimeConfigHome,
+      },
+      notes: [
+        "Copied opencode.json could not be parsed as JSON or JSONC; left it intact and skipped permission.external_directory injection to preserve custom providers.",
+      ],
+      cleanup: async () => {
+        await fs.rm(runtimeConfigHome, { recursive: true, force: true });
+      },
+    };
+  }
+
+  const existingConfig: Record<string, unknown> =
+    configRead.status === "parsed" ? configRead.config : {};
   const existingPermission = isPlainObject(existingConfig.permission)
     ? existingConfig.permission
     : {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; agents run through pluggable runtime adapters.
> - The `opencode_local` adapter runs OpenCode as the agent runtime and, for unattended runs, injects `permission.external_directory: "allow"` into a per-run copy of the user's `opencode.json`.
> - `prepareOpenCodeRuntimeConfig` does this by copying `$XDG_CONFIG_HOME/opencode` into a temp dir, re-reading `opencode.json`, merging the permission, and rewriting the file.
> - The re-read used strict `JSON.parse`, but OpenCode config is **JSONC** (comments + trailing commas), so any JSONC config threw, was swallowed to `{}`, and the rewrite overwrote the copied config with a permission-only stub — silently deleting every custom provider.
> - The agent's OpenCode process then only saw built-in providers, surfacing `Configured OpenCode model is unavailable: ...; Available models: github-copilot/...`. Manual host runs worked because they read `~/.config/opencode` directly with no strict re-parse/overwrite.
> - This PR makes the re-read JSONC-tolerant (via `JSON5`, a strict superset of JSONC) so a valid OpenCode config round-trips and custom providers survive the permission merge, and fails open if a config is truly unparseable.
> - The benefit is that user-defined OpenCode providers are never silently dropped by the adapter, preventing a whole class of "model unavailable" failures.

## Linked Issues or Issue Description

Tracked internally as Paperclip issue **DEV-643** (no public GitHub issue). Described in-PR per the bug template:

- **What happened:** With a JSONC `~/.config/opencode/opencode.json` that defines a custom `provider` (e.g. a local/gateway OpenAI-compatible endpoint), the `opencode_local` adapter generated a per-run `opencode.json` containing only `permission.external_directory: "allow"` — the custom providers were gone. The OpenCode run then failed with `Configured OpenCode model is unavailable`.
- **Root cause:** `readJsonObject()` in `packages/adapters/opencode-local/src/server/runtime-config.ts` parsed the copied config with strict `JSON.parse`. On any JSONC (trailing comma/comment) it threw, returned `{}`, and the subsequent merge+rewrite overwrote the copied config with a permission-only stub.
- **Expected:** A valid OpenCode (JSONC) config round-trips; custom providers are preserved and the permission rule is still injected.

## What Changed

- `runtime-config.ts`: parse the copied runtime `opencode.json` with `JSON5` (strict superset of JSONC) instead of strict `JSON.parse`, so valid OpenCode configs round-trip. `JSON5` never corrupts in-string values such as `"baseURL": "http://host:11434/v1"` (the documented footgun a naive `//` comment stripper would hit).
- `runtime-config.ts`: defensive fail-open — if the copied config cannot be parsed even as JSON5, leave the copied file intact and skip permission injection for that run (preferring "providers preserved, permission maybe not injected" over "providers deleted").
- `package.json`: add `json5@^2.2.3` as a direct dependency of `@paperclipai/adapter-opencode-local` (already resolved in the lockfile; ships its own types).
- `runtime-config.test.ts`: add a raw-JSONC test (line/inline comments + trailing commas + a custom provider whose `options.baseURL` is an `http://` URL) asserting the provider and URL survive and `permission.external_directory: "allow"` is injected; add a fail-open test asserting an unparseable copied config is preserved verbatim. The previous tests only wrote configs via `JSON.stringify`, so they never exercised JSONC — that gap let this ship.

Note: `parseProviderConfig` (which parses the machine-generated `PAPERCLIP_OPENCODE_PROVIDERS` env var) intentionally keeps strict `JSON.parse` — that value is serialized by Paperclip via `JSON.stringify`, so strict parsing is correct and its existing "invalid JSON" diagnostics are preserved.

## Verification

Run from repo root:

- `pnpm exec vitest run packages/adapters/opencode-local/src/server/runtime-config.test.ts` → **13 passed** (11 existing + 2 new).
- `pnpm --filter @paperclipai/adapter-opencode-local typecheck` → exit 0.
- `pnpm --filter @paperclipai/adapter-opencode-local build` → exit 0.
- `pnpm install --frozen-lockfile` → exit 0 (lockfile is consistent).
- `pnpm run check:tokens` → no forbidden tokens.

Manual repro of the parser behavior (proves the bug and the fix):

```
strict JSON.parse => THREW: Expected property name or '}' in JSON at position 4
JSON5 baseURL     => http://localhost:11434/v1
```

i.e. the raw JSONC config (trailing comma + comment) that strict `JSON.parse` rejects is parsed correctly by `JSON5`, and the `http://` provider URL is preserved intact.

## Risks

Low risk. The change is isolated to the `opencode_local` adapter:
- JSONC is a strict subset of JSON5, so every config that previously parsed (strict JSON) still parses identically; only previously-failing JSONC now parses instead of collapsing to `{}`.
- The new dependency (`json5@2.2.3`) was already present in the lockfile transitively; this only adds a direct importer edge.
- The fail-open path only triggers for configs that are unparseable even as JSON5 (which OpenCode itself would also reject); in that case it preserves the user's file instead of destroying it.

## Model Used

Claude (Anthropic) — `claude-opus-4.8`, extended thinking enabled, with tool use / code execution. Authored via Paperclip's CTO agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
