### PR TITLE
docs: require GitHub post-submit follow-up

### DIFF
--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -166,6 +166,18 @@ If any section is missing or empty, do NOT submit the PR. Go back and fill it in
 
 Only after completing Steps 1 and 2, run `gh pr create`. Use the template contents as the structure for `--body` — do not write a freeform summary.
 
+### Step 4 — Post-submit follow-up
+
+After posting to GitHub outside the active company repo — especially PRs, comments, or review replies on `paperclipai/paperclip` — you MUST complete a read-back loop before claiming the post succeeded:
+
+1. Re-read the created PR/comment/reply from GitHub and confirm the URL, author, body, head/base branch, and commit SHA match what you intended.
+2. Confirm the post satisfies the repo's contributing requirements and PR template sections you read in Step 1.
+3. Check CI/status checks, review bots, Vercel/GitHub app comments, and maintainer replies for failures or requested fixes.
+4. If a bot or maintainer requests fixes, either address them in a follow-up commit/comment or leave the Paperclip issue blocked with the exact external owner/action.
+5. Post durable Paperclip evidence with the GitHub URL, validation commands/results, current check/review state, and any remaining follow-up owner.
+
+Do not treat `gh pr create` or `gh pr comment` returning success as sufficient evidence. The proof is the GitHub read-back plus current checks/replies.
+
 ## Hard Rules — Do NOT Bypass
 
 These rules exist because agents have caused real damage by improvising around CLI failures. Follow them exactly.

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -168,7 +168,7 @@ Only after completing Steps 1 and 2, run `gh pr create`. Use the template conten
 
 ### Step 4 — Post-submit follow-up
 
-After posting to GitHub outside the active company repo — especially PRs, comments, or review replies on `paperclipai/paperclip` — you MUST complete a read-back loop before claiming the post succeeded:
+After posting to an external GitHub repository from a Paperclip task — including PRs, comments, or review replies on `paperclipai/paperclip` — you MUST complete a read-back loop before claiming the post succeeded:
 
 1. Re-read the created PR/comment/reply from GitHub and confirm the URL, author, body, head/base branch, and commit SHA match what you intended.
 2. Confirm the post satisfies the repo's contributing requirements and PR template sections you read in Step 1.
@@ -277,3 +277,4 @@ lsof -nP -iTCP:<port> -sTCP:LISTEN
 | Agent tries manual postgres operations | NEVER do this — all DB ops go through the CLI (see Hard Rules above) |
 | Dev server dies between heartbeats | Launch in a detached `tmux` session — see "Persistent Dev Servers" above |
 | Pushed feature branch to `paperclipai/paperclip` when a fork exists | Push to the user's fork remote instead — see "Forks" above |
+| Treating `gh pr create` / `gh pr comment` success as proof the post is correct | Complete the read-back loop in Step 4 — verify URL, body, CI, and reviews before claiming success |


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Its developer workflow skill tells agents how to work with the public `paperclipai/paperclip` repository.
> - Agents already have pre-submit rules for reading the PR template and contributing guide before opening upstream PRs.
> - But a successful `gh pr create` or `gh pr comment` only proves the API accepted a request; it does not prove the post meets repo rules or that checks/review bots have no follow-up.
> - This pull request documents the missing post-submit read-back loop for external GitHub posts.
> - The benefit is that agents must verify the created GitHub post, check CI/reviews/replies, and record durable Paperclip evidence before claiming success.

## Linked Issues or Issue Description

No public GitHub issue exists. This is a documentation/process fix for the Paperclip developer skill.

Problem:
- External GitHub posting by agents needs a documented follow-up rule after PR/comment submission.
- The preflight rule covers reading `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `.github/workflows/pr.yml` before PR creation.
- The missing rule is the post-submit loop: re-read the created PR/comment, confirm template compliance, inspect CI/status/review-bot/maintainer replies, and either fix requested follow-ups or block with the exact owner/action.

Refs: Help2day production-support board request to document this rule for `paperclipai/paperclip` upstream work.

## What Changed

- Added `Step 4 — Post-submit follow-up` to `skills/paperclip-dev/SKILL.md`.
- Requires agents to re-read created GitHub PRs/comments/replies and confirm URL, author, body, branch/base, and commit SHA.
- Requires checking contributing/template compliance, CI/status checks, review bots, app comments, and maintainer replies.
- Requires addressing requested fixes or recording an exact external blocker.
- Clarifies that `gh pr create` / `gh pr comment` returning success is not sufficient evidence.

## Verification

- `git diff --check` — passed.
- Manual read-back of `skills/paperclip-dev/SKILL.md` confirms the new step is placed directly after the PR creation step and before hard rules.
- No runtime code changed; documentation-only process update.

## Risks

Low risk. This only updates a developer skill document.

Operational risk:
- Agents may spend a little more time checking PR/review state after posting, but that is intentional and bounded.

Rollback plan:
- Revert commit `94404f1b` or remove the `Step 4 — Post-submit follow-up` section from `skills/paperclip-dev/SKILL.md`.

DB migrations: none.
Production behavior changes: none.
Secrets/env vars touched: none.
Deploy safety: safe to merge as documentation/process guidance; no staged rollout required.

## Model Used

OpenAI Codex based on GPT-5, accessed via the Codex coding-agent environment with shell, git, and GitHub CLI tool use. No private chain-of-thought is included.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
