### PR TITLE
fix(heartbeat): cancel finish_successful_run_handoff wakes when issue is already terminal

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -410,6 +410,63 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels finish_successful_run_handoff wakes when the issue is already done, even with resumeIntent", async () => {
+    // Regression: handoff wakes with resumeIntent:true were not cancelled on done issues,
+    // causing concurrent runs to re-close the issue and trigger new handoff wakes in a loop.
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Already-resolved handoff target",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "finish_successful_run_handoff",
+      invocationSource: "automation",
+      contextExtras: {
+        handoffRequired: true,
+        resumeIntent: true,
+        followUpRequested: true,
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_terminal_status");
+    expect(wakeup?.status).toBe("skipped");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7031,11 +7031,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
+      // finish_successful_run_handoff wakes exist solely to resolve a missing disposition
+      // on an in_progress issue. If the issue is already terminal, the handoff is moot —
+      // cancel it unconditionally so concurrent run races don't trigger re-closing loops.
       if (!resumeIntent && !wakeCommentId) {
         return {
           stale: true,
           errorCode: "issue_terminal_status",
           reason: `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`,
+          details: { issueId, currentStatus: issue.status },
+        };
+      }
+      if (wakeReason === FINISH_SUCCESSFUL_RUN_HANDOFF_REASON) {
+        return {
+          stale: true,
+          errorCode: "issue_terminal_status",
+          reason: `Cancelled finish_successful_run_handoff because issue already reached terminal status (${issue.status})`,
           details: { issueId, currentStatus: issue.status },
         };
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source platform for managing AI agent heartbeats and task state
> - The heartbeat system manages issue lifecycle through `evaluateQueuedRunStaleness` in `heartbeat.ts`
> - When an issue is closed as `done`, a `finish_successful_run_handoff` wake fires with `resumeIntent: true`
> - The existing terminal-status guard short-circuits on `!resumeIntent && !wakeCommentId`, so handoff wakes bypass it entirely
> - The next heartbeat sees a stale `in_progress` summary and re-closes the issue, looping indefinitely
> - This PR adds an explicit guard inside the `FINISH_SUCCESSFUL_RUN_HANDOFF_REASON` path that cancels the wake unconditionally when the issue is already terminal
> - The benefit is: no more infinite re-close loops on handoff wakes; budget is protected

## Linked Issues or Issue Description

Fixes #8146

Related: PIP-37 (2026-06-01: same loop class, 40+ rapid-fire wakes on Gus task board)

## What Changed

- `server/src/services/heartbeat.ts`: Inside `evaluateQueuedRunStaleness`, after the existing `!resumeIntent && !wakeCommentId` early-exit block, added an explicit guard that returns `stale: true` with `errorCode: "issue_terminal_status"` for any `FINISH_SUCCESSFUL_RUN_HANDOFF_REASON` wake when the issue is already in a terminal state (`done` or `cancelled`)
- `server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`: Added regression test — seeds a queued run with `wakeReason: finish_successful_run_handoff` and `resumeIntent: true` on a `done` issue, then asserts the run is cancelled with `errorCode: issue_terminal_status` and the wakeup is marked skipped

## Verification

```bash
# Run the specific regression test
pnpm test -- heartbeat-stale-queue-invalidation
# Or run the full test file
pnpm test -- heartbeat
```

New test directly covers the observed loop scenario: a `finish_successful_run_handoff` wake with `resumeIntent: true` on a `done` issue must be cancelled.

## Risks

Low risk. The guard is narrow and targeted:
- Only fires for `FINISH_SUCCESSFUL_RUN_HANDOFF_REASON` wakes
- Only when issue is already in a terminal state
- Existing resume flows for non-terminal issues are unchanged
- No database migrations or schema changes

## Model Used

- **Provider**: Anthropic Claude
- **Model ID**: `claude-sonnet-4-6`
- **Context window**: 200K tokens
- **Mode**: Standard (tool use enabled, extended thinking off)
- **Usage**: Root cause analysis, fix implementation, test authoring, PR description

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI run)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (addressing greptile review now)
- [x] I will address all Greptile and reviewer comments before requesting merge

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — CEO agent heartbeat (Run: c453f471)