### PR TITLE
[codex] Fix local issue helper API fallback

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -949,6 +949,18 @@ function buildLocalPaperclipApiUrl(): string {
   return `http://${runtimeHost}:${runtimePort}`;
 }
 
+function uniquePaperclipApiCandidates(candidates: string[]): string[] {
+  const uniqueCandidates: string[] = [];
+  const seen = new Set<string>();
+  for (const rawCandidate of candidates) {
+    const candidate = rawCandidate.trim().replace(/\/+$/, "");
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    uniqueCandidates.push(candidate);
+  }
+  return uniqueCandidates;
+}
+
 export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
   const vars: Record<string, string> = {
     PAPERCLIP_AGENT_ID: agent.id,
@@ -964,7 +976,7 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   }
   vars.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON =
     process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ??
-    JSON.stringify([apiUrl, buildLocalPaperclipApiUrl()]);
+    JSON.stringify(uniquePaperclipApiCandidates([apiUrl, buildLocalPaperclipApiUrl()]));
   return vars;
 }
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -935,26 +935,36 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
-export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+function buildLocalPaperclipApiUrl(): string {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
     if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) return `[${host}]`;
     return host;
   };
-  const vars: Record<string, string> = {
-    PAPERCLIP_AGENT_ID: agent.id,
-    PAPERCLIP_COMPANY_ID: agent.companyId,
-  };
   const runtimeHost = resolveHostForUrl(
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
+  return `http://${runtimeHost}:${runtimePort}`;
+}
+
+export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+  const vars: Record<string, string> = {
+    PAPERCLIP_AGENT_ID: agent.id,
+    PAPERCLIP_COMPANY_ID: agent.companyId,
+  };
   const apiUrl =
     process.env.PAPERCLIP_RUNTIME_API_URL ??
     process.env.PAPERCLIP_API_URL ??
-    `http://${runtimeHost}:${runtimePort}`;
+    buildLocalPaperclipApiUrl();
   vars.PAPERCLIP_API_URL = apiUrl;
+  if (process.env.PAPERCLIP_RUNTIME_API_URL) {
+    vars.PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL;
+  }
+  vars.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON =
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ??
+    JSON.stringify([apiUrl, buildLocalPaperclipApiUrl()]);
   return vars;
 }
 
@@ -1169,6 +1179,7 @@ export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJ
   for (const key of Object.keys(env)) {
     if (!key.startsWith("PAPERCLIP_")) continue;
     if (key === "PAPERCLIP_RUNTIME_API_URL") continue;
+    if (key === "PAPERCLIP_RUNTIME_API_CANDIDATES_JSON") continue;
     if (key === "PAPERCLIP_LISTEN_HOST") continue;
     if (key === "PAPERCLIP_LISTEN_PORT") continue;
     delete env[key];

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -33,6 +33,94 @@ require_command() {
   fi
 }
 
+resolve_local_api_url() {
+  local host="${PAPERCLIP_LISTEN_HOST:-${HOST:-127.0.0.1}}"
+  local port="${PAPERCLIP_LISTEN_PORT:-${PORT:-3100}}"
+  case "$host" in
+    ""|"0.0.0.0"|"::") host="127.0.0.1" ;;
+  esac
+  if [[ "$host" == *:* && "$host" != \[* ]]; then
+    host="[$host]"
+  fi
+  printf 'http://%s:%s' "$host" "$port"
+}
+
+api_base_candidates() {
+  local seen=""
+  add_candidate() {
+    local candidate="${1:-}"
+    candidate="${candidate%/}"
+    if [[ -z "$candidate" || "$seen" == *"|$candidate|"* ]]; then
+      return
+    fi
+    seen="${seen}|${candidate}|"
+    printf '%s\n' "$candidate"
+  }
+
+  add_candidate "${PAPERCLIP_API_URL:-}"
+  add_candidate "${PAPERCLIP_RUNTIME_API_URL:-}"
+  if [[ -n "${PAPERCLIP_RUNTIME_API_CANDIDATES_JSON:-}" ]]; then
+    while IFS= read -r candidate; do
+      add_candidate "$candidate"
+    done < <(jq -r '.[]? | select(type == "string" and length > 0)' <<<"$PAPERCLIP_RUNTIME_API_CANDIDATES_JSON" 2>/dev/null || true)
+  fi
+  add_candidate "$(resolve_local_api_url)"
+}
+
+request_issue_update() {
+  local issue_id="$1"
+  local payload="$2"
+  local response_file error_file status_code curl_status api_base url
+  local saw_failure=0
+  response_file="$(mktemp)"
+  error_file="$(mktemp)"
+
+  while IFS= read -r api_base; do
+    url="${api_base%/}/api/issues/$issue_id"
+    : >"$response_file"
+    : >"$error_file"
+    set +e
+    status_code="$(
+      curl -sS -X PATCH -w '%{http_code}' -o "$response_file" \
+        "$url" \
+        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+        -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+        -H 'Content-Type: application/json' \
+        --data-binary "$payload" \
+        2>"$error_file"
+    )"
+    curl_status=$?
+    set -e
+
+    if [[ "$curl_status" -ne 0 ]]; then
+      saw_failure=1
+      continue
+    fi
+
+    if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
+      printf 'Issue update failed (%s): %s\n' "$status_code" "$url" >&2
+      cat "$response_file" >&2
+      printf '\n' >&2
+      rm -f "$response_file" "$error_file"
+      exit 1
+    fi
+
+    if [[ "$saw_failure" == "1" ]]; then
+      printf 'Paperclip API primary URL was unavailable; used fallback %s.\n' "$api_base" >&2
+    fi
+    cat "$response_file"
+    rm -f "$response_file" "$error_file"
+    return 0
+  done < <(api_base_candidates)
+
+  printf 'Could not reach the Paperclip API using configured or local runtime URLs.\n' >&2
+  if [[ -s "$error_file" ]]; then
+    cat "$error_file" >&2
+  fi
+  rm -f "$response_file" "$error_file"
+  exit 1
+}
+
 issue_id="${PAPERCLIP_TASK_ID:-}"
 status=""
 comment_arg=""
@@ -97,14 +185,9 @@ if [[ "$dry_run" == "1" ]]; then
   exit 0
 fi
 
-if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
-  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
+if [[ -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
+  printf 'Missing PAPERCLIP_API_KEY or PAPERCLIP_RUN_ID.\n' >&2
   exit 1
 fi
 
-curl -sS -X PATCH \
-  "$PAPERCLIP_API_URL/api/issues/$issue_id" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
-  -H 'Content-Type: application/json' \
-  --data-binary "$payload"
+request_issue_update "$issue_id" "$payload"

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -33,47 +33,22 @@ require_command() {
   fi
 }
 
-resolve_local_api_url() {
-  local host="${PAPERCLIP_LISTEN_HOST:-${HOST:-127.0.0.1}}"
-  local port="${PAPERCLIP_LISTEN_PORT:-${PORT:-3100}}"
-  case "$host" in
-    ""|"0.0.0.0"|"::") host="127.0.0.1" ;;
-  esac
-  if [[ "$host" == *:* && "$host" != \[* ]]; then
-    host="[$host]"
-  fi
-  printf 'http://%s:%s' "$host" "$port"
-}
-
-api_base_candidates() {
-  local seen=""
-  add_candidate() {
-    local candidate="${1:-}"
-    candidate="${candidate%/}"
-    if [[ -z "$candidate" || "$seen" == *"|$candidate|"* ]]; then
-      return
-    fi
-    seen="${seen}|${candidate}|"
-    printf '%s\n' "$candidate"
-  }
-
-  add_candidate "${PAPERCLIP_API_URL:-}"
-  add_candidate "${PAPERCLIP_RUNTIME_API_URL:-}"
-  if [[ -n "${PAPERCLIP_RUNTIME_API_CANDIDATES_JSON:-}" ]]; then
-    while IFS= read -r candidate; do
-      add_candidate "$candidate"
-    done < <(jq -r '.[]? | select(type == "string" and length > 0)' <<<"$PAPERCLIP_RUNTIME_API_CANDIDATES_JSON" 2>/dev/null || true)
-  fi
-  add_candidate "$(resolve_local_api_url)"
-}
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+api_candidates_lib="$script_dir/../skills/paperclip/scripts/paperclip-api-candidates.sh"
+if [[ ! -f "$api_candidates_lib" ]]; then
+  printf 'Missing Paperclip API candidate helper: %s\n' "$api_candidates_lib" >&2
+  exit 1
+fi
+source "$api_candidates_lib"
 
 request_issue_update() {
   local issue_id="$1"
   local payload="$2"
-  local response_file error_file status_code curl_status api_base url
+  local response_file error_file errors_file status_code curl_status api_base url
   local saw_failure=0
   response_file="$(mktemp)"
   error_file="$(mktemp)"
+  errors_file="$(mktemp)"
 
   while IFS= read -r api_base; do
     url="${api_base%/}/api/issues/$issue_id"
@@ -94,6 +69,7 @@ request_issue_update() {
 
     if [[ "$curl_status" -ne 0 ]]; then
       saw_failure=1
+      append_api_curl_failure "$errors_file" "$url" "$error_file" "$curl_status"
       continue
     fi
 
@@ -101,7 +77,7 @@ request_issue_update() {
       printf 'Issue update failed (%s): %s\n' "$status_code" "$url" >&2
       cat "$response_file" >&2
       printf '\n' >&2
-      rm -f "$response_file" "$error_file"
+      rm -f "$response_file" "$error_file" "$errors_file"
       exit 1
     fi
 
@@ -109,15 +85,15 @@ request_issue_update() {
       printf 'Paperclip API primary URL was unavailable; used fallback %s.\n' "$api_base" >&2
     fi
     cat "$response_file"
-    rm -f "$response_file" "$error_file"
+    rm -f "$response_file" "$error_file" "$errors_file"
     return 0
   done < <(api_base_candidates)
 
   printf 'Could not reach the Paperclip API using configured or local runtime URLs.\n' >&2
-  if [[ -s "$error_file" ]]; then
-    cat "$error_file" >&2
+  if [[ -s "$errors_file" ]]; then
+    cat "$errors_file" >&2
   fi
-  rm -f "$response_file" "$error_file"
+  rm -f "$response_file" "$error_file" "$errors_file"
   exit 1
 }
 

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -87,6 +87,19 @@ describe("buildPaperclipEnv", () => {
     ]);
   });
 
+  it("deduplicates synthesized runtime API candidates", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://127.0.0.1:3101";
+    delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(JSON.parse(env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON)).toEqual([
+      "http://127.0.0.1:3101",
+    ]);
+  });
+
   it("uses runtime listen host/port when explicit URL is not set", () => {
     delete process.env.PAPERCLIP_RUNTIME_API_URL;
     delete process.env.PAPERCLIP_API_URL;

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildPaperclipEnv } from "../adapters/utils.js";
 
 const ORIGINAL_PAPERCLIP_RUNTIME_API_URL = process.env.PAPERCLIP_RUNTIME_API_URL;
+const ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 const ORIGINAL_PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
 const ORIGINAL_PAPERCLIP_LISTEN_HOST = process.env.PAPERCLIP_LISTEN_HOST;
 const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
@@ -11,6 +12,9 @@ const ORIGINAL_PORT = process.env.PORT;
 afterEach(() => {
   if (ORIGINAL_PAPERCLIP_RUNTIME_API_URL === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
   else process.env.PAPERCLIP_RUNTIME_API_URL = ORIGINAL_PAPERCLIP_RUNTIME_API_URL;
+
+  if (ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON === undefined) delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+  else process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = ORIGINAL_PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
 
   if (ORIGINAL_PAPERCLIP_API_URL === undefined) delete process.env.PAPERCLIP_API_URL;
   else process.env.PAPERCLIP_API_URL = ORIGINAL_PAPERCLIP_API_URL;
@@ -38,6 +42,7 @@ describe("buildPaperclipEnv", () => {
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
     expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
+    expect(env.PAPERCLIP_RUNTIME_API_URL).toBe("http://203.0.113.42:3102");
   });
 
   it("falls back to PAPERCLIP_API_URL when no runtime URL is configured", () => {
@@ -49,6 +54,37 @@ describe("buildPaperclipEnv", () => {
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
     expect(env.PAPERCLIP_API_URL).toBe("http://localhost:4100");
+  });
+
+  it("passes ordered runtime API candidates to local adapter processes", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://127.0.0.1:3101";
+    process.env.PAPERCLIP_API_URL = "http://paperclipmbp.kingfisher-halibut.ts.net:3101";
+    process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify([
+      "http://paperclipmbp.kingfisher-halibut.ts.net:3101",
+      "http://127.0.0.1:3101",
+    ]);
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3101");
+    expect(JSON.parse(env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON)).toEqual([
+      "http://paperclipmbp.kingfisher-halibut.ts.net:3101",
+      "http://127.0.0.1:3101",
+    ]);
+  });
+
+  it("synthesizes a local fallback candidate when runtime candidates are absent", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://paperclipmbp.kingfisher-halibut.ts.net:3101";
+    delete process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON;
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(JSON.parse(env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON)).toEqual([
+      "http://paperclipmbp.kingfisher-halibut.ts.net:3101",
+      "http://127.0.0.1:3101",
+    ]);
   });
 
   it("uses runtime listen host/port when explicit URL is not set", () => {

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -17,6 +17,18 @@ describe("runtime API discovery", () => {
     ).toBe("https://paperclip.example.com");
   });
 
+  it("prefers the local listener when requested for local trusted runs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["paperclipmbp.kingfisher-halibut.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+        preferLocalListener: true,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
   it("builds ordered callback candidates from explicit, allowed, bind, and interface hosts", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -678,11 +678,13 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
+  const preferLocalRuntimeApiUrl = config.deploymentMode === "local_trusted";
   const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
+    preferLocalListener: preferLocalRuntimeApiUrl,
   });
   const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
   const runtimeApiCandidates = buildRuntimeApiCandidateUrls({

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -51,7 +51,16 @@ export function choosePrimaryRuntimeApiUrl(input: {
   allowedHostnames: string[];
   bindHost: string;
   port: number;
+  preferLocalListener?: boolean;
 }): string {
+  const bindHost = normalizeHost(input.bindHost);
+  if (input.preferLocalListener) {
+    if (bindHost && !isWildcardHost(bindHost)) {
+      return formatOrigin("http:", bindHost, input.port);
+    }
+    return formatOrigin("http:", "localhost", input.port);
+  }
+
   const explicitPublicBaseUrl = input.authPublicBaseUrl?.trim();
   if (explicitPublicBaseUrl) {
     try {
@@ -68,7 +77,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }

--- a/skills/paperclip/scripts/paperclip-api-candidates.sh
+++ b/skills/paperclip/scripts/paperclip-api-candidates.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+resolve_local_api_url() {
+  local host="${PAPERCLIP_LISTEN_HOST:-${HOST:-127.0.0.1}}"
+  local port="${PAPERCLIP_LISTEN_PORT:-${PORT:-3100}}"
+  case "$host" in
+    ""|"0.0.0.0"|"::") host="127.0.0.1" ;;
+  esac
+  if [[ "$host" == *:* && "$host" != \[* ]]; then
+    host="[$host]"
+  fi
+  printf 'http://%s:%s' "$host" "$port"
+}
+
+api_base_candidates() {
+  local seen=""
+
+  add_candidate() {
+    local candidate="${1:-}"
+    candidate="${candidate%/}"
+    if [[ -z "$candidate" || "$seen" == *"|$candidate|"* ]]; then
+      return
+    fi
+    seen="${seen}|${candidate}|"
+    printf '%s\n' "$candidate"
+  }
+
+  add_candidate "${PAPERCLIP_API_URL:-}"
+  add_candidate "${PAPERCLIP_RUNTIME_API_URL:-}"
+  if [[ -n "${PAPERCLIP_RUNTIME_API_CANDIDATES_JSON:-}" ]]; then
+    while IFS= read -r candidate; do
+      add_candidate "$candidate"
+    done < <(jq -r '.[]? | select(type == "string" and length > 0)' <<<"$PAPERCLIP_RUNTIME_API_CANDIDATES_JSON" 2>/dev/null || true)
+  fi
+  add_candidate "$(resolve_local_api_url)"
+}
+
+api_path_candidates() {
+  local path="$1"
+  local api_base
+  while IFS= read -r api_base; do
+    printf '%s/api/%s\n' "${api_base%/}" "${path#/}"
+  done < <(api_base_candidates)
+}
+
+append_api_curl_failure() {
+  local errors_file="$1"
+  local url="$2"
+  local error_file="$3"
+  local curl_status="$4"
+
+  {
+    printf 'Request failed before reaching Paperclip: %s\n' "$url"
+    if [[ -s "$error_file" ]]; then
+      sed 's/^/  /' "$error_file"
+    else
+      printf '  curl exited with status %s\n' "$curl_status"
+    fi
+  } >>"$errors_file"
+}

--- a/skills/paperclip/scripts/paperclip-upload-artifact.sh
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.sh
@@ -11,7 +11,11 @@ Uploads a generated file from the current workspace to the current Paperclip
 issue, then creates an attachment-backed artifact work product by default.
 
 Required environment for live uploads:
-  PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_COMPANY_ID, PAPERCLIP_TASK_ID, PAPERCLIP_RUN_ID
+  PAPERCLIP_API_KEY, PAPERCLIP_COMPANY_ID, PAPERCLIP_TASK_ID, PAPERCLIP_RUN_ID
+
+API URL resolution:
+  Uses PAPERCLIP_API_URL when reachable, then runtime candidates and the local
+  listener fallback from PAPERCLIP_LISTEN_HOST/PAPERCLIP_LISTEN_PORT.
 
 Options:
   --issue-id ID          Issue id to attach to (default: PAPERCLIP_TASK_ID)
@@ -85,71 +89,165 @@ detect_content_type() {
 
 request_json() {
   local method="$1"
-  local url="$2"
+  local path_suffix="$2"
   local body="${3:-}"
-  local response_file
-  local status_code
-
+  local response_file error_file status_code curl_status url saw_failure
   response_file="$(mktemp)"
-  if [[ -n "$body" ]]; then
-    status_code="$(
-      curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
-        "$url" \
-        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-        -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
-        -H 'Content-Type: application/json' \
-        --data-binary "$body"
-    )"
-  else
-    status_code="$(
-      curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
-        "$url" \
-        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-        -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"
-    )"
-  fi
+  error_file="$(mktemp)"
+  saw_failure=0
 
-  if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
-    printf 'Request failed (%s): %s\n' "$status_code" "$url" >&2
-    cat "$response_file" >&2
-    printf '\n' >&2
-    rm -f "$response_file"
-    exit 1
-  fi
+  while IFS= read -r url; do
+    : >"$response_file"
+    : >"$error_file"
+    set +e
+    if [[ -n "$body" ]]; then
+      status_code="$(
+        curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
+          "$url" \
+          -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+          -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+          -H 'Content-Type: application/json' \
+          --data-binary "$body" \
+          2>"$error_file"
+      )"
+    else
+      status_code="$(
+        curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
+          "$url" \
+          -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+          -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+          2>"$error_file"
+      )"
+    fi
+    curl_status=$?
+    set -e
 
-  cat "$response_file"
-  rm -f "$response_file"
+    if [[ "$curl_status" -ne 0 ]]; then
+      saw_failure=1
+      continue
+    fi
+
+    if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
+      printf 'Request failed (%s): %s\n' "$status_code" "$url" >&2
+      cat "$response_file" >&2
+      printf '\n' >&2
+      rm -f "$response_file" "$error_file"
+      exit 1
+    fi
+
+    if [[ "$saw_failure" == "1" ]]; then
+      printf 'Paperclip API primary URL was unavailable; used fallback %s.\n' "${url%/api/*}" >&2
+    fi
+    cat "$response_file"
+    rm -f "$response_file" "$error_file"
+    return 0
+  done < <(api_path_candidates "$path_suffix")
+
+  printf 'Could not reach the Paperclip API using configured or local runtime URLs.\n' >&2
+  if [[ -s "$error_file" ]]; then
+    cat "$error_file" >&2
+  fi
+  rm -f "$response_file" "$error_file"
+  exit 1
+}
+
+resolve_local_api_url() {
+  local host="${PAPERCLIP_LISTEN_HOST:-${HOST:-127.0.0.1}}"
+  local port="${PAPERCLIP_LISTEN_PORT:-${PORT:-3100}}"
+  case "$host" in
+    ""|"0.0.0.0"|"::") host="127.0.0.1" ;;
+  esac
+  if [[ "$host" == *:* && "$host" != \[* ]]; then
+    host="[$host]"
+  fi
+  printf 'http://%s:%s' "$host" "$port"
+}
+
+api_base_candidates() {
+  local seen=""
+  add_candidate() {
+    local candidate="${1:-}"
+    candidate="${candidate%/}"
+    if [[ -z "$candidate" || "$seen" == *"|$candidate|"* ]]; then
+      return
+    fi
+    seen="${seen}|${candidate}|"
+    printf '%s\n' "$candidate"
+  }
+
+  add_candidate "${PAPERCLIP_API_URL:-}"
+  add_candidate "${PAPERCLIP_RUNTIME_API_URL:-}"
+  if [[ -n "${PAPERCLIP_RUNTIME_API_CANDIDATES_JSON:-}" ]]; then
+    while IFS= read -r candidate; do
+      add_candidate "$candidate"
+    done < <(jq -r '.[]? | select(type == "string" and length > 0)' <<<"$PAPERCLIP_RUNTIME_API_CANDIDATES_JSON" 2>/dev/null || true)
+  fi
+  add_candidate "$(resolve_local_api_url)"
+}
+
+api_path_candidates() {
+  local path="$1"
+  local api_base
+  while IFS= read -r api_base; do
+    printf '%s/api/%s\n' "${api_base%/}" "${path#/}"
+  done < <(api_base_candidates)
 }
 
 upload_file() {
-  local url="$1"
+  local path_suffix="$1"
   local path="$2"
   local content_type="$3"
   local escaped_path
-  local response_file
-  local status_code
+  local response_file error_file status_code curl_status url saw_failure
 
   escaped_path="${path//\\/\\\\}"
   escaped_path="${escaped_path//\"/\\\"}"
   response_file="$(mktemp)"
-  status_code="$(
-    curl -sS -X POST -w '%{http_code}' -o "$response_file" \
-      "$url" \
-      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-      -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
-      -F "file=@\"${escaped_path}\";type=${content_type}"
-  )"
+  error_file="$(mktemp)"
+  saw_failure=0
 
-  if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
-    printf 'Upload failed (%s): %s\n' "$status_code" "$url" >&2
-    cat "$response_file" >&2
-    printf '\n' >&2
-    rm -f "$response_file"
-    exit 1
+  while IFS= read -r url; do
+    : >"$response_file"
+    : >"$error_file"
+    set +e
+    status_code="$(
+      curl -sS -X POST -w '%{http_code}' -o "$response_file" \
+        "$url" \
+        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+        -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+        -F "file=@\"${escaped_path}\";type=${content_type}" \
+        2>"$error_file"
+    )"
+    curl_status=$?
+    set -e
+
+    if [[ "$curl_status" -ne 0 ]]; then
+      saw_failure=1
+      continue
+    fi
+
+    if [[ "$status_code" -lt 200 || "$status_code" -ge 300 ]]; then
+      printf 'Upload failed (%s): %s\n' "$status_code" "$url" >&2
+      cat "$response_file" >&2
+      printf '\n' >&2
+      rm -f "$response_file" "$error_file"
+      exit 1
+    fi
+
+    if [[ "$saw_failure" == "1" ]]; then
+      printf 'Paperclip API primary URL was unavailable; used fallback %s.\n' "${url%/api/*}" >&2
+    fi
+    cat "$response_file"
+    rm -f "$response_file" "$error_file"
+    return 0
+  done < <(api_path_candidates "$path_suffix")
+
+  printf 'Could not reach the Paperclip API using configured or local runtime URLs.\n' >&2
+  if [[ -s "$error_file" ]]; then
+    cat "$error_file" >&2
   fi
-
-  cat "$response_file"
-  rm -f "$response_file"
+  rm -f "$response_file" "$error_file"
+  exit 1
 }
 
 file_path=""
@@ -271,8 +369,8 @@ if [[ "$dry_run" == "1" ]]; then
   exit 0
 fi
 
-if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
-  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
+if [[ -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
+  printf 'Missing PAPERCLIP_API_KEY or PAPERCLIP_RUN_ID.\n' >&2
   exit 1
 fi
 
@@ -281,10 +379,9 @@ if [[ -z "$issue_id" || -z "$company_id" ]]; then
   exit 1
 fi
 
-api_base="${PAPERCLIP_API_URL%/}/api"
 attachment="$(
   upload_file \
-    "$api_base/companies/$company_id/issues/$issue_id/attachments" \
+    "companies/$company_id/issues/$issue_id/attachments" \
     "$file_path" \
     "$content_type"
 )"
@@ -344,7 +441,7 @@ if [[ "$create_work_product" == "1" ]]; then
   work_product="$(
     request_json \
       POST \
-      "$api_base/issues/$issue_id/work-products" \
+      "issues/$issue_id/work-products" \
       "$work_product_payload"
   )"
 fi

--- a/skills/paperclip/scripts/paperclip-upload-artifact.sh
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.sh
@@ -48,6 +48,14 @@ require_command() {
   fi
 }
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+api_candidates_lib="$script_dir/paperclip-api-candidates.sh"
+if [[ ! -f "$api_candidates_lib" ]]; then
+  printf 'Missing Paperclip API candidate helper: %s\n' "$api_candidates_lib" >&2
+  exit 1
+fi
+source "$api_candidates_lib"
+
 json_bool() {
   if [[ "${1:-0}" == "1" ]]; then
     printf 'true'
@@ -91,9 +99,10 @@ request_json() {
   local method="$1"
   local path_suffix="$2"
   local body="${3:-}"
-  local response_file error_file status_code curl_status url saw_failure
+  local response_file error_file errors_file status_code curl_status url saw_failure
   response_file="$(mktemp)"
   error_file="$(mktemp)"
+  errors_file="$(mktemp)"
   saw_failure=0
 
   while IFS= read -r url; do
@@ -124,6 +133,7 @@ request_json() {
 
     if [[ "$curl_status" -ne 0 ]]; then
       saw_failure=1
+      append_api_curl_failure "$errors_file" "$url" "$error_file" "$curl_status"
       continue
     fi
 
@@ -131,7 +141,7 @@ request_json() {
       printf 'Request failed (%s): %s\n' "$status_code" "$url" >&2
       cat "$response_file" >&2
       printf '\n' >&2
-      rm -f "$response_file" "$error_file"
+      rm -f "$response_file" "$error_file" "$errors_file"
       exit 1
     fi
 
@@ -139,58 +149,16 @@ request_json() {
       printf 'Paperclip API primary URL was unavailable; used fallback %s.\n' "${url%/api/*}" >&2
     fi
     cat "$response_file"
-    rm -f "$response_file" "$error_file"
+    rm -f "$response_file" "$error_file" "$errors_file"
     return 0
   done < <(api_path_candidates "$path_suffix")
 
   printf 'Could not reach the Paperclip API using configured or local runtime URLs.\n' >&2
-  if [[ -s "$error_file" ]]; then
-    cat "$error_file" >&2
+  if [[ -s "$errors_file" ]]; then
+    cat "$errors_file" >&2
   fi
-  rm -f "$response_file" "$error_file"
+  rm -f "$response_file" "$error_file" "$errors_file"
   exit 1
-}
-
-resolve_local_api_url() {
-  local host="${PAPERCLIP_LISTEN_HOST:-${HOST:-127.0.0.1}}"
-  local port="${PAPERCLIP_LISTEN_PORT:-${PORT:-3100}}"
-  case "$host" in
-    ""|"0.0.0.0"|"::") host="127.0.0.1" ;;
-  esac
-  if [[ "$host" == *:* && "$host" != \[* ]]; then
-    host="[$host]"
-  fi
-  printf 'http://%s:%s' "$host" "$port"
-}
-
-api_base_candidates() {
-  local seen=""
-  add_candidate() {
-    local candidate="${1:-}"
-    candidate="${candidate%/}"
-    if [[ -z "$candidate" || "$seen" == *"|$candidate|"* ]]; then
-      return
-    fi
-    seen="${seen}|${candidate}|"
-    printf '%s\n' "$candidate"
-  }
-
-  add_candidate "${PAPERCLIP_API_URL:-}"
-  add_candidate "${PAPERCLIP_RUNTIME_API_URL:-}"
-  if [[ -n "${PAPERCLIP_RUNTIME_API_CANDIDATES_JSON:-}" ]]; then
-    while IFS= read -r candidate; do
-      add_candidate "$candidate"
-    done < <(jq -r '.[]? | select(type == "string" and length > 0)' <<<"$PAPERCLIP_RUNTIME_API_CANDIDATES_JSON" 2>/dev/null || true)
-  fi
-  add_candidate "$(resolve_local_api_url)"
-}
-
-api_path_candidates() {
-  local path="$1"
-  local api_base
-  while IFS= read -r api_base; do
-    printf '%s/api/%s\n' "${api_base%/}" "${path#/}"
-  done < <(api_base_candidates)
 }
 
 upload_file() {
@@ -198,12 +166,13 @@ upload_file() {
   local path="$2"
   local content_type="$3"
   local escaped_path
-  local response_file error_file status_code curl_status url saw_failure
+  local response_file error_file errors_file status_code curl_status url saw_failure
 
   escaped_path="${path//\\/\\\\}"
   escaped_path="${escaped_path//\"/\\\"}"
   response_file="$(mktemp)"
   error_file="$(mktemp)"
+  errors_file="$(mktemp)"
   saw_failure=0
 
   while IFS= read -r url; do
@@ -223,6 +192,7 @@ upload_file() {
 
     if [[ "$curl_status" -ne 0 ]]; then
       saw_failure=1
+      append_api_curl_failure "$errors_file" "$url" "$error_file" "$curl_status"
       continue
     fi
 
@@ -230,7 +200,7 @@ upload_file() {
       printf 'Upload failed (%s): %s\n' "$status_code" "$url" >&2
       cat "$response_file" >&2
       printf '\n' >&2
-      rm -f "$response_file" "$error_file"
+      rm -f "$response_file" "$error_file" "$errors_file"
       exit 1
     fi
 
@@ -238,15 +208,15 @@ upload_file() {
       printf 'Paperclip API primary URL was unavailable; used fallback %s.\n' "${url%/api/*}" >&2
     fi
     cat "$response_file"
-    rm -f "$response_file" "$error_file"
+    rm -f "$response_file" "$error_file" "$errors_file"
     return 0
   done < <(api_path_candidates "$path_suffix")
 
   printf 'Could not reach the Paperclip API using configured or local runtime URLs.\n' >&2
-  if [[ -s "$error_file" ]]; then
-    cat "$error_file" >&2
+  if [[ -s "$errors_file" ]]; then
+    cat "$errors_file" >&2
   fi
-  rm -f "$response_file" "$error_file"
+  rm -f "$response_file" "$error_file" "$errors_file"
   exit 1
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters receive Paperclip API environment variables so they can comment on issues, update status, and upload work products during heartbeats.
> - Local trusted runs can have a configured MagicDNS-style API URL that is useful outside the process, but not resolvable inside the local heartbeat shell.
> - The issue helper scripts treated that single API URL as mandatory, so routine closeout and comment updates failed even while the local listener was reachable.
> - This pull request makes local trusted runtime URL selection prefer the local listener for adapter env and carries ordered runtime candidates to agent processes.
> - The helper scripts now retry connection-level failures through runtime candidates and the local listener while preserving `Authorization` and `X-Paperclip-Run-Id` headers.
> - The benefit is that local heartbeats can finish issue updates without every agent or routine hand-wrapping `PAPERCLIP_API_URL=http://127.0.0.1:3100`.

## Linked Issues or Issue Description

No public GitHub issue exists. Internal Paperclip issue: DAT-6112.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself, not in my agent adapter, API provider, or local configuration.

### What happened?

Local adapter heartbeats received `PAPERCLIP_API_URL` pointing at an unreachable MagicDNS hostname, while the same local Paperclip server was reachable at `http://127.0.0.1:3100`. The issue update and artifact upload helper scripts treated that one configured URL as mandatory, so routine closeout, issue comments, and artifact uploads could fail even though the local listener was healthy and the run token was valid.

### Expected behavior

Local trusted agent runs should receive a reachable local runtime API URL and helper scripts should retry connection-level failures through ordered runtime API candidates, including the local listener, without dropping `Authorization` or `X-Paperclip-Run-Id` headers.

### Steps to reproduce

1. Start a local trusted Paperclip runtime with a reachable loopback listener such as `http://127.0.0.1:3100`.
2. Run a local adapter heartbeat where `PAPERCLIP_API_URL` points at an unresolvable MagicDNS hostname and `PAPERCLIP_LISTEN_HOST` / `PAPERCLIP_LISTEN_PORT` point at the local server.
3. Call `scripts/paperclip-issue-update.sh` or `skills/paperclip/scripts/paperclip-upload-artifact.sh` from the heartbeat.
4. Observe that the helper fails against the unresolvable configured URL instead of using the reachable local listener.

### Paperclip version or commit

Reproduced against `master` at `412a04c964915fd45e15675f064d24332d50f6cc`. This PR fixes the behavior in `41a47c4efa747e29bca70789d15610480156f3c5`.

### Deployment mode

Local dev / local trusted (`pnpm dev` / local adapter heartbeat).

### Installation method

Built from source (`pnpm dev` / `pnpm build`).

### Agent adapter(s) involved

Local adapters using the shared Paperclip heartbeat environment and helper scripts; reproduced through Codex local, but the helper fallback is adapter-agnostic.

### Database mode

Not database-related.

### Access context

Agent bearer API key via `agent_api_keys`.

### Relevant logs or output

The control-plane URL from the heartbeat shell failed DNS resolution with `getaddrinfo ENOTFOUND paperclipmbp.kingfisher-halibut.ts.net`, while fallback smoke against the loopback runtime succeeded with the same helper headers.

### Relevant config (if applicable)

`PAPERCLIP_API_URL` was set to the MagicDNS hostname, and `PAPERCLIP_LISTEN_HOST` / `PAPERCLIP_LISTEN_PORT` identified the local listener.

### Additional context

Duplicate search: searched open GitHub PRs and issues for `MagicDNS localhost issue helper PAPERCLIP_API_URL fallback`; no open match covered helper fallback across issue updates and artifact uploads.

## What Changed

- Local trusted server startup now selects the loopback listener as `PAPERCLIP_RUNTIME_API_URL`, even when allowed hostnames contain a MagicDNS name.
- Adapter env now forwards `PAPERCLIP_RUNTIME_API_URL` and `PAPERCLIP_RUNTIME_API_CANDIDATES_JSON`, synthesizing a local fallback candidate when the server did not provide candidate JSON.
- `scripts/paperclip-issue-update.sh` now retries connection failures across `PAPERCLIP_API_URL`, `PAPERCLIP_RUNTIME_API_URL`, runtime candidate JSON, and the local listener.
- `skills/paperclip/scripts/paperclip-upload-artifact.sh` uses the same candidate fallback for attachment uploads and work-product creation.
- Added regression coverage for local listener preference and candidate propagation.

## Verification

- `bash -n scripts/paperclip-issue-update.sh`
- `bash -n skills/paperclip/scripts/paperclip-upload-artifact.sh`
- `pnpm exec vitest run server/src/__tests__/runtime-api.test.ts server/src/__tests__/paperclip-env.test.ts`
- `pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts`
- `git diff --check`
- `pnpm build`
- Local fallback smoke: with `PAPERCLIP_API_URL` and `PAPERCLIP_RUNTIME_API_URL` pointed at an unreachable primary URL, both helper scripts retried to a fake local listener, propagated `Authorization` and `X-Paperclip-Run-Id`, and completed successfully.
- Live smoke: with `PAPERCLIP_API_URL` still pointing at the unresolved MagicDNS hostname, `scripts/paperclip-issue-update.sh` posted a DAT-6112 checkpoint comment after reporting fallback to `http://127.0.0.1:3100`.

## Risks

Low to medium risk. This changes adapter runtime URL preference for local trusted mode, but keeps external configured API URLs in the runtime candidate list and only retries helper requests on connection-level curl failures. HTTP/API errors still fail immediately rather than being hidden by fallback retries.

## Model Used

OpenAI Codex, GPT-5-based coding agent in Codex CLI with repository file access, shell execution, targeted tests, fallback smoke testing, and build verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
