### PR TITLE
fix(openclaw-gateway): bump PROTOCOL_VERSION to 4 and strip agentParams.paperclip

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,7 +86,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
@@ -1144,7 +1144,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  // OpenClaw gateway v4 AgentParamsSchema rejects unknown root properties (additionalProperties: false).
+  // Wake context is already embedded in message text; omit structured paperclip payload for v4 compatibility.
+  if (PROTOCOL_VERSION < 4) {
+    agentParams.paperclip = paperclipPayload;
+  } else {
+    delete agentParams.paperclip;
+  }
 
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;

--- a/packages/adapters/openclaw-gateway/src/server/test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/test.ts
@@ -145,8 +145,8 @@ async function probeGateway(input: {
             id: connectId,
             method: "connect",
             params: {
-              minProtocol: 3,
-              maxProtocol: 3,
+              minProtocol: 4,
+              maxProtocol: 4,
               client: {
                 id: "gateway-client",
                 version: "paperclip-probe",


### PR DESCRIPTION
## Problem

`@paperclipai/adapter-openclaw-gateway` hardcodes `PROTOCOL_VERSION = 3`. OpenClaw gateway `>= 2026.5.x` negotiates **protocol v4 only** (`probeMin=4`, v3 dropped, no compat flag) and its v4 `AgentParamsSchema` is `additionalProperties: false`. As a result every gateway-backed agent fails to connect with:

```
openclaw_gateway_request_failed: protocol mismatch   (WS close 1002)
```

## Fix

- `PROTOCOL_VERSION = 4`.
- Under v4, omit the root `agentParams.paperclip` field — the v4 schema rejects unknown root properties. Wake context is already embedded in the message text, so no information is lost. The field is still sent for `< 4` to stay backward compatible.
- Update the connectivity probe in `test.ts` to negotiate v4.

## Verification

Probe against a live OpenClaw gateway `2026.5.28`:

| protocol | connect result |
|---|---|
| 3 | `CONNECT_REJECTED` |
| 4 | `CONNECT_OK` |

After the change, gateway-backed agents reconnect and run successfully.

## Notes for maintainers

This is the same fix already proposed independently in several open PRs (e.g. #6480, #5984, #6188, #6138, #7283) — none merged yet. Posting this one with explicit probe evidence against a pinned gateway version to help get a canonical fix landed and **published in the next `paperclipai` release**, since downstream operators currently have to re-patch `node_modules` after every `npm i -g paperclipai` (the patch is wiped on reinstall). Happy to consolidate onto whichever PR you prefer.

If preferred, this could instead negotiate a `[3,4]` range; we pinned to 4 because it matches the gateways we run and is what we verified.