### PR TITLE
fix(routines): link parent issue scope for execution wakeups

### DIFF
--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -224,7 +224,7 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
       id: parentIssueId,
       companyId,
       projectId,
-      identifier: "PAP-11248",
+      identifier: `PAP-${randomUUID().slice(0, 8)}`,
       title: "Routine report target",
       status: "in_progress",
       priority: "high",

--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -219,6 +219,16 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
 
   it("supports creating, scheduling, and manually running a routine through the API", async () => {
     const { companyId, agentId, projectId, userId } = await seedFixture();
+    const parentIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId,
+      identifier: "PAP-11248",
+      title: "Routine report target",
+      status: "in_progress",
+      priority: "high",
+    });
     const app = await createApp({
       type: "board",
       userId,
@@ -231,6 +241,7 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
       .post(`/api/companies/${companyId}/routines`)
       .send({
         projectId,
+        parentIssueId,
         title: "Daily standup prep",
         description: "Summarize blockers and open PRs",
         assigneeAgentId: agentId,
@@ -310,6 +321,19 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
       originKind: "routine_execution",
     });
     expect(issue?.executionRunId).toBeTruthy();
+
+    const [queuedRun] = await db
+      .select({
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, issue!.executionRunId!));
+
+    expect(queuedRun?.contextSnapshot).toMatchObject({
+      issueId: runRes.body.linkedIssueId,
+      issueIds: [runRes.body.linkedIssueId, parentIssueId],
+      source: "routine.dispatch",
+    });
 
     const actions = await db
       .select({

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -21,6 +21,7 @@ export interface IssueAssignmentWakeupDeps {
 export function queueIssueAssignmentWakeup(input: {
   heartbeat: IssueAssignmentWakeupDeps;
   issue: { id: string; assigneeAgentId: string | null; status: string };
+  linkedIssueIds?: string[];
   reason: string;
   mutation: string;
   contextSource: string;
@@ -29,16 +30,17 @@ export function queueIssueAssignmentWakeup(input: {
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  const issueIds = [...new Set([input.issue.id, ...(input.linkedIssueIds ?? [])].filter(Boolean))];
 
   return input.heartbeat
     .wakeup(input.issue.assigneeAgentId, {
       source: "assignment",
       triggerDetail: "system",
       reason: input.reason,
-      payload: { issueId: input.issue.id, mutation: input.mutation },
+      payload: { issueId: input.issue.id, issueIds, mutation: input.mutation },
       requestedByActorType: input.requestedByActorType,
       requestedByActorId: input.requestedByActorId ?? null,
-      contextSnapshot: { issueId: input.issue.id, source: input.contextSource },
+      contextSnapshot: { issueId: input.issue.id, issueIds, source: input.contextSource },
     })
     .catch((err) => {
       logger.warn({ err, issueId: input.issue.id }, "failed to wake assignee on issue assignment");

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -30,17 +30,26 @@ export function queueIssueAssignmentWakeup(input: {
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
-  const issueIds = [...new Set([input.issue.id, ...(input.linkedIssueIds ?? [])].filter(Boolean))];
+  const hasLinkedIssueIds = (input.linkedIssueIds?.length ?? 0) > 0;
+  const issueIds = hasLinkedIssueIds
+    ? [...new Set([input.issue.id, ...(input.linkedIssueIds ?? [])].filter(Boolean))]
+    : null;
+  const payload = issueIds
+    ? { issueId: input.issue.id, issueIds, mutation: input.mutation }
+    : { issueId: input.issue.id, mutation: input.mutation };
+  const contextSnapshot = issueIds
+    ? { issueId: input.issue.id, issueIds, source: input.contextSource }
+    : { issueId: input.issue.id, source: input.contextSource };
 
   return input.heartbeat
     .wakeup(input.issue.assigneeAgentId, {
       source: "assignment",
       triggerDetail: "system",
       reason: input.reason,
-      payload: { issueId: input.issue.id, issueIds, mutation: input.mutation },
+      payload,
       requestedByActorType: input.requestedByActorType,
       requestedByActorId: input.requestedByActorId ?? null,
-      contextSnapshot: { issueId: input.issue.id, issueIds, source: input.contextSource },
+      contextSnapshot,
     })
     .catch((err) => {
       logger.warn({ err, issueId: input.issue.id }, "failed to wake assignee on issue assignment");

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1370,6 +1370,7 @@ export function routineService(
         await queueIssueAssignmentWakeup({
           heartbeat,
           issue: createdIssue,
+          linkedIssueIds: input.routine.parentIssueId ? [input.routine.parentIssueId] : [],
           reason: "issue_assigned",
           mutation: "create",
           contextSource: "routine.dispatch",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and their issue-scoped execution runs.
> - Routine executions create issue-assignment wakeups that adapters turn into runtime environment variables.
> - Adapters already expose trusted linked issue scope through `PAPERCLIP_LINKED_ISSUE_IDS` when `context.issueIds` is present.
> - Routine execution issues can have a parent issue that owns the report/review thread, but the assignment wake context only carried the child execution issue.
> - That meant routine executors could be scoped to the execution issue only and fail when posting back to their parent report issue.
> - This pull request carries the routine execution parent issue as trusted linked scope in the assignment wake context.
> - The benefit is routine executors can safely post to their parent/report issue without broadening access beyond the server-created issue relationship.

## Linked Issues or Issue Description

No upstream issue exists. This PR describes the bug inline following the bug report template.

**Pre-submission checklist**

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am reproducing/fixing against `master`.
- [x] I have confirmed the error originates in Paperclip core routine wakeup scoping, not in an agent adapter, API provider, or local configuration.

**What happened?**

A routine execution issue was created for a routine with a parent/report issue. The assignment wake context only included the execution issue ID, so adapters populated the execution run with no linked parent issue scope. When the routine executor attempted to post its report back to the parent/report issue, issue-scoped authorization rejected the write because the parent issue was not in `PAPERCLIP_LINKED_ISSUE_IDS`.

**Expected behavior**

When Paperclip creates a routine execution issue under a parent/report issue, the queued assignment wake should include the parent issue as trusted linked scope. The executor should retain narrow issue scope while being able to post back to the server-known parent/report issue.

**Steps to reproduce**

1. Create a routine with `parentIssueId` set.
2. Dispatch the routine so Paperclip creates an execution issue and queues an assignment wake.
3. Inspect the queued run context snapshot or adapter environment.
4. Observe that the execution issue is present but the parent/report issue is missing from linked issue scope.

**Paperclip version or commit**

`master` before this PR; fixed and tested at PR head `d832ee63d3f2d057b057486779fe6847b78b3fad`.

**Deployment mode**

Local dev / server test harness.

**Installation method**

Built from source.

**Agent adapter(s) involved**

Not adapter-specific. Core server wakeup context is missing linked issue scope before adapters receive it.

**Database mode**

Test database via existing server test harness.

**Access context**

Agent bearer API key via issue-scoped execution run.

**Node.js version**

Repository default development environment.

**Operating system**

Ubuntu/Linux CI-compatible local environment.

**Relevant logs or output**

Local regression coverage asserts the queued run context now includes both the execution issue ID and parent issue ID. No secrets or customer data are included.

**Relevant config**

Not applicable.

**Additional context**

Related but not duplicate PR found during duplicate search: https://github.com/paperclipai/paperclip/pull/3933.

**Privacy checklist**

- [x] I have reviewed pasted output for PII, file paths, API keys, tokens, company names, and redacted/omitted sensitive values.

## What Changed

- Added optional `linkedIssueIds` support to `queueIssueAssignmentWakeup` and included the deduplicated issue scope in both wake payload and context snapshot.
- Updated routine dispatch to pass the routine parent issue ID as linked scope when creating a routine execution issue.
- Added regression coverage in the routine route E2E test to assert the queued run context includes both execution issue and parent issue IDs.

## Verification

- Dedup/search performed: `gh search prs --repo paperclipai/paperclip "routine linked issue scope"` returned one related closed PR, https://github.com/paperclipai/paperclip/pull/3933, and no open duplicate issue was found by `gh search issues --repo paperclipai/paperclip "routine linked issue scope"`.
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/routines-e2e.test.ts server/src/__tests__/routine-run-telemetry.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

Low risk. The added linked scope is limited to the server-known execution issue and routine parent issue, deduplicated before dispatch. Existing assignment wake consumers that ignore `issueIds` continue to receive the existing `issueId` field.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex via the Codex CLI/API coding agent, with tool-assisted repository inspection, local shell execution, and patch editing in a large-context production-support session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge