### PR TITLE
test(server): root-fix flaky heartbeat teardown CONNECTION_ENDED/DESTROYED race

### DIFF
--- a/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
+++ b/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
@@ -30,6 +30,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -82,6 +83,15 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   const tempRoots: string[] = [];
+  // Drain per-test heartbeat instances before the idle-poll / row cleanup so
+  // detached executeRun chains never query a torn-down socket.
+  const heartbeats: Array<ReturnType<typeof heartbeatService>> = [];
+
+  function makeHeartbeat(...args: Parameters<typeof heartbeatService>) {
+    const heartbeat = heartbeatService(...args);
+    heartbeats.push(heartbeat);
+    return heartbeat;
+  }
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-accepted-plan-workspace-");
@@ -89,6 +99,9 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
   }, 20_000);
 
   afterEach(async () => {
+    while (heartbeats.length > 0) {
+      await heartbeats.pop()?.drain();
+    }
     adapterExecute.mockClear();
     let idlePolls = 0;
     for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -130,7 +143,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
   });
 
   afterAll(async () => {
-    await db.$client.end();
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 
@@ -296,7 +309,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       };
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const run = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",
@@ -471,7 +484,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       };
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const run = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",
@@ -627,7 +640,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       };
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const run = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",
@@ -768,7 +781,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
       };
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const run = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",

--- a/server/src/__tests__/heartbeat-archived-company-guard.test.ts
+++ b/server/src/__tests__/heartbeat-archived-company-guard.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -27,6 +28,15 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  // Drain per-test heartbeat instances before deleting rows / closing the client
+  // so detached executeRun chains never query a torn-down socket.
+  const heartbeats: Array<ReturnType<typeof heartbeatService>> = [];
+
+  function makeHeartbeat(...args: Parameters<typeof heartbeatService>) {
+    const heartbeat = heartbeatService(...args);
+    heartbeats.push(heartbeat);
+    return heartbeat;
+  }
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-archived-company-guard-");
@@ -34,6 +44,9 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   }, 20_000);
 
   afterEach(async () => {
+    while (heartbeats.length > 0) {
+      await heartbeats.pop()?.drain();
+    }
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -43,6 +56,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   });
 
   afterAll(async () => {
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 
@@ -136,7 +150,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   it("does not iterate archived-company agents in tickTimers", async () => {
     const { agentId } = await insertArchivedAgent();
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const result = await heartbeat.tickTimers(new Date("2026-06-04T00:10:00Z"));
 
     expect(result).toMatchObject({
@@ -155,7 +169,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   it("skips background wakeups for non-active companies with a company.inactive reason", async () => {
     const { agentId } = await insertArchivedAgent();
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const run = await heartbeat.wakeup(agentId, {
       source: "automation",
       triggerDetail: "system",
@@ -199,7 +213,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
       monitorAttemptCount: 0,
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     await heartbeat.tickTimers(new Date("2026-06-04T00:10:00Z"));
 
     const row = await db
@@ -230,7 +244,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
       status: "queued",
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     await heartbeat.resumeQueuedRuns();
 
     const status = await db
@@ -243,7 +257,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   it("rejects explicit user invokes for non-active companies", async () => {
     const { agentId } = await insertArchivedAgent();
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     await expect(heartbeat.wakeup(agentId, {
       source: "on_demand",
@@ -265,7 +279,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   it("rejects explicit user invokes for invalid-org-chain agents", async () => {
     const { childId } = await insertInvalidOrgChainAgent();
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     await expect(heartbeat.wakeup(childId, {
       source: "on_demand",
@@ -308,7 +322,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
       wakeupRequestId,
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     await heartbeat.resumeQueuedRuns();
 
     const run = await db
@@ -361,7 +375,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
       scheduledRetryAttempt: 1,
     });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const promoted = await heartbeat.promoteDueScheduledRetries(now);
 
     expect(promoted).toEqual({ promoted: 0, runIds: [] });

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -15,7 +15,7 @@ import {
 import { runningProcesses } from "../adapters/index.js";
 import { heartbeatService } from "../services/heartbeat.ts";
 import { SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY } from "../services/recovery/index.ts";
-import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
+import { closeDbClient, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
 
 async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000, intervalMs = 50) {
   const startedAt = Date.now();
@@ -24,10 +24,6 @@ async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
   throw new Error("Timed out waiting for condition");
-}
-
-async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
-  await db?.$client?.end?.({ timeout: 0 });
 }
 
 async function createControlledGatewayServer() {
@@ -150,6 +146,17 @@ async function createControlledGatewayServer() {
 describe("heartbeat comment wake batching", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  // Heartbeat instances created per test. The gateway wake/batch flow leaves
+  // detached executeRun chains in flight after the test body resolves; we drain
+  // them before the next test (and before the DB client closes) so a settling
+  // query never rejects against a torn-down socket (CONNECTION_ENDED/DESTROYED).
+  const heartbeats: Array<ReturnType<typeof heartbeatService>> = [];
+
+  function makeHeartbeat(...args: Parameters<typeof heartbeatService>) {
+    const heartbeat = heartbeatService(...args);
+    heartbeats.push(heartbeat);
+    return heartbeat;
+  }
 
   beforeAll(async () => {
     const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-comment-wake-");
@@ -162,7 +169,10 @@ describe("heartbeat comment wake batching", () => {
     await tempDb?.cleanup();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    while (heartbeats.length > 0) {
+      await heartbeats.pop()?.drain();
+    }
     runningProcesses.clear();
   });
 
@@ -172,7 +182,7 @@ describe("heartbeat comment wake batching", () => {
     const issueId = randomUUID();
     const runId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     await db.insert(companies).values({
       id: companyId,
@@ -286,7 +296,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -485,7 +495,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -647,7 +657,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -840,7 +850,7 @@ describe("heartbeat comment wake batching", () => {
     const mentionedAgentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -1039,7 +1049,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -1205,7 +1215,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -1416,7 +1426,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -1569,7 +1579,7 @@ describe("heartbeat comment wake batching", () => {
     const mentionedAgentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -1770,7 +1780,7 @@ describe("heartbeat comment wake batching", () => {
     const mentionedAgentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({
@@ -1917,7 +1927,7 @@ describe("heartbeat comment wake batching", () => {
     const agentId = randomUUID();
     const issueId = randomUUID();
     const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
 
     try {
       await db.insert(companies).values({

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -150,6 +151,8 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
   });
 
   afterAll(async () => {
+    await heartbeat?.drain();
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 

--- a/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
+++ b/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -29,6 +30,15 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  // Drain per-test heartbeat instances before deleting rows / closing the client
+  // so detached executeRun chains never query a torn-down socket.
+  const heartbeats: Array<ReturnType<typeof heartbeatService>> = [];
+
+  function makeHeartbeat(...args: Parameters<typeof heartbeatService>) {
+    const heartbeat = heartbeatService(...args);
+    heartbeats.push(heartbeat);
+    return heartbeat;
+  }
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-lock-release-on-reassignment-");
@@ -36,6 +46,9 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
   }, 60_000);
 
   afterEach(async () => {
+    while (heartbeats.length > 0) {
+      await heartbeats.pop()?.drain();
+    }
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
@@ -46,6 +59,7 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
   });
 
   afterAll(async () => {
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 
@@ -137,7 +151,7 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
     const { coderAgentId, reviewerAgentId, issueId, holderRunId, wakeupRequestId } =
       await seedCrossAgentScenario({ holderStatus: "running" });
 
-    const heartbeat = heartbeatService(db);
+    const heartbeat = makeHeartbeat(db);
     const followupRun = await heartbeat.wakeup(reviewerAgentId, {
       source: "automation",
       triggerDetail: "system",

--- a/server/src/__tests__/heartbeat-plugin-environment.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-environment.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -52,17 +53,28 @@ if (!embeddedPostgresSupport.supported) {
 }
 
 describeEmbeddedPostgres("heartbeat plugin environments", () => {
-  let stopDb: (() => Promise<void>) | null = null;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   let db!: ReturnType<typeof createDb>;
   const tempRoots: string[] = [];
+  // Heartbeat instances created per test, so their detached executeRun chains
+  // can be drained before the next test / before the DB client is closed.
+  const heartbeats: Array<ReturnType<typeof heartbeatService>> = [];
+
+  function makeHeartbeat(options?: Parameters<typeof heartbeatService>[1]) {
+    const heartbeat = heartbeatService(db, options);
+    heartbeats.push(heartbeat);
+    return heartbeat;
+  }
 
   beforeAll(async () => {
-    const started = await startEmbeddedPostgresTestDatabase("heartbeat-plugin-environment");
-    stopDb = started.stop;
-    db = createDb(started.connectionString);
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-plugin-environment");
+    db = createDb(tempDb.connectionString);
   }, 20_000);
 
   afterEach(async () => {
+    while (heartbeats.length > 0) {
+      await heartbeats.pop()?.drain();
+    }
     adapterExecute.mockClear();
     while (tempRoots.length > 0) {
       const root = tempRoots.pop();
@@ -71,8 +83,8 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
   });
 
   afterAll(async () => {
-    await db.$client.end();
-    await stopDb?.();
+    await closeDbClient(db);
+    await tempDb?.cleanup();
   });
 
   it("acquires plugin environment leases through the heartbeat execution path", async () => {
@@ -189,7 +201,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       updatedAt: new Date(),
     });
 
-    const heartbeat = heartbeatService(db, { pluginWorkerManager: workerManager });
+    const heartbeat = makeHeartbeat({ pluginWorkerManager: workerManager });
     const run = await heartbeat.wakeup(agentId, {
       source: "on_demand",
       triggerDetail: "manual",
@@ -411,7 +423,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       updatedAt: new Date(),
     });
 
-    const heartbeat = heartbeatService(db, { pluginWorkerManager: workerManager });
+    const heartbeat = makeHeartbeat({ pluginWorkerManager: workerManager });
     const run = await heartbeat.wakeup(agentId, {
       source: "assignment",
       triggerDetail: "manual",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -38,6 +38,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { runningProcesses } from "../adapters/index.ts";
@@ -435,6 +436,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
     cleanupPids.clear();
     runningProcesses.clear();
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
@@ -46,6 +47,9 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   }, 20_000);
 
   afterEach(async () => {
+    // Drain detached executeRun chains before deleting rows so a settling query
+    // never races the truncation / a torn-down socket.
+    await heartbeat?.drain();
     await db.delete(heartbeatRunEvents);
     await db.delete(environmentLeases);
     await db.delete(issueRelations);
@@ -59,6 +63,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   });
 
   afterAll(async () => {
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -16,6 +16,7 @@ import {
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
@@ -177,6 +178,8 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
   });
 
   afterAll(async () => {
+    await heartbeat?.drain();
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 

--- a/server/src/__tests__/helpers/embedded-postgres.ts
+++ b/server/src/__tests__/helpers/embedded-postgres.ts
@@ -4,3 +4,25 @@ export {
   type EmbeddedPostgresTestDatabase,
   type EmbeddedPostgresTestSupport,
 } from "@paperclipai/db";
+
+type DbWithClient = {
+  $client?: { end?: (options?: { timeout?: number }) => Promise<unknown> } | undefined;
+};
+
+/**
+ * Gracefully close a postgres-js client created by createDb() in a test.
+ *
+ * Always call this in afterAll BEFORE EmbeddedPostgresTestDatabase.cleanup()
+ * (which stops the embedded server process). The heartbeat service dispatches
+ * detached `void executeRun(...)` queries that can still be settling when a test
+ * body resolves; force-destroying the socket (end({ timeout: 0 }), or stopping
+ * the server with the client still attached) makes those detached queries reject
+ * with a flaky "write CONNECTION_ENDED/CONNECTION_DESTROYED 127.0.0.1:<port>".
+ * A bounded graceful timeout lets pending queries drain first.
+ *
+ * For suites that drive the heartbeat loop, also call `await heartbeat.drain()`
+ * (per service instance) before this so in-flight executions finish first.
+ */
+export async function closeDbClient(db: DbWithClient | undefined | null): Promise<void> {
+  await db?.$client?.end?.({ timeout: 5 });
+}

--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -132,6 +133,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
   });
 
   afterAll(async () => {
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -30,6 +30,7 @@ import {
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY, LOW_TRUST_REVIEW_PRESET } from "@paperclipai/shared";
 import {
   getEmbeddedPostgresTestSupport,
+  closeDbClient,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { errorHandler } from "../middleware/index.js";
@@ -538,6 +539,7 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
   });
 
   afterAll(async () => {
+    await closeDbClient(db);
     await tempDb?.cleanup();
   });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3119,6 +3119,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
+  // Detached `void executeRun(...)` promises spawned by startNextQueuedRunForAgent.
+  // These keep issuing queries against `db` after the caller (enqueueWakeup,
+  // resumeQueuedRuns, tickTimers, executeRun's own finally) has already resolved.
+  // We track them so drain() can await them before a caller (e.g. a test teardown
+  // or a graceful scheduler shutdown) closes the DB client — otherwise the
+  // detached query rejects against a torn-down socket as
+  // "write CONNECTION_ENDED/CONNECTION_DESTROYED 127.0.0.1:<port>".
+  const pendingExecutions = new Set<Promise<unknown>>();
+  function trackPendingExecution(promise: Promise<unknown>) {
+    pendingExecutions.add(promise);
+    promise.finally(() => {
+      pendingExecutions.delete(promise);
+    }).catch(() => undefined);
+  }
   const liveRunExecutions = {
     has(id: string) {
       return runningProcesses.has(id) || activeRunExecutions.has(id);
@@ -7733,9 +7747,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (claimedRuns.length === 0) return [];
 
       for (const claimedRun of claimedRuns) {
-        void executeRun(claimedRun.id).catch((err) => {
-          logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
-        });
+        trackPendingExecution(
+          executeRun(claimedRun.id).catch((err) => {
+            logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
+          }),
+        );
       }
       return claimedRuns;
     });
@@ -11568,6 +11584,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .orderBy(desc(heartbeatRuns.startedAt))
         .limit(1);
       return run ?? null;
+    },
+
+    /**
+     * Await the detached run executions this service instance spawned (the
+     * fire-and-forget `void executeRun(...)` chains from startNextQueuedRunForAgent).
+     * Call this before closing the DB client / stopping the database so in-flight
+     * queries finish against a live socket instead of rejecting with
+     * "write CONNECTION_ENDED/CONNECTION_DESTROYED".
+     *
+     * Bounded by `timeoutMs` (default 5s): the common case to drain is the fast
+     * post-run unwind (lease release, status writes), which settles in
+     * milliseconds. An execution genuinely stuck on external I/O (e.g. a gateway
+     * agent.wait that never returns, or a scheduled retry) must NOT hang the
+     * caller's teardown forever, so drain resolves once `timeoutMs` elapses even
+     * if some executions are still pending. `maxPasses` re-checks for executions
+     * chained from a draining one within the time budget. Returns true if fully
+     * drained, false if it gave up on a deadline.
+     */
+    drain: async (options: { timeoutMs?: number; maxPasses?: number } = {}): Promise<boolean> => {
+      const timeoutMs = Math.max(0, options.timeoutMs ?? 5_000);
+      const maxPasses = Math.max(1, options.maxPasses ?? 50);
+      const deadline = Date.now() + timeoutMs;
+      for (let pass = 0; pass < maxPasses && pendingExecutions.size > 0; pass += 1) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const budget = new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, remaining);
+          timer.unref?.();
+        });
+        await Promise.race([Promise.allSettled([...pendingExecutions]), budget]);
+        if (timer) clearTimeout(timer);
+      }
+      return pendingExecutions.size === 0;
     },
   };
 }


### PR DESCRIPTION
## Problem

Multiple server test suites that drive the heartbeat service intermittently fail with `write CONNECTION_ENDED 127.0.0.1:<port>` (and the sibling `write CONNECTION_DESTROYED`) thrown mid-query from heartbeat code: `executeRun`, `releaseEnvironmentLeasesForRun`, `getCurrentUserRedactionOptions`, and `startNextQueuedRunForAgent` (queries against `environment_leases`, `agents`, `environments`, `instance_settings`). It surfaces in "General tests (server)" and "Verify serialized server suites" and is non-deterministic (timing-dependent).

## Root cause

`heartbeatService.startNextQueuedRunForAgent` dispatches run work as a **detached** `void executeRun(...)` promise. That chain keeps issuing queries against the DB client *after* the caller (`enqueueWakeup` / `resumeQueuedRuns` / `tickTimers` / `executeRun`'s own `finally`) has already resolved. When a test body finishes and teardown closes the postgres-js client (or stops the embedded server), the still-in-flight detached query rejects against the torn-down socket.

A graceful `end({ timeout })` is **not** sufficient: the detached chain issues *new* queries after `end()` is called, and those reject immediately.

## Fix

- **`server/src/services/heartbeat.ts`**: track the detached `executeRun` promises in a per-instance `pendingExecutions` set and expose `drain({ timeoutMs?, maxPasses? })` that awaits them. It is bounded by a 5s default deadline so a run genuinely stuck on external I/O (a gateway `agent.wait` that never returns, or a scheduled retry) cannot hang teardown. This is the missing graceful-stop primitive for the service and is equally useful for a graceful scheduler shutdown.
- **`server/src/__tests__/helpers/embedded-postgres.ts`**: add `closeDbClient(db)` (graceful `end({ timeout: 5 })`), used in every affected suite's `afterAll` **before** the embedded server is stopped.
- Affected suites now `await heartbeat.drain()` before closing/clearing so in-flight executions finish first. Suites that create a heartbeat per test register the instances and drain them in `afterEach`.

## Stability evidence

Each previously-flaky suite was run repeatedly (5-10x). `CONNECTION_ENDED`/`CONNECTION_DESTROYED` occurrences went from ~20 per 10 runs on pristine `master` to **0 across 55 runs** spanning all 11 affected suites.

Two unrelated, pre-existing flakes remain and reproduce on pristine `master` (out of scope here): a ~90s `waitFor` timeout in one comment-wake test, and a `checkoutRunId` assertion in `heartbeat-process-recovery`.

## Note

This supersedes the narrow band-aid previously landed in `heartbeat-comment-wake-batching.test.ts` (which used `end({ timeout: 0 })` + a suite-level `retry: 2`). That file now uses the real `drain()` and drops the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)