### PR TITLE
fix(plugins): refresh UI contributions on hot lifecycle events

### DIFF
--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -5,7 +5,7 @@ import type { Duplex } from "node:stream";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentApiKeys, companyMemberships, instanceUserRoles } from "@paperclipai/db";
-import type { DeploymentMode } from "@paperclipai/shared";
+import type { DeploymentMode, LiveEvent } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
 import { subscribeCompanyLiveEvents, subscribeGlobalLiveEvents } from "../services/live-events.js";
@@ -205,13 +205,15 @@ export function setupLiveEventsWebSocketServer(
       return;
     }
 
-    const sendEvent = (event: unknown) => {
+    const sendEvent = (event: LiveEvent) => {
       if (socket.readyState !== WebSocket.OPEN) return;
       socket.send(JSON.stringify(event));
     };
 
     const unsubscribeCompany = subscribeCompanyLiveEvents(context.companyId, sendEvent);
-    const unsubscribeGlobal = subscribeGlobalLiveEvents(sendEvent);
+    const unsubscribeGlobal = context.actorType === "board"
+      ? subscribeGlobalLiveEvents(sendEvent)
+      : () => undefined;
     const unsubscribe = () => {
       unsubscribeCompany();
       unsubscribeGlobal();

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -8,7 +8,7 @@ import { agentApiKeys, companyMemberships, instanceUserRoles } from "@paperclipa
 import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
-import { subscribeCompanyLiveEvents } from "../services/live-events.js";
+import { subscribeCompanyLiveEvents, subscribeGlobalLiveEvents } from "../services/live-events.js";
 
 interface WsSocket {
   readyState: number;
@@ -205,10 +205,17 @@ export function setupLiveEventsWebSocketServer(
       return;
     }
 
-    const unsubscribe = subscribeCompanyLiveEvents(context.companyId, (event) => {
+    const sendEvent = (event: unknown) => {
       if (socket.readyState !== WebSocket.OPEN) return;
       socket.send(JSON.stringify(event));
-    });
+    };
+
+    const unsubscribeCompany = subscribeCompanyLiveEvents(context.companyId, sendEvent);
+    const unsubscribeGlobal = subscribeGlobalLiveEvents(sendEvent);
+    const unsubscribe = () => {
+      unsubscribeCompany();
+      unsubscribeGlobal();
+    };
 
     cleanupByClient.set(socket, unsubscribe);
     aliveByClient.set(socket, true);

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { LiveEvent, LiveEventType } from "@paperclipai/shared";
 
+type GlobalLiveEventType = Extract<LiveEventType, "plugin.ui.updated">;
 type LiveEventPayload = Record<string, unknown>;
 type LiveEventListener = (event: LiveEvent) => void;
 
@@ -35,9 +36,11 @@ export function publishLiveEvent(input: {
 }
 
 export function publishGlobalLiveEvent(input: {
-  type: LiveEventType;
+  type: GlobalLiveEventType;
   payload?: LiveEventPayload;
 }) {
+  // The "*" channel is broadcast to board clients across tenant scopes. Keep
+  // this restricted to instance-global, tenant-free event payloads.
   const event = toLiveEvent({ companyId: "*", type: input.type, payload: input.payload });
   emitter.emit("*", event);
   return event;

--- a/ui/src/context/LiveUpdatesProvider.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.test.ts
@@ -15,6 +15,25 @@ import { __liveUpdatesTestUtils } from "./LiveUpdatesProvider";
 import { queryKeys } from "../lib/queryKeys";
 
 describe("LiveUpdatesProvider issue invalidation", () => {
+  it("refreshes plugin registry queries when plugin UI changes hot at runtime", () => {
+    const invalidations: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: (input: unknown) => {
+        invalidations.push(input);
+      },
+      getQueryData: () => undefined,
+    };
+
+    __liveUpdatesTestUtils.invalidatePluginUiQueries(queryClient as never);
+
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.plugins.all,
+    });
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.plugins.uiContributions,
+    });
+  });
+
   it("refreshes touched inbox queries and only the changed issue data for issue updates", () => {
     const invalidations: unknown[] = [];
     const queryClient = {

--- a/ui/src/context/LiveUpdatesProvider.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.test.ts
@@ -11,10 +11,84 @@ vi.mock("../api/issues", () => ({
 }));
 
 import { describe, expect, it, vi } from "vitest";
+
+const resetPluginModuleLoaderMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../plugins/slots", () => ({
+  resetPluginModuleLoader: resetPluginModuleLoaderMock,
+}));
+
 import { __liveUpdatesTestUtils } from "./LiveUpdatesProvider";
 import { queryKeys } from "../lib/queryKeys";
 
 describe("LiveUpdatesProvider issue invalidation", () => {
+  it("handles global plugin UI updates before the company guard", () => {
+    const invalidations: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: (input: unknown) => {
+        invalidations.push(input);
+      },
+      getQueryData: () => undefined,
+    };
+
+    resetPluginModuleLoaderMock.mockClear();
+
+    __liveUpdatesTestUtils.handleLiveEvent(
+      queryClient as never,
+      "company-1",
+      "/",
+      {
+        id: 1,
+        companyId: "*",
+        type: "plugin.ui.updated",
+        createdAt: "2026-06-14T00:00:00.000Z",
+        payload: { pluginId: "plugin-1", action: "upgraded" },
+      },
+      () => null,
+      { cooldownHits: new Map(), suppressUntil: 0 },
+      { userId: null, agentId: null },
+    );
+
+    expect(resetPluginModuleLoaderMock).toHaveBeenCalledTimes(1);
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.plugins.all,
+    });
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.plugins.uiContributions,
+    });
+  });
+
+  it("drops non-global plugin-unrelated events for other companies", () => {
+    const invalidations: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: (input: unknown) => {
+        invalidations.push(input);
+      },
+      getQueryData: () => undefined,
+    };
+
+    resetPluginModuleLoaderMock.mockClear();
+
+    __liveUpdatesTestUtils.handleLiveEvent(
+      queryClient as never,
+      "company-1",
+      "/",
+      {
+        id: 1,
+        companyId: "company-2",
+        type: "agent.status",
+        createdAt: "2026-06-14T00:00:00.000Z",
+        payload: { agentId: "agent-1", status: "error" },
+      },
+      () => null,
+      { cooldownHits: new Map(), suppressUntil: 0 },
+      { userId: null, agentId: null },
+    );
+
+    expect(resetPluginModuleLoaderMock).not.toHaveBeenCalled();
+    expect(invalidations).toEqual([]);
+  });
+
   it("refreshes plugin registry queries when plugin UI changes hot at runtime", () => {
     const invalidations: unknown[] = [];
     const queryClient = {
@@ -24,8 +98,11 @@ describe("LiveUpdatesProvider issue invalidation", () => {
       getQueryData: () => undefined,
     };
 
+    resetPluginModuleLoaderMock.mockClear();
+
     __liveUpdatesTestUtils.invalidatePluginUiQueries(queryClient as never);
 
+    expect(resetPluginModuleLoaderMock).toHaveBeenCalledTimes(1);
     expect(invalidations).toContainEqual({
       queryKey: queryKeys.plugins.all,
     });

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -15,6 +15,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { toCompanyRelativePath } from "../lib/company-routes";
 import { useLocation } from "../lib/router";
 import { buildSameOriginWebSocketUrl } from "../lib/websocket-url";
+import { resetPluginModuleLoader } from "../plugins/slots";
 
 const TOAST_COOLDOWN_WINDOW_MS = 10_000;
 const TOAST_COOLDOWN_MAX = 3;
@@ -769,6 +770,12 @@ function invalidateActivityQueries(
   }
 }
 
+function invalidatePluginUiQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  resetPluginModuleLoader();
+  queryClient.invalidateQueries({ queryKey: queryKeys.plugins.all });
+  queryClient.invalidateQueries({ queryKey: queryKeys.plugins.uiContributions });
+}
+
 interface ToastGate {
   cooldownHits: Map<string, number[]>;
   suppressUntil: number;
@@ -813,6 +820,11 @@ function handleLiveEvent(
   gate: ToastGate,
   currentActor: { userId: string | null; agentId: string | null },
 ) {
+  if (event.type === "plugin.ui.updated") {
+    invalidatePluginUiQueries(queryClient);
+    return;
+  }
+
   if (event.companyId !== expectedCompanyId) return;
 
   const nameOf = (id: string) => resolveAgentName(queryClient, expectedCompanyId, id);
@@ -920,6 +932,7 @@ export const __liveUpdatesTestUtils = {
   hydrateVisibleIssueComment,
   invalidateActivityQueries,
   invalidateVisibleIssueRunQueries,
+  invalidatePluginUiQueries,
   resolveLiveCompanyId,
   shouldDeferIssueRefetchForVisibleAgentActivity,
   shouldDeferVisibleIssueCommentActivity,

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -820,6 +820,8 @@ function handleLiveEvent(
   gate: ToastGate,
   currentActor: { userId: string | null; agentId: string | null },
 ) {
+  // Global plugin UI events are stamped with companyId "*" and must be handled
+  // before the company guard below, or hot plugin UI refresh is silently dropped.
   if (event.type === "plugin.ui.updated") {
     invalidatePluginUiQueries(queryClient);
     return;
@@ -930,6 +932,7 @@ export const __liveUpdatesTestUtils = {
   buildRunStatusToast,
   closeSocketQuietly,
   hydrateVisibleIssueComment,
+  handleLiveEvent,
   invalidateActivityQueries,
   invalidateVisibleIssueRunQueries,
   invalidatePluginUiQueries,

--- a/ui/src/plugins/slots.test.ts
+++ b/ui/src/plugins/slots.test.ts
@@ -7,8 +7,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   PluginSlotMount,
   _collectRegisterableExportNamesForTests,
-  _resetPluginModuleLoader,
   registerPluginWebComponent,
+  resetPluginModuleLoader,
   type ResolvedPluginSlot,
 } from "./slots";
 
@@ -21,7 +21,7 @@ afterEach(() => {
     });
   }
   roots = [];
-  _resetPluginModuleLoader();
+  resetPluginModuleLoader();
 });
 
 describe("plugin slot export registration", () => {

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -927,14 +927,14 @@ export function PluginSlotOutlet({
 }
 
 // ---------------------------------------------------------------------------
-// Test helpers — exported for use in test suites only.
+// Runtime cache management
 // ---------------------------------------------------------------------------
 
 /**
- * Reset the module loader state. Only use in tests.
- * @internal
+ * Reset the plugin module loader state so a hot install, uninstall, or upgrade
+ * can discover fresh UI contributions without a full page reload.
  */
-export function _resetPluginModuleLoader(): void {
+export function resetPluginModuleLoader(): void {
   pluginLoadStates.clear();
   inflightImports.clear();
   registry.clear();
@@ -947,6 +947,12 @@ export function _resetPluginModuleLoader(): void {
     delete shimBlobUrls[key];
   }
 }
+
+/**
+ * Backwards-compatible test helper alias.
+ * @internal
+ */
+export const _resetPluginModuleLoader = resetPluginModuleLoader;
 
 export const _applyJsxRuntimeKeyForTests = applyJsxRuntimeKey;
 export const _createReactShimSourceForTests = createReactShimSource;

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -235,6 +235,7 @@ const pluginLoadStates = new Map<string, PluginLoadState>();
  * Promise cache to prevent concurrent duplicate imports for the same plugin.
  */
 const inflightImports = new Map<string, Promise<void>>();
+let pluginModuleLoaderGeneration = 0;
 
 /**
  * Build the full URL for a plugin's UI entry module.
@@ -465,6 +466,7 @@ async function importPluginModule(url: string): Promise<Record<string, unknown>>
 async function loadPluginModule(contribution: PluginUiContribution): Promise<void> {
   const { pluginId, pluginKey, slots, launchers } = contribution;
   const moduleKey = buildPluginModuleKey(contribution);
+  const generation = pluginModuleLoaderGeneration;
 
   // Already loaded or loading — return early.
   const state = pluginLoadStates.get(moduleKey);
@@ -494,6 +496,7 @@ async function loadPluginModule(contribution: PluginUiContribution): Promise<voi
       // Dynamic ESM import of the plugin's UI entry module with
       // bare-specifier rewriting for host-provided dependencies.
       const mod: Record<string, unknown> = await importPluginModule(url);
+      if (generation !== pluginModuleLoaderGeneration) return;
 
       // Collect the set of export names declared across all UI contributions so
       // we only register what the manifest advertises (ignore extra exports).
@@ -539,10 +542,14 @@ async function loadPluginModule(contribution: PluginUiContribution): Promise<voi
 
       pluginLoadStates.set(moduleKey, "loaded");
     } catch (err) {
-      pluginLoadStates.set(moduleKey, "error");
+      if (generation === pluginModuleLoaderGeneration) {
+        pluginLoadStates.set(moduleKey, "error");
+      }
       console.error(`Failed to load UI module for plugin "${pluginKey}"`, err);
     } finally {
-      inflightImports.delete(pluginId);
+      if (generation === pluginModuleLoaderGeneration) {
+        inflightImports.delete(pluginId);
+      }
     }
   })();
 
@@ -935,24 +942,11 @@ export function PluginSlotOutlet({
  * can discover fresh UI contributions without a full page reload.
  */
 export function resetPluginModuleLoader(): void {
+  pluginModuleLoaderGeneration += 1;
   pluginLoadStates.clear();
   inflightImports.clear();
   registry.clear();
-  if (typeof URL.revokeObjectURL === "function") {
-    for (const url of Object.values(shimBlobUrls)) {
-      URL.revokeObjectURL(url);
-    }
-  }
-  for (const key of Object.keys(shimBlobUrls)) {
-    delete shimBlobUrls[key];
-  }
 }
-
-/**
- * Backwards-compatible test helper alias.
- * @internal
- */
-export const _resetPluginModuleLoader = resetPluginModuleLoader;
 
 export const _applyJsxRuntimeKeyForTests = applyJsxRuntimeKey;
 export const _createReactShimSourceForTests = createReactShimSource;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip exposes plugin UI contributions in the board, and plugin lifecycle changes can happen while the board is open.
> - `PLUGIN_SPEC.md` requires updated plugin UI bundles to become visible after hot install, uninstall, upgrade, and config changes.
> - The server already published `plugin.ui.updated`, but the board did not reliably receive that global event and clear/refetch plugin UI state.
> - This pull request wires the global live event through board WebSocket clients and makes the frontend reset plugin module loader state before refetching plugin contributions.
> - Follow-up review tightened the path so in-flight imports cannot write stale modules after a reset, global events stay board-only, and tests cover the reset side effect.
> - The benefit is that plugin UI changes become visible after hot lifecycle changes without a manual page reload or server restart.

## Linked Issues or Issue Description

No public GitHub issue exists for this focused plugin hot-refresh gap, so the underlying issue is described inline using the feature-request template fields.

### Subsystem affected

Cross-cutting: `server/` realtime live-event fan-out and `ui/` plugin module loading, React Query cache invalidation, and board live updates.

### Problem or motivation

Plugin lifecycle mutations can update UI contributions while the board is already open. Before this PR, the server-side lifecycle path could publish `plugin.ui.updated`, but the board did not reliably receive that instance-global event or use it to clear cached ESM plugin modules and refetch plugin registry/UI contribution data. A changed plugin UI bundle could therefore remain stale until a manual page reload or server restart.

### Proposed solution

When a plugin UI lifecycle event occurs, authenticated board WebSocket clients receive the tenant-free global `plugin.ui.updated` event. The UI handles it before the company-id guard, resets plugin module loader state, and invalidates plugin registry/UI contribution queries so the board fetches and renders fresh plugin UI contributions.

### Alternatives considered

- Rely on manual page reloads after plugin lifecycle changes: rejected because hot plugin lifecycle behavior should not require operator reloads.
- Poll plugin registries more aggressively: rejected because it adds background work and still leaves stale ESM module state unless the loader is reset.
- Send the event to all WebSocket actor types: narrowed after review so only board clients subscribe to global plugin UI updates.

### Roadmap alignment

This is a small targeted improvement to the existing plugin system hot lifecycle behavior. It does not add a new core product surface and does not conflict with `ROADMAP.md`.

## What Changed

- Relay global live events to authenticated board WebSocket clients while keeping agent sockets on company-scoped events only.
- Restrict `publishGlobalLiveEvent` to the tenant-free `plugin.ui.updated` event type and document the cross-tenant `"*"` channel constraint.
- Handle `plugin.ui.updated` before the company-id guard in `LiveUpdatesProvider`, reset plugin module loader state, and invalidate plugin registry/UI contribution queries.
- Add a generation guard around plugin UI module imports so an old in-flight import cannot repopulate caches after a hot reset.
- Keep shared React/SDK shim blob URLs stable across hot resets instead of revoking invariant host shims.
- Remove the unused `_resetPluginModuleLoader` alias and update the current slot tests to use `resetPluginModuleLoader`.
- Add tests covering the reset side effect, global `companyId:"*"` ordering, and mismatched-company event dropping.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/context/LiveUpdatesProvider.test.ts src/plugins/slots.test.ts`
- GitHub PR workflow after rebase: typecheck, build, server/workspace tests, serialized suites, e2e, canary dry run.

## Risks

- Low risk: the change is scoped to plugin UI cache invalidation and live event fan-out.
- Global events are intentionally limited to `plugin.ui.updated`; future global event types must be explicitly added and must not carry company-scoped data.
- Board clients across companies will receive tenant-free plugin UI update notifications by design because plugins are instance-global.
- Agent WebSocket clients no longer receive global plugin UI events.
- This is a behavioral UI refresh path, not a visual layout change, so screenshots are not applicable.

## Model Used

- OpenAI Codex in the Codex desktop app, GPT-5 coding agent, with local shell/tool use and medium reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
