### PR TITLE
fix(ui): theme the onboarding wizard decorative panel instead of hardcoding dark

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1623,7 +1623,7 @@ export function OnboardingWizard() {
               name + mission steps) */}
           <div
             className={cn(
-              "hidden md:block overflow-hidden bg-[#1d1d1d] transition-[width,opacity] duration-500 ease-in-out",
+              "hidden md:block overflow-hidden bg-muted text-muted-foreground transition-[width,opacity] duration-500 ease-in-out",
               step === 1 || step === 2 ? "w-1/2 opacity-100" : "w-0 opacity-0"
             )}
           >

--- a/ui/src/components/OnboardingWizardClassic.tsx
+++ b/ui/src/components/OnboardingWizardClassic.tsx
@@ -1272,7 +1272,7 @@ export function OnboardingWizardClassic() {
           {/* Right half — ASCII art (hidden on mobile) */}
           <div
             className={cn(
-              "hidden md:block overflow-hidden bg-[#1d1d1d] transition-[width,opacity] duration-500 ease-in-out",
+              "hidden md:block overflow-hidden bg-muted text-muted-foreground transition-[width,opacity] duration-500 ease-in-out",
               step === 1 ? "w-1/2 opacity-100" : "w-0 opacity-0"
             )}
           >

--- a/ui/src/components/OnboardingWizardTheme.test.tsx
+++ b/ui/src/components/OnboardingWizardTheme.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The onboarding wizard's decorative right-hand panel (which renders the
+// ASCII paperclip illustration) must follow the active shadcn theme instead of
+// hardcoding a dark surface. Otherwise a light/cream deployer theme (set via
+// the PAPERCLIP_DEFAULT_THEME bootstrap) renders a jarring cream form next to a
+// solid dark panel. The illustration glyphs already use `text-muted-foreground`,
+// so the panel must sit on the paired `bg-muted` surface to read as an
+// intentional ink-on-surface texture in every theme.
+//
+// Asserting against the source keeps this guard cheap: the panel className is a
+// static string literal, and the full wizard dialog is too heavy to mount here.
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function readComponent(file: string): string {
+  return readFileSync(path.join(here, file), "utf8");
+}
+
+describe("OnboardingWizard decorative panel theming", () => {
+  for (const file of ["OnboardingWizard.tsx", "OnboardingWizardClassic.tsx"]) {
+    describe(file, () => {
+      const source = readComponent(file);
+
+      it("does not hardcode a dark decorative panel background", () => {
+        expect(source).not.toContain("bg-[#1d1d1d]");
+        expect(source).not.toMatch(/bg-\[#[0-9a-fA-F]{3,8}\]/);
+      });
+
+      it("themes the decorative panel with shadcn surface tokens", () => {
+        expect(source).toContain("bg-muted text-muted-foreground");
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Problem

The first-run onboarding wizard's right-hand decorative panel (which renders the ASCII paperclip illustration, in both `OnboardingWizard.tsx` and `OnboardingWizardClassic.tsx`) hardcodes `bg-[#1d1d1d]`. So it always renders a solid dark surface even when the document theme is light. Under a light theme, the cream/light shadcn-themed form sits next to a jarring dark panel on signup.

## Fix

Switch the panel background from the hardcoded `bg-[#1d1d1d]` to the shadcn `bg-muted` surface token (plus a `text-muted-foreground` default for any inherited glyphs).

The illustration glyphs in `AsciiArtAnimation.tsx` already use `text-muted-foreground/60`, which is the designed foreground pair for the `muted` surface. On `bg-muted` they read as an intentional ink-on-surface texture that follows the active theme in both light and dark, instead of light-on-dark only.

Only the colors change. The `hidden md:block` layout and the `transition-[width,opacity]` animation are untouched.

## Tests

Adds `OnboardingWizardTheme.test.tsx`: a source-level guard asserting neither wizard variant hardcodes a dark panel hex and both use the `bg-muted text-muted-foreground` surface tokens. `tsc -b` clean; the new test plus the existing `OnboardingWizardVariant` and `Auth` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)