### PR TITLE
fix(routines): skip_if_active scans open siblings, not just live ones (SPC-9521)

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -783,6 +783,57 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
+  it("skips skip_if_active firings when an orphaned in_progress sibling has no live run (SPC-9521)", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "skip_if_active" })
+      .where(eq(routines.id, routine.id));
+
+    const orphanedIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "in_progress",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: orphanedIssue.id,
+    });
+    // No checkoutRunId, no executionRunId, no heartbeatRun — the orphan accumulation
+    // case from SPC-9521: prior execution crashed (process_lost), issue stuck in_progress.
+    await db
+      .update(issues)
+      .set({ checkoutRunId: null, executionRunId: null, executionLockedAt: null })
+      .where(eq(issues.id, orphanedIssue.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("skipped");
+    expect(run.linkedIssueId).toBe(orphanedIssue.id);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(orphanedIssue.id);
+  });
+
   it("touches a coalesced routine issue for the manual runner's inbox", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const userId = randomUUID();

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -952,6 +952,33 @@ export function routineService(
     );
   }
 
+  async function findOpenExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+    origin?: { kind: string; id: string | null },
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    const originKind = origin?.kind ?? "routine_execution";
+    const originId = origin?.id ?? routine.id;
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, originKind),
+          eq(issues.originId, originId),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function findLiveExecutionIssue(
     routine: typeof routines.$inferSelect,
     executor: Db = db,
@@ -1271,7 +1298,11 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+        const findSibling =
+          input.routine.concurrencyPolicy === "skip_if_active"
+            ? findOpenExecutionIssue
+            : findLiveExecutionIssue;
+        const activeIssue = await findSibling(input.routine, txDb, dispatchFingerprint, {
           kind: issueOriginKind,
           id: issueOriginId,
         });
@@ -1335,7 +1366,11 @@ export function routineService(
             throw error;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+          const findExistingSibling =
+            input.routine.concurrencyPolicy === "skip_if_active"
+              ? findOpenExecutionIssue
+              : findLiveExecutionIssue;
+          const existingIssue = await findExistingSibling(input.routine, txDb, dispatchFingerprint, {
             kind: issueOriginKind,
             id: issueOriginId,
           });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Routines (`server/src/services/routines.ts`) are the recurring-task subsystem that periodically dispatches execution issues against the configured `concurrencyPolicy` (`always_enqueue`, `skip_if_active`, `coalesce_if_active`)
> - The `skip_if_active` policy should make a no-op when an open execution of the same routine + dispatch fingerprint already exists, so users get at most one in-flight issue per routine slot
> - Today the policy can silently fail to detect orphaned siblings: `routineService.runRoutine` inserts a duplicate execution issue beside an `in_progress` one that no longer has a live heartbeat run, so the assignee inbox accumulates dead checkouts over time
> - The dedup pipeline gates on a *live run*, not on *open issue status* — both the application-layer `findLiveExecutionIssue` (inner-joins `heartbeatRuns` filtered to LIVE statuses) and the DB-layer `issues_open_routine_execution_uq` index (predicate requires `executionRunId IS NOT NULL`) miss issues whose run reference has been cleared (e.g. after `process_lost`, stranded-recovery reassignment, or any path that nulls `executionRunId` while the issue stays open)
> - This pull request adds a sibling helper `findOpenExecutionIssue` that filters open issues by status alone, and routes `skip_if_active` through it at both the pre-create check and the post-unique-conflict recovery path
> - The benefit is `skip_if_active` now matches its documented semantics — any open same-fingerprint sibling, live or stranded, makes the new firing a no-op — closing a real reliability gap that produced multi-week orphan piles on a real production routine

## Linked Issues or Issue Description

No upstream GitHub issue; describing inline per CONTRIBUTING.md, following the bug-report template field shape.

### What happened?

A routine with `concurrencyPolicy: skip_if_active` (`eu-country-brief-fr`, ~daily firing) accumulated 5 open execution issues with the **same `originFingerprint`** over a multi-week window. Only one ever completed; the rest were `status=in_progress`, `checkoutRunId=null`, `executionRunId=null` — orphans left behind when prior heartbeats exited via `process_lost` and the platform cleared the run reference but kept the issue open. The assignee agent eventually drove to `status=error` from a concurrent-checkout race attempting all four orphans on a single morning heartbeat.

### Expected behavior

With `skip_if_active`, the second and subsequent firings should detect any open execution issue for that routine + dispatch fingerprint and finalize the new run as `skipped`, regardless of whether the prior run is currently live.

### Steps to reproduce

(Also encoded as a vitest test in this PR.)

1. Create a routine with `concurrencyPolicy: skip_if_active`.
2. Run it once → execution issue A is created with `status=todo`.
3. Simulate the orphan shape: set A to `status=in_progress`, clear `checkoutRunId`/`executionRunId`, ensure no `heartbeatRun` references A's id. (In production this happens automatically when the heartbeat exits via `process_lost` and stranded-recovery clears the run.)
4. Call `runRoutine` again on the same routine.
5. Observe: a second execution issue B is created alongside A even though A is still open. (Expected: run finalizes as `skipped`, linked to A.)

### Root cause

- `server/src/services/routines.ts:880` — `findLiveExecutionIssue` inner-joins `heartbeatRuns` filtered to `LIVE_HEARTBEAT_RUN_STATUSES = ['queued', 'running', 'scheduled_retry']`. An open issue with no live run is invisible to it.
- `packages/db/src/schema/issues.ts:93` — the `issues_open_routine_execution_uq` predicate requires `executionRunId IS NOT NULL`. Orphans whose `executionRunId` has been cleared are not covered by the constraint either.

When both layers miss, `routineService.runRoutine` inserts a fresh issue. Repeat → orphan pile.

### Paperclip version

`master` at `412a04c96` (base of this branch).

### Deployment mode

Self-hosted server.

## What Changed

- Add `findOpenExecutionIssue` in `server/src/services/routines.ts` — same origin/fingerprint/`hiddenAt` filters as `findLiveExecutionIssue`, but **no `heartbeatRuns` join**. Picks the most-recently-updated open issue regardless of run state. Filters on `status ∈ OPEN_ISSUE_STATUSES = ['backlog', 'todo', 'in_progress', 'in_review', 'blocked']`.
- Route `concurrencyPolicy === 'skip_if_active'` through the new helper in both the pre-insert check and the post-unique-conflict recovery path. `coalesce_if_active` and `always_enqueue` continue to use `findLiveExecutionIssue`/`issues_open_routine_execution_uq` exactly as before.
- Add regression test `skips skip_if_active firings when an orphaned in_progress sibling has no live run (SPC-9521)` in `server/src/__tests__/routines-service.test.ts`. The test seeds the exact orphan shape (`status=in_progress`, `checkoutRunId=null`, `executionRunId=null`, no `heartbeatRun`) and asserts `runRoutine` returns `status=skipped`, `linkedIssueId=orphan.id`, and that exactly one routine-execution issue exists.

## Verification

- `pnpm --filter @paperclipai/server run typecheck` — clean.
- `pnpm --filter @paperclipai/server exec vitest run server/src/__tests__/routines-service.test.ts` — 37/37 pass, including the new regression test and the pre-existing `skip_if_active`/`coalesce_if_active` cases (`touches a skipped active routine issue for the manual runner's inbox`, `creates a fresh execution issue when the previous routine issue is open but idle`).
- Pre-existing failures in `routines-routes.test.ts` (13) and `routines-e2e.test.ts` (4) reproduce on clean `upstream/master` without this change (verified by `git stash` + re-run); they are unrelated to the dedup path.

## Risks

Low risk:

- The change is additive — `findOpenExecutionIssue` is a new function; `findLiveExecutionIssue` is unchanged.
- Policy routing is narrow: only `skip_if_active` is rerouted; `coalesce_if_active` and `always_enqueue` are bit-for-bit identical to before. The deliberately-different semantics for `coalesce_if_active` are codified by the existing `creates a fresh execution issue when the previous routine issue is open but idle` test (`server/src/__tests__/routines-service.test.ts:226`).
- No migration. The `issues_open_routine_execution_uq` predicate is left as-is; dropping `executionRunId IS NOT NULL` from it would be defense-in-depth but requires cleaning existing duplicates first (the production routine that motivated this fix still has open orphans). Filed as a follow-up.
- Edge case: a `blocked` open sibling now causes `skip_if_active` to skip, where before it would have created a new issue. This matches user intent ("the slot is occupied") but is a behavioral shift worth calling out. If a user wants to bypass a blocked sibling, they should resolve the block or cancel the issue first.

## Model Used

- Provider: Anthropic Claude
- Model: `claude-opus-4-7` (Opus 4.7)
- Context: standard
- Reasoning mode: standard (no extended thinking)
- Tool use: yes (Read/Edit/Grep/Bash for codebase exploration, test execution, and git operations)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found; searched for `skip_if_active`, `routine concurrency`, `orphan` in open + closed PRs)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A — no documented behavior contract changes; `coalesce_if_active`/`skip_if_active` semantics now match the existing in-code documentation)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (the failing `commitperclip PR Review` check was the missing-template-sections gate; re-running after this edit should clear it)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (initial Greptile was 4/5 with one P2 about missing template sections; this edit resolves that)
- [x] I will address all Greptile and reviewer comments before requesting merge
