### PR TITLE
fix(recovery): revalidate stale recovery actions on read_projection and pending-interaction blocked issues

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1320,7 +1320,6 @@ export function issueRoutes(
       return "Recovery action became stale because the source issue was manually moved from blocked to todo.";
     }
 
-    if (input.trigger === "read_projection") return null;
     if (
       input.trigger === "comment" &&
       input.resumeRequested !== true &&
@@ -1331,6 +1330,7 @@ export function issueRoutes(
     }
 
     const durableSourceChange =
+      input.trigger === "read_projection" ||
       input.statusChanged === true ||
       input.assigneeChanged === true ||
       input.blockersChanged === true ||
@@ -1342,12 +1342,36 @@ export function issueRoutes(
       input.reopened === true;
     if (!durableSourceChange) return null;
 
+    const waitingPathResolution = async (): Promise<string | null> => {
+      const executionState = parseIssueExecutionState(issue.executionState);
+      const participant = executionState?.status === "pending" ? executionState.currentParticipant : null;
+      if (
+        (participant?.type === "agent" && readNonEmptyString(participant.agentId)) ||
+        (participant?.type === "user" && readNonEmptyString(participant.userId))
+      ) {
+        return "Recovery action became stale because the source issue now has a typed review participant.";
+      }
+      const interactions = await issueThreadInteractionsSvc.listForIssue(issue.id);
+      if (interactions.some((interaction) => interaction.status === "pending")) {
+        return "Recovery action became stale because the source issue now has a pending issue interaction.";
+      }
+      const approvals = await issueApprovalsSvc.listApprovalsForIssue(issue.id);
+      if (approvals.some((approval) => approval.status === "pending" || approval.status === "revision_requested")) {
+        return "Recovery action became stale because the source issue now has a pending approval.";
+      }
+      const monitor = summarizeIssueMonitor(issue, normalizeIssueExecutionPolicy(issue.executionPolicy ?? null));
+      if (monitor.nextCheckAt && Date.parse(monitor.nextCheckAt) > Date.now()) {
+        return "Recovery action became stale because the source issue now has a scheduled monitor.";
+      }
+      return null;
+    };
+
     if (issue.status === "blocked") {
       const readiness = await svc.getDependencyReadiness(issue.id);
       if (readiness.unresolvedBlockerCount > 0) {
         return "Recovery action became stale because the source issue now has unresolved first-class blockers.";
       }
-      return null;
+      return waitingPathResolution();
     }
 
     if (issue.assigneeUserId && issue.status !== "done" && issue.status !== "cancelled") {
@@ -1359,32 +1383,10 @@ export function issueRoutes(
     }
 
     if (issue.status === "in_review") {
-      const executionState = parseIssueExecutionState(issue.executionState);
-      const participant = executionState?.status === "pending" ? executionState.currentParticipant : null;
-      if (
-        (participant?.type === "agent" && readNonEmptyString(participant.agentId)) ||
-        (participant?.type === "user" && readNonEmptyString(participant.userId))
-      ) {
-        return "Recovery action became stale because the source issue now has a typed review participant.";
-      }
-
-      const interactions = await issueThreadInteractionsSvc.listForIssue(issue.id);
-      if (interactions.some((interaction) => interaction.status === "pending")) {
-        return "Recovery action became stale because the source issue now has a pending issue interaction.";
-      }
-
-      const approvals = await issueApprovalsSvc.listApprovalsForIssue(issue.id);
-      if (approvals.some((approval) => approval.status === "pending" || approval.status === "revision_requested")) {
-        return "Recovery action became stale because the source issue now has a pending approval.";
-      }
+      return waitingPathResolution();
     }
 
-    const monitor = summarizeIssueMonitor(issue, normalizeIssueExecutionPolicy(issue.executionPolicy ?? null));
-    if (monitor.nextCheckAt && Date.parse(monitor.nextCheckAt) > Date.now()) {
-      return "Recovery action became stale because the source issue now has a scheduled monitor.";
-    }
-
-    return null;
+    return waitingPathResolution();
   }
 
   async function revalidateActiveSourceRecovery(input: {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1570,7 +1570,7 @@ async function listIssueBlockerAttentionMap(
             eq(issueRelations.type, "blocks"),
             inArray(issueRelations.relatedIssueId, chunk),
             eq(issues.companyId, companyId),
-            ne(issues.status, "done"),
+            notInArray(issues.status, ["done", "cancelled"]),
           ),
         );
       const childRowsPromise: Promise<IssueBlockerAttentionQueryRow[]> = dbOrTx
@@ -1592,7 +1592,7 @@ async function listIssueBlockerAttentionMap(
           and(
             eq(issues.companyId, companyId),
             inArray(issues.parentId, chunk),
-            ne(issues.status, "done"),
+            notInArray(issues.status, ["done", "cancelled"]),
           ),
         );
       const [explicitBlockerRows, childRows] = await Promise.all([


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery-action subsystem tracks active recovery cases on issues (stranded, liveness escalation) to help operators identify issues that need attention
> - Two bugs in `classifySourceRecoveryRevalidation` (routes/issues.ts) prevented stale recovery actions from being auto-cleared on read paths and for blocked issues that have a pending interaction but no explicit first-class blockers
> - Bug 1: an early `if (input.trigger === "read_projection") return null` short-circuited all revalidation on GET paths, so reading an issue never cleared a stale recovery action — only writes could
> - Bug 2: the `blocked` status branch returned `null` when there were no unresolved first-class blockers, instead of calling `waitingPathResolution()` — so a blocked issue with a pending interaction stayed marked for recovery indefinitely
> - Additionally, `listIssueBlockerAttentionMap` in services/issues.ts excluded only `done` issues from blocker attention, not `cancelled` ones, so cancelled blockers incorrectly contributed to blocker attention scores
> - This PR removes the premature read_projection short-circuit, moves `read_projection` into `durableSourceChange`, extracts a shared `waitingPathResolution()` helper, and fixes the `blocked`/`in_review` status branches and fallthrough to all call it; also extends the attention filter to cover `cancelled`

## Linked Issues or Issue Description

No upstream GitHub issue — reproducing on a local Paperclip instance:

**Bug:** A blocked issue with a pending issue-thread interaction (but no `blockedByIssueIds`) keeps an active recovery action alive permanently. On read (GET heartbeat-context or GET issue), `activeRecoveryAction` is returned non-null even though the issue has a valid waiting path (pending interaction). The parent issue's `blockedBy` summary also inherits the stale `activeRecoveryAction`, causing false `blockerAttention.state = needs_attention` on the parent.

**Expected:** Once a blocked issue has a pending interaction, the recovery action should be classified as stale (covered by the interaction) and auto-cleared on the next read.

**Deployment mode:** local_trusted

## What Changed

- **`server/src/routes/issues.ts` — `classifySourceRecoveryRevalidation`:**
  - Remove the early `if (input.trigger === "read_projection") return null` short-circuit
  - Add `input.trigger === "read_projection"` to `durableSourceChange` so read paths flow through the full classification
  - Extract a `waitingPathResolution()` inner async function that consolidates checks for typed execution participants, pending interactions, pending approvals, and scheduled monitors (previously this logic was only inlined in the `in_review` branch; the monitor check was outside the `in_review` block)
  - For `blocked` issues with no unresolved first-class blockers, call `waitingPathResolution()` instead of `return null`
  - Replace the inline `in_review` branch with `return waitingPathResolution()`
  - Replace the final `return null` fallthrough with `return waitingPathResolution()`
- **`server/src/services/issues.ts` — `listIssueBlockerAttentionMap`:**
  - Change `ne(issues.status, "done")` to `notInArray(issues.status, ["done", "cancelled"])` in both the explicit-blocker and child-issue attention queries

## Verification

1. Create a blocked issue with a pending `request_confirmation` interaction but no `blockedByIssueIds`
2. Before this fix: `GET /api/issues/:id/heartbeat-context` returns non-null `activeRecoveryAction`; `GET /api/issues/:id` returns non-null `activeRecoveryAction`; parent issue shows `blockerAttention.state = needs_attention`
3. After this fix: both endpoints return `activeRecoveryAction: null`; parent shows `blockerAttention.state = covered` or `none`

```bash
# typecheck
pnpm --filter @paperclipai/server typecheck
# build
pnpm --filter @paperclipai/server build
```

## Risks

Low risk. The changes tighten revalidation (more aggressive auto-clearing of stale recovery actions), which is the correct direction. No new DB migrations, no API schema changes, no breaking changes. The `waitingPathResolution()` refactor is behaviorally equivalent to the previous `in_review` inline logic for that status; the change is that `blocked` and the final fallthrough now also run those checks.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context: 200k context window, extended reasoning, tool use enabled
- The change was developed by a Paperclip FSE agent running as Claude Sonnet 4.6 via the Paperclip local adapter

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge