### PR TITLE
VER-1281: Guard instruction markdown against HTML comments (templating-layer guard)

### DIFF
--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -323,7 +323,7 @@ describe("agent instructions service", () => {
     }
 
     expect(dirtyFiles).toEqual([]);
-  });
+  }, 15_000);
 
   it("heals stale managed metadata when deleting bundle files", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-heal-delete-");

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -15,6 +15,25 @@ async function makeTempDir(prefix: string) {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
+async function collectAgentInstructionEntries(rootPath: string): Promise<string[]> {
+  const output: string[] = [];
+
+  async function walk(currentPath: string) {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const entryPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+      } else if (entry.isFile() && entry.name === "AGENTS.md" && entryPath.includes(`${path.sep}agents${path.sep}`)) {
+        output.push(entryPath);
+      }
+    }
+  }
+
+  await walk(rootPath);
+  return output.sort((left, right) => left.localeCompare(right));
+}
+
 function makeAgent(adapterConfig: Record<string, unknown>): TestAgent {
   return {
     id: "agent-1",
@@ -274,6 +293,36 @@ describe("agent instructions service", () => {
       instructionsFilePath: path.join(managedRoot, "AGENTS.md"),
     });
     await expect(fs.readFile(path.join(managedRoot, "docs", "TOOLS.md"), "utf8")).resolves.toBe("## Tools\n");
+  });
+
+  it("rejects block-level HTML comments in markdown bundle writes", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-block-comments-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+
+    await expect(svc.writeFile(agent, "AGENTS.md", "# Agent\n\n<!-- INHERITS: company-wide rules -->\n"))
+      .rejects
+      .toMatchObject({
+        status: 422,
+        message: "Instructions markdown files cannot contain block-level HTML comments",
+      });
+  });
+
+  it("keeps managed per-agent AGENTS.md files free of block-level HTML comments", async () => {
+    const companiesRoot = path.join(os.homedir(), ".paperclip", "instances", "default", "companies");
+    const files = await collectAgentInstructionEntries(companiesRoot);
+    const dirtyFiles: string[] = [];
+
+    for (const filePath of files) {
+      const content = await fs.readFile(filePath, "utf8");
+      if (/<!--[\s\S]*?-->/m.test(content)) dirtyFiles.push(filePath);
+    }
+
+    expect(dirtyFiles).toEqual([]);
   });
 
   it("heals stale managed metadata when deleting bundle files", async () => {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -9,6 +9,7 @@ const ROOT_KEY = "instructionsRootPath";
 const ENTRY_KEY = "instructionsEntryFile";
 const FILE_KEY = "instructionsFilePath";
 const PROMPT_KEY = "promptTemplate";
+const BLOCK_COMMENT_PATTERN = /<!--[\s\S]*?-->/m;
 /** @deprecated Use the managed instructions bundle system instead. */
 const BOOTSTRAP_PROMPT_KEY = "bootstrapPromptTemplate";
 const LEGACY_PROMPT_TEMPLATE_PATH = "promptTemplate.legacy.md";
@@ -620,8 +621,13 @@ export function agentInstructionsService() {
       return { bundle, file, adapterConfig };
     }
 
+    const normalizedPath = normalizeRelativeFilePath(relativePath);
+    if (isMarkdown(normalizedPath) && BLOCK_COMMENT_PATTERN.test(content)) {
+      throw unprocessable("Instructions markdown files cannot contain block-level HTML comments");
+    }
+
     const prepared = await ensureWritableBundle(agent, options);
-    const absolutePath = resolvePathWithinRoot(prepared.state.rootPath!, relativePath);
+    const absolutePath = resolvePathWithinRoot(prepared.state.rootPath!, normalizedPath);
     await fs.mkdir(path.dirname(absolutePath), { recursive: true });
     await fs.writeFile(absolutePath, content, "utf8");
     const nextAgent = { ...agent, adapterConfig: prepared.adapterConfig };


### PR DESCRIPTION
## Summary
Templating-layer guard so generated agent instruction markdown never emits raw `<!-- INHERITS -->` / HTML-comment inheritance placeholders. Two-commit, surgically scoped change.

## Scope (exactly 2 files)
- `server/src/services/agent-instructions.ts` (+8/-1) — guard logic
- `server/src/__tests__/agent-instructions-service.test.ts` (+49) — focused coverage

## Evidence
- Focused service test suite: 10/10 passing.
- Diff verified against `origin/master`: 2 files, +56/-1, no unrelated changes.

## Context
Release-path execution for VER-1281 / VER-1701 / VER-1758. Unblocks the R-series instruction-templating chain (VER-1269 / VER-1273 / VER-1271). Direct push to this repo is unavailable to the Verner.AI agent credential (`permissions.push:false`), so this is published via fork PR; merge requires a paperclipai maintainer.

Co-Authored-By: Paperclip <noreply@paperclip.ing>