### PR TITLE
fix: normalize Hermes profile extra args

### DIFF
--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -385,6 +385,108 @@ describe("server adapter registry", () => {
     expect(patchedCtx.agent.adapterConfig.env.PAPERCLIP_API_KEY).toBe("agent-run-jwt");
   });
 
+  it("normalizes Hermes extraArgs pasted as a full command before execution", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          hermesCommand: "hermes",
+          extraArgs: ["chat", "-p mm3", "—-profile", "backup", "--label 'hello world'"],
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "agent-run-jwt",
+    });
+
+    expect(hermesExecuteMock).toHaveBeenCalledTimes(1);
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.agent.adapterConfig.extraArgs).toEqual([
+      "-p",
+      "mm3",
+      "--profile",
+      "backup",
+      "--label",
+      "hello world",
+    ]);
+  });
+
+  it("normalizes path-qualified Hermes commands pasted into extraArgs", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          extraArgs: ["/opt/bin/hermes chat --profile backup"],
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "agent-run-jwt",
+    });
+
+    expect(hermesExecuteMock).toHaveBeenCalledTimes(1);
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.agent.adapterConfig.extraArgs).toEqual(["--profile", "backup"]);
+  });
+
+  it("preserves already-tokenized Hermes extraArgs values that contain spaces", async () => {
+    const adapter = requireServerAdapter("hermes_local");
+
+    await adapter.execute({
+      runId: "run-123",
+      agent: {
+        id: "agent-123",
+        companyId: "company-123",
+        name: "Hermes Agent",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {
+          hermesCommand: "/opt/bin/hermes",
+          extraArgs: ["--profile", "mm3", "already tokenized value", "--label=hello world", "hello—world"],
+        },
+      },
+      runtime: {},
+      config: {},
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onSpawn: async () => {},
+      authToken: "agent-run-jwt",
+    });
+
+    expect(hermesExecuteMock).toHaveBeenCalledTimes(1);
+    const [patchedCtx] = hermesExecuteMock.mock.calls[0];
+    expect(patchedCtx.agent.adapterConfig.extraArgs).toEqual([
+      "--profile",
+      "mm3",
+      "already tokenized value",
+      "--label=hello world",
+      "hello—world",
+    ]);
+  });
+
   it("passes the original Hermes context through when authToken is absent", async () => {
     const adapter = requireServerAdapter("hermes_local");
     const ctx = {

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type {
   AdapterModel,
   AdapterModelProfileDefinition,
@@ -183,6 +185,86 @@ function buildCursorRuntimeCommandSpec(config: Record<string, unknown>): Adapter
   };
 }
 
+function normalizeHermesOptionDash(value: string): string {
+  return /^[\u2010-\u2015-]/.test(value) ? value.replace(/[\u2010-\u2015]/g, "-") : value;
+}
+
+function splitShellLikeArgs(value: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const char of value.trim()) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if ((char === "'" || char === '"') && quote === null) {
+      quote = char;
+      continue;
+    }
+    if (quote === char) {
+      quote = null;
+      continue;
+    }
+    if (/\s/.test(char) && quote === null) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaped) current += "\\";
+  if (current) args.push(current);
+  return args;
+}
+
+function shouldExpandHermesExtraArg(value: string, commandTokens: Set<string>): boolean {
+  const tokens = splitShellLikeArgs(value);
+  if (tokens.length <= 1) return false;
+  const first = normalizeHermesOptionDash(tokens[0]);
+  return (first.startsWith("-") && !first.includes("=")) || commandTokens.has(first) || commandTokens.has(path.basename(first));
+}
+
+function normalizeHermesExtraArgs(extraArgs: unknown, command?: string): string[] | undefined {
+  const commandTokens = new Set(["chat", "hermes"]);
+  if (command) {
+    commandTokens.add(command);
+    commandTokens.add(path.basename(command));
+  }
+  const rawArgs = Array.isArray(extraArgs)
+    ? extraArgs.flatMap((arg) => {
+        if (typeof arg !== "string") return [];
+        return shouldExpandHermesExtraArg(arg, commandTokens)
+          ? splitShellLikeArgs(arg).map(normalizeHermesOptionDash)
+          : [normalizeHermesOptionDash(arg.trim())].filter(Boolean);
+      })
+    : typeof extraArgs === "string"
+      ? splitShellLikeArgs(extraArgs).map(normalizeHermesOptionDash)
+      : [];
+
+  const normalizedArgs = [...rawArgs];
+  while (normalizedArgs.length > 0) {
+    const first = normalizedArgs[0];
+    if (commandTokens.has(first) || commandTokens.has(path.basename(first))) {
+      normalizedArgs.shift();
+      continue;
+    }
+    break;
+  }
+
+  return normalizedArgs.length > 0 ? normalizedArgs : undefined;
+}
+
 function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(ctx: T): T {
   const config =
     ctx && typeof ctx === "object" && "config" in ctx && ctx.config && typeof ctx.config === "object"
@@ -209,6 +291,17 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
   }
   if (agentAdapterConfig && !agentAdapterConfig.hermesCommand && agentCommand) {
     agentAdapterConfig.hermesCommand = agentCommand;
+  }
+  if (agentAdapterConfig && "extraArgs" in agentAdapterConfig) {
+    const normalizedExtraArgs = normalizeHermesExtraArgs(
+      agentAdapterConfig.extraArgs,
+      typeof agentAdapterConfig.hermesCommand === "string" ? agentAdapterConfig.hermesCommand : undefined,
+    );
+    if (normalizedExtraArgs) {
+      agentAdapterConfig.extraArgs = normalizedExtraArgs;
+    } else {
+      delete agentAdapterConfig.extraArgs;
+    }
   }
 
   return ctx;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - This change is in the server adapter registry, specifically the Hermes local adapter normalization layer.
> - The Hermes adapter already constructs the base `hermes chat ...` invocation, so user-provided `extraArgs` must only contain additional flags.
> - A configured Hermes profile failed when a pasted command fragment such as `chat -p mm3` was saved into `extraArgs`, producing `hermes chat ... chat -p mm3` at runtime.
> - The registry already normalizes legacy Hermes `command` fields before dispatching to the external adapter, so it is the right boundary for defensive persisted-config normalization.
> - This pull request normalizes common pasted Hermes command fragments before execution and adds regression coverage.
> - The benefit is that Hermes profiles can be configured safely even when operators paste CLI-shaped arguments into the adapter config.

## Linked Issues or Issue Description

Bug report:
- Summary: Hermes local agents fail to start when adapter `extraArgs` contains a pasted command fragment such as `chat -p mm3` for selecting a Hermes profile.
- Current behavior: Paperclip dispatches to the Hermes adapter with `extraArgs` containing `chat`, while the adapter also constructs `hermes chat ...`, causing Hermes CLI to exit with `unrecognized arguments: chat -p mm3`.
- Expected behavior: Paperclip should tolerate common pasted Hermes command fragments and pass only the profile flags to the adapter.
- Reproduction: Configure a `hermes_local` agent with `extraArgs: ["chat", "-p mm3"]`, then start a run.

## What Changed

- Added Hermes `extraArgs` normalization in `server/src/adapters/registry.ts` before invoking the adapter.
- Handles string-form and array-form `extraArgs`, shell-like quoted values, Unicode dash normalization for option tokens, leading `hermes`/`chat` command stripping, and path-qualified Hermes command fragments.
- Preserves already-tokenized values containing spaces when they are not recognized flag or command fragments.
- Added regression tests covering pasted `chat -p mm3`, Unicode dash profile flags, quoted values, path-qualified Hermes commands, and already-tokenized values with spaces.

## Verification

- `pnpm exec vitest run server/src/__tests__/adapter-registry.test.ts`
  - 21 tests passed
- `pnpm --filter @paperclipai/server typecheck`
  - passed
- Independent pre-commit review: no blocking security concerns or logic errors found.
- Static scan of added lines found no hardcoded secrets, shell injection, dangerous eval/exec, unsafe deserialization, or SQL injection patterns.

## Risks

- Low risk: this is scoped to Hermes adapter config normalization before execution.
- The main behavioral shift is that pasted command fragments in `extraArgs` are cleaned up instead of passed through literally.
- Shell-like parsing is intentionally limited to argument-token normalization and does not execute through a shell.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI, model `gpt-5.5`, tool-enabled coding session with terminal/file access and independent reviewer subagent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
