### PR TITLE
fix(db): disable prepared statements to avoid postgres Date-bind 500

### DIFF
--- a/packages/db/src/client.prepare.test.ts
+++ b/packages/db/src/client.prepare.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the postgres client and the drizzle adapter so we can assert the options
+// `createDb` passes without opening a real connection. `vi.hoisted` keeps the
+// mock fns available to the hoisted `vi.mock` factories.
+const { postgresMock, drizzleMock } = vi.hoisted(() => ({
+  postgresMock: vi.fn((_url: string, _options?: Record<string, unknown>) => ({
+    __fakeSql: true,
+  })),
+  drizzleMock: vi.fn((client: unknown) => ({ __fakeDrizzle: true, client })),
+}));
+
+vi.mock("postgres", () => ({ default: postgresMock }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: drizzleMock }));
+
+import { createDb } from "./client.js";
+
+describe("createDb prepared-statement safety (#8148)", () => {
+  beforeEach(() => {
+    postgresMock.mockClear();
+    drizzleMock.mockClear();
+  });
+
+  it("passes { prepare: false } to postgres so named prepared statements are disabled", () => {
+    // Regression guard: with prepared statements enabled, postgres@3.4.x can
+    // crash in its ParameterDescription -> Bind path when a Date parameter
+    // reaches Buffer.byteLength (observed as a 500 on the comment-delta query).
+    // Disabling prepare avoids that path; this asserts the flag stays set.
+    const url = "postgres://user:pass@localhost:5432/paperclip";
+
+    createDb(url);
+
+    expect(postgresMock).toHaveBeenCalledTimes(1);
+    const [passedUrl, options] = postgresMock.mock.calls[0];
+    expect(passedUrl).toBe(url);
+    expect(options).toMatchObject({ prepare: false });
+  });
+});

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -46,7 +46,15 @@ export type MigrationState =
     };
 
 export function createDb(url: string) {
-  const sql = postgres(url);
+  // prepare: false disables named/cached prepared statements. This avoids an
+  // intermittent crash in postgres@3.4.x's prepared-statement bind path
+  // (ParameterDescription -> Bind), where a Date parameter can reach
+  // Buffer.byteLength and throw `ERR_INVALID_ARG_TYPE: ... Received an instance
+  // of Date` (observed on GET /issues/:id/comments?after=&order=asc). Parameters
+  // are still sent as out-of-band bind values, so this changes nothing about
+  // SQL-injection safety; the only effect is skipping per-statement plan caching,
+  // which is negligible for this workload.
+  const sql = postgres(url, { prepare: false });
   return drizzlePg(sql, { schema });
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; a Postgres database backs every issue, comment, and run.
> - The `@paperclipai/db` package builds the shared postgres client in `createDb()` (`packages/db/src/client.ts`), used by the server for all queries.
> - That client is created with prepared statements enabled (the `porsager/postgres` default), so parsed statements are named and cached per connection.
> - Under `postgres@3.4.x` a `Date` bind parameter can reach `Buffer.byteLength` inside the prepared-statement `ParameterDescription -> Bind` path and throw `ERR_INVALID_ARG_TYPE`, crashing the request.
> - It surfaces intermittently as a **500 on `GET /api/issues/:id/comments?after=<id>&order=asc`** (the incremental comment-delta call) and clears on restart, so it is easy to miss and hard to reproduce on demand.
> - This PR sets `prepare: false` on the main client so postgres uses unnamed, one-shot statements and never enters the crashing re-bind path.
> - The benefit is a stable comment-delta endpoint with no change to parameterization, results, or meaningful performance.

## Linked Issues or Issue Description

No public GitHub issue exists for this; describing the bug in-PR per the bug-report template.

**Bug report**
- **What happened:** Intermittent `500` responses from `GET /api/issues/:id/comments?after=<id>&order=asc`. Server logs show:
  ```
  TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
    or an instance of Buffer or ArrayBuffer. Received an instance of Date
      at Buffer.byteLength (node:buffer)
      at reset.str (postgres/src/bytes.js:22)
      at Bind (postgres/src/connection.js:954)
      at prepared (postgres/src/connection.js:209)
      at ParameterDescription (postgres/src/connection.js:633)
  ```
- **Expected:** The comment-delta query returns comments without crashing.
- **Steps / conditions:** Non-deterministic — depends on per-connection prepared-statement state under `postgres@3.4.x`. It recurs across a live multi-tenant instance (observed hundreds of times in a single log window, always on this endpoint, never on comment creation) and temporarily clears after a restart.
- **Environment:** `@paperclipai/db` using `postgres@3.4.x`.

## What Changed

- `packages/db/src/client.ts` (`createDb`): pass `{ prepare: false }` to `postgres()` and add an explanatory comment. `createUtilitySql` (migration/admin client) is intentionally left unchanged — it does not bind `Date` parameters.
- `packages/db/src/client.prepare.test.ts` (new): unit test mocking `postgres`/`drizzle` that asserts `createDb` passes `{ prepare: false }`, guarding against regression. Runs without a database.

## Verification

- `pnpm --filter @paperclipai/db exec vitest run src/client.prepare.test.ts` → 1 passed.
- `pnpm --filter @paperclipai/db exec tsc --noEmit` → clean.
- Behavioural rationale: `prepare: false` skips the named-statement `ParameterDescription -> Bind` path the stack trace implicates, so the `Date`-bind crash cannot occur; parameters are still transmitted as out-of-band Bind values.

## Risks

- **Low risk.** No SQL-injection change: `prepare: false` does not switch to string interpolation — parameters remain out-of-band Bind values; only named-statement caching is disabled.
- **No result/behaviour change:** same rows, types, and transactions.
- **Negligible performance cost:** re-parses/re-plans per query instead of reusing a cached statement; no extra round-trip (Parse+Bind+Execute still pipeline in one flush). `prepare: false` is also the recommended setting behind transaction-pooling poolers (e.g. PgBouncer transaction mode).

## Model Used

Anthropic **Claude** via **Claude Code** (autonomous agent). This revision (description + test) authored with **Claude Opus 4.8** (`claude-opus-4-8`), extended-thinking + tool use (shell, git). The original one-line fix was produced by an earlier Claude Code agent run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (searched "prepare false prepared statement", "postgres Date bind 500" — no duplicates found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details (branch `net-53-db-prepare-false-fork` predates this guideline; renaming would require closing/reopening the PR and lose the review thread — happy to do so if a maintainer prefers)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (n/a — no user-facing docs affected)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
