### PR TITLE
feat(heartbeat): company-wide claude_local concurrency admission control

### DIFF
--- a/server/src/__tests__/heartbeat-claude-local-admission.test.ts
+++ b/server/src/__tests__/heartbeat-claude-local-admission.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { agents, companies, createDb, heartbeatRuns } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+// Keep run execution inert: the admission gate decides BEFORE a run is
+// claimed, so the block assertions never reach the adapter. For the
+// "allowed" assertions the run is claimed and `executeRun` is fired
+// (fire-and-forget); a no-op adapter keeps that path quiet.
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "claude_local admission control test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres claude_local admission tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+const INFLIGHT_ENV = "PAPERCLIP_MAX_CLAUDE_LOCAL_INFLIGHT";
+
+describeEmbeddedPostgres("heartbeat claude_local admission control", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-claude-local-admission-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  });
+
+  afterEach(async () => {
+    delete process.env[INFLIGHT_ENV];
+    // The "allowed" cases claim + fire executeRun(), which seeds rows
+    // across many child tables. Truncate from the company root with
+    // CASCADE to clear the whole FK graph in one shot.
+    await db.execute(sql.raw('TRUNCATE TABLE companies CASCADE'));
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function createAgent(companyId: string, adapterType: string) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: `agent-${agentId.slice(0, 8)}`,
+      role: "engineer",
+      status: "active",
+      adapterType,
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  async function createRun(companyId: string, agentId: string, status: "running" | "queued") {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status,
+      contextSnapshot: {},
+    });
+    return runId;
+  }
+
+  async function runStatus(runId: string) {
+    const [row] = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    return row?.status ?? null;
+  }
+
+  // Let the fire-and-forget executeRun() settle so afterEach cleanup
+  // doesn't race in-flight inserts.
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 100));
+
+  it("leaves a second claude_local run queued when the company inflight cap is reached", async () => {
+    const companyId = await createCompany();
+    const busyAgentId = await createAgent(companyId, "claude_local");
+    const waitingAgentId = await createAgent(companyId, "claude_local");
+    await createRun(companyId, busyAgentId, "running"); // inflight = 1
+    const queuedRunId = await createRun(companyId, waitingAgentId, "queued");
+
+    process.env[INFLIGHT_ENV] = "1";
+    await heartbeat.resumeQueuedRuns();
+
+    // Cap (1) already met by the busy agent's running run → the waiting
+    // agent's run is held at the scheduler, not claimed.
+    expect(await runStatus(queuedRunId)).toBe("queued");
+  });
+
+  it("claims the queued run when company inflight is under the cap", async () => {
+    const companyId = await createCompany();
+    const busyAgentId = await createAgent(companyId, "claude_local");
+    const waitingAgentId = await createAgent(companyId, "claude_local");
+    await createRun(companyId, busyAgentId, "running"); // inflight = 1
+    const queuedRunId = await createRun(companyId, waitingAgentId, "queued");
+
+    process.env[INFLIGHT_ENV] = "2"; // 1 < 2 → admit
+    await heartbeat.resumeQueuedRuns();
+    await settle();
+
+    expect(await runStatus(queuedRunId)).not.toBe("queued");
+  });
+
+  it("does not gate when the cap is unset (default unlimited, behavior preserved)", async () => {
+    const companyId = await createCompany();
+    const busyAgentId = await createAgent(companyId, "claude_local");
+    const waitingAgentId = await createAgent(companyId, "claude_local");
+    await createRun(companyId, busyAgentId, "running");
+    const queuedRunId = await createRun(companyId, waitingAgentId, "queued");
+
+    // INFLIGHT_ENV deliberately unset.
+    await heartbeat.resumeQueuedRuns();
+    await settle();
+
+    expect(await runStatus(queuedRunId)).not.toBe("queued");
+  });
+
+  it("only gates claude_local agents, not other backends", async () => {
+    const companyId = await createCompany();
+    const busyAgentId = await createAgent(companyId, "claude_local");
+    const waitingAgentId = await createAgent(companyId, "codex_local");
+    await createRun(companyId, busyAgentId, "running"); // claude_local inflight = 1
+    const queuedRunId = await createRun(companyId, waitingAgentId, "queued");
+
+    process.env[INFLIGHT_ENV] = "1";
+    await heartbeat.resumeQueuedRuns();
+    await settle();
+
+    // The cap is scoped to claude_local; a codex_local run is unaffected.
+    expect(await runStatus(queuedRunId)).not.toBe("queued");
+  });
+});

--- a/server/src/services/claude-local-admission-lock.ts
+++ b/server/src/services/claude-local-admission-lock.ts
@@ -1,0 +1,70 @@
+import { logger } from "../middleware/logger.js";
+
+// In-process lock keyed on companyId to serialize the claude_local admission
+// gate (PAPERCLIP_MAX_CLAUDE_LOCAL_INFLIGHT) check against itself.
+//
+// Without this, multiple agents in the same company concurrently calling
+// startNextQueuedRunForAgent each read inflight=N (where N < cap), each pass
+// the gate, and the cap is silently breached. Manifests at pod startup when
+// a queue of pending wakeups drains in parallel.
+//
+// Why per-company and not global: tenants are isolated. Carrie's admission
+// shouldn't block Fourslide LLC's, and vice versa. The cap is also per
+// company (counted within countRunningClaudeLocalRunsForCompany).
+//
+// Why in-process and not pg_advisory_lock: Paperclip runs a single replica
+// per tenant. If that ever changes, switch to pg_advisory_lock keyed on
+// hashtext('claude_local:' || companyId).
+//
+// Stale-timeout mirrors withAgentStartLock to keep behavior consistent —
+// no caller should ever block longer than 30s on this lock.
+
+const ADMISSION_LOCK_STALE_MS = 30_000;
+const locksByCompany = new Map<string, { promise: Promise<void>; startedAtMs: number }>();
+
+async function waitForAdmissionLock(
+  companyId: string,
+  lock: { promise: Promise<void>; startedAtMs: number },
+) {
+  const elapsedMs = Date.now() - lock.startedAtMs;
+  const remainingMs = ADMISSION_LOCK_STALE_MS - elapsedMs;
+  if (remainingMs <= 0) {
+    logger.warn({ companyId, staleMs: elapsedMs }, "claude_local admission lock stale; continuing");
+    return;
+  }
+
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  await Promise.race([
+    lock.promise,
+    new Promise<void>((resolve) => {
+      timeout = setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, remainingMs);
+    }),
+  ]);
+  if (timeout) clearTimeout(timeout);
+
+  if (timedOut) {
+    logger.warn({ companyId, staleMs: ADMISSION_LOCK_STALE_MS }, "claude_local admission lock timed out; continuing");
+  }
+}
+
+export async function withClaudeLocalAdmissionLock<T>(companyId: string, fn: () => Promise<T>) {
+  const previous = locksByCompany.get(companyId);
+  const waitForPrevious = previous ? waitForAdmissionLock(companyId, previous) : Promise.resolve();
+  const run = waitForPrevious.then(fn);
+  const marker = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  locksByCompany.set(companyId, { promise: marker, startedAtMs: Date.now() });
+  try {
+    return await run;
+  } finally {
+    if (locksByCompany.get(companyId)?.promise === marker) {
+      locksByCompany.delete(companyId);
+    }
+  }
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -159,6 +159,7 @@ import {
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
+import { withClaudeLocalAdmissionLock } from "./claude-local-admission-lock.js";
 import {
   evaluateAgentInvokability,
   evaluateAgentInvokabilityFromDb,
@@ -301,6 +302,21 @@ function resolveCodexTransientFallbackMode(attempt: number): CodexTransientFallb
   if (attempt === 2) return "safer_invocation";
   if (attempt === 3) return "fresh_session";
   return "fresh_session_safer_invocation";
+}
+
+// Instance-wide cap on concurrent claude_local heartbeat runs per company.
+// Used to prevent N agents from stacking onto a single-slot local LLM serve
+// (llama.cpp with MTP doesn't support --parallel > 1; queueing at the
+// scheduler is far cheaper than queueing at the inference layer).
+// Read once per call (cheap, cached implicitly by Node), so operators can
+// flip this without a restart on a process-manager that re-reads env.
+// Default 0 = unlimited (current behavior preserved).
+function readClaudeLocalInflightCap(): number {
+  const raw = process.env.PAPERCLIP_MAX_CLAUDE_LOCAL_INFLIGHT;
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
 }
 
 function readHeartbeatRunErrorFamily(
@@ -6741,6 +6757,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
+  // Count concurrent claude_local heartbeat runs for a company. Used by the
+  // single-slot-LLM admission control gate — see PAPERCLIP_MAX_CLAUDE_LOCAL_INFLIGHT.
+  // The join keeps this aware of adapter type even though heartbeat_runs doesn't
+  // carry it directly.
+  async function countRunningClaudeLocalRunsForCompany(companyId: string) {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.status, "running"),
+          eq(agents.adapterType, "claude_local"),
+        ),
+      );
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -7674,12 +7709,53 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         return [];
       }
-      const policy = parseHeartbeatPolicy(agent);
-      const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
-      if (availableSlots <= 0) return [];
 
-      const queuedRuns = await db
+      // Instance-wide admission control for claude_local backend. When the
+      // operator points the whole fleet at a single-slot llama.cpp/MTP serve
+      // (where --parallel > 1 isn't supported), letting N agents claim N
+      // concurrent runs just serializes them at the inference layer with
+      // worse tail latency and stacked timeouts. Cap company-wide claude_local
+      // inflight via env. Default 0 = unlimited (current behavior preserved).
+      //
+      // The gate check (count) + claim must be atomic to avoid TOCTOU:
+      // without a serializing lock, multiple agents reading inflight=0
+      // would each pass and silently breach the cap. Wrap the whole
+      // gate-check-through-claim body in a company-scoped admission lock
+      // when the cap is engaged for this agent.
+      const claudeLocalInflightCap = readClaudeLocalInflightCap();
+      const needsAdmissionLock = claudeLocalInflightCap > 0 && agent.adapterType === "claude_local";
+
+      const claimBody = async () => {
+        const policy = parseHeartbeatPolicy(agent);
+        const runningCount = await countRunningRunsForAgent(agentId);
+        const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+        if (availableSlots <= 0) return [];
+
+        if (needsAdmissionLock) {
+          const inflight = await countRunningClaudeLocalRunsForCompany(agent.companyId);
+          if (inflight >= claudeLocalInflightCap) {
+            // Leave the queued runs queued; another agent's completion or the
+            // periodic scheduler tick will re-invoke this function and the cap
+            // will reopen naturally.
+            return [];
+          }
+        }
+
+        return doClaim(agent, availableSlots, agentId);
+      };
+
+      return needsAdmissionLock
+        ? withClaudeLocalAdmissionLock(agent.companyId, claimBody)
+        : claimBody();
+    });
+  }
+
+  async function doClaim(
+    agent: typeof agents.$inferSelect,
+    availableSlots: number,
+    agentId: string,
+  ): Promise<Array<typeof heartbeatRuns.$inferSelect>> {
+    const queuedRuns = await db
         .select()
         .from(heartbeatRuns)
         .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
@@ -7738,7 +7814,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
       return claimedRuns;
-    });
   }
 
   async function executeRun(runId: string) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; the heartbeat scheduler decides when an agent's queued run actually starts.
> - Self-hosters increasingly point the whole fleet at a single local LLM serve (e.g. llama.cpp with MTP, where `--parallel > 1` isn't supported) via the `claude_local` adapter.
> - With a single inference slot, letting N agents each claim a run yields N concurrent runs that serialize *inside* the inference layer — worse p95 tail latency and stacked timeouts, with no visibility.
> - Queueing at the heartbeat scheduler is far cheaper and more observable than queueing at the inference layer.
> - This PR adds an opt-in, company-wide cap on concurrent `claude_local` runs, enforced at the scheduler. Default behavior is unchanged.

## Linked Issues or Issue Description

No existing tracked issue. **Problem:** operators running a single-slot local LLM backend have no way to bound fleet-wide `claude_local` concurrency; excess agents stack onto the one inference slot and degrade latency for everyone. There is currently no scheduler-level admission control for local backends.

## What Changed

`PAPERCLIP_MAX_CLAUDE_LOCAL_INFLIGHT` (default unset / `0` = unlimited, current behavior preserved):

- `readClaudeLocalInflightCap()` — parses the env var; invalid/negative → 0.
- `countRunningClaudeLocalRunsForCompany()` — counts `running` heartbeat runs joined to `claude_local` agents for a company.
- `startNextQueuedRunForAgent` — when the cap is engaged for a `claude_local` agent, the count-check-through-claim body runs inside a **company-scoped admission lock** (`withClaudeLocalAdmissionLock`, new `claude-local-admission-lock.ts`) so the check + claim are atomic. Without the lock, multiple agents reading `inflight=0` could each pass and breach the cap (TOCTOU). At the cap, queued runs are left queued — the next completion or scheduler tick reopens it naturally.

Scope is deliberately narrow: the gate is a no-op unless the env var is set **and** the agent is `claude_local`. No schema/migration changes.

## Verification

New: `server/src/__tests__/heartbeat-claude-local-admission.test.ts` (embedded Postgres), 4/4 passing locally:
- leaves a second `claude_local` run queued when the company inflight cap is reached
- claims the queued run when inflight is under the cap
- does not gate when the cap is unset (unlimited / behavior preserved)
- only gates `claude_local`, not other backends (e.g. `codex_local`)

```
$ npx vitest run src/__tests__/heartbeat-claude-local-admission.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
`tsc --noEmit` clean. This patch has also run in production on a fourslide fleet (single-slot local serve) with the cap set to 1.

## Risks

Low. The gate is fully behind an env var and an adapter-type check; with the var unset it is a no-op (an extra cheap function call returning early). The admission lock is only acquired when the cap is engaged for a `claude_local` agent, so non-local backends and unset deployments see no new locking.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`) via Claude Code, extended thinking, with file edits + shell (git, vitest, tsc).

## Checklist

- [x] Thinking path tracing from project context to the change
- [x] Model specified
- [x] Checked for duplicate/related work — no existing scheduler-level local-backend admission control
- [x] Issue described in-PR (no existing tracked issue)
- [x] Ran tests locally and they pass (4/4 + tsc)
- [x] Added tests
- [ ] UI change / screenshots — N/A (scheduler-only)
- [x] Documented risks above
- [x] Will address Greptile + reviewer comments before merge