### PR TITLE
fix(recovery): exempt routine-parent issues from missing-disposition handoff

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4987,6 +4987,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingWake,
       budgetBlock,
       pauseHold,
+      activeRoutineContinuation,
     ] = await Promise.all([
       issue
         ? db
@@ -5112,6 +5113,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issue
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
         : Promise.resolve(null),
+      issue
+        ? db
+          .select({ id: routines.id })
+          .from(routines)
+          .where(
+            and(
+              eq(routines.companyId, issue.companyId),
+              eq(routines.parentIssueId, issue.id),
+              eq(routines.status, "active"),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
     ]);
 
     const decision = decideSuccessfulRunHandoff({
@@ -5127,6 +5142,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       hasExplicitBlockerPath: Boolean(explicitBlocker),
       hasOpenRecoveryIssue: Boolean(openRecoveryIssue),
       hasPauseHold: Boolean(pauseHold),
+      hasActiveRoutineContinuation: Boolean(activeRoutineContinuation),
       budgetBlocked: Boolean(budgetBlock),
       idempotentWakeExists: Boolean(existingWake),
     });

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -52,6 +52,7 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     hasExplicitBlockerPath: false,
     hasOpenRecoveryIssue: false,
     hasPauseHold: false,
+    hasActiveRoutineContinuation: false,
     budgetBlocked: false,
     idempotentWakeExists: false,
     ...overrides,
@@ -127,6 +128,29 @@ describe("successful run handoff decision", () => {
     expect(decide({ hasExplicitBlockerPath: true })).toEqual({
       kind: "skip",
       reason: "explicit blocker path owns the next action",
+    });
+  });
+
+  it("does not queue when the issue is the recurring parent of an active routine", () => {
+    expect(decide({ hasActiveRoutineContinuation: true })).toEqual({
+      kind: "skip",
+      reason: "active routine continuation owns the next action",
+    });
+    expect(decide({
+      hasActiveRoutineContinuation: true,
+      detectedProgressSummary: null,
+      livenessState: null,
+    })).toEqual({
+      kind: "skip",
+      reason: "successful run did not produce handoff-relevant progress",
+    });
+    expect(decide({
+      hasActiveRoutineContinuation: true,
+      livenessState: "advanced",
+      detectedProgressSummary: "Run produced concrete action evidence: 1 issue comment(s)",
+    })).toEqual({
+      kind: "skip",
+      reason: "active routine continuation owns the next action",
     });
   });
 

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -142,7 +142,7 @@ describe("successful run handoff decision", () => {
       livenessState: null,
     })).toEqual({
       kind: "skip",
-      reason: "successful run did not produce handoff-relevant progress",
+      reason: "active routine continuation owns the next action",
     });
     expect(decide({
       hasActiveRoutineContinuation: true,

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -350,6 +350,7 @@ export function decideSuccessfulRunHandoff(input: {
   hasExplicitBlockerPath: boolean;
   hasOpenRecoveryIssue: boolean;
   hasPauseHold: boolean;
+  hasActiveRoutineContinuation: boolean;
   budgetBlocked: boolean;
   idempotentWakeExists: boolean;
 }): SuccessfulRunHandoffDecision {
@@ -387,6 +388,9 @@ export function decideSuccessfulRunHandoff(input: {
   if (input.hasExplicitBlockerPath) return { kind: "skip", reason: "explicit blocker path owns the next action" };
   if (input.hasOpenRecoveryIssue) return { kind: "skip", reason: "open recovery issue owns the ambiguity" };
   if (input.hasPauseHold) return { kind: "skip", reason: "issue is under an active pause hold" };
+  if (input.hasActiveRoutineContinuation) {
+    return { kind: "skip", reason: "active routine continuation owns the next action" };
+  }
   if (input.budgetBlocked) return { kind: "skip", reason: "budget hard stop blocks corrective wake" };
   if (input.idempotentWakeExists) {
     return { kind: "skip", reason: "corrective handoff wake already exists for this source run" };

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -377,6 +377,9 @@ export function decideSuccessfulRunHandoff(input: {
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };
   }
+  if (input.hasActiveRoutineContinuation) {
+    return { kind: "skip", reason: "active routine continuation owns the next action" };
+  }
   if (!isProductiveSuccessfulRun(input)) {
     return { kind: "skip", reason: "successful run did not produce handoff-relevant progress" };
   }
@@ -388,9 +391,6 @@ export function decideSuccessfulRunHandoff(input: {
   if (input.hasExplicitBlockerPath) return { kind: "skip", reason: "explicit blocker path owns the next action" };
   if (input.hasOpenRecoveryIssue) return { kind: "skip", reason: "open recovery issue owns the ambiguity" };
   if (input.hasPauseHold) return { kind: "skip", reason: "issue is under an active pause hold" };
-  if (input.hasActiveRoutineContinuation) {
-    return { kind: "skip", reason: "active routine continuation owns the next action" };
-  }
   if (input.budgetBlocked) return { kind: "skip", reason: "budget hard stop blocks corrective wake" };
   if (input.idempotentWakeExists) {
     return { kind: "skip", reason: "corrective handoff wake already exists for this source run" };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent heartbeats can finish successfully while the source issue still needs a clear control-plane disposition.
> - The recovery handoff path detects that ambiguous state and queues a bounded corrective wake when no valid next-action path exists.
> - Recurring routines are a valid next-action path when an active routine owns continued work for its parent issue.
> - Without that routine-parent exemption, Paperclip can create unnecessary missing-disposition recovery noise for issues that are intentionally waiting on the next routine fire.
> - This pull request teaches successful-run handoff detection to recognize active routine continuations and skip corrective wake creation for those parent issues.
> - The benefit is quieter, more accurate recovery behavior without changing normal issue, blocker, approval, or active-execution handling.

## Linked Issues or Issue Description

No public GitHub issue exists for this exact bug.

Bug summary:

- What happened: a successful heartbeat on a parent issue for an active recurring routine could still be treated as missing a disposition, causing a corrective handoff wake even though the routine owns the next action.
- Expected behavior: active routine-parent issues should be recognized as having a valid continuation path.
- Area: server recovery and heartbeat handoff logic.
- Related public context: Refs #7539, which covers a different issue-disposition surface.

## What Changed

- Added an active-routine-continuation lookup in heartbeat recovery context for issues that are parents of active routines.
- Passed `hasActiveRoutineContinuation` into `decideSuccessfulRunHandoff`.
- Short-circuited successful-run handoff decisions when an active routine continuation owns the next action.
- Moved that guard before the productivity check so traces consistently report the routine-continuation reason.
- Added unit coverage for routine-parent successful-run handoff decisions.

## Verification

- `NODE_ENV=development pnpm exec vitest run server/src/services/recovery/successful-run-handoff.test.ts`
  - 1 test file passed
  - 16 tests passed
- Existing CI on the PR passed all non-description gates before this fixup.

## Risks

Low risk. The change only skips corrective missing-disposition wakes when the same company has an active routine whose `parentIssueId` is the issue being evaluated. Issues without active routine continuations keep the existing recovery behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex using GPT-5 Codex in a local CLI agent session with repository file access, shell command execution, GitHub CLI access, and code editing tools. Exact context window was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge