### PR TITLE
feat(server): gate resume/clear-error with canResumeAgents capability

### DIFF
--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -17,6 +17,7 @@ import type { AgentOrgChainHealth } from "../agent-eligibility.js";
 
 export interface AgentPermissions extends Record<string, unknown> {
   canCreateAgents: boolean;
+  canResumeAgents?: boolean;
   trustPreset?: TrustPreset;
   authorizationPolicy?: TrustAuthorizationPolicy;
 }

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -12,6 +12,7 @@ import { agentDesiredSkillSelectionSchema } from "./adapter-skills.js";
 
 export const agentPermissionsSchema = z.object({
   canCreateAgents: z.boolean().optional().default(false),
+  canResumeAgents: z.boolean().optional().default(false),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),
 }).catchall(z.unknown());
@@ -161,6 +162,7 @@ export type TestAdapterEnvironment = z.infer<typeof testAdapterEnvironmentSchema
 
 export const updateAgentPermissionsSchema = z.object({
   canCreateAgents: z.boolean(),
+  canResumeAgents: z.boolean().optional(),
   canAssignTasks: z.boolean(),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),

--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -395,7 +395,8 @@ describe.sequential("agent cross-tenant route authorization", () => {
     expect(mockAgentService.revokeKey).not.toHaveBeenCalled();
   });
 
-  it("requires board access before clearing an agent error", async () => {
+  it("rejects clear-error from an agent without the resume capability", async () => {
+    // baseAgent: role "engineer", permissions.canResumeAgents falsy.
     const app = await createApp({
       type: "agent",
       agentId,
@@ -408,7 +409,7 @@ describe.sequential("agent cross-tenant route authorization", () => {
     );
 
     expect(res.status).toBe(403);
-    expect(res.body.error).toContain("Board access required");
+    expect(res.body.error).toContain("Missing permission: can resume agents");
     expect(mockAgentService.clearError).not.toHaveBeenCalled();
   });
 
@@ -506,5 +507,127 @@ describe.sequential("agent cross-tenant route authorization", () => {
     expect(res.status).toBe(409);
     expect(res.body.error).toBe("Only agents in error status can have their error cleared");
     expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe.sequential("agent lifecycle capability authorization", () => {
+  const ceoAgentId = "55555555-5555-4555-8555-555555555555";
+  const otherCompanyId = "66666666-6666-4666-8666-666666666666";
+
+  beforeEach(() => {
+    resetMockDefaults();
+  });
+
+  function mockCeoActorAgent() {
+    // Target agent stays baseAgent; the acting CEO agent is a distinct record.
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === ceoAgentId) {
+        return { ...baseAgent, id: ceoAgentId, role: "ceo", permissions: { canCreateAgents: false } };
+      }
+      return { ...baseAgent };
+    });
+  }
+
+  it("lets a CEO run-JWT resume an agent in its own company", async () => {
+    mockCeoActorAgent();
+    const app = await createApp({ type: "agent", agentId: ceoAgentId, companyId, runId: "run-ceo" });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/resume`).send({}),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.resume).toHaveBeenCalledWith(agentId);
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      companyId,
+      actorType: "agent",
+      actorId: ceoAgentId,
+      action: "agent.resumed",
+      entityType: "agent",
+      entityId: agentId,
+    }));
+  });
+
+  it("lets a CEO run-JWT clear an agent error in its own company", async () => {
+    mockCeoActorAgent();
+    const app = await createApp({ type: "agent", agentId: ceoAgentId, companyId, runId: "run-ceo" });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/clear-error`).send({}),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.clearError).toHaveBeenCalledWith(agentId);
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      actorType: "agent",
+      actorId: ceoAgentId,
+      action: "agent.error_cleared",
+    }));
+  });
+
+  it("rejects resume from an agent that lacks the resume capability", async () => {
+    // Default getById returns baseAgent (role engineer, no canResumeAgents).
+    const app = await createApp({ type: "agent", agentId, companyId, runId: "run-engineer" });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/resume`).send({}),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Missing permission: can resume agents");
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("grants resume to a non-CEO agent that holds the canResumeAgents capability", async () => {
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === ceoAgentId) {
+        // Engineer-role acting agent explicitly granted the resume capability.
+        return { ...baseAgent, id: ceoAgentId, role: "engineer", permissions: { canResumeAgents: true } };
+      }
+      return { ...baseAgent };
+    });
+    const app = await createApp({ type: "agent", agentId: ceoAgentId, companyId, runId: "run-granted" });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/resume`).send({}),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.resume).toHaveBeenCalledWith(agentId);
+  });
+
+  it("keeps cross-company agents out of resume (cross-tenant 403 unchanged)", async () => {
+    // Acting agent belongs to another company; target agent is in `companyId`.
+    const app = await createApp({ type: "agent", agentId: ceoAgentId, companyId: otherCompanyId, runId: "run-x" });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/resume`).send({}),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Agent key cannot access another company");
+    expect(mockAgentService.resume).not.toHaveBeenCalled();
+  });
+
+  it("still lets a board session resume an agent (no regression)", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: true,
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/resume`).send({}),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.resume).toHaveBeenCalledWith(agentId);
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      actorType: "user",
+      actorId: "board-user",
+      action: "agent.resumed",
+    }));
   });
 });

--- a/server/src/__tests__/agent-permissions-service.test.ts
+++ b/server/src/__tests__/agent-permissions-service.test.ts
@@ -16,4 +16,21 @@ describe("agent permissions service", () => {
     expect(normalizeAgentPermissions({ canCreateAgents: false }, "cto").canCreateAgents).toBe(false);
     expect(normalizeAgentPermissions({ canCreateAgents: true }, "engineer").canCreateAgents).toBe(true);
   });
+
+  it("grants resume authority to the CEO role by default only", () => {
+    expect(defaultPermissionsForRole("ceo").canResumeAgents).toBe(true);
+    expect(defaultPermissionsForRole("CEO").canResumeAgents).toBe(true);
+    expect(defaultPermissionsForRole("cto").canResumeAgents).toBe(false);
+    expect(defaultPermissionsForRole("engineer").canResumeAgents).toBe(false);
+  });
+
+  it("preserves explicit canResumeAgents overrides", () => {
+    expect(normalizeAgentPermissions({ canResumeAgents: true }, "engineer").canResumeAgents).toBe(true);
+    expect(normalizeAgentPermissions({ canResumeAgents: false }, "ceo").canResumeAgents).toBe(false);
+  });
+
+  it("defaults canResumeAgents from role when unspecified", () => {
+    expect(normalizeAgentPermissions({ canCreateAgents: true }, "ceo").canResumeAgents).toBe(true);
+    expect(normalizeAgentPermissions({ canCreateAgents: false }, "engineer").canResumeAgents).toBe(false);
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -507,6 +507,31 @@ export function agentRoutes(
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
+  function canResumeAgents(agent: { role: string; permissions: Record<string, unknown> | null | undefined }) {
+    if (agent.role === "ceo") return true;
+    if (!agent.permissions || typeof agent.permissions !== "object") return false;
+    return Boolean((agent.permissions as Record<string, unknown>).canResumeAgents);
+  }
+
+  // Lifecycle actions (resume / clear-error) are allowed for board callers and
+  // for agents that hold the resume capability within the same company. Call
+  // this AFTER getAccessibleAgent so cross-tenant access is already rejected.
+  async function assertCanManageAgentLifecycle(req: Request, target: { companyId: string }) {
+    if (req.actor.type === "board") return; // company access enforced by getAccessibleAgent
+    if (req.actor.type === "agent") {
+      if (!req.actor.agentId) throw forbidden("Agent authentication required");
+      const actorAgent = await svc.getById(req.actor.agentId);
+      if (!actorAgent || actorAgent.companyId !== target.companyId) {
+        throw forbidden("Agent key cannot access another company");
+      }
+      // Role-default capability (CEO true) — no authorization-registry grant
+      // path here; granting resume to non-CEO agents is deferred (ENGA-305).
+      if (canResumeAgents(actorAgent)) return;
+      throw forbidden("Missing permission: can resume agents");
+    }
+    throw forbidden("Board or agent access required");
+  }
+
   async function buildAgentAccessState(agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>) {
     const membership = await access.getMembership(agent.companyId, "agent", agent.id);
     const grants = membership
@@ -2916,12 +2941,12 @@ export function agentRoutes(
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
     const existing = await getAccessibleAgent(req, res, id);
     if (!existing) {
       return;
     }
+    await assertCanManageAgentLifecycle(req, existing);
     if (existing.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({
         error: existing.orgChainHealth?.repairGuidance ?? "Repair this agent's reporting chain before resuming it",
@@ -2934,10 +2959,13 @@ export function agentRoutes(
       return;
     }
 
+    const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
       action: "agent.resumed",
       entityType: "agent",
       entityId: agent.id,
@@ -2947,12 +2975,12 @@ export function agentRoutes(
   });
 
   router.post("/agents/:id/clear-error", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
     const existing = await getAccessibleAgent(req, res, id);
     if (!existing) {
       return;
     }
+    await assertCanManageAgentLifecycle(req, existing);
     if (existing.orgChainHealth?.status === "invalid_org_chain") {
       res.status(409).json({
         error: existing.orgChainHealth?.repairGuidance ?? "Repair this agent's reporting chain before clearing its error",
@@ -2966,10 +2994,13 @@ export function agentRoutes(
       return;
     }
 
+    const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
       action: "agent.error_cleared",
       entityType: "agent",
       entityId: agent.id,

--- a/server/src/services/agent-permissions.ts
+++ b/server/src/services/agent-permissions.ts
@@ -1,10 +1,13 @@
 export type NormalizedAgentPermissions = Record<string, unknown> & {
   canCreateAgents: boolean;
+  canResumeAgents: boolean;
 };
 
 export function defaultPermissionsForRole(role: string): NormalizedAgentPermissions {
+  const isCeo = role.trim().toLowerCase() === "ceo";
   return {
-    canCreateAgents: role.trim().toLowerCase() === "ceo",
+    canCreateAgents: isCeo,
+    canResumeAgents: isCeo,
   };
 }
 
@@ -25,5 +28,9 @@ export function normalizeAgentPermissions(
       typeof record.canCreateAgents === "boolean"
         ? record.canCreateAgents
         : defaults.canCreateAgents,
+    canResumeAgents:
+      typeof record.canResumeAgents === "boolean"
+        ? record.canResumeAgents
+        : defaults.canResumeAgents,
   };
 }

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -69,6 +69,7 @@ export interface AgentHireResponse {
 
 export interface AgentPermissionUpdate {
   canCreateAgents: boolean;
+  canResumeAgents?: boolean;
   canAssignTasks: boolean;
   trustPreset?: AgentPermissions["trustPreset"];
   authorizationPolicy?: AgentPermissions["authorizationPolicy"];


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The agent-lifecycle subsystem exposes `POST /agents/:id/resume` and `/agents/:id/clear-error` so a stuck agent can be recovered
> - Both routes open with `assertBoard(req)`, which is unreachable for `req.actor.type === "agent"`, so agent run-JWTs are uniformly rejected with `403 "Board access required"`
> - This blocks a CEO **agent** from self-healing agents stuck in `error` (e.g. after the false-failure bug where a successful run was misread as `Claude run failed: subtype=success:`) — recovery still requires a human board session
> - This pull request introduces a `canResumeAgents` capability (CEO role default `true`) and swaps `assertBoard` for `getAccessibleAgent → assertCanManageAgentLifecycle` on these two routes, while keeping cross-tenant `403`
> - The benefit is that a CEO agent can resume/clear-error same-company agents autonomously, closing the self-healing gap without weakening tenant isolation

## Linked Issues or Issue Description

<!-- ENGA-309 is a Paperclip control-plane issue (no GitHub issue number), so the underlying problem is described in-PR per path (B), following the bug report template. -->

Refs ENGA-309 (Paperclip control-plane issue; branch `feat/enga-309-can-resume-agents`).

**What happened?**

Agent run-JWTs receive `403 "Board access required"` on `POST /agents/:id/resume` and `POST /agents/:id/clear-error`, because both routes begin with `assertBoard(req)` — a check an actor of type `agent` can never satisfy. A CEO agent therefore cannot resume or clear-error a stuck agent; recovery is gated on a human board session.

**Expected behavior**

A CEO agent (or any same-company agent holding the resume capability) can resume or clear the error state of an agent in its own company, while cross-tenant requests stay `403`.

**Steps to reproduce**

1. Authenticate as a CEO agent (run-JWT, `req.actor.type === "agent"`).
2. `POST /api/agents/{id}/resume` for a same-company agent stuck in `error` (e.g. after a successful run was misread as `Claude run failed: subtype=success:`).
3. Observe `403 "Board access required"` instead of the expected `200`.

**Paperclip version or commit**

`master` — reproduces on the branch base commit `3511e0b` and current `master`. Core authz bug in `server/src/routes/agents.ts`; not adapter-, installation-, or database-mode specific.

**Deployment mode**

Both self-hosted and cloud — the two routes share the same `assertBoard` guard regardless of deployment.

## What Changed

- **`server/src/services/agent-permissions.ts`** — normalize a new `canResumeAgents` capability (CEO role default `true`), mirroring the existing `canCreateAgents` pattern.
- **`server/src/routes/agents.ts`** — add `assertCanManageAgentLifecycle` helper; replace `assertBoard` on `resume` and `clear-error` with `getAccessibleAgent → assertCanManageAgentLifecycle`. Board allowed (company access already enforced by `getAccessibleAgent`); same-company agents with the capability allowed; others `403 "Missing permission: can resume agents"`. Cross-tenant agents remain `403` via `getAccessibleAgent`'s `assertCompanyAccess`.
- **`server/src/routes/agents.ts`** — `logActivity` now records the real actor via `getActorInfo` (agent actors attributed correctly instead of hard-coded `"user"`/`"board"`).
- **`packages/shared`** — types + validators for `canResumeAgents`.
- **`ui/src/api/agents.ts`** — follow-on client types.
- `/pause` left board-only (out of scope); granting resume to non-CEO agents via board grant deferred. No authorization-registry action or DB migration — the capability is role-default.

## Verification

Node 22.

- `pnpm --filter @paperclipai/shared run typecheck` ✅
- `pnpm --filter @paperclipai/server run typecheck` ✅
- `pnpm --filter @paperclipai/ui run typecheck` ✅
- `vitest run agent-cross-tenant-authz-routes.test.ts agent-permissions-service.test.ts` → **16 passed**

HTTP-level (supertest, real TCP socket) evidence:

```
✓ lets a CEO run-JWT resume an agent in its own company        → 200
✓ lets a CEO run-JWT clear an agent error in its own company   → 200
✓ rejects resume from an agent that lacks the resume capability → 403
✓ grants resume to a non-CEO agent that holds canResumeAgents   → 200
✓ keeps cross-company agents out of resume (cross-tenant 403)   → 403
✓ still lets a board session resume an agent (no regression)    → 200
```

Live prod curl (`CEO run-JWT → POST /api/agents/{id}/resume → 200`) is performed post-deploy by CEO pulse + the improvement lead per the issue.

## Risks

Low risk. The change widens access on two routes from board-only to board + capability-holding same-company agents; cross-tenant isolation is unchanged and explicitly covered by a regression test. No DB migration and no authorization-registry action — `canResumeAgents` is a role default, so nothing to backfill. Blast radius is limited to `resume`/`clear-error`; `/pause` is untouched. Behavioral shift: activity logs now attribute the real actor rather than a hard-coded `"user"`/`"board"`.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking enabled, with tool use / code execution in the Claude Code harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `canResumeAgents` permission to control agent lifecycle operations (resume and error clearing). CEOs have this permission by default; other roles require explicit assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->