### PR TITLE
Add Approvals link to left nav Work section

### DIFF
--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -286,6 +286,24 @@ describe("Sidebar", () => {
     });
   });
 
+  it("shows an Approvals nav item between Goals and Artifacts", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
+    const root = await renderSidebar();
+
+    const approvalsLink = [...container.querySelectorAll("a")].find(
+      (anchor) => anchor.textContent === "Approvals",
+    );
+    expect(approvalsLink?.getAttribute("href")).toBe("/approvals");
+
+    const navText = container.querySelector("nav")?.textContent ?? "";
+    expect(navText.indexOf("Goals")).toBeLessThan(navText.indexOf("Approvals"));
+    expect(navText.indexOf("Approvals")).toBeLessThan(navText.indexOf("Artifacts"));
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
   it("shows the Conference Room nav item when conference room chat is enabled (PAP-137)", async () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableIsolatedWorkspaces: false,

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   PanelLeftOpen,
   Pin,
   MessagesSquare,
+  ShieldCheck,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { NavLink } from "@/lib/router";
@@ -175,6 +176,7 @@ export function Sidebar() {
           <SidebarNavItem to="/issues" label="Tasks" icon={CircleDot} />
           <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          <SidebarNavItem to="/approvals" label="Approvals" icon={ShieldCheck} />
           <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
           {showWorkspacesLink ? (
             <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The left sidebar `Work` section is the primary navigation rail (Tasks, Routines, Goals, Artifacts, …) for reaching each top-level view
> - The `/approvals` view — where board/users resolve agent approval requests and confirmations — had no entry in this rail, so it was only reachable by typing the URL
> - Approvals are a frequent, time-sensitive surface (agents block waiting on them), so a missing nav entry adds friction to a core loop
> - This pull request adds an `Approvals` item to the `Work` section, between `Goals` and `Artifacts`
> - The benefit is one-click access to approvals as a first-class peer of the other Work views, with identical styling and active-state behavior

## Linked Issues or Issue Description

No upstream GitHub issue. Problem (feature):

- **What's missing:** the `/approvals` route has no left-nav entry, unlike the other top-level Work views (`/issues`, `/routines`, `/goals`, `/artifacts`).
- **Desired behavior:** an `Approvals` link in the `Work` section that navigates to the approvals view and shows active-state highlight like its peers.

## What Changed

- `ui/src/components/Sidebar.tsx`: added `<SidebarNavItem to="/approvals" label="Approvals" icon={ShieldCheck} />` in the `Work` section, ordered between `Goals` and `Artifacts`. Imported `ShieldCheck` from `lucide-react` (matches the Approvals page header icon).
- `ui/src/components/Sidebar.test.tsx`: added a unit test asserting the item renders with `href="/approvals"` and is ordered between `Goals` and `Artifacts`.
- Reuses the existing `SidebarNavItem` component, so styling, collapsed/rail behavior, company-prefix routing (e.g. `/PAP/approvals`), and active-state highlight are inherited by construction.

## Verification

- `pnpm --filter ui test -- Sidebar.test.tsx` → all Sidebar tests pass, including the new Approvals ordering/href assertion (17/17 locally).
- `tsc -b` (ui typecheck) → clean.
- Rendered the real `Sidebar` and confirmed the item appears between Goals and Artifacts and gains `bg-accent` + `text-foreground` on activation, identical to sibling items.

**Screenshots** (rendered `Sidebar`):

Default state — Approvals between Goals and Artifacts:

![Approvals nav item, default state](https://raw.githubusercontent.com/bkempler/paperclip/kem-66-screenshots/.pr-assets/kem-66/approvals-nav-default.png)

Active state — highlight matches sibling items:

![Approvals nav item, active state](https://raw.githubusercontent.com/bkempler/paperclip/kem-66-screenshots/.pr-assets/kem-66/approvals-nav-active.png)

## Risks

- **Low risk.** Two-line additive UI change plus a unit test; no schema, API, or behavioral changes to existing routes. The `/approvals` route already exists; this only adds a link to it.

## Model Used

- Claude Opus 4.8 (`claude-opus-4-8`), 1M context window, extended thinking + tool use (Claude Code / Paperclip agent harness).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
