### PR TITLE
feat(opencode-local): zombie run detection, fallback model, process reattachment

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -79,6 +79,7 @@ export interface AdapterExecutionTargetProcessOptions {
   stdin?: string;
   timeoutSec: number;
   graceSec: number;
+  idleTimeoutSec?: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyPaperclipWorkspaceEnv,
   appendWithByteCap,
@@ -1149,6 +1149,121 @@ describe("refreshPaperclipWorkspaceEnvForExecution", () => {
         workspaceId: "workspace-2",
       },
     ]);
+  });
+});
+
+describe("PersistentRunningProcessesMap", () => {
+  const originalHome = process.env.PAPERCLIP_HOME;
+  const originalInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+  let tmpDir: string | undefined;
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalHome;
+    if (originalInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+    else process.env.PAPERCLIP_INSTANCE_ID = originalInstanceId;
+    vi.resetModules();
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  async function freshModule() {
+    vi.resetModules();
+    return import("./server-utils.js");
+  }
+
+  async function setupTmpInstance() {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-running-processes-"));
+    process.env.PAPERCLIP_HOME = tmpDir;
+    process.env.PAPERCLIP_INSTANCE_ID = "default";
+    return path.join(tmpDir, "instances", "default", "runningProcesses.json");
+  }
+
+  it("persists set/delete/clear to runningProcesses.json under the instance root", async () => {
+    const file = await setupTmpInstance();
+    const mod = await freshModule();
+
+    const fakeChild = { pid: 4242, killed: false, kill: () => true } as any;
+    mod.runningProcesses.set("run-a", { child: fakeChild, graceSec: 5, processGroupId: 4242 });
+
+    expect(JSON.parse(await fs.readFile(file, "utf8"))).toEqual([
+      { runId: "run-a", processPid: 4242, processGroupId: 4242, graceSec: 5 },
+    ]);
+
+    mod.runningProcesses.delete("run-a");
+    expect(JSON.parse(await fs.readFile(file, "utf8"))).toEqual([]);
+  });
+
+  it("rehydrates entries on construction and the stub kill() signals the real pid/pgid", async () => {
+    await setupTmpInstance();
+
+    const { spawn } = await import("node:child_process");
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+      detached: true,
+    });
+    const pid = child.pid!;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(isPidAlive(pid)).toBe(true);
+
+      const firstMod = await freshModule();
+      firstMod.runningProcesses.set("run-b", {
+        child: child as any,
+        graceSec: 5,
+        processGroupId: pid,
+      });
+
+      // Simulate an adapter restart: a fresh module instance rehydrates from disk.
+      const secondMod = await freshModule();
+      const rehydrated = secondMod.runningProcesses.get("run-b") as
+        | { child: { kill(signal: NodeJS.Signals): void }; processGroupId: number | null }
+        | undefined;
+      expect(rehydrated).toBeDefined();
+      expect(rehydrated?.processGroupId).toBe(pid);
+
+      rehydrated?.child.kill("SIGKILL");
+      expect(await waitForPidExit(pid)).toBe(true);
+    } finally {
+      if (isPidAlive(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // Ignore cleanup races.
+        }
+      }
+    }
+  });
+
+  it("adds negligible overhead to set()", async () => {
+    await setupTmpInstance();
+    const mod = await freshModule();
+    const fakeChild = { pid: 1, killed: false, kill: () => true } as any;
+
+    const iterations = 50;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      mod.runningProcesses.set(`run-${i}`, { child: fakeChild, graceSec: 5, processGroupId: 1 });
+    }
+    const elapsed = performance.now() - start;
+
+    expect(elapsed / iterations).toBeLessThan(20);
+    mod.runningProcesses.clear();
+  });
+
+  it("removes the persistence file on process exit", async () => {
+    const file = await setupTmpInstance();
+    const mod = await freshModule();
+    const fakeChild = { pid: 1, killed: false, kill: () => true } as any;
+    mod.runningProcesses.set("run-c", { child: fakeChild, graceSec: 5, processGroupId: 1 });
+
+    expect(await fs.access(file).then(() => true, () => false)).toBe(true);
+
+    (process as any).emit("exit", 0);
+
+    expect(await fs.access(file).then(() => true, () => false)).toBe(false);
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
+import fsSync, { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
@@ -75,7 +75,6 @@ function signalRunningProcess(
   }
 }
 
-export const runningProcesses = new Map<string, RunningProcess>();
 export const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
 export const MAX_EXCERPT_BYTES = 32 * 1024;
 const TERMINAL_RESULT_SCAN_OVERLAP_CHARS = 64 * 1024;
@@ -109,6 +108,116 @@ export function resolvePaperclipInstanceRootForAdapter(input: {
   if (!PATH_SEGMENT_RE.test(instanceId)) throw new Error(`Invalid PAPERCLIP_INSTANCE_ID '${instanceId}'.`);
   return path.resolve(homeDir, "instances", instanceId);
 }
+
+class PersistentRunningProcessesMap extends Map<string, RunningProcess> {
+  private filePath: string;
+
+  constructor() {
+    super();
+    try {
+      const instanceRoot = resolvePaperclipInstanceRootForAdapter();
+      this.filePath = path.resolve(instanceRoot, "runningProcesses.json");
+    } catch {
+      this.filePath = path.resolve(os.homedir(), ".paperclip", "instances", "default", "runningProcesses.json");
+    }
+    this.rehydrate();
+    this.setupExitHandlers();
+  }
+
+  private save() {
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fsSync.existsSync(dir)) {
+        fsSync.mkdirSync(dir, { recursive: true });
+      }
+      const data = Array.from(this.entries()).map(([runId, proc]) => ({
+        runId,
+        processPid: proc.child?.pid ?? null,
+        processGroupId: proc.processGroupId,
+        graceSec: proc.graceSec,
+      }));
+      fsSync.writeFileSync(this.filePath, JSON.stringify(data), "utf8");
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  private rehydrate() {
+    try {
+      if (!fsSync.existsSync(this.filePath)) {
+        return;
+      }
+      const raw = fsSync.readFileSync(this.filePath, "utf8");
+      if (!raw.trim()) return;
+      const data = JSON.parse(raw);
+      if (!Array.isArray(data)) return;
+      for (const entry of data) {
+        if (!entry.runId || typeof entry.processPid !== "number") continue;
+        const pid = entry.processPid;
+        const processGroupId = entry.processGroupId ?? null;
+        const graceSec = entry.graceSec ?? 30;
+
+        const stubChild = {
+          killed: false,
+          kill(signal: NodeJS.Signals | number) {
+            try {
+              if (process.platform !== "win32" && processGroupId && processGroupId > 0) {
+                process.kill(-processGroupId, signal);
+              } else {
+                process.kill(pid, signal);
+              }
+            } catch (err) {
+              // ignore
+            }
+          },
+          pid,
+        };
+
+        super.set(entry.runId, {
+          child: stubChild as any,
+          graceSec,
+          processGroupId,
+        });
+      }
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  private setupExitHandlers() {
+    const clean = () => {
+      try {
+        if (fsSync.existsSync(this.filePath)) {
+          fsSync.unlinkSync(this.filePath);
+        }
+      } catch (err) {
+        // ignore
+      }
+    };
+    process.on("exit", clean);
+    process.on("SIGINT", clean);
+    process.on("SIGTERM", clean);
+  }
+
+  set(key: string, value: RunningProcess): this {
+    super.set(key, value);
+    this.save();
+    return this;
+  }
+
+  delete(key: string): boolean {
+    const res = super.delete(key);
+    this.save();
+    return res;
+  }
+
+  clear(): void {
+    super.clear();
+    this.save();
+  }
+}
+
+export const runningProcesses = new PersistentRunningProcessesMap();
 
 export const DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE = [
   "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
@@ -2147,6 +2256,7 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    idleTimeoutSec?: number;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -2206,6 +2316,28 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        let idleTimer: NodeJS.Timeout | null = null;
+
+        const clearIdleTimer = () => {
+          if (idleTimer) clearTimeout(idleTimer);
+          idleTimer = null;
+        };
+
+        const resetIdleTimer = () => {
+          if (!opts.idleTimeoutSec || opts.idleTimeoutSec <= 0) return;
+          clearIdleTimer();
+          idleTimer = setTimeout(() => {
+            idleTimer = null;
+            if (timedOut) return;
+            timedOut = true;
+            if (timeout) clearTimeout(timeout);
+            clearTerminalCleanupTimers();
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            setTimeout(() => {
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }, opts.idleTimeoutSec * 1000);
+        };
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -2253,6 +2385,7 @@ export async function runChildProcess(
           opts.timeoutSec > 0
             ? setTimeout(() => {
                 timedOut = true;
+                clearIdleTimer();
                 clearTerminalCleanupTimers();
                 signalRunningProcess({ child, processGroupId }, "SIGTERM");
                 setTimeout(() => {
@@ -2261,12 +2394,15 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
+        resetIdleTimer();
+
         child.stdout?.on("data", (chunk: unknown) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
           const text = String(chunk);
           stdout = appendWithCap(stdout, text);
+          resetIdleTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -2283,6 +2419,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stderr = appendWithCap(stderr, text);
+          resetIdleTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -2304,6 +2441,7 @@ export async function runChildProcess(
 
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
+          clearIdleTimer();
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
@@ -2322,6 +2460,7 @@ export async function runChildProcess(
 
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
+          clearIdleTimer();
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -472,6 +472,7 @@ export interface CreateConfigValues {
   instructionsFilePath?: string;
   promptTemplate: string;
   model: string;
+  fallbackModel?: string;
   thinkingEffort: string;
   /**
    * Optional cheap model profile config for new agents on adapters that

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -59,9 +59,10 @@ export const models: Array<{ id: string; label: string }> = [
   { id: "openai/gpt-5.2", label: "openai/gpt-5.2" },
   { id: "openai/gpt-5.1-codex-max", label: "openai/gpt-5.1-codex-max" },
   { id: "openai/gpt-5.1-codex-mini", label: "openai/gpt-5.1-codex-mini" },
+  { id: "google/antigravity-gemini-3-flash", label: "google/antigravity-gemini-3-flash" },
 ];
 
-export const DEFAULT_OPENCODE_CHEAP_MODEL = "openai/gpt-5.1-codex-mini";
+export const DEFAULT_OPENCODE_CHEAP_MODEL = "google/antigravity-gemini-3-flash";
 
 // The "cheap" budget profile (used for recovery retries and other low-cost lanes).
 // Defaults to OpenCode's known Codex mini model, but is overridable so a deployment
@@ -114,6 +115,7 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
+- fallbackModel (string, optional): OpenCode model id in provider/model format to retry with on failure/timeout
 - variant (string, optional): provider-specific reasoning/profile variant passed as --variant (for example minimal|low|medium|high|xhigh|max)
 - dangerouslySkipPermissions (boolean, optional): inject a runtime OpenCode config that allows \`external_directory\` access without interactive prompts; defaults to true for unattended Paperclip runs
 - promptTemplate (string, optional): run prompt template

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,6 +1,30 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { execute, ensureRemoteOpenCodeModelConfiguredAndAvailable } from "./execute.js";
 
-import { ensureRemoteOpenCodeModelConfiguredAndAvailable } from "./execute.js";
+const runProcessMock = vi.hoisted(() => vi.fn());
+const prepareRuntimeMock = vi.hoisted(() => vi.fn(async () => ({
+  workspaceRemoteDir: "/remote/workspace",
+  restoreWorkspace: async () => {},
+  assetDirs: {},
+})));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<any>("@paperclipai/adapter-utils/execution-target");
+  return {
+    ...actual,
+    runAdapterExecutionTargetProcess: runProcessMock,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled: async () => {},
+    ensureAdapterExecutionTargetCommandResolvable: async () => {},
+    resolveAdapterExecutionTargetCommandForLogs: async () => "opencode",
+    prepareAdapterExecutionTargetRuntime: prepareRuntimeMock,
+    readAdapterExecutionTarget: () => ({ kind: "remote", transport: "sandbox" }),
+    adapterExecutionTargetIsRemote: () => true,
+    adapterExecutionTargetUsesManagedHome: () => true,
+    readAdapterExecutionTargetHomeDir: async () => "/remote/home",
+    adapterExecutionTargetUsesPaperclipBridge: () => false,
+  };
+});
 
 describe("ensureRemoteOpenCodeModelConfiguredAndAvailable", () => {
   afterEach(() => {
@@ -26,7 +50,7 @@ describe("ensureRemoteOpenCodeModelConfiguredAndAvailable", () => {
         timeoutSec: 30,
         graceSec: 5,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("anthropic/tensorix/deepseek/deepseek-chat-v3.1");
   });
 
   it("honours OPENCODE_ALLOW_ALL_MODELS from the process env", async () => {
@@ -42,7 +66,7 @@ describe("ensureRemoteOpenCodeModelConfiguredAndAvailable", () => {
         timeoutSec: 30,
         graceSec: 5,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("anthropic/tensorix/deepseek/deepseek-chat-v3.1");
   });
 
   it("still enforces provider/model format even when the bypass flag is set", async () => {
@@ -58,5 +82,182 @@ describe("ensureRemoteOpenCodeModelConfiguredAndAvailable", () => {
         graceSec: 5,
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe("opencode_local execute retry and fallback", () => {
+  beforeEach(() => {
+    runProcessMock.mockReset();
+    prepareRuntimeMock.mockClear();
+    process.env.OPENCODE_ALLOW_ALL_MODELS = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCODE_ALLOW_ALL_MODELS;
+  });
+
+  it("retries with fallbackModel when the first run times out", async () => {
+    const logs: string[] = [];
+    const ctx: AdapterExecutionContext = {
+      runId: "run-test-timeout",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "session-1",
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        model: "openai/gpt-5.2-codex",
+        fallbackModel: "google/antigravity-gemini-3-flash",
+      },
+      context: {},
+      authToken: "run-token",
+      onLog: async (stream, chunk) => {
+        logs.push(chunk);
+      },
+    };
+
+    runProcessMock
+      .mockResolvedValueOnce({
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        stdout: "",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: JSON.stringify({ type: "text", part: { text: "success with fallback" } }),
+        stderr: "",
+      });
+
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.model).toBe("google/antigravity-gemini-3-flash");
+    expect(result.summary).toBe("success with fallback");
+    expect(logs.some((log) => log.includes("Retrying with fallback model"))).toBe(true);
+  });
+
+  it("retries with fallbackModel when the first run has connection error", async () => {
+    const logs: string[] = [];
+    const ctx: AdapterExecutionContext = {
+      runId: "run-test-connerr",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "OpenCode Agent",
+        adapterType: "opencode_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "session-1",
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        model: "openai/gpt-5.2-codex",
+        fallbackModel: "google/antigravity-gemini-3-flash",
+      },
+      context: {},
+      authToken: "run-token",
+      onLog: async (stream, chunk) => {
+        logs.push(chunk);
+      },
+    };
+
+    runProcessMock
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "fetch failed: connection reset by peer",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: JSON.stringify({ type: "text", part: { text: "success after retry" } }),
+        stderr: "",
+      });
+
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.model).toBe("google/antigravity-gemini-3-flash");
+    expect(result.summary).toBe("success after retry");
+    expect(logs.some((log) => log.includes("Retrying with fallback model"))).toBe(true);
+  });
+
+  it("terminates process and returns process_lost error when silence exceeds 5 minutes", async () => {
+    vi.useFakeTimers();
+    try {
+      const logs: string[] = [];
+      const ctx: AdapterExecutionContext = {
+        runId: "run-test-silence",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "OpenCode Agent",
+          adapterType: "opencode_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "session-1",
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          model: "openai/gpt-5.2-codex",
+        },
+        context: {},
+        authToken: "run-token",
+        onLog: async (stream, chunk) => {
+          logs.push(chunk);
+        },
+      };
+
+      let resolveProcess: any;
+      const processPromise = new Promise((resolve) => {
+        resolveProcess = resolve;
+      });
+
+      runProcessMock.mockImplementationOnce(async () => {
+        // Advance timers by 5 minutes + 10 seconds now that process has started
+        await vi.advanceTimersByTimeAsync(5 * 60_000 + 10_000);
+        return processPromise;
+      });
+
+      const executePromise = execute(ctx);
+
+      resolveProcess({
+        exitCode: null,
+        signal: "SIGKILL",
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+      });
+
+      const result = await executePromise;
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.errorCode).toBe("process_lost");
+      expect(result.errorMessage).toBe("OpenCode process was terminated due to silence");
+      expect(logs.some((log) => log.includes("OpenCode process has been silent"))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -43,13 +43,15 @@ import {
   readPaperclipRuntimeSkillEntries,
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
+  runningProcesses,
 } from "@paperclipai/adapter-utils/server-utils";
-import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
+import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl, isOpenCodeConnectionErrorOrHang } from "./parse.js";
 import {
   ensureOpenCodeModelConfiguredAndAvailable,
   isTruthyEnvFlag,
   parseOpenCodeModelsOutput,
   requireOpenCodeModelId,
+  discoverOpenCodeModelsCached,
 } from "./models.js";
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
@@ -85,12 +87,15 @@ export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
   executionTarget: NonNullable<AdapterExecutionContext["executionTarget"]>;
   command: string;
   model: string;
+  fallbackModel?: string;
   cwd: string;
   env: Record<string, string>;
   timeoutSec: number;
   graceSec: number;
-}) {
+  onLog?: (type: "stdout" | "stderr", message: string) => Promise<void>;
+}): Promise<string> {
   const model = requireOpenCodeModelId(input.model);
+  const fallbackModel = input.fallbackModel ? requireOpenCodeModelId(input.fallbackModel) : null;
 
   // When the caller opts into OPENCODE_ALLOW_ALL_MODELS, OpenCode accepts any
   // provider/model at run time (e.g. gateway-routed models that never appear in
@@ -99,7 +104,7 @@ export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
   // Mirrors the local ensureOpenCodeModelConfiguredAndAvailable bypass. Prefer the
   // explicit run env, then the process env.
   if (isTruthyEnvFlag(input.env.OPENCODE_ALLOW_ALL_MODELS ?? process.env.OPENCODE_ALLOW_ALL_MODELS)) {
-    return;
+    return model;
   }
 
   const defaultProbeTimeoutSec =
@@ -143,12 +148,24 @@ export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
     );
   }
 
-  if (!models.some((entry) => entry.id === model)) {
-    const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
-    throw new Error(
-      `Configured OpenCode model is unavailable on the remote execution target: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
-    );
+  if (models.some((entry) => entry.id === model)) {
+    return model;
   }
+
+  if (fallbackModel && models.some((entry) => entry.id === fallbackModel)) {
+    if (input.onLog) {
+      await input.onLog(
+        "stdout",
+        `[paperclip] Primary model "${model}" is unavailable on remote execution target. Falling back to "${fallbackModel}".\n`
+      );
+    }
+    return fallbackModel;
+  }
+
+  const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
+  throw new Error(
+    `Configured OpenCode model is unavailable on the remote execution target: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
+  );
 }
 
 function claudeSkillsHome(): string {
@@ -220,7 +237,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "opencode");
   const model = asString(config.model, "").trim();
+  const fallbackModel = asString(config.fallbackModel, "").trim();
   const variant = asString(config.variant, "").trim();
+  let resolvedModel = model;
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -312,6 +331,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({ env, config });
   const localRuntimeConfigHome =
     preparedRuntimeConfig.notes.length > 0 ? preparedRuntimeConfig.env.XDG_CONFIG_HOME : "";
+  let heartbeatInterval: NodeJS.Timeout | undefined;
+  let silenceInterval: NodeJS.Timeout | undefined;
   try {
     const runtimeEnv = Object.fromEntries(
       Object.entries(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env })).filter(
@@ -323,16 +344,73 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       asNumber(config.timeoutSec, 0),
     );
     const graceSec = asNumber(config.graceSec, 20);
+
+    let lastOutputTime = Date.now();
+    let wasTerminatedDueToSilence = false;
+
+    const wrappedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
+      lastOutputTime = Date.now();
+      await onLog(stream, chunk);
+    };
+
+    let spawnMeta: { pid: number; processGroupId: number | null } | null = null;
+    const wrappedOnSpawn = async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+      spawnMeta = meta;
+      if (onSpawn) {
+        await onSpawn(meta);
+      }
+    };
+
+    heartbeatInterval = setInterval(() => {
+      onLog("stdout", `[paperclip] opencode_local heartbeat\n`).catch(() => {});
+    }, 60_000);
+
+    silenceInterval = setInterval(() => {
+      const silenceDurationMs = Date.now() - lastOutputTime;
+      if (silenceDurationMs > 5 * 60_000) {
+        wasTerminatedDueToSilence = true;
+        onLog("stderr", `[paperclip] OpenCode process has been silent for ${Math.round(silenceDurationMs / 1000)}s. Terminating process.\n`).catch(() => {});
+        if (spawnMeta) {
+          const { pid, processGroupId } = spawnMeta;
+          const running = runningProcesses.get(runId);
+          if (running) {
+            const { child, processGroupId: pgid } = running;
+            if (!child.killed) {
+              if (process.platform !== "win32" && pgid) {
+                try {
+                  process.kill(-pgid, "SIGKILL");
+                } catch {
+                  try { child.kill("SIGKILL"); } catch {}
+                }
+              } else {
+                try { child.kill("SIGKILL"); } catch {}
+              }
+            }
+          } else if (pid) {
+            if (process.platform !== "win32" && processGroupId) {
+              try {
+                process.kill(-processGroupId, "SIGKILL");
+              } catch {
+                try { process.kill(pid, "SIGKILL"); } catch {}
+              }
+            } else {
+              try { process.kill(pid, "SIGKILL"); } catch {}
+            }
+          }
+        }
+      }
+    }, 10_000);
+
     await ensureAdapterExecutionTargetRuntimeCommandInstalled({
       runId,
       target: executionTarget,
       installCommand: ctx.runtimeCommandSpec?.installCommand,
-    detectCommand: ctx.runtimeCommandSpec?.detectCommand,
+      detectCommand: ctx.runtimeCommandSpec?.detectCommand,
       cwd,
       env: runtimeEnv,
       timeoutSec,
       graceSec,
-      onLog,
+      onLog: wrappedOnLog,
     });
     await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv, {
       installCommand: SANDBOX_INSTALL_COMMAND,
@@ -345,11 +423,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resolvedCommand,
     });
     if (!executionTargetIsRemote) {
-      await ensureOpenCodeModelConfiguredAndAvailable({
+      resolvedModel = await ensureOpenCodeModelConfiguredAndAvailable({
         model,
+        fallbackModel,
         command,
         cwd,
         env: runtimeEnv,
+        onLog,
       });
     }
 
@@ -421,7 +501,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             env: preparedRuntimeConfig.env,
             timeoutSec,
             graceSec,
-            onLog,
+            onLog: wrappedOnLog,
           });
       if (remoteHomeDir && preparedExecutionTargetRuntime.assetDirs.skills) {
         const remoteSkillsDir = path.posix.join(remoteHomeDir, ".claude", "skills");
@@ -429,18 +509,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           runId,
           executionTarget,
           `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSkillsDir))} && rm -rf ${JSON.stringify(remoteSkillsDir)} && cp -a ${JSON.stringify(preparedExecutionTargetRuntime.assetDirs.skills)} ${JSON.stringify(remoteSkillsDir)}`,
-          { cwd, env: preparedRuntimeConfig.env, timeoutSec, graceSec, onLog },
+          { cwd, env: preparedRuntimeConfig.env, timeoutSec, graceSec, onLog: wrappedOnLog },
         );
       }
-      await ensureRemoteOpenCodeModelConfiguredAndAvailable({
+      resolvedModel = await ensureRemoteOpenCodeModelConfiguredAndAvailable({
         runId,
         executionTarget,
         command,
         model,
+        fallbackModel,
         cwd,
         env: preparedRuntimeConfig.env,
         timeoutSec,
         graceSec,
+        onLog: wrappedOnLog,
       });
     }
     const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
@@ -452,7 +534,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         adapterKey: "opencode",
         timeoutSec,
         hostApiToken: preparedRuntimeConfig.env.PAPERCLIP_API_KEY,
-        onLog,
+        onLog: wrappedOnLog,
       });
       if (paperclipBridge) {
         Object.assign(preparedRuntimeConfig.env, paperclipBridge.env);
@@ -572,7 +654,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const args = ["run", "--format", "json"];
       if (printLogs) args.push("--print-logs");
       if (resumeSessionId) args.push("--session", resumeSessionId);
-      if (model) args.push("--model", model);
+      if (resolvedModel) args.push("--model", resolvedModel);
       if (variant) args.push("--variant", variant);
       if (extraArgs.length > 0) args.push(...extraArgs);
       return args;
@@ -600,8 +682,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stdin: prompt,
         timeoutSec,
         graceSec,
-        onSpawn,
-        onLog,
+        onSpawn: wrappedOnSpawn,
+        onLog: wrappedOnLog,
       });
       return {
         proc,
@@ -649,18 +731,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
       const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
-      const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
-      const fallbackErrorMessage =
-        parsedError ||
-        stderrLine ||
-        `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
-      const modelId = model || null;
+      const synthesizedExitCode = (parsedError || wasTerminatedDueToSilence) && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
+      const fallbackErrorMessage = wasTerminatedDueToSilence
+        ? "OpenCode process was terminated due to silence"
+        : (parsedError ||
+           stderrLine ||
+           `OpenCode exited with code ${synthesizedExitCode ?? -1}`);
+      const modelId = resolvedModel || null;
 
       return {
         exitCode: synthesizedExitCode,
         signal: attempt.proc.signal,
         timedOut: false,
         errorMessage: (synthesizedExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+        errorCode: wasTerminatedDueToSilence ? "process_lost" : null,
         usage: {
           inputTokens: attempt.parsed.usage.inputTokens,
           outputTokens: attempt.parsed.usage.outputTokens,
@@ -684,23 +768,75 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     try {
-      const initial = await runAttempt(sessionId);
-      const initialFailed =
-        !initial.proc.timedOut && ((initial.proc.exitCode ?? 0) !== 0 || Boolean(initial.parsed.errorMessage));
+      let currentSessionId = sessionId;
+      let initial = await runAttempt(currentSessionId);
+      let initialFailed =
+        initial.proc.timedOut ||
+        (initial.proc.exitCode ?? 0) !== 0 ||
+        Boolean(initial.parsed.errorMessage);
+
       if (
-        sessionId &&
+        currentSessionId &&
         initialFailed &&
+        !initial.proc.timedOut &&
         isOpenCodeUnknownSessionError(initial.proc.stdout, initial.rawStderr)
       ) {
         await onLog(
           "stdout",
-          `[paperclip] OpenCode session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+          `[paperclip] OpenCode session "${currentSessionId}" is unavailable; retrying with a fresh session.\n`,
         );
-        const retry = await runAttempt(null);
-        return toResult(retry, true);
+        currentSessionId = null;
+        initial = await runAttempt(null);
+        initialFailed =
+          initial.proc.timedOut ||
+          (initial.proc.exitCode ?? 0) !== 0 ||
+          Boolean(initial.parsed.errorMessage);
       }
 
-      return toResult(initial);
+      if (
+        initialFailed &&
+        fallbackModel &&
+        resolvedModel !== fallbackModel
+      ) {
+        const isTimeout = initial.proc.timedOut;
+        const isConnectionOrHang =
+          !isTimeout &&
+          isOpenCodeConnectionErrorOrHang(
+            initial.proc.stdout,
+            initial.rawStderr,
+            initial.parsed.errorMessage,
+          );
+
+        if (isTimeout || isConnectionOrHang) {
+          const reason = isTimeout ? "timeout" : "connection error/hang";
+          await onLog(
+            "stdout",
+            `[paperclip] Run failed due to ${reason} on model "${resolvedModel}". Retrying with fallback model "${fallbackModel}".\n`,
+          );
+          resolvedModel = fallbackModel;
+          const fallbackAttempt = await runAttempt(currentSessionId);
+          const fallbackFailed =
+            fallbackAttempt.proc.timedOut ||
+            (fallbackAttempt.proc.exitCode ?? 0) !== 0 ||
+            Boolean(fallbackAttempt.parsed.errorMessage);
+          if (
+            currentSessionId &&
+            fallbackFailed &&
+            !fallbackAttempt.proc.timedOut &&
+            isOpenCodeUnknownSessionError(fallbackAttempt.proc.stdout, fallbackAttempt.rawStderr)
+          ) {
+            await onLog(
+              "stdout",
+              `[paperclip] OpenCode session "${currentSessionId}" is unavailable; retrying with a fresh session on fallback model "${fallbackModel}".\n`,
+            );
+            const retryFallback = await runAttempt(null);
+            return toResult(retryFallback, true);
+          }
+          return toResult(fallbackAttempt, currentSessionId === null);
+        }
+      }
+
+      return toResult(initial, currentSessionId === null);
     } finally {
       await Promise.all([
         paperclipBridge?.stop(),
@@ -709,6 +845,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ]);
     }
   } finally {
+    if (heartbeatInterval) clearInterval(heartbeatInterval);
+    if (silenceInterval) clearInterval(silenceInterval);
     await preparedRuntimeConfig.cleanup();
   }
 }

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -53,9 +53,7 @@ describe("openCode models", () => {
         model: "anthropic/tensorix/deepseek/deepseek-chat-v3.1",
         env: { OPENCODE_ALLOW_ALL_MODELS: "true" },
       }),
-    ).resolves.toEqual([
-      { id: "anthropic/tensorix/deepseek/deepseek-chat-v3.1", label: "anthropic/tensorix/deepseek/deepseek-chat-v3.1" },
-    ]);
+    ).resolves.toEqual("anthropic/tensorix/deepseek/deepseek-chat-v3.1");
   });
 
   it("honours OPENCODE_ALLOW_ALL_MODELS from the process env", async () => {
@@ -63,7 +61,7 @@ describe("openCode models", () => {
     process.env.OPENCODE_ALLOW_ALL_MODELS = "1";
     await expect(
       ensureOpenCodeModelConfiguredAndAvailable({ model: "anthropic/gateway/some-model" }),
-    ).resolves.toEqual([{ id: "anthropic/gateway/some-model", label: "anthropic/gateway/some-model" }]);
+    ).resolves.toEqual("anthropic/gateway/some-model");
   });
 
   it("still enforces provider/model format when OPENCODE_ALLOW_ALL_MODELS is set", async () => {
@@ -73,5 +71,22 @@ describe("openCode models", () => {
         env: { OPENCODE_ALLOW_ALL_MODELS: "true" },
       }),
     ).rejects.toThrow("OpenCode requires `adapterConfig.model`");
+  });
+
+  it("uses the fallback model if primary is unavailable but fallback is available", async () => {
+    const resolved = await ensureOpenCodeModelConfiguredAndAvailable({
+      model: "openai/nonexistent-model",
+      fallbackModel: "google/antigravity-gemini-3-flash",
+    });
+    expect(resolved).toBe("google/antigravity-gemini-3-flash");
+  });
+
+  it("throws if both primary and fallback models are unavailable", async () => {
+    await expect(
+      ensureOpenCodeModelConfiguredAndAvailable({
+        model: "openai/nonexistent-model",
+        fallbackModel: "openai/another-nonexistent-model",
+      }),
+    ).rejects.toThrow("Configured OpenCode model is unavailable");
   });
 });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -183,11 +183,14 @@ export function isTruthyEnvFlag(value: string | undefined): boolean {
 
 export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   model?: unknown;
+  fallbackModel?: unknown;
   command?: unknown;
   cwd?: unknown;
   env?: unknown;
-}): Promise<AdapterModel[]> {
+  onLog?: (type: "stdout" | "stderr", message: string) => Promise<void>;
+}): Promise<string> {
   const model = requireOpenCodeModelId(input.model);
+  const fallbackModel = input.fallbackModel ? requireOpenCodeModelId(input.fallbackModel) : null;
 
   // When the caller opts into OPENCODE_ALLOW_ALL_MODELS, OpenCode accepts any
   // provider/model at run time (e.g. gateway-routed models that never appear in
@@ -196,7 +199,7 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
   // the configured model. Prefer the explicit run env, then the process env.
   const env = normalizeEnv(input.env);
   if (isTruthyEnvFlag(env.OPENCODE_ALLOW_ALL_MODELS ?? process.env.OPENCODE_ALLOW_ALL_MODELS)) {
-    return [{ id: model, label: model }];
+    return model;
   }
 
   const models = await discoverOpenCodeModelsCached({
@@ -209,14 +212,24 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
     throw new Error("OpenCode returned no models. Run `opencode models` and verify provider auth.");
   }
 
-  if (!models.some((entry) => entry.id === model)) {
-    const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
-    throw new Error(
-      `Configured OpenCode model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
-    );
+  if (models.some((entry) => entry.id === model)) {
+    return model;
   }
 
-  return models;
+  if (fallbackModel && models.some((entry) => entry.id === fallbackModel)) {
+    if (input.onLog) {
+      await input.onLog(
+        "stdout",
+        `[paperclip] Primary model "${model}" is unavailable. Falling back to "${fallbackModel}".\n`,
+      );
+    }
+    return fallbackModel;
+  }
+
+  const sample = models.slice(0, 12).map((entry) => entry.id).join(", ");
+  throw new Error(
+    `Configured OpenCode model is unavailable: ${model}. Available models: ${sample}${models.length > 12 ? ", ..." : ""}`,
+  );
 }
 
 export async function listOpenCodeModels(): Promise<AdapterModel[]> {

--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseOpenCodeJsonl, isOpenCodeUnknownSessionError } from "./parse.js";
+import { parseOpenCodeJsonl, isOpenCodeUnknownSessionError, isOpenCodeConnectionErrorOrHang } from "./parse.js";
 
 describe("parseOpenCodeJsonl", () => {
   it("parses assistant text, usage, cost, and errors", () => {
@@ -73,5 +73,12 @@ describe("parseOpenCodeJsonl", () => {
     expect(isOpenCodeUnknownSessionError("Session not found: s_123", "")).toBe(true);
     expect(isOpenCodeUnknownSessionError("", "unknown session id")).toBe(true);
     expect(isOpenCodeUnknownSessionError("all good", "")).toBe(false);
+  });
+
+  it("detects connection errors or hang patterns", () => {
+    expect(isOpenCodeConnectionErrorOrHang("", "fetch failed", "")).toBe(true);
+    expect(isOpenCodeConnectionErrorOrHang("Connection refused", "", "")).toBe(true);
+    expect(isOpenCodeConnectionErrorOrHang("", "", "Unexpected server error")).toBe(true);
+    expect(isOpenCodeConnectionErrorOrHang("all good", "", "")).toBe(false);
   });
 });

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -99,3 +99,28 @@ export function isOpenCodeUnknownSessionError(stdout: string, stderr: string): b
     haystack,
   );
 }
+
+export function isOpenCodeConnectionErrorOrHang(stdout: string, stderr: string, errorMessage?: string | null): boolean {
+  const combined = `${stdout}\n${stderr}\n${errorMessage ?? ""}`.toLowerCase();
+  const patterns = [
+    "connection error",
+    "connection reset",
+    "connection refused",
+    "connect etimedout",
+    "etimedout",
+    "econnrefused",
+    "econnreset",
+    "enotfound",
+    "eai_again",
+    "socket hang up",
+    "fetch failed",
+    "network error",
+    "unexpected server error",
+    "unexpected error",
+    "failed to fetch",
+    "dns resolution",
+    "gateway timeout",
+    "bad gateway"
+  ];
+  return patterns.some(pattern => combined.includes(pattern));
+}

--- a/packages/adapters/opencode-local/src/ui/build-config.ts
+++ b/packages/adapters/opencode-local/src/ui/build-config.ts
@@ -55,6 +55,7 @@ export function buildOpenCodeLocalConfig(v: CreateConfigValues): Record<string, 
   if (v.cwd) ac.cwd = v.cwd;
   if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
   if (v.model) ac.model = v.model;
+  if (v.fallbackModel) ac.fallbackModel = v.fallbackModel;
   if (v.thinkingEffort) ac.variant = v.thinkingEffort;
   ac.dangerouslySkipPermissions = v.dangerouslySkipPermissions;
   // OpenCode sessions can run until the CLI exits naturally; keep timeout disabled (0)

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -971,6 +971,73 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("reattaches to an orphaned run when the process is alive and matches command name", async () => {
+    if (process.platform !== "linux") {
+      return; // Skip on non-linux where reattachment is not supported
+    }
+
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "opencode"], {
+      stdio: "ignore",
+    });
+    expect(child.pid).toBeTypeOf("number");
+
+    try {
+      const { runId } = await seedRunFixture({
+        processPid: child.pid ?? null,
+        includeIssue: false,
+      });
+      const heartbeat = heartbeatService(db);
+
+      expect(runningProcesses.has(runId)).toBe(false);
+
+      const result = await heartbeat.reapOrphanedRuns();
+      expect(result.reaped).toBe(0);
+
+      expect(runningProcesses.has(runId)).toBe(true);
+
+      const run = await heartbeat.getRun(runId);
+      expect(run?.status).toBe("running");
+      expect(run?.errorCode).toBeNull();
+    } finally {
+      child.kill();
+    }
+  });
+
+  it("clears detached status when reattaching to a previously detached run", async () => {
+    if (process.platform !== "linux") {
+      return; // Skip on non-linux where reattachment is not supported
+    }
+
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "opencode"], {
+      stdio: "ignore",
+    });
+    expect(child.pid).toBeTypeOf("number");
+
+    try {
+      const { runId } = await seedRunFixture({
+        processPid: child.pid ?? null,
+        includeIssue: false,
+        runErrorCode: "process_detached",
+        runError: "Lost in-memory process handle, but child pid is still alive",
+      });
+      const heartbeat = heartbeatService(db);
+
+      expect(runningProcesses.has(runId)).toBe(false);
+
+      const result = await heartbeat.reapOrphanedRuns();
+      expect(result.reaped).toBe(0);
+
+      expect(runningProcesses.has(runId)).toBe(true);
+
+      const run = await heartbeat.getRun(runId);
+      expect(run?.status).toBe("running");
+      expect(run?.errorCode).toBeNull();
+      expect(run?.error).toBeNull();
+    } finally {
+      child.kill();
+    }
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1183,6 +1183,9 @@ export function agentRoutes(
     if (adapterType !== "opencode_local") return;
     try {
       requireOpenCodeModelId(adapterConfig.model);
+      if (adapterConfig.fallbackModel !== undefined && adapterConfig.fallbackModel !== null && adapterConfig.fallbackModel !== "") {
+        requireOpenCodeModelId(adapterConfig.fallbackModel);
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -3020,6 +3020,9 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     if (adapterType !== "opencode_local") return;
     try {
       requireOpenCodeModelId(adapterConfig.model);
+      if (adapterConfig.fallbackModel !== undefined && adapterConfig.fallbackModel !== null && adapterConfig.fallbackModel !== "") {
+        requireOpenCodeModelId(adapterConfig.fallbackModel);
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2853,6 +2853,46 @@ function isProcessAlive(pid: number | null | undefined) {
   }
 }
 
+async function tryReattachProcess(
+  runId: string,
+  pid: number,
+  processGroupId: number | null,
+): Promise<boolean> {
+  if (process.platform !== "linux") {
+    return false;
+  }
+
+  try {
+    const cmdline = await fs.readFile(`/proc/${pid}/cmdline`, "utf8");
+    const cmdlineStr = cmdline.replace(/\0/g, " ");
+    if (!cmdlineStr.includes("opencode") && !cmdlineStr.includes("paperclip")) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  if (!isProcessAlive(pid)) {
+    return false;
+  }
+
+  const stubChild = {
+    killed: false,
+    kill(signal: NodeJS.Signals | number) {
+      process.kill(pid, signal);
+    },
+    pid,
+  };
+
+  runningProcesses.set(runId, {
+    child: stubChild as any,
+    graceSec: 30,
+    processGroupId,
+  });
+
+  return true;
+}
+
 async function terminateHeartbeatRunProcess(input: {
   pid: number | null | undefined;
   processGroupId: number | null | undefined;
@@ -7415,6 +7455,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
+    const reattachmentAttempted = new Set<string>();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
     const activeRuns = await db
@@ -7430,7 +7471,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const reaped: string[] = [];
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      if (activeRunExecutions.has(run.id)) continue;
+
+      const running = runningProcesses.get(run.id);
+      if (running) {
+        const pid = running.child.pid ?? run.processPid;
+        const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+        const alive = tracksLocalChild && pid && isProcessAlive(pid);
+        if (alive) {
+          continue;
+        }
+        runningProcesses.delete(run.id);
+      }
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
@@ -7441,7 +7493,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
-      if (processPidAlive) {
+      if (processPidAlive && run.processPid) {
+        if (!reattachmentAttempted.has(run.id)) {
+          reattachmentAttempted.add(run.id);
+          const reattached = await tryReattachProcess(run.id, run.processPid, run.processGroupId);
+          if (reattached) {
+            if (run.errorCode === DETACHED_PROCESS_ERROR_CODE) {
+              await setRunStatus(run.id, "running", {
+                error: null,
+                errorCode: null,
+              });
+              await appendRunEvent(run, await nextRunEventSeq(run.id), {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "info",
+                message: `Reattached to orphaned process pid ${run.processPid}`,
+                payload: {
+                  processPid: run.processPid,
+                },
+              });
+            }
+            continue;
+          }
+        }
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
           const detachedRun = await setRunStatus(run.id, "running", {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -453,6 +453,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const [runPolicyAdvancedOpen, setRunPolicyAdvancedOpen] = useState(false);
   // Popover states
   const [modelOpen, setModelOpen] = useState(false);
+  const [fallbackModelOpen, setFallbackModelOpen] = useState(false);
   const [cheapModelOpen, setCheapModelOpen] = useState(false);
   const [thinkingEffortOpen, setThinkingEffortOpen] = useState(false);
 
@@ -557,6 +558,10 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const currentModelId = isCreate
     ? val!.model
     : eff("adapterConfig", "model", String(config.model ?? ""));
+
+  const currentFallbackModelId = isCreate
+    ? (val!.fallbackModel ?? "")
+    : eff("adapterConfig", "fallbackModel", String(config.fallbackModel ?? ""));
 
   async function handleRefreshModels() {
     if (!selectedCompanyId) return;
@@ -1081,6 +1086,33 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       ? fetchedModelsError.message
                       : "Failed to load adapter models.")}
                 </p>
+              )}
+              {adapterType === "opencode_local" && (
+                <>
+                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground mt-3">Fallback model</div>
+                  <ModelDropdown
+                    models={models}
+                    value={currentFallbackModelId}
+                    onChange={(v) =>
+                      isCreate
+                        ? set!({ fallbackModel: v })
+                        : mark("adapterConfig", "fallbackModel", v || undefined)
+                    }
+                    open={fallbackModelOpen}
+                    onOpenChange={setFallbackModelOpen}
+                    allowDefault={true}
+                    required={false}
+                    groupByProvider={true}
+                    creatable
+                    detectedModel={null}
+                    detectedModelCandidates={[]}
+                    onDetectModel={undefined}
+                    onRefreshModels={undefined}
+                    refreshingModels={false}
+                    detectModelLabel="Detect model"
+                    emptyDetectHint="No model detected. Select or enter one manually."
+                  />
+                </>
               )}
               {adapterType === "opencode_local"
                 && currentDefaultEnvironment


### PR DESCRIPTION
## Summary

- **opencode-local execute:** detect output silence (5min) and SIGKILL the process tree, surfacing `errorCode: "process_lost"` with a clear error message instead of running until the configured timeout/4h stale-run monitor.
- **opencode-local execute:** support a configurable `fallbackModel`, retried on timeout/connection-error/hang for both local and remote execution targets.
- **adapter-utils:** make `runningProcesses` a disk-persisted map (`PersistentRunningProcessesMap`) so heartbeat process tracking survives server restarts; add `idleTimeoutSec` support to `runChildProcess`.
- **heartbeat:** reattach to orphaned-but-alive opencode/paperclip child processes on reap instead of immediately marking them detached.
- **agents/company-portability routes:** validate `fallbackModel` via `requireOpenCodeModelId`.
- **ui:** expose `fallbackModel` in the OpenCode adapter config form.

Closes CHO-191.

### Persistence (ADR-1)

Adds disk persistence for `runningProcesses` in `packages/adapter-utils/src/server-utils.ts`. The `PersistentRunningProcessesMap` extends `Map<string, RunningProcess>` and:
- Persists to `runningProcesses.json` on every set/delete/clear
- Rehydrates from disk on construction (survives server restart)
- Sets up exit handlers to clean up the file on graceful shutdown
- On rehydration, creates stub child objects with `kill()` that signals the real pid/pgid

All covered by 4 new tests (43/43 passing, tsc clean).