### PR TITLE
PGC-710 include review issues in agent inbox-lite

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -82,6 +82,11 @@ const mockIssueApprovalService = vi.hoisted(() => ({
 
 const mockIssueService = vi.hoisted(() => ({
   list: vi.fn(),
+  listDependencyReadiness: vi.fn(),
+}));
+
+const mockIssueRecoveryActionService = vi.hoisted(() => ({
+  listActiveForIssues: vi.fn(),
 }));
 
 const mockSecretService = vi.hoisted(() => ({
@@ -195,6 +200,7 @@ function registerModuleMocks() {
     heartbeatService: () => mockHeartbeatService,
     ISSUE_LIST_DEFAULT_LIMIT: 500,
     issueApprovalService: () => mockIssueApprovalService,
+    issueRecoveryActionService: () => mockIssueRecoveryActionService,
     issueService: () => mockIssueService,
     logActivity: mockLogActivity,
     secretService: () => mockSecretService,
@@ -319,6 +325,8 @@ describe.sequential("agent permission routes", () => {
     mockHeartbeatService.cancelRun.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
     mockIssueService.list.mockReset();
+    mockIssueService.listDependencyReadiness.mockReset();
+    mockIssueRecoveryActionService.listActiveForIssues.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
     mockSecretService.resolveAdapterConfigForRuntime.mockReset();
     mockAgentInstructionsService.materializeManagedBundle.mockReset();
@@ -1490,6 +1498,83 @@ describe.sequential("agent permission routes", () => {
       status: "backlog,todo,in_progress,in_review,blocked,done",
       limit: 500,
     });
+  });
+
+  it("keeps waiting assigned issues in the compact agent inbox", async () => {
+    const updatedAt = new Date("2026-04-22T12:00:00.000Z");
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: "review-issue",
+        identifier: "PAP-710",
+        title: "Waiting on review",
+        status: "in_review",
+        priority: "high",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+      {
+        id: "blocked-issue",
+        identifier: "PAP-711",
+        title: "Waiting on blocker",
+        status: "blocked",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt,
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map([
+      ["review-issue", {
+        isDependencyReady: true,
+        unresolvedBlockerCount: 0,
+        unresolvedBlockerIssueIds: [],
+      }],
+      ["blocked-issue", {
+        isDependencyReady: false,
+        unresolvedBlockerCount: 1,
+        unresolvedBlockerIssueIds: ["blocker-1"],
+      }],
+    ]));
+    mockIssueRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map());
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+      source: "agent_key",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get("/api/agents/me/inbox-lite"));
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(companyId, {
+      assigneeAgentId: agentId,
+      status: "todo,in_progress,in_review,blocked",
+      includeRoutineExecutions: true,
+      limit: 500,
+    });
+    expect(res.body).toEqual([
+      expect.objectContaining({
+        id: "review-issue",
+        status: "in_review",
+        dependencyReady: true,
+        unresolvedBlockerCount: 0,
+        unresolvedBlockerIssueIds: [],
+      }),
+      expect.objectContaining({
+        id: "blocked-issue",
+        status: "blocked",
+        dependencyReady: false,
+        unresolvedBlockerCount: 1,
+        unresolvedBlockerIssueIds: ["blocker-1"],
+      }),
+    ]);
   });
 
   describe("agent configuration read gate", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1398,7 +1398,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
 
     const inboxIssueIds = (await svc.list(companyId, {
       assigneeAgentId: agentId,
-      status: "todo,in_progress,blocked",
+      status: "todo,in_progress,in_review,blocked",
       includeRoutineExecutions: true,
     })).map((issue) => issue.id);
     expect(inboxIssueIds).toContain(normalIssueId);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1920,7 +1920,7 @@ export function agentRoutes(
     const recoveryActionsSvc = issueRecoveryActionService(db);
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
-      status: "todo,in_progress,blocked",
+      status: "todo,in_progress,in_review,blocked",
       includeRoutineExecutions: true,
       limit: ISSUE_LIST_DEFAULT_LIMIT,
     });


### PR DESCRIPTION
## Summary

PGC-710 구현 (`PGC-710 include review issues in agent inbox-lite`) 을 `master`에 반영하기 위한 PR입니다. 단일 커밋 `fc4cdedf7f43dc196864a9bf96eff42ea43555d5` 로, 현재 `master`(`412a04c9`) 기준 깨끗한 fast-forward 입니다.

- review 이슈를 agent inbox-lite 에 포함하도록 수정
- 변경 범위: 3 files, +87 / -2

## Changes

- `server/src/routes/agents.ts` — inbox-lite 쿼리에 review 이슈 포함
- `server/src/__tests__/agent-permissions-routes.test.ts` — 신규 회귀 테스트 (+85)
- `server/src/__tests__/issues-service.test.ts` — 기존 단언 보정

## Verification (local)

- `pnpm run preflight:workspace-links`
- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts -t "hides plugin operation issues"`

## Context

- 원본 구현 이슈: PGC-710
- 퍼블리시 트래킹 이슈: PGC-979
- 이 PR은 봇 신원(`hsnoh-t`)이 upstream에 read-only 권한만 있어 fork(`hsnoh-t/paperclip`) 기반으로 올립니다. 머지에는 write 권한 보유자의 승인이 필요합니다.
- 정확한 SHA / 선형 히스토리를 보존하려면 fast-forward 직접 push (`git push origin master`) 도 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
