### PR TITLE
fix(recovery): keep deliberately-sleeping issues asleep and add a per-issue handoff cooldown (#7661)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4902,6 +4902,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const detectedProgressSummary = await buildDetectedSuccessfulRunProgressSummary(run);
 
     const [
+      recentHandoffWake,
+      latestUserComment,
       activeExecutionPath,
       queuedWake,
       pendingInteraction,
@@ -4911,9 +4913,46 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingWake,
       budgetBlock,
       pauseHold,
-      recentHandoffWake,
-      latestUserComment,
     ] = await Promise.all([
+      // Most recent successful_run_missing_state handoff wake already queued for this
+      // issue across ANY source run — used to enforce the per-issue recovery cooldown.
+      issue
+        ? db
+          .select({ createdAt: agentWakeupRequests.createdAt })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, issue.companyId),
+              eq(agentWakeupRequests.reason, FINISH_SUCCESSFUL_RUN_HANDOFF_REASON),
+              sql`(
+                ${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}
+                or ${agentWakeupRequests.payload} ->> 'taskId' = ${issue.id}
+                or ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'issueId' = ${issue.id}
+                or ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'taskId' = ${issue.id}
+              )`,
+            ),
+          )
+          .orderBy(desc(agentWakeupRequests.createdAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
+      // Most recent human/board (authorType = "user") comment on the issue — a fresh
+      // one after the last handoff wake bypasses the cooldown.
+      issue
+        ? db
+          .select({ createdAt: issueComments.createdAt })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, issue.companyId),
+              eq(issueComments.issueId, issue.id),
+              eq(issueComments.authorType, "user"),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
       issue
         ? db
           .select({ id: heartbeatRuns.id })
@@ -5037,45 +5076,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         : Promise.resolve(null),
       issue
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
-        : Promise.resolve(null),
-      // Most recent successful_run_missing_state handoff wake already queued for this
-      // issue across ANY source run — used to enforce the per-issue recovery cooldown.
-      issue
-        ? db
-          .select({ createdAt: agentWakeupRequests.createdAt })
-          .from(agentWakeupRequests)
-          .where(
-            and(
-              eq(agentWakeupRequests.companyId, issue.companyId),
-              eq(agentWakeupRequests.reason, FINISH_SUCCESSFUL_RUN_HANDOFF_REASON),
-              sql`(
-                ${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}
-                or ${agentWakeupRequests.payload} ->> 'taskId' = ${issue.id}
-                or ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'issueId' = ${issue.id}
-                or ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'taskId' = ${issue.id}
-              )`,
-            ),
-          )
-          .orderBy(desc(agentWakeupRequests.createdAt))
-          .limit(1)
-          .then((rows) => rows[0] ?? null)
-        : Promise.resolve(null),
-      // Most recent human/board (authorType = "user") comment on the issue — a fresh
-      // one after the last handoff wake bypasses the cooldown.
-      issue
-        ? db
-          .select({ createdAt: issueComments.createdAt })
-          .from(issueComments)
-          .where(
-            and(
-              eq(issueComments.companyId, issue.companyId),
-              eq(issueComments.issueId, issue.id),
-              eq(issueComments.authorType, "user"),
-            ),
-          )
-          .orderBy(desc(issueComments.createdAt))
-          .limit(1)
-          .then((rows) => rows[0] ?? null)
         : Promise.resolve(null),
     ]);
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4916,6 +4916,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     ] = await Promise.all([
       // Most recent successful_run_missing_state handoff wake already queued for this
       // issue across ANY source run — used to enforce the per-issue recovery cooldown.
+      // Cancelled wakes never delivered a corrective nudge, so they must not arm
+      // the cooldown (a cancelled prior wake is exactly the requeue case).
       issue
         ? db
           .select({ createdAt: agentWakeupRequests.createdAt })
@@ -4924,6 +4926,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             and(
               eq(agentWakeupRequests.companyId, issue.companyId),
               eq(agentWakeupRequests.reason, FINISH_SUCCESSFUL_RUN_HANDOFF_REASON),
+              notInArray(agentWakeupRequests.status, ["cancelled"]),
               sql`(
                 ${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}
                 or ${agentWakeupRequests.payload} ->> 'taskId' = ${issue.id}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4885,6 +4885,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
+        monitorNotes: issues.monitorNotes,
         projectId: issues.projectId,
       })
       .from(issues)
@@ -4909,6 +4911,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingWake,
       budgetBlock,
       pauseHold,
+      recentHandoffWake,
+      latestUserComment,
     ] = await Promise.all([
       issue
         ? db
@@ -5034,7 +5038,57 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issue
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
         : Promise.resolve(null),
+      // Most recent successful_run_missing_state handoff wake already queued for this
+      // issue across ANY source run — used to enforce the per-issue recovery cooldown.
+      issue
+        ? db
+          .select({ createdAt: agentWakeupRequests.createdAt })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, issue.companyId),
+              eq(agentWakeupRequests.reason, FINISH_SUCCESSFUL_RUN_HANDOFF_REASON),
+              sql`(
+                ${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}
+                or ${agentWakeupRequests.payload} ->> 'taskId' = ${issue.id}
+                or ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'issueId' = ${issue.id}
+                or ${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'taskId' = ${issue.id}
+              )`,
+            ),
+          )
+          .orderBy(desc(agentWakeupRequests.createdAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
+      // Most recent human/board (authorType = "user") comment on the issue — a fresh
+      // one after the last handoff wake bypasses the cooldown.
+      issue
+        ? db
+          .select({ createdAt: issueComments.createdAt })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, issue.companyId),
+              eq(issueComments.issueId, issue.id),
+              eq(issueComments.authorType, "user"),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
     ]);
+
+    const recentHandoffWakeAtMs = recentHandoffWake?.createdAt
+      ? new Date(recentHandoffWake.createdAt).getTime()
+      : null;
+    const latestUserCommentAtMs = latestUserComment?.createdAt
+      ? new Date(latestUserComment.createdAt).getTime()
+      : null;
+    const hasNewSignalSinceRecentHandoff =
+      recentHandoffWakeAtMs != null &&
+      latestUserCommentAtMs != null &&
+      latestUserCommentAtMs > recentHandoffWakeAtMs;
 
     const decision = decideSuccessfulRunHandoff({
       run,
@@ -5051,6 +5105,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       hasPauseHold: Boolean(pauseHold),
       budgetBlocked: Boolean(budgetBlock),
       idempotentWakeExists: Boolean(existingWake),
+      nowMs: Date.now(),
+      recentHandoffWakeAtMs,
+      hasNewSignalSinceRecentHandoff,
     });
 
     if (decision.kind !== "enqueue" || !issue) return;

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_SUCCESSFUL_RUN_HANDOFF_COOLDOWN_MS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
@@ -11,7 +12,11 @@ import {
   isIdempotentFinishSuccessfulRunHandoffWakeStatus,
   isSuccessfulRunHandoffRequiredNoticeBody,
   noticeMetadataReferencesRecoveryAction,
+  parseWakeNotBeforeMs,
+  resolveScheduledWakeAtMs,
 } from "./successful-run-handoff.js";
+
+const NOW_MS = Date.parse("2026-06-13T12:00:00.000Z");
 
 const run = {
   id: "run-1",
@@ -30,6 +35,8 @@ const issue = {
   assigneeAgentId: "agent-1",
   assigneeUserId: null,
   executionState: null,
+  monitorNextCheckAt: null,
+  monitorNotes: null,
 } as any;
 
 const agent = {
@@ -54,6 +61,9 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     hasPauseHold: false,
     budgetBlocked: false,
     idempotentWakeExists: false,
+    nowMs: NOW_MS,
+    recentHandoffWakeAtMs: null,
+    hasNewSignalSinceRecentHandoff: false,
     ...overrides,
   });
 }
@@ -189,6 +199,75 @@ describe("successful run handoff decision", () => {
       issueId: "issue-1",
       sourceRunId: "run-1",
     })).toBe("finish_successful_run_handoff:issue-1:run-1:1");
+  });
+
+  it("does not wake an issue that is sleeping until a future monitorNextCheckAt", () => {
+    const future = new Date(NOW_MS + 6 * 60 * 60 * 1000).toISOString();
+    expect(decide({ issue: { ...issue, monitorNextCheckAt: future } as any })).toEqual({
+      kind: "skip",
+      reason: "issue is sleeping until a scheduled wake time",
+    });
+  });
+
+  it("does not wake an issue with a future wakeNotBefore annotation in monitorNotes", () => {
+    const future = new Date(NOW_MS + 30 * 60 * 1000).toISOString();
+    expect(decide({
+      issue: { ...issue, monitorNotes: `deferred check\nwakeNotBefore: ${future}\n` } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "issue is sleeping until a scheduled wake time",
+    });
+  });
+
+  it("still wakes once the scheduled wake time has passed", () => {
+    const past = new Date(NOW_MS - 60 * 1000).toISOString();
+    const decision = decide({
+      issue: { ...issue, monitorNextCheckAt: past, monitorNotes: `wakeNotBefore: ${past}` } as any,
+    });
+    expect(decision.kind).toBe("enqueue");
+  });
+
+  it("suppresses a re-fire within the cooldown when there is no new source signal", () => {
+    expect(decide({ recentHandoffWakeAtMs: NOW_MS - 5 * 60 * 1000 })).toEqual({
+      kind: "skip",
+      reason: "recent handoff wake within cooldown without new source signal",
+    });
+  });
+
+  it("re-fires within the cooldown when a new human/board signal arrived", () => {
+    const decision = decide({
+      recentHandoffWakeAtMs: NOW_MS - 5 * 60 * 1000,
+      hasNewSignalSinceRecentHandoff: true,
+    });
+    expect(decision.kind).toBe("enqueue");
+  });
+
+  it("re-fires once the cooldown window has elapsed", () => {
+    const decision = decide({
+      recentHandoffWakeAtMs: NOW_MS - (DEFAULT_SUCCESSFUL_RUN_HANDOFF_COOLDOWN_MS + 60 * 1000),
+    });
+    expect(decision.kind).toBe("enqueue");
+  });
+
+  it("parses wakeNotBefore annotations and ignores malformed ones", () => {
+    const iso = "2026-06-13T18:00:00.000Z";
+    expect(parseWakeNotBeforeMs(`wakeNotBefore: ${iso}`)).toBe(Date.parse(iso));
+    expect(parseWakeNotBeforeMs("WAKENOTBEFORE:   2026-06-13T18:00:00Z extra")).toBe(
+      Date.parse("2026-06-13T18:00:00Z"),
+    );
+    expect(parseWakeNotBeforeMs("wakeNotBefore: not-a-date")).toBeNull();
+    expect(parseWakeNotBeforeMs("no annotation here")).toBeNull();
+    expect(parseWakeNotBeforeMs(null)).toBeNull();
+  });
+
+  it("resolves the latest of monitorNextCheckAt and wakeNotBefore", () => {
+    const earlier = "2026-06-13T13:00:00.000Z";
+    const later = "2026-06-13T15:00:00.000Z";
+    expect(resolveScheduledWakeAtMs({
+      monitorNextCheckAt: new Date(earlier),
+      monitorNotes: `wakeNotBefore: ${later}`,
+    })).toBe(Date.parse(later));
+    expect(resolveScheduledWakeAtMs({ monitorNextCheckAt: null, monitorNotes: null })).toBeNull();
   });
 
   it("allows failed or cancelled corrective wakes to be retried", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -7,6 +7,11 @@ import { withRecoveryModelProfileHint } from "./model-profile-hint.js";
 export const FINISH_SUCCESSFUL_RUN_HANDOFF_REASON = "finish_successful_run_handoff";
 export const SUCCESSFUL_RUN_MISSING_STATE_REASON = "successful_run_missing_state";
 export const DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS = 1;
+// Minimum gap before the successful_run_missing_state detector may re-fire against
+// the same issue+cause when nothing new has happened on the source issue. Without
+// this, every fresh successful run mints a new source-run-scoped idempotency key and
+// trivially defeats deduplication, producing an indefinite recovery wake loop.
+export const DEFAULT_SUCCESSFUL_RUN_HANDOFF_COOLDOWN_MS = 30 * 60 * 1000;
 export const SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY =
   "Paperclip needs a disposition before this issue can continue.";
 export const SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY =
@@ -45,7 +50,16 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "title"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionState"
+  | "monitorNextCheckAt"
+  | "monitorNotes"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -272,6 +286,37 @@ export async function findExistingFinishSuccessfulRunHandoffWake(
     .then((rows) => rows[0] ?? null);
 }
 
+// Matches a "wakeNotBefore: <ISO-8601 UTC>" annotation line in monitorNotes.
+const WAKE_NOT_BEFORE_PATTERN = /wakeNotBefore:\s*(\S+)/i;
+
+function readTimestampMs(value: Date | string | null | undefined): number | null {
+  if (value == null) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function parseWakeNotBeforeMs(notes: string | null | undefined): number | null {
+  if (typeof notes !== "string") return null;
+  const match = notes.match(WAKE_NOT_BEFORE_PATTERN);
+  if (!match) return null;
+  return readTimestampMs(match[1]);
+}
+
+// The earliest time an issue has asked to be woken, derived from the first-class
+// monitorNextCheckAt column and/or a wakeNotBefore: annotation in monitorNotes.
+// Returns the latest of the two future signals, or null when neither is present.
+export function resolveScheduledWakeAtMs(input: {
+  monitorNextCheckAt: Date | string | null | undefined;
+  monitorNotes: string | null | undefined;
+}): number | null {
+  const candidates = [
+    readTimestampMs(input.monitorNextCheckAt),
+    parseWakeNotBeforeMs(input.monitorNotes),
+  ].filter((ms): ms is number => ms != null);
+  if (candidates.length === 0) return null;
+  return Math.max(...candidates);
+}
+
 function readRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -344,6 +389,14 @@ export function decideSuccessfulRunHandoff(input: {
   hasPauseHold: boolean;
   budgetBlocked: boolean;
   idempotentWakeExists: boolean;
+  nowMs: number;
+  // createdAt (ms) of the most recent finish_successful_run_handoff wake already
+  // queued for this issue, across any source run; null when none exists.
+  recentHandoffWakeAtMs: number | null;
+  // True when the source issue gained a new human/board comment (or other fresh
+  // signal) after recentHandoffWakeAtMs, which should bypass the cooldown.
+  hasNewSignalSinceRecentHandoff: boolean;
+  handoffCooldownMs?: number;
 }): SuccessfulRunHandoffDecision {
   const { run, issue, agent } = input;
 
@@ -364,6 +417,13 @@ export function decideSuccessfulRunHandoff(input: {
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
+  const scheduledWakeAtMs = resolveScheduledWakeAtMs({
+    monitorNextCheckAt: issue.monitorNextCheckAt,
+    monitorNotes: issue.monitorNotes,
+  });
+  if (scheduledWakeAtMs != null && scheduledWakeAtMs > input.nowMs) {
+    return { kind: "skip", reason: "issue is sleeping until a scheduled wake time" };
+  }
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };
   }
@@ -381,6 +441,14 @@ export function decideSuccessfulRunHandoff(input: {
   if (input.budgetBlocked) return { kind: "skip", reason: "budget hard stop blocks corrective wake" };
   if (input.idempotentWakeExists) {
     return { kind: "skip", reason: "corrective handoff wake already exists for this source run" };
+  }
+  const cooldownMs = input.handoffCooldownMs ?? DEFAULT_SUCCESSFUL_RUN_HANDOFF_COOLDOWN_MS;
+  if (
+    input.recentHandoffWakeAtMs != null &&
+    input.nowMs - input.recentHandoffWakeAtMs < cooldownMs &&
+    !input.hasNewSignalSinceRecentHandoff
+  ) {
+    return { kind: "skip", reason: "recent handoff wake within cooldown without new source signal" };
   }
 
   const instruction = buildSuccessfulRunHandoffInstruction({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; a recovery layer watches for issues stranded after a run ends without a state transition (`successful_run_missing_state`) and wakes the assignee.
> - That detector has two distinct failure modes reported in #7661: it ignores deliberate sleep signals, and it loops because dedup is keyed on the source run id.
> - The detector is already a pure function (`decideSuccessfulRunHandoff`) with full unit coverage, so the cleanest, lowest-risk fix is to add two new skip conditions there and have the single caller in `heartbeat.ts` supply the new inputs (current time, last handoff-wake time, whether a newer user comment exists).
> - Honoring scheduled wakes is data-model-cheap: `monitorNextCheckAt` is a first-class column and `wakeNotBefore:` is a documented `monitorNotes` convention, so both are parsed and the later future timestamp wins.
> - For the loop, a per-issue cooldown keyed on (company, issue) with a "new human/board signal bypasses it" escape hatch matches the issue's request without changing the existing source-run idempotency key contract.
> - The benefit is deliberately-sleeping issues stay asleep and stuck-issue wakes stop ping-ponging, while genuinely-stuck issues with fresh board attention still wake immediately.

## Linked Issues or Issue Description

Fixes #7661.

**Duplicate/related PR search** — searched the PR list for `successful_run_missing_state`, `handoff`, `recovery wake`; none open for #7661 (adjacent recovery PRs #7889/#7871 touch cancellation and terminal-retry caps, different detectors).

## What Changed

- `server/src/services/recovery/successful-run-handoff.ts`: add `DEFAULT_SUCCESSFUL_RUN_HANDOFF_COOLDOWN_MS` (30 min), `parseWakeNotBeforeMs` / `resolveScheduledWakeAtMs` helpers, extend `IssueRow` with `monitorNextCheckAt` + `monitorNotes`, and add two skip branches to `decideSuccessfulRunHandoff`: (1) skip while the issue sleeps until a future scheduled wake, (2) skip a re-fire within the cooldown unless a new source signal arrived.
- `server/src/services/heartbeat.ts`: select the two monitor columns, query the most recent prior handoff wake for the issue and the latest `authorType = "user"` comment, and pass `nowMs` / `recentHandoffWakeAtMs` / `hasNewSignalSinceRecentHandoff` into the detector.
- `server/src/services/recovery/successful-run-handoff.test.ts`: 8 new cases covering future `monitorNextCheckAt`, future/elapsed `wakeNotBefore`, cooldown suppression, new-signal bypass, cooldown elapse, and the parser.

## Verification

- `npx vitest run src/services/recovery/successful-run-handoff.test.ts` → 22/22 pass (8 new).
- `npx tsc --noEmit` introduces **zero** new errors vs the pristine base commit (verified by stashing the change and re-running: identical 16 pre-existing unrelated errors with and without the change).

## Risks

- Low. The change only adds `skip` paths to a recovery wake; it never enqueues a wake it would not have before, so worst case is a missed corrective wake, not a spurious one. Sleeping-issue suppression is gated on a strictly-future timestamp; the cooldown is bypassed by any new `user` comment, so genuinely-stuck issues with board attention still wake.
- The cooldown default (30 min) is configurable via `handoffCooldownMs`.

## Model Used

- Claude (Anthropic), model ID `claude-opus-4-8` (Claude Opus 4.8), extended thinking + tool use, large context. Used to design and implement the change end-to-end. PR description/template revision with `claude-fable-5` (Claude Fable 5, extended thinking + tool use).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no doc-facing surface changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
