### PR TITLE
fix(heartbeat): hysteresis on agents.status=error (OUT-46970)

### DIFF
--- a/packages/db/src/migrations/0102_agent_consecutive_failure_count.sql
+++ b/packages/db/src/migrations/0102_agent_consecutive_failure_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN "consecutive_failure_count" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -715,6 +715,13 @@
       "when": 1781490000000,
       "tag": "0101_plugin_company_id_tenant_isolation",
       "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1781544000000,
+      "tag": "0102_agent_consecutive_failure_count",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -33,6 +33,7 @@ export const agents = pgTable(
     pausedAt: timestamp("paused_at", { withTimezone: true }),
     permissions: jsonb("permissions").$type<Record<string, unknown>>().notNull().default({}),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
+    consecutiveFailureCount: integer("consecutive_failure_count").notNull().default(0),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -70,6 +70,17 @@ describeEmbeddedPostgres("agent service clearError", () => {
       adapterConfig: {},
       runtimeConfig: {},
       permissions: {},
+      consecutiveFailureCount: 4,
+      metadata: {
+        lastFailure: {
+          outcome: "failed",
+          errorCode: "adapter_failed",
+          errorMessage: "Adapter exited with code 1",
+          runId,
+          consecutiveFailures: 4,
+        },
+        otherField: "preserved",
+      },
     });
 
     await db.insert(heartbeatRuns).values({
@@ -116,7 +127,9 @@ describeEmbeddedPostgres("agent service clearError", () => {
       status: "idle",
       pauseReason: null,
       pausedAt: null,
+      consecutiveFailureCount: 0,
     });
+    expect(cleared?.metadata).toEqual({ otherField: "preserved" });
 
     const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(run).toMatchObject({

--- a/server/src/__tests__/heartbeat-agent-error-hysteresis.test.ts
+++ b/server/src/__tests__/heartbeat-agent-error-hysteresis.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import {
   agents,
   agentWakeupRequests,
@@ -220,6 +220,67 @@ describeEmbeddedPostgres("heartbeat agent status hysteresis (finalizeAgentStatus
     expect((row.metadata as Record<string, unknown>).lastFailure).toMatchObject({
       errorCode: WORKSPACE_VALIDATION_FAILURE_CODE,
     });
+  });
+
+  it("keeps the column and metadata consistent when a concurrent run is still in flight", async () => {
+    const { companyId, agentId } = await insertHealthyAgent({ consecutiveFailureCount: 1 });
+    // Simulate a sibling run that is still running on this agent — finalizeAgentStatus
+    // should keep status="running" and must not bump the column. Metadata.lastFailure
+    // and the live event must report the same count that the column actually holds.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "on_demand",
+      startedAt: new Date(),
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "failed", {
+      errorCode: "adapter_failed",
+      errorMessage: "transient",
+      runId: randomUUID(),
+    });
+
+    const row = await readAgent(agentId);
+    expect(row.status).toBe("running");
+    // Column was NOT bumped because another run is still in flight.
+    expect(row.consecutiveFailureCount).toBe(1);
+    // Metadata's consecutiveFailures must match the stored column value, not priorCount+1.
+    expect((row.metadata as Record<string, unknown>).lastFailure).toMatchObject({
+      outcome: "failed",
+      errorCode: "adapter_failed",
+      consecutiveFailures: 1,
+    });
+  });
+
+  it("clears stale metadata.lastFailure when the run-start writer flips the agent to running", async () => {
+    const { companyId, agentId } = await insertHealthyAgent({
+      consecutiveFailureCount: 2,
+      metadata: {
+        lastFailure: { outcome: "failed", consecutiveFailures: 2, errorCode: "adapter_failed" },
+        otherField: "preserved",
+      },
+    });
+
+    // Mirror the run-start writer in heartbeat.ts:8858 — status=running, counter=0,
+    // and the jsonb minus expression that strips the stale lastFailure marker.
+    await db
+      .update(agents)
+      .set({
+        status: "running",
+        consecutiveFailureCount: 0,
+        metadata: sql`${agents.metadata} - 'lastFailure'`,
+        updatedAt: new Date(),
+      })
+      .where(eq(agents.id, agentId));
+
+    const row = await readAgent(agentId);
+    expect(row.status).toBe("running");
+    expect(row.consecutiveFailureCount).toBe(0);
+    expect(row.metadata).toEqual({ otherField: "preserved" });
+    expect(companyId).toBeTruthy();
   });
 
   it("does not touch paused or terminated agents", async () => {

--- a/server/src/__tests__/heartbeat-agent-error-hysteresis.test.ts
+++ b/server/src/__tests__/heartbeat-agent-error-hysteresis.test.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  WORKSPACE_VALIDATION_FAILURE_CODE,
+  heartbeatService,
+} from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent-status hysteresis tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat agent status hysteresis (finalizeAgentStatus)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-status-hysteresis-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  beforeEach(() => {
+    delete process.env.PAPERCLIP_AGENT_ERROR_FAIL_THRESHOLD;
+  });
+
+  afterEach(async () => {
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+    delete process.env.PAPERCLIP_AGENT_ERROR_FAIL_THRESHOLD;
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function insertHealthyAgent(opts: {
+    consecutiveFailureCount?: number;
+    metadata?: Record<string, unknown> | null;
+    status?: string;
+  } = {}) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Hysteresis Co",
+      status: "active",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Agent A",
+      role: "engineer",
+      status: opts.status ?? "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      consecutiveFailureCount: opts.consecutiveFailureCount ?? 0,
+      metadata: opts.metadata ?? null,
+    });
+
+    return { companyId, agentId };
+  }
+
+  async function readAgent(agentId: string) {
+    const [row] = await db.select().from(agents).where(eq(agents.id, agentId));
+    return row;
+  }
+
+  it("increments the counter and keeps the agent idle below the default threshold (3)", async () => {
+    const { agentId } = await insertHealthyAgent();
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "failed", {
+      errorCode: "adapter_failed",
+      errorMessage: "boom",
+      runId: randomUUID(),
+    });
+
+    let row = await readAgent(agentId);
+    expect(row.status).toBe("idle");
+    expect(row.consecutiveFailureCount).toBe(1);
+    expect((row.metadata as Record<string, unknown>).lastFailure).toMatchObject({
+      outcome: "failed",
+      errorCode: "adapter_failed",
+      errorMessage: "boom",
+      consecutiveFailures: 1,
+    });
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "timed_out", {
+      errorCode: "timed_out",
+      errorMessage: "deadline",
+      runId: randomUUID(),
+    });
+
+    row = await readAgent(agentId);
+    expect(row.status).toBe("idle");
+    expect(row.consecutiveFailureCount).toBe(2);
+    expect((row.metadata as Record<string, unknown>).lastFailure).toMatchObject({
+      outcome: "timed_out",
+      consecutiveFailures: 2,
+    });
+  });
+
+  it("flips to error on the threshold-th consecutive failure", async () => {
+    const { agentId } = await insertHealthyAgent({ consecutiveFailureCount: 2 });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "failed", {
+      errorCode: "adapter_failed",
+      errorMessage: "fatal",
+      runId: randomUUID(),
+    });
+
+    const row = await readAgent(agentId);
+    expect(row.status).toBe("error");
+    expect(row.consecutiveFailureCount).toBe(3);
+  });
+
+  it("honors PAPERCLIP_AGENT_ERROR_FAIL_THRESHOLD override", async () => {
+    process.env.PAPERCLIP_AGENT_ERROR_FAIL_THRESHOLD = "5";
+    const { agentId } = await insertHealthyAgent({ consecutiveFailureCount: 3 });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "failed", {
+      errorCode: "adapter_failed",
+      errorMessage: "still soft",
+      runId: randomUUID(),
+    });
+
+    let row = await readAgent(agentId);
+    expect(row.status).toBe("idle");
+    expect(row.consecutiveFailureCount).toBe(4);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "failed", {
+      errorCode: "adapter_failed",
+      errorMessage: "now hard",
+      runId: randomUUID(),
+    });
+
+    row = await readAgent(agentId);
+    expect(row.status).toBe("error");
+    expect(row.consecutiveFailureCount).toBe(5);
+  });
+
+  it("resets the counter and clears metadata.lastFailure on succeeded outcome", async () => {
+    const { agentId } = await insertHealthyAgent({
+      consecutiveFailureCount: 2,
+      metadata: {
+        lastFailure: { outcome: "failed", consecutiveFailures: 2 },
+        otherField: "preserved",
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "succeeded");
+
+    const row = await readAgent(agentId);
+    expect(row.status).toBe("idle");
+    expect(row.consecutiveFailureCount).toBe(0);
+    expect(row.metadata).toEqual({ otherField: "preserved" });
+  });
+
+  it("preserves the counter on cancelled outcome (cancelled is not a health signal)", async () => {
+    const { agentId } = await insertHealthyAgent({
+      consecutiveFailureCount: 2,
+      metadata: { lastFailure: { outcome: "failed", consecutiveFailures: 2 } },
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "cancelled");
+
+    const row = await readAgent(agentId);
+    expect(row.status).toBe("idle");
+    expect(row.consecutiveFailureCount).toBe(2);
+    expect((row.metadata as Record<string, unknown>).lastFailure).toMatchObject({
+      consecutiveFailures: 2,
+    });
+  });
+
+  it("bypasses the threshold and goes straight to error on workspace_validation_failed", async () => {
+    const { agentId } = await insertHealthyAgent();
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(agentId, "failed", {
+      errorCode: WORKSPACE_VALIDATION_FAILURE_CODE,
+      errorMessage: "workspace cwd missing",
+      runId: randomUUID(),
+    });
+
+    const row = await readAgent(agentId);
+    expect(row.status).toBe("error");
+    expect(row.consecutiveFailureCount).toBe(1);
+    expect((row.metadata as Record<string, unknown>).lastFailure).toMatchObject({
+      errorCode: WORKSPACE_VALIDATION_FAILURE_CODE,
+    });
+  });
+
+  it("does not touch paused or terminated agents", async () => {
+    const { agentId: pausedId } = await insertHealthyAgent({
+      status: "paused",
+      consecutiveFailureCount: 2,
+    });
+    const { agentId: termId } = await insertHealthyAgent({
+      status: "terminated",
+      consecutiveFailureCount: 2,
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.__test_finalizeAgentStatus(pausedId, "failed", { errorCode: "adapter_failed" });
+    await heartbeat.__test_finalizeAgentStatus(termId, "failed", { errorCode: "adapter_failed" });
+
+    const paused = await readAgent(pausedId);
+    const terminated = await readAgent(termId);
+    expect(paused.status).toBe("paused");
+    expect(paused.consecutiveFailureCount).toBe(2);
+    expect(terminated.status).toBe("terminated");
+    expect(terminated.consecutiveFailureCount).toBe(2);
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -537,12 +537,26 @@ export function agentService(db: Db) {
         throw conflict("Only agents in error status can have their error cleared");
       }
 
+      const existingMetadata =
+        existing.metadata && typeof existing.metadata === "object" && !Array.isArray(existing.metadata)
+          ? (existing.metadata as Record<string, unknown>)
+          : null;
+      const nextMetadata = existingMetadata
+        ? (() => {
+          const copy: Record<string, unknown> = { ...existingMetadata };
+          delete copy.lastFailure;
+          return copy;
+        })()
+        : null;
+
       const updated = await db
         .update(agents)
         .set({
           status: "idle",
           pauseReason: null,
           pausedAt: null,
+          consecutiveFailureCount: 0,
+          metadata: nextMetadata,
           updatedAt: new Date(),
         })
         .where(and(eq(agents.id, id), eq(agents.status, "error")))

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -254,6 +254,15 @@ const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
+const AGENT_ERROR_FAIL_THRESHOLD_DEFAULT = 3;
+const AGENT_ERROR_FAIL_THRESHOLD_CAP = 100;
+function resolveAgentErrorFailThreshold(): number {
+  const raw = process.env.PAPERCLIP_AGENT_ERROR_FAIL_THRESHOLD;
+  if (!raw) return AGENT_ERROR_FAIL_THRESHOLD_DEFAULT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return AGENT_ERROR_FAIL_THRESHOLD_DEFAULT;
+  return Math.min(AGENT_ERROR_FAIL_THRESHOLD_CAP, parsed);
+}
 // Keep this in sync with local adapters that require a git workspace before launch.
 const GIT_SENSITIVE_LOCAL_ADAPTER_TYPES = new Set([
   "acpx_local",
@@ -7145,6 +7154,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+    failureContext?: {
+      errorCode?: string | null;
+      errorMessage?: string | null;
+      runId?: string | null;
+    },
   ) {
     const existing = await getAgent(agentId);
     if (!existing) return;
@@ -7156,18 +7170,71 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const isFirstHeartbeat = !existing.lastHeartbeatAt;
 
     const runningCount = await countRunningRunsForAgent(agentId);
-    const nextStatus =
-      runningCount > 0
-        ? "running"
-        : outcome === "succeeded" || outcome === "cancelled"
-          ? "idle"
-          : "error";
+    const isFailureOutcome = outcome === "failed" || outcome === "timed_out";
+    const failureErrorCode = readNonEmptyString(failureContext?.errorCode);
+    const validationBypass = failureErrorCode === WORKSPACE_VALIDATION_FAILURE_CODE;
+    const threshold = resolveAgentErrorFailThreshold();
+
+    const priorMetadata =
+      existing.metadata && typeof existing.metadata === "object" && !Array.isArray(existing.metadata)
+        ? (existing.metadata as Record<string, unknown>)
+        : null;
+    const priorFailureCount = Math.max(
+      0,
+      Number.isFinite(existing.consecutiveFailureCount as number)
+        ? Number(existing.consecutiveFailureCount)
+        : 0,
+    );
+
+    let nextFailureCount = priorFailureCount;
+    let nextMetadata: Record<string, unknown> | null = priorMetadata;
+    let softFail = false;
+
+    if (isFailureOutcome) {
+      nextFailureCount = priorFailureCount + 1;
+      const lastFailure: Record<string, unknown> = {
+        outcome,
+        errorCode: failureErrorCode ?? null,
+        errorMessage: readNonEmptyString(failureContext?.errorMessage) ?? null,
+        runId: readNonEmptyString(failureContext?.runId) ?? null,
+        at: new Date().toISOString(),
+        consecutiveFailures: nextFailureCount,
+      };
+      nextMetadata = { ...(priorMetadata ?? {}), lastFailure };
+      softFail = !validationBypass && nextFailureCount < threshold;
+    } else if (outcome === "succeeded") {
+      nextFailureCount = 0;
+      if (priorMetadata && Object.prototype.hasOwnProperty.call(priorMetadata, "lastFailure")) {
+        const copy: Record<string, unknown> = { ...priorMetadata };
+        delete copy.lastFailure;
+        nextMetadata = copy;
+      }
+    } else if (outcome === "cancelled") {
+      // Cancelled runs are not a health signal — preserve the counter and metadata as-is.
+      nextFailureCount = priorFailureCount;
+      nextMetadata = priorMetadata;
+    }
+
+    let nextStatus: "running" | "idle" | "error";
+    if (runningCount > 0) {
+      nextStatus = "running";
+    } else if (outcome === "succeeded" || outcome === "cancelled") {
+      nextStatus = "idle";
+    } else if (validationBypass) {
+      nextStatus = "error";
+    } else if (nextFailureCount >= threshold) {
+      nextStatus = "error";
+    } else {
+      nextStatus = "idle";
+    }
 
     const updated = await db
       .update(agents)
       .set({
         status: nextStatus,
         lastHeartbeatAt: new Date(),
+        consecutiveFailureCount: nextStatus === "running" ? priorFailureCount : nextFailureCount,
+        metadata: nextMetadata,
         updatedAt: new Date(),
       })
       .where(eq(agents.id, agentId))
@@ -7190,6 +7257,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ? new Date(updated.lastHeartbeatAt).toISOString()
             : null,
           outcome,
+          ...(isFailureOutcome
+            ? {
+              consecutiveFailures: nextFailureCount,
+              threshold,
+              softFail,
+              ...(validationBypass ? { workspaceValidationFailure: true } : {}),
+            }
+            : {}),
         },
       });
     }
@@ -7529,7 +7604,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       });
 
-      await finalizeAgentStatus(run.agentId, "failed");
+      await finalizeAgentStatus(run.agentId, "failed", {
+        errorCode: "process_lost",
+        errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        runId: run.id,
+      });
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
@@ -8778,7 +8857,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const runningAgent = await db
         .update(agents)
-        .set({ status: "running", updatedAt: new Date() })
+        .set({ status: "running", consecutiveFailureCount: 0, updatedAt: new Date() })
         .where(eq(agents.id, agent.id))
         .returning()
         .then((rows) => rows[0] ?? null);
@@ -9452,7 +9531,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
       }
 
-      await finalizeAgentStatus(agent.id, "failed");
+      await finalizeAgentStatus(agent.id, "failed", {
+        errorCode: failureErrorCode,
+        errorMessage: message,
+        runId: failedRun?.id ?? run.id,
+      });
     }
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
@@ -9497,7 +9580,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
           // Ensure the agent is not left stuck in "running" if the inner catch handler's
           // DB calls threw (e.g. a transient DB error in finalizeAgentStatus).
-          await finalizeAgentStatus(run.agentId, "failed").catch(() => undefined);
+          await finalizeAgentStatus(run.agentId, "failed", {
+            errorCode: "setup_failed",
+            errorMessage: outerErr instanceof Error ? outerErr.message : null,
+            runId,
+          }).catch(() => undefined);
         } finally {
           const latestRun = await getRun(run.id).catch(() => null);
           await releaseEnvironmentLeasesForRun({
@@ -11569,5 +11656,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .limit(1);
       return run ?? null;
     },
+
+    __test_finalizeAgentStatus: (
+      agentId: string,
+      outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+      failureContext?: { errorCode?: string | null; errorMessage?: string | null; runId?: string | null },
+    ) => finalizeAgentStatus(agentId, outcome, failureContext),
   };
 }
+
+export { WORKSPACE_VALIDATION_FAILURE_CODE };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7187,33 +7187,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     );
 
     let nextFailureCount = priorFailureCount;
-    let nextMetadata: Record<string, unknown> | null = priorMetadata;
-    let softFail = false;
-
     if (isFailureOutcome) {
       nextFailureCount = priorFailureCount + 1;
-      const lastFailure: Record<string, unknown> = {
-        outcome,
-        errorCode: failureErrorCode ?? null,
-        errorMessage: readNonEmptyString(failureContext?.errorMessage) ?? null,
-        runId: readNonEmptyString(failureContext?.runId) ?? null,
-        at: new Date().toISOString(),
-        consecutiveFailures: nextFailureCount,
-      };
-      nextMetadata = { ...(priorMetadata ?? {}), lastFailure };
-      softFail = !validationBypass && nextFailureCount < threshold;
     } else if (outcome === "succeeded") {
       nextFailureCount = 0;
-      if (priorMetadata && Object.prototype.hasOwnProperty.call(priorMetadata, "lastFailure")) {
-        const copy: Record<string, unknown> = { ...priorMetadata };
-        delete copy.lastFailure;
-        nextMetadata = copy;
-      }
-    } else if (outcome === "cancelled") {
-      // Cancelled runs are not a health signal — preserve the counter and metadata as-is.
-      nextFailureCount = priorFailureCount;
-      nextMetadata = priorMetadata;
     }
+    // cancelled: nextFailureCount stays at priorFailureCount.
 
     let nextStatus: "running" | "idle" | "error";
     if (runningCount > 0) {
@@ -7228,12 +7207,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       nextStatus = "idle";
     }
 
+    // The counter we will actually persist. When other runs are still in flight we keep
+    // the prior count so the bump is only observed once the agent settles — metadata and
+    // the live event must agree with the stored column value.
+    const storedFailureCount = nextStatus === "running" ? priorFailureCount : nextFailureCount;
+    const softFail = isFailureOutcome && !validationBypass && nextStatus === "idle";
+
+    let nextMetadata: Record<string, unknown> | null = priorMetadata;
+    if (isFailureOutcome) {
+      const lastFailure: Record<string, unknown> = {
+        outcome,
+        errorCode: failureErrorCode ?? null,
+        errorMessage: readNonEmptyString(failureContext?.errorMessage) ?? null,
+        runId: readNonEmptyString(failureContext?.runId) ?? null,
+        at: new Date().toISOString(),
+        consecutiveFailures: storedFailureCount,
+      };
+      nextMetadata = { ...(priorMetadata ?? {}), lastFailure };
+    } else if (outcome === "succeeded") {
+      if (priorMetadata && Object.prototype.hasOwnProperty.call(priorMetadata, "lastFailure")) {
+        const copy: Record<string, unknown> = { ...priorMetadata };
+        delete copy.lastFailure;
+        nextMetadata = copy;
+      }
+    }
+    // cancelled: preserve metadata as-is.
+
     const updated = await db
       .update(agents)
       .set({
         status: nextStatus,
         lastHeartbeatAt: new Date(),
-        consecutiveFailureCount: nextStatus === "running" ? priorFailureCount : nextFailureCount,
+        consecutiveFailureCount: storedFailureCount,
         metadata: nextMetadata,
         updatedAt: new Date(),
       })
@@ -7259,7 +7264,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           outcome,
           ...(isFailureOutcome
             ? {
-              consecutiveFailures: nextFailureCount,
+              consecutiveFailures: storedFailureCount,
               threshold,
               softFail,
               ...(validationBypass ? { workspaceValidationFailure: true } : {}),
@@ -8857,7 +8862,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const runningAgent = await db
         .update(agents)
-        .set({ status: "running", consecutiveFailureCount: 0, updatedAt: new Date() })
+        .set({
+          status: "running",
+          consecutiveFailureCount: 0,
+          // Strip any soft-fail `lastFailure` marker from the prior cycle so the dashboard
+          // doesn't render a stale failure card alongside a healthy run.
+          metadata: sql`${agents.metadata} - 'lastFailure'`,
+          updatedAt: new Date(),
+        })
         .where(eq(agents.id, agent.id))
         .returning()
         .then((rows) => rows[0] ?? null);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The control-plane heartbeat service is the single authority that writes `agents.status` after every heartbeat run.
> - From the OUT-46964 writer audit there is exactly one production writer of `agents.status = 'error'` — `finalizeAgentStatus` in `server/src/services/heartbeat.ts` — and the recurring flicker in OUT-46944 is policy, not stuck state: a single per-cycle `failed`/`timed_out` outcome flips an otherwise-healthy agent fully to `error`, and the CEO sweep PATCH-to-idle then races the next failed cycle.
> - We need hysteresis at the policy layer: tolerate N transient failures before flipping to `error`, but keep the existing single-writer model so recovery paths (`clearError`, run-start `running`) stay simple.
> - This pull request adds a per-agent `consecutive_failure_count` column, threshold-driven status decisions, soft-fail metadata + live-event fields, and surgical resets at run-start and `clearError`. Adapter-validation failures bypass the threshold because they are not transient.
> - The benefit is that the OUT-46944 12 lane-queued agents stop re-flickering between `idle` and `error`, while real sustained outages still trip `error` after N cycles.

## Linked Issues or Issue Description

Tracked internally as **OUT-46970** (with scoping context from OUT-46964 and the lane-queue flicker observed in OUT-46944). The underlying bug, following the `.github/ISSUE_TEMPLATE/bug_report.yml` template:

### What happened

After every heartbeat run, `finalizeAgentStatus` in `server/src/services/heartbeat.ts` writes the agent's status. A single per-cycle `outcome ∈ {failed, timed_out}` flips an otherwise-healthy agent fully to `error`. The CEO sweep then PATCHes the agent back to `idle`, which races the next failed cycle — producing a visible flicker between `idle` and `error` on the dashboard even when the agent's heartbeats are otherwise landing on time. Observed against 12 lane-queued agents in production.

### Expected behavior

An otherwise-healthy agent (heartbeats landing, run starts OK) should not flip to `error` until N consecutive failed runs are observed. Genuine sustained outages should still surface as `error`. Adapter-validation failures (`workspace_validation_failed`) should keep their straight-to-`error` semantics because they indicate unrecoverable configuration problems, not transient errors.

### Steps to reproduce

1. Bring up an agent with at least one upstream adapter that intermittently fails (e.g. transient `adapter_failed` from a flaky provider).
2. Drive a normal heartbeat workload at the agent.
3. Observe `agents.status` toggling between `idle` and `error` on every single failed cycle.

### Environment

- Paperclip control plane on `master`, prior to this PR.
- Any adapter where transient failures are possible — observed initially with `claude_local` and `codex_local` adapters under network instability.

### Fix shape

Hysteresis at the policy layer: track per-agent consecutive failure count, write `error` only at/above the threshold, merge `metadata.lastFailure` for soft-fail state, reset on `succeeded` outcomes and at run-start, preserve on `cancelled`, and bypass for `workspace_validation_failed`. Detailed in `## What Changed` below.

## What Changed

- `packages/db/src/schema/agents.ts` — adds `consecutiveFailureCount` (`integer NOT NULL DEFAULT 0`).
- `packages/db/src/migrations/0102_agent_consecutive_failure_count.sql` — additive migration with safe default; `_journal.json` updated with idx 102.
- `server/src/services/heartbeat.ts`:
  - New `AGENT_ERROR_FAIL_THRESHOLD_DEFAULT = 3`, `AGENT_ERROR_FAIL_THRESHOLD_CAP = 100`, `resolveAgentErrorFailThreshold()` (env override `PAPERCLIP_AGENT_ERROR_FAIL_THRESHOLD`, parsed safely with clamp).
  - `finalizeAgentStatus(agentId, outcome, failureContext?)` — failed/timed_out increment counter; succeeded resets to 0 and strips `metadata.lastFailure`; cancelled preserves both; `workspace_validation_failed` bypasses the threshold straight to `error`; below threshold the agent stays `idle` with failure details merged into `metadata.lastFailure`.
  - Column and metadata are consistent: when a concurrent run is in flight the counter is preserved and the metadata + live-event payload report the stored value.
  - Run-start writer (`claimQueuedRun`) resets the counter to 0 and strips any stale `metadata.lastFailure` via `jsonb - 'lastFailure'`.
  - All failure call sites (process-loss reaper, adapter inner catch, outer setup catch) pass `{ errorCode, errorMessage, runId }`.
  - Soft-fail `agent.status` live event carries `consecutiveFailures`, `threshold`, `softFail`, and `workspaceValidationFailure` when applicable.
  - Exposes `__test_finalizeAgentStatus` and the named export `WORKSPACE_VALIDATION_FAILURE_CODE` for tests.
- `server/src/services/agents.ts` — `clearError` now resets the counter to 0 and surgically removes `metadata.lastFailure` while preserving every other metadata field.
- `server/src/__tests__/heartbeat-agent-error-hysteresis.test.ts` — new file with 9 cases covering counter increments, threshold transition, env override, succeeded reset + metadata strip, cancelled preservation, workspace-validation bypass, paused/terminated guard, concurrent-run column/metadata agreement, and run-start stale-metadata clear.
- `server/src/__tests__/agents-service-clear-error.test.ts` — extended to assert counter and selective metadata reset.

## Verification

- `pnpm --filter @paperclipai/db build` — clean.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-agent-error-hysteresis.test.ts src/__tests__/agents-service-clear-error.test.ts` — 12/12 pass.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-archived-company-guard.test.ts` — 8/8 pass (regression smoke).
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — no errors in changed files.
- Post-merge manual smoke (VPE owns, tracked on OUT-46970):
  - Induce 1–2 transient `adapter_failed`; confirm the affected agent stays `idle` and `metadata.lastFailure` updates with the expected `consecutiveFailures` count.
  - Induce ≥ threshold consecutive failures; confirm transition to `error` and that recovery on the next success resets the counter + clears `metadata.lastFailure`.
  - Re-snapshot the OUT-46944 12 agents over 30 minutes; confirm zero re-flicker.

## Risks

- Low — additive schema migration with a safe `DEFAULT 0`, no data backfill required. The behavioral change is gated entirely on a new column that starts at 0 for every existing agent, so the first cycle behaves exactly like the legacy single-strike policy until the policy threshold is hit. The threshold is env-tunable and capped at 100. `workspace_validation_failed` retains today's straight-to-`error` semantics so genuine configuration outages still surface immediately. The redundant per-cycle CEO sweep-to-idle stays in place as a safety net until the dashboard reflects soft-fail state cleanly (explicitly out of scope per OUT-46970).

## Model Used

- Claude Opus 4 (claude-opus-4-7) via Paperclip's `claude_local` adapter, with thinking-mode enabled and tool use (Read, Edit, Bash, Grep, Glob, Task) inside an embedded-Postgres test loop.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — server-only change)
- [x] I have updated relevant documentation to reflect my changes (no docs touched — internal policy change with no public surface)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (both display-layer gaps addressed in commit 53c2f348)
- [x] I will address all Greptile and reviewer comments before requesting merge
