### PR TITLE
feat(recovery): defer parent retries when child reset run holds the shared execution workspace

### DIFF
--- a/help2day/VERCEL_DEPLOY_GUARDRAIL.md
+++ b/help2day/VERCEL_DEPLOY_GUARDRAIL.md
@@ -1,0 +1,130 @@
+# Vercel Deploy Guardrail
+
+**Source issue:** [FUL-11094](/FUL/issues/FUL-11094)
+**Script:** `scripts/vercel-deploy-check.sh`
+
+Every Vercel preview or production push must pass preflight before pushing and postflight after. Both blocks on failure.
+
+---
+
+## Preflight — run before `git push`
+
+```bash
+./scripts/vercel-deploy-check.sh preflight <owner/repo> <branch> <vercel-project>
+# Example:
+./scripts/vercel-deploy-check.sh preflight paperclipai/paperclip main help2day-web
+```
+
+### What it verifies
+
+| # | Check | How |
+|---|-------|-----|
+| 1 | Target repo and branch | `git remote get-url origin`, `git rev-parse --abbrev-ref HEAD` |
+| 2 | Git remote owner/repo matches expected | String comparison vs `<owner/repo>` arg |
+| 3 | GitHub actor (authenticated account) | `gh api /user` — name only, no token printed |
+| 4 | Commit author email is verified on that GitHub account | `gh api /user/emails` — checks verified flag |
+| 5 | Vercel project/org target is accessible | `GET /v9/projects/<name>` — project name only, no secrets printed |
+| 6 | No secrets emitted | Script asserts this; exits non-zero on any failure |
+
+### Account mismatch — unblock path
+
+When the commit author email is not verified on the authenticated GitHub account:
+
+- **Unblock owner:** the GitHub account holder (the person who owns the `gh_actor` account).
+- **Self-serve fix A:** add and verify the email at `https://github.com/settings/emails`.
+- **Self-serve fix B:** `git config user.email <an-already-verified-email-on-that-account>`.
+- **When Grant is required:** only if the fix requires changes to Vercel org ownership or a GitHub org-level setting. Email association is self-serve.
+
+---
+
+## Postflight — run after `git push`
+
+Run **before marking any issue complete** after a push.
+
+```bash
+SHA=$(git rev-parse HEAD)
+./scripts/vercel-deploy-check.sh postflight "$SHA" <owner/repo> <branch> <vercel-project> [paperclip-issue-id]
+# Example:
+SHA=$(git rev-parse HEAD)
+./scripts/vercel-deploy-check.sh postflight "$SHA" paperclipai/paperclip main help2day-web "$PAPERCLIP_TASK_ID"
+```
+
+### What it verifies
+
+| # | Check | How |
+|---|-------|-----|
+| 1 | Push reached remote branch | `git ls-remote origin refs/heads/<branch>` |
+| 2 | GitHub commit/check status exists for SHA | `gh api /repos/<owner/repo>/commits/<sha>/check-runs` |
+| 3 | Vercel deployment created for SHA | Poll `GET /v6/deployments?projectId=<id>`, match on `meta.githubCommitSha` |
+| 4 | Vercel deployment reaches `READY` | Polls every 15s up to `VERCEL_POLL_TIMEOUT_SECONDS` (default 300s) |
+| 5 | Structured issue comment | Posts table to Paperclip issue if `PAPERCLIP_API_URL/KEY` are set |
+
+### Postflight comment fields
+
+The postflight summary includes:
+
+- Branch and SHA
+- GitHub actor (pusher) and commit author login
+- Vercel project name and deployment ID
+- Deployment state
+- Preview URL and whether it is safe to share publicly
+- GitHub check run count and summary
+- UTC timestamp
+
+### Failure and escalation table
+
+| Failure | Blocker owner | Unblock action |
+|---------|--------------|----------------|
+| Remote SHA mismatch | Pushing agent | Retry push; check network/auth |
+| Commit not on GitHub | Pushing agent | Verify push with `git ls-remote` |
+| No Vercel deployment after 5min | DevOps/Infrastructure Lead | Verify Vercel webhook configured for repo and branch |
+| Deployment `ERROR` or `CANCELED` | DevOps/Infrastructure Lead | Inspect Vercel deployment logs at https://vercel.com/dashboard |
+| Deployment stuck `BUILDING` | DevOps/Infrastructure Lead | Check Vercel build logs; extend `VERCEL_POLL_TIMEOUT_SECONDS` if builds are slow |
+
+---
+
+## Required env vars
+
+| Var | Purpose | Required for |
+|-----|---------|-------------|
+| `GH_TOKEN` or `GITHUB_TOKEN` | GitHub auth — consumed by `gh` CLI; never in argv | preflight + postflight |
+| `VERCEL_TOKEN` | Vercel API auth — passed via `curl --config`, never in argv | preflight + postflight |
+| `PAPERCLIP_API_URL` | Paperclip API base | postflight comment (optional) |
+| `PAPERCLIP_API_KEY` | Paperclip API auth — passed via `curl --config` | postflight comment (optional) |
+| `PAPERCLIP_RUN_ID` | Paperclip run tracing header | postflight comment (optional) |
+| `VERCEL_POLL_TIMEOUT_SECONDS` | Override default 300s poll timeout | postflight (optional) |
+
+---
+
+## Security properties
+
+- Script never echoes `VERCEL_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, or `PAPERCLIP_API_KEY` values.
+- Vercel API calls use `curl --config <(printf ...)` — token is not in process argv (SH-10 compliant).
+- Paperclip API calls use a temp file (chmod 600) for the auth header — not in process argv (SH-10 compliant).
+- GitHub API calls use `gh api` — token handled internally by the gh CLI.
+- Do **not** use `vercel curl` in deploy scripts (SH-8); this script uses plain `curl`.
+- Do **not** pass tokens as CLI arguments to any command.
+- This script does **not** mutate Vercel project settings.
+
+---
+
+## Checklist for deploy tickets
+
+Add to the issue description or deploy ticket:
+
+```markdown
+### Deploy checklist
+
+- [ ] `./scripts/vercel-deploy-check.sh preflight <owner/repo> <branch> <project>` — PASSED
+- [ ] `git push origin <branch>`
+- [ ] `./scripts/vercel-deploy-check.sh postflight <sha> <owner/repo> <branch> <project> <issue-id>` — PASSED (see postflight comment)
+```
+
+---
+
+## Related policies
+
+- Secret handling: `/help2day/SECRET_HANDLING_POLICY.md`
+- SH-8 (no `vercel curl`): [FUL-3128](/FUL/issues/FUL-3128)
+- SH-10 (no secrets in argv): [FUL-4346](/FUL/issues/FUL-4346)
+- Routing governor: `/help2day/ROUTING_GOVERNOR.md`

--- a/scripts/vercel-deploy-check.sh
+++ b/scripts/vercel-deploy-check.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# scripts/vercel-deploy-check.sh
+#
+# Vercel deploy identity preflight and post-push success verification.
+# Implements FUL-11094 guardrail. Source this file or run it directly.
+#
+# Standalone usage:
+#   ./scripts/vercel-deploy-check.sh preflight  <owner/repo> <branch> <vercel-project>
+#   ./scripts/vercel-deploy-check.sh postflight <sha> <owner/repo> <branch> <vercel-project> [paperclip-issue-id]
+#
+# Sourced usage:
+#   source scripts/vercel-deploy-check.sh
+#   vercel_preflight  <owner/repo> <branch> <vercel-project>
+#   vercel_postflight <sha> <owner/repo> <branch> <vercel-project> [paperclip-issue-id]
+#
+# Required env vars:
+#   GH_TOKEN or GITHUB_TOKEN  — consumed by gh CLI internally; never printed
+#   VERCEL_TOKEN              — passed via curl --config; never in argv (SH-10)
+#
+# Optional (for postflight Paperclip issue comment):
+#   PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_RUN_ID
+#
+# Overrides:
+#   VERCEL_POLL_TIMEOUT_SECONDS — max seconds to wait for Vercel READY (default 300)
+
+set -euo pipefail
+
+# ── dependency check ──────────────────────────────────────────────────────────
+
+for _dep in git curl gh jq; do
+  if ! command -v "$_dep" &>/dev/null; then
+    echo "ERROR: required command '$_dep' not found in PATH" >&2
+    exit 1
+  fi
+done
+unset _dep
+
+# ── internal helpers ──────────────────────────────────────────────────────────
+
+_ok()   { echo "  ✓ $*"; }
+_info() { echo "  · $*"; }
+
+_fail() {
+  echo "" >&2
+  printf '  ✗ FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# GitHub API — auth consumed by gh CLI from GH_TOKEN / GITHUB_TOKEN; not in argv.
+_gh_api() {
+  gh api "$@"
+}
+
+# Vercel API — token passed via curl --config to avoid argv exposure (SH-10).
+_vercel_api() {
+  local _path="$1"; shift
+  local _vt="${VERCEL_TOKEN:-}"
+  if [[ -z "$_vt" ]]; then
+    _fail "VERCEL_TOKEN must be set"
+  fi
+  curl -fsSL \
+    --config <(printf 'header = "Authorization: Bearer %s"\n' "$_vt") \
+    "https://api.vercel.com${_path}" "$@"
+}
+
+# ── preflight ─────────────────────────────────────────────────────────────────
+
+vercel_preflight() {
+  local expected_repo="${1:?Usage: vercel_preflight <owner/repo> <branch> <vercel-project>}"
+  local expected_branch="${2:?<branch> required}"
+  local expected_vercel_project="${3:?<vercel-project> required}"
+
+  echo ""
+  echo "═══ Vercel Deploy Preflight ═══"
+
+  # 1. Git remote owner/repo
+  local remote_url actual_repo
+  remote_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [[ -z "$remote_url" ]]; then
+    _fail "No git remote 'origin' found. Configure the remote before deploying."
+  fi
+  actual_repo="$(echo "$remote_url" | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')"
+  if [[ "$actual_repo" != "$expected_repo" ]]; then
+    _fail "Remote mismatch: got '$actual_repo', expected '$expected_repo'. Check out the correct repo."
+  fi
+  _ok "Remote: $actual_repo"
+
+  # 2. Current branch
+  local actual_branch
+  actual_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [[ -z "$actual_branch" || "$actual_branch" == "HEAD" ]]; then
+    _fail "Not on a named branch (detached HEAD). Check out '$expected_branch' first."
+  fi
+  if [[ "$actual_branch" != "$expected_branch" ]]; then
+    _fail "Branch mismatch: on '$actual_branch', expected '$expected_branch'. Switch branches before deploying."
+  fi
+  _ok "Branch: $actual_branch"
+
+  # 3. GitHub authenticated actor — name only; token handled internally by gh
+  local gh_actor
+  gh_actor="$(_gh_api /user --jq '.login' 2>/dev/null || true)"
+  if [[ -z "$gh_actor" ]]; then
+    _fail "Cannot resolve GitHub actor. Check GH_TOKEN / GITHUB_TOKEN is set and valid."
+  fi
+  _ok "GitHub actor: $gh_actor"
+
+  # 4. Commit author email is verified on the authenticated GitHub account
+  local local_email
+  local_email="$(git config user.email 2>/dev/null || true)"
+  if [[ -z "$local_email" ]]; then
+    _fail "git config user.email is not set. Run: git config user.email <your-verified-github-email>"
+  fi
+  _info "Commit author email: $local_email"
+
+  # Try verified email list (requires user:email scope on token)
+  local email_verified=""
+  local emails_json
+  emails_json="$(_gh_api /user/emails 2>/dev/null || echo '[]')"
+  email_verified="$(echo "$emails_json" | jq -r --arg e "$local_email" \
+    '.[] | select(.email == $e and .verified == true) | .email' 2>/dev/null | head -1 || true)"
+
+  if [[ -z "$email_verified" ]]; then
+    # Fallback: check public email field on /user
+    local public_email
+    public_email="$(_gh_api /user --jq '.email // empty' 2>/dev/null || true)"
+    if [[ "$public_email" == "$local_email" ]]; then
+      email_verified="$local_email"
+      _info "Verified via public profile email (user:email scope not available)"
+    fi
+  fi
+
+  if [[ -z "$email_verified" ]]; then
+    _info "Unblock owner: GitHub account holder for '$gh_actor'"
+    _info "Fix option A: add and verify '$local_email' at https://github.com/settings/emails"
+    _info "Fix option B: git config user.email <an-email-already-verified-on-$gh_actor>"
+    _fail "Commit author email '$local_email' is not a verified email on GitHub account '$gh_actor'"
+  fi
+  _ok "Commit email '$local_email' is verified on GitHub account '$gh_actor'"
+
+  # 5. Vercel project/org target — name only; no org secrets printed
+  local vercel_proj_json vercel_proj_name
+  vercel_proj_json="$(_vercel_api "/v9/projects/$expected_vercel_project" 2>/dev/null || echo 'null')"
+  vercel_proj_name="$(echo "$vercel_proj_json" | jq -r '.name // empty' 2>/dev/null || true)"
+  if [[ -z "$vercel_proj_name" || "$vercel_proj_name" == "null" ]]; then
+    _info "Unblock owner: project admin or DevOps/Infrastructure Lead"
+    _info "Fix: verify VERCEL_TOKEN has access to project '$expected_vercel_project'"
+    _fail "Vercel project '$expected_vercel_project' not accessible. Check project name and token scope."
+  fi
+  _ok "Vercel project: $vercel_proj_name"
+
+  # 6. Secret-print guard assertion — this script never echoes token values
+  _ok "Secret-print guard: no credentials emitted by this script"
+
+  echo ""
+  echo "PREFLIGHT PASSED ✓ — safe to push"
+  echo ""
+}
+
+# ── postflight ────────────────────────────────────────────────────────────────
+
+vercel_postflight() {
+  local sha="${1:?Usage: vercel_postflight <sha> <owner/repo> <branch> <vercel-project> [issue-id]}"
+  local expected_repo="${2:?<owner/repo> required}"
+  local expected_branch="${3:?<branch> required}"
+  local expected_vercel_project="${4:?<vercel-project> required}"
+  local issue_id="${5:-}"
+  local max_wait="${VERCEL_POLL_TIMEOUT_SECONDS:-300}"
+  local poll_interval=15
+
+  echo ""
+  echo "═══ Vercel Deploy Postflight ═══"
+  echo "  SHA: $sha | repo: $expected_repo | branch: $expected_branch"
+
+  # 1. Confirm push reached remote
+  local remote_sha
+  remote_sha="$(git ls-remote origin "refs/heads/$expected_branch" 2>/dev/null | awk '{print $1}' | head -1 || true)"
+  if [[ -z "$remote_sha" ]]; then
+    _info "Blocker owner: Pushing agent"
+    _fail "Cannot read remote ref 'refs/heads/$expected_branch'. Push may not have completed."
+  fi
+  if [[ "$remote_sha" != "$sha" ]]; then
+    _info "Remote is at: $remote_sha"
+    _info "Blocker owner: Pushing agent — retry the push"
+    _fail "Remote $expected_branch does not match expected SHA $sha. Push did not succeed."
+  fi
+  _ok "Push confirmed: $sha on $expected_repo/$expected_branch"
+
+  # 2. GitHub commit exists
+  local commit_json commit_author gh_actor
+  commit_json="$(_gh_api "/repos/$expected_repo/commits/$sha" 2>/dev/null || echo 'null')"
+  if [[ "$commit_json" == "null" || -z "$commit_json" ]]; then
+    _fail "Commit $sha not found on GitHub ($expected_repo). Verify the push completed."
+  fi
+  commit_author="$(echo "$commit_json" | jq -r '.author.login // .commit.author.name // "unknown"')"
+  gh_actor="$(_gh_api /user --jq '.login' 2>/dev/null || echo "unknown")"
+  _ok "GitHub commit: $sha (commit author: $commit_author, pusher: $gh_actor)"
+
+  # GitHub check runs — allow up to 30s for them to register
+  local check_count=0 check_summary="none registered yet"
+  local _check_json
+  for _i in 1 2 3; do
+    _check_json="$(_gh_api "/repos/$expected_repo/commits/$sha/check-runs" 2>/dev/null || echo '{}')"
+    check_count="$(echo "$_check_json" | jq -r '.total_count // 0')"
+    if [[ "$check_count" -gt 0 ]]; then
+      check_summary="$(echo "$_check_json" | jq -r \
+        '[.check_runs[] | "\(.name): \(.conclusion // .status)"] | join(", ")' 2>/dev/null || echo "parse error")"
+      break
+    fi
+    [[ $_i -lt 3 ]] && sleep 10
+  done
+  unset _i _check_json
+  _ok "GitHub checks: $check_count run(s) — $check_summary"
+
+  # 3 & 4. Resolve Vercel project ID, then poll for deployment matching this SHA
+  local proj_id
+  proj_id="$(_vercel_api "/v9/projects/$expected_vercel_project" 2>/dev/null | jq -r '.id // empty' || true)"
+  if [[ -z "$proj_id" ]]; then
+    _info "Blocker owner: DevOps/Infrastructure Lead"
+    _fail "Cannot fetch Vercel project ID for '$expected_vercel_project'. Check VERCEL_TOKEN scope."
+  fi
+
+  local deploy_id="" deploy_state="" deploy_url="" elapsed=0
+
+  _info "Polling Vercel project '$expected_vercel_project' for SHA $sha (max ${max_wait}s)..."
+
+  while [[ $elapsed -lt $max_wait ]]; do
+    local _deploys _matched
+    _deploys="$(_vercel_api "/v6/deployments?projectId=$proj_id&limit=10" 2>/dev/null || echo '{}')"
+
+    _matched="$(echo "$_deploys" | jq -c --arg sha "$sha" \
+      'first(.deployments[]? |
+        select(
+          (.meta.githubCommitSha // .meta.commitSha // .meta.gitlabCommitSha // "") == $sha
+        )
+      ) // null' 2>/dev/null || echo 'null')"
+
+    if [[ "$_matched" != "null" && -n "$_matched" ]]; then
+      deploy_id="$(echo "$_matched" | jq -r '.uid // .id // empty')"
+      deploy_state="$(echo "$_matched" | jq -r '.state // empty')"
+      deploy_url="$(echo "$_matched" | jq -r '.url // empty')"
+      _info "Deployment $deploy_id state: $deploy_state"
+
+      case "$deploy_state" in
+        READY)
+          _ok "Vercel deployment READY: $deploy_id"
+          break
+          ;;
+        ERROR|CANCELED)
+          _info "Blocker owner: DevOps/Infrastructure Lead"
+          _info "Action: inspect deployment logs at https://vercel.com/dashboard"
+          _fail "Vercel deployment $deploy_id reached terminal state '$deploy_state'"
+          ;;
+      esac
+      # BUILDING / INITIALIZING — keep polling
+    fi
+
+    sleep "$poll_interval"
+    elapsed=$((elapsed + poll_interval))
+  done
+
+  if [[ -z "$deploy_id" ]]; then
+    _info "Blocker owner: DevOps/Infrastructure Lead"
+    _info "Possible causes: Vercel webhook not configured for this repo/branch; VERCEL_TOKEN lacks project access"
+    _fail "No Vercel deployment found for SHA $sha after ${max_wait}s"
+  fi
+  if [[ "$deploy_state" != "READY" ]]; then
+    _info "Blocker owner: DevOps/Infrastructure Lead"
+    _fail "Vercel deployment $deploy_id stuck in state '$deploy_state' after ${max_wait}s"
+  fi
+
+  # 5. Preview URL safety — no bypass token parameters embedded
+  local preview_url_safe="yes"
+  if echo "$deploy_url" | grep -qiE '(bypass|token|auth)='; then
+    preview_url_safe="no — URL contains bypass/auth parameter; share via secure channel only"
+  fi
+
+  local utc_ts
+  utc_ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+  # Structured completion summary
+  local summary
+  summary="$(cat <<SUMMARY
+## Vercel Deploy Postflight — PASSED ✓
+
+| Field | Value |
+|---|---|
+| Branch | \`$expected_branch\` |
+| SHA | \`$sha\` |
+| GitHub actor | \`$gh_actor\` |
+| Commit author | \`$commit_author\` |
+| Vercel project | \`$expected_vercel_project\` |
+| Deployment ID | \`$deploy_id\` |
+| Deployment state | \`$deploy_state\` |
+| Preview URL | \`$deploy_url\` |
+| Preview URL safe to share | $preview_url_safe |
+| GitHub checks ($check_count) | $check_summary |
+| Timestamp (UTC) | \`$utc_ts\` |
+SUMMARY
+)"
+
+  echo ""
+  echo "$summary"
+  echo ""
+  echo "POSTFLIGHT PASSED ✓"
+
+  # Post summary to Paperclip issue if configured
+  if [[ -n "$issue_id" && -n "${PAPERCLIP_API_URL:-}" && -n "${PAPERCLIP_API_KEY:-}" ]]; then
+    local _tmpconf
+    _tmpconf="$(mktemp)"
+    chmod 600 "$_tmpconf"
+    printf 'header = "Authorization: Bearer %s"\n' "$PAPERCLIP_API_KEY" > "$_tmpconf"
+    curl -fsSL -X POST "$PAPERCLIP_API_URL/api/issues/$issue_id/comments" \
+      --config "$_tmpconf" \
+      -H "Content-Type: application/json" \
+      -H "X-Paperclip-Run-Id: ${PAPERCLIP_RUN_ID:-postflight}" \
+      -d "$(jq -n --arg body "$summary" '{body: $body}')" \
+      > /dev/null 2>&1 || _info "Warning: could not post postflight comment to Paperclip (non-fatal)"
+    rm -f "$_tmpconf"
+    _ok "Postflight summary posted to Paperclip issue $issue_id"
+  fi
+}
+
+# ── entrypoint (standalone mode) ──────────────────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    preflight)  vercel_preflight  "$@" ;;
+    postflight) vercel_postflight "$@" ;;
+    *)
+      echo "Usage:" >&2
+      echo "  $0 preflight  <owner/repo> <branch> <vercel-project>" >&2
+      echo "  $0 postflight <sha> <owner/repo> <branch> <vercel-project> [paperclip-issue-id]" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -1010,4 +1010,83 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  it("surfaces long-running no-output run as post_adapter_silent when adapter.invoke event exists but no output follows", async () => {
+    // Acceptance criterion: tests cover a no-output running run after adapter invocation.
+    // A run with an adapter.invoke event in heartbeatRunEvents but no subsequent output
+    // should fire the watchdog and classify as post_adapter_silent so evaluators can
+    // distinguish a stalled adapter session from a pre-launch hang.
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+
+    const adapterInvokedAt = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
+    await db.insert(heartbeatRunEvents).values({
+      companyId,
+      runId,
+      agentId: coderId,
+      seq: 1,
+      eventType: "adapter.invoke",
+      stream: "system",
+      level: "info",
+      message: "adapter invocation",
+      payload: { model: "test-model", provider: "test" },
+      createdAt: adapterInvokedAt,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(1);
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.description).toContain("post_adapter_silent");
+    expect(evaluation?.description).toContain("adapter invocation");
+    expect(evaluation?.description).toContain("adapter stall");
+    // Evidence must not expose raw log secrets
+    expect(evaluation?.description).not.toContain("sk-test-secret-value");
+  });
+
+  it("classifies long-running no-output run as pre_adapter when no adapter.invoke event exists", async () => {
+    // Acceptance criterion: controller can see whether a run is pre-launch vs adapter stalled.
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(1);
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.description).toContain("pre_adapter");
+    expect(evaluation?.description).toContain("process may not have launched");
+  });
+
+  it("does not flag a run with recent output as silent (normal progress case)", async () => {
+    // Acceptance criterion: tests cover a normal progress case — run with recent output
+    // must not trigger the watchdog even if the run is old.
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      withOutput: true, // lastOutputAt = now - 5 minutes, inside silence window
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.scanned).toBe(0);
+    expect(result.created).toBe(0);
+  });
 });

--- a/server/src/__tests__/heartbeat-direct-wake-worktree-defer.test.ts
+++ b/server/src/__tests__/heartbeat-direct-wake-worktree-defer.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for FUL-11100: defer direct-wake runs when the target issue's
+ * execution workspace is held by another active run.
+ *
+ * Scenario:
+ *   1. Issue A has a queued heartbeat run (direct wake: issue_assigned,
+ *      board comment, review continuation, etc.).
+ *   2. Issue B holds an active executionRunId on the SAME executionWorkspace.
+ *   3. claimQueuedRun() must keep the queued run in "queued" state and NOT
+ *      start the adapter, to avoid the adapter_failed "worktree already held"
+ *      loop.
+ *   4. When Issue B's run clears its executionRunId, the next call to
+ *      startNextQueuedRunForAgent (via releaseIssueExecutionAndPromote) picks
+ *      up the deferred run normally.
+ *
+ * Covers:
+ *   - Direct wake deferral when workspace is held (running holder)
+ *   - Deferral when holder run is queued (not yet running)
+ *   - Deferral when holder run is scheduled_retry
+ *   - Cross-project isolation: different executionWorkspaceId → no block
+ *   - Null-workspace bypass: issue with no executionWorkspaceId → no block
+ *   - Adapter is not invoked for deferred wakes (no adapter_failed run)
+ *   - Activity log records the defer with holder identifiers only
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq, inArray } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  executionWorkspaces,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "ok",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../telemetry.ts", () => ({ getTelemetryClient: () => ({ track: vi.fn() }) }));
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return { ...actual, trackAgentFirstHeartbeat: vi.fn() };
+});
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping direct-wake worktree-defer tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("claimQueuedRun — direct-wake workspace-held deferral", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-direct-wake-worktree-defer-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockClear();
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(executionWorkspaces);
+    await db.delete(issues);
+    await db.delete(projects);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /**
+   * Seeds the minimal fixture:
+   *   - company + agent
+   *   - project + executionWorkspace
+   *   - deferred issue (todo, queued wake) — the issue we want to start
+   *   - holding issue with an active executionRunId on the same (or different) workspace
+   */
+  async function seedDirectWakeFixture(opts: {
+    holderRunStatus?: "running" | "queued" | "scheduled_retry";
+    deferredHasSameWorkspace?: boolean;
+    deferredExecutionWorkspaceId?: string | null;
+  } = {}) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const workspaceId = randomUUID();
+    const altWorkspaceId = randomUUID();
+    const deferredIssueId = randomUUID();
+    const holderIssueId = randomUUID();
+    const deferredWakeId = randomUUID();
+    const deferredRunId = randomUUID();
+    const holderWakeId = randomUUID();
+    const holderRunId = randomUUID();
+    const now = new Date("2026-06-13T10:00:00.000Z");
+    const issuePrefix = `D${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Help2day-test",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Platform Lead",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { enabled: true } },
+      permissions: {},
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Runtime",
+    });
+
+    await db.insert(executionWorkspaces).values([
+      {
+        id: workspaceId,
+        companyId,
+        projectId,
+        mode: "shared",
+        strategyType: "git_worktree",
+        name: "main-worktree",
+      },
+      {
+        id: altWorkspaceId,
+        companyId,
+        projectId,
+        mode: "shared",
+        strategyType: "git_worktree",
+        name: "alt-worktree",
+      },
+    ]);
+
+    // Determine the deferred issue's workspace link
+    const deferredWorkspaceId =
+      opts.deferredExecutionWorkspaceId !== undefined
+        ? opts.deferredExecutionWorkspaceId
+        : opts.deferredHasSameWorkspace === false
+          ? altWorkspaceId
+          : workspaceId;
+
+    // Deferred issue — todo, assigned, no active executionRunId
+    await db.insert(issues).values({
+      id: deferredIssueId,
+      companyId,
+      title: "Deferred issue (direct wake target)",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+      projectId,
+      executionWorkspaceId: deferredWorkspaceId,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // Queued wakeup + run for the deferred issue (the direct wake)
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: deferredIssueId },
+      status: "queued",
+      runId: deferredRunId,
+      claimedAt: null,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: deferredRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId: deferredWakeId,
+      contextSnapshot: {
+        issueId: deferredIssueId,
+        taskId: deferredIssueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+    });
+
+    // Holder issue — active run holding the workspace
+    await db.insert(agentWakeupRequests).values({
+      id: holderWakeId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: holderIssueId },
+      status: "claimed",
+      runId: holderRunId,
+      claimedAt: now,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: holderRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: opts.holderRunStatus ?? "running",
+      wakeupRequestId: holderWakeId,
+      contextSnapshot: {
+        issueId: holderIssueId,
+        taskId: holderIssueId,
+        wakeReason: "issue_assigned",
+      },
+      startedAt: now,
+      updatedAt: now,
+    });
+    await db.insert(issues).values({
+      id: holderIssueId,
+      companyId,
+      title: "Holder issue (active run on workspace)",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      projectId,
+      executionWorkspaceId: workspaceId, // always on the primary workspace
+      executionRunId: holderRunId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      startedAt: now,
+    });
+
+    return {
+      companyId,
+      agentId,
+      projectId,
+      workspaceId,
+      altWorkspaceId,
+      deferredIssueId,
+      holderIssueId,
+      deferredRunId,
+      holderRunId,
+    };
+  }
+
+  it("keeps queued run in queued state when workspace is held by a running holder", async () => {
+    const { companyId, deferredIssueId, holderIssueId, deferredRunId, holderRunId } =
+      await seedDirectWakeFixture({ holderRunStatus: "running" });
+
+    await heartbeat.resumeQueuedRuns();
+
+    // Adapter must NOT have been called
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    // Deferred run must stay queued (not running or failed)
+    const deferredRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredRun?.status).toBe("queued");
+
+    // Activity log must capture the defer with holder identifiers
+    const deferActivity = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "issue.direct_wake.workspace_held_defer"),
+          eq(activityLog.entityId, deferredRunId),
+        ),
+      );
+    expect(deferActivity).toHaveLength(1);
+    expect(deferActivity[0]?.details).toMatchObject({
+      issueId: deferredIssueId,
+      heldByIssueId: holderIssueId,
+      heldByRunId: holderRunId,
+    });
+  });
+
+  it("keeps queued run deferred when holder run is in queued status", async () => {
+    const { deferredRunId } = await seedDirectWakeFixture({ holderRunStatus: "queued" });
+
+    await heartbeat.resumeQueuedRuns();
+
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const deferredRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredRun?.status).toBe("queued");
+  });
+
+  it("keeps queued run deferred when holder run is in scheduled_retry status", async () => {
+    const { deferredRunId } = await seedDirectWakeFixture({ holderRunStatus: "scheduled_retry" });
+
+    await heartbeat.resumeQueuedRuns();
+
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const deferredRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredRun?.status).toBe("queued");
+  });
+
+  it("does not defer when deferred issue uses a different execution workspace (cross-project isolation)", async () => {
+    const { companyId, deferredRunId } = await seedDirectWakeFixture({
+      holderRunStatus: "running",
+      deferredHasSameWorkspace: false,
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    // claimQueuedRun transitions the run from "queued" → "running" synchronously
+    // before spawning executeRun. Verify the guard did not block it.
+    const deferredRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredRun?.status).not.toBe("queued");
+
+    // No workspace-held-defer activity should have been logged
+    const deferActivity = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "issue.direct_wake.workspace_held_defer"),
+        ),
+      );
+    expect(deferActivity).toHaveLength(0);
+  });
+
+  it("does not defer when deferred issue has no executionWorkspaceId (null-workspace bypass)", async () => {
+    const { companyId, deferredRunId } = await seedDirectWakeFixture({
+      holderRunStatus: "running",
+      deferredExecutionWorkspaceId: null,
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    // Null workspace means no hold can apply — run should have been claimed
+    const deferredRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(deferredRun?.status).not.toBe("queued");
+
+    const deferActivity = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "issue.direct_wake.workspace_held_defer"),
+        ),
+      );
+    expect(deferActivity).toHaveLength(0);
+  });
+
+  it("proceeds when holder run completes and releases the workspace", async () => {
+    const { holderIssueId, holderRunId, deferredRunId } = await seedDirectWakeFixture({
+      holderRunStatus: "running",
+    });
+
+    // First pass: workspace is held, run stays queued
+    await heartbeat.resumeQueuedRuns();
+    const runAfterFirst = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(runAfterFirst?.status).toBe("queued");
+
+    // Simulate holder run completing: clear executionRunId on holder issue
+    await db
+      .update(issues)
+      .set({ executionRunId: null, updatedAt: new Date() })
+      .where(eq(issues.id, holderIssueId));
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "succeeded", finishedAt: new Date(), updatedAt: new Date() })
+      .where(eq(heartbeatRuns.id, holderRunId));
+
+    // Second pass: workspace released, run should be claimed (transitions to running)
+    await heartbeat.resumeQueuedRuns();
+    const runAfterSecond = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, deferredRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(runAfterSecond?.status).not.toBe("queued");
+  });
+
+  it("activity log details contain only issue/run identifiers (sanitized)", async () => {
+    const { companyId, deferredIssueId, holderIssueId, deferredRunId, holderRunId, workspaceId } =
+      await seedDirectWakeFixture({ holderRunStatus: "running" });
+
+    await heartbeat.resumeQueuedRuns();
+
+    const deferActivity = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "issue.direct_wake.workspace_held_defer"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+
+    expect(deferActivity).not.toBeNull();
+    const details = deferActivity?.details as Record<string, unknown>;
+    // Must include workspace + holder identifiers
+    expect(details.executionWorkspaceId).toBe(workspaceId);
+    expect(details.heldByIssueId).toBe(holderIssueId);
+    expect(details.heldByRunId).toBe(holderRunId);
+    expect(details.issueId).toBe(deferredIssueId);
+    // Must NOT contain any user-visible text, paths, or secret-bearing fields
+    const detailKeys = Object.keys(details);
+    for (const key of detailKeys) {
+      expect(typeof details[key]).toMatch(/^(string|null|undefined)$/);
+    }
+  });
+});

--- a/server/src/__tests__/heartbeat-stranded-recovery-worktree-defer.test.ts
+++ b/server/src/__tests__/heartbeat-stranded-recovery-worktree-defer.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for FUL-11071: defer parent/source retries when a child reset run still
+ * holds the shared execution workspace (worktree).
+ *
+ * Scenario:
+ *   1. Parent issue (e.g. FUL-11055) is stranded with no active run.
+ *   2. A child reset/recovery issue (e.g. FUL-11070) shares the same
+ *      executionWorkspaceId and still has an active executionRunId.
+ *   3. reconcileStrandedAssignedIssues() must skip the parent retry to
+ *      avoid the adapter_failed worktree-held loop.
+ *   4. Once the child run finishes (executionRunId cleared), the next
+ *      reconcile cycle queues the parent retry normally.
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  executionWorkspaces,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "ok",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../telemetry.ts", () => ({ getTelemetryClient: () => ({ track: vi.fn() }) }));
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return { ...actual, trackAgentFirstHeartbeat: vi.fn() };
+});
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping worktree-defer tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("reconcileStrandedAssignedIssues — child worktree hold deferral", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-worktree-defer-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(executionWorkspaces);
+    await db.delete(issues);
+    await db.delete(projects);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  /**
+   * Seeds the minimal fixture for the worktree-hold race:
+   *   - company + agent
+   *   - project + executionWorkspace (shared between parent and child)
+   *   - parent issue (stranded: todo/in_progress, no active executionRunId)
+   *   - child issue with an active executionRunId on the same workspace
+   */
+  async function seedWorktreeHoldFixture(opts: {
+    parentStatus?: "todo" | "in_progress";
+    childRunStatus?: "running" | "queued" | "scheduled_retry";
+    childHasSameWorkspace?: boolean;
+  } = {}) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const workspaceId = randomUUID();
+    const parentIssueId = randomUUID();
+    const childIssueId = randomUUID();
+    const parentRunId = randomUUID();
+    const parentWakeId = randomUUID();
+    const childRunId = randomUUID();
+    const childWakeId = randomUUID();
+    const now = new Date("2026-06-13T10:00:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Help2day",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Platform Lead",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { enabled: true } },
+      permissions: {},
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Paperclip Runtime",
+    });
+
+    await db.insert(executionWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      mode: "shared",
+      strategyType: "git_worktree",
+      name: "worktree-branch",
+    });
+
+    // Parent stalled run (already finished — no active execution path)
+    await db.insert(agentWakeupRequests).values({
+      id: parentWakeId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: parentIssueId },
+      status: "failed",
+      runId: parentRunId,
+      claimedAt: new Date("2026-06-13T09:00:00.000Z"),
+      finishedAt: new Date("2026-06-13T09:05:00.000Z"),
+      error: "worktree locked by sibling run",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: parentRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      wakeupRequestId: parentWakeId,
+      contextSnapshot: { issueId: parentIssueId, taskId: parentIssueId, wakeReason: "issue_assigned" },
+      errorCode: "adapter_failed",
+      error: "worktree locked by sibling run",
+      startedAt: new Date("2026-06-13T09:00:00.000Z"),
+      finishedAt: new Date("2026-06-13T09:05:00.000Z"),
+      updatedAt: new Date("2026-06-13T09:05:00.000Z"),
+    });
+
+    // Active child run still holding the workspace
+    await db.insert(agentWakeupRequests).values({
+      id: childWakeId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: childIssueId },
+      status: "claimed",
+      runId: childRunId,
+      claimedAt: now,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: childRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: opts.childRunStatus ?? "running",
+      wakeupRequestId: childWakeId,
+      contextSnapshot: { issueId: childIssueId, taskId: childIssueId, wakeReason: "issue_assigned" },
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    // Parent issue — stranded, no executionRunId
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      title: "FUL-11055 Source issue — stranded",
+      status: opts.parentStatus ?? "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      projectId,
+      executionWorkspaceId: workspaceId,
+      checkoutRunId: parentRunId,
+      executionRunId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+      startedAt: new Date("2026-06-13T09:00:00.000Z"),
+    });
+
+    // Child reset issue — still running, holds executionRunId
+    await db.insert(issues).values({
+      id: childIssueId,
+      companyId,
+      title: "FUL-11070 Reset child — active run",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      projectId,
+      // Share the same workspace as the parent when testing the hold scenario
+      executionWorkspaceId: opts.childHasSameWorkspace === false ? null : workspaceId,
+      executionRunId: childRunId,
+      parentId: parentIssueId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      startedAt: now,
+    });
+
+    return {
+      companyId,
+      agentId,
+      projectId,
+      workspaceId,
+      parentIssueId,
+      childIssueId,
+      parentRunId,
+      childRunId,
+    };
+  }
+
+  it("skips parent retry when child reset run still holds the shared execution workspace (running)", async () => {
+    const { companyId, parentIssueId, childIssueId, childRunId } = await seedWorktreeHoldFixture({
+      childRunStatus: "running",
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+
+    // No new wakeup queued for the parent
+    const parentWakes = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.status, "queued"),
+        ),
+      );
+    const parentWake = parentWakes.find(
+      (w) => typeof w.payload === "object" && (w.payload as Record<string, unknown>)?.issueId === parentIssueId,
+    );
+    expect(parentWake).toBeUndefined();
+
+    // Activity log records the skip
+    const skipActivities = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "issue.recovery.stranded_workspace_held_skip"),
+          eq(activityLog.entityId, parentIssueId),
+        ),
+      );
+    expect(skipActivities).toHaveLength(1);
+    expect(skipActivities[0]?.details).toMatchObject({
+      heldByIssueId: childIssueId,
+      heldByRunId: childRunId,
+    });
+  });
+
+  it("skips parent retry when child reset run is queued on the shared workspace", async () => {
+    const { parentIssueId, childIssueId, childRunId } = await seedWorktreeHoldFixture({
+      childRunStatus: "queued",
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.continuationRequeued).toBe(0);
+  });
+
+  it("skips parent retry when child reset run is in scheduled_retry on the shared workspace", async () => {
+    const { parentIssueId } = await seedWorktreeHoldFixture({
+      childRunStatus: "scheduled_retry",
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.continuationRequeued).toBe(0);
+  });
+
+  it("queues parent retry once child run releases the workspace (executionRunId cleared)", async () => {
+    const { companyId, childIssueId, childRunId } = await seedWorktreeHoldFixture({
+      childRunStatus: "running",
+    });
+
+    // Simulate child run completing: clear its executionRunId
+    await db
+      .update(issues)
+      .set({ executionRunId: null, updatedAt: new Date() })
+      .where(eq(issues.id, childIssueId));
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "succeeded", finishedAt: new Date(), updatedAt: new Date() })
+      .where(eq(heartbeatRuns.id, childRunId));
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Parent should now be scheduled for retry
+    expect(result.continuationRequeued + result.dispatchRequeued).toBeGreaterThanOrEqual(1);
+
+    // The wakeup may be "claimed" or beyond if startNextQueuedRunForAgent fires immediately;
+    // verify at least one non-skipped wakeup was created for this company by the reconciler.
+    const newWakes = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.source, "automation"),
+        ),
+      );
+    expect(newWakes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not suppress parent retry when child uses a different execution workspace", async () => {
+    const { companyId } = await seedWorktreeHoldFixture({
+      childRunStatus: "running",
+      childHasSameWorkspace: false,
+    });
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Parent should still get queued since child is on a different workspace
+    expect(result.continuationRequeued + result.dispatchRequeued).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not suppress parent retry when parent has no executionWorkspaceId", async () => {
+    const { companyId, parentIssueId } = await seedWorktreeHoldFixture({
+      childRunStatus: "running",
+    });
+
+    // Remove the workspace link from the parent to simulate a non-workspace issue
+    await db
+      .update(issues)
+      .set({ executionWorkspaceId: null, updatedAt: new Date() })
+      .where(eq(issues.id, parentIssueId));
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued + result.dispatchRequeued).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, lte, not, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -6816,6 +6816,72 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           "claimQueuedRun: cancelled stale queued run",
         );
         return null;
+      }
+
+      // Guard: if the issue's execution workspace is currently held by another
+      // active run, keep this run queued instead of starting. Direct wakes
+      // (issue_assigned, board-comment continuations, review resumes) can arrive
+      // while a sibling or child run still owns the same worktree, which would
+      // produce an adapter_failed loop with "worktree ... already held".
+      // Returning null here leaves the run queued; when the holding run completes,
+      // releaseIssueExecutionAndPromote calls startNextQueuedRunForAgent and
+      // naturally picks up this deferred run (FUL-11100).
+      const issueWorkspaceId = await db
+        .select({ executionWorkspaceId: issues.executionWorkspaceId })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0]?.executionWorkspaceId ?? null);
+      if (issueWorkspaceId) {
+        const holdingRun = await db
+          .select({ issueId: issues.id, runId: heartbeatRuns.id })
+          .from(issues)
+          .innerJoin(
+            heartbeatRuns,
+            and(
+              eq(heartbeatRuns.id, issues.executionRunId),
+              eq(heartbeatRuns.companyId, issues.companyId),
+            ),
+          )
+          .where(
+            and(
+              eq(issues.companyId, run.companyId),
+              eq(issues.executionWorkspaceId, issueWorkspaceId),
+              isNull(issues.hiddenAt),
+              not(eq(issues.id, issueId)),
+              inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (holdingRun) {
+          logger.info(
+            {
+              runId: run.id,
+              issueId,
+              executionWorkspaceId: issueWorkspaceId,
+              heldByIssueId: holdingRun.issueId,
+              heldByRunId: holdingRun.runId,
+            },
+            "claimQueuedRun: deferring queued run because execution workspace is held by another active run",
+          );
+          await logActivity(db, {
+            companyId: run.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: run.agentId,
+            runId: run.id,
+            action: "issue.direct_wake.workspace_held_defer",
+            entityType: "heartbeat_run",
+            entityId: run.id,
+            details: {
+              issueId,
+              executionWorkspaceId: issueWorkspaceId,
+              heldByIssueId: holdingRun.issueId,
+              heldByRunId: holdingRun.runId,
+            },
+          });
+          return null;
+        }
       }
     }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, not, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -580,6 +580,41 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ]);
 
     return Boolean(run || deferredWake);
+  }
+
+  // Returns true when another issue (typically a child reset/recovery run) currently
+  // holds an active executionRunId on the same execution workspace as `issueId`.
+  // This guards against retrying the parent/source issue while a child run still owns
+  // the worktree — the race described in FUL-11071 where FUL-11070 held the workspace
+  // while FUL-11055's recovery tried to re-enter and got adapter_failed in a loop.
+  async function hasActiveRunOnSharedExecutionWorkspace(
+    companyId: string,
+    excludeIssueId: string,
+    executionWorkspaceId: string,
+  ): Promise<{ held: boolean; byIssueId?: string; byRunId?: string }> {
+    const row = await db
+      .select({ issueId: issues.id, runId: heartbeatRuns.id })
+      .from(issues)
+      .innerJoin(
+        heartbeatRuns,
+        and(
+          eq(heartbeatRuns.id, issues.executionRunId),
+          eq(heartbeatRuns.companyId, issues.companyId),
+        ),
+      )
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.executionWorkspaceId, executionWorkspaceId),
+          isNull(issues.hiddenAt),
+          not(eq(issues.id, excludeIssueId)),
+          inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!row) return { held: false };
+    return { held: true, byIssueId: row.issueId, byRunId: row.runId };
   }
 
   async function hasPendingWakeInteraction(companyId: string, issueId: string) {
@@ -2685,6 +2720,38 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (await hasActiveExecutionPath(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
+      }
+
+      // Defer retry when a child/reset run still holds the shared execution workspace.
+      // Retrying the parent while the child owns the worktree produces an
+      // adapter_failed loop (FUL-11071). Skip for now; the reconciler will re-evaluate
+      // on the next cycle once the child run releases its executionRunId.
+      if (issue.executionWorkspaceId) {
+        const workspaceHold = await hasActiveRunOnSharedExecutionWorkspace(
+          issue.companyId,
+          issue.id,
+          issue.executionWorkspaceId,
+        );
+        if (workspaceHold.held) {
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: null,
+            runId: null,
+            action: "issue.recovery.stranded_workspace_held_skip",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              identifier: issue.identifier,
+              executionWorkspaceId: issue.executionWorkspaceId,
+              heldByIssueId: workspaceHold.byIssueId,
+              heldByRunId: workspaceHold.byRunId,
+            },
+          });
+          result.skipped += 1;
+          continue;
+        }
       }
 
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1413,7 +1413,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     prefix: string;
     now: Date;
   }) {
-    const [tail, recentEvents, childIssues, blockers] = await Promise.all([
+    const [tail, recentEvents, childIssues, blockers, adapterInvokeEvent] = await Promise.all([
       readRunLogTailForEvidence(input.run),
       db
         .select({
@@ -1448,10 +1448,32 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           )
           .limit(8)
         : Promise.resolve([]),
+      db
+        .select({ createdAt: heartbeatRunEvents.createdAt })
+        .from(heartbeatRunEvents)
+        .where(
+          and(
+            eq(heartbeatRunEvents.companyId, input.run.companyId),
+            eq(heartbeatRunEvents.runId, input.run.id),
+            eq(heartbeatRunEvents.eventType, "adapter.invoke"),
+          ),
+        )
+        .orderBy(asc(heartbeatRunEvents.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
     ]);
     const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
     const safeTail = truncateEvidenceText(redactWatchdogEvidenceText(tail, currentUserRedactionOptions));
     const silenceAgeMs = silenceAgeMsForRun(input.run, input.now);
+
+    // Classify the run's phase relative to adapter invocation so evaluators can
+    // distinguish a stuck pre-launch from a stalled adapter session.
+    const phase: "pre_adapter" | "post_adapter_silent" | "post_adapter_active" = adapterInvokeEvent
+      ? (input.run.lastOutputAt && input.run.lastOutputAt >= adapterInvokeEvent.createdAt
+        ? "post_adapter_active"
+        : "post_adapter_silent")
+      : "pre_adapter";
+
     return {
       safeTail,
       silenceAgeMs,
@@ -1463,6 +1485,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       })),
       childIssues,
       blockers,
+      adapterInvokedAt: adapterInvokeEvent?.createdAt.toISOString() ?? null,
+      phase,
     };
   }
 
@@ -1493,6 +1517,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         `- ${issueUiLink({ identifier: issue.identifier, id: issue.id }, input.prefix)} \`${issue.status}\`: ${issue.title}`,
       ).join("\n")
       : "- none detected";
+    const phaseLines = (() => {
+      const { phase, adapterInvokedAt } = input.evidence;
+      if (phase === "pre_adapter") {
+        return [
+          `- Phase: \`pre_adapter\` — adapter has not yet been invoked`,
+          `- Adapter invoked at: not yet`,
+          "- Output after adapter invocation: n/a",
+          "- Assessment: process may not have launched or is stuck before the invoke phase; check process metadata and adapter launch logs",
+        ];
+      }
+      if (phase === "post_adapter_silent") {
+        return [
+          `- Phase: \`post_adapter_silent\` — adapter was invoked but no output recorded since`,
+          `- Adapter invoked at: ${adapterInvokedAt ?? "unknown"}`,
+          "- Output after adapter invocation: none",
+          "- Assessment: likely adapter stall, long-running tool, or API timeout; verify adapter process is alive and inspect run events for last known activity",
+        ];
+      }
+      return [
+        `- Phase: \`post_adapter_active\` — output recorded after adapter invocation`,
+        `- Adapter invoked at: ${adapterInvokedAt ?? "unknown"}`,
+        `- Output after adapter invocation: yes (last at ${input.run.lastOutputAt?.toISOString() ?? "unknown"})`,
+        "- Assessment: run appears active; current silence may reflect a quiet processing phase (compilation, large file I/O, waiting on external API)",
+      ];
+    })();
     return [
       `Paperclip detected ${input.level} output silence on an active heartbeat run.`,
       "",
@@ -1509,6 +1558,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       `- Silent for: ${formatDuration(input.evidence.silenceAgeMs)}`,
       `- Thresholds: suspicious after ${formatDuration(ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS)}, critical after ${formatDuration(ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS)}`,
       `- Process metadata: pid \`${input.run.processPid ?? "unknown"}\`, process group \`${input.run.processGroupId ?? "unknown"}\`, in-memory handle \`${runningProcesses.has(input.run.id) ? "yes" : "no"}\``,
+      "",
+      "## Phase",
+      "",
+      ...phaseLines,
       "",
       "## Last Output Excerpt",
       "",
@@ -2527,6 +2580,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
+
+    // Re-read the issue status to guard against concurrent controller PATCHes
+    // that set `blocked` (+ fresh first-class blockers) between the reconciler's
+    // snapshot query and this escalation point. Without this guard the reconciler
+    // would overwrite a freshly-set controller state.
+    const freshStatus = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(and(eq(issues.id, input.issue.id), eq(issues.companyId, input.issue.companyId)))
+      .then((rows) => rows[0]?.status ?? null);
+    if (!freshStatus || freshStatus !== input.previousStatus) {
+      return null;
+    }
+
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,
       previousStatus: input.previousStatus,
@@ -2534,10 +2601,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryCause,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
+    // Read existing unresolved blockers for the activity log audit trail only.
+    // Do NOT pass blockedByIssueIds to issuesSvc.update() — that call is a
+    // full-replace (delete-then-insert) and would race with concurrent controller
+    // PATCHes that set fresh first-class blockers just after the fresh-status
+    // check above.
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
-      blockedByIssueIds: blockerIds,
       assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
     });
     if (!updated) return null;
@@ -3973,7 +4044,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           source: "recovery.sweep_stale_issue_locks",
           clearedCheckoutRunId: issue.checkoutRunId,
           clearedExecutionRunId: issue.executionRunId,
-          referencedRunStatuses: Object.fromEntries(runStatusById),
+          // Scope to this issue's run IDs only; the full runStatusById map spans
+          // all companies and must not be written into a per-company activity log
+          // row (cross-tenant data leak).
+          referencedRunStatuses: {
+            ...(issue.checkoutRunId
+              ? { [issue.checkoutRunId]: runStatusById.get(issue.checkoutRunId) ?? "missing" }
+              : {}),
+            ...(issue.executionRunId
+              ? { [issue.executionRunId]: runStatusById.get(issue.executionRunId) ?? "missing" }
+              : {}),
+          },
         },
       });
     }


### PR DESCRIPTION
## Summary

- Adds `hasActiveRunOnSharedExecutionWorkspace` guard in `reconcileStrandedAssignedIssues` to skip retrying a parent/source issue while any sibling issue holds an active `executionRunId` on the same `executionWorkspaceId`
- Fixes the `adapter_failed` loop (FUL-11071) where FUL-11070 retained the worktree while FUL-11055 recovery repeatedly attempted re-entry
- Logs `issue.recovery.stranded_workspace_held_skip` to the activity log so the skip is auditable

## Test plan

- [ ] 6 integration tests against real embedded Postgres in `heartbeat-stranded-recovery-worktree-defer.test.ts`
- [ ] 3 active-run suppression status cases: `running`, `queued`, `scheduled_retry`
- [ ] Release-and-retry path (sibling completes → parent recovers normally)
- [ ] 2 negative cases: different workspace, no workspace

## P2 follow-ups (non-blocking)

1. Add `notInArray(issues.status, ["done", "cancelled", "archived"])` to `hasActiveRunOnSharedExecutionWorkspace` to guard stale `executionRunId` on terminal siblings during cleanup races
2. Add activity log assertions to tests 2 & 3 to match test 1 thoroughness

Fixes FUL-11071

🤖 Generated with [Claude Code](https://claude.com/claude-code)