### PR TITLE
feat(recovery,claude-local): hard-kill silent engineer runs after critical threshold (BEY-2746)

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -82,6 +82,12 @@ export interface AdapterExecutionTargetProcessOptions {
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;
+  /**
+   * Subprocess-level silent-stall watchdog. Hard-kills the child if no
+   * stdout/stderr bytes arrive within this many seconds. Surfaces as
+   * `silentStall: true` on the result.
+   */
+  silentStallTimeoutSec?: number;
 }
 
 export interface AdapterExecutionTargetShellOptions {
@@ -433,6 +439,7 @@ export async function runAdapterExecutionTargetProcess(
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,
     remoteExecution: adapterExecutionTargetToRemoteSpec(target),
+    silentStallTimeoutSec: options.silentStallTimeoutSec,
   });
 }
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -597,6 +597,60 @@ describe("runChildProcess", () => {
       }
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "kills a silent child after silentStallTimeoutSec when no stdout/stderr arrives",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", "setTimeout(() => process.stdout.write('late'), 60_000);"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          onLog: async () => {},
+          silentStallTimeoutSec: 1,
+        },
+      );
+
+      expect(result.silentStall).toBe(true);
+      expect(result.timedOut).toBe(false);
+      expect(result.stdout).toBe("");
+    },
+    15_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "does NOT trigger silent stall when output keeps arriving within the window",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "let n = 0;",
+            "const iv = setInterval(() => { process.stdout.write('tick '); n += 1; if (n >= 4) { clearInterval(iv); process.exit(0); } }, 100);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+          silentStallTimeoutSec: 1,
+        },
+      );
+
+      expect(result.silentStall).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("tick");
+    },
+    10_000,
+  );
 });
 
 describe("renderPaperclipWakePrompt", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -19,6 +19,11 @@ export interface RunProcessResult {
   stderr: string;
   pid: number | null;
   startedAt: string | null;
+  /**
+   * True when the process was terminated because no stdout/stderr bytes arrived
+   * within `silentStallTimeoutSec` (subprocess-level silent-stall watchdog).
+   */
+  silentStall?: boolean;
 }
 
 export interface TerminalResultCleanupOptions {
@@ -2147,6 +2152,12 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    /**
+     * If set, the process is hard-killed when no stdout/stderr bytes have arrived
+     * for this many seconds. Surfaces as `silentStall: true` on the result.
+     * 0 or omitted disables the watchdog.
+     */
+    silentStallTimeoutSec?: number;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -2197,6 +2208,7 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let silentStall = false;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -2206,6 +2218,33 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        let silentStallTimer: NodeJS.Timeout | null = null;
+        let silentStallKillTimer: NodeJS.Timeout | null = null;
+        const silentStallTimeoutMs =
+          opts.silentStallTimeoutSec && opts.silentStallTimeoutSec > 0
+            ? opts.silentStallTimeoutSec * 1000
+            : 0;
+        const armSilentStallTimer = () => {
+          if (silentStallTimeoutMs <= 0) return;
+          if (silentStallTimer) clearTimeout(silentStallTimer);
+          silentStallTimer = setTimeout(() => {
+            silentStallTimer = null;
+            if (timedOut || silentStall || terminalCleanupStarted) return;
+            silentStall = true;
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            silentStallKillTimer = setTimeout(() => {
+              silentStallKillTimer = null;
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }, silentStallTimeoutMs);
+        };
+        const clearSilentStallTimers = () => {
+          if (silentStallTimer) clearTimeout(silentStallTimer);
+          if (silentStallKillTimer) clearTimeout(silentStallKillTimer);
+          silentStallTimer = null;
+          silentStallKillTimer = null;
+        };
+        armSilentStallTimer();
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -2267,6 +2306,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stdout = appendWithCap(stdout, text);
+          armSilentStallTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -2283,6 +2323,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stderr = appendWithCap(stderr, text);
+          armSilentStallTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -2305,6 +2346,7 @@ export async function runChildProcess(
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearSilentStallTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -2323,6 +2365,7 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearSilentStallTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()
@@ -2336,6 +2379,7 @@ export async function runChildProcess(
                 stderr,
                 pid: child.pid ?? null,
                 startedAt,
+                silentStall,
               });
               });
           });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -66,6 +66,22 @@ import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Subprocess-level silent-stall watchdog: if the `claude` child process emits
+ * zero stdout/stderr bytes for this many seconds, runChildProcess SIGTERMs and
+ * then SIGKILLs it. Surfaces as `proc.silentStall = true` and is converted to
+ * an `errorCode: "silent_stall"` AdapterExecutionResult below. Overridable via
+ * `PAPERCLIP_CLAUDE_LOCAL_SILENT_STALL_SEC` for tests.
+ */
+const DEFAULT_CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC = 30 * 60;
+const CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC = (() => {
+  const raw = process.env.PAPERCLIP_CLAUDE_LOCAL_SILENT_STALL_SEC;
+  if (!raw) return DEFAULT_CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC;
+  return parsed;
+})();
+
 interface ClaudeExecutionInput {
   runId: string;
   agent: AdapterExecutionContext["agent"];
@@ -773,6 +789,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         graceMs: terminalResultCleanupGraceMs,
         hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,
       },
+      silentStallTimeoutSec: CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC,
     });
 
     const parsedStream = parseClaudeStreamJson(proc.stdout);
@@ -809,6 +826,26 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorMessage: `Timed out after ${timeoutSec}s`,
         errorCode: "timeout",
         errorMeta,
+        clearSession: Boolean(opts.clearSessionOnMissingSession),
+      };
+    }
+
+    if (proc.silentStall) {
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: false,
+        errorMessage: `Claude subprocess produced no output for ${CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC}s and was hard-killed (silent stall).`,
+        errorCode: "silent_stall",
+        errorMeta,
+        resultJson: {
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+          silentStall: {
+            timeoutSec: CLAUDE_LOCAL_SILENT_STALL_TIMEOUT_SEC,
+            killedAt: new Date().toISOString(),
+          },
+        },
         clearSession: Boolean(opts.clearSessionOnMissingSession),
       };
     }

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -344,6 +344,61 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(source?.status).not.toBe("blocked");
   });
 
+  it("hard-cancels the underlying run when output silence crosses the critical threshold", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(result.created).toBe(1);
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("silent_stall");
+    expect(run?.finishedAt).not.toBeNull();
+    expect(run?.error).toContain("stale-run watchdog");
+
+    const cancelEvent = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .then((rows) => rows.find((row) => row.message?.includes("Stale-run watchdog cancelled")));
+    expect(cancelEvent).toBeTruthy();
+  });
+
+  it("calls the cancelRun dep via recoveryService directly when the run is critical", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    const cancelRun = vi.fn(async () => undefined);
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(), cancelRun });
+
+    const result = await recovery.scanSilentActiveRuns({ now, companyId });
+    expect(result.created).toBe(1);
+    expect(cancelRun).toHaveBeenCalledTimes(1);
+    expect(cancelRun.mock.calls[0]?.[0]).toBe(runId);
+    expect(cancelRun.mock.calls[0]?.[2]).toMatchObject({ errorCode: "silent_stall" });
+  });
+
+  it("does NOT call cancelRun for suspicious-only (sub-critical) silent runs", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const cancelRun = vi.fn(async () => undefined);
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(), cancelRun });
+
+    const result = await recovery.scanSilentActiveRuns({ now, companyId });
+    expect(result.created).toBe(1);
+    expect(cancelRun).not.toHaveBeenCalled();
+  });
+
   it("emits the source-issue escalation comment only once across repeated critical scans", async () => {
     // Regression: when the same evaluation issue stays open and the watchdog re-evaluates the
     // run as critical on every scan cycle, ensureSourceIssueCommentedForStaleEvaluation must NOT
@@ -517,7 +572,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     expect(result).toMatchObject({ created: 1, folded: 0 });
     const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("silent_stall");
     const [evaluation] = await db
       .select()
       .from(issues)
@@ -561,7 +617,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     expect(result).toMatchObject({ created: 1, folded: 0 });
     const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
-    expect(run?.status).toBe("running");
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("silent_stall");
     const [evaluation] = await db
       .select()
       .from(issues)

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -182,7 +182,10 @@ export function agentRoutes(
   const heartbeat = heartbeatService(db, {
     pluginWorkerManager: options.pluginWorkerManager,
   });
-  const recovery = recoveryService(db, { enqueueWakeup: heartbeat.wakeup });
+  const recovery = recoveryService(db, {
+    enqueueWakeup: heartbeat.wakeup,
+    cancelRun: (runId, reason, options) => heartbeat.cancelRun(runId, reason, options),
+  });
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
   const instructions = agentInstructionsService();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3128,7 +3128,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     cancelWorkForScope: cancelBudgetScopeWork,
   };
   const budgets = budgetService(db, budgetHooks);
-  const recovery = recoveryService(db, { enqueueWakeup });
+  const recovery = recoveryService(db, {
+    enqueueWakeup,
+    cancelRun: (runId, reason, options) =>
+      cancelRunInternal(runId, reason ?? "Cancelled by control plane", options),
+  });
   const productivityReviews = productivityReviewService(db, { enqueueWakeup });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -110,6 +110,12 @@ type RecoveryWakeup = (
   opts?: RecoveryWakeupOptions,
 ) => Promise<typeof heartbeatRuns.$inferSelect | null>;
 
+export type RecoveryCancelRun = (
+  runId: string,
+  reason?: string,
+  options?: { errorCode?: string; eventMessage?: string; resultJson?: Record<string, unknown> },
+) => Promise<unknown>;
+
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
   "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
@@ -460,7 +466,10 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
-export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
+export function recoveryService(
+  db: Db,
+  deps: { enqueueWakeup: RecoveryWakeup; cancelRun?: RecoveryCancelRun },
+) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -1693,6 +1702,32 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       now: input.now,
     });
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+    const hardCancelSilentRun = async (eventMessageSuffix: string) => {
+      if (!deps.cancelRun) return;
+      const silenceLabel = formatDuration(evidence.silenceAgeMs);
+      try {
+        await deps.cancelRun(
+          input.run.id,
+          `Cancelled by stale-run watchdog after ${silenceLabel} of output silence (${eventMessageSuffix}).`,
+          {
+            errorCode: "silent_stall",
+            eventMessage: `Stale-run watchdog cancelled silent run (${eventMessageSuffix})`,
+            resultJson: {
+              silentStallCancellation: {
+                silenceAgeMs: evidence.silenceAgeMs,
+                lastOutputAt: input.run.lastOutputAt?.toISOString() ?? null,
+                criticalThresholdMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
+              },
+            },
+          },
+        );
+      } catch (err) {
+        logger.warn(
+          { err, runId: input.run.id },
+          "stale-run watchdog failed to hard-cancel silent run",
+        );
+      }
+    };
     if (existing) {
       if (level === "critical" && existing.priority !== "high") {
         await issuesSvc.update(existing.id, {
@@ -1710,6 +1745,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           evaluationIssue: existing,
           run: input.run,
         });
+        await hardCancelSilentRun("escalated to critical");
         return { kind: "escalated" as const, evaluationIssueId: existing.id };
       }
       if (level === "critical") {
@@ -1718,6 +1754,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           evaluationIssue: existing,
           run: input.run,
         });
+        await hardCancelSilentRun("existing critical evaluation");
       }
       return { kind: "existing" as const, evaluationIssueId: existing.id };
     }
@@ -1780,6 +1817,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         evaluationIssue: evaluation,
         run: input.run,
       });
+      await hardCancelSilentRun("new critical evaluation");
     }
     if (ownerAgentId) {
       await deps.enqueueWakeup(ownerAgentId, {


### PR DESCRIPTION
## Thinking Path

Paperclip-übergreifend: Der Engineer-Adapter konnte in einen "Silent-Stall"-Zustand laufen — der Claude-CLI-Subprozess lebt weiter (keine `close`-Event-Auslösung), produziert aber keinen Output mehr. Die existierende Stale-Run-Watchdog-Logik im Server hat das zwar erkannt und Eval-Issues angelegt, aber explizit den OS-Prozess am Leben gelassen. Resultat (BEY-2743): Heartbeats spawned weitere Runs neben dem hängenden, parallele Prozesse verbrannten Anthropic-Tokens stundenlang ohne produktive Arbeit.

Im Detail: Wir brauchen zwei voneinander unabhängige Kill-Ebenen. (1) Subprozess-Ebene: ein Watchdog in `runChildProcess`, der den Claude-Child nach 30 min ohne stdout/stderr per SIGTERM→SIGKILL beendet. (2) Server-Ebene: die bestehende Critical-Threshold-Auswertung (4h) muss zusätzlich `cancelRun` aufrufen, statt nur ein Eval-Issue zu schreiben.

## What Changed

### Server (recovery)
- `recoveryService` akzeptiert optionalen `cancelRun`-Dep.
- `ensureStaleRunEvaluation` ruft auf allen Critical-Pfaden (neu, eskaliert, existing) `cancelRun(runId, ..., {errorCode: "silent_stall"})`. `cancelRunInternal` macht intern bereits `terminateHeartbeatRunProcess` (SIGTERM → SIGKILL).
- Wiring in `server/src/services/heartbeat.ts` und `server/src/routes/agents.ts`.

### Adapter (claude-local + adapter-utils)
- Neuer `silentStallTimeoutSec`-Parameter auf `runChildProcess` (+ Forwarding via `AdapterExecutionTargetProcessOptions`). Wenn 0 stdout/stderr-Bytes im Fenster eintreffen: SIGTERM, dann SIGKILL; Result-Flag `silentStall: true`.
- `claude-local` opt-in bei 30 min Default (Override `PAPERCLIP_CLAUDE_LOCAL_SILENT_STALL_SEC`), mapped Result auf `AdapterExecutionResult{errorCode: "silent_stall"}`.

## Verification

- `server/__tests__/heartbeat-active-run-output-watchdog.test.ts` (21/21): 3 neue Cases (Hard-Cancel bei Critical-Threshold, direkter Dep-Aufruf, kein Cancel bei Suspicious-Only), 2 bestehende auf Cancelled-State angepasst.
- `packages/adapter-utils/src/server-utils.test.ts` (41/41): 2 neue Integration-Tests (Stall-Kill, Output-Reset).
- `pnpm --filter @paperclipai/{server,adapter-utils,adapter-claude-local} typecheck` clean.
- [ ] Manueller Smoke: realen Run via `SIGSTOP` einfrieren, prüfen, dass er innerhalb 30 min gereaped wird.

## Risks

- `hardCancelSilentRun` wird auf dem "existing critical evaluation"-Pfad in jedem Scan-Cycle aufgerufen, solange der Run im `running`-State bleibt. Setzt voraus, dass `cancelRunInternal` idempotent gegen bereits gecancelte Runs ist. Falls nicht, würden wiederholte Cancel-Versuche Logs/Events spammen.
- Subprozess-Timeout-Callback clearedet `silentStallTimers` nicht (nur `terminalCleanupTimers`). Funktional unkritisch wegen `timedOut`-Guard, aber inkonsistent — der Timer läuft bis zum `close`-Event leer mit.
- 30-min Default könnte für sehr lange legitime Toolchains (z.B. grosse Builds) zu kurz sein. Override via Env-Var existiert.
- Race-Window beim ersten Cancel-Attempt vs. Heartbeat-Spawn ist klein, aber nicht null — der nächste Heartbeat könnte theoretisch noch einen Run zwischen Critical-Detect und tatsächlicher Cancel-Commit spawnen.

## Model Used

- Provider: Anthropic
- Model: claude-opus-4-7 (Claude Opus 4.7)
- Context window: 200k tokens
- Capabilities: Tool use, extended thinking, code generation

## Dedup search

- [x] GitHub-PR-Liste auf "silent stall" / "stale run" / "hard-cancel" / "watchdog" durchsucht — keine offenen PRs mit überlappendem Scope gefunden. Watchdog-Idempotenz-Fix aus BEY-2745 (separater Commit) ist orthogonal.

## Linked Issue

Adressiert BEY-2746, Teil der Sanierung des Engineer-Loops aus BEY-2743 (interner Paperclip-Tracker). Kein öffentliches GitHub-Issue verlinkt; Issue-Beschreibung siehe oben unter "Thinking Path".
