### PR TITLE
fix(issues): allow recovery owners to clear stale blockers

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -11,6 +11,7 @@ import {
   createDb,
   environmentLeases,
   environments,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueRecoveryActions,
@@ -136,6 +137,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.delete(issueComments);
     await db.delete(environmentLeases);
     await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(environments);
@@ -953,6 +955,113 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       removedBlockedByIssueIds: [blockerIssueId],
       blockedByIssueIds: [],
     });
+  });
+
+  it("requires checked-out assignees to prove run ownership for recovery-shaped source patches", async () => {
+    const { companyId, managerId, coderId, sourceIssueId, prefix } = await seedCompany();
+    const recoveryOwnerId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const activeRunId = randomUUID();
+    const staleRunId = randomUUID();
+    await db.insert(agents).values({
+      id: recoveryOwnerId,
+      companyId,
+      name: "Recovery Owner",
+      role: "platform_owner",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values([
+      {
+        id: activeRunId,
+        companyId,
+        agentId: coderId,
+        invocationSource: "manual",
+        status: "running",
+        startedAt: new Date("2026-05-13T18:00:00.000Z"),
+        contextSnapshot: { issueId: sourceIssueId },
+      },
+      {
+        id: staleRunId,
+        companyId,
+        agentId: coderId,
+        invocationSource: "manual",
+        status: "running",
+        startedAt: new Date("2026-05-13T18:01:00.000Z"),
+        contextSnapshot: { issueId: sourceIssueId },
+      },
+    ]);
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Implementation handoff",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+    });
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        assigneeAgentId: coderId,
+        checkoutRunId: activeRunId,
+        executionRunId: activeRunId,
+      })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: sourceIssueId,
+      type: "blocks",
+    });
+    await issueRecoveryActionService(db).upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: recoveryOwnerId,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:assignee-checkout-required",
+      evidence: { latestIssueStatus: "blocked", blockerIssueId },
+      nextAction: "Remove the stale blocker and restore the original assignee's live path.",
+      wakePolicy: { type: "manual" },
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: coderId,
+      companyId,
+      runId: staleRunId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({
+        status: "todo",
+        blockedByIssueIds: [],
+        comment: "Assignee must still prove active checkout ownership.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Issue run ownership conflict");
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: coderId,
+      checkoutRunId: activeRunId,
+      executionRunId: activeRunId,
+    });
+    const relationRows = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.relatedIssueId, sourceIssueId));
+    expect(relationRows).toHaveLength(1);
+    expect(relationRows[0]?.issueId).toBe(blockerIssueId);
   });
 
   it("rejects ordinary agents clearing stale blockers on another assignee's issue", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -27,6 +27,25 @@ import { issueRoutes } from "../routes/issues.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
 import { recoveryService } from "../services/recovery/service.js";
 
+const mockRouteHeartbeatService = vi.hoisted(() => ({
+  cancelRun: vi.fn(async () => null),
+  reportRunActivity: vi.fn(async () => undefined),
+  retryScheduledRetryNow: vi.fn(async () => ({ outcome: "noop", message: "noop", scheduledRetry: null })),
+  triggerIssueMonitor: vi.fn(async () => null),
+  wakeup: vi.fn(async () => null),
+}));
+
+vi.mock(
+  "../services/index.js",
+  async (importOriginal: () => Promise<typeof import("../services/index.js")>) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      heartbeatService: () => mockRouteHeartbeatService,
+    };
+  },
+);
+
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -852,6 +852,200 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("allows the named recovery owner to clear stale blockers without taking issue ownership", async () => {
+    const { companyId, managerId, coderId, sourceIssueId, prefix } = await seedCompany();
+    const recoveryOwnerId = randomUUID();
+    const blockerIssueId = randomUUID();
+    await db.insert(agents).values({
+      id: recoveryOwnerId,
+      companyId,
+      name: "Platform Owner",
+      role: "platform_owner",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Implementation handoff",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+    });
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: coderId })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: sourceIssueId,
+      type: "blocks",
+    });
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: recoveryOwnerId,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:stale-blocker-cleanup",
+      evidence: { latestIssueStatus: "blocked", blockerIssueId },
+      nextAction: "Remove the stale blocker and restore the original assignee's live path.",
+      wakePolicy: { type: "manual" },
+    });
+    const runId = randomUUID();
+    const app = createApp({
+      type: "agent",
+      agentId: recoveryOwnerId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    await seedHeartbeatRun({
+      companyId,
+      agentId: recoveryOwnerId,
+      runId,
+      issueId: sourceIssueId,
+    });
+
+    const restored = await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({
+        status: "todo",
+        blockedByIssueIds: [],
+        comment: "Recovery owner cleared a stale blocker and restored the assigned work path.",
+      })
+      .expect(200);
+
+    expect(restored.body).toMatchObject({
+      id: sourceIssueId,
+      status: "todo",
+      assigneeAgentId: coderId,
+      blockedBy: [],
+    });
+    const relationRows = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.relatedIssueId, sourceIssueId));
+    expect(relationRows).toHaveLength(0);
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "cancelled",
+      outcome: "cancelled",
+      resolutionNote: "Recovery action became stale because the source issue was manually moved from blocked to todo.",
+    });
+    const activityRows = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, sourceIssueId));
+    expect(activityRows.some((row) => row.action === "issue.updated")).toBe(true);
+    expect(activityRows.find((row) => row.action === "issue.blockers_updated")?.details).toMatchObject({
+      removedBlockedByIssueIds: [blockerIssueId],
+      blockedByIssueIds: [],
+    });
+  });
+
+  it("rejects ordinary agents clearing stale blockers on another assignee's issue", async () => {
+    const { companyId, managerId, coderId, sourceIssueId, prefix } = await seedCompany();
+    const recoveryOwnerId = randomUUID();
+    const peerAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    await db.insert(agents).values([
+      {
+        id: recoveryOwnerId,
+        companyId,
+        name: "Recovery Owner",
+        role: "platform_owner",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: peerAgentId,
+        companyId,
+        name: "Peer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Implementation handoff",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: managerId,
+      issueNumber: 2,
+      identifier: `${prefix}-2`,
+    });
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: coderId })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: sourceIssueId,
+      type: "blocks",
+    });
+    await issueRecoveryActionService(db).upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: recoveryOwnerId,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:ordinary-agent-denied",
+      evidence: { latestIssueStatus: "blocked", blockerIssueId },
+      nextAction: "Remove the stale blocker and restore the original assignee's live path.",
+      wakePolicy: { type: "manual" },
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: peerAgentId,
+      companyId,
+      runId: randomUUID(),
+      source: "agent_jwt",
+    });
+
+    await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({
+        status: "todo",
+        blockedByIssueIds: [],
+        comment: "Peer agent should not be able to clear this blocker.",
+      })
+      .expect(403);
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({
+      status: "blocked",
+      assigneeAgentId: coderId,
+    });
+    const relationRows = await db
+      .select()
+      .from(issueRelations)
+      .where(eq(issueRelations.relatedIssueId, sourceIssueId));
+    expect(relationRows).toHaveLength(1);
+    expect(relationRows[0]?.issueId).toBe(blockerIssueId);
+  });
+
   it("rejects peer-agent recovery action resolution on a board-owned source issue", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1842,6 +1842,29 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  async function agentHasRecoveryActionAuthority(
+    req: Request,
+    issue: { companyId: string; assigneeAgentId: string | null },
+    activeRecoveryAction: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>> | null,
+  ) {
+    if (req.actor.type !== "agent") return true;
+    if (!activeRecoveryAction) return false;
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) return false;
+    if (issue.assigneeAgentId === actorAgentId) return true;
+    if (
+      issue.assigneeAgentId &&
+      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)
+    ) {
+      return true;
+    }
+    if (activeRecoveryAction.ownerAgentId === actorAgentId) return true;
+    return Boolean(
+      activeRecoveryAction.ownerAgentId &&
+      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, activeRecoveryAction.ownerAgentId)
+    );
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -1854,12 +1877,22 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    options: {
+      activeRecoveryAction?: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>> | null;
+      allowRecoveryActionAuthority?: boolean;
+    } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
       res.status(403).json({ error: "Agent authentication required" });
       return false;
+    }
+    if (
+      options.allowRecoveryActionAuthority === true &&
+      await agentHasRecoveryActionAuthority(req, issue, options.activeRecoveryAction ?? null)
+    ) {
+      return true;
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
@@ -2169,20 +2202,7 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
-    if (issue.assigneeAgentId === actorAgentId) return true;
-    if (
-      issue.assigneeAgentId &&
-      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)
-    ) {
-      return true;
-    }
-    if (activeRecoveryAction.ownerAgentId === actorAgentId) return true;
-    if (
-      activeRecoveryAction.ownerAgentId &&
-      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, activeRecoveryAction.ownerAgentId)
-    ) {
-      return true;
-    }
+    if (await agentHasRecoveryActionAuthority(req, issue, activeRecoveryAction)) return true;
 
     res.status(403).json({
       error: "Agent cannot resolve another owner's recovery action",
@@ -2197,6 +2217,13 @@ export function issueRoutes(
       },
     });
     return false;
+  }
+
+  function isRecoveryOwnerSourceIssuePatchRequest(body: Record<string, unknown>) {
+    const allowedKeys = new Set(["blockedByIssueIds", "comment", "status"]);
+    const keys = Object.keys(body);
+    if (!keys.some((key) => key === "blockedByIssueIds" || key === "status")) return false;
+    return keys.every((key) => allowedKeys.has(key));
   }
 
   async function resolveActiveIssueRun(issue: {
@@ -2961,8 +2988,15 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id);
+    if (
+      !(await assertAgentIssueMutationAllowed(req, res, existing, {
+        activeRecoveryAction,
+        allowRecoveryActionAuthority: true,
+      }))
+    ) {
+      return;
+    }
     if (
       !(await assertRecoveryActionAuthority(
         req,
@@ -4800,7 +4834,25 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    const sourceMutationTouchesRecoveryPath =
+      req.body.status !== undefined ||
+      req.body.assigneeAgentId !== undefined ||
+      req.body.assigneeUserId !== undefined ||
+      Array.isArray(req.body.blockedByIssueIds) ||
+      req.body.executionPolicy !== undefined ||
+      req.body.resume === true ||
+      req.body.reopen === true;
+    const activeRecoveryActionBeforeUpdate = sourceMutationTouchesRecoveryPath
+      ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
+      : null;
+    if (
+      !(await assertAgentIssueMutationAllowed(req, res, existing, {
+        activeRecoveryAction: activeRecoveryActionBeforeUpdate,
+        allowRecoveryActionAuthority: isRecoveryOwnerSourceIssuePatchRequest(req.body),
+      }))
+    ) {
+      return;
+    }
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -4853,9 +4905,6 @@ export function issueRoutes(
       Array.isArray(req.body.blockedByIssueIds) ||
       req.body.executionPolicy !== undefined ||
       explicitMoveToTodoRequested;
-    const activeRecoveryActionBeforeUpdate = recoveryRelevantSourceMutationRequested
-      ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
-      : null;
     if (
       recoveryRelevantSourceMutationRequested &&
       !(await assertRecoveryActionAuthority(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1847,7 +1847,6 @@ export function issueRoutes(
     issue: { companyId: string; assigneeAgentId: string | null },
     activeRecoveryAction: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>> | null,
   ) {
-    if (req.actor.type !== "agent") return true;
     if (!activeRecoveryAction) return false;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) return false;
@@ -1888,8 +1887,10 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
+    const isIssueAssignee = issue.assigneeAgentId === actorAgentId;
     if (
       options.allowRecoveryActionAuthority === true &&
+      !isIssueAssignee &&
       await agentHasRecoveryActionAuthority(req, issue, options.activeRecoveryAction ?? null)
     ) {
       return true;
@@ -1902,7 +1903,7 @@ export function issueRoutes(
     if (issue.assigneeAgentId === null) {
       return true;
     }
-    if (issue.assigneeAgentId !== actorAgentId) {
+    if (!isIssueAssignee) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane operators use to assign, govern, and recover AI-agent work.
> - Issue mutation authority is part of the server route layer that protects company boundaries and task ownership.
> - Source-scoped recovery actions can name a recovery owner, but the normal issue PATCH authorization check was running before that recovery authority could be applied.
> - That meant an authorized recovery owner could be assigned stale-blocker cleanup but still receive a cross-boundary 403 before reaching the audited recovery update path.
> - This pull request narrows recovery-owner PATCH access to the existing audited stale-blocker recovery fields instead of weakening normal agent issue mutation authority.
> - The benefit is that operators can clear stale dependency blockers through a product rule with tests and audit comments, while ordinary agents still cannot edit out-of-bound issues.

## Linked Issues or Issue Description

- Refs #8109
- Bug: source-scoped issue recovery owners cannot clear stale blockers because `PATCH /api/issues/:id` enforces normal issue mutation boundaries before checking active recovery-action authority.
- System8 operating context: SYSA-1267 / SYSA-1269 need this fix deployed before the assigned recovery owner can unblock SYSA-1254.

## What Changed

- Allows the named active source-scoped recovery owner to use the existing issue PATCH path for narrow recovery edits: `status`, `blockedByIssueIds`, and `comment`.
- Keeps normal issue authority required for assignee, workspace, content, and other non-recovery edits.
- Adds targeted tests for recovery-owner stale-blocker cleanup and negative cases where ordinary agents cannot mutate another assignee's issue.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts` - 23 tests passed.
- `pnpm --filter @paperclipai/server typecheck` - passed.

## Risks

- Main risk is accidentally broadening cross-boundary issue edits. The implementation limits recovery-owner PATCH access to source recovery fields and tests the ordinary-agent denial path.
- This PR has not been deployed to `agents.gosystem8.com`; live stale-blocker cleanup remains blocked until an authorized maintainer merges and deploys it or approves an equivalent recovery path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex Local, GPT-5-based coding agent with shell/tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge