### PR TITLE
fix(ui): land invitees on the inviter company when membership lags

### DIFF
--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -634,6 +634,88 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("refreshes the companies list until the joined company appears before redirecting an authenticated invitee", async () => {
+    // An already-authenticated user opens /invite/:token as their FIRST page load
+    // (no selected/last company yet). The accept auto-fires, but the new
+    // membership is not yet readable by the companies endpoint. If the page
+    // navigates to "/" on that first stale list, the company root redirect cannot
+    // find the just-joined company and falls back to companies[0] (e.g. a
+    // pre-existing default company), stranding the invitee on the wrong board. The
+    // accept must refetch the list until the joined company appears before it
+    // hands off navigation.
+    getSessionMock.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: {
+        id: "user-1",
+        name: "Jane Example",
+        email: "jane@example.com",
+        image: null,
+      },
+    });
+    // The membership write lags: the list returns ONLY the user's pre-existing
+    // company for the first few post-accept refetches, then becomes readable and
+    // includes the joined inviter company.
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockResolvedValueOnce([{ id: "own-company", name: "Existing Co" }]);
+    listCompaniesMock.mockResolvedValue([
+      { id: "own-company", name: "Existing Co" },
+      { id: "company-1", name: "Acme Robotics" },
+    ]);
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "approved",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    // Drain the bounded backoff between membership refetches.
+    for (let i = 0; i < 30; i += 1) {
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 60));
+      });
+      const cached = queryClient.getQueryData(queryKeys.companies.all) as
+        | { companies: Array<{ id: string }> }
+        | undefined;
+      if (cached?.companies.some((company) => company.id === "company-1")) break;
+    }
+
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(setSelectedCompanyIdMock).toHaveBeenCalledWith("company-1", { source: "manual" });
+
+    // The accept refetched the companies list more than once, waiting out the
+    // lagging membership write rather than navigating on the first stale list.
+    expect(listCompaniesMock.mock.calls.length).toBeGreaterThan(2);
+
+    // The joined company must be present in the shared companies cache by the time
+    // navigation happens, so the company root redirect can resolve the inviter
+    // company rather than falling back to companies[0].
+    const cached = queryClient.getQueryData(queryKeys.companies.all) as
+      | { companies: Array<{ id: string }> }
+      | undefined;
+    expect(cached?.companies.map((company) => company.id)).toContain("company-1");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("asks unauthenticated users to sign in before completing an accepted human invite", async () => {
     getInviteMock.mockResolvedValue({
       id: "invite-1",

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -314,6 +314,45 @@ export function InviteLandingPage() {
     password.trim().length > 0 &&
     (authMode === "sign_in" || (name.trim().length > 0 && password.trim().length >= 8));
 
+  // After a successful accept we hand off to the company root redirect via
+  // navigate("/"). That redirect resolves the destination company by looking the
+  // selected id up in the companies list, so the just-joined company must be in
+  // the list before we navigate. For a user whose FIRST page load is
+  // /invite/:token (no selected/last company yet), the membership write may not
+  // be readable by the companies endpoint on the immediate refetch; if we
+  // navigate before it lands, the root redirect cannot find the selected company
+  // and falls back to companies[0] (e.g. an auto-provisioned default company),
+  // stranding the invitee on the wrong board. Refetch the list a bounded number
+  // of times until the joined company appears, then select + navigate.
+  const enterJoinedCompany = async (companyId: string) => {
+    // Persist the selection up front so it survives the refetch loop and any
+    // re-render: the root redirect keys off this id once the company is in the
+    // list.
+    setSelectedCompanyId(companyId, { source: "manual" });
+    let present = false;
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const { companies } = await queryClient.fetchQuery({
+        ...companiesListQueryOptions,
+        staleTime: 0,
+      });
+      if (companies.some((company) => company.id === companyId)) {
+        present = true;
+        break;
+      }
+      // Short backoff for the membership write to become readable before the
+      // next refetch. Skip the wait on the final attempt.
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, 120 * (attempt + 1)));
+      }
+    }
+    // Navigate regardless: if the list is still lagging after the bounded
+    // retries the selection persists, so the root redirect (or a later companies
+    // refetch) still lands on the right company rather than silently choosing
+    // companies[0].
+    navigate("/", { replace: true });
+    return present;
+  };
+
   const acceptMutation = useMutation({
     mutationFn: async () => {
       if (!invite) throw new Error("Invite not found");
@@ -340,10 +379,10 @@ export function InviteLandingPage() {
       setResult({ kind: asBootstrap ? "bootstrap" : "join", payload });
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
       await queryClient.invalidateQueries({ queryKey: queryKeys.access.currentBoardAccess });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       if (invite?.companyId && isApprovedHumanJoinPayload(payload, showsAgentForm)) {
-        setSelectedCompanyId(invite.companyId, { source: "manual" });
-        navigate("/", { replace: true });
+        await enterJoinedCompany(invite.companyId);
+      } else {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       }
     },
     onError: (err) => {
@@ -379,8 +418,7 @@ export function InviteLandingPage() {
 
       if (invite?.companyId && freshCompanies.some((company) => company.id === invite.companyId)) {
         clearPendingInviteToken(token);
-        setSelectedCompanyId(invite.companyId, { source: "manual" });
-        navigate("/", { replace: true });
+        await enterJoinedCompany(invite.companyId);
         return;
       }
 


### PR DESCRIPTION
## Problem

When an authenticated user opens `/invite/:token` as their **first page load** (no selected/last company yet), `InviteLanding` auto-accepts the invite and then hands off to the company root redirect via `navigate("/")`. That redirect resolves the destination company by looking the selected company id up in the companies list, so the just-joined company must be present in the list **before** we navigate.

For a freshly signed-up user (or any deployment that auto-provisions a default company), the new membership is frequently not yet readable by the companies endpoint on the immediate post-accept refetch. The old code fired a single `invalidateQueries` and navigated right away, so the root redirect could not find the selected company and fell back to `companies[0]` (the user's own default company) — stranding them un-joined on the wrong board.

An established user who already had the dashboard loaded (companies cached, selection set) was unaffected, which is why this only reproduced on the first authenticated load.

## Fix

Refetch the companies list a bounded number of times (with a short backoff) until the joined company appears, then select + navigate. The selection is set up front so it persists across the refetch loop. If the list is still lagging after the bounded retries we navigate anyway and let a later refetch land the right company, rather than silently choosing `companies[0]`.

Applied to both the `acceptMutation` success path and the post-sign-in existing-member path.

## Test

Added a regression test: an already-authenticated invitee whose membership lags several refetches behind the accept now refetches until the joined company appears before navigating. FAIL→PASS on this change.

`tsc -b` clean; `InviteLanding.test.tsx` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)