### PR TITLE
FUL-9946 enforce owner guardrail for critical issue creation

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
 import {
   addIssueCommentSchema,
+  createChildIssueSchema,
   createIssueSchema,
   issueBlockedInboxAttentionSchema,
   resolveIssueRecoveryActionSchema,
@@ -38,6 +39,76 @@ describe("issue validators", () => {
     });
 
     expect(parsed.description).toBe("PR: https://example.com/pr/1\n\nShip the follow-up.");
+  });
+
+  describe("critical-priority owner guardrail (FUL-9946)", () => {
+    const agentId = "11111111-1111-4111-8111-111111111111";
+
+    it("rejects a critical issue created without an owner", () => {
+      const result = createIssueSchema.safeParse({
+        title: "Sev1 outage",
+        priority: "critical",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((issue) => issue.path.includes("assigneeAgentId"))).toBe(true);
+      }
+    });
+
+    it("rejects a critical issue with explicitly null assignees", () => {
+      const result = createIssueSchema.safeParse({
+        title: "Sev1 outage",
+        priority: "critical",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a critical issue assigned to an agent", () => {
+      const result = createIssueSchema.safeParse({
+        title: "Sev1 outage",
+        priority: "critical",
+        assigneeAgentId: agentId,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a critical issue assigned to a user", () => {
+      const result = createIssueSchema.safeParse({
+        title: "Sev1 outage",
+        priority: "critical",
+        assigneeUserId: "user-123",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts an unowned critical issue when the missing owner is acknowledged", () => {
+      const result = createIssueSchema.safeParse({
+        title: "Sev1 outage",
+        priority: "critical",
+        missingOwnerAcknowledged: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("does not restrict non-critical priorities", () => {
+      expect(createIssueSchema.safeParse({ title: "Routine", priority: "high" }).success).toBe(true);
+      expect(createIssueSchema.safeParse({ title: "Routine" }).success).toBe(true);
+    });
+
+    it("enforces the guardrail on child issue creation too", () => {
+      expect(
+        createChildIssueSchema.safeParse({ title: "Sev1 child", priority: "critical" }).success,
+      ).toBe(false);
+      expect(
+        createChildIssueSchema.safeParse({
+          title: "Sev1 child",
+          priority: "critical",
+          assigneeAgentId: agentId,
+        }).success,
+      ).toBe(true);
+    });
   });
 
   it("normalizes escaped line breaks in issue update comments", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -372,6 +372,35 @@ function withCreateIssueStatusDefault<T extends z.ZodRawShape>(schema: z.ZodObje
   }, schema);
 }
 
+type CriticalOwnerGuardrailInput = {
+  priority?: unknown;
+  assigneeAgentId?: unknown;
+  assigneeUserId?: unknown;
+  missingOwnerAcknowledged?: unknown;
+};
+
+/**
+ * Guardrail (FUL-9946): a `critical` priority issue must be created with an owner
+ * (`assigneeAgentId` or `assigneeUserId`). Creators may explicitly opt out of the
+ * requirement by passing `missingOwnerAcknowledged: true`. Prevents recurrence of
+ * the FUL-9731 finding where 40+ critical issues were created with a null assignee.
+ */
+function enforceCriticalPriorityOwner(value: CriticalOwnerGuardrailInput, ctx: z.RefinementCtx) {
+  if (value.priority !== "critical") return;
+  if (value.missingOwnerAcknowledged === true) return;
+  const hasOwner =
+    (typeof value.assigneeAgentId === "string" && value.assigneeAgentId.length > 0)
+    || (typeof value.assigneeUserId === "string" && value.assigneeUserId.length > 0);
+  if (hasOwner) return;
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message:
+      "Critical-priority issues require an owner (assigneeAgentId or assigneeUserId). "
+      + "Assign the issue, or pass missingOwnerAcknowledged: true to explicitly create an unowned critical issue.",
+    path: ["assigneeAgentId"],
+  });
+}
+
 const createIssueBaseSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   projectWorkspaceId: z.string().uuid().optional().nullable(),
@@ -386,6 +415,16 @@ const createIssueBaseSchema = z.object({
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
   assigneeAgentId: z.string().uuid().optional().nullable(),
   assigneeUserId: z.string().optional().nullable(),
+  // Control-only flag: explicit opt-out of the critical-priority owner guardrail
+  // (see enforceCriticalPriorityOwner). Not persisted — stripped in issueService.create.
+  missingOwnerAcknowledged: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      "Set true to explicitly create a critical-priority issue without an owner. "
+      + "Critical issues otherwise require assigneeAgentId or assigneeUserId (FUL-9946).",
+    ),
   requestDepth: issueRequestDepthInputSchema.optional().default(0),
   billingCode: z.string().optional().nullable(),
   assigneeAdapterOverrides: issueAssigneeAdapterOverridesSchema.optional().nullable(),
@@ -400,7 +439,8 @@ export const createIssueInputSchema = createIssueBaseSchema.extend({
   status: createIssueBaseSchema.shape.status.optional(),
 });
 
-export const createIssueSchema = withCreateIssueStatusDefault(createIssueBaseSchema);
+export const createIssueSchema = withCreateIssueStatusDefault(createIssueBaseSchema)
+  .superRefine(enforceCriticalPriorityOwner);
 
 export type CreateIssue = z.infer<typeof createIssueSchema>;
 
@@ -412,7 +452,8 @@ export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBa
   .extend({
     acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
     blockParentUntilDone: z.boolean().optional().default(false),
-  }));
+  }))
+  .superRefine(enforceCriticalPriorityOwner);
 
 export type CreateChildIssue = z.infer<typeof createChildIssueSchema>;
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -1334,6 +1334,10 @@ registry.registerPath({
   path: "/api/companies/{companyId}/issues",
   tags: ["issues"],
   summary: "Create an issue",
+  description:
+    "Creates an issue. Guardrail (FUL-9946): a `critical` priority issue must include an owner "
+    + "(`assigneeAgentId` or `assigneeUserId`) or it is rejected with a 400 validation error. "
+    + "Pass `missingOwnerAcknowledged: true` to deliberately create an unowned critical issue.",
   request: {
     params: z.object({ companyId: z.string() }),
     body: jsonBody(createIssueSchema),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -354,6 +354,8 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   labelIds?: string[];
   blockedByIssueIds?: string[];
   inheritExecutionWorkspaceFromIssueId?: string | null;
+  // Control-only flag for the critical-owner guardrail (FUL-9946); never persisted.
+  missingOwnerAcknowledged?: boolean;
 };
 type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
@@ -4857,6 +4859,8 @@ export function issueService(db: Db) {
         labelIds: inputLabelIds,
         blockedByIssueIds,
         inheritExecutionWorkspaceFromIssueId,
+        // Control-only flag for the critical-owner guardrail (FUL-9946); never persisted.
+        missingOwnerAcknowledged: _missingOwnerAcknowledged,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;


### PR DESCRIPTION
## Problem

FUL-9731 found 40+ P1/critical issues created with null owner, leaving them unassigned and stalling in the backlog indefinitely. This guardrail prevents recurrence.

## Fix

Added a shared Zod `superRefine` (`enforceCriticalPriorityOwner`) that rejects issue creation requests where `priority: "critical"` and both `assigneeAgentId` and `assigneeUserId` are null, unless the creator explicitly passes `missingOwnerAcknowledged: true`.

## Coverage

- Applies to `POST /api/companies/:companyId/issues` **and** `POST /api/issues/:id/children` through shared schemas (`createIssueSchema` / `createChildIssueSchema`)
- `missingOwnerAcknowledged` is a control-only field — stripped in `issueService.create` before persistence (never stored in DB)
- OpenAPI create-issue endpoint description updated to document the guardrail

## Tests

```
npx vitest run src/validators/issue.test.ts
Test Files  1 passed (1)
Tests  31 passed (31)
```

7 new guardrail test cases:
- critical + no owner → 400
- critical + assigneeAgentId set → passes
- critical + assigneeUserId set → passes
- critical + no owner + `missingOwnerAcknowledged: true` → passes (opt-out)
- non-critical (high) + no owner → passes
- child issue: critical + no owner → 400
- child issue: critical + owner set → passes

## Risk

- Code-only validation change
- No data migration
- No secrets involved
- No production mutation
- Backwards-compatible: existing callers that assign owners are unaffected; callers that intentionally create unowned critical issues can opt out with `missingOwnerAcknowledged: true`

## Follow-up

FUL-9947 handles bulk assignment of the existing 40+ unowned critical issues already in the system.

## Files changed (4)

- `packages/shared/src/validators/issue.ts` — guardrail logic + `missingOwnerAcknowledged` field
- `packages/shared/src/validators/issue.test.ts` — 7 new test cases
- `server/src/services/issues.ts` — strip control-only flag before persistence
- `server/src/routes/openapi.ts` — document guardrail on create-issue endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)