### PR TITLE
fix(cursor-cloud): detect phantom success via git-evidence validation

### DIFF
--- a/packages/adapters/cursor-cloud/src/server/execute.test.ts
+++ b/packages/adapters/cursor-cloud/src/server/execute.test.ts
@@ -40,6 +40,9 @@ function createMockRun(options: MockRunOptions = {}) {
     result: "Done\nWith detail",
     model: { id: "gpt-5.4" },
     durationMs: 1234,
+    git: {
+      branches: [{ repoUrl: "https://github.com/paperclipai/paperclip.git", branch: "main" }],
+    },
   };
   const streamMessages = options.streamMessages ?? [];
   const streamError = options.streamError ?? null;
@@ -265,6 +268,9 @@ describe("cursor_cloud execute", () => {
         status: "finished",
         result: "Follow-up result",
         model: { id: "gpt-5.4" },
+        git: {
+          branches: [{ repoUrl: "https://github.com/paperclipai/paperclip.git", branch: "main" }],
+        },
       },
     });
     const sdkAgent = createMockSdkAgent({ agentId: "agent-attached", sendRun: followUpRun });
@@ -342,6 +348,100 @@ describe("cursor_cloud execute", () => {
         status: "cancelled",
         cursorAgentId: "agent-cancelled",
         cursorRunId: "run-cancelled",
+      },
+    });
+  });
+
+  it("detects phantom success when status is finished but no git evidence", async () => {
+    const phantomRun = createMockRun({
+      id: "run-phantom",
+      agentId: "agent-phantom",
+      status: "finished",
+      waitResult: {
+        id: "run-phantom",
+        status: "finished",
+        result: "I analyzed the code and here are my thoughts...",
+        model: { id: "gpt-5.4" },
+        durationMs: 5000,
+      },
+    });
+    const sdkAgent = createMockSdkAgent({ agentId: "agent-phantom", sendRun: phantomRun });
+    createMock.mockResolvedValue(sdkAgent);
+    const ctx = createContext();
+
+    const result = await execute(ctx);
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      errorMessage: expect.stringContaining("Phantom success detected"),
+      sessionId: "agent-phantom",
+      resultJson: {
+        status: "finished",
+        phantomSuccess: true,
+        hasGitEvidence: false,
+      },
+    });
+    expect(result.errorMessage).toContain("no git branches/PRs");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("accepts finished status when git evidence exists", async () => {
+    const realRun = createMockRun({
+      id: "run-real",
+      agentId: "agent-real",
+      status: "finished",
+      waitResult: {
+        id: "run-real",
+        status: "finished",
+        result: "Fixed the bug\nWith detail",
+        model: { id: "gpt-5.4" },
+        durationMs: 12000,
+        git: {
+          branches: [
+            { repoUrl: "https://github.com/example/repo.git", branch: "fix/bug-123" },
+          ],
+        },
+      },
+    });
+    const sdkAgent = createMockSdkAgent({ agentId: "agent-real", sendRun: realRun });
+    createMock.mockResolvedValue(sdkAgent);
+    const ctx = createContext();
+
+    const result = await execute(ctx);
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      errorMessage: null,
+      sessionId: "agent-real",
+      summary: "Fixed the bug",
+    });
+    expect(result.resultJson).not.toHaveProperty("phantomSuccess");
+  });
+
+  it("detects phantom success with empty git branches array", async () => {
+    const emptyGitRun = createMockRun({
+      id: "run-empty-git",
+      agentId: "agent-empty-git",
+      status: "finished",
+      waitResult: {
+        id: "run-empty-git",
+        status: "finished",
+        result: "Done",
+        model: { id: "gpt-5.4" },
+        git: { branches: [] },
+      },
+    });
+    const sdkAgent = createMockSdkAgent({ agentId: "agent-empty-git", sendRun: emptyGitRun });
+    createMock.mockResolvedValue(sdkAgent);
+    const ctx = createContext();
+
+    const result = await execute(ctx);
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      resultJson: {
+        phantomSuccess: true,
+        hasGitEvidence: false,
       },
     });
   });

--- a/packages/adapters/cursor-cloud/src/server/execute.ts
+++ b/packages/adapters/cursor-cloud/src/server/execute.ts
@@ -518,6 +518,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         };
     await streamPromise;
 
+    const hasGitEvidence = !!(result.git?.branches?.length);
+    const isPhantomSuccess = result.status === "finished" && !hasGitEvidence;
+    const phantomDiagnostic = isPhantomSuccess
+      ? `Phantom success detected: Cursor run finished without evidence of code execution (no git branches/PRs). Result text: ${trimNullable(result.result)?.slice(0, 200) ?? "(empty)"}`
+      : null;
+
     const modelId = result.model?.id ?? model?.id ?? null;
     await onLog("stdout", eventLine({
       type: "cursor_cloud.result",
@@ -527,6 +533,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ...(typeof result.durationMs === "number" ? { durationMs: result.durationMs } : {}),
       ...(result.git ? { git: result.git } : {}),
       ...(streamError ? { error: streamError } : {}),
+      ...(isPhantomSuccess ? { phantomSuccess: true } : {}),
     }));
 
     const nextSession: CursorCloudSession = {
@@ -537,12 +544,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ...(envName ? { envName } : {}),
       repos,
     };
-    const isError = result.status !== "finished";
+    const isError = result.status !== "finished" || isPhantomSuccess;
     return {
       exitCode: isError ? 1 : 0,
       signal: null,
       timedOut: false,
-      errorMessage: isError ? (trimNullable(result.result) ?? streamError ?? `Cursor run ${result.status}`) : null,
+      errorMessage: phantomDiagnostic ?? (isError ? (trimNullable(result.result) ?? streamError ?? `Cursor run ${result.status}`) : null),
       sessionId: run.agentId,
       sessionDisplayId: run.agentId,
       sessionParams: nextSession,
@@ -563,6 +570,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         ...(result.git ? { git: result.git } : {}),
         ...(typeof result.durationMs === "number" ? { durationMs: result.durationMs } : {}),
         ...(streamError ? { streamError } : {}),
+        ...(isPhantomSuccess ? { phantomSuccess: true, hasGitEvidence: false } : {}),
       },
       clearSession: false,
     };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The cursor_cloud adapter is responsible for executing agent runs via Cursor Cloud SDK
> - The adapter determined success solely by `result.status !== "finished"`, trusting Cursor Cloud blindly
> - When the SDK returns a text completion (no tool execution), status is "finished" but no code was executed — a phantom success
> - This PR adds git-evidence validation: check `result.git?.branches?.length > 0` before declaring success
> - If status is "finished" but no git evidence, the run is reported as a phantom success error with diagnostic message
> - The benefit is that phantom successes are now detected and reported as failures, preventing silent failures

## Linked Issues or Issue Description

Refs: LQDA-767, LQDA-766

The cursor_cloud adapter had a phantom success bug where runs that returned text completions without executing code were treated as successful. Root cause diagnosis confirmed in LQDA-766; this PR implements the fix.

## What happened

The cursor_cloud adapter treated runs that returned text completions without executing any code as successful, because it only checked `result.status !== "finished"`.

## Expected behavior

Runs that finish without evidence of code execution (no git branches) should be reported as failures.

## Steps to reproduce

1. Run an agent via cursor_cloud that returns a text completion.
2. Observe that the run is marked as successful even though no code was executed.

## What Changed

- Added git-evidence validation in `execute.ts`: `result.git?.branches?.length > 0`
- Phantom success detection: `status === "finished" && !hasGitEvidence`
- Diagnostic message includes truncated result text for debugging
- `phantomSuccess` flag emitted in result event and `resultJson`
- Added 3 new tests: phantom success, real success with git, empty git branches
- Updated existing tests to include git evidence in mock results

## Verification

1. Run adapter tests: `npx vitest run packages/adapters/cursor-cloud/src/server/execute.test.ts`
2. Run adapter typecheck: `cd packages/adapters/cursor-cloud && npx tsc --noEmit`
3. All 7 tests pass including 3 new phantom success detection tests

## Risks

Low risk — the change is backward compatible. Research/analysis tasks that don't produce git changes will now be flagged as phantom success. This is intentional behavior; the diagnostic message includes the result text for operators to distinguish legitimate non-code tasks from actual phantom successes. No migration needed.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-20250514 via opencode
- Context: 200K
- Tool use: enabled

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have searched the PR list for similar PRs and found none