### PR TITLE
fix(security): ANT-885 — semantic-only redaction of adapterConfig.env on agent read endpoints

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1595,4 +1595,96 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(403);
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
+
+  // ANT-885 endpoint-level regression — fail-old/pass-new
+  // Unit tests on redactAdapterConfig alone cannot catch Defect 1 (missing call-site gate).
+  describe("ANT-885 — agent cross-read env redaction (endpoint regression)", () => {
+    const peerAgentId = "99999999-9999-4999-8999-999999999999";
+    const agentWithSecret = {
+      ...baseAgent,
+      id: peerAgentId,
+      adapterConfig: {
+        command: "pnpm agent:run",
+        env: {
+          GITHUB_TOKEN: { type: "plain", value: "ghp_compromised_token" },
+          ANTHROPIC_API_KEY: { type: "plain", value: "sk-ant-compromised" },
+        },
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          default: {
+            adapterConfig: {
+              env: {
+                NESTED_TOKEN: { type: "plain", value: "nested-secret-value" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it("redacts env for agent-actor reading a peer agent (ANT-885 Defect 1 regression)", async () => {
+      mockAgentService.getById.mockResolvedValue(agentWithSecret);
+
+      const app = await createApp({
+        type: "agent",
+        agentId, // reading agent (not peerAgentId — cross-read)
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(`/api/agents/${peerAgentId}`),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.adapterConfig.env.GITHUB_TOKEN).toEqual({ type: "plain", value: "***REDACTED***" });
+      expect(res.body.adapterConfig.env.ANTHROPIC_API_KEY).toEqual({ type: "plain", value: "***REDACTED***" });
+      // command (non-env field) preserved
+      expect(res.body.adapterConfig.command).toBe("pnpm agent:run");
+    }, 20_000);
+
+    it("redacts nested runtimeConfig env for agent-actor cross-read (ANT-885 Defect 2 regression)", async () => {
+      mockAgentService.getById.mockResolvedValue(agentWithSecret);
+
+      const app = await createApp({
+        type: "agent",
+        agentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(`/api/agents/${peerAgentId}`),
+      );
+
+      expect(res.status).toBe(200);
+      const defaultProfile = res.body.runtimeConfig?.modelProfiles?.default as Record<string, unknown> | undefined;
+      const nestedEnv = (defaultProfile?.adapterConfig as Record<string, unknown> | undefined)?.env as Record<string, unknown> | undefined;
+      expect(nestedEnv?.NESTED_TOKEN).toEqual({ type: "plain", value: "***REDACTED***" });
+    }, 20_000);
+
+    it("keeps env unredacted for human board/instance-admin reading agent (board contract, ANT-885)", async () => {
+      mockAgentService.getById.mockResolvedValue(agentWithSecret);
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      });
+
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(`/api/agents/${peerAgentId}`),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.adapterConfig.env.GITHUB_TOKEN).toEqual({ type: "plain", value: "ghp_compromised_token" });
+      expect(res.body.adapterConfig.env.ANTHROPIC_API_KEY).toEqual({ type: "plain", value: "sk-ant-compromised" });
+    }, 20_000);
+  });
+
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import { REDACTED_EVENT_VALUE, redactAdapterConfig, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -134,5 +134,96 @@ describe("redaction", () => {
 
     expect(result?.args).toEqual(["--api-key", "not-a-command-secret"]);
     expect(result?.argv).toEqual(["--api-key", REDACTED_EVENT_VALUE]);
+  });
+});
+
+describe("redactAdapterConfig", () => {
+  it("redacts EVERY env value regardless of key name — GITHUB_TOKEN leak regression (Defect 2)", () => {
+    const config = {
+      env: {
+        GITHUB_TOKEN: { type: "plain", value: "ghp_xxxxxxxxxxxxxxxxxxxx" },
+        CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: "oauth-token-value" },
+        ANTHROPIC_API_KEY: { type: "plain", value: "sk-ant-key" },
+        PAPERCLIP_API_URL: { type: "plain", value: "http://localhost:3100" },
+        SECRET_REF_KEY: { type: "secret_ref", secretId: "abc-123-def" },
+      },
+    };
+
+    const result = redactAdapterConfig(config);
+
+    expect(result?.env).toEqual({
+      GITHUB_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+      CLAUDE_CODE_OAUTH_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+      ANTHROPIC_API_KEY: { type: "plain", value: REDACTED_EVENT_VALUE },
+      PAPERCLIP_API_URL: { type: "plain", value: REDACTED_EVENT_VALUE },
+      SECRET_REF_KEY: { type: "secret_ref", secretId: "abc-123-def" },
+    });
+  });
+
+  it("redacts env namespaces nested inside runtimeConfig modelProfiles", () => {
+    const runtimeConfig = {
+      modelProfiles: [
+        {
+          name: "default",
+          adapterConfig: {
+            env: {
+              GITHUB_TOKEN: { type: "plain", value: "ghp_nested_token" },
+              SAFE_URL: { type: "plain", value: "http://localhost:3100" },
+              REF: { type: "secret_ref", secretId: "nested-ref-id" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = redactAdapterConfig(runtimeConfig);
+
+    expect((result?.modelProfiles as Array<unknown>)?.[0]).toEqual({
+      name: "default",
+      adapterConfig: {
+        env: {
+          GITHUB_TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+          SAFE_URL: { type: "plain", value: REDACTED_EVENT_VALUE },
+          REF: { type: "secret_ref", secretId: "nested-ref-id" },
+        },
+      },
+    });
+  });
+
+  it("redacts plain-string env values that have no binding wrapper", () => {
+    const config = {
+      env: {
+        GITHUB_TOKEN: "ghp_raw_string_token",
+        SAFE_URL: "http://localhost:3100",
+      },
+    };
+
+    const result = redactAdapterConfig(config);
+
+    expect(result?.env).toEqual({
+      GITHUB_TOKEN: REDACTED_EVENT_VALUE,
+      SAFE_URL: REDACTED_EVENT_VALUE,
+    });
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(redactAdapterConfig(null)).toBeNull();
+    expect(redactAdapterConfig(undefined)).toBeNull();
+  });
+
+  it("preserves non-env fields via normal key-based sanitization", () => {
+    const config = {
+      model: "claude-sonnet-4-6",
+      apiKey: "sk-ant-key",
+      env: {
+        SECRET_REF: { type: "secret_ref", secretId: "ref-id" },
+      },
+    };
+
+    const result = redactAdapterConfig(config);
+
+    expect(result?.model).toBe("claude-sonnet-4-6");
+    expect(result?.apiKey).toBe(REDACTED_EVENT_VALUE);
+    expect(result?.env).toEqual({ SECRET_REF: { type: "secret_ref", secretId: "ref-id" } });
   });
 });

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -132,3 +132,40 @@ export function redactSensitiveText(input: string): string {
     REDACTED_EVENT_VALUE,
   );
 }
+
+// Env keys are arbitrary user-chosen names (GITHUB_TOKEN, MY_SECRET, etc.).
+// Key-name regex is insufficient — redact every binding value unconditionally.
+function redactEnvNamespace(env: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (isSecretRefBinding(value)) {
+      result[key] = value;
+    } else if (isPlainBinding(value)) {
+      result[key] = { type: "plain", value: REDACTED_EVENT_VALUE };
+    } else {
+      result[key] = REDACTED_EVENT_VALUE;
+    }
+  }
+  return result;
+}
+
+function redactEnvNamespacesDeep(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(redactEnvNamespacesDeep);
+  if (!isPlainObject(obj)) return obj;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] =
+      key === "env" && isPlainObject(value)
+        ? redactEnvNamespace(value)
+        : redactEnvNamespacesDeep(value);
+  }
+  return result;
+}
+
+export function redactAdapterConfig(
+  config: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (config == null) return null;
+  if (!isPlainObject(config)) return config;
+  return redactEnvNamespacesDeep(sanitizeRecord(config)) as Record<string, unknown>;
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -76,7 +76,7 @@ import {
   refreshAdapterModels,
   requireServerAdapter,
 } from "../adapters/index.js";
-import { redactEventPayload } from "../redaction.js";
+import { redactAdapterConfig, redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
@@ -560,15 +560,28 @@ export function agentRoutes(
 
   async function buildAgentDetail(
     agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
-    options?: { restricted?: boolean },
+    options?: { restricted?: boolean; redactSecrets?: boolean },
   ) {
     const [chainOfCommand, accessState] = await Promise.all([
       svc.getChainOfCommand(agent.id),
       buildAgentAccessState(agent),
     ]);
 
+    let base: Record<string, unknown>;
+    if (options?.restricted) {
+      base = redactForRestrictedAgentView(agent);
+    } else if (options?.redactSecrets) {
+      // Agent-to-agent cross-read: redact every env value regardless of key name (ANT-885 Defect 1+2)
+      base = {
+        ...agent,
+        adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
+        runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
+      };
+    } else {
+      base = { ...agent };
+    }
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...base,
       chainOfCommand,
       access: accessState,
     };
@@ -1454,8 +1467,8 @@ export function agentRoutes(
       status: agent.status,
       reportsTo: agent.reportsTo,
       adapterType: agent.adapterType,
-      adapterConfig: redactEventPayload(agent.adapterConfig),
-      runtimeConfig: redactEventPayload(agent.runtimeConfig),
+      adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
+      runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
     };
@@ -1466,12 +1479,12 @@ export function agentRoutes(
     const record = snapshot as Record<string, unknown>;
     return {
       ...record,
-      adapterConfig: redactEventPayload(
+      adapterConfig: redactAdapterConfig(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
       ),
-      runtimeConfig: redactEventPayload(
+      runtimeConfig: redactAdapterConfig(
         typeof record.runtimeConfig === "object" && record.runtimeConfig !== null
           ? (record.runtimeConfig as Record<string, unknown>)
           : {},
@@ -1996,7 +2009,9 @@ export function agentRoutes(
       res.json(await buildAgentDetail(agent, { restricted: true }));
       return;
     }
-    res.json(await buildAgentDetail(agent));
+    // Agent-to-agent cross-read: redact env secrets (ANT-885). Human board/admin actors keep raw env.
+    const isAgentActor = req.actor.type === "agent" && !isSelf;
+    res.json(await buildAgentDetail(agent, { redactSecrets: isAgentActor }));
   });
 
   router.get("/agents/:id/configuration", async (req, res) => {
@@ -2490,7 +2505,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(await buildAgentDetail(agent));
+    res.json(await buildAgentDetail(agent, { redactSecrets: req.actor.type === "agent" }));
   });
 
   router.patch("/agents/:id/instructions-path", validate(updateAgentInstructionsPathSchema), async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -567,21 +567,16 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
-    let base: Record<string, unknown>;
-    if (options?.restricted) {
-      base = redactForRestrictedAgentView(agent);
-    } else if (options?.redactSecrets) {
-      // Agent-to-agent cross-read: redact every env value regardless of key name (ANT-885 Defect 1+2)
-      base = {
-        ...agent,
-        adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
-        runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
-      };
-    } else {
-      base = { ...agent };
-    }
+    const agentData = options?.redactSecrets
+      ? {
+          ...agent,
+          // Agent-to-agent cross-read: redact every env value regardless of key name (ANT-885 Defect 1+2)
+          adapterConfig: redactAdapterConfig(agent.adapterConfig as Record<string, unknown> | null),
+          runtimeConfig: redactAdapterConfig(agent.runtimeConfig as Record<string, unknown> | null),
+        }
+      : agent;
     return {
-      ...base,
+      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agentData),
       chainOfCommand,
       access: accessState,
     };


### PR DESCRIPTION
## Summary

Fixes **ANT-885** — `adapterConfig.env` values (incl. `GITHUB_TOKEN`) leak through agent read APIs when an agent-actor cross-reads a peer agent.

**Semantic-only: no ADR-0008 preflight, no line-ending reformats, no client paths in fixtures.**

### Root cause

`GET /api/agents/:id` returned raw config for any caller passing `actorCanReadConfigurationsForCompany`, including agent-to-agent cross-reads. Every `{type:"plain"}` env binding was exposed.

### Fix — 4 files only

- `server/src/redaction.ts` — `redactAdapterConfig()`: redacts ALL plain env bindings (key-name-agnostic), preserves `{type:"secret_ref"}`
- `server/src/routes/agents.ts` — 4 read-paths covered; agent cross-reads get `redactSecrets: true`
- `server/src/__tests__/redaction.test.ts` — 5 unit tests for `redactAdapterConfig`
- `server/src/__tests__/agent-permissions-routes.test.ts` — 3 endpoint regression tests

### NOT included
- ADR-0008 preflight-denylist (separate issue)  
- `scripts/migrate-inline-env-secrets.ts` (unrelated)
- No client workspace paths in fixtures

### Greptile P1 resolved
`redactForRestrictedAgentView` already returns `adapterConfig: {}, runtimeConfig: {}` — completely blank, no leak. Greptile concern addressed by new `redactSecrets` branch in `buildAgentDetail`.

Closes ANT-885. Unblocks ANT-908 Action 1.