### PR TITLE
fix(server): cancel stale process-loss retries on terminal issues

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -410,6 +410,78 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels process-lost retries carrying stale wake comments after the issue is done", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const staleCommentId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Completed task with stale retry context",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(issueComments).values({
+      id: staleCommentId,
+      companyId,
+      issueId,
+      authorUserId: "local-board",
+      body: "[paperclip-sweeper] All blockers on this ticket are now `done`.",
+      createdAt: new Date("2026-06-13T06:53:43.758Z"),
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "process_lost_retry",
+      invocationSource: "automation",
+      scheduledRetryReason: "process_lost",
+      contextExtras: {
+        retryReason: "process_lost",
+        commentId: staleCommentId,
+        wakeCommentId: staleCommentId,
+        wakeCommentIds: [staleCommentId],
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          resultJson: heartbeatRuns.resultJson,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_terminal_status");
+    expect(run?.resultJson).toMatchObject({ stopReason: "issue_terminal_status" });
+    expect(wakeup?.status).toBe("skipped");
+    expect(wakeup?.error).toContain("terminal status");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6986,6 +6986,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
+    const isProcessLossRetry = wakeReason === "process_lost_retry" || retryReason === "process_lost";
 
     if (
       issue.status === "in_progress" &&
@@ -7031,12 +7032,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
-      if (!resumeIntent && !wakeCommentId) {
+      if (isProcessLossRetry || (!resumeIntent && !wakeCommentId)) {
         return {
           stale: true,
           errorCode: "issue_terminal_status",
           reason: `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`,
-          details: { issueId, currentStatus: issue.status },
+          details: { issueId, currentStatus: issue.status, wakeReason, retryReason },
         };
       }
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat queue decides whether queued agent runs are still valid before starting them.
> - Terminal issues should not be re-run by old automation retries once their work is complete.
> - A process-loss retry could still carry a stale `wakeCommentId`, which made the terminal-issue stale gate treat the run as actionable.
> - This pull request treats `process_lost` retries on `done`/`cancelled` issues as stale even when old wake comment context is still present.
> - The benefit is completed tickets stay closed unless a fresh explicit reopen/follow-up path exists.

## Linked Issues or Issue Description

Bug report, inline because there is no public GitHub issue for the local CON-4903 tracker.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on `master` for this fix.
- [x] I have confirmed the error originates in Paperclip itself, specifically heartbeat queued-run staleness handling.

### What happened?

A completed deploy ticket received repeated process-loss retry wakes carrying an old sweeper comment id. Because the retry context still had `wakeCommentId`, Paperclip treated the queued run as actionable even though the issue was already `done`. A later `resume:true` acknowledgement then reopened the closed issue.

### Expected behavior

A queued `process_lost_retry` / `retryReason=process_lost` targeting a `done` or `cancelled` issue should be cancelled as stale with `issue_terminal_status`, even if the saved run context still includes stale `commentId` / `wakeCommentId` values.

### Steps to reproduce

1. Create a `done` issue assigned to an agent.
2. Add an older comment on that issue.
3. Queue a heartbeat run with `wakeReason: "process_lost_retry"`, `retryReason: "process_lost"`, and `commentId` / `wakeCommentId` pointing at that old comment.
4. Call `resumeQueuedRuns()`.
5. Before this fix, the run executes and can succeed; after this fix, it is cancelled as `issue_terminal_status` and the wakeup request is skipped.

### Paperclip version or commit

Observed on the local Paperclip instance backing CON-4903. Fixed against `master` at commit `9e64d71ea02d746270e3b33731cf0a1ff1dbd44b`.

### Deployment mode

Local trusted Paperclip instance.

### Installation method

Built from source for this PR; observed from the local package-backed instance.

### Agent adapter(s) involved

- [x] Codex
- [x] Not adapter-specific (core bug)

### Database mode

External/embedded Postgres test coverage through the heartbeat stale-queue invalidation embedded Postgres suite.

### Access context

Both board/user comment context and agent heartbeat execution context are involved.

### Relevant logs or output

```shell
Red regression before fix:
expected 'succeeded' to be 'cancelled'

Green verification after fix:
pnpm vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
# 9 tests passed
```

### Privacy checklist

- [x] I have reviewed all pasted output for PII and avoided including local paths, secrets, tokens, or private issue bodies beyond the internal CON identifier.

Internal tracker: Refs CON-4903.
No duplicate GitHub issues/PRs found for `process_lost_retry wakeCommentId terminal` or `stale queued run terminal issue comment`.

## What Changed

- Added a regression test for process-loss retries that carry stale wake comment context after the issue is already `done`.
- Updated queued-run staleness evaluation so `process_lost_retry` / `retryReason=process_lost` cancels on terminal issues regardless of stale comment ids.
- Included wake/retry reason in the stale-run cancellation details for easier diagnosis.

## Verification

- Red check before fix: `pnpm vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts` failed with `expected 'succeeded' to be 'cancelled'` for the new stale process-loss retry test.
- Green check after fix: `pnpm vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts` passed, 9 tests.
- `git diff --check` passed.
- GitHub PR checks are green except the Commitperclip body gate this edit addresses; Greptile reported 5/5 with no required changes.

## Risks

Low risk. The behavior change is limited to process-loss retries for issues already in terminal status. It preserves the existing allowance for genuine comment-driven or explicit resume paths outside process-loss retry handling.

## Model Used

OpenAI Codex, GPT-5-based coding agent with repository tool use and terminal execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge