### PR TITLE
Fix claude_local marking successful runs as failed after post-result SIGTERM

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.local.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.local.test.ts
@@ -1,0 +1,155 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runChildProcess, ensureCommandResolvable, resolveCommandForLogs } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "claude"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function streamJsonStdout(resultEvent: Record<string, unknown>): string {
+  return [
+    JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-opus" }),
+    JSON.stringify({
+      type: "assistant",
+      session_id: "claude-session-1",
+      message: { content: [{ type: "text", text: "working on it" }] },
+    }),
+    JSON.stringify({
+      type: "result",
+      session_id: "claude-session-1",
+      usage: { input_tokens: 10, cache_read_input_tokens: 2, output_tokens: 5 },
+      total_cost_usd: 0.25,
+      ...resultEvent,
+    }),
+  ].join("\n");
+}
+
+function processResult(overrides: Partial<{ exitCode: number | null; signal: string | null; stdout: string }>) {
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("claude local run result classification", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function runExecute() {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-local-"));
+    cleanupDirs.push(rootDir);
+    const instructionsPath = path.join(rootDir, "instructions.md");
+    await writeFile(instructionsPath, "Do the work.\n", "utf8");
+
+    return execute({
+      runId: "run-local-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+        cwd: rootDir,
+        instructionsFilePath: instructionsPath,
+      },
+      context: {},
+      onLog: async () => {},
+    });
+  }
+
+  it("treats an explicit success result as success even when the lingering process exits 143 after SIGTERM cleanup", async () => {
+    runChildProcess.mockResolvedValue(
+      processResult({
+        exitCode: 143,
+        stdout: streamJsonStdout({
+          subtype: "success",
+          is_error: false,
+          result: "Everything is committed and the issue is closed out.",
+        }),
+      }),
+    );
+
+    const result = await runExecute();
+
+    expect(result.errorMessage).toBeNull();
+    expect(result.errorCode).toBeNull();
+    // The server derives run status from exitCode too, so a self-inflicted
+    // post-result kill must not leak a non-zero code.
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("Everything is committed and the issue is closed out.");
+    expect(result.resultJson).toMatchObject({ processExitCode: 143 });
+  });
+
+  it("still fails when the result event reports is_error=true despite subtype=success", async () => {
+    runChildProcess.mockResolvedValue(
+      processResult({
+        exitCode: 1,
+        stdout: streamJsonStdout({
+          subtype: "success",
+          is_error: true,
+          result: "API Error: The socket connection was closed unexpectedly.",
+        }),
+      }),
+    );
+
+    const result = await runExecute();
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("API Error");
+    expect(result.errorMessage).not.toContain("subtype=success");
+  });
+
+  it("keeps non-zero exits failed when no terminal result event was emitted", async () => {
+    runChildProcess.mockResolvedValue(
+      processResult({
+        exitCode: 1,
+        stdout: JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1" }),
+      }),
+    );
+
+    const result = await runExecute();
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).not.toBeNull();
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -878,7 +878,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const poisonedPreviousMessageId = isClaudePoisonedPreviousMessageIdError(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    // A terminal result event with subtype=success and is_error=false is
+    // authoritative: the run completed even if the process later exits
+    // non-zero — e.g. Claude lingers on background tasks after the result and
+    // the terminalResultCleanup SIGTERM makes it exit 143.
+    // Default is_error to true so an absent field is never read as success.
+    const completedSuccessfully =
+      !asBoolean(parsed.is_error, true) && asString(parsed.subtype, "") === "success";
+    const failed = !completedSuccessfully && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
+    const maskedExitCode = completedSuccessfully && (proc.exitCode ?? 0) !== 0;
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
     // session id; if the last entry contains a non-`msg_`-prefixed
@@ -936,6 +944,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
     const mergedResultJson: Record<string, unknown> = {
       ...parsed,
+      ...(maskedExitCode
+        ? { processExitCode: proc.exitCode, ...(proc.signal ? { processSignal: proc.signal } : {}) }
+        : {}),
       ...(failed && clearSessionForMaxTurns ? { stopReason: "max_turns_exhausted" } : {}),
       ...(failed && poisonedPreviousMessageId ? { stopReason: "claude_poisoned_previous_message_id" } : {}),
       ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
@@ -944,8 +955,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     return {
-      exitCode: proc.exitCode,
-      signal: proc.signal,
+      exitCode: maskedExitCode ? 0 : proc.exitCode,
+      signal: maskedExitCode ? null : proc.signal,
       timedOut: false,
       errorMessage,
       errorCode: resolvedErrorCode,

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -159,7 +159,9 @@ export function describeClaudeFailure(parsed: Record<string, unknown>): string |
   }
 
   const parts = ["Claude run failed"];
-  if (subtype) parts.push(`subtype=${subtype}`);
+  // Claude can report subtype=success alongside is_error=true (e.g. mid-run
+  // API errors); the label would only mislead, so omit it for that case.
+  if (subtype && subtype !== "success") parts.push(`subtype=${subtype}`);
   if (detail) parts.push(detail);
   return parts.length > 1 ? parts.join(": ") : null;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run through adapters; the `claude_local` adapter shells out to the Claude Code CLI and parses its stream-json output to decide whether a run succeeded
> - Claude emits a terminal result event (`subtype=success`, `is_error=false`) and can then stay alive on background work (a `run_in_background` Bash process, a monitor that re-invokes the agent)
> - The adapter's own `terminalResultCleanup` SIGTERMs that lingering process after the grace window; Claude traps SIGTERM and exits 143, and `toAdapterResult` judged failure from the non-zero exit code alone
> - So a finished run was recorded as `Claude run failed: subtype=success: <final text>` and the agent was flipped to `status=error` and stopped
> - This PR trusts the explicit success result over the exit code Paperclip itself caused, so successful runs are recorded as succeeded
> - The benefit is that agents using background tasks stop accumulating false failures and no longer get stranded in `status=error`

## Linked Issues or Issue Description

No existing issue tagged. Describing inline as a bug report:

**Bug:** `claude_local` marks successful runs as failed when the Claude process lingers after its terminal result and is killed by the post-result SIGTERM cleanup (exit 143).

**Steps to reproduce:** Run a `claude_local` agent whose turn starts a background task (Bash `run_in_background`, or any monitor that keeps the process alive after the result event). The `claude` process stays up past the `{type:"result",subtype:"success",is_error:false}` event, `terminalResultCleanup` SIGTERMs it after the grace window, and Claude exits 143.

**Expected:** Run recorded as succeeded — the result event explicitly reported success.

**Actual:** Run recorded as failed with `error = "Claude run failed: subtype=success: <final assistant text>"`; the misclassified `is_error` haystack can also tag it `claude_transient_upstream`, and the agent drops to `status=error`. Observed as the dominant failure mode for a background-task-heavy agent (39 of 40 failed runs).

**Related / duplicate PRs found during dedup search** — this bug has been submitted several times and none are merged; linking for maintainer triage:
- Refs #7284 — fix(claude-local): treat subtype=success as success regardless of process exit (ZDA-2909)
- Refs #5553 — fix(claude-local): trust Claude success result over SIGTERM exit code
- Refs #5124 — fix(claude_local): treat clean terminal result + grace-SIGTERM exit as success, not failure
- Refs #4335 — fix(adapter-claude-local): treat parsed success envelope as authoritative

## What Changed

- `execute.ts`: add a `completedSuccessfully` guard (`!asBoolean(parsed.is_error, true) && subtype === "success"`) that short-circuits the `failed` check. When a clean success result is present, normalize the returned `exitCode`/`signal` to `0`/`null` (the run engine in `server/src/services/heartbeat.ts` also derives run status from the raw exit code, so clearing `errorMessage` alone is not enough) and preserve the real values as `processExitCode`/`processSignal` in `resultJson`.
- `parse.ts`: stop appending `subtype=success` to failure messages — Claude reports mid-run API errors with `is_error=true` but `subtype=success`, so the label only misled.
- `execute.local.test.ts`: new test file covering the three classification cases.

## Verification

- `npx vitest run packages/adapters/claude-local/` → 31 passed (4 files)
- `npx tsc --noEmit` in `packages/adapters/claude-local` → clean (exit 0)
- Replayed real captured run logs from an affected deployment through the new classifier: an exit-143 run with a clean success result now succeeds; a genuine socket-error run (`is_error=true`) still fails, now with a cleaner message (`Claude run failed: API Error: ...`).

New tests:
1. Success result after an exit-143 cleanup → succeeds, `exitCode` normalized to 0, raw code kept in `resultJson.processExitCode`.
2. `is_error=true` despite `subtype=success` → still fails, message no longer contains `subtype=success`.
3. Non-zero exit with no terminal result event → still fails.

## Risks

Low risk. The masking only applies when the stream already reported a clean success (`subtype=success` and an explicitly-`false` `is_error`); an absent `is_error` defaults to `true` and is never read as success. Genuine failure paths (API errors, max-turns, poisoned-session, missing result) are unchanged. The real exit code/signal are preserved in `resultJson` for debugging.

## Model Used

Claude (Anthropic), via Claude Code with tool use and extended thinking. Investigation and fix authored with Claude Fable 5 (`claude-fable-5`, 1M context); PR revision and rebase under Claude Opus 4.8 (`claude-opus-4-8`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — no UI changes)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
