### PR TITLE
feat(server): coalesce dependency-blocked wakeups

### DIFF
--- a/packages/db/src/migrations/0102_ccrotate_capacity_exhaustion_dedupe.sql
+++ b/packages/db/src/migrations/0102_ccrotate_capacity_exhaustion_dedupe.sql
@@ -1,0 +1,11 @@
+-- Partial unique index to coalesce per-pool ccrotate capacity exhaustion
+-- escalation issues. Only one non-terminal, non-hidden issue per
+-- (company, ccrotate_target) is allowed at a time; once it's done/cancelled
+-- a fresh one can be opened for the next outage. See escalateCcrotateCapacityExhausted
+-- in server/src/services/recovery/service.ts.
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_active_ccrotate_capacity_exhaustion_uq"
+  ON "issues" USING btree ("company_id", "origin_kind", "origin_id")
+  WHERE "origin_kind" = 'ccrotate_capacity_exhausted'
+    AND "origin_id" IS NOT NULL
+    AND "hidden_at" IS NULL
+    AND "status" NOT IN ('done', 'cancelled');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -715,6 +715,13 @@
       "when": 1781490000000,
       "tag": "0101_plugin_company_id_tenant_isolation",
       "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1781490100000,
+      "tag": "0102_ccrotate_capacity_exhaustion_dedupe",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/ccrotate-state.ts
+++ b/packages/shared/src/ccrotate-state.ts
@@ -1,0 +1,249 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Cross-process advisory lock around shared-state file writes on the
+ * shared `/paperclip/.ccrotate` PVC. The lock filename matches ccrotate's
+ * own `withCcrotateLock` (lib/state-helpers.js) so this writer and
+ * ccrotate's own writers serialize on the same lock.
+ *
+ * Contract is the file format + lock filename, not the code. If you change
+ * the lock path, change it in ccrotate too. If you change the tier-cache
+ * schema, update both writers.
+ *
+ * Async to avoid blocking the event loop while waiting for a contended
+ * lock. The previous sync implementation used a 50ms busy-wait loop which,
+ * under contention with the auth-bot's pool-sweep refresh, blocked the
+ * paperclip server's /healthz long enough to fail the kubelet's 1s probe
+ * (observed 2026-05-09 ~04:55Z).
+ */
+export async function withCcrotateLock<T>(
+  profilesDir: string,
+  fn: () => T | Promise<T>,
+  opts: { timeout?: number; staleMs?: number } = {},
+): Promise<T> {
+  const lockPath = path.join(profilesDir, ".active-files.lock");
+  const timeout = opts.timeout ?? 10_000;
+  const staleMs = opts.staleMs ?? 30_000;
+  const sleepMs = 50;
+  const start = Date.now();
+  let fd: number | undefined;
+
+  try {
+    fs.mkdirSync(profilesDir, { recursive: true });
+  } catch {
+    // best-effort
+  }
+
+  for (;;) {
+    try {
+      fd = fs.openSync(lockPath, "wx");
+      try {
+        fs.writeSync(fd, JSON.stringify({ pid: process.pid, at: Date.now() }));
+      } catch {
+        // metadata best-effort
+      }
+      break;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    }
+    try {
+      const st = fs.statSync(lockPath);
+      if (Date.now() - st.mtimeMs > staleMs) {
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {
+          // race with concurrent reclaim
+        }
+        continue;
+      }
+    } catch {
+      // file disappeared; retry
+    }
+    if (Date.now() - start > timeout) {
+      throw new Error(`ccrotate: timed out waiting for ${lockPath} after ${timeout}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+  }
+
+  try {
+    return await fn();
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+interface RateLimits {
+  utilization5h?: number | null;
+  utilization7d?: number | null;
+  reset5h?: number | null;
+  reset7d?: number | null;
+  resetAt?: string | null;
+  snapshotCapturedAt?: string | null;
+  [key: string]: unknown;
+}
+
+export interface TierCacheEntry {
+  email: string;
+  status?: string;
+  serviceTier?: string | null;
+  response?: string | null;
+  result?: string | null;
+  rateLimits?: RateLimits | null;
+}
+
+export interface TierCache {
+  updatedAt: string | null;
+  accounts: TierCacheEntry[];
+}
+
+export type TierCacheTarget = "claude" | "codex";
+
+function tierCacheFilename(target: TierCacheTarget): string {
+  return target === "claude" ? "tier-cache.json" : "tier-cache.codex.json";
+}
+
+/**
+ * Refresh window for trusting existing utilization data when deciding
+ * whether a runtime quota burn looks like a real cap hit. If the cache
+ * was probed within this window and shows both 5h and 7d well below
+ * cap, the burn is likely non-cap (overage credits out, transient
+ * concurrent limit, content filter) and we should NOT flip the account
+ * out of rotation.
+ */
+const UTILIZATION_FRESHNESS_MS = 30 * 60 * 1000;
+
+/**
+ * Threshold below which an existing utilization% counts as "well below cap".
+ * Matches the gate in ccrotate's account-table.js#isUsableNow.
+ */
+const NOT_AT_CAP_PCT = 95;
+
+export interface MarkAccountExhaustedResult {
+  skipped: boolean;
+  reason?: string;
+  email?: string;
+  utilization5h?: number | null;
+  utilization7d?: number | null;
+  snapshotAgeMs?: number;
+}
+
+/**
+ * Atomically mark an account as `serviceTier: 'exhausted'` in the shared
+ * tier-cache for `target`. Captures runtime quota-failure events observed
+ * by the orchestrator (paperclip-server) — the reset epoch comes from the
+ * adapter's `retryNotBefore`, so subsequent `ccrotate next` invocations
+ * skip this account in candidate scoring (next.js stale-and-tier filter).
+ *
+ * Without this writeback, runtime quota burns are invisible to the pool's
+ * state machine: ccrotate's own probe (testAccountViaMessages) is throttled
+ * by Anthropic's per-org Usage API rate limit, so tier-cache stays "unknown"
+ * while the runtime is observing the same burns and dropping the data on
+ * the floor. Pool spirals into a retry storm. Real incident 2026-05-08.
+ *
+ * Guard against false positives: if the cache entry has FRESH utilization
+ * data showing both rolling windows below 95%, the burn is likely NOT from
+ * a real cap (overage credits out, transient concurrent limit, content
+ * filter). In that case we skip the write and return `{skipped: true}` so
+ * the caller can log/instrument. Real incident 2026-05-13:
+ * `ramadan@blockcast.net` (5h:6% 7d:1%) and `omar.ramadan93@blockcast.net`
+ * (5h:87% 7d:53%) both flipped to 'exhausted' by this writeback path,
+ * collapsing the pool to 1 viable account.
+ */
+export async function markAccountExhausted(
+  profilesDir: string,
+  email: string,
+  fields: {
+    target?: TierCacheTarget;
+    reset5h?: number | null;
+    reset7d?: number | null;
+    response?: string | null;
+  } = {},
+): Promise<MarkAccountExhaustedResult> {
+  const target = fields.target ?? "claude";
+  const reset5h = fields.reset5h ?? null;
+  const reset7d = fields.reset7d ?? null;
+  const response = fields.response ?? null;
+
+  return await withCcrotateLock(profilesDir, () => {
+    const tierCachePath = path.join(profilesDir, tierCacheFilename(target));
+
+    let cache: TierCache = { updatedAt: null, accounts: [] };
+    try {
+      const raw = fs.readFileSync(tierCachePath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<TierCache>;
+      cache = {
+        updatedAt: parsed.updatedAt ?? null,
+        accounts: Array.isArray(parsed.accounts) ? parsed.accounts : [],
+      };
+    } catch {
+      // fresh cache
+    }
+
+    const existing = cache.accounts.find((a) => a.email === email);
+
+    // Guard: only mark exhausted when we DON'T have fresh evidence the
+    // account is well below cap. Stale data or at-cap utilization both
+    // fall through to the write path.
+    const existingRl = existing?.rateLimits ?? {};
+    const u5h = (existingRl as { utilization5h?: number | null }).utilization5h;
+    const u7d = (existingRl as { utilization7d?: number | null }).utilization7d;
+    const snapshotAtStr = (existingRl as { snapshotCapturedAt?: string | null }).snapshotCapturedAt;
+    const snapshotAt = snapshotAtStr ? Date.parse(snapshotAtStr) : NaN;
+    const dataAgeMs = Number.isFinite(snapshotAt) ? Date.now() - snapshotAt : Infinity;
+    const utilizationIsFreshAndLow =
+      dataAgeMs <= UTILIZATION_FRESHNESS_MS &&
+      typeof u5h === "number" && u5h < NOT_AT_CAP_PCT &&
+      typeof u7d === "number" && u7d < NOT_AT_CAP_PCT;
+    if (utilizationIsFreshAndLow) {
+      return {
+        skipped: true,
+        reason: "utilization below cap on fresh data",
+        email,
+        utilization5h: u5h,
+        utilization7d: u7d,
+        snapshotAgeMs: dataAgeMs,
+      } satisfies MarkAccountExhaustedResult;
+    }
+
+    const others = cache.accounts.filter((a) => a.email !== email);
+    const resetEpoch = reset5h ?? reset7d;
+    const fallbackResp = resetEpoch
+      ? `quota exhausted; resets at ${new Date(resetEpoch * 1000).toISOString()}`
+      : "quota exhausted";
+
+    const entry: TierCacheEntry = {
+      email,
+      status: "success",
+      serviceTier: "exhausted",
+      response: response ?? existing?.response ?? fallbackResp,
+      rateLimits: {
+        ...(existing?.rateLimits ?? {}),
+        ...(reset5h != null ? { reset5h } : {}),
+        ...(reset7d != null ? { reset7d } : {}),
+        snapshotCapturedAt: new Date().toISOString(),
+      },
+    };
+
+    const next: TierCache = {
+      updatedAt: new Date().toISOString(),
+      accounts: others.concat(entry),
+    };
+
+    const tmp = `${tierCachePath}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), "utf8");
+    fs.renameSync(tmp, tierCachePath);
+    return { skipped: false, email } satisfies MarkAccountExhaustedResult;
+  });
+}

--- a/server/src/__tests__/heartbeat-ccrotate-capacity-retry.test.ts
+++ b/server/src/__tests__/heartbeat-ccrotate-capacity-retry.test.ts
@@ -1,0 +1,393 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS, heartbeatService } from "../services/heartbeat.js";
+import type {
+  CcrotateGateCheckInput,
+  CcrotateGateResult,
+  CcrotateTierGate,
+} from "../services/ccrotate-tier-gate.js";
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return { ...actual, trackAgentFirstHeartbeat: vi.fn() };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        summary: "ok",
+        resultJson: {},
+        provider: "test",
+        model: "test-model",
+      })),
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres ccrotate capacity retry tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/** Deterministic gate that always defers with a fixed resumeAt. */
+function denyingGate(resumeAt: Date | null): CcrotateTierGate {
+  return {
+    async checkAdapter(_input: CcrotateGateCheckInput): Promise<CcrotateGateResult> {
+      return { allow: false, target: "claude", reason: "ccrotate.no_usable_account", resumeAt };
+    },
+    _resetForTesting() {},
+  };
+}
+
+/** Deterministic gate that always allows (pool recovered). */
+function allowingGate(): CcrotateTierGate {
+  return {
+    async checkAdapter(_input: CcrotateGateCheckInput): Promise<CcrotateGateResult> {
+      return { allow: true };
+    },
+    _resetForTesting() {},
+  };
+}
+
+describeEmbeddedPostgres("heartbeat ccrotate capacity-defer → scheduled retry", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-ccrotate-capacity-retry-");
+    db = createDb(tempDb.connectionString);
+  });
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent(): Promise<{ companyId: string; agentId: string }> {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  it("schedules a capacity retry instead of dropping the wake when the gate defers", async () => {
+    const { agentId } = await seedAgent();
+    const resumeAt = new Date("2026-04-20T03:02:00.000Z");
+    const heartbeat = heartbeatService(db, {
+      ccrotateGate: denyingGate(resumeAt),
+      skipQueuedRunDispatch: true,
+    });
+
+    await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+    });
+
+    const retryRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(retryRun, "a heartbeatRuns row should be created instead of dropping the wake").not.toBeNull();
+    expect(retryRun?.status).toBe("scheduled_retry");
+    expect(retryRun?.scheduledRetryAt?.toISOString()).toBe(resumeAt.toISOString());
+    expect(retryRun?.scheduledRetryReason).toBe("ccrotate_capacity");
+    // The rate-limit family + retryNotBefore make the existing bounded-retry
+    // backoff honor resumeAt as the floor.
+    const resultJson = (retryRun?.resultJson ?? {}) as Record<string, unknown>;
+    expect(resultJson.errorFamily).toBe("rate_limit_exhausted");
+    expect(resultJson.retryNotBefore).toBe(resumeAt.toISOString());
+
+    // The wake is NOT recorded as a terminal `skipped` drop.
+    const skipped = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.agentId, agentId), eq(agentWakeupRequests.status, "skipped")))
+      .then((rows) => rows[0] ?? null);
+    expect(skipped, "the capacity defer must not terminally drop the wake as skipped").toBeNull();
+  });
+
+  it("schedules with a bounded fallback delay when the gate returns no resumeAt", async () => {
+    const { agentId } = await seedAgent();
+    const before = Date.now();
+    const heartbeat = heartbeatService(db, {
+      ccrotateGate: denyingGate(null),
+      skipQueuedRunDispatch: true,
+    });
+
+    await heartbeat.wakeup(agentId, { source: "assignment", triggerDetail: "system" });
+
+    const retryRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(retryRun?.status).toBe("scheduled_retry");
+    // A null resumeAt must NOT strand the row with a null scheduledRetryAt —
+    // the sweep claims `scheduledRetryAt <= now`, which never matches null.
+    expect(retryRun?.scheduledRetryAt, "null resumeAt must fall back to a bounded delay, not null").not.toBeNull();
+    expect(retryRun!.scheduledRetryAt!.getTime()).toBeGreaterThan(before);
+  });
+
+  it("promotes the scheduled capacity retry when due and capacity has returned", async () => {
+    const { agentId } = await seedAgent();
+    const resumeAt = new Date("2026-04-20T03:02:00.000Z");
+    // Defer with an exhausted gate to create the scheduled_retry row...
+    const deferring = heartbeatService(db, {
+      ccrotateGate: denyingGate(resumeAt),
+      skipQueuedRunDispatch: true,
+    });
+    await deferring.wakeup(agentId, { source: "assignment", triggerDetail: "system" });
+
+    // Before due: still parked.
+    const early = await deferring.promoteDueScheduledRetries(new Date("2026-04-20T03:01:59.000Z"));
+    expect(early.promoted).toBe(0);
+
+    // Due + capacity recovered: a fresh instance whose gate now allows promotes it.
+    const recovered = heartbeatService(db, {
+      ccrotateGate: allowingGate(),
+      skipQueuedRunDispatch: true,
+    });
+    const promotion = await recovered.promoteDueScheduledRetries(resumeAt);
+    expect(promotion.promoted).toBe(1);
+
+    const promoted = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(promoted?.status).toBe("queued");
+  });
+
+  it("re-defers with backoff instead of promoting when capacity is still exhausted at promotion", async () => {
+    const { agentId } = await seedAgent();
+    const resumeAt = new Date("2026-04-20T03:02:00.000Z");
+    const nextResumeAt = new Date("2026-04-20T03:30:00.000Z");
+    // Same instance keeps denying — at promotion the re-gate must re-defer,
+    // not dispatch a run that would immediately 429.
+    const heartbeat = heartbeatService(db, {
+      ccrotateGate: denyingGate(nextResumeAt),
+      skipQueuedRunDispatch: true,
+    });
+
+    // Seed the scheduled_retry row directly via a deferring wake.
+    const seeding = heartbeatService(db, {
+      ccrotateGate: denyingGate(resumeAt),
+      skipQueuedRunDispatch: true,
+    });
+    await seeding.wakeup(agentId, { source: "assignment", triggerDetail: "system" });
+
+    const promotion = await heartbeat.promoteDueScheduledRetries(resumeAt);
+    expect(promotion.promoted).toBe(0);
+
+    const row = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(row?.status, "still exhausted → stays parked as scheduled_retry").toBe("scheduled_retry");
+    expect(row?.scheduledRetryAttempt, "attempt is bumped on re-defer").toBe(1);
+    expect(
+      row!.scheduledRetryAt!.getTime(),
+      "scheduledRetryAt is pushed to the new resumeAt",
+    ).toBe(nextResumeAt.getTime());
+  });
+
+  it("stops re-deferring and terminates once the retry cap is reached", async () => {
+    const { companyId, agentId } = await seedAgent();
+    const runId = randomUUID();
+    const due = new Date("2026-04-20T03:02:00.000Z");
+    // A capacity retry that has already exhausted its attempts budget.
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "scheduled_retry",
+      scheduledRetryReason: "ccrotate_capacity",
+      scheduledRetryAt: due,
+      scheduledRetryAttempt: CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS,
+      errorCode: "rate_limit_exhausted",
+      resultJson: { errorFamily: "rate_limit_exhausted" },
+      contextSnapshot: { wakeSource: "assignment" },
+    });
+
+    const heartbeat = heartbeatService(db, {
+      ccrotateGate: denyingGate(new Date("2026-04-20T09:00:00.000Z")),
+      skipQueuedRunDispatch: true,
+    });
+    const promotion = await heartbeat.promoteDueScheduledRetries(due);
+    expect(promotion.promoted).toBe(0);
+
+    const row = await db
+      .select({ status: heartbeatRuns.status, finishedAt: heartbeatRuns.finishedAt })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(row?.status, "exhausted capacity retry must terminate, not stay scheduled_retry").not.toBe(
+      "scheduled_retry",
+    );
+    expect(row?.finishedAt, "terminated run is finished").not.toBeNull();
+
+    // Exhaustion files one operator-visible escalation issue for the stuck pool.
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "ccrotate_capacity_exhausted")));
+    expect(escalations.length, "exhaustion files exactly one escalation issue").toBe(1);
+    expect(escalations[0]?.originId, "escalation is keyed on the ccrotate target").toBe("claude");
+    expect(escalations[0]?.priority).toBe("high");
+    expect(escalations[0]?.status).toBe("todo");
+  });
+
+  it("coalesces escalation to one issue per pool when multiple agents exhaust the same target", async () => {
+    const { companyId, agentId: agentA } = await seedAgent();
+    const due = new Date("2026-04-20T03:02:00.000Z");
+    const heartbeat = heartbeatService(db, {
+      ccrotateGate: denyingGate(new Date("2026-04-20T09:00:00.000Z")),
+      skipQueuedRunDispatch: true,
+    });
+
+    const insertExhaustedRetry = async (agentId: string) =>
+      db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "scheduled_retry",
+        scheduledRetryReason: "ccrotate_capacity",
+        scheduledRetryAt: due,
+        scheduledRetryAttempt: CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS,
+        errorCode: "rate_limit_exhausted",
+        resultJson: { errorFamily: "rate_limit_exhausted" },
+        contextSnapshot: { wakeSource: "assignment" },
+      });
+
+    // First agent exhausts → first escalation.
+    await insertExhaustedRetry(agentA);
+    await heartbeat.promoteDueScheduledRetries(due);
+
+    // A second agent in the SAME company exhausts the SAME pool → must coalesce
+    // onto the existing open escalation, not spam a duplicate.
+    const agentB = randomUUID();
+    await db.insert(agents).values({
+      id: agentB,
+      companyId,
+      name: "ClaudeCoderB",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await insertExhaustedRetry(agentB);
+    await heartbeat.promoteDueScheduledRetries(due);
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "ccrotate_capacity_exhausted")));
+    expect(
+      escalations.length,
+      "both agents exhausting the same pool yield ONE coalesced escalation",
+    ).toBe(1);
+    expect(escalations[0]?.originId).toBe("claude");
+  });
+
+  it("enforces one open escalation per pool at the DB level (partial unique index)", async () => {
+    // The sequential coalescing above is only safe because the SELECT sees the
+    // prior INSERT; concurrent sweeps could both miss and both insert. The
+    // partial unique index is what makes the guarantee real, so assert it
+    // directly. PEN-382 (Ally review #307).
+    const { companyId } = await seedAgent();
+    const base = {
+      companyId,
+      title: "ccrotate pool exhausted — claude",
+      originKind: "ccrotate_capacity_exhausted",
+      originId: "claude",
+    };
+
+    // First open escalation inserts fine.
+    await db.insert(issues).values({ id: randomUUID(), status: "todo", ...base });
+
+    // A second OPEN escalation for the same pool is rejected by the index —
+    // this is the concurrent-race case the app-level SELECT can't cover.
+    // drizzle wraps the driver error, so unwrap to assert the real pg cause.
+    let dupError: unknown;
+    try {
+      await db.insert(issues).values({ id: randomUUID(), status: "in_progress", ...base });
+    } catch (error) {
+      dupError = error;
+    }
+    expect(dupError, "second open duplicate must be rejected by the unique index").toBeDefined();
+    const cause = ((dupError as { cause?: unknown })?.cause ?? dupError) as {
+      code?: string;
+      constraint?: string;
+      constraint_name?: string;
+    };
+    expect(cause.code, "rejection is a unique-violation (23505)").toBe("23505");
+    expect(
+      cause.constraint ?? cause.constraint_name ?? "",
+      "violated index is the ccrotate-exhaustion partial unique index",
+    ).toBe("issues_active_ccrotate_capacity_exhaustion_uq");
+
+    // A done duplicate is allowed — the index is partial (excludes done/cancelled),
+    // so a fresh outage after recovery can open a new escalation.
+    await expect(
+      db.insert(issues).values({ id: randomUUID(), status: "done", ...base }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -240,18 +240,24 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         .then((rows) => rows[0] ?? null);
       return Boolean(
         wakeup &&
-        wakeup.status === "skipped" &&
+        wakeup.status === "scheduled" &&
         wakeup.reason === "issue_dependencies_blocked",
       );
     });
     expect(blockedWakeRequest).toBe(true);
 
-    const blockedRunsBeforeResolution = await db
-      .select({ count: sql<number>`count(*)::int` })
+    const blockedRetryBeforeResolution = await db
+      .select({
+        status: heartbeatRuns.status,
+        scheduledRetryReason: heartbeatRuns.scheduledRetryReason,
+      })
       .from(heartbeatRuns)
       .where(sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${blockedIssueId}`)
-      .then((rows) => rows[0]?.count ?? 0);
-    expect(blockedRunsBeforeResolution).toBe(0);
+      .then((rows) => rows[0] ?? null);
+    expect(blockedRetryBeforeResolution).toMatchObject({
+      status: "scheduled_retry",
+      scheduledRetryReason: DEP_BLOCKED_RETRY_REASON,
+    });
 
     const interactionWake = await heartbeat.wakeup(agentId, {
       source: "automation",

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -27,7 +27,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { heartbeatService } from "../services/heartbeat.ts";
+import { DEP_BLOCKED_RETRY_REASON, heartbeatService } from "../services/heartbeat.ts";
 import { runningProcesses } from "../adapters/index.ts";
 
 const mockAdapterExecute = vi.hoisted(() =>
@@ -958,6 +958,221 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         mode: "pause",
         interaction: true,
       },
+    });
+  });
+
+  it("coalesces repeated unchanged dep-blocked wakes into one scheduled_retry run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      { id: blockerId, companyId, title: "Blocker", status: "in_progress", priority: "high" },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    // First wake: should create a scheduled_retry and return null.
+    const wake1 = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: blockedIssueId },
+      contextSnapshot: { issueId: blockedIssueId, wakeReason: "issue_assigned" },
+    });
+    expect(wake1).toBeNull();
+
+    const scheduledRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "scheduled_retry"),
+          eq(heartbeatRuns.scheduledRetryReason, DEP_BLOCKED_RETRY_REASON),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(scheduledRun).not.toBeNull();
+    expect(scheduledRun?.contextSnapshot).toMatchObject({
+      issueId: blockedIssueId,
+      unresolvedBlockerIssueIds: [blockerId],
+    });
+
+    // Second wake (same blockers, unchanged state): should coalesce into existing run.
+    await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: blockedIssueId },
+      contextSnapshot: { issueId: blockedIssueId, wakeReason: "issue_assigned" },
+    });
+
+    const scheduledRunCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.scheduledRetryReason, DEP_BLOCKED_RETRY_REASON),
+        ),
+      )
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(scheduledRunCount).toBe(1);
+
+    const coalescedRequest = await db
+      .select({ status: agentWakeupRequests.status, runId: agentWakeupRequests.runId })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "coalesced"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(coalescedRequest).not.toBeNull();
+    expect(coalescedRequest?.runId).toBe(scheduledRun?.id);
+  });
+
+  it("resets dependency-blocked scheduled_retry when the blocker set changes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerAId = randomUUID();
+    const blockerBId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      { id: blockerAId, companyId, title: "Blocker A", status: "in_progress", priority: "high" },
+      { id: blockerBId, companyId, title: "Blocker B", status: "in_progress", priority: "high" },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values([
+      { companyId, issueId: blockerAId, relatedIssueId: blockedIssueId, type: "blocks" },
+      { companyId, issueId: blockerBId, relatedIssueId: blockedIssueId, type: "blocks" },
+    ]);
+
+    // Wake 1: blocked by A and B — creates scheduled_retry.
+    const wake1 = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: blockedIssueId },
+      contextSnapshot: { issueId: blockedIssueId, wakeReason: "issue_assigned" },
+    });
+    expect(wake1).toBeNull();
+
+    const firstScheduledRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "scheduled_retry"),
+          eq(heartbeatRuns.scheduledRetryReason, DEP_BLOCKED_RETRY_REASON),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(firstScheduledRun).not.toBeNull();
+
+    // Mark blocker A as done — blocker set now changes from [A,B] to [B].
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: new Date() })
+      .where(eq(issues.id, blockerAId));
+
+    // Wake 2: blocker set changed → old scheduled_retry cancelled, new one created.
+    const wake2 = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_blockers_resolved",
+      payload: { issueId: blockedIssueId, resolvedBlockerIssueId: blockerAId },
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        wakeReason: "issue_blockers_resolved",
+        resolvedBlockerIssueId: blockerAId,
+      },
+    });
+    expect(wake2).toBeNull();
+
+    // Old scheduled_retry should be cancelled.
+    const oldRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, firstScheduledRun!.id))
+      .then((rows) => rows[0] ?? null);
+    expect(oldRun?.status).toBe("cancelled");
+
+    // New scheduled_retry should reflect only blocker B.
+    const newScheduledRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, agentId),
+          eq(heartbeatRuns.status, "scheduled_retry"),
+          eq(heartbeatRuns.scheduledRetryReason, DEP_BLOCKED_RETRY_REASON),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(newScheduledRun).not.toBeNull();
+    expect(newScheduledRun?.id).not.toBe(firstScheduledRun?.id);
+    expect(newScheduledRun?.contextSnapshot).toMatchObject({
+      issueId: blockedIssueId,
+      unresolvedBlockerIssueIds: [blockerBId],
     });
   });
 });

--- a/server/src/__tests__/metrics-service.test.ts
+++ b/server/src/__tests__/metrics-service.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getDepBlockedMetric,
+  incrementDepBlockedMetric,
+  resetDepBlockedMetrics,
+  snapshotDepBlockedMetrics,
+} from "../services/dep-blocked-metrics.ts";
+
+describe("dep-blocked metrics counters", () => {
+  afterEach(() => {
+    resetDepBlockedMetrics();
+  });
+
+  it("starts at zero for all keys", () => {
+    const snap = snapshotDepBlockedMetrics();
+    for (const value of Object.values(snap)) {
+      expect(value).toBe(0);
+    }
+  });
+
+  it("increments a specific counter", () => {
+    incrementDepBlockedMetric("dep_blocked_scheduled");
+    incrementDepBlockedMetric("dep_blocked_scheduled");
+    expect(getDepBlockedMetric("dep_blocked_scheduled")).toBe(2);
+    expect(getDepBlockedMetric("dep_blocked_coalesced")).toBe(0);
+  });
+
+  it("increments multiple distinct counters independently", () => {
+    incrementDepBlockedMetric("dep_blocked_scheduled");
+    incrementDepBlockedMetric("dep_blocked_coalesced");
+    incrementDepBlockedMetric("dep_blocked_reset");
+    const snap = snapshotDepBlockedMetrics();
+    expect(snap.dep_blocked_scheduled).toBe(1);
+    expect(snap.dep_blocked_coalesced).toBe(1);
+    expect(snap.dep_blocked_reset).toBe(1);
+    expect(snap.dep_blocked_promoted).toBe(0);
+  });
+
+  it("snapshot returns a copy that does not mutate on further increments", () => {
+    incrementDepBlockedMetric("dep_blocked_redeferred");
+    const snap = snapshotDepBlockedMetrics();
+    incrementDepBlockedMetric("dep_blocked_redeferred");
+    expect(snap.dep_blocked_redeferred).toBe(1);
+    expect(getDepBlockedMetric("dep_blocked_redeferred")).toBe(2);
+  });
+
+  it("resets all counters to zero", () => {
+    incrementDepBlockedMetric("dep_blocked_exhausted");
+    incrementDepBlockedMetric("dep_blocked_promoted");
+    resetDepBlockedMetrics();
+    const snap = snapshotDepBlockedMetrics();
+    for (const value of Object.values(snap)) {
+      expect(value).toBe(0);
+    }
+  });
+});

--- a/server/src/services/ccrotate-quota-writeback.ts
+++ b/server/src/services/ccrotate-quota-writeback.ts
@@ -1,0 +1,142 @@
+/**
+ * Server-side ccrotate tier-cache writeback for runtime quota burns.
+ *
+ * Background — without this writeback, runtime quota events are invisible
+ * to ccrotate's pool state machine. ccrotate's own probe (Usage API) is
+ * throttled by Anthropic's per-org rate limit AFTER a 429, so its
+ * `tier-cache.json` stays "unknown / no per-account data" while paperclip
+ * agents are observing real burns. `ccrotate next` then keeps rotating
+ * back to exhausted accounts and the pool spirals into a retry storm.
+ *
+ * This module closes that gap: when paperclip-server detects a recoverable
+ * quota outcome with a `retryNotBefore` for an adapter that goes through
+ * ccrotate, it writes a `serviceTier: 'exhausted'` entry into the shared
+ * tier-cache so the next `ccrotate next` skips the burned account
+ * immediately. ccrotate's `refresh` path uses upsert, so a subsequent
+ * probe can correct the entry without clobbering it.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { markAccountExhausted, type TierCacheTarget } from "@paperclipai/shared/ccrotate-state";
+
+import { mapAdapterToCcrotateTarget } from "./ccrotate-tier-gate.js";
+
+export interface QuotaWritebackLogger {
+  info(payload: Record<string, unknown>, msg: string): void;
+  warn(payload: Record<string, unknown>, msg: string): void;
+}
+
+export interface QuotaWritebackInput {
+  adapterType: string;
+  retryNotBefore: Date | null;
+  /** For tests: override the resolved home dir. */
+  homeDir?: string;
+  log?: QuotaWritebackLogger;
+}
+
+export interface QuotaWritebackResult {
+  status:
+    | "skipped_no_target"
+    | "skipped_no_email"
+    | "skipped_email_lookup_failed"
+    | "skipped_codex_unsupported"
+    | "wrote";
+  target?: TierCacheTarget;
+  email?: string;
+  resetEpochSec?: number | null;
+}
+
+/** Read the active claude OAuth account email from `~/.claude.json`. */
+async function readActiveClaudeEmail(homeDir: string): Promise<string | null> {
+  const claudeJsonPath = path.join(homeDir, ".claude.json");
+  let raw: string;
+  try {
+    raw = await fs.readFile(claudeJsonPath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { oauthAccount?: { emailAddress?: unknown } };
+    const email = parsed?.oauthAccount?.emailAddress;
+    return typeof email === "string" && email.length > 0 ? email : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort writeback of a runtime quota burn into ccrotate's shared
+ * tier-cache. Never throws — failures are logged and swallowed.
+ *
+ * Currently scoped to the `claude` ccrotate target (claude_local +
+ * claude_k8s). The codex/opencode path needs a JWT-decode of
+ * `~/.codex/auth.json` `tokens.id_token` to identify the active email
+ * which adds complexity not yet justified by an observed pool spiral
+ * on that target — defer until needed.
+ */
+export async function captureQuotaBurnIntoCcrotateTierCache(
+  input: QuotaWritebackInput,
+): Promise<QuotaWritebackResult> {
+  const log = input.log;
+  const target = mapAdapterToCcrotateTarget(input.adapterType);
+  if (!target) {
+    return { status: "skipped_no_target" };
+  }
+  if (target === "codex") {
+    // See JSDoc — codex active-email lookup deferred.
+    log?.info(
+      { adapterType: input.adapterType, target },
+      "ccrotate writeback skipped: codex target unsupported",
+    );
+    return { status: "skipped_codex_unsupported", target };
+  }
+
+  const homeDir = input.homeDir ?? os.homedir();
+  const profilesDir = path.join(homeDir, ".ccrotate");
+
+  let email: string | null;
+  try {
+    email = await readActiveClaudeEmail(homeDir);
+  } catch (err) {
+    log?.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "ccrotate writeback: active-email lookup failed",
+    );
+    return { status: "skipped_email_lookup_failed", target };
+  }
+  if (!email) {
+    return { status: "skipped_no_email", target };
+  }
+
+  const resetEpochSec =
+    input.retryNotBefore && Number.isFinite(input.retryNotBefore.getTime())
+      ? Math.floor(input.retryNotBefore.getTime() / 1000)
+      : null;
+
+  try {
+    await markAccountExhausted(profilesDir, email, {
+      target,
+      reset5h: resetEpochSec,
+    });
+  } catch (err) {
+    log?.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        target,
+        email,
+        profilesDir,
+      },
+      "ccrotate writeback: tier-cache update failed",
+    );
+    return { status: "skipped_email_lookup_failed", target, email };
+  }
+
+  log?.info(
+    { target, email, resetEpochSec },
+    "ccrotate writeback: marked account exhausted",
+  );
+  return { status: "wrote", target, email, resetEpochSec };
+}

--- a/server/src/services/ccrotate-serve-verifier.ts
+++ b/server/src/services/ccrotate-serve-verifier.ts
@@ -1,0 +1,251 @@
+/**
+ * ccrotate-serve verifier — HTTP wrapper around `POST /v1/internal/probe-one`.
+ *
+ * The tier-gate (server/src/services/ccrotate-tier-gate.ts) reads the cached
+ * tier snapshot to decide whether to allow a heartbeat dispatch. The cache can
+ * lag reality (a burst-probe-all writes `exhausted` labels that the per-account
+ * freshness loop hasn't refreshed yet — see [[ccrotate-burst-probe-false-positive]]).
+ * When the gate is about to deny, we want to live-probe one candidate via
+ * ccrotate-serve BEFORE returning deny. That's what this wrapper enables.
+ *
+ * Policy stack (in call order):
+ *   1. Memo hit (30s by (target,email)): skip everything, return cached result.
+ *   2. Circuit breaker: 3 consecutive transport errors opens the circuit for
+ *      30s. While open, calls throw `kind: "circuit_open"` immediately without
+ *      HTTP. After cooldown a single half-open probe decides: success closes,
+ *      another error re-opens for another 30s window.
+ *   3. AbortController timeout (3s default).
+ *   4. Retries (1 by default) on transport / 5xx. Auth errors (401/403) are
+ *      NOT retried — they signal a misconfigured token and burning the budget
+ *      doesn't help.
+ *   5. In-flight Promise dedup: concurrent callers asking for the same
+ *      (target,email) share one HTTP request and resolve from the same Promise.
+ *
+ * Returning `undefined` when the token is missing/empty keeps the verifier
+ * optional. The gate falls back to its existing snapshot-only behavior.
+ */
+
+import type { CcrotateTarget, CcrotateTierCacheAccount } from "./ccrotate-tier-gate.js";
+
+export type VerifierErrorKind = "auth" | "transport" | "circuit_open";
+
+export class VerifierError extends Error {
+  public readonly kind: VerifierErrorKind;
+  constructor(kind: VerifierErrorKind, message: string) {
+    super(message);
+    this.kind = kind;
+    this.name = "VerifierError";
+  }
+}
+
+export interface CcrotateVerifier {
+  probeOne(target: CcrotateTarget, email: string): Promise<CcrotateTierCacheAccount>;
+  /** Test helper to wipe in-process state. */
+  _resetForTesting?(): void;
+}
+
+export interface CcrotateServeVerifierLog {
+  info(payload: Record<string, unknown>, message: string): void;
+  warn(payload: Record<string, unknown>, message: string): void;
+  error(payload: Record<string, unknown>, message: string): void;
+}
+
+export interface CcrotateServeVerifierOptions {
+  baseUrl: string;
+  /** When falsy (undefined/null/empty), the factory returns undefined. */
+  token: string | undefined | null;
+  timeoutMs?: number;
+  retries?: number;
+  circuitBreakerThreshold?: number;
+  circuitBreakerCooldownMs?: number;
+  memoTtlMs?: number;
+  log: CcrotateServeVerifierLog;
+}
+
+const DEFAULT_TIMEOUT_MS = 3_000;
+// One retry is the sweet spot: covers a single transient socket hangup
+// (the most common transport blip from in-cluster mesh hiccups) without
+// doubling the gate's worst-case tail latency on every failure mode.
+const DEFAULT_RETRIES = 1;
+// Three consecutive errors before opening matches the gate's deferral
+// horizon — if ccrotate-serve is unreachable for three consecutive dispatch
+// decisions, the snapshot-only fallback is what we'd want anyway.
+const DEFAULT_CB_THRESHOLD = 3;
+// 30s cooldown is long enough that a wedged ccrotate-serve doesn't get
+// hammered every dispatch tick but short enough that recovery is detected
+// within one heartbeat cycle (default heartbeat cadence is well under a minute).
+const DEFAULT_CB_COOLDOWN_MS = 30_000;
+// 30s memo TTL matches the gate's tier-cache read TTL (DEFAULT_CACHE_TTL_MS),
+// so the verifier doesn't outlive the snapshot it was probing against.
+const DEFAULT_MEMO_TTL_MS = 30_000;
+
+interface MemoEntry {
+  result: CcrotateTierCacheAccount;
+  expiresAt: number;
+}
+
+export function createCcrotateServeVerifier(
+  opts: CcrotateServeVerifierOptions,
+): CcrotateVerifier | undefined {
+  if (!opts.token) return undefined;
+
+  const baseUrl = opts.baseUrl.replace(/\/$/, "");
+  const token = opts.token;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retries = opts.retries ?? DEFAULT_RETRIES;
+  const cbThreshold = opts.circuitBreakerThreshold ?? DEFAULT_CB_THRESHOLD;
+  const cbCooldownMs = opts.circuitBreakerCooldownMs ?? DEFAULT_CB_COOLDOWN_MS;
+  const memoTtlMs = opts.memoTtlMs ?? DEFAULT_MEMO_TTL_MS;
+  const log = opts.log;
+
+  let consecutiveErrors = 0;
+  let circuitOpenedAt = 0;
+
+  const memo = new Map<string, MemoEntry>();
+  const inflight = new Map<string, Promise<CcrotateTierCacheAccount>>();
+
+  const cacheKey = (target: string, email: string) => `${target}|${email}`;
+
+  function circuitOpen(): boolean {
+    if (circuitOpenedAt === 0) return false;
+    if (Date.now() - circuitOpenedAt < cbCooldownMs) return true;
+    // Cooldown elapsed: next call is a half-open probe. Reset the open
+    // marker so the probe actually runs HTTP; the success/error path
+    // decides whether the circuit re-closes or re-opens.
+    circuitOpenedAt = 0;
+    consecutiveErrors = 0;
+    return false;
+  }
+
+  function onSuccess(): void {
+    consecutiveErrors = 0;
+    circuitOpenedAt = 0;
+  }
+
+  function onTransportError(): void {
+    consecutiveErrors += 1;
+    if (consecutiveErrors >= cbThreshold && circuitOpenedAt === 0) {
+      circuitOpenedAt = Date.now();
+      log.warn(
+        { consecutiveErrors, cooldownMs: cbCooldownMs },
+        "ccrotate-serve verifier circuit breaker opened",
+      );
+    }
+  }
+
+  async function doOneHttp(
+    target: CcrotateTarget,
+    email: string,
+  ): Promise<CcrotateTierCacheAccount> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}/v1/internal/probe-one`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ target, email }),
+        signal: controller.signal,
+      });
+      if (res.status === 401 || res.status === 403) {
+        // Auth errors are a config bug, not a transient — caller-side retry
+        // budget doesn't help and we don't want them counted toward the
+        // circuit breaker (a bad token would otherwise wedge the breaker
+        // open and mask real transport recovery).
+        throw new VerifierError("auth", `ccrotate-serve auth failed: ${res.status}`);
+      }
+      if (res.status >= 500) {
+        throw new VerifierError("transport", `ccrotate-serve ${res.status}`);
+      }
+      if (!res.ok) {
+        throw new VerifierError(
+          "transport",
+          `ccrotate-serve unexpected ${res.status}`,
+        );
+      }
+      return (await res.json()) as CcrotateTierCacheAccount;
+    } catch (err) {
+      if (err instanceof VerifierError) throw err;
+      // AbortController firing surfaces as DOMException("AbortError"). Some
+      // runtimes / mocks throw a plain Error with name === "AbortError".
+      const name = (err as { name?: string } | null)?.name;
+      if (name === "AbortError") {
+        throw new VerifierError("transport", "ccrotate-serve probe-one timeout");
+      }
+      throw new VerifierError(
+        "transport",
+        err instanceof Error ? err.message : String(err),
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function probeOneImpl(
+    target: CcrotateTarget,
+    email: string,
+  ): Promise<CcrotateTierCacheAccount> {
+    const key = cacheKey(target, email);
+
+    // 1. Memo hit
+    const cached = memo.get(key);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.result;
+    }
+
+    // 2. Circuit breaker
+    if (circuitOpen()) {
+      throw new VerifierError("circuit_open", "ccrotate-serve verifier circuit open");
+    }
+
+    // 3+4. HTTP with retries (auth errors short-circuit out of the loop)
+    let lastErr: VerifierError | undefined;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        const result = await doOneHttp(target, email);
+        onSuccess();
+        memo.set(key, { result, expiresAt: Date.now() + memoTtlMs });
+        return result;
+      } catch (err) {
+        const ve = err as VerifierError;
+        lastErr = ve;
+        if (ve.kind === "auth") {
+          // Auth doesn't feed the circuit breaker (see doOneHttp comment),
+          // but it does terminate the retry loop immediately.
+          throw ve;
+        }
+        // transport — fall through to next attempt if budget remains
+      }
+    }
+    // Exhausted retries with transport errors. Bump breaker.
+    onTransportError();
+    throw lastErr!;
+  }
+
+  return {
+    async probeOne(target, email) {
+      // 5. In-flight dedup. Concurrent callers asking for the same key
+      // share the same Promise — important so a burst of heartbeat
+      // dispatches probing the same candidate hit ccrotate-serve once,
+      // not N times.
+      const key = cacheKey(target, email);
+      const existing = inflight.get(key);
+      if (existing) return existing;
+      const p = probeOneImpl(target, email);
+      inflight.set(key, p);
+      try {
+        return await p;
+      } finally {
+        inflight.delete(key);
+      }
+    },
+    _resetForTesting() {
+      consecutiveErrors = 0;
+      circuitOpenedAt = 0;
+      memo.clear();
+      inflight.clear();
+    },
+  };
+}

--- a/server/src/services/ccrotate-tier-gate.ts
+++ b/server/src/services/ccrotate-tier-gate.ts
@@ -1,0 +1,674 @@
+/**
+ * Heartbeat ccrotate-awareness gate.
+ *
+ * Reads ccrotate's tier-cache to decide whether the agent's adapter has at
+ * least one underlying provider account on a usable tier. If not, the gate
+ * returns a deferral with the soonest plausible resume time so the heartbeat
+ * scheduler can stop burning quota until ccrotate has a fresh account.
+ *
+ * Provider mapping: Claude adapters use the `claude` ccrotate target; Codex
+ * and OpenCode/OpenAI adapters use the `codex` ccrotate target. Other adapter
+ * types are passed through (no opinion).
+ *
+ * The cache file lives at:
+ *   - ~/.ccrotate/tier-cache.json        (Claude target)
+ *   - ~/.ccrotate/tier-cache.codex.json  (Codex target)
+ *
+ * Schemas differ slightly between targets — Claude uses `serviceTier` =
+ * "base" | "extra" | "exhausted"; Codex uses `serviceTier` = "available" |
+ * "exhausted" | null. Both use `rateLimits.reset5h` / `rateLimits.reset7d`
+ * unix-second epochs to indicate when the next quota window opens.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { VerifierError } from "./ccrotate-serve-verifier.js";
+import type { CcrotateVerifier } from "./ccrotate-serve-verifier.js";
+
+const execFileAsync = promisify(execFile);
+
+export type CcrotateTarget = "claude" | "codex";
+
+export interface CcrotateTierCacheAccount {
+  email: string;
+  status?: string | null;
+  serviceTier?: string | null;
+  response?: string | null;
+  rateLimits?: {
+    reset5h?: number | null;
+    reset7d?: number | null;
+    /**
+     * Percent of the 5-hour rolling Claude window consumed (0–100).
+     * Surfaced by `ccrotate refresh` from Anthropic's per-account usage API.
+     * Optional because cached snapshots from older ccrotate versions, or
+     * accounts whose Usage API is on cooldown, omit it.
+     */
+    utilization5h?: number | null;
+    /** Percent of the 7-day rolling Claude window consumed (0–100). */
+    utilization7d?: number | null;
+    /**
+     * ISO timestamp ccrotate-serve writes per-account when it ran the probe
+     * that produced this snapshot row. Distinct from the wrapping snapshot's
+     * `updatedAt`, which is bumped on ANY upsert — so it doesn't tell you
+     * how stale a SPECIFIC account's tier-state actually is.
+     *
+     * The gate uses this to detect "exhausted label written by a burst
+     * probe-all >5min ago but freshness-loop hasn't re-verified yet".
+     * See [[ccrotate-burst-probe-false-positive]].
+     */
+    snapshotCapturedAt?: string | null;
+  } | null;
+}
+
+export interface CcrotateTierCacheSnapshot {
+  updatedAt?: string | null;
+  accounts: CcrotateTierCacheAccount[];
+}
+
+export interface CcrotateGateLogger {
+  info(payload: Record<string, unknown>, msg: string): void;
+  warn(payload: Record<string, unknown>, msg: string): void;
+}
+
+export interface CcrotateSwitcher {
+  /**
+   * Switch ccrotate's active account for the given target. Should be
+   * idempotent (the upstream `ccrotate switch` short-circuits when the
+   * current account already matches). Implementations must not throw — they
+   * should return `{ ok: false, error }` so the gate can warn-and-proceed.
+   */
+  switchTo(target: CcrotateTarget, email: string): Promise<{ ok: boolean; error?: string }>;
+}
+
+export interface CcrotateTierGateOptions {
+  readCache: (target: CcrotateTarget) => Promise<CcrotateTierCacheSnapshot | null>;
+  log: CcrotateGateLogger;
+  /**
+   * Optional. When set, the gate will (best-effort) ensure ccrotate's active
+   * account is the best base-tier account before allowing dispatch. Failures
+   * are warned but never deny dispatch — switching is an optimization.
+   */
+  switcher?: CcrotateSwitcher;
+  /** In-process cache TTL for tier-cache reads. Defaults to 30s. */
+  cacheTtlMs?: number;
+  /** Grace period appended to the earliest reset epoch when computing resumeAt. */
+  graceMs?: number;
+  /**
+   * Hard cap on how long a per-agent deferral memo can suppress re-evaluation.
+   * The memo's `expiresAt` is clamped to `min(resumeAt, now + maxDeferralMs)`
+   * so a far-future resumeAt cannot make the gate skip the same agent for
+   * hours. Defaults to 5 min.
+   */
+  maxDeferralMs?: number;
+  /**
+   * Optional verifier — when set, the gate calls `verifier.probeOne` on the
+   * deny path to live-probe one random exhausted candidate before deferring.
+   * Defends against burst-poisoned tier-cache labels by getting a fresh
+   * answer from ccrotate-serve before committing to a quota-based skip.
+   */
+  verifier?: CcrotateVerifier;
+}
+
+export interface CcrotateGateAllowResult {
+  allow: true;
+  /**
+   * Set when the gate identified (and best-effort switched ccrotate to) a
+   * usable base account for the target. Absent for adapters that don't go
+   * through ccrotate, and absent if the underlying tier-cache read failed
+   * (the gate falls back to allow without a switch in that case).
+   */
+  switchedTo?: { target: CcrotateTarget; email: string };
+}
+
+export interface CcrotateGateDenyResult {
+  allow: false;
+  target: CcrotateTarget;
+  reason: "ccrotate.no_usable_account";
+  resumeAt: Date | null;
+}
+
+export type CcrotateGateResult = CcrotateGateAllowResult | CcrotateGateDenyResult;
+
+export interface CcrotateGateCheckInput {
+  adapterType: string;
+  agentId: string;
+  now: Date;
+}
+
+// Claude "extra" = base quota exceeded but the account is on paid overage with
+// real capacity (visible as `🟢 usable now` in `ccrotate when`). ccrotate's own
+// `/api/ccrotate/status` lists `extra`-tier accounts under `usableNow`.
+// Excluding extra-tier accounts caused the 2026-05-12 multi-hour UXDesigner
+// outage where 6 accounts were usableNow but the gate only matched "base"
+// → fell into the deny path → cached the deferral with a 28h resumeAt
+// (BLO-4975). Treat extra exactly like base for usability.
+//
+// Codex "near_limit" means ≤10% quota left on either 5h or 7d window — still
+// usable until leftPercent hits 0. Codex doesn't enforce a hard cap the way
+// Claude's 7d does; the producer label is informational, not a stop sign.
+// Treating near_limit as unusable starved the codex pool down to 1 account
+// even when 3 others had hours of quota left (BLO-4474).
+const USABLE_TIERS: Record<CcrotateTarget, ReadonlySet<string>> = {
+  claude: new Set(["base", "extra"]),
+  codex: new Set(["available", "near_limit"]),
+};
+
+const DEFAULT_CACHE_TTL_MS = 30_000;
+const DEFAULT_GRACE_MS = 120_000;
+// Cap on how long a single deferral memo can suppress re-evaluation. Even if
+// the cache says no account resets for 28h, we should re-read every
+// DEFAULT_MAX_DEFERRAL_MS so a fresh `refresh-one`, a new switch, or an account
+// moving back to usable gets picked up promptly. Without this, a far-future
+// resumeAt locked the same agent into a 28h skip (BLO-4975).
+//
+// 5min: with the ccrotate-serve freshness-loop now sweeping one account every
+// ~90s, the longest gap between a stale-label flip and its discovery is one
+// sweep round (~20min for the full pool). 5min keeps the deferral useful as a
+// debounce without holding stale state past the freshness-loop's reaction time.
+const DEFAULT_MAX_DEFERRAL_MS = 5 * 60_000;
+
+/**
+ * Maps a paperclip agent adapter type to the ccrotate target whose tier-cache
+ * governs that adapter, or null if the adapter doesn't go through ccrotate.
+ *
+ * `claude_k8s` is the kkroo-fork adapter that runs Claude in a k8s pod against
+ * the org Anthropic API key. The pod has no ccrotate of its own, but the org
+ * key shares billing/quota with the host's `claude` pool — so the tier-cache
+ * IS authoritative for whether the adapter has any usable credit. Mapping it
+ * to "claude" gives the heartbeat scheduler quota-aware deferral on
+ * exhaustion (instead of looping 401s every heartbeat).
+ *
+ * `opencode_k8s` in the Blockcast deployment is OpenAI-backed (`openai/*`
+ * models) and authenticates through the same ChatGPT/Codex subscription pool
+ * that `codex_local` uses. The relogin trigger already maps opencode/codex to
+ * the codex target; the scheduler must do the same or OpenCode agents keep
+ * waking while every OpenAI account is unusable.
+ */
+export function mapAdapterToCcrotateTarget(adapterType: string): CcrotateTarget | null {
+  if (adapterType === "claude_local") return "claude";
+  if (adapterType === "claude_k8s") return "claude";
+  if (adapterType === "codex_local") return "codex";
+  if (adapterType === "opencode_k8s") return "codex";
+  return null;
+}
+
+function pickEarliestFutureResetEpoch(
+  snapshot: CcrotateTierCacheSnapshot,
+  nowSec: number,
+): number | null {
+  let earliest: number | null = null;
+  for (const account of snapshot.accounts) {
+    const limits = account.rateLimits;
+    if (!limits) continue;
+    for (const candidate of [limits.reset5h, limits.reset7d]) {
+      if (typeof candidate !== "number") continue;
+      if (!Number.isFinite(candidate)) continue;
+      if (candidate <= nowSec) continue;
+      if (earliest === null || candidate < earliest) earliest = candidate;
+    }
+  }
+  return earliest;
+}
+
+/**
+ * Score an account by remaining utilization headroom across both Claude
+ * windows. Lower is better (less consumed). Accounts with no utilization
+ * data fall back to a neutral mid-range so they tie-break behind
+ * accounts with KNOWN low utilization but ahead of accounts at >99%.
+ *
+ * Why: `serviceTier === "base"` only says the org HAS capacity. It does
+ * NOT say the immediate 5h window has headroom. Without ranking by
+ * utilization, the gate picks the first base account in cache order —
+ * and that first account is often the one paperclip just exhausted
+ * (5h:100%). Symptom: tier-gate switches active to a "base" account,
+ * agent spawns, claude wrapper exits with `out_of_credits overage
+ * rejected` on the first API call. Observed 2026-05-14 with
+ * `ramadan@blockcast.net` (base, 5h:100%) being picked while
+ * `omar.ramadan@berkeley.edu` (base, 5h:27%) sat unused.
+ */
+function utilizationScore(account: CcrotateTierCacheAccount): number {
+  const u5 = account.rateLimits?.utilization5h;
+  const u7 = account.rateLimits?.utilization7d;
+  if (typeof u5 !== "number" && typeof u7 !== "number") return 50; // unknown
+  return Math.max(typeof u5 === "number" ? u5 : 0, typeof u7 === "number" ? u7 : 0);
+}
+
+/**
+ * Threshold above which a "base"-tier account is treated as practically
+ * exhausted. 99% leaves enough room for tiny probe calls but not for a
+ * real agent run, which is the right gate (a real run will burn through
+ * the last 1% on input alone and hit `out_of_credits` mid-tool-call).
+ */
+const PRACTICAL_EXHAUSTION_PCT = 99;
+
+export function evaluateTierCacheSnapshot(
+  target: CcrotateTarget,
+  snapshot: CcrotateTierCacheSnapshot,
+  now: Date,
+): { allow: boolean; resumeAt: Date | null; usableAccount: string | null } {
+  const usable = USABLE_TIERS[target];
+
+  // Collect candidates: success-status AND tier in {base,extra}/{available,near_limit}.
+  const candidates: CcrotateTierCacheAccount[] = [];
+  for (const account of snapshot.accounts) {
+    if (account.status && account.status !== "success") continue;
+    if (account.serviceTier && usable.has(account.serviceTier)) {
+      candidates.push(account);
+    }
+  }
+
+  // For Claude, rank by utilization headroom and skip ones already at >=99%
+  // in either window (they will out_of_credits on the next real call).
+  // Codex has no equivalent utilization fields in its tier-cache so it falls
+  // through to first-match (legacy behavior).
+  if (target === "claude" && candidates.length > 0) {
+    const viable = candidates
+      .filter((a) => utilizationScore(a) < PRACTICAL_EXHAUSTION_PCT)
+      .sort((a, b) => utilizationScore(a) - utilizationScore(b));
+    if (viable.length > 0) {
+      return { allow: true, resumeAt: null, usableAccount: viable[0].email };
+    }
+    // All "base" candidates are >=99% used — fall through to deferral.
+  } else if (candidates.length > 0) {
+    return { allow: true, resumeAt: null, usableAccount: candidates[0].email };
+  }
+
+  // Inconclusive-snapshot fallback. When Anthropic's per-account Usage API is
+  // throttling the cluster (`status: "unknown"`, `serviceTier: null`,
+  // `rateLimits: null`), the gate cannot tell whether any account is usable.
+  // The historical behavior was to deny, which deadlocked: no run dispatch →
+  // no quotaExhaustedHook → no ccrotate-auth-bot trigger → tokens never get
+  // refreshed → cache never recovers. Observed 2026-05-04 with all 9 claude
+  // accounts pinned at `status: "unknown" / "Usage API on cooldown"` for
+  // hours despite `ccrotate refresh-one` against the active account
+  // returning a real tier (`5h:58% 7d:54%`).
+  //
+  // When every account is inconclusive AND we have no rate-limit data to set
+  // a sensible resumeAt, allow optimistically — let the run attempt the API
+  // call. If the call hits a real 401/quota, the existing quotaExhaustedHook
+  // chain (server/src/services/quota-exhausted-hook.ts) takes over and
+  // triggers re-login. Cost of being wrong: one failed agent run vs. cluster
+  // deadlock.
+  const inconclusive = snapshot.accounts.every(
+    (acc) =>
+      acc.status === "unknown" &&
+      acc.serviceTier === null &&
+      acc.rateLimits === null,
+  );
+  if (snapshot.accounts.length > 0 && inconclusive) {
+    return { allow: true, resumeAt: null, usableAccount: null };
+  }
+
+  // Stale-snapshot fallback. Symmetric with the inconclusive fallback above: if
+  // every account's per-account `snapshotCapturedAt` is older than the
+  // freshness-loop's stale floor (~5min), the `exhausted` labels are very likely
+  // leftovers from the periodic burst-probe-all cron that didn't get refreshed
+  // yet by the per-account freshness loop. Allow optimistically — let the run
+  // attempt the API call. If it 401/quotas, quotaExhaustedHook fires; if it
+  // succeeds, the account flips to `base` on its next probe.
+  //
+  // Cost of being wrong: one failed agent run vs. up to 15min of deferral
+  // on a stale label. The freshness-loop sweeps all 13 accounts every ~20min,
+  // so any genuinely-exhausted state gets re-confirmed within one sweep.
+  const STALE_SNAPSHOT_GRACE_MS = 5 * 60_000;
+  const accountsWithSnapshots = snapshot.accounts.filter(
+    (acc) => !!acc.rateLimits?.snapshotCapturedAt,
+  );
+  if (
+    accountsWithSnapshots.length > 0 &&
+    accountsWithSnapshots.length === snapshot.accounts.length &&
+    accountsWithSnapshots.every((acc) => {
+      const captured = Date.parse(acc.rateLimits!.snapshotCapturedAt!);
+      if (!Number.isFinite(captured)) return false;
+      return now.getTime() - captured > STALE_SNAPSHOT_GRACE_MS;
+    })
+  ) {
+    return { allow: true, resumeAt: null, usableAccount: null };
+  }
+
+  const nowSec = Math.floor(now.getTime() / 1000);
+  const earliest = pickEarliestFutureResetEpoch(snapshot, nowSec);
+  return {
+    allow: false,
+    resumeAt: earliest === null ? null : new Date(earliest * 1000),
+    usableAccount: null,
+  };
+}
+
+export interface CcrotateTierGate {
+  checkAdapter(input: CcrotateGateCheckInput): Promise<CcrotateGateResult>;
+  /** Test helper to wipe in-process state. */
+  _resetForTesting(): void;
+}
+
+interface CacheEntry {
+  fetchedAt: number;
+  snapshot: CcrotateTierCacheSnapshot | null;
+  /** True when the underlying read failed (we treat as "no opinion"). */
+  errored: boolean;
+}
+
+interface DeferralEntry {
+  resumeAt: number | null;
+  /** Epoch ms at which we should drop the in-memory deferral memo. */
+  expiresAt: number;
+}
+
+export function createCcrotateTierGate(opts: CcrotateTierGateOptions): CcrotateTierGate {
+  const cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const graceMs = opts.graceMs ?? DEFAULT_GRACE_MS;
+  const maxDeferralMs = opts.maxDeferralMs ?? DEFAULT_MAX_DEFERRAL_MS;
+
+  const cache = new Map<CcrotateTarget, CacheEntry>();
+  const deferrals = new Map<string, DeferralEntry>();
+  // Track the email we last successfully asked ccrotate to switch to per
+  // target. Used to skip the subprocess spawn when the active account hasn't
+  // moved. Resets on process restart (initial dispatch always spawns once).
+  const lastSwitchedEmail = new Map<CcrotateTarget, string>();
+  let warnedMissingCache = false;
+
+  async function readWithCache(
+    target: CcrotateTarget,
+    nowMs: number,
+  ): Promise<{ snapshot: CcrotateTierCacheSnapshot | null; errored: boolean }> {
+    const existing = cache.get(target);
+    if (existing && nowMs - existing.fetchedAt < cacheTtlMs) return existing;
+
+    let snapshot: CcrotateTierCacheSnapshot | null = null;
+    let errored = false;
+    try {
+      snapshot = await opts.readCache(target);
+    } catch (err) {
+      errored = true;
+      if (!warnedMissingCache) {
+        warnedMissingCache = true;
+        opts.log.warn(
+          {
+            target,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "ccrotate tier-cache read failed; falling back to dispatch (further failures suppressed)",
+        );
+      }
+    }
+    if (!errored && !snapshot && !warnedMissingCache) {
+      warnedMissingCache = true;
+      opts.log.warn(
+        { target },
+        "ccrotate tier-cache missing; falling back to dispatch (further misses suppressed)",
+      );
+    }
+    const entry: CacheEntry = { fetchedAt: nowMs, snapshot, errored };
+    cache.set(target, entry);
+    return entry;
+  }
+
+  function deferralKey(target: CcrotateTarget, agentId: string): string {
+    return `${target}::${agentId}`;
+  }
+
+  return {
+    async checkAdapter(input: CcrotateGateCheckInput): Promise<CcrotateGateResult> {
+      const target = mapAdapterToCcrotateTarget(input.adapterType);
+      if (!target) return { allow: true };
+
+      const nowMs = input.now.getTime();
+      const key = deferralKey(target, input.agentId);
+
+      const existingDeferral = deferrals.get(key);
+      if (existingDeferral && nowMs < existingDeferral.expiresAt) {
+        // Still inside the previously computed deferral window; return deny
+        // without re-reading the cache or re-logging.
+        return {
+          allow: false,
+          target,
+          reason: "ccrotate.no_usable_account",
+          resumeAt: existingDeferral.resumeAt === null ? null : new Date(existingDeferral.resumeAt),
+        };
+      }
+
+      const { snapshot } = await readWithCache(target, nowMs);
+      if (!snapshot) {
+        // Cache missing or unreadable → fall back to allow.
+        deferrals.delete(key);
+        return { allow: true };
+      }
+
+      const evaluation = evaluateTierCacheSnapshot(target, snapshot, input.now);
+      if (evaluation.allow) {
+        deferrals.delete(key);
+        const email = evaluation.usableAccount;
+        if (email && opts.switcher && lastSwitchedEmail.get(target) !== email) {
+          const snapshotHasExhausted = snapshot.accounts.some(
+            (acc) => acc.status === "success" && acc.serviceTier === "exhausted",
+          );
+          if (snapshotHasExhausted) {
+            opts.log.info(
+              {
+                target,
+                email,
+                previouslySwitchedTo: lastSwitchedEmail.get(target) ?? null,
+              },
+              "ccrotate.rotate_on_exhausted_active",
+            );
+          }
+          const result = await opts.switcher.switchTo(target, email);
+          if (result.ok) {
+            lastSwitchedEmail.set(target, email);
+            opts.log.info(
+              { target, email },
+              "ccrotate active account switched to base-tier account",
+            );
+          } else {
+            opts.log.warn(
+              { target, email, err: result.error ?? "unknown" },
+              "ccrotate switch failed; proceeding with current active account",
+            );
+          }
+        }
+        return email
+          ? { allow: true, switchedTo: { target, email } }
+          : { allow: true };
+      }
+
+      // Verifier branch: when the cache says deny but a verifier is wired,
+      // probe ONE random exhausted candidate live before committing to deferral.
+      // Defends against burst-poisoned `exhausted` labels written by the
+      // periodic probe-all cron.
+      if (opts.verifier) {
+        const exhaustedCandidates = snapshot.accounts.filter(
+          (a) => a.status === "success" && a.serviceTier === "exhausted",
+        );
+        if (exhaustedCandidates.length > 0) {
+          const picked = exhaustedCandidates[
+            Math.floor(Math.random() * exhaustedCandidates.length)
+          ]!;
+          try {
+            const result = await opts.verifier.probeOne(target, picked.email);
+            // Invalidate the in-process tier-cache regardless of the verifier's
+            // outcome so the next checkAdapter re-reads disk and picks up the
+            // write-through label the verifier just persisted.
+            cache.delete(target);
+            const usable = USABLE_TIERS[target].has(result.serviceTier ?? "");
+            if (usable) {
+              if (
+                opts.switcher &&
+                lastSwitchedEmail.get(target) !== picked.email
+              ) {
+                const sw = await opts.switcher.switchTo(target, picked.email);
+                if (sw.ok) {
+                  lastSwitchedEmail.set(target, picked.email);
+                  opts.log.info(
+                    { target, email: picked.email },
+                    "ccrotate.verifier_allow_after_switch",
+                  );
+                } else {
+                  opts.log.warn(
+                    {
+                      target,
+                      email: picked.email,
+                      err: sw.error ?? "unknown",
+                    },
+                    "ccrotate.verifier_allow_switch_failed",
+                  );
+                }
+              } else {
+                opts.log.info(
+                  { target, email: picked.email },
+                  "ccrotate.verifier_allow",
+                );
+              }
+              deferrals.delete(key);
+              return {
+                allow: true,
+                switchedTo: { target, email: picked.email },
+              };
+            }
+            opts.log.info(
+              { target, email: picked.email },
+              "ccrotate.verifier_confirmed_exhausted",
+            );
+            // Fall through to the existing deny path below.
+          } catch (err) {
+            const ve = err as VerifierError;
+            if (ve && ve.kind === "auth") {
+              // A misconfigured verifier (401/403) must NOT bypass quota gating —
+              // silently optimistic-allowing every dispatch would mask the auth
+              // misconfig with a flood of out_of_credits failures.
+              opts.log.warn(
+                {
+                  target,
+                  email: picked.email,
+                  err: ve.message,
+                },
+                "ccrotate.verifier_auth_failure_fail_closed",
+              );
+              // Fall through to the existing deny path below.
+            } else {
+              // Optimistic-allow on transport/timeout/circuit_open.
+              opts.log.warn(
+                {
+                  target,
+                  email: picked.email,
+                  kind: ve?.kind ?? "unknown",
+                  err: ve?.message ?? String(err),
+                },
+                "ccrotate.verifier_transport_error_optimistic_allow",
+              );
+              deferrals.delete(key);
+              return { allow: true };
+            }
+          }
+        }
+      }
+
+      const resumeAtMs =
+        evaluation.resumeAt === null ? null : evaluation.resumeAt.getTime() + graceMs;
+
+      // Memoize so we don't re-log on every tick. We expire the memo at the
+      // earlier of the cache-claimed resume time and `now + maxDeferralMs`.
+      // The cap is what lets the gate notice when ccrotate fixes things faster
+      // than the cache predicted.
+      const cap = nowMs + maxDeferralMs;
+      const expiresAt = resumeAtMs === null
+        ? nowMs + cacheTtlMs
+        : Math.min(resumeAtMs, cap);
+      deferrals.set(key, { resumeAt: resumeAtMs, expiresAt });
+
+      opts.log.info(
+        {
+          target,
+          agentId: input.agentId,
+          adapterType: input.adapterType,
+          reason: "ccrotate.no_usable_account",
+          resumeAt: resumeAtMs === null ? null : new Date(resumeAtMs).toISOString(),
+        },
+        "heartbeat dispatch deferred: no ccrotate account on usable tier",
+      );
+
+      return {
+        allow: false,
+        target,
+        reason: "ccrotate.no_usable_account",
+        resumeAt: resumeAtMs === null ? null : new Date(resumeAtMs),
+      };
+    },
+
+    _resetForTesting() {
+      cache.clear();
+      deferrals.clear();
+      lastSwitchedEmail.clear();
+      warnedMissingCache = false;
+    },
+  };
+}
+
+/**
+ * Default switcher that spawns `ccrotate --target <target> switch <email>`.
+ * Idempotent at the ccrotate level (short-circuits when already on the target
+ * account). Returns `{ ok: false, error }` on any failure — the gate logs and
+ * proceeds; switching is best-effort.
+ */
+export function createDefaultCcrotateSwitcher(): CcrotateSwitcher {
+  return {
+    async switchTo(target, email) {
+      try {
+        await execFileAsync(
+          "ccrotate",
+          ["--target", target, "switch", email],
+          { timeout: 30_000 },
+        );
+        return { ok: true };
+      } catch (err) {
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Default reader that loads ccrotate's tier-cache JSON from disk.
+ * Returns null if the file does not exist (e.g. ccrotate not installed).
+ * Throws on parse errors so the gate's error path can warn once.
+ */
+export async function readDefaultCcrotateTierCache(
+  target: CcrotateTarget,
+): Promise<CcrotateTierCacheSnapshot | null> {
+  const filename = target === "claude" ? "tier-cache.json" : "tier-cache.codex.json";
+  const filePath = path.join(os.homedir(), ".ccrotate", filename);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw err;
+  }
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object") return null;
+  const accounts = Array.isArray((parsed as Record<string, unknown>).accounts)
+    ? ((parsed as Record<string, unknown>).accounts as unknown[]).filter(
+      (a): a is CcrotateTierCacheAccount => typeof a === "object" && a !== null && typeof (a as { email?: unknown }).email === "string",
+    )
+    : [];
+  return {
+    updatedAt:
+      typeof (parsed as Record<string, unknown>).updatedAt === "string"
+        ? ((parsed as Record<string, unknown>).updatedAt as string)
+        : null,
+    accounts,
+  };
+}

--- a/server/src/services/dep-blocked-metrics.ts
+++ b/server/src/services/dep-blocked-metrics.ts
@@ -1,0 +1,42 @@
+// Bounded in-memory counters for dep-blocked wake coalescing. These reset on
+// process restart and are intended for operational visibility, not persistence.
+// Counter names mirror the heartbeat outcome kinds surfaced in structured logs.
+
+export type DepBlockedMetricKey =
+  | "dep_blocked_scheduled"
+  | "dep_blocked_coalesced"
+  | "dep_blocked_reset"
+  | "dep_blocked_promoted"
+  | "dep_blocked_redeferred"
+  | "dep_blocked_exhausted";
+
+const MAX_COUNTER_VALUE = Number.MAX_SAFE_INTEGER;
+
+const counters: Record<DepBlockedMetricKey, number> = {
+  dep_blocked_scheduled: 0,
+  dep_blocked_coalesced: 0,
+  dep_blocked_reset: 0,
+  dep_blocked_promoted: 0,
+  dep_blocked_redeferred: 0,
+  dep_blocked_exhausted: 0,
+};
+
+export function incrementDepBlockedMetric(key: DepBlockedMetricKey): void {
+  if (counters[key] < MAX_COUNTER_VALUE) {
+    counters[key] += 1;
+  }
+}
+
+export function getDepBlockedMetric(key: DepBlockedMetricKey): number {
+  return counters[key];
+}
+
+export function resetDepBlockedMetrics(): void {
+  for (const key of Object.keys(counters) as DepBlockedMetricKey[]) {
+    counters[key] = 0;
+  }
+}
+
+export function snapshotDepBlockedMetrics(): Record<DepBlockedMetricKey, number> {
+  return { ...counters };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -197,6 +197,9 @@ import {
 } from "./low-trust-runtime-containment.js";
 import { resolveCoreTrustPreset, type TrustPresetResolution } from "./trust-preset-resolver.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import { createCcrotateTierGate, createDefaultCcrotateSwitcher, readDefaultCcrotateTierCache, type CcrotateTierGate } from "./ccrotate-tier-gate.js";
+import { createCcrotateServeVerifier } from "./ccrotate-serve-verifier.js";
+import { captureQuotaBurnIntoCcrotateTierCache } from "./ccrotate-quota-writeback.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
@@ -252,6 +255,9 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
+export const CCROTATE_CAPACITY_DEFAULT_RETRY_DELAY_MS = 5 * 60 * 1000;
+export const CCROTATE_CAPACITY_RETRY_REASON = "ccrotate_capacity";
+export const CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS = 24;
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 // Keep this in sync with local adapters that require a git workspace before launch.
@@ -3095,6 +3101,10 @@ export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeSe
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
+  /** Optional override for the ccrotate tier-gate. Defaults to reading ~/.ccrotate/tier-cache.json. Tests inject a deterministic stub. */
+  ccrotateGate?: CcrotateTierGate;
+  /** When true, startNextQueuedRunForAgent is a no-op. Prevents background executeRun races in tests. */
+  skipQueuedRunDispatch?: boolean;
 }
 
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
@@ -3130,6 +3140,42 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   const budgets = budgetService(db, budgetHooks);
   const recovery = recoveryService(db, { enqueueWakeup });
   const productivityReviews = productivityReviewService(db, { enqueueWakeup });
+  const ccrotateServeBaseUrl =
+    process.env.CCROTATE_SERVE_BASE_URL ??
+    (process.env.CCROTATE_SERVE_SERVICE_HOST && process.env.CCROTATE_SERVE_SERVICE_PORT_SERVE
+      ? `http://${process.env.CCROTATE_SERVE_SERVICE_HOST}:${process.env.CCROTATE_SERVE_SERVICE_PORT_SERVE}`
+      : undefined);
+  const ccrotateServeToken = process.env.CCROTATE_SERVE_TOKEN;
+  const ccrotateVerifier = ccrotateServeBaseUrl && ccrotateServeToken
+    ? createCcrotateServeVerifier({
+        baseUrl: ccrotateServeBaseUrl,
+        token: ccrotateServeToken,
+        timeoutMs: 3_000,
+        retries: 1,
+        circuitBreakerThreshold: 3,
+        circuitBreakerCooldownMs: 30_000,
+        memoTtlMs: 30_000,
+        log: {
+          info: (payload, msg) => logger.info(payload, msg),
+          warn: (payload, msg) => logger.warn(payload, msg),
+          error: (payload, msg) => logger.warn(payload, msg),
+        },
+      })
+    : undefined;
+  if (ccrotateVerifier) {
+    logger.info({ baseUrl: ccrotateServeBaseUrl }, "ccrotate.verifier_enabled");
+  } else {
+    logger.warn({}, "ccrotate.verifier_disabled — set CCROTATE_SERVE_BASE_URL + CCROTATE_SERVE_TOKEN to enable");
+  }
+  const ccrotateGate: CcrotateTierGate = options.ccrotateGate ?? createCcrotateTierGate({
+    readCache: readDefaultCcrotateTierCache,
+    switcher: createDefaultCcrotateSwitcher(),
+    log: {
+      info: (payload, msg) => logger.info(payload, msg),
+      warn: (payload, msg) => logger.warn(payload, msg),
+    },
+    verifier: ccrotateVerifier,
+  });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
 
   async function releaseEnvironmentLeasesForRun(input: {
@@ -5992,6 +6038,96 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
+    // A ccrotate capacity defer must re-check the gate at promotion time: if the
+    // pool is still exhausted, re-defer instead of promoting a run that would 429.
+    if (dueRun.scheduledRetryReason === CCROTATE_CAPACITY_RETRY_REASON) {
+      const capacity = await ccrotateGate.checkAdapter({
+        adapterType: agent.adapterType,
+        agentId: dueRun.agentId,
+        now,
+      });
+      if (!capacity.allow) {
+        const nextAttempt = (dueRun.scheduledRetryAttempt ?? 0) + 1;
+        if (nextAttempt > CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS) {
+          const exhausted = await db
+            .update(heartbeatRuns)
+            .set({
+              status: "cancelled",
+              finishedAt: now,
+              error: `ccrotate capacity retry exhausted after ${dueRun.scheduledRetryAttempt ?? 0} attempts; pool did not recover`,
+              errorCode: "rate_limit_exhausted",
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(heartbeatRuns.id, dueRun.id),
+                eq(heartbeatRuns.status, "scheduled_retry"),
+                lte(heartbeatRuns.scheduledRetryAt, now),
+              ),
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (exhausted) {
+            await appendRunEvent(exhausted, await nextRunEventSeq(exhausted.id), {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "warn",
+              message: "ccrotate capacity retry exhausted; pool did not recover within the retry budget",
+              payload: {
+                scheduledRetryAttempt: dueRun.scheduledRetryAttempt ?? 0,
+                maxAttempts: CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS,
+                ccrotateTarget: capacity.target,
+              },
+            });
+            try {
+              await recovery.escalateCcrotateCapacityExhausted({
+                companyId: dueRun.companyId,
+                ccrotateTarget: capacity.target,
+                agentId: dueRun.agentId,
+                agentName: agent.name ?? null,
+                runId: exhausted.id,
+                attempts: dueRun.scheduledRetryAttempt ?? 0,
+              });
+            } catch (escalationError) {
+              logger.warn(
+                { err: escalationError, runId: exhausted.id, ccrotateTarget: capacity.target },
+                "ccrotate capacity exhaustion escalation failed",
+              );
+            }
+          }
+          return { outcome: "not_promoted", run: exhausted };
+        }
+        const nextDueAt =
+          capacity.resumeAt ?? new Date(now.getTime() + CCROTATE_CAPACITY_DEFAULT_RETRY_DELAY_MS);
+        const rescheduled = await db
+          .update(heartbeatRuns)
+          .set({ scheduledRetryAttempt: nextAttempt, scheduledRetryAt: nextDueAt, updatedAt: now })
+          .where(
+            and(
+              eq(heartbeatRuns.id, dueRun.id),
+              eq(heartbeatRuns.status, "scheduled_retry"),
+              lte(heartbeatRuns.scheduledRetryAt, now),
+            ),
+          )
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (rescheduled) {
+          await appendRunEvent(rescheduled, await nextRunEventSeq(rescheduled.id), {
+            eventType: "lifecycle",
+            stream: "system",
+            level: "info",
+            message: "ccrotate capacity still exhausted at promotion; re-deferred with backoff",
+            payload: {
+              scheduledRetryAttempt: nextAttempt,
+              scheduledRetryAt: nextDueAt.toISOString(),
+              ccrotateTarget: capacity.target,
+            },
+          });
+        }
+        return { outcome: "not_promoted", run: rescheduled };
+      }
+    }
+
     const promoted = await db
       .update(heartbeatRuns)
       .set({
@@ -7664,6 +7800,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function startNextQueuedRunForAgent(agentId: string) {
+    if (options.skipQueuedRunDispatch) return [];
     return withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
@@ -10249,6 +10386,52 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (source !== "timer" && !policy.wakeOnDemand) {
       await writeSkippedRequest("heartbeat.wakeOnDemand.disabled");
       return null;
+    }
+
+    // Ccrotate capacity preflight: if the pool is exhausted for this adapter,
+    // persist as a scheduled_retry rather than starting a doomed pod. Timer,
+    // automation, and assignment wakes go through the gate; manual/on_demand
+    // are user-initiated and pass through unconditionally.
+    const gateAppliesToWake =
+      source === "timer" ||
+      source === "automation" ||
+      source === "assignment";
+    if (gateAppliesToWake) {
+      const gateResult = await ccrotateGate.checkAdapter({
+        adapterType: agent.adapterType,
+        agentId,
+        now: new Date(),
+      });
+      if (!gateResult.allow) {
+        const resumeAtIso = gateResult.resumeAt ? gateResult.resumeAt.toISOString() : null;
+        const scheduledRetryAt =
+          gateResult.resumeAt ?? new Date(Date.now() + CCROTATE_CAPACITY_DEFAULT_RETRY_DELAY_MS);
+        await db.insert(heartbeatRuns).values({
+          companyId: agent.companyId,
+          agentId,
+          invocationSource: source,
+          triggerDetail,
+          status: "scheduled_retry",
+          scheduledRetryAt,
+          scheduledRetryReason: CCROTATE_CAPACITY_RETRY_REASON,
+          scheduledRetryAttempt: 0,
+          errorCode: "rate_limit_exhausted",
+          resultJson: {
+            errorFamily: "rate_limit_exhausted",
+            ...(resumeAtIso ? { retryNotBefore: resumeAtIso, transientRetryNotBefore: resumeAtIso } : {}),
+            ccrotateTarget: gateResult.target,
+            ccrotateReason: gateResult.reason,
+          },
+          contextSnapshot: {
+            ...enrichedContextSnapshot,
+            wakeSource: source,
+            wakeTriggerDetail: triggerDetail,
+            ccrotateTarget: gateResult.target,
+            ...(resumeAtIso ? { ccrotateResumeAt: resumeAtIso } : {}),
+          },
+        });
+        return null;
+      }
     }
 
     if (issueId) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10914,6 +10914,59 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
 
         if (
+          activeExecutionRun?.status === "scheduled_retry" &&
+          activeExecutionRun.scheduledRetryReason === DEP_BLOCKED_RETRY_REASON &&
+          dependencyReadiness?.isDependencyReady
+        ) {
+          const now = new Date();
+          const cancelled = await tx
+            .update(heartbeatRuns)
+            .set({
+              status: "cancelled",
+              finishedAt: now,
+              error: "Cancelled because dependency blockers resolved before the scheduled retry became due",
+              errorCode: "dep_blockers_resolved",
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(heartbeatRuns.id, activeExecutionRun.id),
+                eq(heartbeatRuns.status, "scheduled_retry"),
+              ),
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (cancelled) {
+            if (activeExecutionRun.wakeupRequestId) {
+              await tx
+                .update(agentWakeupRequests)
+                .set({
+                  status: "cancelled",
+                  finishedAt: now,
+                  error: "Cancelled because dependency blockers resolved",
+                  updatedAt: now,
+                })
+                .where(eq(agentWakeupRequests.id, activeExecutionRun.wakeupRequestId));
+            }
+            await tx
+              .update(issues)
+              .set({
+                executionRunId: null,
+                executionAgentNameKey: null,
+                executionLockedAt: null,
+                updatedAt: now,
+              })
+              .where(
+                and(
+                  eq(issues.id, issue.id),
+                  eq(issues.executionRunId, activeExecutionRun.id),
+                ),
+              );
+            activeExecutionRun = null;
+          }
+        }
+
+        if (
           blockedInteractionWake &&
           activeExecutionRun?.status === "scheduled_retry" &&
           activeExecutionRun.scheduledRetryReason === DEP_BLOCKED_RETRY_REASON

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10913,6 +10913,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
 
+        if (
+          blockedInteractionWake &&
+          activeExecutionRun?.status === "scheduled_retry" &&
+          activeExecutionRun.scheduledRetryReason === DEP_BLOCKED_RETRY_REASON
+        ) {
+          // Keep the dependency retry parked, but do not let it absorb a
+          // verified human interaction wake. The interaction should run in its
+          // bounded mode even while the dependency remains unresolved.
+          activeExecutionRun = null;
+        }
+
         if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {
           const now = new Date();
           const scheduledRetryAt = new Date(now.getTime() + DEP_BLOCKED_BASE_DELAY_MS);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -258,6 +258,14 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBE
 export const CCROTATE_CAPACITY_DEFAULT_RETRY_DELAY_MS = 5 * 60 * 1000;
 export const CCROTATE_CAPACITY_RETRY_REASON = "ccrotate_capacity";
 export const CCROTATE_CAPACITY_MAX_RETRY_ATTEMPTS = 24;
+export const DEP_BLOCKED_RETRY_REASON = "dependency_blocked";
+export const DEP_BLOCKED_BASE_DELAY_MS = 5 * 60 * 1000;
+export const DEP_BLOCKED_MAX_DELAY_MS = 60 * 60 * 1000;
+export const DEP_BLOCKED_MAX_RETRY_ATTEMPTS = 72;
+
+function depBlockedRetryDelayMs(attempt: number): number {
+  return Math.min(DEP_BLOCKED_BASE_DELAY_MS * Math.pow(2, attempt), DEP_BLOCKED_MAX_DELAY_MS);
+}
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 // Keep this in sync with local adapters that require a git workspace before launch.
@@ -6025,6 +6033,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ) {
         // Preserve legacy transient retry behavior for runs that only carry a
         // loose task context rather than a persisted issue row.
+      } else if (
+        gate.errorCode === "issue_dependencies_blocked" &&
+        dueRun.scheduledRetryReason === DEP_BLOCKED_RETRY_REASON
+      ) {
+        // Re-defer logic handled in the dep-blocked block below instead of cancelling.
       } else {
         const cancelled = await cancelScheduledRetryForGate(dueRun, gate, now);
         return cancelled
@@ -6125,6 +6138,81 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           });
         }
         return { outcome: "not_promoted", run: rescheduled };
+      }
+    }
+
+    // A dep-blocked defer must re-check dependency readiness at promotion time.
+    // If still blocked → re-defer with exponential backoff. If resolved → fall
+    // through to normal promotion so the run becomes queued and runs.
+    if (dueRun.scheduledRetryReason === DEP_BLOCKED_RETRY_REASON) {
+      const depIssueId = readNonEmptyString(parseObject(dueRun.contextSnapshot).issueId);
+      if (depIssueId) {
+        const readiness = (await issuesSvc.listDependencyReadiness(dueRun.companyId, [depIssueId])).get(depIssueId);
+        if (readiness && !readiness.isDependencyReady) {
+          const nextAttempt = (dueRun.scheduledRetryAttempt ?? 0) + 1;
+          if (nextAttempt > DEP_BLOCKED_MAX_RETRY_ATTEMPTS) {
+            const exhausted = await db
+              .update(heartbeatRuns)
+              .set({
+                status: "cancelled",
+                finishedAt: now,
+                error: `dependency-blocked retry exhausted after ${dueRun.scheduledRetryAttempt ?? 0} attempts; blockers never resolved`,
+                errorCode: "issue_dependencies_blocked",
+                updatedAt: now,
+              })
+              .where(
+                and(
+                  eq(heartbeatRuns.id, dueRun.id),
+                  eq(heartbeatRuns.status, "scheduled_retry"),
+                  lte(heartbeatRuns.scheduledRetryAt, now),
+                ),
+              )
+              .returning()
+              .then((rows) => rows[0] ?? null);
+            if (exhausted) {
+              await appendRunEvent(exhausted, await nextRunEventSeq(exhausted.id), {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "warn",
+                message: "dependency-blocked retry exhausted; blockers never resolved within the retry budget",
+                payload: {
+                  scheduledRetryAttempt: dueRun.scheduledRetryAttempt ?? 0,
+                  maxAttempts: DEP_BLOCKED_MAX_RETRY_ATTEMPTS,
+                  unresolvedBlockerIssueIds: readiness.unresolvedBlockerIssueIds,
+                },
+              });
+            }
+            return { outcome: "not_promoted", run: exhausted };
+          }
+          const nextDueAt = new Date(now.getTime() + depBlockedRetryDelayMs(nextAttempt));
+          const rescheduled = await db
+            .update(heartbeatRuns)
+            .set({ scheduledRetryAttempt: nextAttempt, scheduledRetryAt: nextDueAt, updatedAt: now })
+            .where(
+              and(
+                eq(heartbeatRuns.id, dueRun.id),
+                eq(heartbeatRuns.status, "scheduled_retry"),
+                lte(heartbeatRuns.scheduledRetryAt, now),
+              ),
+            )
+            .returning()
+            .then((rows) => rows[0] ?? null);
+          if (rescheduled) {
+            await appendRunEvent(rescheduled, await nextRunEventSeq(rescheduled.id), {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "info",
+              message: "dependencies still blocked at promotion; re-deferred with backoff",
+              payload: {
+                scheduledRetryAttempt: nextAttempt,
+                scheduledRetryAt: nextDueAt.toISOString(),
+                unresolvedBlockerIssueIds: readiness.unresolvedBlockerIssueIds,
+              },
+            });
+          }
+          return { outcome: "not_promoted", run: rescheduled };
+        }
+        // Dependencies resolved — fall through to promote the run.
       }
     }
 
@@ -10757,25 +10845,132 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           );
         }
 
+        // If there is an existing dep-blocked scheduled_retry whose blocker set no longer
+        // matches the current blockers, cancel it so we create a fresh one below.
+        if (
+          activeExecutionRun &&
+          activeExecutionRun.scheduledRetryReason === DEP_BLOCKED_RETRY_REASON &&
+          dependencyReadiness &&
+          !dependencyReadiness.isDependencyReady
+        ) {
+          const storedBlockerIds: unknown[] = Array.isArray(
+            parseObject(activeExecutionRun.contextSnapshot).unresolvedBlockerIssueIds,
+          )
+            ? (parseObject(activeExecutionRun.contextSnapshot).unresolvedBlockerIssueIds as unknown[])
+            : [];
+          const currentBlockerIds = dependencyReadiness.unresolvedBlockerIssueIds ?? [];
+          const storedSet = new Set(storedBlockerIds.map(String));
+          const currentSet = new Set(currentBlockerIds.map(String));
+          const setsMatch =
+            storedSet.size === currentSet.size && [...storedSet].every((id) => currentSet.has(id));
+          if (!setsMatch) {
+            const now = new Date();
+            const cancelled = await tx
+              .update(heartbeatRuns)
+              .set({
+                status: "cancelled",
+                finishedAt: now,
+                error: "Cancelled because the dependency blocker set changed before the scheduled retry became due",
+                errorCode: "dep_blockers_changed",
+                updatedAt: now,
+              })
+              .where(
+                and(
+                  eq(heartbeatRuns.id, activeExecutionRun.id),
+                  eq(heartbeatRuns.status, "scheduled_retry"),
+                ),
+              )
+              .returning()
+              .then((rows) => rows[0] ?? null);
+            if (cancelled) {
+              if (activeExecutionRun.wakeupRequestId) {
+                await tx
+                  .update(agentWakeupRequests)
+                  .set({
+                    status: "cancelled",
+                    finishedAt: now,
+                    error: "Cancelled because the dependency blocker set changed",
+                    updatedAt: now,
+                  })
+                  .where(eq(agentWakeupRequests.id, activeExecutionRun.wakeupRequestId));
+              }
+              await tx
+                .update(issues)
+                .set({
+                  executionRunId: null,
+                  executionAgentNameKey: null,
+                  executionLockedAt: null,
+                  updatedAt: now,
+                })
+                .where(
+                  and(
+                    eq(issues.id, issue.id),
+                    eq(issues.executionRunId, activeExecutionRun.id),
+                  ),
+                );
+              activeExecutionRun = null;
+            }
+          }
+        }
+
         if (!activeExecutionRun && dependencyReadiness && !dependencyReadiness.isDependencyReady && !blockedInteractionWake) {
-          await tx.insert(agentWakeupRequests).values({
-            companyId: agent.companyId,
-            agentId,
-            source,
-            triggerDetail,
-            reason: "issue_dependencies_blocked",
-            payload: {
-              ...(payload ?? {}),
-              issueId,
-              unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
-            },
-            status: "skipped",
-            requestedByActorType: opts.requestedByActorType ?? null,
-            requestedByActorId: opts.requestedByActorId ?? null,
-            idempotencyKey: opts.idempotencyKey ?? null,
-            finishedAt: new Date(),
-          });
-          return { kind: "skipped" as const };
+          const now = new Date();
+          const scheduledRetryAt = new Date(now.getTime() + DEP_BLOCKED_BASE_DELAY_MS);
+          const depBlockedSnapshot = {
+            ...enrichedContextSnapshot,
+            unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
+            unresolvedBlockerCount: dependencyReadiness.unresolvedBlockerCount,
+          };
+          const wakeupRequest = await tx
+            .insert(agentWakeupRequests)
+            .values({
+              companyId: agent.companyId,
+              agentId,
+              source,
+              triggerDetail,
+              reason: "issue_dependencies_blocked",
+              payload: {
+                ...(payload ?? {}),
+                issueId,
+                unresolvedBlockerIssueIds: dependencyReadiness.unresolvedBlockerIssueIds,
+              },
+              status: "scheduled",
+              requestedByActorType: opts.requestedByActorType ?? null,
+              requestedByActorId: opts.requestedByActorId ?? null,
+              idempotencyKey: opts.idempotencyKey ?? null,
+            })
+            .returning()
+            .then((rows) => rows[0]);
+          const scheduledRun = await tx
+            .insert(heartbeatRuns)
+            .values({
+              companyId: agent.companyId,
+              agentId,
+              invocationSource: source,
+              triggerDetail,
+              status: "scheduled_retry",
+              scheduledRetryAt,
+              scheduledRetryAttempt: 0,
+              scheduledRetryReason: DEP_BLOCKED_RETRY_REASON,
+              wakeupRequestId: wakeupRequest.id,
+              contextSnapshot: depBlockedSnapshot,
+            })
+            .returning()
+            .then((rows) => rows[0]);
+          await tx
+            .update(agentWakeupRequests)
+            .set({ runId: scheduledRun.id, updatedAt: now })
+            .where(eq(agentWakeupRequests.id, wakeupRequest.id));
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: scheduledRun.id,
+              executionAgentNameKey: agentNameKey,
+              executionLockedAt: now,
+              updatedAt: now,
+            })
+            .where(eq(issues.id, issue.id));
+          return { kind: "dep_blocked_scheduled" as const, run: scheduledRun };
         }
 
         if (activeExecutionRun) {
@@ -10955,7 +11150,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "queued" as const, run: newRun };
       });
 
-      if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
+      if (outcome.kind === "deferred" || outcome.kind === "skipped" || outcome.kind === "dep_blocked_scheduled") return null;
       if (outcome.kind === "coalesced") {
         await startNextQueuedRunForAgent(agent.id);
         return outcome.run;

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -3,6 +3,7 @@ export const RECOVERY_ORIGIN_KINDS = {
   issueProductivityReview: "issue_productivity_review",
   strandedIssueRecovery: "stranded_issue_recovery",
   staleActiveRunEvaluation: "stale_active_run_evaluation",
+  ccrotateCapacityExhausted: "ccrotate_capacity_exhausted",
 } as const;
 
 export const RECOVERY_REASON_KINDS = {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3921,8 +3921,81 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return result;
   }
 
+  // Fires when the ccrotate capacity retry budget is exhausted for a run.
+  // Creates one coalesced operator-visible issue per (company, ccrotate target)
+  // so a pool-wide outage doesn't flood the board with per-run escalations. Many
+  // agents' retries can fire at once, so the escalation is keyed on the target —
+  // one open issue per pool, not one per cancelled run.
+  async function escalateCcrotateCapacityExhausted(input: {
+    companyId: string;
+    ccrotateTarget: string;
+    agentId: string;
+    agentName: string | null;
+    runId: string;
+    attempts: number;
+  }): Promise<{ kind: "created" | "coalesced"; issueId: string }> {
+    const originId = input.ccrotateTarget;
+    const findOpen = () =>
+      db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, input.companyId),
+            eq(issues.originKind, RECOVERY_ORIGIN_KINDS.ccrotateCapacityExhausted),
+            eq(issues.originId, originId),
+            isNull(issues.hiddenAt),
+            notInArray(issues.status, ["done", "cancelled"]),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+    const existing = await findOpen();
+    if (existing) return { kind: "coalesced", issueId: existing.id };
+
+    const agentLabel = input.agentName
+      ? `${input.agentName} (${input.agentId})`
+      : input.agentId;
+    try {
+      const created = await issuesSvc.create(input.companyId, {
+        title: `ccrotate pool exhausted — ${input.ccrotateTarget}`,
+        description: [
+          `The ccrotate capacity pool **${input.ccrotateTarget}** did not recover within the auto-retry budget.`,
+          "",
+          `- Agent: ${agentLabel}`,
+          `- Cancelled run: ${input.runId}`,
+          `- Retry attempts before giving up: ${input.attempts}`,
+          "",
+          "Agent runs are deferring and then cancelling because no account in this pool has usable capacity and none reported a future reset within the retry window. This usually needs a ccrotate token refresh / capacity top-up rather than agent action. This issue is coalesced per pool, so it represents the whole outage rather than a single run — mark it done once the pool recovers.",
+        ].join("\n"),
+        status: "todo",
+        priority: "high",
+        originKind: RECOVERY_ORIGIN_KINDS.ccrotateCapacityExhausted,
+        originId,
+      });
+      return { kind: "created", issueId: created.id };
+    } catch (error) {
+      // Lost the check-then-create race to a concurrent exhaustion of the same
+      // pool. The partial unique index issues_active_ccrotate_capacity_exhaustion_uq
+      // guarantees only one open escalation per (company, target), so coalesce
+      // onto whoever won the insert rather than surfacing the conflict.
+      const conflict = unwrapDatabaseConflictError(error);
+      const isDedupeConflict =
+        conflict?.code === "23505" &&
+        (conflict.constraint === "issues_active_ccrotate_capacity_exhaustion_uq" ||
+          (typeof conflict.message === "string" &&
+            conflict.message.includes("issues_active_ccrotate_capacity_exhaustion_uq")));
+      if (!isDedupeConflict) throw error;
+      const winner = await findOpen();
+      if (winner) return { kind: "coalesced", issueId: winner.id };
+      throw error;
+    }
+  }
+
   return {
     buildRunOutputSilence,
+    escalateCcrotateCapacityExhausted,
     escalateStrandedRecoveryIssueInPlace,
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip's scheduler/heartbeat service decides when agent work is eligible to run.
> - The current scheduler can create noisy churn when work cannot actually dispatch, especially when dependencies remain blocked or ccrotate capacity is exhausted.
> - BLO-10273 handles exhausted ccrotate pools by deferring wakeups as scheduled retries instead of launching pods that immediately fail.
> - BLO-10272 handles unchanged `issue_dependencies_blocked` sweeps by coalescing repeated wakeups into one retry path per `(issue, agent)`.
> - This pull request publishes both scheduler fixes as one stacked review artifact because the dep-blocked coalescer branch is based on the ccrotate preflight commit and no separate upstream PR exists for that base.
> - The benefit is lower scheduler churn, fewer wasted runs, and clearer operator-visible escalation when retry paths remain blocked.

## Linked Issues or Issue Description

External tracker refs:
- BLO-10273: add dispatch preflight for exhausted ccrotate pool.
- BLO-10272: coalesce `issue_dependencies_blocked` wakeup storms.
- BLO-10429: package/publish the BLO-10272 branch into a PR artifact.

No matching GitHub issue exists in `paperclipai/paperclip`, so the issue is described inline using the feature request template fields below.

## Problem or motivation

Repeated blocked-dependency sweeps and exhausted-provider dispatch attempts create large volumes of skipped or failed scheduler runs without useful progress. Operators see noisy churn instead of a stable retry/escalation state, and the system wastes execution capacity on work that cannot dispatch.

## Proposed solution

Convert exhausted ccrotate capacity and unchanged dependency-blocked wakeups into scheduled retry paths. Add coalescing by `(issue, agent)` for repeated unchanged blocked-dependency sweeps, bounded retry metadata, scheduler metrics, blocker-set reset handling, and an escalation dedupe path for exhausted ccrotate capacity.

## Alternatives considered

Leaving the immediate wake/skip behavior in place preserves noisy churn and hides the real actionable state. Recording only operator notes would improve observability but would not reduce scheduler load or failed dispatch attempts.

## Roadmap alignment

This is scheduler reliability and operational health work for Paperclip agent execution. I checked `ROADMAP.md`; this does not duplicate planned core product work.

Related search:
- Searched open and closed PRs for `BLO-10272`, `BLO-10273`, `ccrotate dispatch preflight`, and `dep-blocked coalescer`; no separate upstream PR for this branch/base was found.

## What Changed

- Added ccrotate tier-cache state helpers and capacity gate plumbing.
- Added ccrotate pre-dispatch defer behavior so exhausted pools create `scheduled_retry` rows rather than doomed pod launches.
- Added ccrotate probe and runtime quota writeback helpers.
- Added a unique-index migration for ccrotate exhausted-capacity escalation dedupe.
- Added dependency-blocked retry/coalescing behavior in `heartbeat.ts` with blocker-set reset handling.
- Added bounded dependency-blocked scheduler metrics.
- Added scheduler and metrics regression tests for ccrotate capacity retry and dependency-blocked coalescing/reset behavior.

## Verification

Reported local verification from the BLO-10429 handoff before publish:

```bash
pnpm vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts -t "coalesces repeated unchanged|resets dependency-blocked"
pnpm vitest run server/src/__tests__/metrics-service.test.ts
```

Additional verification after PR publication:

```bash
pnpm --filter @paperclipai/db run check:migrations
pnpm --filter @paperclipai/db build
git diff --check
```

Additional verification expected on this PR:
- GitHub Actions `PR` workflow on this branch.
- Automated review gates after this template-compliant PR body is present.

## Risks

- Scheduler behavior changes from immediate skipped wakeups to scheduled retry rows, so dashboards or operators that counted skipped runs may see different counts.
- Retry metadata must stay compatible with existing `promoteDueScheduledRetries` behavior.
- The PR is stacked: it includes both ccrotate capacity preflight and dependency-blocked coalescing because the second patch is based on the first. Reviewers should treat this as a scheduler-reliability bundle.
- Low database risk from the ccrotate dedupe migration: it adds a partial unique index for open escalation issues.

## Model Used

- Claude Sonnet 4.6 assisted with the implementation commits, as recorded in commit trailers.
- OpenAI Codex / GPT-5 assisted with PR packaging, cross-fork publication, and PR description cleanup in a tool-using coding session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge