### PR TITLE
fix(adapter-opencode-local): update default models to available github-copilot endpoints

### DIFF
--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -44,7 +44,7 @@ export const SANDBOX_INSTALL_COMMAND =
   'fi; ' +
   'fi';
 
-export const DEFAULT_OPENCODE_LOCAL_MODEL = "openai/gpt-5.2-codex";
+export const DEFAULT_OPENCODE_LOCAL_MODEL = "github-copilot/claude-sonnet-4.6";
 
 export function isValidOpenCodeModelId(value: unknown): value is string {
   if (typeof value !== "string") return false;
@@ -54,14 +54,13 @@ export function isValidOpenCodeModelId(value: unknown): value is string {
 }
 
 export const models: Array<{ id: string; label: string }> = [
-  { id: DEFAULT_OPENCODE_LOCAL_MODEL, label: DEFAULT_OPENCODE_LOCAL_MODEL },
-  { id: "openai/gpt-5.4", label: "openai/gpt-5.4" },
-  { id: "openai/gpt-5.2", label: "openai/gpt-5.2" },
-  { id: "openai/gpt-5.1-codex-max", label: "openai/gpt-5.1-codex-max" },
-  { id: "openai/gpt-5.1-codex-mini", label: "openai/gpt-5.1-codex-mini" },
+  { id: "github-copilot/claude-sonnet-4.6", label: "github-copilot/claude-sonnet-4.6" },
+  { id: "github-copilot/claude-opus-4.7", label: "github-copilot/claude-opus-4.7" },
+  { id: "github-copilot/gpt-5.3-codex", label: "github-copilot/gpt-5.3-codex" },
+  { id: "opencode/big-pickle", label: "opencode/big-pickle" },
 ];
 
-export const DEFAULT_OPENCODE_CHEAP_MODEL = "openai/gpt-5.1-codex-mini";
+export const DEFAULT_OPENCODE_CHEAP_MODEL = "github-copilot/gpt-5.3-codex";
 
 // The "cheap" budget profile (used for recovery retries and other low-cost lanes).
 // Defaults to OpenCode's known Codex mini model, but is overridable so a deployment


### PR DESCRIPTION
## Summary

- `DEFAULT_OPENCODE_LOCAL_MODEL`: `openai/gpt-5.2-codex` → `github-copilot/claude-sonnet-4.6`
- `DEFAULT_OPENCODE_CHEAP_MODEL`: `openai/gpt-5.1-codex-mini` → `github-copilot/gpt-5.3-codex`
- `models[]`: replaced unavailable `openai/*` entries with verified-available endpoints

## Problem

The previous defaults (`openai/gpt-5.2-codex` and `openai/gpt-5.1-codex-mini`) are no longer available via the OpenCode adapter source. This caused:
- New `opencode_local` agents created without an explicit `model` field to receive an invalid default
- Recovery retries for all `opencode_local` agents to use `openai/gpt-5.1-codex-mini` → guaranteed failure

## Verified available models (via `opencode models`)

- `github-copilot/claude-sonnet-4.6` ✅
- `github-copilot/gpt-5.3-codex` ✅
- `github-copilot/claude-opus-4.7` ✅
- `opencode/big-pickle` ✅

## Changes

- `DEFAULT_OPENCODE_LOCAL_MODEL` → `github-copilot/claude-sonnet-4.6` (primary default, balanced capability/cost)
- `DEFAULT_OPENCODE_CHEAP_MODEL` → `github-copilot/gpt-5.3-codex` (budget lane for recovery retries)
- `models[]` updated to list all four verified-available endpoints