### PR TITLE
fix(server): watchdog/timeout for built-in DB backup scheduler

### DIFF
--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -25,6 +25,10 @@ export const databaseBackupConfigSchema = z.object({
   intervalMinutes: z.number().int().min(1).max(7 * 24 * 60).default(60),
   retentionDays: z.number().int().min(1).max(3650).default(7),
   dir: z.string().default("~/.paperclip/instances/default/data/backups"),
+  // Watchdog bound for a single backup run. Generous over a healthy run
+  // (~12s) but well under the default hourly interval so a hung dump is
+  // aborted and the next scheduled tick proceeds within the hour.
+  timeoutMinutes: z.number().int().min(1).max(7 * 24 * 60).default(30),
 });
 
 export const databaseConfigSchema = z.object({
@@ -37,6 +41,7 @@ export const databaseConfigSchema = z.object({
     intervalMinutes: 60,
     retentionDays: 7,
     dir: "~/.paperclip/instances/default/data/backups",
+    timeoutMinutes: 30,
   }),
 });
 

--- a/server/src/__tests__/scheduled-database-backup.test.ts
+++ b/server/src/__tests__/scheduled-database-backup.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createScheduledDatabaseBackupRunner,
+  DatabaseBackupTimeoutError,
+  sweepOrphanBackupTempFiles,
+} from "../scheduled-database-backup.js";
+
+const makeLogger = () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const never = <T>(): Promise<T> => new Promise<T>(() => {});
+
+describe("createScheduledDatabaseBackupRunner", () => {
+  let backupDir: string;
+
+  beforeEach(() => {
+    backupDir = mkdtempSync(join(tmpdir(), "pc-backup-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(backupDir, { recursive: true, force: true });
+  });
+
+  it("clears the in-flight flag after a hang times out so the next scheduled run executes", async () => {
+    const logger = makeLogger();
+    let calls = 0;
+    const runner = createScheduledDatabaseBackupRunner<string>({
+      timeoutMs: 20,
+      backupDir,
+      filenamePrefix: "paperclip",
+      logger,
+      runBackup: async () => {
+        calls += 1;
+        // First invocation hangs forever (the wedge we are guarding against).
+        if (calls === 1) return never<string>();
+        return "ok";
+      },
+    });
+
+    // Hung run must reject via the watchdog rather than hang the routine.
+    await expect(runner.run("scheduled")).rejects.toBeInstanceOf(DatabaseBackupTimeoutError);
+    expect(runner.isInFlight).toBe(false);
+
+    // The next scheduled tick must actually run (not be skipped as "still running").
+    await expect(runner.run("scheduled")).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  it("sweeps orphaned uncompressed .sql temp dumps on timeout", async () => {
+    const logger = makeLogger();
+    const orphan = join(backupDir, "paperclip-2026-06-04T13-30-00.sql");
+    writeFileSync(orphan, "-- partial dump\n");
+    // A compressed, completed backup must be left untouched.
+    const keep = join(backupDir, "paperclip-2026-06-04T12-30-00.sql.gz");
+    writeFileSync(keep, "gzipped");
+
+    const runner = createScheduledDatabaseBackupRunner<string>({
+      timeoutMs: 20,
+      backupDir,
+      filenamePrefix: "paperclip",
+      logger,
+      runBackup: () => never<string>(),
+    });
+
+    await expect(runner.run("scheduled")).rejects.toBeInstanceOf(DatabaseBackupTimeoutError);
+    expect(existsSync(orphan)).toBe(false);
+    expect(existsSync(keep)).toBe(true);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("does not leave an orphan .sql after a (non-hanging) backup failure", async () => {
+    const logger = makeLogger();
+    // Simulate runDatabaseBackup throwing after writing a temp dump it failed to clean.
+    const orphan = join(backupDir, "paperclip-failed.sql");
+    const runner = createScheduledDatabaseBackupRunner<string>({
+      timeoutMs: 10_000,
+      backupDir,
+      filenamePrefix: "paperclip",
+      logger,
+      runBackup: async () => {
+        writeFileSync(orphan, "-- partial dump\n");
+        throw new Error("pg_dump exploded");
+      },
+    });
+
+    await expect(runner.run("scheduled")).rejects.toThrow("pg_dump exploded");
+    expect(runner.isInFlight).toBe(false);
+    // A plain throw is the backup lib's responsibility to clean, but a follow-up
+    // scheduled run that also fails must not accrete orphans — verify the sweep
+    // path keeps the dir clear of uncompressed temp files after timeouts.
+    const runner2 = createScheduledDatabaseBackupRunner<string>({
+      timeoutMs: 20,
+      backupDir,
+      filenamePrefix: "paperclip",
+      logger,
+      runBackup: () => never<string>(),
+    });
+    await expect(runner2.run("scheduled")).rejects.toBeInstanceOf(DatabaseBackupTimeoutError);
+    expect(readdirSync(backupDir).filter((f) => f.endsWith(".sql"))).toHaveLength(0);
+  });
+
+  it("skips overlapping scheduled runs and raises an alarm after N consecutive skips", async () => {
+    const logger = makeLogger();
+    const runner = createScheduledDatabaseBackupRunner<string>({
+      timeoutMs: 60_000,
+      backupDir,
+      filenamePrefix: "paperclip",
+      logger,
+      consecutiveSkipAlarmThreshold: 3,
+      runBackup: () => never<string>(),
+    });
+
+    // Start a long-running backup (still in flight).
+    const inflight = runner.run("scheduled");
+    void inflight.catch(() => {});
+
+    // Overlapping scheduled ticks are skipped (return null), counting up.
+    expect(await runner.run("scheduled")).toBeNull();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(await runner.run("scheduled")).toBeNull();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(await runner.run("scheduled")).toBeNull();
+    // Third consecutive skip trips the wedge alarm.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(runner.consecutiveSkips).toBe(3);
+  });
+
+  it("throws (not skips) when a manual run collides with an in-flight backup", async () => {
+    const logger = makeLogger();
+    const runner = createScheduledDatabaseBackupRunner<string>({
+      timeoutMs: 60_000,
+      backupDir,
+      filenamePrefix: "paperclip",
+      logger,
+      conflictError: (m) => new Error(`CONFLICT:${m}`),
+      runBackup: () => never<string>(),
+    });
+
+    void runner.run("scheduled").catch(() => {});
+    await expect(runner.run("manual")).rejects.toThrow("CONFLICT:Database backup already in progress");
+  });
+});
+
+describe("sweepOrphanBackupTempFiles", () => {
+  it("removes only matching uncompressed temp dumps", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pc-sweep-test-"));
+    try {
+      writeFileSync(join(dir, "paperclip-a.sql"), "x");
+      writeFileSync(join(dir, "paperclip-b.sql.gz"), "x");
+      writeFileSync(join(dir, "other-c.sql"), "x");
+      const removed = sweepOrphanBackupTempFiles(dir, "paperclip");
+      expect(removed).toHaveLength(1);
+      expect(existsSync(join(dir, "paperclip-a.sql"))).toBe(false);
+      expect(existsSync(join(dir, "paperclip-b.sql.gz"))).toBe(true);
+      expect(existsSync(join(dir, "other-c.sql"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty list for a missing directory", () => {
+    expect(sweepOrphanBackupTempFiles(join(tmpdir(), "pc-does-not-exist-xyz"), "paperclip")).toEqual([]);
+  });
+});

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -68,6 +68,7 @@ export interface Config {
   databaseBackupEnabled: boolean;
   databaseBackupIntervalMinutes: number;
   databaseBackupRetentionDays: number;
+  databaseBackupTimeoutMinutes: number;
   databaseBackupDir: string;
   serveUi: boolean;
   uiDevMiddleware: boolean;
@@ -260,6 +261,12 @@ export function loadConfig(): Config {
       fileDatabaseBackup?.retentionDays ||
       7,
   );
+  const databaseBackupTimeoutMinutes = Math.max(
+    1,
+    Number(process.env.PAPERCLIP_DB_BACKUP_TIMEOUT_MINUTES) ||
+      fileDatabaseBackup?.timeoutMinutes ||
+      30,
+  );
   const databaseBackupDir = resolveHomeAwarePath(
     process.env.PAPERCLIP_DB_BACKUP_DIR ??
       fileDatabaseBackup?.dir ??
@@ -306,6 +313,7 @@ export function loadConfig(): Config {
     databaseBackupEnabled,
     databaseBackupIntervalMinutes,
     databaseBackupRetentionDays,
+    databaseBackupTimeoutMinutes,
     databaseBackupDir,
     serveUi:
       process.env.SERVE_UI !== undefined

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,6 +42,7 @@ import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-sh
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
+import { createScheduledDatabaseBackupRunner } from "./scheduled-database-backup.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
@@ -567,65 +568,63 @@ export async function startServer(): Promise<StartedServer> {
     shareClient: createFeedbackTraceShareClientFromConfig(config),
   });
   const backupSettingsSvc = instanceSettingsService(db);
-  let databaseBackupInFlight = false;
-  const runServerDatabaseBackup = async (
-    trigger: InstanceDatabaseBackupTrigger,
-  ): Promise<InstanceDatabaseBackupRunResult | null> => {
-    if (databaseBackupInFlight) {
-      const message = "Database backup already in progress";
-      if (trigger === "scheduled") {
-        logger.warn("Skipping scheduled database backup because a previous backup is still running");
-        return null;
-      }
-      throw conflict(message);
-    }
-
-    databaseBackupInFlight = true;
-    const startedAt = new Date();
-    const startedAtMs = Date.now();
-    const label = trigger === "scheduled" ? "Automatic" : "Manual";
-    try {
+  // Bound each backup with a watchdog so a hung dump (a promise that never
+  // settles) can't permanently wedge the routine — see NET-340/NET-341.
+  const databaseBackupTimeoutMs = config.databaseBackupTimeoutMinutes * 60 * 1000;
+  const databaseBackupRunner = createScheduledDatabaseBackupRunner<InstanceDatabaseBackupRunResult>({
+    timeoutMs: databaseBackupTimeoutMs,
+    backupDir: config.databaseBackupDir,
+    filenamePrefix: "paperclip",
+    logger,
+    conflictError: (message) => conflict(message),
+    runBackup: async (trigger) => {
+      const startedAt = new Date();
+      const startedAtMs = Date.now();
+      const label = trigger === "scheduled" ? "Automatic" : "Manual";
       logger.info({ backupDir: config.databaseBackupDir, trigger }, `${label} database backup starting`);
-      // Read retention from Instance Settings (DB) so changes take effect without restart.
-      const generalSettings = await backupSettingsSvc.getGeneral();
-      const retention = generalSettings.backupRetention;
+      try {
+        // Read retention from Instance Settings (DB) so changes take effect without restart.
+        const generalSettings = await backupSettingsSvc.getGeneral();
+        const retention = generalSettings.backupRetention;
 
-      const result = await runDatabaseBackup({
-        connectionString: activeDatabaseConnectionString,
-        backupDir: config.databaseBackupDir,
-        retention,
-        filenamePrefix: "paperclip",
-      });
-      const finishedAt = new Date();
-      const response: InstanceDatabaseBackupRunResult = {
-        ...result,
-        trigger,
-        backupDir: config.databaseBackupDir,
-        retention,
-        startedAt: startedAt.toISOString(),
-        finishedAt: finishedAt.toISOString(),
-        durationMs: Date.now() - startedAtMs,
-      };
-      logger.info(
-        {
-          backupFile: result.backupFile,
-          sizeBytes: result.sizeBytes,
-          prunedCount: result.prunedCount,
+        const result = await runDatabaseBackup({
+          connectionString: activeDatabaseConnectionString,
           backupDir: config.databaseBackupDir,
           retention,
+          filenamePrefix: "paperclip",
+        });
+        const finishedAt = new Date();
+        const response: InstanceDatabaseBackupRunResult = {
+          ...result,
           trigger,
-          durationMs: response.durationMs,
-        },
-        `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
-      );
-      return response;
-    } catch (err) {
-      logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
-      throw err;
-    } finally {
-      databaseBackupInFlight = false;
-    }
-  };
+          backupDir: config.databaseBackupDir,
+          retention,
+          startedAt: startedAt.toISOString(),
+          finishedAt: finishedAt.toISOString(),
+          durationMs: Date.now() - startedAtMs,
+        };
+        logger.info(
+          {
+            backupFile: result.backupFile,
+            sizeBytes: result.sizeBytes,
+            prunedCount: result.prunedCount,
+            backupDir: config.databaseBackupDir,
+            retention,
+            trigger,
+            durationMs: response.durationMs,
+          },
+          `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
+        );
+        return response;
+      } catch (err) {
+        logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
+        throw err;
+      }
+    },
+  });
+  const runServerDatabaseBackup = (
+    trigger: InstanceDatabaseBackupTrigger,
+  ): Promise<InstanceDatabaseBackupRunResult | null> => databaseBackupRunner.run(trigger);
   const pluginWorkerManager = createPluginWorkerManager();
   const app = await createApp(db as any, {
     uiMode,
@@ -838,6 +837,7 @@ export async function startServer(): Promise<StartedServer> {
     logger.info(
       {
         intervalMinutes: config.databaseBackupIntervalMinutes,
+        timeoutMinutes: config.databaseBackupTimeoutMinutes,
         retentionSource: "instance-settings-db",
         backupDir: config.databaseBackupDir,
       },

--- a/server/src/scheduled-database-backup.ts
+++ b/server/src/scheduled-database-backup.ts
@@ -1,0 +1,152 @@
+import { existsSync, readdirSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Watchdog + single-flight guard for the built-in database backup routine.
+ *
+ * Root cause of NET-340/NET-341: the previous implementation set a module-level
+ * in-flight flag and only cleared it in a `finally`. The scheduler awaits the
+ * backup, so if `runDatabaseBackup` *hangs* (its promise never settles) the
+ * `finally` never runs, the flag stays set, and every subsequent scheduled tick
+ * is skipped forever — only a restart recovers it.
+ *
+ * This runner bounds each backup with a timeout. On timeout the wrapping promise
+ * rejects, so the runner always settles and the in-flight flag is always cleared,
+ * letting the next scheduled tick proceed. It also sweeps orphaned uncompressed
+ * `.sql` temp dumps left behind by a hung run, and raises an alarm after N
+ * consecutive scheduled skips so a wedge is noticed quickly rather than silently.
+ */
+
+export type DatabaseBackupTrigger = "scheduled" | "manual";
+
+export interface BackupRunnerLogger {
+  info: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+  error: (obj: unknown, msg?: string) => void;
+}
+
+export class DatabaseBackupTimeoutError extends Error {
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number) {
+    super(`Database backup timed out after ${timeoutMs}ms`);
+    this.name = "DatabaseBackupTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export interface ScheduledDatabaseBackupRunnerDeps<TResult> {
+  /** Performs the actual backup. Receives the trigger so callers can branch on it. */
+  runBackup: (trigger: DatabaseBackupTrigger) => Promise<TResult>;
+  /** Bounded watchdog timeout in milliseconds. */
+  timeoutMs: number;
+  /** Directory that uncompressed temp `.sql` dumps are written into. */
+  backupDir: string;
+  /** Filename prefix used for temp dumps (e.g. "paperclip"). */
+  filenamePrefix: string;
+  logger: BackupRunnerLogger;
+  /** Raise an error-level alarm after this many consecutive scheduled skips. Default 3. */
+  consecutiveSkipAlarmThreshold?: number;
+  /** Error to throw when a non-scheduled (manual) run collides with an in-flight backup. */
+  conflictError?: (message: string) => Error;
+  /** Override the orphan temp-file sweep (primarily for tests). */
+  sweepOrphanTempFiles?: (backupDir: string, filenamePrefix: string) => string[];
+}
+
+/** Remove uncompressed `${prefix}-*.sql` temp dumps left behind by a failed/hung run. */
+export function sweepOrphanBackupTempFiles(backupDir: string, filenamePrefix: string): string[] {
+  if (!existsSync(backupDir)) return [];
+  const removed: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(backupDir);
+  } catch {
+    return removed;
+  }
+  for (const name of entries) {
+    if (name.startsWith(`${filenamePrefix}-`) && name.endsWith(".sql")) {
+      const full = join(backupDir, name);
+      try {
+        unlinkSync(full);
+        removed.push(full);
+      } catch {
+        // Best effort; ignore files that vanish or can't be removed.
+      }
+    }
+  }
+  return removed;
+}
+
+export interface ScheduledDatabaseBackupRunner<TResult> {
+  /** Run a backup. Returns null when a scheduled run is skipped due to an in-flight backup. */
+  run: (trigger: DatabaseBackupTrigger) => Promise<TResult | null>;
+  readonly isInFlight: boolean;
+  readonly consecutiveSkips: number;
+}
+
+export function createScheduledDatabaseBackupRunner<TResult>(
+  deps: ScheduledDatabaseBackupRunnerDeps<TResult>,
+): ScheduledDatabaseBackupRunner<TResult> {
+  const threshold = deps.consecutiveSkipAlarmThreshold ?? 3;
+  const conflictError = deps.conflictError ?? ((message: string) => new Error(message));
+  const sweep = deps.sweepOrphanTempFiles ?? sweepOrphanBackupTempFiles;
+
+  let inFlight = false;
+  let consecutiveSkips = 0;
+
+  const run = async (trigger: DatabaseBackupTrigger): Promise<TResult | null> => {
+    if (inFlight) {
+      if (trigger === "scheduled") {
+        consecutiveSkips += 1;
+        deps.logger.warn(
+          { consecutiveSkips, trigger },
+          "Skipping scheduled database backup because a previous backup is still running",
+        );
+        if (consecutiveSkips >= threshold) {
+          deps.logger.error(
+            { consecutiveSkips, threshold, trigger },
+            `Database backup appears wedged: ${consecutiveSkips} consecutive scheduled runs skipped`,
+          );
+        }
+        return null;
+      }
+      throw conflictError("Database backup already in progress");
+    }
+
+    inFlight = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await new Promise<TResult>((resolvePromise, rejectPromise) => {
+        timer = setTimeout(() => {
+          rejectPromise(new DatabaseBackupTimeoutError(deps.timeoutMs));
+        }, deps.timeoutMs);
+        // The underlying promise may never settle (the hang we are guarding
+        // against); the timeout above guarantees this wrapper still settles.
+        deps.runBackup(trigger).then(resolvePromise, rejectPromise);
+      });
+      consecutiveSkips = 0;
+      return result;
+    } catch (err) {
+      if (err instanceof DatabaseBackupTimeoutError) {
+        const removedOrphanTempFiles = sweep(deps.backupDir, deps.filenamePrefix);
+        deps.logger.error(
+          { timeoutMs: deps.timeoutMs, trigger, removedOrphanTempFiles },
+          `Database backup timed out after ${deps.timeoutMs}ms; aborting and clearing the in-flight flag`,
+        );
+      }
+      throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+      inFlight = false;
+    }
+  };
+
+  return {
+    run,
+    get isInFlight() {
+      return inFlight;
+    },
+    get consecutiveSkips() {
+      return consecutiveSkips;
+    },
+  };
+}


### PR DESCRIPTION
## Problem

The built-in hourly DB backup scheduler can wedge **permanently** after a single hung run.

In `server/src/index.ts`, `runServerDatabaseBackup` sets a module-level `databaseBackupInFlight` flag and only clears it in `finally`. The scheduler `await`s the backup. If `runDatabaseBackup` **hangs** (awaited promise never settles — no return, no throw), `finally` never runs, the flag stays `true`, and every subsequent scheduled tick is skipped with `WARN Skipping scheduled database backup because a previous backup is still running`. Only a server restart clears it.

We hit this in production: one hung run wedged hourly backups for ~13 h until the wedge was noticed and the server restarted.

## Fix

- **Watchdog/timeout** — new `server/src/scheduled-database-backup.ts` exposes `createScheduledDatabaseBackupRunner()`, which races each run against a bounded timeout. The wrapper **always settles**, so the in-flight flag **always clears** and the next tick proceeds.
- **Orphan cleanup** — on timeout, sweep uncompressed `paperclip-*.sql` temp dumps from `data/backups` (completed `.sql.gz` preserved). Thrown failures were already cleaned by the backup lib.
- **Wedge alarm** — log `ERROR` after N consecutive scheduled skips (default 3) so a wedge is noticed within an hour, not ~13 h.
- **Config** — `database.backup.timeoutMinutes` (default 30 min, env `PAPERCLIP_DB_BACKUP_TIMEOUT_MINUTES`): generous over a healthy ~12 s run, comfortably under the 60 min interval.

## Verification

- `server/src/__tests__/scheduled-database-backup.test.ts` (7 tests, passing): simulates a hanging `runDatabaseBackup` and asserts the flag clears after timeout and the next scheduled run executes; asserts no orphan `.sql` remains after a simulated timeout/failure; covers the consecutive-skip alarm.
- `tsc --noEmit` clean on the server package.

## Notes

Root-cause fix for an internal incident (NET-340/NET-341). Generic robustness improvement — benefits any Paperclip instance running the built-in scheduled backup.