### PR TITLE
fix(auth): allow managers to comment on direct reports' issues via chainOfCommand

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -912,4 +912,50 @@ describeEmbeddedPostgres("authorization service", () => {
       grant: { permissionKey: "tasks:assign" },
     });
   });
+
+  it("allows issue:mutate for a manager acting on a direct report's issue", async () => {
+    const company = await createCompany(db, "ManagerMutate");
+    const managerAgent = await createAgent(db, company.id, { role: "manager" });
+    const reportAgent = await createAgent(db, company.id, { role: "engineer", reportsTo: managerAgent.id });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: reportAgent.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: managerAgent.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        assigneeAgentId: reportAgent.id,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_manager_chain",
+    });
+  });
+
+  it("denies issue:mutate for an agent acting on a peer's issue (non-manager)", async () => {
+    const company = await createCompany(db, "PeerMutate");
+    const peerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const reportAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: reportAgent.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: peerAgent.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        assigneeAgentId: reportAgent.id,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+  });
 });

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1170,6 +1170,13 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
+      if (resource.assigneeAgentId && await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId)) {
+        return allow({
+          action: input.action,
+          reason: "allow_manager_chain",
+          explanation: "Allowed because the actor manages the issue assignee in the reporting chain.",
+        });
+      }
     }
     if (
       input.action === "agent_config:update" &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The authorization subsystem gates every POST /api/issues/:id/comments through issue:mutate in authorization.ts
> - The issue:mutate block only allows the assignee itself (allow_self) or issues with no assignee (allow_company_agent) — a manager posting on a direct report's assigned issue falls through to deny_missing_grant
> - Every manager in a company roster running the review-team skill was hitting 403 outside authorization boundary because of this gap
> - The existing codebase already has isManagerOf (used for tasks:manage_active_checkouts) and assertAgentIssueMutationAllowed already calls hasActiveCheckoutManagementOverride (which uses isManagerOf) as the next gate once the boundary check passes
> - This pull request adds a third arm to the issue:mutate block that calls isManagerOf, mirroring the tasks:manage_active_checkouts pattern
> - The benefit is: every manager can write feedback comments on their direct reports assigned issues; security envelope widens only by manager-report relationships already encoded in the org graph

## Linked Issues or Issue Description

No upstream issue exists. Bug description:

POST /api/issues/:id/comments returns 403 Issue is outside this actors authorization boundary when the actor is a manager (via chainOfCommand) of the issues assignee.

Expected: a manager can comment on a direct report issue.
Actual: 403 deny_missing_grant.

Steps to reproduce: create two agents where reportAgent.reportsTo = managerAgent.id, create an issue assigned to reportAgent, POST a comment as managerAgent.

## What Changed

- server/src/services/authorization.ts: added third arm to the issue:mutate block — if isManagerOf(companyId, actorAgentId, resource.assigneeAgentId) is true, return allow_manager_chain
- server/src/__tests__/authorization-service.test.ts: added two tests covering the new allow path and the preserved peer-deny path

## Verification

1. npx tsc --project server/tsconfig.json --noEmit passes with no type errors
2. New tests directly exercise the two code paths
3. Existing tasks:manage_active_checkouts tests confirm isManagerOf DB logic is sound

## Risks

Security envelope widens only by manager-report relationships already in agents.reportsTo chains — same set already accepted for tasks:manage_active_checkouts. No new relationship types. Two existing allow paths (allow_self, allow_company_agent) are untouched.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6
- Capabilities: tool use, agentic loop

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR following the bug report template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge