### PR TITLE
fix(invite): consume invite token after signup-via-invite for non-bootstrap company invites

### DIFF
--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -506,6 +506,84 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("consumes a non-bootstrap invite from sign-up onSuccess even when the session query has not refreshed yet", async () => {
+    // The session query keeps resolving to null for the whole flow, so the
+    // auto-accept effect (which requires a session) can never fire. This pins
+    // the responsibility on authMutation.onSuccess: after a fresh sign-up it
+    // must consume the invite token itself, otherwise the brand-new user gets
+    // an account but is never added to the inviting company's membership.
+    getSessionMock.mockResolvedValue(null);
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "approved",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const inputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    expect(inputValueSetter).toBeTypeOf("function");
+
+    const nameInput = container.querySelector('input[name="name"]') as HTMLInputElement | null;
+    const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement | null;
+    const passwordInput = container.querySelector('input[name="password"]') as HTMLInputElement | null;
+    expect(nameInput).not.toBeNull();
+    expect(emailInput).not.toBeNull();
+    expect(passwordInput).not.toBeNull();
+
+    await act(async () => {
+      inputValueSetter!.call(nameInput, "Jane Example");
+      nameInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(emailInput, "jane@example.com");
+      emailInput!.dispatchEvent(new Event("input", { bubbles: true }));
+      inputValueSetter!.call(passwordInput, "supersecret");
+      passwordInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const authForm = container.querySelector('[data-testid="invite-inline-auth"]') as HTMLFormElement | null;
+    expect(authForm).not.toBeNull();
+
+    await act(async () => {
+      authForm?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(signUpEmailMock).toHaveBeenCalledWith({
+      name: "Jane Example",
+      email: "jane@example.com",
+      password: "supersecret",
+    });
+    // The invite token must be consumed so the new user joins the company.
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+    expect(localStorage.getItem("paperclip:pending-invite-token")).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("shows the pending approval page with the company icon and linked access instructions", async () => {
     acceptInviteMock.mockResolvedValue({
       id: "join-1",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -384,13 +384,27 @@ export function InviteLandingPage() {
         return;
       }
 
-      if (!invite || invite.inviteType !== "bootstrap_ceo") {
+      if (!invite) {
         return;
       }
 
+      // A brand-new account that just signed up via this invite is not a member
+      // of the inviting company yet, so we must consume the invite token here.
+      // Without this, sign-up creates the account but never adds the user to the
+      // company membership. (Bootstrap invites take the bootstrap branch below.)
       try {
         const payload = await acceptMutation.mutateAsync();
-        if (isBootstrapAcceptancePayload(payload)) {
+        if (invite.inviteType === "bootstrap_ceo") {
+          if (isBootstrapAcceptancePayload(payload)) {
+            navigate("/", { replace: true });
+          }
+          return;
+        }
+        // Non-bootstrap company invite: acceptMutation.onSuccess already cleared
+        // the pending token and invalidated caches. Navigate the newly joined
+        // user into the company, mirroring the existing-account accept path.
+        if (invite.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
+          setSelectedCompanyId(invite.companyId, { source: "manual" });
           navigate("/", { replace: true });
         }
       } catch {


### PR DESCRIPTION
## The bug

When a brand-new user (no existing account) opens a **non-bootstrap company invite** link and signs up inline on `InviteLanding`, they get an account but are **never added to the inviting company's membership** — the invite token is never consumed.

Root cause: `authMutation.onSuccess` (post-signup) had an early `return` for any invite that is not `bootstrap_ceo`. It only called the accept mutation for bootstrap invites:

```ts
if (!invite || invite.inviteType !== "bootstrap_ceo") {
  return; // <- non-bootstrap company invite bails out here, accept never runs
}
```

The auto-accept effect that would normally pick this up only fires once the session query has refreshed to an authenticated session. In the common race where `onSuccess` runs before that refresh lands, nobody consumes the invite, so the new user is left with an account but no company.

## The fix

In the post-signup path, drop the non-bootstrap early return and call `acceptMutation.mutateAsync()` for company invites too, then navigate the newly joined user into the company (mirroring the existing-account accept path). The accept mutation's own `onSuccess` already clears the remembered invite token and invalidates the relevant caches. The `bootstrap_ceo` branch keeps its exact existing behavior.

## Test

Adds a regression test that pins the responsibility on `onSuccess`: with the session query held at `null` (so the auto-accept effect can never fire), a fresh sign-up must still consume the invite token (`acceptInvite` called) and select the company. The test fails on the old code (accept called 0 times) and passes with the fix. All existing `InviteLanding` tests stay green (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)