### PR TITLE
fix(server): UUID-safe heartbeat run + project lookups, FK-safe activity log (PUL-4125)

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2593,6 +2593,23 @@ export function issueRoutes(
   const instanceSettings = instanceSettingsService(db);
   const agentsSvc = agentService(db);
   const projectsSvc = projectService(db);
+
+  // issues.project_id is a uuid column. Callers routinely filter by a project
+  // shortname instead (e.g. ?projectId=QA), which Postgres rejects at the cast.
+  // Resolve the reference first; an unresolvable one yields undefined so the
+  // filter is skipped rather than failing the whole request.
+  async function resolveProjectIdFilter(
+    companyId: string,
+    raw: string | string[] | undefined,
+  ): Promise<string | undefined> {
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof value !== "string" || value.trim().length === 0) return undefined;
+    const trimmed = value.trim();
+    if (isUuidLike(trimmed)) return trimmed;
+    const resolved = await projectsSvc.resolveByReference(companyId, trimmed);
+    return resolved.project?.id ?? undefined;
+  }
+
   const goalsSvc = goalService(db);
   const issueApprovalsSvc = issueApprovalService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
@@ -2696,9 +2713,13 @@ export function issueRoutes(
     issue?: { companyId: string; projectId?: string | null; executionPolicy?: unknown } | null,
   ): Promise<TrustPresetResolution | null> {
     if (!input.agentId) return null;
+    // heartbeat_runs.id is a uuid column. Manual / non-heartbeat callers may send
+    // a synthetic X-Paperclip-Run-Id (e.g. "manual-<ts>"), which Postgres rejects
+    // at the cast. Treat a non-uuid run id as "no heartbeat run" instead.
+    const runIdForLookup = input.runId && isUuidLike(input.runId) ? input.runId : null;
     const [agent, run] = await Promise.all([
       agentsSvc.getById(input.agentId),
-      input.runId
+      runIdForLookup
         ? db
             .select({
               companyId: heartbeatRuns.companyId,
@@ -2706,7 +2727,7 @@ export function issueRoutes(
               contextSnapshot: heartbeatRuns.contextSnapshot,
             })
             .from(heartbeatRuns)
-            .where(and(eq(heartbeatRuns.id, input.runId), eq(heartbeatRuns.companyId, companyId)))
+            .where(and(eq(heartbeatRuns.id, runIdForLookup), eq(heartbeatRuns.companyId, companyId)))
             .then((rows) => rows[0] ?? null)
         : Promise.resolve(null),
     ]);
@@ -4745,6 +4766,11 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
+    const resolvedProjectIdFilter = await resolveProjectIdFilter(
+      companyId,
+      req.query.projectId as string | string[] | undefined,
+    );
+
     const listFilters: IssueFilters = {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | string[] | undefined,
@@ -4754,7 +4780,7 @@ export function issueRoutes(
       touchedByUserId,
       inboxArchivedByUserId,
       unreadForUserId,
-      projectId: req.query.projectId as string | undefined,
+      projectId: resolvedProjectIdFilter,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
       parentId: req.query.parentId as string | undefined,
@@ -4946,7 +4972,10 @@ export function issueRoutes(
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId: req.query.assigneeUserId as string | undefined,
-      projectId: req.query.projectId as string | undefined,
+      projectId: await resolveProjectIdFilter(
+        companyId,
+        req.query.projectId as string | string[] | undefined,
+      ),
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
       parentId: req.query.parentId as string | undefined,

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -133,6 +133,11 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;
   const responsibleUserId = await resolveResponsibleUserIdForActivity(db, input);
+  // activity_log.run_id is a uuid column with an FK to heartbeat_runs.id. Manual /
+  // non-heartbeat callers may send a synthetic X-Paperclip-Run-Id (e.g. "manual-<ts>"),
+  // which Postgres rejects at the cast and fails the whole insert. Drop non-uuid ids
+  // here; the original value is still emitted on the live event below.
+  const persistedRunId = input.runId && isUuidLike(input.runId) ? input.runId : null;
   await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,
@@ -141,7 +146,7 @@ export async function logActivity(db: Db, input: LogActivityInput) {
     entityType: input.entityType,
     entityId: input.entityId,
     agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
+    runId: persistedRunId,
     responsibleUserId,
     details: redactedDetails,
   });


### PR DESCRIPTION
## Problem

Three call sites pass a caller-supplied string straight into a `uuid` column. Postgres rejects the cast and the request 500s.

Observed in a live instance: **162** × `invalid input syntax for type uuid`, **18** × `activity_log_run_id_heartbeat_runs_id_fk` violations, **136** HTTP 500s.

| # | Site | Cause |
| --- | --- | --- |
| 1 | `routes/issues.ts` — `resolveAgentTrustForIssue` | `X-Paperclip-Run-Id` may be synthetic (e.g. `manual-<ts>`) for non-heartbeat callers. It goes straight to `where heartbeat_runs.id = $1`. The lookup was gated on truthiness only, not on shape. |
| 2 | `services/activity-log.ts` — `logActivity` | `activity_log.run_id` is `uuid` with an FK to `heartbeat_runs.id`. The insert passed `input.runId` raw. The *lookup* path in `resolveResponsibleUserIdForActivity` is already `isUuidLike`-guarded — the *insert* was not. |
| 3 | `routes/issues.ts` — `GET /companies/:companyId/issues` and `/issues/count` | `?projectId=` is routinely a project shortname (`QA`, `PUL`) rather than a uuid; it reaches `eq(issues.projectId, …)` unresolved. |

Pattern 2 is the cosmetic-but-loud one: the issue **is** created, then the audit insert throws, so the caller still sees a 500 and retries.

## Fix

Apply the same `isUuidLike` containment already used for `middleware/auth.ts`:

1. Gate the `heartbeat_runs` lookup on `isUuidLike`; a non-uuid run id means "no heartbeat run" instead of a cast error.
2. Drop a non-uuid `runId` before the `activity_log` insert. The original value is still emitted on the live event, so observability is unchanged.
3. Resolve `?projectId=` via `projectsSvc.resolveByReference()` (handles both uuid and shortname). An unresolvable reference skips the filter rather than failing the request.

## Verification

- `tsc --noEmit` on `server/` passes clean (0 errors).
- Checker calibrated first: with a deliberate `const x: number = "string"` injected into `activity-log.ts`, tsc reports exactly that one error and nothing else — so the green above is meaningful rather than a toolchain no-op.

## Known limitation

The `isUuidLike` guard fixes the **cast** failures. A run id that is a well-formed uuid but absent from `heartbeat_runs` would still trip the FK. Closing that needs an existence check on a hot path, which felt out of scope for a containment fix — happy to add it if you'd prefer.

## Note

Rebased onto current `master`: the original branch was 421 commits behind and had become unmergeable, so the change was re-applied cleanly rather than resolved through a large rebase. All three patterns were re-verified as still present on `master` before re-porting.
