### PR TITLE
BEY-2747: Anthropic-Quota-Guard im claude-local Adapter

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -62,6 +62,7 @@ import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
 import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
+import { getActivePause, recordRetryAfter } from "./quota-guard.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -363,6 +364,29 @@ export async function runClaudeLogin(input: {
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+
+  const activePause = getActivePause();
+  if (activePause) {
+    const pauseIso = activePause.pauseUntil.toISOString();
+    await onLog(
+      "stdout",
+      `[paperclip] Anthropic quota guard: skipping Claude run; pausing until ${pauseIso} (reason=${activePause.reason}).\n`,
+    );
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorMessage: `Anthropic quota exhausted (${activePause.reason}); paused until ${pauseIso}`,
+      errorCode: "claude_quota_exhausted",
+      errorFamily: "transient_upstream",
+      retryNotBefore: pauseIso,
+      resultJson: {
+        errorFamily: "transient_upstream",
+        retryNotBefore: pauseIso,
+        quotaGuard: { reason: activePause.reason, pauseUntil: pauseIso },
+      },
+    };
+  }
   const executionTarget = readAdapterExecutionTarget({
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
@@ -832,6 +856,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             errorMessage: fallbackErrorMessage,
           })
         : null;
+      if (transientRetryNotBefore) recordRetryAfter(transientRetryNotBefore);
       const errorCode = loginMeta.requiresLogin
         ? "claude_auth_required"
         : transientUpstream
@@ -925,6 +950,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           errorMessage,
         })
       : null;
+    if (transientRetryNotBefore) recordRetryAfter(transientRetryNotBefore);
     const resolvedErrorCode = loginMeta.requiresLogin
       ? "claude_auth_required"
       : failed && clearSessionForMaxTurns

--- a/packages/adapters/claude-local/src/server/quota-guard.test.ts
+++ b/packages/adapters/claude-local/src/server/quota-guard.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_TOKENS_REMAINING_THRESHOLD,
+  __setQuotaStateForTests,
+  getActivePause,
+  parseAnthropicRateLimitHeaders,
+} from "./quota-guard.js";
+
+afterEach(() => {
+  __setQuotaStateForTests(null);
+});
+
+describe("parseAnthropicRateLimitHeaders", () => {
+  it("parses tokens-remaining, reset, and retry-after from a plain header map", () => {
+    const now = new Date("2026-06-15T18:00:00.000Z");
+    const result = parseAnthropicRateLimitHeaders(
+      {
+        "anthropic-ratelimit-tokens-remaining": "1234",
+        "anthropic-ratelimit-tokens-reset": "2026-06-15T18:30:00Z",
+        "retry-after": "60",
+      },
+      now,
+    );
+
+    expect(result.tokensRemaining).toBe(1234);
+    expect(result.resetAt?.toISOString()).toBe("2026-06-15T18:30:00.000Z");
+    expect(result.retryAfterAt?.toISOString()).toBe("2026-06-15T18:01:00.000Z");
+  });
+
+  it("treats retry-after as an HTTP-date when not numeric", () => {
+    const now = new Date("2026-06-15T18:00:00.000Z");
+    const result = parseAnthropicRateLimitHeaders(
+      { "retry-after": "2026-06-15T19:00:00Z" },
+      now,
+    );
+    expect(result.retryAfterAt?.toISOString()).toBe("2026-06-15T19:00:00.000Z");
+  });
+
+  it("returns nulls for missing or malformed headers", () => {
+    const result = parseAnthropicRateLimitHeaders({});
+    expect(result.tokensRemaining).toBeNull();
+    expect(result.resetAt).toBeNull();
+    expect(result.retryAfterAt).toBeNull();
+
+    const malformed = parseAnthropicRateLimitHeaders({
+      "anthropic-ratelimit-tokens-remaining": "not-a-number",
+      "anthropic-ratelimit-tokens-reset": "definitely-not-a-date",
+    });
+    expect(malformed.tokensRemaining).toBeNull();
+    expect(malformed.resetAt).toBeNull();
+  });
+
+  it("is case-insensitive on header names", () => {
+    const result = parseAnthropicRateLimitHeaders({
+      "Anthropic-RateLimit-Tokens-Remaining": "42",
+    });
+    expect(result.tokensRemaining).toBe(42);
+  });
+
+  it("works with a Web Headers instance", () => {
+    const h = new Headers({
+      "anthropic-ratelimit-tokens-remaining": "9000",
+      "anthropic-ratelimit-tokens-reset": "2026-06-15T20:00:00Z",
+    });
+    const result = parseAnthropicRateLimitHeaders(h);
+    expect(result.tokensRemaining).toBe(9000);
+    expect(result.resetAt?.toISOString()).toBe("2026-06-15T20:00:00.000Z");
+  });
+});
+
+describe("getActivePause", () => {
+  const now = new Date("2026-06-15T18:00:00.000Z");
+
+  it("returns null when there is no recorded state", () => {
+    expect(getActivePause(now)).toBeNull();
+  });
+
+  it("returns a pause when retry-after is in the future", () => {
+    __setQuotaStateForTests({
+      tokensRemaining: null,
+      resetAt: null,
+      retryAfterAt: new Date("2026-06-15T18:05:00.000Z").toISOString(),
+      recordedAt: now.toISOString(),
+    });
+    const pause = getActivePause(now);
+    expect(pause).not.toBeNull();
+    expect(pause?.reason).toBe("retry-after");
+    expect(pause?.pauseUntil.toISOString()).toBe("2026-06-15T18:05:00.000Z");
+  });
+
+  it("returns a pause when remaining tokens are below the threshold and reset is in the future", () => {
+    __setQuotaStateForTests({
+      tokensRemaining: DEFAULT_TOKENS_REMAINING_THRESHOLD - 1,
+      resetAt: new Date("2026-06-15T18:15:00.000Z").toISOString(),
+      retryAfterAt: null,
+      recordedAt: now.toISOString(),
+    });
+    const pause = getActivePause(now);
+    expect(pause?.reason).toBe("tokens-remaining-below-threshold");
+    expect(pause?.pauseUntil.toISOString()).toBe("2026-06-15T18:15:00.000Z");
+  });
+
+  it("does not pause when tokens are above threshold", () => {
+    __setQuotaStateForTests({
+      tokensRemaining: DEFAULT_TOKENS_REMAINING_THRESHOLD + 1,
+      resetAt: new Date("2026-06-15T18:15:00.000Z").toISOString(),
+      retryAfterAt: null,
+      recordedAt: now.toISOString(),
+    });
+    expect(getActivePause(now)).toBeNull();
+  });
+
+  it("does not pause when retry-after lies in the past", () => {
+    __setQuotaStateForTests({
+      tokensRemaining: null,
+      resetAt: null,
+      retryAfterAt: new Date("2026-06-15T17:00:00.000Z").toISOString(),
+      recordedAt: now.toISOString(),
+    });
+    expect(getActivePause(now)).toBeNull();
+  });
+
+  it("honours a custom token threshold", () => {
+    __setQuotaStateForTests({
+      tokensRemaining: 1000,
+      resetAt: new Date("2026-06-15T18:30:00.000Z").toISOString(),
+      retryAfterAt: null,
+      recordedAt: now.toISOString(),
+    });
+    expect(getActivePause(now, 500)).toBeNull();
+    expect(getActivePause(now, 5000)?.reason).toBe("tokens-remaining-below-threshold");
+  });
+});

--- a/packages/adapters/claude-local/src/server/quota-guard.ts
+++ b/packages/adapters/claude-local/src/server/quota-guard.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import path from "node:path";
+import { claudeConfigDir } from "./quota.js";
+
+export interface RateLimitSignal {
+  tokensRemaining: number | null;
+  resetAt: Date | null;
+  retryAfterAt: Date | null;
+}
+
+export interface QuotaState {
+  tokensRemaining: number | null;
+  resetAt: string | null;
+  retryAfterAt: string | null;
+  recordedAt: string;
+}
+
+export const DEFAULT_TOKENS_REMAINING_THRESHOLD = 5000;
+
+const QUOTA_STORE_FILENAME = "paperclip-quota.json";
+
+let memoryStore: QuotaState | null = null;
+
+function quotaStorePath(): string {
+  return path.join(claudeConfigDir(), QUOTA_STORE_FILENAME);
+}
+
+function readHeader(
+  headers: Headers | Record<string, string | string[] | undefined> | Map<string, string>,
+  name: string,
+): string | null {
+  const lower = name.toLowerCase();
+  if (headers instanceof Headers) {
+    const v = headers.get(lower);
+    return v == null ? null : v;
+  }
+  if (headers instanceof Map) {
+    for (const [k, v] of headers.entries()) {
+      if (k.toLowerCase() === lower) return v;
+    }
+    return null;
+  }
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() !== lower) continue;
+    if (Array.isArray(v)) return v[0] ?? null;
+    return typeof v === "string" ? v : null;
+  }
+  return null;
+}
+
+function parsePositiveInt(value: string | null): number | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.floor(n);
+}
+
+function parseIsoDate(value: string | null): Date | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const t = Date.parse(trimmed);
+  if (!Number.isFinite(t)) return null;
+  return new Date(t);
+}
+
+function parseRetryAfter(value: string | null, now: Date): Date | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return new Date(now.getTime() + seconds * 1000);
+  }
+  return parseIsoDate(trimmed);
+}
+
+export function parseAnthropicRateLimitHeaders(
+  headers: Headers | Record<string, string | string[] | undefined> | Map<string, string>,
+  now: Date = new Date(),
+): RateLimitSignal {
+  const tokensRemaining = parsePositiveInt(readHeader(headers, "anthropic-ratelimit-tokens-remaining"));
+  const resetAt = parseIsoDate(readHeader(headers, "anthropic-ratelimit-tokens-reset"));
+  const retryAfterAt = parseRetryAfter(readHeader(headers, "retry-after"), now);
+  return { tokensRemaining, resetAt, retryAfterAt };
+}
+
+function loadFromDisk(): QuotaState | null {
+  try {
+    const raw = fs.readFileSync(quotaStorePath(), "utf8");
+    const parsed = JSON.parse(raw) as Partial<QuotaState> | null;
+    if (!parsed || typeof parsed !== "object") return null;
+    return {
+      tokensRemaining:
+        typeof parsed.tokensRemaining === "number" && Number.isFinite(parsed.tokensRemaining)
+          ? parsed.tokensRemaining
+          : null,
+      resetAt: typeof parsed.resetAt === "string" ? parsed.resetAt : null,
+      retryAfterAt: typeof parsed.retryAfterAt === "string" ? parsed.retryAfterAt : null,
+      recordedAt: typeof parsed.recordedAt === "string" ? parsed.recordedAt : new Date(0).toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function persistToDisk(state: QuotaState): void {
+  try {
+    const dir = path.dirname(quotaStorePath());
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(quotaStorePath(), JSON.stringify(state, null, 2), "utf8");
+  } catch {
+    // best-effort — in-memory store remains authoritative for this process
+  }
+}
+
+function currentState(): QuotaState | null {
+  if (memoryStore) return memoryStore;
+  const fromDisk = loadFromDisk();
+  if (fromDisk) memoryStore = fromDisk;
+  return memoryStore;
+}
+
+export function recordQuotaSignal(signal: RateLimitSignal, now: Date = new Date()): QuotaState {
+  const state: QuotaState = {
+    tokensRemaining: signal.tokensRemaining,
+    resetAt: signal.resetAt ? signal.resetAt.toISOString() : null,
+    retryAfterAt: signal.retryAfterAt ? signal.retryAfterAt.toISOString() : null,
+    recordedAt: now.toISOString(),
+  };
+  memoryStore = state;
+  persistToDisk(state);
+  return state;
+}
+
+export function recordRetryAfter(retryAfterAt: Date, now: Date = new Date()): QuotaState {
+  return recordQuotaSignal({ tokensRemaining: null, resetAt: null, retryAfterAt }, now);
+}
+
+export function clearQuotaStore(): void {
+  memoryStore = null;
+  try {
+    fs.rmSync(quotaStorePath(), { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+export interface ActivePause {
+  pauseUntil: Date;
+  reason: "tokens-remaining-below-threshold" | "retry-after" | "tokens-reset-in-future";
+}
+
+export function getActivePause(
+  now: Date = new Date(),
+  tokensThreshold: number = DEFAULT_TOKENS_REMAINING_THRESHOLD,
+): ActivePause | null {
+  const state = currentState();
+  if (!state) return null;
+
+  const retryAfterAt = state.retryAfterAt ? new Date(state.retryAfterAt) : null;
+  if (retryAfterAt && retryAfterAt.getTime() > now.getTime()) {
+    return { pauseUntil: retryAfterAt, reason: "retry-after" };
+  }
+
+  const resetAt = state.resetAt ? new Date(state.resetAt) : null;
+  const belowThreshold =
+    typeof state.tokensRemaining === "number" && state.tokensRemaining < tokensThreshold;
+
+  if (belowThreshold && resetAt && resetAt.getTime() > now.getTime()) {
+    return { pauseUntil: resetAt, reason: "tokens-remaining-below-threshold" };
+  }
+
+  return null;
+}
+
+/** Test helper: replace the in-memory store directly without touching disk. */
+export function __setQuotaStateForTests(state: QuotaState | null): void {
+  memoryStore = state;
+}


### PR DESCRIPTION
## Thinking Path

Paperclip-übergreifend: Der claude_local-Adapter spawned Claude-CLI-Subprozesse pro Heartbeat. Wenn Anthropic gerade ein Rate-Limit-/Token-Cap-Signal sendet (429 mit `retry-after`, oder `anthropic-ratelimit-tokens-remaining: 0`), war der Adapter blind dafür: jeder Heartbeat startete einen weiteren CLI-Prozess, der sofort wieder mit demselben Quota-Fehler abbrach. Das verbrannte Tokens, erzeugte Rauschen und blockierte Issues über Stunden im Loop-Verhalten.

Innerhalb des Adapters: Wir brauchen ein Pre-Flight-Gate, das vor dem `spawn()` den Quota-Zustand prüft und bei aktiver Pause sofort einen typisierten Fehler zurückgibt, statt einen weiteren Subprozess zu starten. Der Quota-Zustand muss Heartbeat-Restarts überleben, also liegt er als JSON in `CLAUDE_CONFIG_DIR` und wird zusätzlich im Prozess gecached.

## What Changed

- `packages/adapters/claude-local/src/server/quota-guard.ts` (neu): `getActivePause()`, `recordRetryAfter()`, `parseAnthropicRateLimitHeaders()` plus persistierter Quota-State.
- `packages/adapters/claude-local/src/server/execute.ts`: Pre-Flight-Gate ganz oben in `execute()` (gibt `claude_quota_exhausted` / `transient_upstream` mit `retryNotBefore` zurück), zwei `recordRetryAfter()`-Calls an den bestehenden Transient-Upstream-Exit-Points.
- `packages/adapters/claude-local/src/server/quota-guard.test.ts` (neu): 11 Unit-Tests für Header-Parsing und In-Memory-Pause-Logik.

## Verification

- `pnpm exec vitest run` in `packages/adapters/claude-local` → 39/39 grün.
- `pnpm exec tsc --noEmit` in `packages/adapters/claude-local` → ok.
- [ ] Manueller 429-Smoke: Anthropic-429 provozieren, dass `recordRetryAfter` greift, zweiten Run starten und prüfen, dass kein Subprozess startet.

## Risks

- Disk-Persistence-Pfad ist noch nicht durch Tests abgedeckt (nur In-Memory). Heartbeat-Restart-Überleben damit nicht regressionsgesichert.
- `recordRetryAfter` überschreibt bestehende `tokensRemaining`/`resetAt` mit `null` — falls wir später den direkten-API-Pfad nutzen, müsste das ein Merge statt Replace werden.
- Synchroner `fs.readFileSync` in `loadFromDisk()` blockt den Event-Loop kurzzeitig beim ersten `execute()`-Call nach Prozessstart.
- Kein Upper Bound auf `retry-after`-Sekunden — bösartiger oder fehlerhafter Upstream könnte unrealistisch lange Pausen erzeugen.

Diese Punkte sind in den Code-Review-Kommentaren von Greptile/CodeRabbit erfasst und werden in Follow-up-Issues adressiert, sofern wir den direkten-API-Pfad aktivieren.

## Model Used

- Provider: Anthropic
- Model: claude-opus-4-7 (Claude Opus 4.7)
- Context window: 200k tokens
- Capabilities: Tool use, extended thinking, code generation

## Dedup search

- [x] GitHub-PR-Liste auf "quota guard" / "claude quota" / "anthropic rate" durchsucht — keine vorherigen PRs zu diesem Pre-Flight-Gate gefunden.

## Linked Issue

Adressiert BEY-2747 (interner Paperclip-Tracker), Teil der Sanierung des Engineer-Loops aus BEY-2743. Kein öffentliches GitHub-Issue verlinkt; Issue-Beschreibung siehe oben unter "Thinking Path".
