### PR TITLE
docs(onboarding): add memory context guidance for agents

### DIFF
--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -1,5 +1,11 @@
 You are an agent at Paperclip company.
 
+## Memory & context
+
+- Before substantive work, call `gbrain_recall_cache` to read the prefetched issue neighborhood. If it is empty or isolated, query gbrain for the repo, component, or domain you are about to touch so published playbooks and prior decisions are not missed.
+- Recall relevant hindsight memory for the entities involved, including prior decisions, gotchas, and durable user or operator preferences.
+- When you discover a reusable repo, infra, or process gotcha, write it back to gbrain or hindsight so the next agent inherits it instead of rediscovering it.
+
 ## Execution Contract
 
 - Start actionable work in the same heartbeat. Do not stop at a plan unless the issue explicitly asks for planning.
@@ -13,6 +19,7 @@ You are an agent at Paperclip company.
 - Use `request_confirmation` instead of asking for yes/no decisions in markdown. For plan approval, update the `plan` document first, create a confirmation bound to the latest plan revision, use an idempotency key like `confirmation:{issueId}:plan:{revisionId}`, and wait for acceptance before creating implementation subtasks.
 - Set `supersedeOnUserComment: true` when a board/user comment should invalidate the pending confirmation. If you wake up from that comment, revise the artifact or proposal and create a fresh confirmation if confirmation is still needed.
 - If someone needs to unblock you, assign or route the ticket with a comment that names the unblock owner and action.
+- When you reference an issue identifier (e.g. `BLO-1234`) in a GitHub PR comment, review, or any text that renders outside Paperclip, link it with a full `https://` URL to the correct system: Paperclip (`https://paperclip.blockcast.net/BLO/issues/BLO-1234`) if the identifier is a Paperclip issue, otherwise Linear (`https://linear.app/blockcast/issue/BLO-1234`). The two share the `BLO-N` scheme for different issues, so disambiguate by which system actually owns the id; never emit a bare `BLO-1234` or app-relative markdown like `[BLO-1234](/BLO/issues/BLO-1234)` in external output.
 - Respect budget, pause/cancel, approval gates, and company boundaries.
 
 Do not let work sit here. You must always update your task with a comment.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The default onboarding `AGENTS.md` defines the execution contract agents inherit when starting work
> - Agents need durable memory and prior-decision context before changing code or infrastructure
> - The existing default guidance did not explicitly require consulting prefetched gbrain/hindsight context or writing reusable gotchas back
> - External GitHub comments also need unambiguous links because Paperclip and Linear can both use `BLO-N` identifiers
> - This pull request adds compact default guidance for memory/context recall and external issue-linking hygiene
> - The benefit is fewer repeated investigations and less ambiguity when issue references leave Paperclip

## Linked Issues or Issue Description

Refs: https://paperclip.blockcast.net/BLO/issues/BLO-10261
Refs: https://paperclip.blockcast.net/BLO/issues/BLO-10287
Refs: https://paperclip.blockcast.net/BLO/issues/BLO-10328

## What Changed

- Adds a `Memory & context` section to the default onboarding `AGENTS.md` asset.
- Instructs agents to read prefetched issue-neighborhood context and recall relevant hindsight memory before substantive work.
- Instructs agents to write reusable repo, infra, or process gotchas back to shared memory.
- Adds a rule requiring full `https://` links for external issue references so Paperclip and Linear `BLO-N` identifiers are not confused.

## Verification

- Confirmed upstream compare is clean: `ahead_by=1`, `behind_by=0`.
- Confirmed only `server/src/onboarding-assets/default/AGENTS.md` changes.
- Branch head: `a9e0291593c635ceecc949f32001740712fdf00f`.

## Risks

Low. This changes default onboarding documentation only; runtime behavior is unaffected until new or refreshed onboarding assets are consumed.

## Model Used

OpenAI Codex, GPT-5 coding agent with terminal and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge