### PR TITLE
feat(issues): Layer 2 — explicit idempotencyKey on POST /issues (FUC-361)

### DIFF
--- a/packages/db/src/migrations/0102_issue_idempotency_key.sql
+++ b/packages/db/src/migrations/0102_issue_idempotency_key.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "idempotency_key" text;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "issues_company_idempotency_key_idx"
+  ON "issues" USING btree ("company_id","idempotency_key")
+  WHERE "issues"."idempotency_key" IS NOT NULL;

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -49,6 +49,7 @@ export const issues = pgTable(
     originFingerprint: text("origin_fingerprint").notNull().default("default"),
     requestDepth: integer("request_depth").notNull().default(0),
     billingCode: text("billing_code"),
+    idempotencyKey: text("idempotency_key"),
     assigneeAdapterOverrides: jsonb("assignee_adapter_overrides").$type<Record<string, unknown>>(),
     executionPolicy: jsonb("execution_policy").$type<Record<string, unknown>>(),
     executionState: jsonb("execution_state").$type<Record<string, unknown>>(),
@@ -90,6 +91,7 @@ export const issues = pgTable(
     dueMonitorIdx: index("issues_company_monitor_due_idx").on(table.companyId, table.monitorNextCheckAt),
     identifierIdx: uniqueIndex("issues_identifier_idx").on(table.identifier),
     titleSearchIdx: index("issues_title_search_idx").using("gin", table.title.op("gin_trgm_ops")),
+    idempotencyKeyIdx: index("issues_company_idempotency_key_idx").on(table.companyId, table.idempotencyKey).where(sql`"issues"."idempotency_key" IS NOT NULL`),
     identifierSearchIdx: index("issues_identifier_search_idx").using("gin", table.identifier.op("gin_trgm_ops")),
     descriptionSearchIdx: index("issues_description_search_idx").using("gin", table.description.op("gin_trgm_ops")),
     openRoutineExecutionIdx: uniqueIndex("issues_open_routine_execution_uq")

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -388,6 +388,7 @@ const createIssueBaseSchema = z.object({
   assigneeUserId: z.string().optional().nullable(),
   requestDepth: issueRequestDepthInputSchema.optional().default(0),
   billingCode: z.string().optional().nullable(),
+  idempotencyKey: z.string().trim().max(255).optional().nullable(),
   assigneeAdapterOverrides: issueAssigneeAdapterOverridesSchema.optional().nullable(),
   executionPolicy: issueExecutionPolicySchema.optional().nullable(),
   executionWorkspaceId: z.string().uuid().optional().nullable(),

--- a/server/src/__tests__/issue-create-dedup-routes.test.ts
+++ b/server/src/__tests__/issue-create-dedup-routes.test.ts
@@ -1,0 +1,266 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { agents, companies, companyMemberships, createDb, heartbeatRuns, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import type { StorageService } from "../storage/types.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping issue dedup route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("POST /companies/:companyId/issues — 60s time-window dedup", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let agentId!: string;
+  let agentId2!: string;
+  let runId!: string;
+  let parentIssueId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-dedup-");
+    db = createDb(tempDb.connectionString);
+
+    companyId = randomUUID();
+    agentId = randomUUID();
+    agentId2 = randomUUID();
+    runId = randomUUID();
+    parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Dedup Test Corp",
+      issuePrefix: "DED",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "board-user",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values([
+      {
+        id: agentId,
+        companyId,
+        name: "TestAgent",
+        role: "engineer",
+        status: "running",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: agentId2,
+        companyId,
+        name: "OtherAgent",
+        role: "engineer",
+        status: "running",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      contextSnapshot: { issueId: parentIssueId },
+    });
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function makeStorage(): StorageService {
+    return {
+      provider: "local_disk",
+      putFile: vi.fn(async () => { throw new Error("unexpected putFile"); }),
+      getObject: vi.fn(async () => { throw new Error("unexpected getObject"); }),
+      headObject: vi.fn(async () => ({ exists: false })),
+      deleteObject: vi.fn(async () => undefined),
+    };
+  }
+
+  function makeApp(actorOverride: Partial<Express.Request["actor"]> = {}) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "agent",
+        agentId,
+        companyId,
+        runId,
+        source: "agent_jwt",
+        ...actorOverride,
+      } as Express.Request["actor"];
+      next();
+    });
+    app.use("/api", issueRoutes(db, makeStorage()));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function countChildIssues(title: string) {
+    const rows = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.parentId, parentIssueId), eq(issues.title, title)));
+    return rows.length;
+  }
+
+  // ---- Happy path ----
+
+  it("returns 201 on first create (no dedup)", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: `dedup-first-${randomUUID()}`, parentId: parentIssueId, priority: "medium" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  it("returns 200 with original issue body on duplicate within 60s", async () => {
+    const title = `dedup-happy-${randomUUID()}`;
+    const app = makeApp();
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+    expect(r1.status, JSON.stringify(r1.body)).toBe(201);
+
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+
+    expect(r2.status, JSON.stringify(r2.body)).toBe(200);
+    expect(r2.body.id).toBe(r1.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBe("true");
+  });
+
+  it("creates exactly one DB row when the same child issue is POSTed twice", async () => {
+    const title = `dedup-one-row-${randomUUID()}`;
+    const app = makeApp();
+
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+
+    expect(await countChildIssues(title)).toBe(1);
+  });
+
+  // ---- Edge cases from the spec ----
+
+  it("does NOT dedup top-level issues (no parentId)", async () => {
+    const title = `top-level-${randomUUID()}`;
+    const app = makeApp();
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, priority: "medium" });
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, priority: "medium" });
+
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
+    expect(r1.body.id).not.toBe(r2.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  it("does NOT dedup when parentId differs", async () => {
+    const title = `diff-parent-${randomUUID()}`;
+    const parent2Id = randomUUID();
+    await db.insert(issues).values({
+      id: parent2Id,
+      companyId,
+      title: "Second parent for dedup edge case",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const app = makeApp();
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parent2Id, priority: "medium" });
+
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
+    expect(r1.body.id).not.toBe(r2.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  it("does NOT dedup when createdByAgentId differs", async () => {
+    const title = `diff-agent-${randomUUID()}`;
+    const appAgent1 = makeApp();
+    const appAgent2 = makeApp({ agentId: agentId2 });
+
+    const r1 = await request(appAgent1)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+    const r2 = await request(appAgent2)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
+    expect(r1.body.id).not.toBe(r2.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  it("does NOT dedup a cancelled original — allows genuine re-create", async () => {
+    const title = `cancelled-origin-${randomUUID()}`;
+    const app = makeApp();
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+    expect(r1.status).toBe(201);
+
+    // Cancel the original in DB
+    await db.update(issues).set({ status: "cancelled" }).where(eq(issues.id, r1.body.id));
+
+    // Re-create should produce a new issue
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, parentId: parentIssueId, priority: "medium" });
+
+    expect(r2.status).toBe(201);
+    expect(r2.body.id).not.toBe(r1.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+});

--- a/server/src/__tests__/issue-create-idempotency-key-routes.test.ts
+++ b/server/src/__tests__/issue-create-idempotency-key-routes.test.ts
@@ -1,0 +1,270 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { agents, companies, companyMemberships, createDb, heartbeatRuns, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import type { StorageService } from "../storage/types.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping issue idempotencyKey route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("POST /companies/:companyId/issues — idempotencyKey dedup", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let companyId2!: string;
+  let agentId!: string;
+  let runId!: string;
+  let parentIssueId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-idempotency-key-");
+    db = createDb(tempDb.connectionString);
+
+    companyId = randomUUID();
+    companyId2 = randomUUID();
+    agentId = randomUUID();
+    runId = randomUUID();
+    parentIssueId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Idempotency Test Corp",
+        issuePrefix: "IKY",
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: companyId2,
+        name: "Other Corp",
+        issuePrefix: "OTH",
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+    await db.insert(companyMemberships).values([
+      {
+        companyId,
+        principalType: "user",
+        principalId: "board-user",
+        status: "active",
+        membershipRole: "owner",
+        updatedAt: new Date(),
+      },
+      {
+        companyId: companyId2,
+        principalType: "user",
+        principalId: "board-user",
+        status: "active",
+        membershipRole: "owner",
+        updatedAt: new Date(),
+      },
+    ]);
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "running",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      contextSnapshot: { issueId: parentIssueId },
+    });
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function makeStorage(): StorageService {
+    return {
+      provider: "local_disk",
+      putFile: vi.fn(async () => { throw new Error("unexpected putFile"); }),
+      getObject: vi.fn(async () => { throw new Error("unexpected getObject"); }),
+      headObject: vi.fn(async () => ({ exists: false })),
+      deleteObject: vi.fn(async () => undefined),
+    };
+  }
+
+  function makeApp(actorOverride: Partial<Express.Request["actor"]> = {}) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "agent",
+        agentId,
+        companyId,
+        runId,
+        source: "agent_jwt",
+        ...actorOverride,
+      } as Express.Request["actor"];
+      next();
+    });
+    app.use("/api", issueRoutes(db, makeStorage()));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function makeAppForCompany2() {
+    const agent2Id = randomUUID();
+    return makeApp({ companyId: companyId2, agentId: agent2Id });
+  }
+
+  async function countIssuesByKey(key: string, inCompanyId: string = companyId) {
+    const rows = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(and(eq(issues.companyId, inCompanyId), eq(issues.idempotencyKey, key)));
+    return rows.length;
+  }
+
+  // ---- Happy path ----
+
+  it("returns 201 on first create with idempotencyKey (no dedup)", async () => {
+    const app = makeApp();
+    const key = `issue:${parentIssueId}:first-create-${randomUUID()}`;
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "First create", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  it("stores idempotencyKey on the created issue", async () => {
+    const app = makeApp();
+    const key = `issue:${parentIssueId}:stored-key-${randomUUID()}`;
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Store key test", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+
+    expect(res.status).toBe(201);
+    expect(res.body.idempotencyKey).toBe(key);
+  });
+
+  it("returns 200 with original issue body on duplicate key within 24h", async () => {
+    const app = makeApp();
+    const key = `issue:${parentIssueId}:happy-dedup-${randomUUID()}`;
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Dedup happy path", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+    expect(r1.status, JSON.stringify(r1.body)).toBe(201);
+
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Dedup happy path", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+
+    expect(r2.status, JSON.stringify(r2.body)).toBe(200);
+    expect(r2.body.id).toBe(r1.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBe("true");
+  });
+
+  it("creates exactly one DB row when same idempotencyKey is POSTed twice", async () => {
+    const app = makeApp();
+    const key = `issue:${parentIssueId}:one-row-${randomUUID()}`;
+
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "One row test", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "One row test", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+
+    expect(await countIssuesByKey(key)).toBe(1);
+  });
+
+  // ---- Key reset on cancel ----
+
+  it("allows re-create when original issue is cancelled (key released)", async () => {
+    const app = makeApp();
+    const key = `issue:${parentIssueId}:cancel-reset-${randomUUID()}`;
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Cancel reset test", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+    expect(r1.status, JSON.stringify(r1.body)).toBe(201);
+
+    // Cancel the original
+    await db.update(issues).set({ status: "cancelled" }).where(eq(issues.id, r1.body.id));
+
+    // Re-create should produce a new issue (not deduplicated)
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Cancel reset test", parentId: parentIssueId, priority: "medium", idempotencyKey: key });
+
+    expect(r2.status, JSON.stringify(r2.body)).toBe(201);
+    expect(r2.body.id).not.toBe(r1.body.id);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  // ---- Cross-company isolation ----
+
+  it("does NOT dedup across companies — same key in company B creates a new issue", async () => {
+    const appA = makeApp();
+    const key = `issue:shared-key-${randomUUID()}`;
+
+    // Company A creates with the key
+    const rA = await request(appA)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Cross-company test", priority: "medium", idempotencyKey: key });
+    expect(rA.status, JSON.stringify(rA.body)).toBe(201);
+
+    // Company B uses the same key — should get a fresh issue
+    const appB = makeAppForCompany2();
+    const rB = await request(appB)
+      .post(`/api/companies/${companyId2}/issues`)
+      .send({ title: "Cross-company test", priority: "medium", idempotencyKey: key });
+
+    expect(rB.status, JSON.stringify(rB.body)).toBe(201);
+    expect(rB.body.id).not.toBe(rA.body.id);
+    expect(rB.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+
+  // ---- Without idempotencyKey — normal creation, Layer 1 still works ----
+
+  it("does NOT dedup when no idempotencyKey is provided (normal Layer 1 behaviour unaffected)", async () => {
+    const app = makeApp();
+    const title = `no-key-${randomUUID()}`;
+
+    const r1 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, priority: "medium" });
+    const r2 = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title, priority: "medium" });
+
+    // Both should succeed — top-level issues without idempotencyKey are not deduplicated by Layer 2
+    // (Layer 1 only fires on child issues with same parentId+title+agent)
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
+    expect(r2.headers["x-paperclip-deduplicated"]).toBeUndefined();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { z } from "zod";
-import { and, desc, eq, inArray, notInArray } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, ne, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -137,6 +137,7 @@ import {
   resolveCoreTrustPreset,
   type TrustPresetResolution,
 } from "../services/trust-preset-resolver.js";
+import { getRunLogStore } from "../services/run-log-store.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -997,6 +998,40 @@ class AutoApprovalIssueMissingError extends Error {
   constructor() {
     super("Issue not found during auto-approval transaction");
     this.name = "AutoApprovalIssueMissingError";
+  }
+}
+
+async function appendDedupEventToRunLog(
+  db: Db,
+  actor: ReturnType<typeof getActorInfo>,
+  event: { originalIssueId: string; matchedTitle: string; matchedParentId: string },
+) {
+  if (actor.actorType !== "agent" || !actor.agentId || !actor.runId) return;
+  try {
+    const run = await db
+      .select({ logStore: heartbeatRuns.logStore, logRef: heartbeatRuns.logRef })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, actor.runId))
+      .then((rows) => rows[0] ?? null);
+    if (!run?.logStore || !run?.logRef) return;
+    const store = getRunLogStore();
+    await store.append(
+      { store: run.logStore as "local_file", logRef: run.logRef },
+      {
+        stream: "system",
+        chunk: JSON.stringify({
+          event: "issue_dedup",
+          originalIssueId: event.originalIssueId,
+          matchedTitle: event.matchedTitle,
+          matchedParentId: event.matchedParentId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+        }),
+        ts: new Date().toISOString(),
+      },
+    );
+  } catch (err) {
+    logger.warn({ err }, "failed to append issue dedup event to run log");
   }
 }
 
@@ -4372,6 +4407,43 @@ export function issueRoutes(
       actor.actorType,
     );
     await assertCanManageIssueMonitor(access, req, companyId, createBody.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+
+    // 60-second time-window dedup: prevent duplicate child issues from LLM tool-call regeneration.
+    // Only applies when parentId is set (top-level issues with identical titles are legitimately periodic).
+    if (createBody.parentId && actor.agentId) {
+      const sixtySecondsAgo = new Date(Date.now() - 60_000);
+      const [existingIssue] = await db
+        .select()
+        .from(issueRows)
+        .where(
+          and(
+            eq(issueRows.companyId, companyId),
+            eq(issueRows.parentId, createBody.parentId),
+            eq(issueRows.title, createBody.title),
+            eq(issueRows.createdByAgentId, actor.agentId),
+            ne(issueRows.status, "cancelled"),
+            gt(issueRows.createdAt, sixtySecondsAgo),
+          ),
+        )
+        .limit(1);
+
+      if (existingIssue) {
+        void appendDedupEventToRunLog(db, actor, {
+          originalIssueId: existingIssue.id,
+          matchedTitle: createBody.title,
+          matchedParentId: createBody.parentId,
+        });
+        const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(existingIssue.id);
+        res.setHeader("X-Paperclip-Deduplicated", "true");
+        res.status(200).json({
+          ...existingIssue,
+          relatedWork: referenceSummary,
+          referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+        });
+        return;
+      }
+    }
+
     const issueId = randomUUID();
     const sourceTrust = await sourceTrustForActorWrite({
       id: issueId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4444,6 +4444,35 @@ export function issueRoutes(
       }
     }
 
+    // Layer 2 — explicit idempotencyKey dedup (24-hour TTL, company-scoped).
+    // Returns 200 + original issue + X-Paperclip-Deduplicated: true on a key hit.
+    if (createBody.idempotencyKey) {
+      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const [existingByKey] = await db
+        .select()
+        .from(issueRows)
+        .where(
+          and(
+            eq(issueRows.companyId, companyId),
+            eq(issueRows.idempotencyKey, createBody.idempotencyKey),
+            ne(issueRows.status, "cancelled"),
+            gt(issueRows.createdAt, twentyFourHoursAgo),
+          ),
+        )
+        .limit(1);
+
+      if (existingByKey) {
+        const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(existingByKey.id);
+        res.setHeader("X-Paperclip-Deduplicated", "true");
+        res.status(200).json({
+          ...existingByKey,
+          relatedWork: referenceSummary,
+          referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+        });
+        return;
+      }
+    }
+
     const issueId = randomUUID();
     const sourceTrust = await sourceTrustForActorWrite({
       id: issueId,


### PR DESCRIPTION
## Thinking Path

> - Layer 1 (PR #8088) added a transparent 60-second time-window dedup keyed on `parentId + title + createdByAgentId`
> - Layer 1 is the safety net for LLM tool-call regeneration; Layer 2 makes dedup explicit and auditable for agents that want deterministic idempotency across the full 24-hour window
> - Agents create the same child issue (Bill action, blocker, delegation) in multiple heartbeats separated by more than 60 s — only a named key with a longer TTL prevents those duplicates
> - The idempotency pattern already exists for issue-thread interactions (migration 0064); the same nullable-column + application-level-lookup approach is used here so key reuse after expiry works without DB cleanup
> - No unique DB constraint: the 24-hour window is enforced by the application query (`createdAt > now-24h AND status != 'cancelled'`), allowing the same key to be reused after expiry or cancellation without having to null out the old row

## Linked Issues

Stacks on Layer 1 — PR #8088 (`fuc-360-issue-dedup-60s`) must be merged before this one. Internal task: FUC-361 (child of FUC-327 root-cause diagnosis).

## What Changed

- **`packages/db/src/migrations/0102_issue_idempotency_key.sql`** — New migration: adds nullable `idempotency_key` text column to `issues` table; creates a partial btree index on `(company_id, idempotency_key) WHERE idempotency_key IS NOT NULL` for fast lookup.
- **`packages/db/src/schema/issues.ts`** — Added `idempotencyKey: text("idempotency_key")` column and `idempotencyKeyIdx` index to the Drizzle schema.
- **`packages/shared/src/validators/issue.ts`** — Added `idempotencyKey: z.string().trim().max(255).optional().nullable()` to `createIssueBaseSchema`.
- **`server/src/routes/issues.ts`** — Added Layer 2 dedup block after the Layer 1 block, before `svc.create()`: queries for a matching non-cancelled issue with the same key created within 24 h in the same company; on hit, returns HTTP 200 with original body + `X-Paperclip-Deduplicated: true`.
- **`server/src/__tests__/issue-create-idempotency-key-routes.test.ts`** — New embedded-postgres integration tests covering happy path, key stored on row, cancel-reset, cross-company isolation, and no-dedup when key absent.

## Scope vs FUC-361 acceptance criteria

| Criterion | Status |
|---|---|
| `POST /issues` accepts optional `idempotencyKey`; duplicate returns 200 + original + header | ✅ |
| Key TTL 24 h | ✅ |
| Cancelled issues release the key | ✅ |
| Keys are company-scoped | ✅ |
| Layer 1 dedup coexists | ✅ |
| Paperclip skill doc updated | ✅ (local `api-reference.md`) |
| Tests: happy path, cancel-reset, cross-company isolation | ✅ |

## Out of scope

- AGENTS.md changes — skill doc is sufficient per ticket spec.
- Removing Layer 1 — it remains as the transparent backstop.

## Risks

- No unique DB constraint: the application query enforces the 24-hour TTL. Race conditions between two concurrent POSTs with the same key within milliseconds could both pass the lookup and create two rows. This is the same trade-off as Layer 1. The 60-second Layer 1 guard covers the highest-risk window; Layer 2 covers the longer TTL case.
- No migration required for Layer 1 data: the column is nullable and the index is partial.

## Model Used

- Provider: Anthropic  
- Model ID: `claude-sonnet-4-6`
- Context window: 200 k tokens

## Checklist

- [x] Thinking path included
- [x] Stacks on Layer 1 PR #8088 (must merge first)
- [x] Tests: happy path, cancel-reset, cross-company isolation
- [x] Skill doc updated (`api-reference.md`)
- [ ] All Paperclip CI gates are green
- [ ] Greptile review complete