### PR TITLE
fix(plugins): wire the plugin stream bus so SSE streaming actually works

### DIFF
--- a/server/src/__tests__/plugin-stream-bus.test.ts
+++ b/server/src/__tests__/plugin-stream-bus.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPluginStreamBus,
+  publishWorkerStreamNotification,
+} from "../services/plugin-stream-bus.js";
+import { createPluginWorkerManager } from "../services/plugin-worker-manager.js";
+
+describe("PluginStreamBus", () => {
+  it("delivers a published event only to subscribers of the matching tuple", () => {
+    const bus = createPluginStreamBus();
+    const match = vi.fn();
+    const wrongChannel = vi.fn();
+    const wrongCompany = vi.fn();
+
+    bus.subscribe("plugin-a", "chan-1", "co-1", match);
+    bus.subscribe("plugin-a", "chan-2", "co-1", wrongChannel);
+    bus.subscribe("plugin-a", "chan-1", "co-2", wrongCompany);
+
+    bus.publish("plugin-a", "chan-1", "co-1", { type: "text", text: "hi" });
+
+    expect(match).toHaveBeenCalledTimes(1);
+    expect(match).toHaveBeenCalledWith({ type: "text", text: "hi" }, "message");
+    expect(wrongChannel).not.toHaveBeenCalled();
+    expect(wrongCompany).not.toHaveBeenCalled();
+  });
+
+  it("stops delivering after unsubscribe", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    const unsubscribe = bus.subscribe("p", "c", "co", listener);
+
+    bus.publish("p", "c", "co", { n: 1 });
+    unsubscribe();
+    bus.publish("p", "c", "co", { n: 2 });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ n: 1 }, "message");
+  });
+});
+
+describe("publishWorkerStreamNotification", () => {
+  it("maps streams.emit to a 'message' event and forwards the payload", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("p", "chat:thread", "co", listener);
+
+    publishWorkerStreamNotification(bus, "p", "streams.emit", {
+      channel: "chat:thread",
+      companyId: "co",
+      event: { type: "text", text: "token" },
+    });
+
+    expect(listener).toHaveBeenCalledWith({ type: "text", text: "token" }, "message");
+  });
+
+  it("maps streams.open and streams.close to their event types", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("p", "c", "co", listener);
+
+    publishWorkerStreamNotification(bus, "p", "streams.open", { channel: "c", companyId: "co" });
+    publishWorkerStreamNotification(bus, "p", "streams.close", { channel: "c", companyId: "co" });
+
+    expect(listener).toHaveBeenNthCalledWith(1, null, "open");
+    expect(listener).toHaveBeenNthCalledWith(2, null, "close");
+  });
+
+  it("drops notifications missing channel or companyId", () => {
+    const bus = createPluginStreamBus();
+    const publishSpy = vi.spyOn(bus, "publish");
+
+    publishWorkerStreamNotification(bus, "p", "streams.emit", { companyId: "co", event: {} });
+    publishWorkerStreamNotification(bus, "p", "streams.emit", { channel: "c", event: {} });
+
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("PluginWorkerManager stream handler wiring", () => {
+  it("exposes a settable stream-notification handler (fixes the orphaned-bus case)", () => {
+    // Regression guard for the wiring gap: the server must be able to attach the
+    // stream handler to a manager it was handed (the production entrypoint
+    // injects the manager), not only via the constructor. A manager that lacked
+    // this setter would leave the SSE bus orphaned — opening connections that
+    // never receive events instead of failing fast.
+    const manager = createPluginWorkerManager();
+    expect(typeof manager.setStreamNotificationHandler).toBe("function");
+    // Setting and detaching must not throw.
+    expect(() => manager.setStreamNotificationHandler(() => {})).not.toThrow();
+    expect(() => manager.setStreamNotificationHandler(null)).not.toThrow();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -52,6 +52,7 @@ import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
 import { createPluginWorkerManager, type PluginWorkerManager } from "./services/plugin-worker-manager.js";
+import { createPluginStreamBus, publishWorkerStreamNotification } from "./services/plugin-stream-bus.js";
 import { createPluginJobScheduler } from "./services/plugin-job-scheduler.js";
 import { pluginJobStore } from "./services/plugin-job-store.js";
 import { createPluginToolDispatcher } from "./services/plugin-tool-dispatcher.js";
@@ -203,7 +204,22 @@ export async function createApp(
   app.use(llmRoutes(db));
 
   const hostServicesDisposers = new Map<string, () => void>();
+
+  // Real-time plugin streaming. The SSE pipeline (PluginStreamBus, the
+  // /plugins/:id/bridge/stream/:channel route, worker-side stream RPC handlers,
+  // and the usePluginStream() hook) already exists in core but was never
+  // connected: nothing created a stream bus or routed worker stream
+  // notifications into it, so the SSE route returned 501 and `ctx.streams.emit`
+  // went nowhere. Wire them together here. We set the manager's stream handler
+  // *after* obtaining the manager (rather than only via its constructor) so the
+  // bus is populated whether the manager was created here or injected by the
+  // caller (the production entrypoint injects one). Plugins that don't stream
+  // are unaffected (they never open a channel).
+  const streamBus = createPluginStreamBus();
   const workerManager = opts.pluginWorkerManager ?? createPluginWorkerManager();
+  workerManager.setStreamNotificationHandler((pluginId, method, params) =>
+    publishWorkerStreamNotification(streamBus, pluginId, method, params),
+  );
 
   // Mount API routes
   const api = Router();
@@ -317,7 +333,7 @@ export async function createApp(
       { scheduler, jobStore },
       { workerManager },
       { toolDispatcher },
-      { workerManager },
+      { workerManager, streamBus },
     ),
   );
   api.use(adapterRoutes());

--- a/server/src/services/plugin-stream-bus.ts
+++ b/server/src/services/plugin-stream-bus.ts
@@ -46,6 +46,26 @@ export interface PluginStreamBus {
 }
 
 /**
+ * Map a worker stream notification (`streams.open` / `streams.emit` /
+ * `streams.close`, as forwarded by the worker manager) onto a bus publish.
+ * Drops notifications missing a channel or companyId. Shared so every caller
+ * that wires the manager's stream handler maps event types identically.
+ */
+export function publishWorkerStreamNotification(
+  bus: PluginStreamBus,
+  pluginId: string,
+  method: string,
+  params: Record<string, unknown>,
+): void {
+  const channel = typeof params.channel === "string" ? params.channel : "";
+  const companyId = typeof params.companyId === "string" ? params.companyId : "";
+  if (!channel || !companyId) return;
+  const eventType: StreamEventType =
+    method === "streams.open" ? "open" : method === "streams.close" ? "close" : "message";
+  bus.publish(pluginId, channel, companyId, (params as { event?: unknown }).event ?? null, eventType);
+}
+
+/**
  * Create a new PluginStreamBus instance.
  */
 export function createPluginStreamBus(): PluginStreamBus {

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -322,6 +322,21 @@ export interface PluginWorkerManager {
   startWorker(pluginId: string, options: WorkerStartOptions): Promise<PluginWorkerHandle>;
 
   /**
+   * Register (or replace) the manager-level stream-notification handler. The
+   * manager forwards every worker's `streams.open/emit/close` notifications to
+   * it, unless that worker supplied its own per-start `onStreamNotification`.
+   * The server wires this to the PluginStreamBus. It is safe to call after the
+   * manager is constructed (and after it has been injected into the app),
+   * because workers are started later; the forwarder reads the current handler
+   * at notification time. Pass `null` to detach.
+   */
+  setStreamNotificationHandler(
+    handler:
+      | ((pluginId: string, method: string, params: Record<string, unknown>) => void)
+      | null,
+  ): void;
+
+  /**
    * Stop and unregister a specific plugin worker.
    */
   stopWorker(pluginId: string): Promise<void>;
@@ -1325,6 +1340,20 @@ export interface PluginWorkerManagerOptions {
     signal?: string | null;
     willRestart?: boolean;
   }) => void;
+
+  /**
+   * Optional callback invoked when any worker emits a stream notification
+   * (`streams.open` / `streams.emit` / `streams.close`). The server wires this
+   * to the `PluginStreamBus` so `ctx.streams.emit()` events fan out to SSE
+   * clients. Without it, plugin streaming is inert and plugins fall back to
+   * polling. The manager injects it into per-worker options for every worker
+   * that does not already supply its own `onStreamNotification`.
+   */
+  onStreamNotification?: (
+    pluginId: string,
+    method: string,
+    params: Record<string, unknown>,
+  ) => void;
 }
 
 /**
@@ -1360,8 +1389,20 @@ export function createPluginWorkerManager(
   const workers = new Map<string, PluginWorkerHandle>();
   /** Per-plugin startup locks to prevent concurrent spawn races. */
   const startupLocks = new Map<string, Promise<PluginWorkerHandle>>();
+  /**
+   * Manager-level stream-notification handler. Initialized from options and
+   * replaceable via setStreamNotificationHandler(); the per-worker forwarder
+   * reads it live so it can be wired after construction.
+   */
+  let streamHandler:
+    | ((pluginId: string, method: string, params: Record<string, unknown>) => void)
+    | null = managerOptions?.onStreamNotification ?? null;
 
   return {
+    setStreamNotificationHandler(handler) {
+      streamHandler = handler;
+    },
+
     async startWorker(
       pluginId: string,
       options: WorkerStartOptions,
@@ -1380,7 +1421,21 @@ export function createPluginWorkerManager(
         );
       }
 
-      const handle = createPluginWorkerHandle(pluginId, options);
+      // Forward this worker's stream notifications to the manager-level handler
+      // (e.g. the PluginStreamBus) unless the worker supplied its own. This is
+      // what connects `ctx.streams.emit()` to SSE clients; the per-worker hook
+      // already existed, but nothing populated it from the manager level. The
+      // forwarder reads `streamHandler` at notification time, so wiring the
+      // handler after construction (the server does this once it has the bus)
+      // still applies to workers started later.
+      const effectiveOptions: WorkerStartOptions = options.onStreamNotification
+        ? options
+        : {
+            ...options,
+            onStreamNotification: (method, params) => streamHandler?.(pluginId, method, params),
+          };
+
+      const handle = createPluginWorkerHandle(pluginId, effectiveOptions);
       workers.set(pluginId, handle);
 
       // Subscribe to crash/ready events for live event forwarding


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and it ships a plugin SDK so third parties can extend the UI and workers.
> - The plugin runtime includes a real-time streaming capability: workers call `ctx.streams.open/emit/close`, the UI subscribes with `usePluginStream()`, and an SSE endpoint `GET /api/plugins/:pluginId/bridge/stream/:channel` bridges the two.
> - Every backing piece exists in core — `PluginStreamBus`, the worker RPC handlers for `streams.*`, the worker manager's per-worker `onStreamNotification` hook, the SSE route, and the UI hook.
> - But nothing ever constructs a `PluginStreamBus` or feeds the worker manager's stream hook, so the SSE route always sees `bridgeDeps.streamBus === undefined` and returns 501. `ctx.streams.emit()` silently goes nowhere and plugins are forced to poll.
> - This pull request connects the already-implemented pieces: it creates the bus, lets the worker manager forward stream notifications into it, and passes it to the plugin route bridge deps.
> - The benefit is that plugin real-time streaming actually works (SSE instead of 501), with no new dependencies and no behavior change for plugins that don't stream.

## Linked Issues or Issue Description

Closes #5879 — `usePluginStream` returns 501 because `/api/plugins/<id>/bridge/stream/<name>` is effectively unimplemented (the route exists but the bus is never wired).
Refs #440 — original request to add the SSE bridge for worker-to-UI streaming; the bridge landed but was never connected, which this PR completes.

I searched open and closed issues and PRs for plugin streaming / SSE / `usePluginStream` / `streamBus`; the two issues above are the only related items and I found no prior or competing PR.

## What Changed

- `server/src/services/plugin-worker-manager.ts`: add `setStreamNotificationHandler()` to the manager (plus an optional constructor option) so its stream handler can be attached after construction. `startWorker` forwards each worker's `streams.*` notifications to the live handler, unless that worker supplied its own. Reading the handler at notification time means it works whether the manager is created by `createApp` or injected by the caller.
- `server/src/services/plugin-stream-bus.ts`: add `publishWorkerStreamNotification()`, a shared mapping from a worker stream notification to a bus publish (drops ones missing a channel/companyId; maps `open`/`emit`/`close` to event types).
- `server/src/app.ts`: construct the `PluginStreamBus`, attach the handler to the worker manager via `setStreamNotificationHandler()`, and pass `streamBus` in the `pluginRoutes` bridge deps so the SSE route stops returning 501.
- `server/src/__tests__/plugin-stream-bus.test.ts`: new tests for bus delivery semantics, the notification→event-type mapping, and the settable manager handler.

Note on the design: the production entrypoint injects the worker manager into `createApp`, so a constructor-only hook would leave the bus orphaned (the SSE route would open connections that never receive events instead of failing fast). Attaching the handler to the manager after it is obtained covers both the injected and the factory-created manager.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passes.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-stream-bus.test.ts src/__tests__/plugin-worker-manager.test.ts` — 17/17 pass (6 new + 11 existing).

End-to-end, against a locally running server with a plugin installed (identifiers redacted), exercising the injected-manager path that production uses:

```
# Before (without this change) — the route's first guard returns 501:
GET /api/plugins/<plugin-id>/bridge/stream/<channel>?companyId=<company-id>
  -> HTTP 501  {"error":"Plugin stream bridge is not enabled"}

# After (this change) — the same request opens the SSE stream:
GET /api/plugins/<plugin-id>/bridge/stream/<channel>?companyId=<company-id>
  -> HTTP 200  (SSE stream opens; ":ok" keep-alive frame)
```

The before/after was observed on the same running instance by swapping only these files and letting the dev server reload between requests.

## Risks

Low. No new dependencies and no schema/migration changes. Behavior is unchanged for plugins that never open a stream channel. The only functional change is that `bridgeDeps.streamBus` is now defined and populated, so the SSE route serves the stream instead of 501ing. The manager-level handler is only forwarded to when a worker doesn't already provide its own `onStreamNotification`, preserving existing per-worker behavior.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), 1M-context configuration, with extended thinking and tool use / code execution. Used to locate the wiring gap, implement the change, and run the verification above; all changes human-reviewed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [ ] I have updated relevant documentation to reflect my changes (N/A — the SDK streaming API is already documented; this only connects it)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after CI runs)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address after review)
- [x] I will address all Greptile and reviewer comments before requesting merge
