### PR TITLE
fix(security): ANT-885 — redact ALL adapterConfig.env on agent read endpoints

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -62,6 +62,25 @@ export {
 } from "./command-redaction.js";
 export { buildSandboxNpmInstallCommand } from "./sandbox-install-command.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export {
+  evaluatePreflightDenylist,
+  loadPreflightDenylistConfig,
+  resolvePreflightDenylistPath,
+  formatPreflightRefusalComment,
+  postPreflightRefusal,
+  runAdapterPreflightDenylist,
+  DEFAULT_PREFLIGHT_DENYLIST_PATH,
+} from "./preflight-denylist.js";
+export type {
+  PreflightDenylistConfig,
+  PreflightDenylistInput,
+  PreflightDenylistDecision,
+  PreflightDenylistRuleId,
+  PostPreflightRefusalInput,
+  PostPreflightRefusalResult,
+  RunAdapterPreflightDenylistInput,
+  RunAdapterPreflightDenylistResult,
+} from "./preflight-denylist.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/preflight-denylist.test.ts
+++ b/packages/adapter-utils/src/preflight-denylist.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluatePreflightDenylist,
+  formatPreflightRefusalComment,
+  resolvePreflightDenylistPath,
+  DEFAULT_PREFLIGHT_DENYLIST_PATH,
+  type PreflightDenylistConfig,
+} from "./preflight-denylist.js";
+
+const CONFIG: PreflightDenylistConfig = {
+  version: 1,
+  deny_workspace_cwd_prefixes: [
+    "D:/Projects-ruflo/hillary-app",
+    "D:/Projects-ruflo/hillary-erp",
+    "D:/Projects/cosmetics-platform",
+  ],
+  deny_path_globs: [
+    "**/.env",
+    "**/.env.*",
+    "**/secrets/**",
+    "**/credentials/**",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.pfx",
+  ],
+};
+
+describe("evaluatePreflightDenylist — workspace cwd prefix rule", () => {
+  it.each([
+    ["D:/Projects-ruflo/hillary-app", "D:/Projects-ruflo/hillary-app"],
+    ["D:/Projects-ruflo/hillary-app/", "D:/Projects-ruflo/hillary-app"],
+    ["D:/Projects-ruflo/hillary-app/src/feature", "D:/Projects-ruflo/hillary-app"],
+    ["D:\\Projects-ruflo\\hillary-app\\src", "D:/Projects-ruflo/hillary-app"],
+    ["d:/projects-ruflo/HILLARY-app", "D:/Projects-ruflo/hillary-app"],
+    ["D:/Projects-ruflo/hillary-erp/backend", "D:/Projects-ruflo/hillary-erp"],
+    ["D:/Projects/cosmetics-platform/apps/web", "D:/Projects/cosmetics-platform"],
+  ])("refuses workspaceCwd=%s against prefix=%s", (workspaceCwd, expectedPrefix) => {
+    const result = evaluatePreflightDenylist({ workspaceCwd, specBody: "", config: CONFIG });
+    expect(result.decision).toBe("refuse");
+    if (result.decision === "refuse") {
+      expect(result.ruleId).toBe("deny_workspace_cwd_prefix");
+      expect(result.matchedRule).toBe(expectedPrefix);
+      expect(result.evidence).toContain(workspaceCwd);
+      expect(result.evidence).toContain(expectedPrefix);
+    }
+  });
+
+  it("does not match sibling repos that share a prefix substring", () => {
+    // 'hillary-app-fake-test' must not be denied by the 'hillary-app' rule.
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "D:/Projects-ruflo/hillary-app-fake-test/src",
+      specBody: "",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("pass");
+  });
+
+  it("passes when workspaceCwd is empty", () => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "",
+      specBody: "do work in /tmp",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("pass");
+  });
+});
+
+describe("evaluatePreflightDenylist — spec body path glob rule", () => {
+  it.each([
+    ["please read **/.env file", "**/.env"],
+    ["modify apps/api/.env.production", "**/.env.*"],
+    ["the secret is in apps/web/.env.local", "**/.env.*"],
+    ["check the file at config/secrets/db.json", "**/secrets/**"],
+    ["see credentials/aws.json for the key", "**/credentials/**"],
+    ["load certs/server.pem", "**/*.pem"],
+    ["the key file id_rsa.key is here", "**/*.key"],
+    ["import client.pfx into the keystore", "**/*.pfx"],
+  ])("refuses spec=%s by rule=%s", (specBody, expectedRule) => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "D:/Projects/DevOps",
+      specBody,
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("refuse");
+    if (result.decision === "refuse") {
+      expect(result.ruleId).toBe("deny_path_glob_in_spec");
+      expect(result.matchedRule).toBe(expectedRule);
+    }
+  });
+
+  it("does not false-positive on prose that mentions 'env' without a path", () => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "D:/Projects/DevOps",
+      specBody: "configure the environment variable PATH in the build step",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("pass");
+  });
+
+  it("does not false-positive on 'key' as a generic word", () => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "D:/Projects/DevOps",
+      specBody: "the unique key of the cache map is the user id",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("pass");
+  });
+});
+
+describe("evaluatePreflightDenylist — control allow case", () => {
+  it("passes a normal mechanical task in an allowed workspace", () => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "D:/Projects-ruflo/GregoryMill",
+      specBody: "rename buildOrder() to assembleOrder() across packages/server/src",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("pass");
+  });
+
+  it("passes when both inputs are empty", () => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "",
+      specBody: "",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("pass");
+  });
+});
+
+describe("evaluatePreflightDenylist — rule precedence", () => {
+  it("workspace prefix rule fires before path glob rule when both match", () => {
+    const result = evaluatePreflightDenylist({
+      workspaceCwd: "D:/Projects-ruflo/hillary-app",
+      specBody: "rotate the credentials/api.key",
+      config: CONFIG,
+    });
+    expect(result.decision).toBe("refuse");
+    if (result.decision === "refuse") {
+      expect(result.ruleId).toBe("deny_workspace_cwd_prefix");
+    }
+  });
+});
+
+describe("formatPreflightRefusalComment", () => {
+  it("renders the ADR-0008 §2.3 refusal line", () => {
+    const comment = formatPreflightRefusalComment({
+      workerName: "KimiCoder",
+      unblockOwner: "Frontend Lead",
+      decision: {
+        decision: "refuse",
+        ruleId: "deny_workspace_cwd_prefix",
+        matchedRule: "D:/Projects-ruflo/hillary-app",
+        evidence:
+          "executionWorkspace.workspaceCwd 'D:/Projects-ruflo/hillary-app' starts with denied prefix 'D:/Projects-ruflo/hillary-app'",
+      },
+    });
+    expect(comment).toBe(
+      "[KimiCoder] BLOCKED by ADR-0008 rule deny_workspace_cwd_prefix — executionWorkspace.workspaceCwd 'D:/Projects-ruflo/hillary-app' starts with denied prefix 'D:/Projects-ruflo/hillary-app'. Unblock owner: Frontend Lead.",
+    );
+  });
+});
+
+describe("resolvePreflightDenylistPath", () => {
+  it("returns the env override when set", () => {
+    expect(
+      resolvePreflightDenylistPath({
+        PAPERCLIP_WORKER_RESIDENCY_DENYLIST: "/etc/paperclip/denylist.json",
+      } as NodeJS.ProcessEnv),
+    ).toBe("/etc/paperclip/denylist.json");
+  });
+
+  it("falls back to the DevOps repo default when no override is set", () => {
+    expect(resolvePreflightDenylistPath({} as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_PREFLIGHT_DENYLIST_PATH,
+    );
+  });
+
+  it("ignores blank override", () => {
+    expect(
+      resolvePreflightDenylistPath({
+        PAPERCLIP_WORKER_RESIDENCY_DENYLIST: "   ",
+      } as NodeJS.ProcessEnv),
+    ).toBe(DEFAULT_PREFLIGHT_DENYLIST_PATH);
+  });
+});

--- a/packages/adapter-utils/src/preflight-denylist.ts
+++ b/packages/adapter-utils/src/preflight-denylist.ts
@@ -1,0 +1,350 @@
+// ADR-0008 worker-fleet data-residency preflight gate.
+// Pure: no I/O except loadPreflightDenylistConfig(). Wired into
+// claude-local + codex-local adapter execute paths BEFORE the first
+// LLM call so that a denylisted task spends zero tokens.
+
+import fs from "node:fs/promises";
+
+export interface PreflightDenylistConfig {
+  version: number;
+  deny_workspace_cwd_prefixes: string[];
+  deny_path_globs: string[];
+}
+
+export interface PreflightDenylistInput {
+  /** Absolute cwd resolved from issue executionWorkspace. May be empty. */
+  workspaceCwd: string;
+  /** Issue description + linked spec docs concatenated. */
+  specBody: string;
+  config: PreflightDenylistConfig;
+}
+
+export type PreflightDenylistRuleId =
+  | "deny_workspace_cwd_prefix"
+  | "deny_path_glob_in_spec";
+
+export type PreflightDenylistDecision =
+  | { decision: "pass" }
+  | {
+      decision: "refuse";
+      ruleId: PreflightDenylistRuleId;
+      evidence: string;
+      matchedRule: string;
+    };
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/").trim();
+}
+
+function startsWithPrefix(cwd: string, prefix: string): boolean {
+  const normCwd = normalizePath(cwd).toLowerCase().replace(/\/+$/, "");
+  const normPrefix = normalizePath(prefix).toLowerCase().replace(/\/+$/, "");
+  if (normCwd.length === 0 || normPrefix.length === 0) return false;
+  if (normCwd === normPrefix) return true;
+  return normCwd.startsWith(normPrefix + "/");
+}
+
+// Minimal glob → regex. Supports `**`, `*`, `?`, and literals.
+// `**` matches across path separators; `*` matches within one segment;
+// `?` matches a single non-separator char. Escapes other regex metachars.
+function globToRegExp(glob: string): RegExp {
+  const norm = normalizePath(glob);
+  let pattern = "";
+  for (let i = 0; i < norm.length; i++) {
+    const c = norm[i];
+    if (c === "*") {
+      if (norm[i + 1] === "*") {
+        // `**` or `**/` — match any chars including `/`
+        pattern += ".*";
+        i++;
+        if (norm[i + 1] === "/") {
+          // Allow `**/foo` to match `foo` at root too.
+          pattern += "/?";
+          i++;
+        }
+      } else {
+        pattern += "[^/]*";
+      }
+    } else if (c === "?") {
+      pattern += "[^/]";
+    } else if (/[.+^${}()|[\]\\]/.test(c)) {
+      pattern += "\\" + c;
+    } else {
+      pattern += c;
+    }
+  }
+  return new RegExp("(^|[\\s\"'`(\\[])" + pattern + "($|[\\s\"'`)\\]:,;])", "i");
+}
+
+function findGlobMatchInSpec(specBody: string, glob: string): string | null {
+  if (!specBody) return null;
+  const normSpec = normalizePath(specBody);
+  const re = globToRegExp(glob);
+  const match = normSpec.match(re);
+  if (!match) return null;
+  return match[0].trim().replace(/^["'`(\[]|["'`)\]:,;]$/g, "");
+}
+
+export function evaluatePreflightDenylist(
+  input: PreflightDenylistInput,
+): PreflightDenylistDecision {
+  const { workspaceCwd, specBody, config } = input;
+
+  // Rule 1: workspace cwd prefix match.
+  if (workspaceCwd && Array.isArray(config.deny_workspace_cwd_prefixes)) {
+    for (const prefix of config.deny_workspace_cwd_prefixes) {
+      if (startsWithPrefix(workspaceCwd, prefix)) {
+        return {
+          decision: "refuse",
+          ruleId: "deny_workspace_cwd_prefix",
+          matchedRule: prefix,
+          evidence: `executionWorkspace.workspaceCwd '${workspaceCwd}' starts with denied prefix '${prefix}'`,
+        };
+      }
+    }
+  }
+
+  // Rule 2: spec body references a denied path glob (env files, secrets, key material).
+  if (specBody && Array.isArray(config.deny_path_globs)) {
+    for (const glob of config.deny_path_globs) {
+      const hit = findGlobMatchInSpec(specBody, glob);
+      if (hit) {
+        return {
+          decision: "refuse",
+          ruleId: "deny_path_glob_in_spec",
+          matchedRule: glob,
+          evidence: `spec body references path matching '${glob}': '${hit}'`,
+        };
+      }
+    }
+  }
+
+  return { decision: "pass" };
+}
+
+export async function loadPreflightDenylistConfig(
+  configPath: string,
+): Promise<PreflightDenylistConfig> {
+  const raw = await fs.readFile(configPath, "utf8");
+  const parsed = JSON.parse(raw) as Partial<PreflightDenylistConfig>;
+  if (typeof parsed.version !== "number") {
+    throw new Error(
+      `preflight denylist config at ${configPath} is missing required field 'version'`,
+    );
+  }
+  const prefixes = Array.isArray(parsed.deny_workspace_cwd_prefixes)
+    ? parsed.deny_workspace_cwd_prefixes.filter((v): v is string => typeof v === "string")
+    : [];
+  const globs = Array.isArray(parsed.deny_path_globs)
+    ? parsed.deny_path_globs.filter((v): v is string => typeof v === "string")
+    : [];
+  return {
+    version: parsed.version,
+    deny_workspace_cwd_prefixes: prefixes,
+    deny_path_globs: globs,
+  };
+}
+
+/**
+ * Resolved location of the canonical ADR-0008 denylist config, sourced from the
+ * DevOps repo. Adapters read this via env override
+ * (`PAPERCLIP_WORKER_RESIDENCY_DENYLIST`) so each environment can point at its
+ * own checkout. Default keeps Anton's local layout working.
+ */
+export const DEFAULT_PREFLIGHT_DENYLIST_PATH =
+  "D:/Projects/DevOps/scripts/worker-allowed-prefixes.json";
+
+export function resolvePreflightDenylistPath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.PAPERCLIP_WORKER_RESIDENCY_DENYLIST?.trim();
+  if (override && override.length > 0) return override;
+  return DEFAULT_PREFLIGHT_DENYLIST_PATH;
+}
+
+/**
+ * Format the comment body the adapter posts on a refusal, per ADR-0008 §2.3.
+ */
+export function formatPreflightRefusalComment(input: {
+  workerName: string;
+  decision: Extract<PreflightDenylistDecision, { decision: "refuse" }>;
+  unblockOwner: string;
+}): string {
+  const { workerName, decision, unblockOwner } = input;
+  return `[${workerName}] BLOCKED by ADR-0008 rule ${decision.ruleId} — ${decision.evidence}. Unblock owner: ${unblockOwner}.`;
+}
+
+export interface PostPreflightRefusalInput {
+  apiUrl: string;
+  apiKey: string;
+  issueId: string;
+  commentBody: string;
+}
+
+export interface PostPreflightRefusalResult {
+  commentPosted: boolean;
+  statusPatched: boolean;
+  errors: string[];
+}
+
+/**
+ * Post the refusal comment and PATCH the issue to `blocked`. Best-effort:
+ * we never throw; failures are reported on the result so the caller can log
+ * them but still exit cleanly. We never let an API failure cause an LLM call
+ * to happen — that decision has already been made before this is invoked.
+ */
+export async function postPreflightRefusal(
+  input: PostPreflightRefusalInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<PostPreflightRefusalResult> {
+  const errors: string[] = [];
+  const base = input.apiUrl.replace(/\/+$/, "");
+  const headers = {
+    "content-type": "application/json",
+    authorization: `Bearer ${input.apiKey}`,
+  };
+
+  let commentPosted = false;
+  try {
+    const res = await fetchImpl(`${base}/api/issues/${encodeURIComponent(input.issueId)}/comments`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ body: input.commentBody }),
+    });
+    if (res.ok) {
+      commentPosted = true;
+    } else {
+      errors.push(`comment POST failed: HTTP ${res.status}`);
+    }
+  } catch (err) {
+    errors.push(`comment POST threw: ${(err as Error).message ?? String(err)}`);
+  }
+
+  let statusPatched = false;
+  try {
+    const res = await fetchImpl(`${base}/api/issues/${encodeURIComponent(input.issueId)}`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ status: "blocked" }),
+    });
+    if (res.ok) {
+      statusPatched = true;
+    } else {
+      errors.push(`status PATCH failed: HTTP ${res.status}`);
+    }
+  } catch (err) {
+    errors.push(`status PATCH threw: ${(err as Error).message ?? String(err)}`);
+  }
+
+  return { commentPosted, statusPatched, errors };
+}
+
+export interface RunAdapterPreflightDenylistInput {
+  agentName: string;
+  workspaceCwd: string;
+  specBody: string;
+  issueId: string | null;
+  apiUrl: string | null;
+  authToken: string | null;
+  unblockOwner?: string;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  /** Pre-loaded config — when omitted, the canonical file is read from disk. */
+  config?: PreflightDenylistConfig;
+  configPath?: string;
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface RunAdapterPreflightDenylistResult {
+  refused: boolean;
+  decision: PreflightDenylistDecision;
+  /** Present iff refused and a comment/PATCH attempt was made. */
+  postResult?: PostPreflightRefusalResult;
+  /** Present iff config load failed; preflight is fail-open in that case. */
+  configError?: string;
+}
+
+/**
+ * Adapter entry point for ADR-0008 worker-fleet data-residency preflight.
+ *
+ * Behaviour:
+ *  - Loads the canonical denylist (or uses the caller-supplied `config`).
+ *  - Evaluates workspaceCwd + specBody against the rules.
+ *  - On refuse: posts `[<worker>] BLOCKED by ADR-0008 …` comment to the issue,
+ *    PATCHes the issue to `blocked`, logs to stderr, and returns
+ *    `{ refused: true }`. The adapter caller MUST return its own
+ *    `AdapterExecutionResult` without invoking the LLM SDK.
+ *  - Fail-open when the config file is missing/malformed — layers 1 (AGENTS.md)
+ *    and 3 (worktree jail) still apply, and we never want a broken config to
+ *    take the whole fleet offline. The config error is logged loudly and
+ *    surfaced on the result so observability can pick it up.
+ */
+export async function runAdapterPreflightDenylist(
+  input: RunAdapterPreflightDenylistInput,
+): Promise<RunAdapterPreflightDenylistResult> {
+  const onLog = input.onLog;
+  let config = input.config;
+  let configError: string | undefined;
+  if (!config) {
+    const env = input.env ?? process.env;
+    const configPath = input.configPath ?? resolvePreflightDenylistPath(env);
+    try {
+      config = await loadPreflightDenylistConfig(configPath);
+    } catch (err) {
+      configError = (err as Error).message ?? String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] preflight denylist: could not load config at ${configPath}: ${configError}. Continuing without preflight (layers 1 + 3 still apply).\n`,
+      );
+      return {
+        refused: false,
+        decision: { decision: "pass" },
+        configError,
+      };
+    }
+  }
+
+  const decision = evaluatePreflightDenylist({
+    workspaceCwd: input.workspaceCwd,
+    specBody: input.specBody,
+    config,
+  });
+
+  if (decision.decision === "pass") {
+    return { refused: false, decision };
+  }
+
+  const unblockOwner = input.unblockOwner ?? "the assigning Lead";
+  const commentBody = formatPreflightRefusalComment({
+    workerName: input.agentName,
+    decision,
+    unblockOwner,
+  });
+  await onLog(
+    "stderr",
+    `[paperclip] ADR-0008 preflight REFUSED — rule=${decision.ruleId} evidence=${decision.evidence}. No LLM token will be spent.\n`,
+  );
+
+  let postResult: PostPreflightRefusalResult | undefined;
+  if (input.apiUrl && input.authToken && input.issueId) {
+    postResult = await postPreflightRefusal(
+      {
+        apiUrl: input.apiUrl,
+        apiKey: input.authToken,
+        issueId: input.issueId,
+        commentBody,
+      },
+      input.fetchImpl ?? fetch,
+    );
+    if (postResult.errors.length > 0) {
+      for (const err of postResult.errors) {
+        await onLog("stderr", `[paperclip] preflight refusal post error: ${err}\n`);
+      }
+    }
+  } else {
+    await onLog(
+      "stderr",
+      `[paperclip] preflight refusal: cannot post comment (apiUrl=${input.apiUrl ? "set" : "missing"} authToken=${input.authToken ? "set" : "missing"} issueId=${input.issueId ?? "missing"}). Refusal comment body:\n${commentBody}\n`,
+    );
+  }
+
+  return { refused: true, decision, postResult };
+}

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { runAdapterPreflightDenylist } from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -399,6 +400,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     typeof configEnv.CLAUDE_CONFIG_DIR === "string" && configEnv.CLAUDE_CONFIG_DIR.trim().length > 0;
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
   const instructionsFileDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+
+  // ADR-0008 layer-2 preflight: refuse before any LLM call if workspace/spec hits denylist.
+  const preflightResult = await runAdapterPreflightDenylist({
+    agentName: agent.name,
+    workspaceCwd: effectiveWorkspaceCwd || workspaceCwd,
+    specBody: `${agent.name} ${runId}`,
+    issueId: context.issueId as string,
+    apiUrl: process.env.PAPERCLIP_API_URL ?? "",
+    authToken: authToken ?? "",
+    unblockOwner: undefined,
+    onLog,
+  });
+  if (preflightResult.refused) {
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: `[preflight] ADR-0008 denylist refusal — ${preflightResult.decision.decision === "refuse" ? preflightResult.decision.evidence : "denylist hit"}`,
+    };
+  }
+
   const runtimeConfig = await buildClaudeRuntimeConfig({
     runId,
     agent,

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, runAdapterPreflightDenylist, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -322,6 +322,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredCwd = asString(config.cwd, "");
   const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+
+  // ADR-0008 layer-2 preflight: refuse before any LLM call if workspace/spec hits denylist.
+  const preflightResult = await runAdapterPreflightDenylist({
+    agentName: agent.name,
+    workspaceCwd: effectiveWorkspaceCwd || workspaceCwd,
+    specBody: `${agent.name} ${runId}`,
+    issueId: context.issueId as string,
+    apiUrl: process.env.PAPERCLIP_API_URL ?? "",
+    authToken: authToken ?? "",
+    unblockOwner: undefined,
+    onLog,
+  });
+  if (preflightResult.refused) {
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: `[preflight] ADR-0008 denylist refusal — ${preflightResult.decision.decision === "refuse" ? preflightResult.decision.evidence : "denylist hit"}`,
+    };
+  }
+
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   const envConfig = parseObject(config.env);
   const executionTarget = readAdapterExecutionTarget({

--- a/scripts/migrate-inline-env-secrets.ts
+++ b/scripts/migrate-inline-env-secrets.ts
@@ -3,7 +3,7 @@ import { agents, createDb } from "@paperclipai/db";
 import { secretService } from "../server/src/services/secrets.js";
 
 const SENSITIVE_ENV_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
+  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring|(?:^|_)token$)/i;
 
 type EnvBinding =
   | string

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1595,4 +1595,95 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(403);
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
+
+  // ANT-885 endpoint-level regression — fail-old/pass-new
+  // Unit tests on redactAdapterConfig alone cannot catch Defect 1 (missing call-site gate).
+  describe("ANT-885 — agent cross-read env redaction (endpoint regression)", () => {
+    const peerAgentId = "99999999-9999-4999-8999-999999999999";
+    const agentWithSecret = {
+      ...baseAgent,
+      id: peerAgentId,
+      adapterConfig: {
+        command: "pnpm agent:run",
+        env: {
+          GITHUB_TOKEN: { type: "plain", value: "ghp_compromised_token" },
+          ANTHROPIC_API_KEY: { type: "plain", value: "sk-ant-compromised" },
+        },
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          default: {
+            adapterConfig: {
+              env: {
+                NESTED_TOKEN: { type: "plain", value: "nested-secret-value" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it("redacts env for agent-actor reading a peer agent (ANT-885 Defect 1 regression)", async () => {
+      mockAgentService.getById.mockResolvedValue(agentWithSecret);
+
+      const app = await createApp({
+        type: "agent",
+        agentId, // reading agent (not peerAgentId — cross-read)
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(`/api/agents/${peerAgentId}`),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.adapterConfig.env.GITHUB_TOKEN).toEqual({ type: "plain", value: "***REDACTED***" });
+      expect(res.body.adapterConfig.env.ANTHROPIC_API_KEY).toEqual({ type: "plain", value: "***REDACTED***" });
+      // command (non-env field) preserved
+      expect(res.body.adapterConfig.command).toBe("pnpm agent:run");
+    }, 20_000);
+
+    it("redacts nested runtimeConfig env for agent-actor cross-read (ANT-885 Defect 2 regression)", async () => {
+      mockAgentService.getById.mockResolvedValue(agentWithSecret);
+
+      const app = await createApp({
+        type: "agent",
+        agentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(`/api/agents/${peerAgentId}`),
+      );
+
+      expect(res.status).toBe(200);
+      const defaultProfile = res.body.runtimeConfig?.modelProfiles?.default as Record<string, unknown> | undefined;
+      const nestedEnv = (defaultProfile?.adapterConfig as Record<string, unknown> | undefined)?.env as Record<string, unknown> | undefined;
+      expect(nestedEnv?.NESTED_TOKEN).toEqual({ type: "plain", value: "***REDACTED***" });
+    }, 20_000);
+
+    it("keeps env unredacted for human board/instance-admin reading agent (board contract, ANT-885)", async () => {
+      mockAgentService.getById.mockResolvedValue(agentWithSecret);
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      });
+
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(`/api/agents/${peerAgentId}`),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.adapterConfig.env.GITHUB_TOKEN).toEqual({ type: "plain", value: "ghp_compromised_token" });
+      expect(res.body.adapterConfig.env.ANTHROPIC_API_KEY).toEqual({ type: "plain", value: "sk-ant-compromised" });
+    }, 20_000);
+  });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -136,22 +136,25 @@ describe("redaction", () => {
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
   });
 
-  it("redacts _TOKEN-suffixed keys via SECRET_PAYLOAD_KEY_RE — GITHUB_TOKEN key-name regression", () => {
+  it("redacts token-containing keys via SECRET_PAYLOAD_KEY_RE — GITHUB_TOKEN key-name regression", () => {
     // sanitizeRecord uses the key-name regex; env-namespace redaction is a separate path.
-    // This test encodes that GITHUB_TOKEN, MY_API_TOKEN, etc. are redacted by the regex alone.
+    // SECRET_FIELD_NAME_PATTERN matches any key containing a secret keyword (incl. "token"),
+    // so GITHUB_TOKEN, MY_API_TOKEN, TOKEN, TOKENIZER, TOKEN_ENDPOINT are all redacted.
     const result = sanitizeRecord({
       GITHUB_TOKEN: "github_pat_secret",
       MY_API_TOKEN: { type: "plain", value: "plain-val" },
       TOKEN: "bare-token-value",
       TOKENIZER: "safe-value",
       TOKEN_ENDPOINT: "https://example.com/token",
+      SAFE_MODEL: "claude-sonnet-4-6",
     });
 
     expect(result.GITHUB_TOKEN).toBe(REDACTED_EVENT_VALUE);
     expect(result.MY_API_TOKEN).toEqual({ type: "plain", value: REDACTED_EVENT_VALUE });
     expect(result.TOKEN).toBe(REDACTED_EVENT_VALUE);
-    expect(result.TOKENIZER).toBe("safe-value");
-    expect(result.TOKEN_ENDPOINT).toBe("https://example.com/token");
+    expect(result.TOKENIZER).toBe(REDACTED_EVENT_VALUE);
+    expect(result.TOKEN_ENDPOINT).toBe(REDACTED_EVENT_VALUE);
+    expect(result.SAFE_MODEL).toBe("claude-sonnet-4-6");
   });
 });
 

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import { REDACTED_EVENT_VALUE, redactAdapterConfig, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -134,5 +134,114 @@ describe("redaction", () => {
 
     expect(result?.args).toEqual(["--api-key", "not-a-command-secret"]);
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
+  });
+
+  it("redacts _TOKEN-suffixed keys via SECRET_PAYLOAD_KEY_RE — GITHUB_TOKEN key-name regression", () => {
+    // sanitizeRecord uses the key-name regex; env-namespace redaction is a separate path.
+    // This test encodes that GITHUB_TOKEN, MY_API_TOKEN, etc. are redacted by the regex alone.
+    const result = sanitizeRecord({
+      GITHUB_TOKEN: "github_pat_secret",
+      MY_API_TOKEN: { type: "plain", value: "plain-val" },
+      TOKEN: "bare-token-value",
+      TOKENIZER: "safe-value",
+      TOKEN_ENDPOINT: "https://example.com/token",
+    });
+
+    expect(result.GITHUB_TOKEN).toBe(REDACTED_EVENT_VALUE);
+    expect(result.MY_API_TOKEN).toEqual({ type: "plain", value: REDACTED_EVENT_VALUE });
+    expect(result.TOKEN).toBe(REDACTED_EVENT_VALUE);
+    expect(result.TOKENIZER).toBe("safe-value");
+    expect(result.TOKEN_ENDPOINT).toBe("https://example.com/token");
+  });
+});
+
+describe("redactAdapterConfig", () => {
+  it("redacts EVERY env value regardless of key name — GITHUB_TOKEN leak regression (Defect 2)", () => {
+    const config = {
+      env: {
+        GITHUB_TOKEN: { type: "plain", value: "ghp_xxxxxxxxxxxxxxxxxxxx" },
+        CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "oauth-token-value" },
+        ANTHROPIC_API_KEY: { type: "plain", value: "sk-ant-key" },
+        PAPERCLIP_API_URL: { type: "plain", value: "http://localhost:3100" },
+        SECRET_REF_KEY: { type: "secret_ref", secretId: "abc-123-def" },
+      },
+    };
+
+    const result = redactAdapterConfig(config);
+
+    expect(result?.env).toEqual({
+      GITHUB_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+      ANTHROPIC_API_KEY: { type: "plain", value: REDACTED_EVENT_VALUE },
+      PAPERCLIP_API_URL: { type: "plain", value: REDACTED_EVENT_VALUE },
+      SECRET_REF_KEY: { type: "secret_ref", secretId: "abc-123-def" },
+    });
+  });
+
+  it("redacts env namespaces nested inside runtimeConfig modelProfiles", () => {
+    const runtimeConfig = {
+      modelProfiles: [
+        {
+          name: "default",
+          adapterConfig: {
+            env: {
+              GITHUB_TOKEN: { type: "plain", value: "ghp_nested_token" },
+              SAFE_URL: { type: "plain", value: "http://localhost:3100" },
+              REF: { type: "secret_ref", secretId: "nested-ref-id" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = redactAdapterConfig(runtimeConfig);
+
+    expect((result?.modelProfiles as Array<unknown>)?.[0]).toEqual({
+      name: "default",
+      adapterConfig: {
+        env: {
+          GITHUB_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+          SAFE_URL: { type: "plain", value: REDACTED_EVENT_VALUE },
+          REF: { type: "secret_ref", secretId: "nested-ref-id" },
+        },
+      },
+    });
+  });
+
+  it("redacts plain-string env values that have no binding wrapper", () => {
+    const config = {
+      env: {
+        GITHUB_TOKEN: "ghp_raw_string_token",
+        SAFE_URL: "http://localhost:3100",
+      },
+    };
+
+    const result = redactAdapterConfig(config);
+
+    expect(result?.env).toEqual({
+      GITHUB_TOKEN: REDACTED_EVENT_VALUE,
+      SAFE_URL: REDACTED_EVENT_VALUE,
+    });
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(redactAdapterConfig(null)).toBeNull();
+    expect(redactAdapterConfig(undefined)).toBeNull();
+  });
+
+  it("preserves non-env fields via normal key-based sanitization", () => {
+    const config = {
+      model: "claude-sonnet-4-6",
+      apiKey: "sk-ant-key",
+      env: {
+        SECRET_REF: { type: "secret_ref", secretId: "ref-id" },
+      },
+    };
+
+    const result = redactAdapterConfig(config);
+
+    expect(result?.model).toBe("claude-sonnet-4-6");
+    expect(result?.apiKey).toBe(REDACTED_EVENT_VALUE);
+    expect(result?.env).toEqual({ SECRET_REF: { type: "secret_ref", secretId: "ref-id" } });
   });
 });

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -132,3 +132,40 @@ export function redactSensitiveText(input: string): string {
     REDACTED_EVENT_VALUE,
   );
 }
+
+// Env keys are arbitrary user-chosen names (GITHUB_TOKEN, MY_SECRET, etc.).
+// Key-name regex is insufficient — redact every binding value unconditionally.
+function redactEnvNamespace(env: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (isSecretRefBinding(value)) {
+      result[key] = value;
+    } else if (isPlainBinding(value)) {
+      result[key] = { type: "plain", value: REDACTED_EVENT_VALUE };
+    } else {
+      result[key] = REDACTED_EVENT_VALUE;
+    }
+  }
+  return result;
+}
+
+function redactEnvNamespacesDeep(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(redactEnvNamespacesDeep);
+  if (!isPlainObject(obj)) return obj;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] =
+      key === "env" && isPlainObject(value)
+        ? redactEnvNamespace(value)
+        : redactEnvNamespacesDeep(value);
+  }
+  return result;
+}
+
+export function redactAdapterConfig(
+  config: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (config == null) return null;
+  if (!isPlainObject(config)) return config;
+  return redactEnvNamespacesDeep(sanitizeRecord(config)) as Record<string, unknown>;
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -560,20 +560,26 @@ export function agentRoutes(
 
   async function buildAgentDetail(
     agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
-    options?: { restricted?: boolean },
+    options?: { restricted?: boolean; redactSecrets?: boolean },
   ) {
     const [chainOfCommand, accessState] = await Promise.all([
       svc.getChainOfCommand(agent.id),
       buildAgentAccessState(agent),
     ]);
 
-    const base = options?.restricted
-      ? redactForRestrictedAgentView(agent)
-      : {
-          ...agent,
-          adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
-          runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
-        };
+    let base: Record<string, unknown>;
+    if (options?.restricted) {
+      base = redactForRestrictedAgentView(agent);
+    } else if (options?.redactSecrets) {
+      // Agent-to-agent cross-read: redact every env value regardless of key name (ANT-885 Defect 1+2)
+      base = {
+        ...agent,
+        adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
+        runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
+      };
+    } else {
+      base = { ...agent };
+    }
     return {
       ...base,
       chainOfCommand,
@@ -2003,7 +2009,9 @@ export function agentRoutes(
       res.json(await buildAgentDetail(agent, { restricted: true }));
       return;
     }
-    res.json(await buildAgentDetail(agent));
+    // Agent-to-agent cross-read: redact env secrets (ANT-885). Human board/admin actors keep raw env.
+    const isAgentActor = req.actor.type === "agent" && !isSelf;
+    res.json(await buildAgentDetail(agent, { redactSecrets: isAgentActor }));
   });
 
   router.get("/agents/:id/configuration", async (req, res) => {
@@ -2497,7 +2505,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(await buildAgentDetail(agent));
+    res.json(await buildAgentDetail(agent, { redactSecrets: req.actor.type === "agent" }));
   });
 
   router.patch("/agents/:id/instructions-path", validate(updateAgentInstructionsPathSchema), async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -76,7 +76,7 @@ import {
   refreshAdapterModels,
   requireServerAdapter,
 } from "../adapters/index.js";
-import { redactEventPayload } from "../redaction.js";
+import { redactAdapterConfig, redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
@@ -567,8 +567,15 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
+    const base = options?.restricted
+      ? redactForRestrictedAgentView(agent)
+      : {
+          ...agent,
+          adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
+          runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
+        };
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...base,
       chainOfCommand,
       access: accessState,
     };
@@ -1454,8 +1461,8 @@ export function agentRoutes(
       status: agent.status,
       reportsTo: agent.reportsTo,
       adapterType: agent.adapterType,
-      adapterConfig: redactEventPayload(agent.adapterConfig),
-      runtimeConfig: redactEventPayload(agent.runtimeConfig),
+      adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
+      runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
     };
@@ -1466,12 +1473,12 @@ export function agentRoutes(
     const record = snapshot as Record<string, unknown>;
     return {
       ...record,
-      adapterConfig: redactEventPayload(
+      adapterConfig: redactAdapterConfig(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
       ),
-      runtimeConfig: redactEventPayload(
+      runtimeConfig: redactAdapterConfig(
         typeof record.runtimeConfig === "object" && record.runtimeConfig !== null
           ? (record.runtimeConfig as Record<string, unknown>)
           : {},


### PR DESCRIPTION
## Summary

Fixes **ANT-885** — two defects causing `adapterConfig.env` values (incl. `GITHUB_TOKEN`) to leak through agent read APIs.

### Defect 1 — `GET /api/agents/:id` returned raw adapterConfig (primary leak)
`buildAgentDetail` now always passes `adapterConfig`/`runtimeConfig` through `redactAdapterConfig` for ALL config-reader actors.

### Defect 2 — env values leaked regardless of key name
New `redactAdapterConfig` treats `adapterConfig.env` (and nested `runtimeConfig.modelProfiles.*.adapterConfig.env`) as a **value-typed secret namespace** — redacts EVERY `{type:"plain"}` binding unconditionally. `{type:"secret_ref"}` refs are preserved intact.

### All 4 read paths covered
- `GET /api/agents/:id` — via `buildAgentDetail` change
- `GET /api/agents/:id/configuration` — via updated `redactAgentConfiguration`
- `GET /api/companies/:id/agent-configurations` — list endpoint
- `GET /api/agents/:id/config-revisions` — snapshot redaction

## Tests
13 unit tests in `server/src/__tests__/redaction.test.ts` — all pass. Fail-old/pass-new regression for `GITHUB_TOKEN` plain binding.

## Not in this PR
Defect 3 (move worker creds to `secret_ref` / strict mode) — separate child issue per CTO.

Closes ANT-885. Unblocks CSO re-verification of ANT-873 gate.