### PR TITLE
feat(opencode-local): adapterConfig.jsonMode spike — per-model json_object injection (SAG-4195)

### DIFF
--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -31,6 +31,7 @@ Core fields:
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
 - variant (string, optional): provider-specific reasoning/profile variant passed as --variant (for example minimal|low|medium|high|xhigh|max)
 - dangerouslySkipPermissions (boolean, optional): inject a runtime OpenCode config that allows \`external_directory\` access without interactive prompts; defaults to true for unattended Paperclip runs
+- jsonMode (boolean, optional): inject \`responseFormat:{type:"json_object"}\` into the runtime OpenCode config for the configured model's options, constraining every completion to valid JSON; use for structured-output agents (catalog enrichers, doc extractors) to prevent think-tag and preamble leakage; requires \`model\` in \`provider/model\` format and dangerouslySkipPermissions=true (default)
 - promptTemplate (string, optional): run prompt template
 - command (string, optional): defaults to "opencode"
 - extraArgs (string[], optional): additional CLI args
@@ -52,4 +53,7 @@ Notes:
 - When \`dangerouslySkipPermissions\` is enabled, Paperclip injects a temporary \
   runtime config with \`permission.external_directory=allow\` so headless runs do \
   not stall on approval prompts.
+- When \`jsonMode\` is enabled, Paperclip injects \`responseFormat:{type:"json_object"}\` \
+  into the model's options in the runtime config so that Ollama constrains every \
+  completion to valid JSON output, preventing <think> tag leakage.
 `;

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ensureRemoteOpenCodeModelConfiguredAndAvailable,
+  stripThinkBlocks,
+} from "./execute.js";
+
+describe("ensureRemoteOpenCodeModelConfiguredAndAvailable", () => {
+  afterEach(() => {
+    delete process.env.OPENCODE_ALLOW_ALL_MODELS;
+  });
+
+  // The remote/sandbox execution path must honour OPENCODE_ALLOW_ALL_MODELS just
+  // like the local path: gateway-routed models (e.g. anthropic/<gateway>/<model>
+  // via Bifrost) never appear in `opencode models`, so the availability probe
+  // must be skipped. The early return happens before the executionTarget is ever
+  // touched, so a bogus target proves the probe was not run.
+  const bogusTarget = {} as never;
+
+  it("skips the remote availability probe when OPENCODE_ALLOW_ALL_MODELS is set in the run env", async () => {
+    await expect(
+      ensureRemoteOpenCodeModelConfiguredAndAvailable({
+        runId: "run-1",
+        executionTarget: bogusTarget,
+        command: "opencode",
+        model: "anthropic/tensorix/deepseek/deepseek-chat-v3.1",
+        cwd: "/tmp",
+        env: { OPENCODE_ALLOW_ALL_MODELS: "true" },
+        timeoutSec: 30,
+        graceSec: 5,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("honours OPENCODE_ALLOW_ALL_MODELS from the process env", async () => {
+    process.env.OPENCODE_ALLOW_ALL_MODELS = "1";
+    await expect(
+      ensureRemoteOpenCodeModelConfiguredAndAvailable({
+        runId: "run-2",
+        executionTarget: bogusTarget,
+        command: "opencode",
+        model: "anthropic/tensorix/deepseek/deepseek-chat-v3.1",
+        cwd: "/tmp",
+        env: {},
+        timeoutSec: 30,
+        graceSec: 5,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still enforces provider/model format even when the bypass flag is set", async () => {
+    await expect(
+      ensureRemoteOpenCodeModelConfiguredAndAvailable({
+        runId: "run-3",
+        executionTarget: bogusTarget,
+        command: "opencode",
+        model: "",
+        cwd: "/tmp",
+        env: { OPENCODE_ALLOW_ALL_MODELS: "true" },
+        timeoutSec: 30,
+        graceSec: 5,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("stripThinkBlocks", () => {
+  it("strips a single-line think block, leaving the rest", () => {
+    expect(stripThinkBlocks("<think>internal reasoning</think>done")).toBe("done");
+  });
+
+  it("strips a multiline think block (dotall)", () => {
+    const input = "<think>\nstep 1\nstep 2\n</think>Result text";
+    expect(stripThinkBlocks(input)).toBe("Result text");
+  });
+
+  it("strips multiple think blocks", () => {
+    const input = "<think>a</think>middle<think>b</think>end";
+    expect(stripThinkBlocks(input)).toBe("middleend");
+  });
+
+  it("is inert when no think block is present", () => {
+    const text = "Hello, this is normal output with no think tags.";
+    expect(stripThinkBlocks(text)).toBe(text);
+  });
+
+  it("does not corrupt JSON payloads with no think tags", () => {
+    const json = '{"key":"value","array":[1,2,3],"nested":{"ok":true}}';
+    expect(stripThinkBlocks(json)).toBe(json);
+  });
+
+  it("does not match arbitrary angle-bracket words (only literal think tags)", () => {
+    const text = "a <b>bold</b> word";
+    expect(stripThinkBlocks(text)).toBe(text);
+  });
+
+  it("trims leading whitespace left after stripping a leading think block", () => {
+    const input = "<think>reasoning</think>\n\nActual answer.";
+    expect(stripThinkBlocks(input)).toBe("Actual answer.");
+  });
+
+  it("is non-greedy: two think blocks do not merge into one match", () => {
+    const input = "<think>A</think>KEEP<think>B</think>";
+    expect(stripThinkBlocks(input)).toBe("KEEP");
+  });
+});

--- a/packages/adapters/opencode-local/src/server/execute.test.ts
+++ b/packages/adapters/opencode-local/src/server/execute.test.ts
@@ -103,4 +103,9 @@ describe("stripThinkBlocks", () => {
     const input = "<think>A</think>KEEP<think>B</think>";
     expect(stripThinkBlocks(input)).toBe("KEEP");
   });
+
+  it("leaves an unclosed think tag intact (does not truncate real output)", () => {
+    const input = "<think>partial reasoning without closing tag\nActual answer.";
+    expect(stripThinkBlocks(input)).toBe(input);
+  });
 });

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  type AdapterExecutionTarget,
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetPaperclipApiUrl,
   adapterExecutionTargetRemoteCwd,
@@ -52,6 +53,40 @@ const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 // Non-greedy, dotall (s flag), case-sensitive. Exported for unit tests.
 export function stripThinkBlocks(text: string): string {
   return text.replace(/<think>.*?<\/think>/gs, "").trim();
+}
+
+// Remote-execution-target-aware model availability guard. Unlike the local
+// variant (ensureOpenCodeModelConfiguredAndAvailable in models.ts), this one
+// honours OPENCODE_ALLOW_ALL_MODELS so that gateway-routed models (e.g.
+// anthropic/<gateway>/<model> via Bifrost) that never appear in `opencode
+// models` output can still be used on remote/sandbox targets.
+// Format validation (non-empty, provider/model) always runs — the bypass only
+// skips the availability probe.
+// Exported for unit tests.
+export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
+  runId: string;
+  executionTarget: AdapterExecutionTarget;
+  command: string;
+  model: string;
+  cwd: string;
+  env: Record<string, string>;
+  timeoutSec: number;
+  graceSec: number;
+}): Promise<void> {
+  const model = input.model.trim();
+  if (!model) {
+    throw new Error("OpenCode requires `adapterConfig.model` in provider/model format.");
+  }
+  const allowAllModels =
+    (input.env.OPENCODE_ALLOW_ALL_MODELS?.trim().length ?? 0) > 0 ||
+    (process.env.OPENCODE_ALLOW_ALL_MODELS?.trim().length ?? 0) > 0;
+  if (allowAllModels) return;
+  await ensureOpenCodeModelConfiguredAndAvailable({
+    model: input.model,
+    command: input.command,
+    cwd: input.cwd,
+    env: input.env,
+  });
 }
 
 function firstNonEmptyLine(text: string): string {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -48,6 +48,12 @@ import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
+// Sourced from enrichment/dispatcher.py:280 — matches re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
+// Non-greedy, dotall (s flag), case-sensitive. Exported for unit tests.
+export function stripThinkBlocks(text: string): string {
+  return text.replace(/<think>.*?<\/think>/gs, "").trim();
+}
+
 function firstNonEmptyLine(text: string): string {
   return (
     text
@@ -540,7 +546,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
         },
-        summary: attempt.parsed.summary,
+        summary: stripThinkBlocks(attempt.parsed.summary),
         clearSession: Boolean(clearSessionOnMissingSession && !attempt.parsed.sessionId),
       };
     };

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -76,4 +76,109 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     expect(prepared.notes).toEqual([]);
     await prepared.cleanup();
   });
+
+  it("injects responseFormat json_object options for the configured model when jsonMode is true", async () => {
+    const configHome = await makeConfigHome();
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {
+        jsonMode: true,
+        model: "ollama/gemma4:26b-a4b-it-q4_K_M",
+      },
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(runtimeConfig).toMatchObject({
+      provider: {
+        ollama: {
+          models: {
+            "gemma4:26b-a4b-it-q4_K_M": {
+              options: {
+                responseFormat: { type: "json_object" },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(prepared.notes.some((n) => n.includes("responseFormat"))).toBe(true);
+
+    await prepared.cleanup();
+    cleanupPaths.delete(prepared.env.XDG_CONFIG_HOME);
+  });
+
+  it("does not inject responseFormat when jsonMode is false", async () => {
+    const configHome = await makeConfigHome();
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {
+        jsonMode: false,
+        model: "ollama/gemma4:26b-a4b-it-q4_K_M",
+      },
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect((runtimeConfig as { provider?: unknown }).provider).toBeUndefined();
+
+    await prepared.cleanup();
+    cleanupPaths.delete(prepared.env.XDG_CONFIG_HOME);
+  });
+
+  it("preserves existing provider config when injecting jsonMode", async () => {
+    const configHome = await makeConfigHome({
+      provider: {
+        ollama: {
+          npm: "@ai-sdk/openai-compatible",
+          options: { baseURL: "http://localhost:11434/v1" },
+          models: {
+            "llama3.3:70b": { name: "Llama 3.3", tools: true },
+          },
+        },
+      },
+    });
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {
+        jsonMode: true,
+        model: "ollama/gemma4:26b-a4b-it-q4_K_M",
+      },
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(runtimeConfig).toMatchObject({
+      provider: {
+        ollama: {
+          npm: "@ai-sdk/openai-compatible",
+          options: { baseURL: "http://localhost:11434/v1" },
+          models: {
+            "llama3.3:70b": { name: "Llama 3.3", tools: true },
+            "gemma4:26b-a4b-it-q4_K_M": {
+              options: { responseFormat: { type: "json_object" } },
+            },
+          },
+        },
+      },
+    });
+
+    await prepared.cleanup();
+    cleanupPaths.delete(prepared.env.XDG_CONFIG_HOME);
+  });
 });

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -67,13 +67,50 @@ export async function prepareOpenCodeRuntimeConfig(input: {
   const existingPermission = isPlainObject(existingConfig.permission)
     ? existingConfig.permission
     : {};
-  const nextConfig = {
+  const notes = [
+    "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
+  ];
+  const nextConfig: Record<string, unknown> = {
     ...existingConfig,
     permission: {
       ...existingPermission,
       external_directory: "allow",
     },
   };
+
+  // Inject per-model responseFormat: json_object when jsonMode is enabled. This
+  // constrains the model's output to valid JSON on every request, preventing
+  // <think> tags and free-text preambles from leaking into structured-output
+  // agents (Local-AI Catalog Enricher, Doc Extractor, SKU Cataloger).
+  const jsonMode = input.config.jsonMode === true;
+  const configModel = typeof input.config.model === "string" ? input.config.model.trim() : "";
+  const slashIdx = configModel.indexOf("/");
+  if (jsonMode && slashIdx > 0 && slashIdx < configModel.length - 1) {
+    const providerId = configModel.slice(0, slashIdx);
+    const modelId = configModel.slice(slashIdx + 1);
+    const baseProvider = isPlainObject(existingConfig.provider) ? existingConfig.provider : {};
+    const baseProviderEntry = isPlainObject(baseProvider[providerId]) ? baseProvider[providerId] : {};
+    const baseModels = isPlainObject(baseProviderEntry.models) ? baseProviderEntry.models : {};
+    const baseModelEntry = isPlainObject(baseModels[modelId]) ? baseModels[modelId] : {};
+    nextConfig.provider = {
+      ...baseProvider,
+      [providerId]: {
+        ...baseProviderEntry,
+        models: {
+          ...baseModels,
+          [modelId]: {
+            ...baseModelEntry,
+            options: {
+              ...(isPlainObject(baseModelEntry.options) ? baseModelEntry.options : {}),
+              responseFormat: { type: "json_object" },
+            },
+          },
+        },
+      },
+    };
+    notes.push(`Injected responseFormat:json_object for model ${configModel} via jsonMode.`);
+  }
+
   await fs.writeFile(runtimeConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`, "utf8");
 
   return {
@@ -81,9 +118,7 @@ export async function prepareOpenCodeRuntimeConfig(input: {
       ...input.env,
       XDG_CONFIG_HOME: runtimeConfigHome,
     },
-    notes: [
-      "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
-    ],
+    notes,
     cleanup: async () => {
       await fs.rm(runtimeConfigHome, { recursive: true, force: true });
     },

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,0 +1,29 @@
+# Virtual environments
+venv/
+.venv/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Coverage
+.coverage
+htmlcov/
+
+# Test / lint caches
+.pytest_cache/
+.ruff_cache/
+
+# Logs and run artifacts
+*.log
+qa_results/
+test_results.log
+pytest_results.log
+pytest_output.log
+tests_output.log
+integration_test_run.log
+
+# Nested / stray workspace dirs (env-var-named artifacts)
+packages/
+$PAPERCLIP_WORKSPACE_CWD/

--- a/packages/api/app/auth.py
+++ b/packages/api/app/auth.py
@@ -1,0 +1,195 @@
+import asyncio
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+security = HTTPBearer()
+
+# JWKS cache keyed by JWKS URL, with TTL
+_jwks_cache: dict[str, dict[str, Any]] = {}
+_jwks_fetched_at: dict[str, float] = {}
+_JWKS_TTL_SECONDS = 3600  # re-fetch keys every hour
+
+# Static JWKS override — no network call needed when set.
+_STATIC_JWKS: dict[str, Any] | None = None
+if settings.CLERK_JWKS_OVERRIDE:
+    try:
+        _STATIC_JWKS = json.loads(settings.CLERK_JWKS_OVERRIDE)
+    except Exception as _e:
+        logger.error("Failed to parse CLERK_JWKS_OVERRIDE: %s", _e)
+# Explicit JWKS URL override (from CLERK_JWKS_URL env var).
+_STATIC_JWKS_URL: str | None = settings.CLERK_JWKS_URL or None
+
+if _STATIC_JWKS:
+    logger.info("Using static JWKS override (%d key(s))", len(_STATIC_JWKS.get("keys", [])))
+elif _STATIC_JWKS_URL:
+    logger.info("Using explicit JWKS URL: %s", _STATIC_JWKS_URL)
+
+
+async def _fetch_jwks(jwks_url: str) -> dict[str, Any]:
+    """Fetch JWKS from a full URL with retry and TTL cache."""
+    now = time.monotonic()
+    cached = _jwks_cache.get(jwks_url)
+    if cached is not None and (now - _jwks_fetched_at.get(jwks_url, 0)) < _JWKS_TTL_SECONDS:
+        return cached
+
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(jwks_url, timeout=15)
+                resp.raise_for_status()
+                result = resp.json()
+                _jwks_cache[jwks_url] = result
+                _jwks_fetched_at[jwks_url] = time.monotonic()
+                return result
+        except httpx.HTTPError as exc:
+            last_error = exc
+            logger.warning("JWKS fetch from %s attempt %d failed: %s", jwks_url, attempt + 1, exc)
+            if attempt < 2:
+                await asyncio.sleep(1 * (attempt + 1))
+
+    # All retries exhausted — use stale cache if available
+    if cached is not None:
+        logger.warning("Using stale JWKS cache for %s after fetch failure", jwks_url)
+        return cached
+
+    raise last_error  # type: ignore[misc]
+
+
+_CLERK_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # UUID namespace OID
+
+
+class CurrentUser:
+    def __init__(self, user_id: str, tenant_id: str | None, claims: dict[str, Any]) -> None:
+        self.user_id = user_id
+        self.tenant_id = tenant_id
+        self.claims = claims
+
+    @property
+    def effective_tenant_id(self) -> str:
+        """Return the org tenant_id, or a deterministic UUID derived from the
+        Clerk user_id for solo users with no Clerk Organisation attached.
+        The UUID5 derivation is stable and valid so DB UUID columns accept it."""
+        if self.tenant_id:
+            return self.tenant_id
+        return str(uuid.uuid5(_CLERK_NS, self.user_id))
+
+
+async def ensure_tenant_exists(db: "AsyncSession", user: "CurrentUser") -> str:
+    """Auto-provision a tenant row for solo users so FK constraints are satisfied.
+
+    For users with a real Clerk org the tenant_id comes from the JWT and the
+    tenant row is expected to exist already (created during org provisioning).
+    For solo users we derive a stable UUID5 from the Clerk user_id and create
+    the row on-demand so any property/data write succeeds.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models import Tenant
+
+    tenant_id = user.effective_tenant_id
+    result = await db.execute(select(Tenant).where(Tenant.id == tenant_id))
+    if result.scalar_one_or_none() is None:
+        try:
+            async with db.begin_nested():  # savepoint — rolls back only on conflict
+                db.add(
+                    Tenant(
+                        id=tenant_id,
+                        name="Personal Workspace",
+                        slug=f"solo-{tenant_id[:8]}",
+                    )
+                )
+        except IntegrityError:
+            pass  # concurrent request already created it
+    return tenant_id
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> CurrentUser:
+    token = credentials.credentials
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        # Decode header and claims without verification to get kid and issuer
+        unverified_header = jwt.get_unverified_header(token)
+        kid = unverified_header.get("kid")
+        unverified_claims = jwt.get_unverified_claims(token)
+        issuer = unverified_claims.get("iss")
+
+        if not issuer:
+            raise credentials_exception
+
+        # Resolve JWKS: static override > explicit URL > derive from iss
+        if _STATIC_JWKS is not None:
+            jwks = _STATIC_JWKS
+        else:
+            jwks_url = _STATIC_JWKS_URL or f"{issuer.rstrip('/')}/.well-known/jwks.json"
+            jwks = await _fetch_jwks(jwks_url)
+        signing_key: dict[str, Any] | None = None
+        for key in jwks.get("keys", []):
+            if key.get("kid") == kid:
+                signing_key = key
+                break
+
+        if signing_key is None:
+            raise credentials_exception
+
+        payload: dict[str, Any] = jwt.decode(
+            token,
+            signing_key,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+            issuer=issuer,
+        )
+
+        # Clerk stores the subject as the user ID
+        user_id: str | None = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+
+        # tenant_id may be stored in custom claims (org_id or tenant_id)
+        tenant_id: str | None = payload.get("org_id") or payload.get("tenant_id")
+
+        return CurrentUser(user_id=user_id, tenant_id=tenant_id, claims=payload)
+
+    except JWTError:
+        raise credentials_exception
+    except httpx.HTTPError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to fetch authentication keys",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/me")
+async def get_me(current_user: CurrentUser = Depends(get_current_user)) -> dict[str, Any]:
+    return {
+        "user_id": current_user.user_id,
+        "tenant_id": current_user.tenant_id,
+        "claims": current_user.claims,
+    }

--- a/packages/api/app/config.py
+++ b/packages/api/app/config.py
@@ -1,0 +1,41 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    DATABASE_URL: str = "postgresql+asyncpg://localhost:5432/gcp_renovation"
+    REDIS_URL: str = ""
+    AWS_ACCESS_KEY: str = ""
+    AWS_SECRET_KEY: str = ""
+    S3_BUCKET: str = ""
+    CLERK_SECRET_KEY: str = ""
+    # Explicit JWKS URL — fetched at request time when set.
+    CLERK_JWKS_URL: str = ""
+    # Static JWKS JSON override — when set, no network call is made for auth.
+    # Format: {"keys": [{...JWK...}]}
+    CLERK_JWKS_OVERRIDE: str = ""
+    ANTHROPIC_API_KEY: str = ""
+    STRIPE_SECRET_KEY: str = ""
+    ZILLOW_API_KEY: str = ""
+    RENTCAST_API_KEY: str = ""
+    PROPSTREAM_API_KEY: str = ""
+    GOOGLE_PLACES_API_KEY: str = ""
+    FEMA_API_KEY: str = ""
+
+    # Sage API (formal integration — Sprint 1.9)
+    SAGE_API_URL: str = ""
+    SAGE_API_KEY: str = ""
+
+    # Dynamics 365
+    D365_TENANT_ID: str = ""
+    D365_CLIENT_ID: str = ""
+    D365_CLIENT_SECRET: str = ""
+    D365_RESOURCE_URL: str = ""
+    D365_API_URL: str = ""
+
+    # CORS — comma-separated origins, defaults to wildcard for local dev
+    CORS_ORIGINS: str = "*"
+
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
+
+
+settings = Settings()

--- a/packages/api/app/database.py
+++ b/packages/api/app/database.py
@@ -1,0 +1,35 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from app.config import settings
+
+_is_sqlite = settings.DATABASE_URL.startswith("sqlite")
+_engine_kwargs: dict = {"echo": False, "pool_pre_ping": not _is_sqlite}
+if not _is_sqlite:
+    _engine_kwargs.update({"pool_size": 10, "max_overflow": 20})
+
+engine = create_async_engine(settings.DATABASE_URL, **_engine_kwargs)
+
+AsyncSessionLocal = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autoflush=False,
+    autocommit=False,
+)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+async def get_db() -> AsyncSession:  # type: ignore[return]
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -1,0 +1,133 @@
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user, router as auth_router
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+from app.routers.comps import router as comps_router
+from app.routers.properties import router as properties_router
+from app.routers.financing import router as financing_router
+from app.routers.catalog import router as catalog_router
+from app.routers.photo_analysis import router as photo_analysis_router
+from app.routers.orders import router as orders_router
+from app.routers.quotes import router as quotes_router
+from app.routers.risk import router as risk_router
+from app.routers.credit_memos import router as credit_memos_router
+from app.routers.credit_memo_report import router as credit_memo_report_router
+
+app = FastAPI(
+    title="GCP Renovation API",
+    description="Backend API for the GCP Renovation platform",
+    version="0.1.0",
+)
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+_origins = (
+    [o.strip() for o in settings.CORS_ORIGINS.split(",")]
+    if settings.CORS_ORIGINS != "*"
+    else ["*"]
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# ---------------------------------------------------------------------------
+# Routers
+# ---------------------------------------------------------------------------
+
+app.include_router(auth_router)
+app.include_router(properties_router)
+app.include_router(comps_router)
+app.include_router(risk_router)
+app.include_router(financing_router)
+app.include_router(catalog_router)
+app.include_router(photo_analysis_router)
+app.include_router(quotes_router)
+app.include_router(orders_router)
+app.include_router(credit_memos_router)
+app.include_router(credit_memo_report_router)
+
+# ---------------------------------------------------------------------------
+# Core routes
+# ---------------------------------------------------------------------------
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled error on %s %s", request.method, request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error", "type": type(exc).__name__},
+    )
+
+
+@app.get("/health", tags=["health"])
+async def health_check() -> dict[str, str]:
+    return {"status": "ok", "service": "gcp-renovation-api"}
+
+
+@app.get("/auth-config", tags=["health"])
+async def auth_config() -> dict:
+    """Non-sensitive debug: shows which auth mode is active."""
+    from app.auth import _STATIC_JWKS, _STATIC_JWKS_URL
+    return {
+        "static_jwks_loaded": _STATIC_JWKS is not None,
+        "static_jwks_key_count": len(_STATIC_JWKS.get("keys", [])) if _STATIC_JWKS else 0,
+        "static_jwks_url_set": bool(_STATIC_JWKS_URL),
+        "clerk_jwks_override_env_len": len(settings.CLERK_JWKS_OVERRIDE),
+    }
+
+
+@app.post("/seed-demo", tags=["health"])
+async def seed_demo(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Insert sample properties for the authenticated user's tenant so the
+    dashboard has demo data to display. Safe to call multiple times — skips
+    rows that already exist (checked by address + tenant_id)."""
+    import uuid as _uuid
+    from sqlalchemy import select
+    from app.models import Property
+
+    tenant_id = await ensure_tenant_exists(db, current_user)
+    samples = [
+        dict(address="1234 Oak Creek Dr", city="The Woodlands", state="TX", zip="77381",
+             beds=4, baths=3.0, sqft=2800, listing_price=450000, arv_estimate=520000,
+             property_type="Single Family", data_source="demo"),
+        dict(address="5678 Pine Ridge Ln", city="The Woodlands", state="TX", zip="77381",
+             beds=3, baths=2.0, sqft=1950, listing_price=310000, arv_estimate=370000,
+             property_type="Single Family", data_source="demo"),
+        dict(address="9012 Elm Street", city="Spring", state="TX", zip="77373",
+             beds=2, baths=1.5, sqft=1200, listing_price=185000, arv_estimate=220000,
+             property_type="Townhouse", data_source="demo"),
+    ]
+    added = 0
+    for s in samples:
+        existing = await db.execute(
+            select(Property).where(
+                Property.address == s["address"],
+                Property.tenant_id == tenant_id,
+            )
+        )
+        if existing.scalar_one_or_none() is None:
+            db.add(Property(id=str(_uuid.uuid4()), tenant_id=tenant_id, status="active", **s))
+            added += 1
+    await db.commit()
+    return {"seeded": added, "tenant_id": tenant_id}

--- a/packages/api/app/models.py
+++ b/packages/api/app/models.py
@@ -1,0 +1,913 @@
+import uuid
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _now() -> datetime:
+    return datetime.utcnow()
+
+
+# ---------------------------------------------------------------------------
+# Tenants
+# ---------------------------------------------------------------------------
+
+
+class Tenant(Base):
+    __tablename__ = "tenants"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    plan: Mapped[str] = mapped_column(String(50), nullable=False, default="free")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    users: Mapped[list["User"]] = relationship("User", back_populates="tenant")
+    properties: Mapped[list["Property"]] = relationship("Property", back_populates="tenant")
+    deals: Mapped[list["Deal"]] = relationship("Deal", back_populates="tenant")
+    quotes: Mapped[list["Quote"]] = relationship("Quote", back_populates="tenant")
+    trade_partners: Mapped[list["TradePartner"]] = relationship(
+        "TradePartner", back_populates="tenant"
+    )
+    orders: Mapped[list["Order"]] = relationship("Order", back_populates="tenant")
+    products: Mapped[list["Product"]] = relationship("Product", back_populates="tenant")
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    clerk_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    tenant_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="SET NULL"), nullable=True
+    )
+    role: Mapped[str] = mapped_column(String(50), nullable=False, default="member")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    tenant: Mapped["Tenant | None"] = relationship("Tenant", back_populates="users")
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class Property(Base):
+    __tablename__ = "properties"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    address: Mapped[str] = mapped_column(String(500), nullable=False)
+    city: Mapped[str] = mapped_column(String(100), nullable=False)
+    state: Mapped[str] = mapped_column(String(50), nullable=False)
+    zip: Mapped[str] = mapped_column(String(20), nullable=False)
+    county: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    lat: Mapped[float | None] = mapped_column(Float, nullable=True)
+    lng: Mapped[float | None] = mapped_column(Float, nullable=True)
+    year_built: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sqft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    lot_sqft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    beds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    baths: Mapped[float | None] = mapped_column(Float, nullable=True)
+    property_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    zillow_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    propstream_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    listing_price: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    arv_estimate: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    arv_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    data_source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    ownership_history: Mapped[Any] = mapped_column(JSON, nullable=True)
+    tax_assessment: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="active")
+    mls_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    neighborhood: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    zillow_estimate: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    lendability_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    lendability_category: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="properties")
+    deals: Mapped[list["Deal"]] = relationship("Deal", back_populates="property")
+    comps: Mapped[list["Comp"]] = relationship("Comp", back_populates="property")
+    rental_comps: Mapped[list["RentalComp"]] = relationship("RentalComp", back_populates="property")
+    arv_calculations: Mapped[list["ARVCalculation"]] = relationship("ARVCalculation", back_populates="property")
+    risk_flags: Mapped[list["RiskFlag"]] = relationship("RiskFlag", back_populates="property")
+    photo_analyses: Mapped[list["PropertyPhotoAnalysis"]] = relationship(
+        "PropertyPhotoAnalysis", back_populates="property"
+    )
+    quotes: Mapped[list["Quote"]] = relationship("Quote", back_populates="property")
+
+
+# ---------------------------------------------------------------------------
+# Deals
+# ---------------------------------------------------------------------------
+
+
+class Deal(Base):
+    __tablename__ = "deals"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    property_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("properties.id", ondelete="CASCADE"), nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="prospect")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="deals")
+    property: Mapped["Property"] = relationship("Property", back_populates="deals")
+    image_captures: Mapped[list["ImageCapture"]] = relationship(
+        "ImageCapture", back_populates="deal"
+    )
+    walk_sessions: Mapped[list["WalkSession"]] = relationship(
+        "WalkSession", back_populates="deal"
+    )
+    quotes: Mapped[list["Quote"]] = relationship("Quote", back_populates="deal")
+
+
+# ---------------------------------------------------------------------------
+# Comps
+# ---------------------------------------------------------------------------
+
+
+class Comp(Base):
+    __tablename__ = "comps"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    property_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("properties.id", ondelete="CASCADE"), nullable=False
+    )
+    address: Mapped[str] = mapped_column(String(500), nullable=False)
+    city: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    state: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    zip: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    lat: Mapped[float | None] = mapped_column(Float, nullable=True)
+    lng: Mapped[float | None] = mapped_column(Float, nullable=True)
+    sale_price: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    sale_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    sqft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    beds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    baths: Mapped[float | None] = mapped_column(Float, nullable=True)
+    year_built: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    property_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    distance: Mapped[float | None] = mapped_column(Float, nullable=True)
+    similarity: Mapped[float | None] = mapped_column(Float, nullable=True)
+    source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    mls_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    propstream_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    property: Mapped["Property"] = relationship("Property", back_populates="comps")
+
+
+# ---------------------------------------------------------------------------
+# Rental Comps
+# ---------------------------------------------------------------------------
+
+
+class RentalComp(Base):
+    __tablename__ = "rental_comps"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    property_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("properties.id", ondelete="CASCADE"), nullable=False
+    )
+    address: Mapped[str] = mapped_column(String(500), nullable=False)
+    city: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    state: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    zip: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    lat: Mapped[float | None] = mapped_column(Float, nullable=True)
+    lng: Mapped[float | None] = mapped_column(Float, nullable=True)
+    rent_price: Mapped[Any] = mapped_column(Numeric(10, 2), nullable=True)
+    sqft: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    beds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    baths: Mapped[float | None] = mapped_column(Float, nullable=True)
+    property_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    distance: Mapped[float | None] = mapped_column(Float, nullable=True)
+    correlation: Mapped[float | None] = mapped_column(Float, nullable=True)
+    source: Mapped[str] = mapped_column(String(100), nullable=False, default="rentcast")
+    last_seen_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    property: Mapped["Property"] = relationship("Property", back_populates="rental_comps")
+
+
+# ---------------------------------------------------------------------------
+# ARV Calculations
+# ---------------------------------------------------------------------------
+
+
+class ARVCalculation(Base):
+    __tablename__ = "arv_calculations"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    property_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("properties.id", ondelete="CASCADE"), nullable=False
+    )
+    arv_low: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=False)
+    arv_mid: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=False)
+    arv_high: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    comp_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    methodology: Mapped[Any] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    property: Mapped["Property"] = relationship("Property", back_populates="arv_calculations")
+
+
+# ---------------------------------------------------------------------------
+# Image Captures
+# ---------------------------------------------------------------------------
+
+
+class ImageCapture(Base):
+    __tablename__ = "image_captures"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    deal_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("deals.id", ondelete="CASCADE"), nullable=False
+    )
+    room: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    shot_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    s3_key: Mapped[str] = mapped_column(String(1000), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    deal: Mapped["Deal"] = relationship("Deal", back_populates="image_captures")
+    analyses: Mapped[list["ImageAnalysis"]] = relationship(
+        "ImageAnalysis", back_populates="capture"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Image Analyses
+# ---------------------------------------------------------------------------
+
+
+class ImageAnalysis(Base):
+    __tablename__ = "image_analyses"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    capture_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("image_captures.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    labels: Mapped[Any] = mapped_column(JSON, nullable=True)
+    conditions: Mapped[Any] = mapped_column(JSON, nullable=True)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    capture: Mapped["ImageCapture"] = relationship("ImageCapture", back_populates="analyses")
+
+
+# ---------------------------------------------------------------------------
+# Walk Sessions
+# ---------------------------------------------------------------------------
+
+
+class WalkSession(Base):
+    __tablename__ = "walk_sessions"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    deal_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("deals.id", ondelete="CASCADE"), nullable=False
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    room_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    deal: Mapped["Deal"] = relationship("Deal", back_populates="walk_sessions")
+
+
+# ---------------------------------------------------------------------------
+# Quotes
+# ---------------------------------------------------------------------------
+
+
+class Quote(Base):
+    __tablename__ = "quotes"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    deal_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("deals.id", ondelete="CASCADE"), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    property_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("properties.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    photo_analysis_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("property_photo_analyses.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="draft")
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    total_material: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    total_labor: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    platform_fee: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    platform_fee_pct: Mapped[Any] = mapped_column(Numeric(5, 4), nullable=True)
+    tax_amount: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    grand_total: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    pdf_s3_key: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    deal: Mapped["Deal"] = relationship("Deal", back_populates="quotes")
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="quotes")
+    property: Mapped["Property | None"] = relationship("Property", back_populates="quotes")
+    photo_analysis: Mapped["PropertyPhotoAnalysis | None"] = relationship(
+        "PropertyPhotoAnalysis", back_populates="quotes"
+    )
+    items: Mapped[list["QuoteItem"]] = relationship(
+        "QuoteItem", back_populates="quote", cascade="all, delete-orphan"
+    )
+    orders: Mapped[list["Order"]] = relationship("Order", back_populates="quote")
+
+
+# ---------------------------------------------------------------------------
+# Quote Items
+# ---------------------------------------------------------------------------
+
+
+class QuoteItem(Base):
+    __tablename__ = "quote_items"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    quote_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("quotes.id", ondelete="CASCADE"), nullable=False
+    )
+    room: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    trade_category: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    sage_sku: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    quantity: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    unit_cost: Mapped[Any] = mapped_column(Numeric(10, 2), nullable=True)
+    labor_cost: Mapped[Any] = mapped_column(Numeric(10, 2), nullable=True)
+    markup_pct: Mapped[Any] = mapped_column(Numeric(5, 2), nullable=True)
+    subtotal: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    ai_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    is_ai_generated: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    unit_of_measure: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    quote: Mapped["Quote"] = relationship("Quote", back_populates="items")
+
+
+# ---------------------------------------------------------------------------
+# Product Categories
+# ---------------------------------------------------------------------------
+
+
+class ProductCategory(Base):
+    __tablename__ = "product_categories"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    parent_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("product_categories.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    sage_category_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    parent: Mapped["ProductCategory | None"] = relationship(
+        "ProductCategory", back_populates="children", remote_side="ProductCategory.id"
+    )
+    children: Mapped[list["ProductCategory"]] = relationship(
+        "ProductCategory", back_populates="parent"
+    )
+    products: Mapped[list["Product"]] = relationship("Product", back_populates="category")
+
+
+# ---------------------------------------------------------------------------
+# Products
+# ---------------------------------------------------------------------------
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    category_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("product_categories.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    sage_product_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    sku: Mapped[str] = mapped_column(String(100), nullable=False)
+    name: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    brand: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    unit_of_measure: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    dimensions: Mapped[Any] = mapped_column(JSON, nullable=True)
+    image_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    availability_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="in_stock"
+    )
+    last_synced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "sku", name="uq_products_tenant_sku"),
+    )
+
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="products")
+    category: Mapped["ProductCategory | None"] = relationship(
+        "ProductCategory", back_populates="products"
+    )
+    prices: Mapped[list["ProductPrice"]] = relationship(
+        "ProductPrice", back_populates="product"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Product Prices (append-only history)
+# ---------------------------------------------------------------------------
+
+
+class ProductPrice(Base):
+    __tablename__ = "product_prices"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    product_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    price_cents: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False, default="USD")
+    effective_date: Mapped[date] = mapped_column(Date, nullable=False)
+    source: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    product: Mapped["Product"] = relationship("Product", back_populates="prices")
+
+
+# ---------------------------------------------------------------------------
+# Trade Partners
+# ---------------------------------------------------------------------------
+
+
+class TradePartner(Base):
+    __tablename__ = "trade_partners"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    company_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    trade: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    contact_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    rating: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="trade_partners")
+
+
+# ---------------------------------------------------------------------------
+# Risk Flags
+# ---------------------------------------------------------------------------
+
+
+class RiskFlag(Base):
+    __tablename__ = "risk_flags"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    property_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("properties.id", ondelete="CASCADE"), nullable=False
+    )
+    flag_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    severity: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    property: Mapped["Property"] = relationship("Property", back_populates="risk_flags")
+
+
+# ---------------------------------------------------------------------------
+# Orders
+# ---------------------------------------------------------------------------
+
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    quote_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("quotes.id", ondelete="CASCADE"), nullable=False
+    )
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    property_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("properties.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    sage_order_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    sage_confirmation: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    d365_opportunity_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    d365_opportunity_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="pending")
+    submission_method: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_amount: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    submitted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    confirmed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    shipped_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    quote: Mapped["Quote"] = relationship("Quote", back_populates="orders")
+    tenant: Mapped["Tenant"] = relationship("Tenant", back_populates="orders")
+    property: Mapped["Property | None"] = relationship("Property")
+    platform_fees: Mapped[list["PlatformFee"]] = relationship(
+        "PlatformFee", back_populates="order"
+    )
+    line_items: Mapped[list["OrderLineItem"]] = relationship(
+        "OrderLineItem", back_populates="order", cascade="all, delete-orphan"
+    )
+    status_history: Mapped[list["OrderStatusHistory"]] = relationship(
+        "OrderStatusHistory", back_populates="order", cascade="all, delete-orphan"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Platform Fees
+# ---------------------------------------------------------------------------
+
+
+class PlatformFee(Base):
+    __tablename__ = "platform_fees"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    order_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False
+    )
+    amount: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    fee_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    order: Mapped["Order"] = relationship("Order", back_populates="platform_fees")
+
+
+# ---------------------------------------------------------------------------
+# Property Photo Analyses
+# ---------------------------------------------------------------------------
+
+
+class PropertyPhotoAnalysis(Base):
+    __tablename__ = "property_photo_analyses"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    property_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("properties.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(
+        String(30), nullable=False, default="pending"
+    )
+    photo_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    model_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    renovation_signal: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    renovation_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    total_cost_cents: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    property: Mapped["Property"] = relationship(
+        "Property", back_populates="photo_analyses"
+    )
+    labels: Mapped[list["PhotoLabel"]] = relationship(
+        "PhotoLabel", back_populates="analysis"
+    )
+    quotes: Mapped[list["Quote"]] = relationship(
+        "Quote", back_populates="photo_analysis"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Photo Labels
+# ---------------------------------------------------------------------------
+
+
+class PhotoLabel(Base):
+    __tablename__ = "photo_labels"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    analysis_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("property_photo_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    photo_url: Mapped[str] = mapped_column(String(2000), nullable=False)
+    photo_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    room_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    condition: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    damage_issues: Mapped[Any] = mapped_column(JSON, nullable=True)
+    renovation_needed: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    confidence_tier: Mapped[str] = mapped_column(
+        String(10), nullable=False, default="medium"
+    )
+    raw_response: Mapped[Any] = mapped_column(JSON, nullable=True)
+    review_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="auto_accepted"
+    )
+    reviewer_override: Mapped[Any] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    analysis: Mapped["PropertyPhotoAnalysis"] = relationship(
+        "PropertyPhotoAnalysis", back_populates="labels"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Order Line Items (snapshot of quote items at order time)
+# ---------------------------------------------------------------------------
+
+
+class OrderLineItem(Base):
+    __tablename__ = "order_line_items"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    order_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False
+    )
+    quote_item_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("quote_items.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    room: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    trade_category: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    sage_sku: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    unit_cost: Mapped[Any] = mapped_column(Numeric(10, 2), nullable=True)
+    labor_cost: Mapped[Any] = mapped_column(Numeric(10, 2), nullable=True)
+    markup_pct: Mapped[Any] = mapped_column(Numeric(5, 2), nullable=True)
+    subtotal: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    sage_line_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    unit_of_measure: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    order: Mapped["Order"] = relationship("Order", back_populates="line_items")
+
+
+# ---------------------------------------------------------------------------
+# Order Status History
+# ---------------------------------------------------------------------------
+
+
+class OrderStatusHistory(Base):
+    __tablename__ = "order_status_history"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=_uuid
+    )
+    order_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False
+    )
+    from_status: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    to_status: Mapped[str] = mapped_column(String(50), nullable=False)
+    changed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    order: Mapped["Order"] = relationship("Order", back_populates="status_history")
+
+
+# ---------------------------------------------------------------------------
+# Credit Memos
+# ---------------------------------------------------------------------------
+
+
+class CreditMemo(Base):
+    __tablename__ = "credit_memos"
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True, default=_uuid)
+    tenant_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Enum values enforced at the application/schema layer; stored as VARCHAR for
+    # forward-compatibility if new codes are added before a migration.
+    cause_code: Mapped[str] = mapped_column(String(50), nullable=False)
+    job_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    qc_stage: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Nullable: no source in current Order/OrderLineItem data; captured for future backfill.
+    rsm_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    territory_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Derived from first OrderLineItem.trade_category on job# lookup; manual otherwise.
+    product_tier: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    amount: Mapped[Any] = mapped_column(Numeric(12, 2), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    tenant: Mapped["Tenant"] = relationship("Tenant")

--- a/packages/api/app/redis.py
+++ b/packages/api/app/redis.py
@@ -1,0 +1,22 @@
+"""Redis connection pool singleton."""
+
+from __future__ import annotations
+
+import redis.asyncio as redis
+
+from app.config import settings
+
+_pool: redis.Redis | None = None
+
+
+async def get_redis() -> redis.Redis | None:
+    """Return a shared async Redis client, or None if REDIS_URL is unset."""
+    global _pool
+    if not settings.REDIS_URL:
+        return None
+    if _pool is None:
+        _pool = redis.from_url(
+            settings.REDIS_URL,
+            decode_responses=True,
+        )
+    return _pool

--- a/packages/api/app/routers/catalog.py
+++ b/packages/api/app/routers/catalog.py
@@ -1,0 +1,125 @@
+"""Catalog browser endpoints — search, detail, categories."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.redis import get_redis
+from app.schemas.catalog import (
+    CatalogSearchResponse,
+    CategoryTreeResponse,
+    ProductDetailResponse,
+    ProductResponse,
+)
+from app.services.catalog_service import CatalogService
+from app.services.sage_playwright import SagePlaywrightBridge
+
+router = APIRouter(prefix="/catalog", tags=["catalog"])
+
+# ---------------------------------------------------------------------------
+# Dependency: CatalogService
+# ---------------------------------------------------------------------------
+
+_bridge: SagePlaywrightBridge | None = None
+
+
+def _get_bridge() -> SagePlaywrightBridge:
+    global _bridge
+    if _bridge is None:
+        _bridge = SagePlaywrightBridge()
+    return _bridge
+
+
+async def _get_catalog_service() -> CatalogService:
+    redis_client = await get_redis()
+    return CatalogService(bridge=_get_bridge(), redis_client=redis_client)
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/search", response_model=CatalogSearchResponse)
+async def search_products(
+    q: str | None = Query(None, description="Search query"),
+    category: str | None = Query(None, description="Category ID filter"),
+    brand: str | None = Query(None, description="Brand name filter"),
+    price_min: int | None = Query(None, ge=0, description="Min price in cents"),
+    price_max: int | None = Query(None, ge=0, description="Max price in cents"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    svc: CatalogService = Depends(_get_catalog_service),
+) -> CatalogSearchResponse:
+    tenant_id = await ensure_tenant_exists(db, user)
+    result = await svc.search_products(
+        db=db,
+        tenant_id=tenant_id,
+        query=q,
+        category=category,
+        brand=brand,
+        price_min=price_min,
+        price_max=price_max,
+        limit=limit,
+        offset=offset,
+    )
+    return CatalogSearchResponse(**result)
+
+
+@router.get("/products/{product_id}", response_model=ProductDetailResponse)
+async def get_product_detail(
+    product_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    svc: CatalogService = Depends(_get_catalog_service),
+) -> ProductDetailResponse:
+    tenant_id = await ensure_tenant_exists(db, user)
+    result = await svc.get_product_detail(db=db, tenant_id=tenant_id, product_id=product_id)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Product {product_id} not found",
+        )
+    return ProductDetailResponse(**result)
+
+
+@router.get("/categories", response_model=list[CategoryTreeResponse])
+async def list_categories(
+    db: AsyncSession = Depends(get_db),
+    svc: CatalogService = Depends(_get_catalog_service),
+    _user: CurrentUser = Depends(get_current_user),
+) -> list[CategoryTreeResponse]:
+    cats = await svc.get_categories(db=db)
+    return [CategoryTreeResponse(**c) for c in cats]
+
+
+@router.get(
+    "/categories/{category_id}/products",
+    response_model=CatalogSearchResponse,
+)
+async def list_category_products(
+    category_id: str,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    svc: CatalogService = Depends(_get_catalog_service),
+) -> CatalogSearchResponse:
+    tenant_id = await ensure_tenant_exists(db, user)
+    result = await svc.get_category_products(
+        db=db,
+        tenant_id=tenant_id,
+        category_id=category_id,
+        limit=limit,
+        offset=offset,
+    )
+    return CatalogSearchResponse(**result)

--- a/packages/api/app/routers/comps.py
+++ b/packages/api/app/routers/comps.py
@@ -1,0 +1,375 @@
+"""Comps engine endpoints — sold comps, ARV calculation, rental comps."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import ARVCalculation, Comp, Property, RentalComp
+from app.schemas.comps import (
+    ARVRequest,
+    ARVResponse,
+    CompResponse,
+    RentalCompResponse,
+    RentalCompsResponse,
+    RentalCompsSearch,
+    SoldCompsResponse,
+    SoldCompsSearch,
+)
+from app.services import rentcast, sold_comps
+from app.services.arv_calculator import InsufficientCompsError, calculate_arv
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/comps", tags=["comps"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+async def _get_property(db: AsyncSession, property_id: str, tenant_id: str) -> Property:
+    result = await db.execute(
+        select(Property).where(Property.id == property_id, Property.tenant_id == tenant_id)
+    )
+    prop = result.scalar_one_or_none()
+    if not prop:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
+    return prop
+
+
+def _property_as_dict(prop: Property) -> dict:
+    return {
+        "address": prop.address,
+        "city": prop.city,
+        "state": prop.state,
+        "zip": prop.zip,
+        "lat": prop.lat,
+        "lng": prop.lng,
+        "sqft": prop.sqft,
+        "beds": prop.beds,
+        "baths": prop.baths,
+        "year_built": prop.year_built,
+        "property_type": prop.property_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sold Comps
+# ---------------------------------------------------------------------------
+
+
+@router.post("/sold", response_model=SoldCompsResponse)
+async def search_sold_comps_endpoint(
+    body: SoldCompsSearch,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SoldCompsResponse:
+    """Search for sold comps around a subject property.
+
+    Queries PropStream for comparable sold properties within the given radius
+    and time window. Filters by property type, bed/bath, sqft, year built.
+    Returns sorted by relevance (distance + recency + similarity).
+    """
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = await _get_property(db, body.property_id, tenant_id)
+    subject = _property_as_dict(prop)
+
+    try:
+        comp_dicts = await sold_comps.search_sold_comps(
+            subject,
+            radius_miles=body.radius_miles,
+            months_back=body.months_back,
+            property_type=body.property_type,
+            min_beds=body.min_beds,
+            max_beds=body.max_beds,
+            min_baths=body.min_baths,
+            max_baths=body.max_baths,
+            min_sqft=body.min_sqft,
+            max_sqft=body.max_sqft,
+            min_year_built=body.min_year_built,
+            max_year_built=body.max_year_built,
+        )
+    except RuntimeError as exc:
+        logger.error("PropStream error during sold comp search: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Sold comps data source temporarily unavailable",
+        )
+
+    # Persist comps to database
+    saved_comps: list[Comp] = []
+    for cd in comp_dicts:
+        comp = Comp(
+            property_id=body.property_id,
+            address=cd["address"],
+            city=cd.get("city"),
+            state=cd.get("state"),
+            zip=cd.get("zip"),
+            lat=cd.get("lat"),
+            lng=cd.get("lng"),
+            sale_price=cd.get("sale_price"),
+            sale_date=cd.get("sale_date"),
+            sqft=cd.get("sqft"),
+            beds=cd.get("beds"),
+            baths=cd.get("baths"),
+            year_built=cd.get("year_built"),
+            property_type=cd.get("property_type"),
+            distance=cd.get("distance"),
+            similarity=cd.get("similarity"),
+            source=cd.get("source", "propstream"),
+            mls_id=cd.get("mls_id"),
+            propstream_id=cd.get("propstream_id"),
+        )
+        db.add(comp)
+        saved_comps.append(comp)
+
+    await db.flush()
+    for c in saved_comps:
+        await db.refresh(c)
+
+    return SoldCompsResponse(
+        property_id=body.property_id,
+        comps=[CompResponse.model_validate(c) for c in saved_comps],
+        total=len(saved_comps),
+    )
+
+
+@router.get("/{property_id}/sold", response_model=SoldCompsResponse)
+async def list_sold_comps(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SoldCompsResponse:
+    """List previously stored sold comps for a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+    await _get_property(db, property_id, tenant_id)
+
+    result = await db.execute(
+        select(Comp)
+        .where(Comp.property_id == property_id)
+        .order_by(Comp.similarity.desc().nulls_last())
+    )
+    comps = result.scalars().all()
+
+    return SoldCompsResponse(
+        property_id=property_id,
+        comps=[CompResponse.model_validate(c) for c in comps],
+        total=len(comps),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ARV Calculator
+# ---------------------------------------------------------------------------
+
+
+@router.post("/arv", response_model=ARVResponse)
+async def calculate_arv_endpoint(
+    body: ARVRequest,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ARVResponse:
+    """Calculate After Repair Value from sold comps.
+
+    Returns low / mid / high confidence band. Minimum 3 comps required.
+    If no comps exist for this property, searches for them first.
+    """
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = await _get_property(db, body.property_id, tenant_id)
+    subject = _property_as_dict(prop)
+
+    # Check if we have existing comps; if not, search for them
+    existing = await db.execute(
+        select(Comp).where(Comp.property_id == body.property_id)
+    )
+    comp_rows = existing.scalars().all()
+
+    if len(comp_rows) < 3:
+        # Search for fresh comps
+        try:
+            comp_dicts = await sold_comps.search_sold_comps(
+                subject,
+                radius_miles=body.radius_miles,
+                months_back=body.months_back,
+            )
+        except RuntimeError as exc:
+            logger.error("PropStream error during ARV comp search: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Sold comps data source temporarily unavailable",
+            )
+    else:
+        # Use existing comps as dicts
+        comp_dicts = []
+        for c in comp_rows:
+            comp_dicts.append({
+                "address": c.address,
+                "sale_price": float(c.sale_price) if c.sale_price else None,
+                "sale_date": c.sale_date,
+                "sqft": c.sqft,
+                "beds": c.beds,
+                "baths": c.baths,
+                "year_built": c.year_built,
+                "distance": c.distance,
+                "similarity": c.similarity,
+            })
+
+    try:
+        arv_result = calculate_arv(comp_dicts, subject)
+    except InsufficientCompsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Insufficient comps for ARV: {exc.available} found, 3 required",
+        )
+
+    # Persist ARV calculation
+    arv_calc = ARVCalculation(
+        property_id=body.property_id,
+        arv_low=arv_result["arv_low"],
+        arv_mid=arv_result["arv_mid"],
+        arv_high=arv_result["arv_high"],
+        confidence=arv_result["confidence"],
+        comp_count=arv_result["comp_count"],
+        methodology=arv_result["methodology"],
+    )
+    db.add(arv_calc)
+    await db.flush()
+    await db.refresh(arv_calc)
+
+    # Also update the property's arv_estimate and confidence
+    prop.arv_estimate = arv_result["arv_mid"]
+    prop.arv_confidence = arv_result["confidence"]
+    await db.flush()
+
+    return ARVResponse.model_validate(arv_calc)
+
+
+@router.get("/{property_id}/arv", response_model=list[ARVResponse])
+async def list_arv_calculations(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ARVResponse]:
+    """List all ARV calculations for a property (most recent first)."""
+    tenant_id = await ensure_tenant_exists(db, user)
+    await _get_property(db, property_id, tenant_id)
+
+    result = await db.execute(
+        select(ARVCalculation)
+        .where(ARVCalculation.property_id == property_id)
+        .order_by(ARVCalculation.created_at.desc())
+    )
+    calcs = result.scalars().all()
+    return [ARVResponse.model_validate(c) for c in calcs]
+
+
+# ---------------------------------------------------------------------------
+# Rental Comps (Rentcast)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/rental", response_model=RentalCompsResponse)
+async def search_rental_comps_endpoint(
+    body: RentalCompsSearch,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> RentalCompsResponse:
+    """Search rental comps via Rentcast for a property.
+
+    Queries by address or coordinates. Returns rental estimate with
+    confidence interval and comparable rental listings.
+    """
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = await _get_property(db, body.property_id, tenant_id)
+
+    # Determine search method
+    try:
+        if body.address:
+            raw = await rentcast.get_rental_comps_by_address(body.address)
+        elif body.lat is not None and body.lng is not None:
+            raw = await rentcast.get_rental_comps_by_coordinates(body.lat, body.lng)
+        elif prop.lat is not None and prop.lng is not None:
+            raw = await rentcast.get_rental_comps_by_coordinates(prop.lat, prop.lng)
+        else:
+            address = f"{prop.address}, {prop.city}, {prop.state} {prop.zip}"
+            raw = await rentcast.get_rental_comps_by_address(address)
+    except RuntimeError as exc:
+        logger.error("Rentcast error during rental comp search: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Rental comps data source temporarily unavailable",
+        )
+
+    normalized = rentcast.normalize_rental_comps(raw)
+
+    # Persist rental comps
+    saved_comps: list[RentalComp] = []
+    for rc in normalized["comps"]:
+        rental_comp = RentalComp(
+            property_id=body.property_id,
+            address=rc.get("address", ""),
+            city=rc.get("city"),
+            state=rc.get("state"),
+            zip=rc.get("zip"),
+            lat=rc.get("lat"),
+            lng=rc.get("lng"),
+            rent_price=rc.get("rent_price"),
+            sqft=rc.get("sqft"),
+            beds=rc.get("beds"),
+            baths=rc.get("baths"),
+            property_type=rc.get("property_type"),
+            distance=rc.get("distance"),
+            correlation=rc.get("correlation"),
+            source="rentcast",
+            last_seen_date=rc.get("last_seen_date"),
+        )
+        db.add(rental_comp)
+        saved_comps.append(rental_comp)
+
+    await db.flush()
+    for c in saved_comps:
+        await db.refresh(c)
+
+    return RentalCompsResponse(
+        property_id=body.property_id,
+        rent_estimate_low=normalized.get("rent_estimate_low"),
+        rent_estimate_mid=normalized.get("rent_estimate_mid"),
+        rent_estimate_high=normalized.get("rent_estimate_high"),
+        comps=[RentalCompResponse.model_validate(c) for c in saved_comps],
+        total=len(saved_comps),
+    )
+
+
+@router.get("/{property_id}/rental", response_model=RentalCompsResponse)
+async def list_rental_comps(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> RentalCompsResponse:
+    """List previously stored rental comps for a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+    await _get_property(db, property_id, tenant_id)
+
+    result = await db.execute(
+        select(RentalComp)
+        .where(RentalComp.property_id == property_id)
+        .order_by(RentalComp.correlation.desc().nulls_last())
+    )
+    comps = result.scalars().all()
+
+    return RentalCompsResponse(
+        property_id=property_id,
+        comps=[RentalCompResponse.model_validate(c) for c in comps],
+        total=len(comps),
+    )

--- a/packages/api/app/routers/credit_memo_report.py
+++ b/packages/api/app/routers/credit_memo_report.py
@@ -1,0 +1,205 @@
+"""Credit-memo cause-code reporting view (SAG-2806).
+
+Endpoints:
+  GET /credit-memos/report        — segmented daily/weekly JSON report
+  GET /credit-memos/report/export — CSV download matching JSON totals
+
+Segmentation dimensions: cause_code, territory_id, rsm_id, product_tier, qc_stage.
+Cross-tab via optional ?dim2=<dimension>.
+
+Aggregation is done in Python (not SQL) for SQLite/PostgreSQL portability. Data
+volumes for credit memos are small (<10 k rows/month), so this is acceptable.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections import defaultdict
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import CurrentUser, get_current_user
+from app.database import get_db
+from app.models import CreditMemo
+from app.schemas.credit_memo_report import (
+    ReportGranularity,
+    ReportResponse,
+    ReportRow,
+    ReportSegment,
+)
+
+router = APIRouter(prefix="/credit-memos", tags=["credit-memos"])
+
+# Map enum value → model attribute name (they are identical, but explicit is safer)
+_SEGMENT_ATTR: dict[str, str] = {
+    "cause_code": "cause_code",
+    "territory_id": "territory_id",
+    "rsm_id": "rsm_id",
+    "product_tier": "product_tier",
+    "qc_stage": "qc_stage",
+}
+
+
+def _period_key(dt: datetime, granularity: ReportGranularity) -> str:
+    """Return a sortable string period key for a datetime."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    d = dt.date()
+    if granularity == ReportGranularity.daily:
+        return d.isoformat()
+    # ISO week: Monday as week start, e.g. "2024-W03"
+    iso = d.isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def _aggregate(
+    memos: list[CreditMemo],
+    granularity: ReportGranularity,
+    segment_by: ReportSegment,
+    dim2: ReportSegment | None,
+) -> list[ReportRow]:
+    """Group memos into report rows. O(n) over memo list."""
+    # key: (period, seg_value, dim2_value)
+    buckets: dict[tuple[str, str | None, str | None], dict[str, Any]] = defaultdict(
+        lambda: {"credit_amount_total": Decimal("0"), "memo_count": 0}
+    )
+
+    seg_attr = _SEGMENT_ATTR[segment_by.value]
+    dim2_attr = _SEGMENT_ATTR[dim2.value] if dim2 else None
+
+    for memo in memos:
+        period = _period_key(memo.created_at, granularity)
+        seg_val: str | None = getattr(memo, seg_attr)
+        d2_val: str | None = getattr(memo, dim2_attr) if dim2_attr else None
+        key = (period, seg_val, d2_val)
+        bucket = buckets[key]
+        bucket["credit_amount_total"] += memo.amount if memo.amount is not None else Decimal("0")
+        bucket["memo_count"] += 1
+
+    rows = [
+        ReportRow(
+            period=period,
+            segment_value=seg_val,
+            dim2_value=d2_val,
+            credit_amount_total=v["credit_amount_total"],
+            memo_count=v["memo_count"],
+        )
+        for (period, seg_val, d2_val), v in sorted(buckets.items())
+    ]
+    return rows
+
+
+async def _fetch_memos(
+    db: AsyncSession,
+    tenant_id: str,
+    start_date: date,
+    end_date: date,
+) -> list[CreditMemo]:
+    start_dt = datetime(start_date.year, start_date.month, start_date.day, tzinfo=timezone.utc)
+    # End date is inclusive — extend to end-of-day
+    end_dt = datetime(end_date.year, end_date.month, end_date.day, 23, 59, 59, tzinfo=timezone.utc)
+
+    result = await db.execute(
+        select(CreditMemo)
+        .where(
+            CreditMemo.tenant_id == tenant_id,
+            CreditMemo.created_at >= start_dt,
+            CreditMemo.created_at <= end_dt,
+        )
+        .order_by(CreditMemo.created_at)
+    )
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# GET /credit-memos/report
+# ---------------------------------------------------------------------------
+
+
+@router.get("/report", response_model=ReportResponse)
+async def credit_memo_report(
+    start_date: date = Query(..., description="Start date (inclusive), YYYY-MM-DD"),
+    end_date: date = Query(..., description="End date (inclusive), YYYY-MM-DD"),
+    segment_by: ReportSegment = Query(..., description="Primary segmentation dimension"),
+    granularity: ReportGranularity = Query(ReportGranularity.daily, description="daily or weekly"),
+    dim2: ReportSegment | None = Query(None, description="Optional second dimension for cross-tab"),
+    current_user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ReportResponse:
+    """Return credit $ + count segmented by dimension, for a date range, at daily or weekly granularity."""
+    if end_date < start_date:
+        raise HTTPException(status_code=422, detail="end_date must be >= start_date")
+
+    tenant_id = current_user.effective_tenant_id
+    memos = await _fetch_memos(db, tenant_id, start_date, end_date)
+    rows = _aggregate(memos, granularity, segment_by, dim2)
+
+    total_amount = sum((r.credit_amount_total for r in rows), Decimal("0"))
+    total_count = sum(r.memo_count for r in rows)
+
+    return ReportResponse(
+        granularity=granularity,
+        segment_by=segment_by,
+        dim2=dim2,
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+        rows=rows,
+        total_credit_amount=total_amount,
+        total_memo_count=total_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /credit-memos/report/export  (CSV)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/report/export")
+async def credit_memo_report_export(
+    start_date: date = Query(..., description="Start date (inclusive), YYYY-MM-DD"),
+    end_date: date = Query(..., description="End date (inclusive), YYYY-MM-DD"),
+    segment_by: ReportSegment = Query(..., description="Primary segmentation dimension"),
+    granularity: ReportGranularity = Query(ReportGranularity.daily),
+    dim2: ReportSegment | None = Query(None),
+    current_user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Download credit-memo report as CSV. Columns match JSON /report rows."""
+    if end_date < start_date:
+        raise HTTPException(status_code=422, detail="end_date must be >= start_date")
+
+    tenant_id = current_user.effective_tenant_id
+    memos = await _fetch_memos(db, tenant_id, start_date, end_date)
+    rows = _aggregate(memos, granularity, segment_by, dim2)
+
+    buf = io.StringIO()
+    fieldnames = ["period", "segment_value", "credit_amount_total", "memo_count"]
+    if dim2:
+        fieldnames.insert(2, "dim2_value")
+
+    writer = csv.DictWriter(buf, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        record: dict[str, Any] = {
+            "period": row.period,
+            "segment_value": row.segment_value if row.segment_value is not None else "",
+            "credit_amount_total": str(row.credit_amount_total),
+            "memo_count": row.memo_count,
+        }
+        if dim2:
+            record["dim2_value"] = row.dim2_value if row.dim2_value is not None else ""
+        writer.writerow(record)
+
+    filename = f"credit_memo_report_{start_date}_{end_date}_{segment_by.value}.csv"
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/packages/api/app/routers/credit_memos.py
+++ b/packages/api/app/routers/credit_memos.py
@@ -1,0 +1,134 @@
+"""Credit memo endpoints — required cause-code + job-key capture (SAG-2805).
+
+Enums for cause_code and qc_stage are validated by Pydantic at the request layer.
+job_key is stored as-is; the /job-lookup endpoint lets callers confirm a job#
+against existing Orders and pre-fill product_tier from the first line item.
+
+Auto-population mapping:
+  job_key      → Order.sage_order_id (the GCP-formatted job number)
+  product_tier → first OrderLineItem.trade_category for that order (or None)
+  rsm_id       → no source today; captured as manual entry
+  territory_id → no source today; captured as manual entry
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import CreditMemo, Order
+from app.schemas.credit_memo import (
+    CreditMemoCreate,
+    CreditMemoListResponse,
+    CreditMemoResponse,
+    JobLookupResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/credit-memos", tags=["credit-memos"])
+
+
+# ---------------------------------------------------------------------------
+# GET /credit-memos/job-lookup
+# ---------------------------------------------------------------------------
+
+
+@router.get("/job-lookup", response_model=JobLookupResponse)
+async def job_lookup(
+    job_number: str = Query(..., description="Sage order number to look up (e.g. GCP-001-20240425)"),
+    current_user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> JobLookupResponse:
+    """Look up a job# against existing Orders and return auto-population data."""
+    tenant_id = current_user.effective_tenant_id
+
+    result = await db.execute(
+        select(Order)
+        .where(Order.sage_order_id == job_number, Order.tenant_id == tenant_id)
+        .options(selectinload(Order.line_items))
+        .limit(1)
+    )
+    order = result.scalar_one_or_none()
+
+    if order is None:
+        return JobLookupResponse(found=False, job_key=None, product_tier=None)
+
+    product_tier: str | None = None
+    if order.line_items:
+        product_tier = order.line_items[0].trade_category
+
+    return JobLookupResponse(
+        found=True,
+        job_key=order.sage_order_id,
+        product_tier=product_tier,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /credit-memos
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=CreditMemoResponse, status_code=201)
+async def create_credit_memo(
+    body: CreditMemoCreate,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> CreditMemoResponse:
+    """Create a credit memo. cause_code, job_key, and qc_stage are required."""
+    tenant_id = await ensure_tenant_exists(db, current_user)
+
+    memo = CreditMemo(
+        tenant_id=tenant_id,
+        cause_code=body.cause_code.value,
+        job_key=body.job_key,
+        qc_stage=body.qc_stage.value,
+        rsm_id=body.rsm_id,
+        territory_id=body.territory_id,
+        product_tier=body.product_tier,
+        amount=body.amount,
+        description=body.description,
+        created_by=current_user.user_id,
+    )
+    db.add(memo)
+    await db.commit()
+    await db.refresh(memo)
+    return CreditMemoResponse.model_validate(memo)
+
+
+# ---------------------------------------------------------------------------
+# GET /credit-memos
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=CreditMemoListResponse)
+async def list_credit_memos(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> CreditMemoListResponse:
+    """List all credit memos for the current tenant."""
+    tenant_id = current_user.effective_tenant_id
+
+    count_result = await db.execute(
+        select(func.count()).select_from(CreditMemo).where(CreditMemo.tenant_id == tenant_id)
+    )
+    total = count_result.scalar_one()
+
+    items_result = await db.execute(
+        select(CreditMemo)
+        .where(CreditMemo.tenant_id == tenant_id)
+        .order_by(CreditMemo.created_at.desc())
+    )
+    items = items_result.scalars().all()
+
+    return CreditMemoListResponse(
+        total=total,
+        items=[CreditMemoResponse.model_validate(m) for m in items],
+    )

--- a/packages/api/app/routers/financing.py
+++ b/packages/api/app/routers/financing.py
@@ -1,0 +1,291 @@
+"""Financing engine endpoints — 8 models, MAO, IRR, scenario comparison."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.auth import CurrentUser, get_current_user
+from app.schemas.financing import (
+    BRRRRRequest,
+    BuyAndHoldRequest,
+    FinancingModelResponse,
+    FixAndFlipRequest,
+    HardMoneyBridgeRequest,
+    IRRRequest,
+    IRRResponse,
+    MAORequest,
+    MAOResponse,
+    ScenarioComparisonRequest,
+    ScenarioComparisonResponse,
+    SellerFinancingRequest,
+    ShortTermRentalRequest,
+    SubjectToRequest,
+    WholesaleRequest,
+)
+from app.services.financing import (
+    brrrr,
+    buy_and_hold,
+    calculate_irr,
+    calculate_mao,
+    compare_scenarios,
+    fix_and_flip,
+    hard_money_bridge,
+    seller_financing,
+    short_term_rental,
+    subject_to,
+    wholesale,
+)
+
+router = APIRouter(prefix="/financing", tags=["financing"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# Individual model endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/fix-and-flip", response_model=FinancingModelResponse)
+async def run_fix_and_flip(
+    body: FixAndFlipRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Fix & Flip financing model."""
+    _ensure_tenant(user)
+    result = fix_and_flip(
+        body.purchase_price,
+        body.rehab_cost,
+        body.arv,
+        hold_months=body.hold_months,
+        monthly_hold_cost=body.monthly_hold_cost,
+        buying_closing_pct=body.buying_closing_pct,
+        selling_closing_pct=body.selling_closing_pct,
+        loan_amount=body.loan_amount,
+        loan_rate=body.loan_rate,
+    )
+    return FinancingModelResponse(model="fix_and_flip", result=result)
+
+
+@router.post("/brrrr", response_model=FinancingModelResponse)
+async def run_brrrr(
+    body: BRRRRRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run BRRRR financing model."""
+    _ensure_tenant(user)
+    result = brrrr(
+        body.purchase_price,
+        body.rehab_cost,
+        body.arv,
+        body.monthly_rent,
+        hold_months_before_refi=body.hold_months_before_refi,
+        refi_ltv=body.refi_ltv,
+        refi_rate=body.refi_rate,
+        refi_term_years=body.refi_term_years,
+        monthly_expenses=body.monthly_expenses,
+        vacancy_rate=body.vacancy_rate,
+        buying_closing_pct=body.buying_closing_pct,
+        initial_loan_amount=body.initial_loan_amount,
+        initial_loan_rate=body.initial_loan_rate,
+    )
+    return FinancingModelResponse(model="brrrr", result=result)
+
+
+@router.post("/buy-and-hold", response_model=FinancingModelResponse)
+async def run_buy_and_hold(
+    body: BuyAndHoldRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Buy & Hold (long-term rental) financing model."""
+    _ensure_tenant(user)
+    result = buy_and_hold(
+        body.purchase_price,
+        body.monthly_rent,
+        down_payment_pct=body.down_payment_pct,
+        loan_rate=body.loan_rate,
+        loan_term_years=body.loan_term_years,
+        monthly_expenses=body.monthly_expenses,
+        vacancy_rate=body.vacancy_rate,
+        annual_appreciation=body.annual_appreciation,
+        annual_rent_growth=body.annual_rent_growth,
+        closing_costs_pct=body.closing_costs_pct,
+    )
+    return FinancingModelResponse(model="buy_and_hold", result=result)
+
+
+@router.post("/short-term-rental", response_model=FinancingModelResponse)
+async def run_short_term_rental(
+    body: ShortTermRentalRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Short-Term Rental (Airbnb) financing model."""
+    _ensure_tenant(user)
+    result = short_term_rental(
+        body.purchase_price,
+        body.nightly_rate,
+        occupancy_rate=body.occupancy_rate,
+        down_payment_pct=body.down_payment_pct,
+        loan_rate=body.loan_rate,
+        loan_term_years=body.loan_term_years,
+        monthly_expenses=body.monthly_expenses,
+        platform_fee_pct=body.platform_fee_pct,
+        cleaning_fee_per_turn=body.cleaning_fee_per_turn,
+        avg_stay_nights=body.avg_stay_nights,
+        seasonal_adjustments=body.seasonal_adjustments,
+        closing_costs_pct=body.closing_costs_pct,
+    )
+    return FinancingModelResponse(model="short_term_rental", result=result)
+
+
+@router.post("/wholesale", response_model=FinancingModelResponse)
+async def run_wholesale(
+    body: WholesaleRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Wholesale deal analysis."""
+    _ensure_tenant(user)
+    result = wholesale(
+        body.arv,
+        body.rehab_cost,
+        assignment_fee=body.assignment_fee,
+        buyer_profit_margin=body.buyer_profit_margin,
+        closing_costs_pct=body.closing_costs_pct,
+        earnest_money=body.earnest_money,
+    )
+    return FinancingModelResponse(model="wholesale", result=result)
+
+
+@router.post("/subject-to", response_model=FinancingModelResponse)
+async def run_subject_to(
+    body: SubjectToRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Subject-To (existing mortgage takeover) analysis."""
+    _ensure_tenant(user)
+    result = subject_to(
+        body.property_value,
+        body.existing_mortgage_balance,
+        body.existing_mortgage_rate,
+        body.existing_mortgage_remaining_months,
+        body.monthly_rent,
+        cash_to_seller=body.cash_to_seller,
+        monthly_expenses=body.monthly_expenses,
+        vacancy_rate=body.vacancy_rate,
+        closing_costs=body.closing_costs,
+        wrap_rate=body.wrap_rate,
+        wrap_term_months=body.wrap_term_months,
+    )
+    return FinancingModelResponse(model="subject_to", result=result)
+
+
+@router.post("/seller-financing", response_model=FinancingModelResponse)
+async def run_seller_financing(
+    body: SellerFinancingRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Seller Financing model with custom terms and amortization."""
+    _ensure_tenant(user)
+    result = seller_financing(
+        body.purchase_price,
+        body.monthly_rent,
+        down_payment_pct=body.down_payment_pct,
+        seller_rate=body.seller_rate,
+        seller_term_months=body.seller_term_months,
+        balloon_month=body.balloon_month,
+        monthly_expenses=body.monthly_expenses,
+        vacancy_rate=body.vacancy_rate,
+        closing_costs_pct=body.closing_costs_pct,
+    )
+    return FinancingModelResponse(model="seller_financing", result=result)
+
+
+@router.post("/hard-money-bridge", response_model=FinancingModelResponse)
+async def run_hard_money_bridge(
+    body: HardMoneyBridgeRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> FinancingModelResponse:
+    """Run Hard Money / Bridge loan analysis."""
+    _ensure_tenant(user)
+    result = hard_money_bridge(
+        body.purchase_price,
+        body.rehab_cost,
+        body.arv,
+        loan_to_cost_pct=body.loan_to_cost_pct,
+        interest_rate=body.interest_rate,
+        points=body.points,
+        term_months=body.term_months,
+        interest_only=body.interest_only,
+        refi_after_months=body.refi_after_months,
+        refi_rate=body.refi_rate,
+        refi_ltv=body.refi_ltv,
+        refi_term_years=body.refi_term_years,
+        monthly_rent_after_refi=body.monthly_rent_after_refi,
+        monthly_expenses=body.monthly_expenses,
+        vacancy_rate=body.vacancy_rate,
+    )
+    return FinancingModelResponse(model="hard_money_bridge", result=result)
+
+
+# ---------------------------------------------------------------------------
+# MAO & IRR
+# ---------------------------------------------------------------------------
+
+
+@router.post("/mao", response_model=MAOResponse)
+async def run_mao(
+    body: MAORequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> MAOResponse:
+    """Calculate Maximum Allowable Offer."""
+    _ensure_tenant(user)
+    result = calculate_mao(
+        body.arv,
+        body.rehab_cost,
+        profit_margin=body.profit_margin,
+        closing_costs_pct=body.closing_costs_pct,
+        hold_costs=body.hold_costs,
+    )
+    return MAOResponse(**result)
+
+
+@router.post("/irr", response_model=IRRResponse)
+async def run_irr(
+    body: IRRRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> IRRResponse:
+    """Calculate Internal Rate of Return from cash flows."""
+    _ensure_tenant(user)
+    irr = calculate_irr(body.cash_flows)
+    return IRRResponse(irr=irr, cash_flows=body.cash_flows)
+
+
+# ---------------------------------------------------------------------------
+# Scenario Comparison
+# ---------------------------------------------------------------------------
+
+
+@router.post("/compare", response_model=ScenarioComparisonResponse)
+async def compare_financing_scenarios(
+    body: ScenarioComparisonRequest,
+    user: CurrentUser = Depends(get_current_user),
+) -> ScenarioComparisonResponse:
+    """Run multiple financing models against the same property for side-by-side comparison.
+
+    Provide property_data with keys: purchase_price, arv, rehab_cost, monthly_rent.
+    Optionally provide per-model assumptions and select specific models to run.
+    """
+    _ensure_tenant(user)
+    result = compare_scenarios(
+        body.property_data,
+        body.assumptions,
+        models=body.models,
+    )
+    return ScenarioComparisonResponse(**result)

--- a/packages/api/app/routers/orders.py
+++ b/packages/api/app/routers/orders.py
@@ -1,0 +1,470 @@
+"""Order management endpoints — Sage order submission, status tracking, D365 integration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import (
+    Order,
+    OrderLineItem,
+    OrderStatusHistory,
+    PlatformFee,
+    Property,
+    Quote,
+    QuoteItem,
+)
+from app.schemas.order import (
+    D365OpportunityResponse,
+    OrderDetailResponse,
+    OrderListResponse,
+    OrderResponse,
+    SubmitOrderRequest,
+)
+from app.services.order_service import (
+    MAX_RETRY_COUNT,
+    calculate_order_total,
+    snapshot_quote_items,
+    submit_order_to_sage,
+    sync_order_status_from_sage,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["orders"])
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# POST /quotes/{quote_id}/submit-order
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/quotes/{quote_id}/submit-order",
+    response_model=OrderDetailResponse,
+    status_code=201,
+)
+async def submit_order(
+    quote_id: str,
+    body: SubmitOrderRequest = SubmitOrderRequest(),
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Order:
+    """Convert an approved quote into a Sage purchase order."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Load quote with items
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.id == quote_id, Quote.tenant_id == tenant_id)
+        .options(selectinload(Quote.items))
+    )
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    if quote.status != "approved":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Quote must be approved before ordering (current: {quote.status})",
+        )
+
+    # Snapshot quote items into order line items
+    item_snapshots = snapshot_quote_items(quote.items)
+    total = calculate_order_total(item_snapshots)
+
+    # Create order
+    order = Order(
+        quote_id=quote.id,
+        tenant_id=tenant_id,
+        property_id=quote.property_id,
+        status="pending",
+        total_amount=total,
+    )
+    db.add(order)
+    await db.flush()
+
+    # Create line items
+    for snap in item_snapshots:
+        li = OrderLineItem(order_id=order.id, **snap)
+        db.add(li)
+
+    # Record initial status
+    db.add(OrderStatusHistory(
+        order_id=order.id,
+        from_status=None,
+        to_status="pending",
+        changed_by="system",
+        note="Order created from approved quote",
+    ))
+
+    # Create platform fee record
+    if quote.platform_fee:
+        db.add(PlatformFee(
+            order_id=order.id,
+            amount=quote.platform_fee,
+            fee_type="platform",
+        ))
+
+    await db.flush()
+
+    # Attempt Sage submission
+    try:
+        sage_result = await submit_order_to_sage(
+            item_snapshots, method=body.submission_method
+        )
+        order.sage_order_id = sage_result.get("sage_order_id")
+        order.sage_confirmation = sage_result.get("sage_confirmation")
+        order.submission_method = sage_result.get("method")
+        order.status = "submitted"
+        order.submitted_at = datetime.now(timezone.utc)
+        order.error_message = None
+
+        # Map Sage line IDs back if returned
+        sage_line_ids = sage_result.get("line_ids", [])
+        if sage_line_ids:
+            line_items_result = await db.execute(
+                select(OrderLineItem)
+                .where(OrderLineItem.order_id == order.id)
+                .order_by(OrderLineItem.id)
+            )
+            line_items = line_items_result.scalars().all()
+            for li, sage_lid in zip(line_items, sage_line_ids):
+                li.sage_line_id = str(sage_lid)
+
+        db.add(OrderStatusHistory(
+            order_id=order.id,
+            from_status="pending",
+            to_status="submitted",
+            changed_by="system",
+            note=f"Submitted to Sage via {order.submission_method}",
+        ))
+
+    except Exception as exc:
+        logger.error("Sage submission failed for order %s: %s", order.id, exc)
+        order.status = "failed"
+        order.error_message = str(exc)[:500]
+        order.retry_count += 1
+
+        db.add(OrderStatusHistory(
+            order_id=order.id,
+            from_status="pending",
+            to_status="failed",
+            changed_by="system",
+            note=f"Sage submission failed: {str(exc)[:200]}",
+        ))
+
+    await db.flush()
+
+    # Reload with relationships
+    result = await db.execute(
+        select(Order)
+        .where(Order.id == order.id)
+        .options(
+            selectinload(Order.line_items),
+            selectinload(Order.status_history),
+        )
+    )
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# GET /orders
+# ---------------------------------------------------------------------------
+
+
+@router.get("/orders", response_model=OrderListResponse)
+async def list_orders(
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    status: str | None = Query(None),
+    property_id: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> OrderListResponse:
+    """List orders with optional filters."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    base = select(Order).where(Order.tenant_id == tenant_id)
+    if status:
+        base = base.where(Order.status == status)
+    if property_id:
+        base = base.where(Order.property_id == property_id)
+
+    count_q = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_q)).scalar() or 0
+
+    q = base.order_by(Order.created_at.desc()).offset(offset).limit(limit)
+    rows = (await db.execute(q)).scalars().all()
+
+    return OrderListResponse(items=list(rows), total=total)
+
+
+# ---------------------------------------------------------------------------
+# GET /orders/{order_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/orders/{order_id}", response_model=OrderDetailResponse)
+async def get_order(
+    order_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Order:
+    """Get order detail with line items and status history."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Order)
+        .where(Order.id == order_id, Order.tenant_id == tenant_id)
+        .options(
+            selectinload(Order.line_items),
+            selectinload(Order.status_history),
+        )
+    )
+    order = result.scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return order
+
+
+# ---------------------------------------------------------------------------
+# POST /orders/{order_id}/sync-status
+# ---------------------------------------------------------------------------
+
+
+@router.post("/orders/{order_id}/sync-status", response_model=OrderDetailResponse)
+async def sync_status(
+    order_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Order:
+    """Refresh order status from Sage."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Order)
+        .where(Order.id == order_id, Order.tenant_id == tenant_id)
+        .options(
+            selectinload(Order.line_items),
+            selectinload(Order.status_history),
+        )
+    )
+    order = result.scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    if not order.sage_order_id:
+        raise HTTPException(
+            status_code=400, detail="Order has no Sage order ID to sync"
+        )
+
+    try:
+        sage_status = await sync_order_status_from_sage(order.sage_order_id)
+        new_status = sage_status["status"]
+
+        if new_status != order.status:
+            old_status = order.status
+            order.status = new_status
+
+            # Update lifecycle timestamps
+            now = datetime.now(timezone.utc)
+            if new_status == "confirmed" and not order.confirmed_at:
+                order.confirmed_at = now
+            elif new_status == "shipped" and not order.shipped_at:
+                order.shipped_at = now
+            elif new_status == "delivered" and not order.delivered_at:
+                order.delivered_at = now
+
+            if sage_status.get("sage_confirmation"):
+                order.sage_confirmation = sage_status["sage_confirmation"]
+
+            db.add(OrderStatusHistory(
+                order_id=order.id,
+                from_status=old_status,
+                to_status=new_status,
+                changed_by="sage_sync",
+                note=f"Status synced from Sage",
+            ))
+
+        order.error_message = None
+        await db.flush()
+
+    except Exception as exc:
+        logger.error("Sage status sync failed for order %s: %s", order.id, exc)
+        order.error_message = f"Sync failed: {str(exc)[:300]}"
+        await db.flush()
+
+    # Reload
+    result = await db.execute(
+        select(Order)
+        .where(Order.id == order.id)
+        .options(
+            selectinload(Order.line_items),
+            selectinload(Order.status_history),
+        )
+    )
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# POST /orders/{order_id}/create-opportunity
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/orders/{order_id}/create-opportunity",
+    response_model=D365OpportunityResponse,
+)
+async def create_opportunity(
+    order_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> D365OpportunityResponse:
+    """Create a D365 opportunity from an order."""
+    from app.services.d365_service import create_d365_opportunity
+
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Order).where(Order.id == order_id, Order.tenant_id == tenant_id)
+    )
+    order = result.scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    if order.d365_opportunity_id:
+        return D365OpportunityResponse(
+            order_id=order.id,
+            d365_opportunity_id=order.d365_opportunity_id,
+            d365_opportunity_url=order.d365_opportunity_url,
+            status="already_exists",
+            message="D365 opportunity already created for this order",
+        )
+
+    # Get property info for D365 mapping
+    property_data = None
+    if order.property_id:
+        prop_result = await db.execute(
+            select(Property).where(Property.id == order.property_id)
+        )
+        prop = prop_result.scalar_one_or_none()
+        if prop:
+            property_data = {
+                "id": prop.id,
+                "address": prop.address,
+                "city": prop.city,
+                "state": prop.state,
+                "zip": prop.zip,
+                "property_type": prop.property_type,
+                "sqft": prop.sqft,
+                "beds": prop.beds,
+                "baths": prop.baths,
+                "arv_estimate": prop.arv_estimate,
+            }
+
+    # Get quote info
+    quote_data = None
+    quote_result = await db.execute(
+        select(Quote).where(Quote.id == order.quote_id)
+    )
+    quote = quote_result.scalar_one_or_none()
+    if quote:
+        quote_data = {
+            "id": quote.id,
+            "grand_total": quote.grand_total,
+            "total_material": quote.total_material,
+            "total_labor": quote.total_labor,
+        }
+
+    order_data = {
+        "id": order.id,
+        "quote_id": order.quote_id,
+        "sage_order_id": order.sage_order_id,
+        "total_amount": order.total_amount,
+        "status": order.status,
+    }
+
+    try:
+        d365_result = await create_d365_opportunity(
+            order_data, property_data, quote_data
+        )
+        order.d365_opportunity_id = d365_result["opportunity_id"]
+        order.d365_opportunity_url = d365_result.get("opportunity_url")
+        await db.flush()
+
+        return D365OpportunityResponse(
+            order_id=order.id,
+            d365_opportunity_id=order.d365_opportunity_id,
+            d365_opportunity_url=order.d365_opportunity_url,
+            status="created",
+            message="D365 opportunity created successfully",
+        )
+
+    except Exception as exc:
+        logger.error("D365 opportunity creation failed for order %s: %s", order.id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"D365 opportunity creation failed: {str(exc)[:300]}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /orders/{order_id}/opportunity
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/orders/{order_id}/opportunity",
+    response_model=D365OpportunityResponse,
+)
+async def get_opportunity_status(
+    order_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> D365OpportunityResponse:
+    """Get D365 opportunity status for an order."""
+    from app.services.d365_service import get_d365_opportunity_status
+
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Order).where(Order.id == order_id, Order.tenant_id == tenant_id)
+    )
+    order = result.scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    if not order.d365_opportunity_id:
+        raise HTTPException(
+            status_code=404,
+            detail="No D365 opportunity exists for this order",
+        )
+
+    try:
+        status = await get_d365_opportunity_status(order.d365_opportunity_id)
+        return D365OpportunityResponse(
+            order_id=order.id,
+            d365_opportunity_id=order.d365_opportunity_id,
+            d365_opportunity_url=order.d365_opportunity_url,
+            status=status.get("state", "unknown"),
+            message=f"Opportunity: {status.get('name', 'N/A')}",
+        )
+
+    except Exception as exc:
+        logger.error("D365 status fetch failed for order %s: %s", order.id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"D365 status fetch failed: {str(exc)[:300]}",
+        )

--- a/packages/api/app/routers/photo_analysis.py
+++ b/packages/api/app/routers/photo_analysis.py
@@ -1,0 +1,273 @@
+"""Photo analysis endpoints for listing photo pre-screening via Claude Vision."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import PhotoLabel, Property, PropertyPhotoAnalysis
+from app.schemas.photo_analysis import (
+    AnalyzePhotosRequest,
+    PhotoLabelOverride,
+    PhotoLabelResponse,
+    PropertyPhotoAnalysisResponse,
+    ReviewQueueItem,
+    ReviewQueueResponse,
+)
+from app.services.claude_vision import ClaudeVisionService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["photo-analysis"])
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# POST /properties/{id}/analyze-photos
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/properties/{property_id}/analyze-photos",
+    response_model=PropertyPhotoAnalysisResponse,
+)
+async def analyze_photos(
+    property_id: str,
+    body: AnalyzePhotosRequest,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PropertyPhotoAnalysisResponse:
+    """Trigger Claude Vision analysis on listing photos for a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Verify property exists and belongs to tenant
+    prop = await db.execute(
+        select(Property).where(
+            Property.id == property_id, Property.tenant_id == tenant_id
+        )
+    )
+    if not prop.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Property not found")
+
+    vision = ClaudeVisionService()
+
+    # Create analysis record
+    analysis = PropertyPhotoAnalysis(
+        property_id=property_id,
+        status="processing",
+        photo_count=len(body.photo_urls),
+        model_id=vision._model,
+    )
+    db.add(analysis)
+    await db.flush()
+
+    try:
+        summary = await vision.analyze_property_photos(body.photo_urls)
+
+        # Persist labels
+        for result in summary.labels:
+            review_status = (
+                "pending_review" if result.confidence_tier == "low" else "auto_accepted"
+            )
+            label = PhotoLabel(
+                analysis_id=analysis.id,
+                photo_url=result.photo_url,
+                photo_index=result.photo_index,
+                room_type=result.room_type,
+                condition=result.condition,
+                damage_issues=result.damage_issues,
+                renovation_needed=result.renovation_needed,
+                confidence=result.confidence,
+                confidence_tier=result.confidence_tier,
+                raw_response=result.raw_response,
+                review_status=review_status,
+            )
+            db.add(label)
+
+        # Update analysis with aggregated results
+        analysis.status = "completed"
+        analysis.renovation_signal = summary.renovation_signal
+        analysis.renovation_confidence = summary.renovation_confidence
+        analysis.total_cost_cents = (
+            summary.total_input_tokens * 3 + summary.total_output_tokens * 15
+        )  # approx cost tracking in hundredths of cents
+        analysis.completed_at = datetime.now(timezone.utc)
+
+    except Exception as exc:
+        logger.exception("Photo analysis failed for property %s", property_id)
+        analysis.status = "failed"
+        analysis.error_message = str(exc)[:2000]
+
+    await db.flush()
+
+    # Reload with labels for response
+    result = await db.execute(
+        select(PropertyPhotoAnalysis)
+        .where(PropertyPhotoAnalysis.id == analysis.id)
+        .options(selectinload(PropertyPhotoAnalysis.labels))
+    )
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# GET /properties/{id}/photo-analysis
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/properties/{property_id}/photo-analysis",
+    response_model=list[PropertyPhotoAnalysisResponse],
+)
+async def get_photo_analysis(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[PropertyPhotoAnalysis]:
+    """Get all photo analysis results for a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Verify property belongs to tenant
+    prop = await db.execute(
+        select(Property).where(
+            Property.id == property_id, Property.tenant_id == tenant_id
+        )
+    )
+    if not prop.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Property not found")
+
+    result = await db.execute(
+        select(PropertyPhotoAnalysis)
+        .where(PropertyPhotoAnalysis.property_id == property_id)
+        .options(selectinload(PropertyPhotoAnalysis.labels))
+        .order_by(PropertyPhotoAnalysis.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# GET /review-queue
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/review-queue",
+    response_model=ReviewQueueResponse,
+    tags=["review-queue"],
+)
+async def get_review_queue(
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+) -> ReviewQueueResponse:
+    """List low-confidence photo labels pending human review."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Count total
+    count_q = (
+        select(func.count(PhotoLabel.id))
+        .join(
+            PropertyPhotoAnalysis,
+            PhotoLabel.analysis_id == PropertyPhotoAnalysis.id,
+        )
+        .join(Property, PropertyPhotoAnalysis.property_id == Property.id)
+        .where(
+            Property.tenant_id == tenant_id,
+            PhotoLabel.review_status == "pending_review",
+        )
+    )
+    total = (await db.execute(count_q)).scalar() or 0
+
+    # Fetch page
+    offset = (page - 1) * page_size
+    q = (
+        select(PhotoLabel, Property.id, Property.address)
+        .join(
+            PropertyPhotoAnalysis,
+            PhotoLabel.analysis_id == PropertyPhotoAnalysis.id,
+        )
+        .join(Property, PropertyPhotoAnalysis.property_id == Property.id)
+        .where(
+            Property.tenant_id == tenant_id,
+            PhotoLabel.review_status == "pending_review",
+        )
+        .order_by(PhotoLabel.confidence.asc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    rows = (await db.execute(q)).all()
+
+    items = [
+        ReviewQueueItem(
+            label=PhotoLabelResponse.model_validate(row[0]),
+            property_id=row[1],
+            property_address=row[2],
+            analysis_id=row[0].analysis_id,
+        )
+        for row in rows
+    ]
+
+    return ReviewQueueResponse(
+        items=items, total=total, page=page, page_size=page_size
+    )
+
+
+# ---------------------------------------------------------------------------
+# PATCH /photo-labels/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.patch(
+    "/photo-labels/{label_id}",
+    response_model=PhotoLabelResponse,
+    tags=["review-queue"],
+)
+async def override_photo_label(
+    label_id: str,
+    body: PhotoLabelOverride,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PhotoLabel:
+    """Human override for a photo label (approve/reject/correct)."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Fetch label and verify tenant ownership
+    q = (
+        select(PhotoLabel)
+        .join(
+            PropertyPhotoAnalysis,
+            PhotoLabel.analysis_id == PropertyPhotoAnalysis.id,
+        )
+        .join(Property, PropertyPhotoAnalysis.property_id == Property.id)
+        .where(PhotoLabel.id == label_id, Property.tenant_id == tenant_id)
+    )
+    result = await db.execute(q)
+    label = result.scalar_one_or_none()
+    if not label:
+        raise HTTPException(status_code=404, detail="Photo label not found")
+
+    override_data = body.model_dump(exclude_none=True)
+    if override_data:
+        label.reviewer_override = override_data
+        # Apply overrides to the label fields
+        if body.room_type is not None:
+            label.room_type = body.room_type
+        if body.condition is not None:
+            label.condition = body.condition
+        if body.damage_issues is not None:
+            label.damage_issues = body.damage_issues
+        if body.renovation_needed is not None:
+            label.renovation_needed = body.renovation_needed
+
+    label.review_status = "reviewed"
+    return label

--- a/packages/api/app/routers/properties.py
+++ b/packages/api/app/routers/properties.py
@@ -1,0 +1,308 @@
+"""Property endpoints — ingestion, listing feed, and integrations."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import Property
+from app.schemas.property import (
+    GeocodeResult,
+    GooglePlacesAutocomplete,
+    PlacesAutocompleteResponse,
+    PlacePrediction,
+    PropertyCreate,
+    PropertyListResponse,
+    PropertyResponse,
+    PropertyUpdate,
+    PropStreamSearch,
+    ZillowUrlImport,
+)
+from app.services import apillow, google_places, propstream, zillow_scraper
+
+router = APIRouter(prefix="/properties", tags=["properties"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _property_to_response(prop: Property) -> PropertyResponse:
+    return PropertyResponse.model_validate(prop)
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# Manual CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=PropertyResponse, status_code=status.HTTP_201_CREATED)
+async def create_property(
+    body: PropertyCreate,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PropertyResponse:
+    """Create a property via manual entry."""
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = Property(
+        tenant_id=tenant_id,
+        data_source="manual",
+        **body.model_dump(exclude_none=True),
+    )
+    db.add(prop)
+    await db.flush()
+    await db.refresh(prop)
+    return _property_to_response(prop)
+
+
+@router.get("/{property_id}", response_model=PropertyResponse)
+async def get_property(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PropertyResponse:
+    """Get a single property by ID."""
+    tenant_id = _ensure_tenant(user)
+    result = await db.execute(
+        select(Property).where(Property.id == property_id, Property.tenant_id == tenant_id)
+    )
+    prop = result.scalar_one_or_none()
+    if not prop:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
+    return _property_to_response(prop)
+
+
+@router.patch("/{property_id}", response_model=PropertyResponse)
+async def update_property(
+    property_id: str,
+    body: PropertyUpdate,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PropertyResponse:
+    """Partially update a property."""
+    tenant_id = _ensure_tenant(user)
+    result = await db.execute(
+        select(Property).where(Property.id == property_id, Property.tenant_id == tenant_id)
+    )
+    prop = result.scalar_one_or_none()
+    if not prop:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
+
+    for key, value in body.model_dump(exclude_unset=True).items():
+        setattr(prop, key, value)
+
+    await db.flush()
+    await db.refresh(prop)
+    return _property_to_response(prop)
+
+
+# ---------------------------------------------------------------------------
+# Listing Feed — paginated, filterable, sortable
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=PropertyListResponse)
+async def list_properties(
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    # Filters
+    property_status: str | None = Query(None, alias="status"),
+    property_type: str | None = Query(None),
+    min_price: float | None = Query(None, ge=0),
+    max_price: float | None = Query(None, ge=0),
+    city: str | None = Query(None),
+    state: str | None = Query(None),
+    zip_code: str | None = Query(None, alias="zip"),
+    min_beds: int | None = Query(None, ge=0),
+    min_baths: float | None = Query(None, ge=0),
+    # Sort
+    sort_by: str = Query("created_at", pattern="^(created_at|listing_price|arv_estimate|address)$"),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$"),
+) -> PropertyListResponse:
+    """List properties with pagination, filtering, and sorting."""
+    tenant_id = _ensure_tenant(user)
+
+    # Base query
+    query = select(Property).where(Property.tenant_id == tenant_id)
+
+    # Apply filters
+    if property_status:
+        query = query.where(Property.status == property_status)
+    if property_type:
+        query = query.where(Property.property_type == property_type)
+    if min_price is not None:
+        query = query.where(Property.listing_price >= min_price)
+    if max_price is not None:
+        query = query.where(Property.listing_price <= max_price)
+    if city:
+        query = query.where(func.lower(Property.city) == city.lower())
+    if state:
+        query = query.where(func.lower(Property.state) == state.lower())
+    if zip_code:
+        query = query.where(Property.zip == zip_code)
+    if min_beds is not None:
+        query = query.where(Property.beds >= min_beds)
+    if min_baths is not None:
+        query = query.where(Property.baths >= min_baths)
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Sort
+    sort_column = getattr(Property, sort_by)
+    if sort_order == "desc":
+        query = query.order_by(sort_column.desc().nulls_last())
+    else:
+        query = query.order_by(sort_column.asc().nulls_last())
+
+    # Paginate
+    offset = (page - 1) * page_size
+    query = query.offset(offset).limit(page_size)
+
+    result = await db.execute(query)
+    properties = result.scalars().all()
+
+    return PropertyListResponse(
+        items=[_property_to_response(p) for p in properties],
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=math.ceil(total / page_size) if total > 0 else 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PropStream integration
+# ---------------------------------------------------------------------------
+
+
+@router.post("/search/propstream", response_model=PropertyResponse, status_code=status.HTTP_201_CREATED)
+async def import_from_propstream(
+    body: PropStreamSearch,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PropertyResponse:
+    """Search PropStream and import a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    if not body.address and not body.mls_id and not (body.lat and body.lng):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide at least one of: address, mls_id, or lat/lng coordinates",
+        )
+
+    # Search PropStream
+    if body.address:
+        raw = await propstream.search_by_address(body.address)
+    elif body.mls_id:
+        raw = await propstream.search_by_mls_id(body.mls_id)
+    else:
+        raw = await propstream.search_by_coordinates(
+            body.lat, body.lng, body.radius_miles or 1.0  # type: ignore[arg-type]
+        )
+
+    normalized = propstream.normalize_propstream_data(raw)
+
+    # Try APIllow enrichment
+    if normalized.get("address"):
+        apillow_raw = await apillow.fetch_property_data(normalized["address"])
+        if apillow_raw:
+            apillow_normalized = apillow.normalize_apillow_data(apillow_raw)
+            normalized = apillow.merge_enrichment(normalized, apillow_normalized)
+
+    # Remove empty strings before creating
+    clean = {k: v for k, v in normalized.items() if v is not None and v != ""}
+
+    prop = Property(tenant_id=tenant_id, **clean)
+    db.add(prop)
+    await db.flush()
+    await db.refresh(prop)
+    return _property_to_response(prop)
+
+
+# ---------------------------------------------------------------------------
+# Zillow URL paste
+# ---------------------------------------------------------------------------
+
+
+@router.post("/import/zillow", response_model=PropertyResponse, status_code=status.HTTP_201_CREATED)
+async def import_from_zillow_url(
+    body: ZillowUrlImport,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PropertyResponse:
+    """Create a property record from a Zillow listing URL."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    try:
+        data = await zillow_scraper.scrape_zillow_listing(body.url)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    if not data.get("address") or not data.get("city") or not data.get("state") or not data.get("zip"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Could not extract required address fields from Zillow listing",
+        )
+
+    # Try APIllow enrichment for the address
+    apillow_raw = await apillow.fetch_property_data(data["address"])
+    if apillow_raw:
+        apillow_normalized = apillow.normalize_apillow_data(apillow_raw)
+        data = apillow.merge_enrichment(data, apillow_normalized)
+
+    clean = {k: v for k, v in data.items() if v is not None and v != ""}
+    prop = Property(tenant_id=tenant_id, **clean)
+    db.add(prop)
+    await db.flush()
+    await db.refresh(prop)
+    return _property_to_response(prop)
+
+
+# ---------------------------------------------------------------------------
+# Google Places
+# ---------------------------------------------------------------------------
+
+
+@router.post("/places/autocomplete", response_model=PlacesAutocompleteResponse)
+async def places_autocomplete(
+    body: GooglePlacesAutocomplete,
+    user: CurrentUser = Depends(get_current_user),
+) -> PlacesAutocompleteResponse:
+    """Return address autocomplete suggestions from Google Places."""
+    _ensure_tenant(user)
+    predictions = await google_places.autocomplete(body.input, body.session_token)
+    return PlacesAutocompleteResponse(
+        predictions=[PlacePrediction(**p) for p in predictions]
+    )
+
+
+@router.get("/places/geocode", response_model=GeocodeResult)
+async def geocode_address(
+    address: str = Query(..., min_length=1),
+    user: CurrentUser = Depends(get_current_user),
+) -> GeocodeResult:
+    """Geocode an address to lat/lng."""
+    _ensure_tenant(user)
+    result = await google_places.geocode(address)
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Could not geocode address",
+        )
+    return GeocodeResult(**result)

--- a/packages/api/app/routers/quotes.py
+++ b/packages/api/app/routers/quotes.py
@@ -1,0 +1,545 @@
+"""Quote builder endpoints — create, read, update quotes + PDF SOW generation."""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import (
+    Deal,
+    PhotoLabel,
+    Property,
+    PropertyPhotoAnalysis,
+    Quote,
+    QuoteItem,
+)
+from app.schemas.quote import (
+    GenerateSOWResponse,
+    QuoteCreate,
+    QuoteDetailResponse,
+    QuoteListResponse,
+    QuoteResponse,
+    QuoteUpdate,
+)
+from app.services.quote_service import (
+    calculate_item_subtotal,
+    calculate_quote_totals,
+    download_sow_from_s3,
+    generate_ai_line_items,
+    generate_sow_pdf,
+    upload_sow_to_s3,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["quotes"])
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+# ---------------------------------------------------------------------------
+# POST /properties/{property_id}/quotes
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/properties/{property_id}/quotes",
+    response_model=QuoteDetailResponse,
+    status_code=201,
+)
+async def create_quote(
+    property_id: str,
+    body: QuoteCreate,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Quote:
+    """Create a quote for a property — manual or AI-populated."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Verify property
+    prop_result = await db.execute(
+        select(Property).where(
+            Property.id == property_id, Property.tenant_id == tenant_id
+        )
+    )
+    prop = prop_result.scalar_one_or_none()
+    if not prop:
+        raise HTTPException(status_code=404, detail="Property not found")
+
+    # Resolve deal — use provided deal_id or find/create one for this property
+    deal_id = body.deal_id
+    if not deal_id:
+        deal_result = await db.execute(
+            select(Deal).where(
+                Deal.property_id == property_id, Deal.tenant_id == tenant_id
+            ).limit(1)
+        )
+        deal = deal_result.scalar_one_or_none()
+        if not deal:
+            deal = Deal(tenant_id=tenant_id, property_id=property_id, status="prospect")
+            db.add(deal)
+            await db.flush()
+        deal_id = deal.id
+    else:
+        deal_result = await db.execute(
+            select(Deal).where(Deal.id == deal_id, Deal.tenant_id == tenant_id)
+        )
+        if not deal_result.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Deal not found")
+
+    # Create quote
+    quote = Quote(
+        deal_id=deal_id,
+        tenant_id=tenant_id,
+        property_id=property_id,
+        status="draft",
+        version=1,
+        notes=body.notes,
+        platform_fee_pct=body.platform_fee_pct,
+    )
+
+    # AI mode: generate line items from photo analysis
+    if body.mode == "ai":
+        if not body.photo_analysis_id:
+            raise HTTPException(
+                status_code=400,
+                detail="photo_analysis_id is required for AI mode",
+            )
+
+        analysis_result = await db.execute(
+            select(PropertyPhotoAnalysis)
+            .where(
+                PropertyPhotoAnalysis.id == body.photo_analysis_id,
+                PropertyPhotoAnalysis.property_id == property_id,
+                PropertyPhotoAnalysis.status == "completed",
+            )
+            .options(selectinload(PropertyPhotoAnalysis.labels))
+        )
+        analysis = analysis_result.scalar_one_or_none()
+        if not analysis:
+            raise HTTPException(
+                status_code=404,
+                detail="Completed photo analysis not found for this property",
+            )
+
+        quote.photo_analysis_id = analysis.id
+
+        # Convert labels to dicts for the AI generator
+        label_dicts = [
+            {
+                "room_type": lbl.room_type,
+                "condition": lbl.condition,
+                "damage_issues": lbl.damage_issues,
+                "renovation_needed": lbl.renovation_needed,
+                "confidence": lbl.confidence,
+            }
+            for lbl in analysis.labels
+        ]
+        ai_items = generate_ai_line_items(label_dicts)
+
+        db.add(quote)
+        await db.flush()
+
+        for item_data in ai_items:
+            subtotal = calculate_item_subtotal(
+                item_data["quantity"],
+                item_data["unit_cost"],
+                item_data["labor_cost"],
+                item_data.get("markup_pct"),
+            )
+            qi = QuoteItem(
+                quote_id=quote.id,
+                room=item_data["room"],
+                trade_category=item_data["trade_category"],
+                description=item_data["description"],
+                sage_sku=item_data.get("sage_sku"),
+                quantity=item_data["quantity"],
+                unit_cost=item_data["unit_cost"],
+                labor_cost=item_data["labor_cost"],
+                markup_pct=item_data.get("markup_pct"),
+                subtotal=subtotal,
+                ai_confidence=item_data.get("ai_confidence"),
+                is_ai_generated=True,
+                unit_of_measure=item_data.get("unit_of_measure"),
+            )
+            db.add(qi)
+
+    else:
+        # Manual mode
+        db.add(quote)
+        await db.flush()
+
+        for item_data in body.items:
+            subtotal = calculate_item_subtotal(
+                item_data.quantity,
+                item_data.unit_cost,
+                item_data.labor_cost,
+                item_data.markup_pct,
+            )
+            qi = QuoteItem(
+                quote_id=quote.id,
+                room=item_data.room,
+                trade_category=item_data.trade_category,
+                description=item_data.description,
+                sage_sku=item_data.sage_sku,
+                quantity=item_data.quantity,
+                unit_cost=item_data.unit_cost,
+                labor_cost=item_data.labor_cost,
+                markup_pct=item_data.markup_pct,
+                subtotal=subtotal,
+                is_ai_generated=False,
+                unit_of_measure=item_data.unit_of_measure,
+            )
+            db.add(qi)
+
+    await db.flush()
+
+    # Recalculate totals
+    await _recalculate_totals(db, quote)
+
+    # Reload with items
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.id == quote.id)
+        .options(selectinload(Quote.items))
+    )
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# GET /properties/{property_id}/quotes
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/properties/{property_id}/quotes",
+    response_model=QuoteListResponse,
+)
+async def list_quotes(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    status: str | None = Query(None, pattern=r"^(draft|submitted|approved|rejected)$"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> QuoteListResponse:
+    """List quotes for a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    # Verify property
+    prop_result = await db.execute(
+        select(Property).where(
+            Property.id == property_id, Property.tenant_id == tenant_id
+        )
+    )
+    if not prop_result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Property not found")
+
+    base = select(Quote).where(
+        Quote.property_id == property_id, Quote.tenant_id == tenant_id
+    )
+    if status:
+        base = base.where(Quote.status == status)
+
+    # Count
+    count_q = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_q)).scalar() or 0
+
+    # Fetch
+    q = base.order_by(Quote.created_at.desc()).offset(offset).limit(limit)
+    rows = (await db.execute(q)).scalars().all()
+
+    return QuoteListResponse(items=list(rows), total=total)
+
+
+# ---------------------------------------------------------------------------
+# GET /quotes/{quote_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/quotes/{quote_id}",
+    response_model=QuoteDetailResponse,
+)
+async def get_quote(
+    quote_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Quote:
+    """Get a single quote with line items."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.id == quote_id, Quote.tenant_id == tenant_id)
+        .options(selectinload(Quote.items))
+    )
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+    return quote
+
+
+# ---------------------------------------------------------------------------
+# PATCH /quotes/{quote_id}
+# ---------------------------------------------------------------------------
+
+
+@router.patch(
+    "/quotes/{quote_id}",
+    response_model=QuoteDetailResponse,
+)
+async def update_quote(
+    quote_id: str,
+    body: QuoteUpdate,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Quote:
+    """Update quote status, notes, or line items."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.id == quote_id, Quote.tenant_id == tenant_id)
+        .options(selectinload(Quote.items))
+    )
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    # Status change
+    if body.status is not None:
+        quote.status = body.status
+
+    if body.notes is not None:
+        quote.notes = body.notes
+
+    if body.platform_fee_pct is not None:
+        quote.platform_fee_pct = body.platform_fee_pct
+
+    # Remove items
+    if body.remove_item_ids:
+        existing_ids = {item.id for item in quote.items}
+        for item_id in body.remove_item_ids:
+            if item_id not in existing_ids:
+                raise HTTPException(
+                    status_code=404, detail=f"Item {item_id} not found on this quote"
+                )
+        quote.items = [i for i in quote.items if i.id not in set(body.remove_item_ids)]
+
+    # Update items
+    if body.update_items:
+        item_map = {item.id: item for item in quote.items}
+        for item_id, updates in body.update_items.items():
+            qi = item_map.get(item_id)
+            if not qi:
+                raise HTTPException(
+                    status_code=404, detail=f"Item {item_id} not found on this quote"
+                )
+            update_data = updates.model_dump(exclude_none=True)
+            for field, value in update_data.items():
+                setattr(qi, field, value)
+            qi.subtotal = calculate_item_subtotal(
+                qi.quantity or 1,
+                Decimal(str(qi.unit_cost or 0)),
+                Decimal(str(qi.labor_cost or 0)),
+                Decimal(str(qi.markup_pct)) if qi.markup_pct else None,
+            )
+
+    # Add items
+    for item_data in body.add_items:
+        subtotal = calculate_item_subtotal(
+            item_data.quantity,
+            item_data.unit_cost,
+            item_data.labor_cost,
+            item_data.markup_pct,
+        )
+        qi = QuoteItem(
+            quote_id=quote.id,
+            room=item_data.room,
+            trade_category=item_data.trade_category,
+            description=item_data.description,
+            sage_sku=item_data.sage_sku,
+            quantity=item_data.quantity,
+            unit_cost=item_data.unit_cost,
+            labor_cost=item_data.labor_cost,
+            markup_pct=item_data.markup_pct,
+            subtotal=subtotal,
+            is_ai_generated=False,
+            unit_of_measure=item_data.unit_of_measure,
+        )
+        db.add(qi)
+
+    # Bump version on any item changes
+    if body.add_items or body.update_items or body.remove_item_ids:
+        quote.version += 1
+
+    await db.flush()
+    await _recalculate_totals(db, quote)
+
+    # Expire cached relationships so reload picks up new items
+    await db.refresh(quote)
+
+    # Reload with items
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.id == quote.id)
+        .options(selectinload(Quote.items))
+    )
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# POST /quotes/{quote_id}/generate-sow
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/quotes/{quote_id}/generate-sow",
+    response_model=GenerateSOWResponse,
+)
+async def generate_sow(
+    quote_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> GenerateSOWResponse:
+    """Generate a PDF Scope of Work for a quote and upload to S3."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Quote)
+        .where(Quote.id == quote_id, Quote.tenant_id == tenant_id)
+        .options(selectinload(Quote.items))
+    )
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    # Get property info for the PDF
+    property_info = None
+    if quote.property_id:
+        prop_result = await db.execute(
+            select(Property).where(Property.id == quote.property_id)
+        )
+        prop = prop_result.scalar_one_or_none()
+        if prop:
+            property_info = {
+                "address": prop.address,
+                "city": prop.city,
+                "state": prop.state,
+                "zip": prop.zip,
+                "property_type": prop.property_type,
+                "sqft": prop.sqft,
+                "beds": prop.beds,
+                "baths": prop.baths,
+            }
+
+    quote_dict = {
+        "id": quote.id,
+        "status": quote.status,
+        "created_at": quote.created_at,
+        "notes": quote.notes,
+        "total_material": quote.total_material,
+        "total_labor": quote.total_labor,
+        "platform_fee": quote.platform_fee,
+        "platform_fee_pct": quote.platform_fee_pct,
+        "grand_total": quote.grand_total,
+    }
+    items_dicts = [
+        {
+            "room": item.room,
+            "trade_category": item.trade_category,
+            "description": item.description,
+            "quantity": item.quantity,
+            "unit_cost": item.unit_cost,
+            "labor_cost": item.labor_cost,
+            "markup_pct": item.markup_pct,
+        }
+        for item in quote.items
+    ]
+
+    pdf_bytes = generate_sow_pdf(quote_dict, items_dicts, property_info)
+    s3_key = await upload_sow_to_s3(pdf_bytes, quote.id)
+
+    quote.pdf_s3_key = s3_key
+    await db.flush()
+
+    return GenerateSOWResponse(
+        quote_id=quote.id,
+        pdf_s3_key=s3_key,
+        message="SOW PDF generated and uploaded successfully",
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /quotes/{quote_id}/sow
+# ---------------------------------------------------------------------------
+
+
+@router.get("/quotes/{quote_id}/sow")
+async def download_sow(
+    quote_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Download the generated SOW PDF for a quote."""
+    tenant_id = await ensure_tenant_exists(db, user)
+
+    result = await db.execute(
+        select(Quote).where(Quote.id == quote_id, Quote.tenant_id == tenant_id)
+    )
+    quote = result.scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+    if not quote.pdf_s3_key:
+        raise HTTPException(
+            status_code=404, detail="No SOW has been generated for this quote"
+        )
+
+    pdf_bytes = await download_sow_from_s3(quote.pdf_s3_key)
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="sow-{quote_id}.pdf"'
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _recalculate_totals(db: AsyncSession, quote: Quote) -> None:
+    """Recalculate and persist quote totals from current items."""
+    items_result = await db.execute(
+        select(QuoteItem).where(QuoteItem.quote_id == quote.id)
+    )
+    items = items_result.scalars().all()
+
+    item_dicts = [
+        {
+            "quantity": i.quantity,
+            "unit_cost": i.unit_cost,
+            "labor_cost": i.labor_cost,
+            "markup_pct": i.markup_pct,
+        }
+        for i in items
+    ]
+
+    totals = calculate_quote_totals(item_dicts, quote.platform_fee_pct)
+    quote.total_material = totals["total_material"]
+    quote.total_labor = totals["total_labor"]
+    quote.platform_fee = totals["platform_fee"]
+    quote.grand_total = totals["grand_total"]

--- a/packages/api/app/routers/risk.py
+++ b/packages/api/app/routers/risk.py
@@ -1,0 +1,303 @@
+"""Risk flag system endpoints — evaluation, FEMA flood zone, lendability."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import CurrentUser, ensure_tenant_exists, get_current_user
+from app.database import get_db
+from app.models import ARVCalculation, Property, RiskFlag
+from app.schemas.risk import (
+    LendabilityBreakdown,
+    LendabilityScoreResponse,
+    RiskEvaluationResponse,
+    RiskFlagListResponse,
+    RiskFlagResponse,
+)
+from app.services import fema
+from app.services.lendability import calculate_lendability
+from app.services.risk_flags import evaluate_year_flags
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/risk", tags=["risk"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tenant(user: CurrentUser) -> str:
+    return user.effective_tenant_id
+
+
+async def _get_property(db: AsyncSession, property_id: str, tenant_id: str) -> Property:
+    result = await db.execute(
+        select(Property).where(Property.id == property_id, Property.tenant_id == tenant_id)
+    )
+    prop = result.scalar_one_or_none()
+    if not prop:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
+    return prop
+
+
+# ---------------------------------------------------------------------------
+# List risk flags
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{property_id}/flags", response_model=RiskFlagListResponse)
+async def list_risk_flags(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> RiskFlagListResponse:
+    """List all stored risk flags for a property."""
+    tenant_id = await ensure_tenant_exists(db, user)
+    await _get_property(db, property_id, tenant_id)
+
+    result = await db.execute(
+        select(RiskFlag).where(RiskFlag.property_id == property_id)
+    )
+    flags = result.scalars().all()
+
+    return RiskFlagListResponse(
+        property_id=property_id,
+        flags=[RiskFlagResponse.model_validate(f) for f in flags],
+        total=len(flags),
+    )
+
+
+# ---------------------------------------------------------------------------
+# FEMA flood zone query
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{property_id}/fema", response_model=RiskFlagListResponse)
+async def query_fema_flood_zone(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> RiskFlagListResponse:
+    """Query FEMA flood zone for a property and store result as a risk flag."""
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = await _get_property(db, property_id, tenant_id)
+
+    if prop.lat is None or prop.lng is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Property missing lat/lng coordinates for FEMA lookup",
+        )
+
+    flood_data = await fema.query_flood_zone(prop.lat, prop.lng)
+    if flood_data is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="FEMA flood zone service temporarily unavailable",
+        )
+
+    # Remove existing FEMA flags for this property (replace with fresh data)
+    await db.execute(
+        delete(RiskFlag).where(
+            RiskFlag.property_id == property_id, RiskFlag.source == "fema"
+        )
+    )
+
+    if flood_data["is_high_risk"]:
+        severity = "high"
+        detail = (
+            f"FEMA flood zone {flood_data['zone']} — high-risk area. "
+            "Flood insurance required for federally backed mortgages. "
+            "Expect significant insurance premium impact."
+        )
+    else:
+        severity = "low"
+        detail = (
+            f"FEMA flood zone {flood_data['zone']} — minimal to moderate flood risk."
+        )
+
+    flag = RiskFlag(
+        property_id=property_id,
+        flag_type="flood_zone",
+        severity=severity,
+        detail=detail,
+        source="fema",
+    )
+    db.add(flag)
+    await db.flush()
+    await db.refresh(flag)
+
+    return RiskFlagListResponse(
+        property_id=property_id,
+        flags=[RiskFlagResponse.model_validate(flag)],
+        total=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full risk evaluation
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{property_id}/evaluate", response_model=RiskEvaluationResponse)
+async def evaluate_risk(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> RiskEvaluationResponse:
+    """Run full risk evaluation: year flags + FEMA + lendability score.
+
+    Clears existing risk flags for this property and re-evaluates from scratch.
+    """
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = await _get_property(db, property_id, tenant_id)
+
+    # Clear existing flags
+    await db.execute(
+        delete(RiskFlag).where(RiskFlag.property_id == property_id)
+    )
+
+    # --- Year-based flags ---
+    year_flag_dicts = evaluate_year_flags(prop.year_built)
+    saved_flags: list[RiskFlag] = []
+
+    for fd in year_flag_dicts:
+        flag = RiskFlag(property_id=property_id, **fd)
+        db.add(flag)
+        saved_flags.append(flag)
+
+    # --- FEMA flood zone ---
+    if prop.lat is not None and prop.lng is not None:
+        flood_data = await fema.query_flood_zone(prop.lat, prop.lng)
+        if flood_data is not None:
+            if flood_data["is_high_risk"]:
+                severity = "high"
+                detail = (
+                    f"FEMA flood zone {flood_data['zone']} — high-risk area. "
+                    "Flood insurance required for federally backed mortgages."
+                )
+            else:
+                severity = "low"
+                detail = (
+                    f"FEMA flood zone {flood_data['zone']} — minimal to moderate flood risk."
+                )
+
+            fema_flag = RiskFlag(
+                property_id=property_id,
+                flag_type="flood_zone",
+                severity=severity,
+                detail=detail,
+                source="fema",
+            )
+            db.add(fema_flag)
+            saved_flags.append(fema_flag)
+
+    await db.flush()
+    for f in saved_flags:
+        await db.refresh(f)
+
+    # --- Lendability score ---
+    flag_dicts = [
+        {
+            "flag_type": f.flag_type,
+            "severity": f.severity,
+            "source": f.source,
+        }
+        for f in saved_flags
+    ]
+
+    # Get ARV calculations
+    arv_result = await db.execute(
+        select(ARVCalculation)
+        .where(ARVCalculation.property_id == property_id)
+        .order_by(ARVCalculation.created_at.desc())
+    )
+    arv_rows = arv_result.scalars().all()
+    arv_dicts = [
+        {"arv_mid": float(a.arv_mid), "confidence": a.confidence}
+        for a in arv_rows
+    ]
+
+    prop_data = {
+        "year_built": prop.year_built,
+        "listing_price": prop.listing_price,
+    }
+    lendability = calculate_lendability(prop_data, flag_dicts, arv_dicts)
+
+    # Persist lendability on property
+    prop.lendability_score = lendability["score"]
+    prop.lendability_category = lendability["category"]
+    await db.flush()
+
+    return RiskEvaluationResponse(
+        property_id=property_id,
+        flags=[RiskFlagResponse.model_validate(f) for f in saved_flags],
+        lendability=LendabilityScoreResponse(
+            score=lendability["score"],
+            category=lendability["category"],
+            breakdown=LendabilityBreakdown(**lendability["breakdown"]),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lendability score (read-only)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{property_id}/lendability", response_model=LendabilityScoreResponse)
+async def get_lendability_score(
+    property_id: str,
+    user: CurrentUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> LendabilityScoreResponse:
+    """Get the current lendability score for a property.
+
+    Returns the last computed score. Run POST /evaluate to refresh.
+    """
+    tenant_id = await ensure_tenant_exists(db, user)
+    prop = await _get_property(db, property_id, tenant_id)
+
+    if prop.lendability_score is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No lendability score computed yet. Run POST /risk/{id}/evaluate first.",
+        )
+
+    # Recompute breakdown from current flags
+    flags_result = await db.execute(
+        select(RiskFlag).where(RiskFlag.property_id == property_id)
+    )
+    flags = flags_result.scalars().all()
+    flag_dicts = [
+        {"flag_type": f.flag_type, "severity": f.severity, "source": f.source}
+        for f in flags
+    ]
+
+    arv_result = await db.execute(
+        select(ARVCalculation)
+        .where(ARVCalculation.property_id == property_id)
+        .order_by(ARVCalculation.created_at.desc())
+    )
+    arv_rows = arv_result.scalars().all()
+    arv_dicts = [
+        {"arv_mid": float(a.arv_mid), "confidence": a.confidence}
+        for a in arv_rows
+    ]
+
+    prop_data = {
+        "year_built": prop.year_built,
+        "listing_price": prop.listing_price,
+    }
+    lendability = calculate_lendability(prop_data, flag_dicts, arv_dicts)
+
+    return LendabilityScoreResponse(
+        score=lendability["score"],
+        category=lendability["category"],
+        breakdown=LendabilityBreakdown(**lendability["breakdown"]),
+    )

--- a/packages/api/app/schemas/catalog.py
+++ b/packages/api/app/schemas/catalog.py
@@ -1,0 +1,122 @@
+"""Pydantic schemas for catalog endpoints."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Enums / constants
+# ---------------------------------------------------------------------------
+
+AVAILABILITY_VALUES = {"in_stock", "out_of_stock", "limited", "discontinued"}
+PRICE_SOURCE_VALUES = {"sage_scrape", "sage_api", "manual"}
+
+
+# ---------------------------------------------------------------------------
+# Product Category
+# ---------------------------------------------------------------------------
+
+
+class ProductCategoryBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    parent_id: str | None = None
+    sage_category_id: str | None = None
+
+
+class ProductCategoryCreate(ProductCategoryBase):
+    pass
+
+
+class ProductCategoryResponse(ProductCategoryBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CategoryTreeResponse(ProductCategoryResponse):
+    children: list[CategoryTreeResponse] = []
+
+
+# ---------------------------------------------------------------------------
+# Product Price
+# ---------------------------------------------------------------------------
+
+
+class ProductPriceCreate(BaseModel):
+    price_cents: int = Field(..., ge=0)
+    currency: str = Field("USD", max_length=3)
+    effective_date: date
+    source: str = Field(..., max_length=50)
+
+
+class ProductPriceResponse(ProductPriceCreate):
+    id: str
+    product_id: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Product
+# ---------------------------------------------------------------------------
+
+
+class ProductBase(BaseModel):
+    sku: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=500)
+    description: str | None = None
+    brand: str | None = None
+    unit_of_measure: str | None = None
+    dimensions: dict[str, Any] | None = None
+    image_url: str | None = None
+    availability_status: str = Field("in_stock")
+    category_id: str | None = None
+    sage_product_id: str | None = None
+
+
+class ProductCreate(ProductBase):
+    tenant_id: str
+
+
+class ProductResponse(ProductBase):
+    id: str
+    tenant_id: str
+    last_synced_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProductDetailResponse(ProductResponse):
+    prices: list[ProductPriceResponse] = []
+    category: ProductCategoryResponse | None = None
+
+
+# ---------------------------------------------------------------------------
+# Search / Pagination
+# ---------------------------------------------------------------------------
+
+
+class CatalogSearchRequest(BaseModel):
+    query: str | None = None
+    category: str | None = None
+    brand: str | None = None
+    price_min: int | None = Field(None, ge=0, description="Min price in cents")
+    price_max: int | None = Field(None, ge=0, description="Max price in cents")
+    limit: int = Field(20, ge=1, le=100)
+    offset: int = Field(0, ge=0)
+
+
+class CatalogSearchResponse(BaseModel):
+    items: list[ProductResponse]
+    total: int
+    limit: int
+    offset: int

--- a/packages/api/app/schemas/comps.py
+++ b/packages/api/app/schemas/comps.py
@@ -1,0 +1,141 @@
+"""Pydantic schemas for comps engine endpoints."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class SoldCompsSearch(BaseModel):
+    """Search for sold comps around a subject property."""
+
+    property_id: str = Field(..., description="Subject property UUID")
+    radius_miles: float = Field(0.5, ge=0.1, le=25, description="Search radius in miles")
+    months_back: int = Field(6, ge=1, le=24, description="Lookback window in months")
+    # Optional filters to override subject property attributes
+    property_type: str | None = None
+    min_beds: int | None = Field(None, ge=0)
+    max_beds: int | None = Field(None, ge=0)
+    min_baths: float | None = Field(None, ge=0)
+    max_baths: float | None = Field(None, ge=0)
+    min_sqft: int | None = Field(None, ge=1)
+    max_sqft: int | None = Field(None, ge=1)
+    min_year_built: int | None = Field(None, ge=1600)
+    max_year_built: int | None = Field(None, le=2100)
+
+
+class ARVRequest(BaseModel):
+    """Request ARV calculation for a property."""
+
+    property_id: str = Field(..., description="Subject property UUID")
+    radius_miles: float = Field(0.5, ge=0.1, le=25)
+    months_back: int = Field(6, ge=1, le=24)
+
+
+class RentalCompsSearch(BaseModel):
+    """Search for rental comps via Rentcast."""
+
+    property_id: str = Field(..., description="Subject property UUID")
+    # Optionally override with explicit address/coords
+    address: str | None = None
+    lat: float | None = Field(None, ge=-90, le=90)
+    lng: float | None = Field(None, ge=-180, le=180)
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class CompResponse(BaseModel):
+    """Single sold comp."""
+
+    id: str
+    property_id: str
+    address: str
+    city: str | None = None
+    state: str | None = None
+    zip: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    sale_price: float | None = None
+    sale_date: date | None = None
+    sqft: int | None = None
+    beds: int | None = None
+    baths: float | None = None
+    year_built: int | None = None
+    property_type: str | None = None
+    distance: float | None = None
+    similarity: float | None = None
+    source: str | None = None
+    mls_id: str | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SoldCompsResponse(BaseModel):
+    """Sold comps search result."""
+
+    property_id: str
+    comps: list[CompResponse]
+    total: int
+
+
+class ARVResponse(BaseModel):
+    """ARV calculation result with confidence band."""
+
+    id: str
+    property_id: str
+    arv_low: float
+    arv_mid: float
+    arv_high: float
+    confidence: float
+    comp_count: int
+    methodology: dict[str, Any] | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class RentalCompResponse(BaseModel):
+    """Single rental comp."""
+
+    id: str
+    property_id: str
+    address: str
+    city: str | None = None
+    state: str | None = None
+    zip: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    rent_price: float | None = None
+    sqft: int | None = None
+    beds: int | None = None
+    baths: float | None = None
+    property_type: str | None = None
+    distance: float | None = None
+    correlation: float | None = None
+    source: str = "rentcast"
+    last_seen_date: date | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class RentalCompsResponse(BaseModel):
+    """Rental comps search result with estimate."""
+
+    property_id: str
+    rent_estimate_low: float | None = None
+    rent_estimate_mid: float | None = None
+    rent_estimate_high: float | None = None
+    comps: list[RentalCompResponse]
+    total: int

--- a/packages/api/app/schemas/credit_memo.py
+++ b/packages/api/app/schemas/credit_memo.py
@@ -1,0 +1,72 @@
+"""Pydantic schemas for credit memo endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class CauseCode(str, Enum):
+    MEAS_FAB = "MEAS-FAB"
+    MEAS_TEMPLATE = "MEAS-TEMPLATE"
+    EDGE_CHIP = "EDGE-CHIP"
+    POLISH = "POLISH"
+    CUTOUT = "CUTOUT"
+    INSTALL_DAMAGE = "INSTALL-DAMAGE"
+    HIDDEN_DEFECT = "HIDDEN-DEFECT"
+    CLIENT_DAMAGE = "CLIENT-DAMAGE"
+    SLAB_DEFECT = "SLAB-DEFECT"
+    DELIVERY_DAMAGE = "DELIVERY-DAMAGE"
+    OTHER = "OTHER"
+
+
+class QcStage(str, Enum):
+    FAB = "fab"
+    PRE_SHIP = "pre-ship"
+    INSTALL = "install"
+    POST_INSTALL = "post-install"
+
+
+class CreditMemoCreate(BaseModel):
+    cause_code: CauseCode
+    job_key: str = Field(..., min_length=1)
+    qc_stage: QcStage
+    rsm_id: str | None = None
+    territory_id: str | None = None
+    product_tier: str | None = None
+    amount: Decimal | None = None
+    description: str | None = None
+
+
+class CreditMemoResponse(BaseModel):
+    id: str
+    tenant_id: str
+    cause_code: str
+    job_key: str
+    qc_stage: str
+    rsm_id: str | None
+    territory_id: str | None
+    product_tier: str | None
+    amount: Decimal | None
+    description: str | None
+    created_by: str | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CreditMemoListResponse(BaseModel):
+    total: int
+    items: list[CreditMemoResponse]
+
+
+class JobLookupResponse(BaseModel):
+    found: bool
+    job_key: str | None
+    product_tier: str | None
+    rsm_id: str | None = None
+    territory_id: str | None = None

--- a/packages/api/app/schemas/credit_memo_report.py
+++ b/packages/api/app/schemas/credit_memo_report.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for credit-memo reporting view (SAG-2806)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ReportGranularity(str, Enum):
+    daily = "daily"
+    weekly = "weekly"
+
+
+class ReportSegment(str, Enum):
+    cause_code = "cause_code"
+    territory_id = "territory_id"
+    rsm_id = "rsm_id"
+    product_tier = "product_tier"
+    qc_stage = "qc_stage"
+
+
+class ReportRow(BaseModel):
+    period: str  # ISO date "2024-01-15" (daily) or "2024-W03" (weekly)
+    segment_value: str | None
+    dim2_value: str | None = None  # populated only in cross-tab mode
+    credit_amount_total: Decimal
+    memo_count: int
+
+
+class ReportResponse(BaseModel):
+    granularity: ReportGranularity
+    segment_by: ReportSegment
+    dim2: ReportSegment | None = None
+    start_date: str
+    end_date: str
+    rows: list[ReportRow]
+    total_credit_amount: Decimal
+    total_memo_count: int

--- a/packages/api/app/schemas/financing.py
+++ b/packages/api/app/schemas/financing.py
@@ -1,0 +1,198 @@
+"""Pydantic schemas for financing engine endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Request schemas — individual models
+# ---------------------------------------------------------------------------
+
+
+class FixAndFlipRequest(BaseModel):
+    purchase_price: float = Field(..., gt=0)
+    rehab_cost: float = Field(..., ge=0)
+    arv: float = Field(..., gt=0)
+    hold_months: int = Field(6, ge=1, le=60)
+    monthly_hold_cost: float = Field(0, ge=0)
+    buying_closing_pct: float = Field(0.02, ge=0, le=0.10)
+    selling_closing_pct: float = Field(0.06, ge=0, le=0.15)
+    loan_amount: float = Field(0, ge=0)
+    loan_rate: float = Field(0, ge=0, le=1.0)
+
+
+class BRRRRRequest(BaseModel):
+    purchase_price: float = Field(..., gt=0)
+    rehab_cost: float = Field(..., ge=0)
+    arv: float = Field(..., gt=0)
+    monthly_rent: float = Field(..., gt=0)
+    hold_months_before_refi: int = Field(6, ge=1, le=24)
+    refi_ltv: float = Field(0.75, ge=0.1, le=1.0)
+    refi_rate: float = Field(0.07, ge=0, le=0.20)
+    refi_term_years: int = Field(30, ge=1, le=40)
+    monthly_expenses: float = Field(0, ge=0)
+    vacancy_rate: float = Field(0.08, ge=0, le=1.0)
+    buying_closing_pct: float = Field(0.02, ge=0, le=0.10)
+    initial_loan_amount: float = Field(0, ge=0)
+    initial_loan_rate: float = Field(0, ge=0, le=1.0)
+
+
+class BuyAndHoldRequest(BaseModel):
+    purchase_price: float = Field(..., gt=0)
+    monthly_rent: float = Field(..., gt=0)
+    down_payment_pct: float = Field(0.20, ge=0, le=1.0)
+    loan_rate: float = Field(0.07, ge=0, le=0.20)
+    loan_term_years: int = Field(30, ge=1, le=40)
+    monthly_expenses: float = Field(0, ge=0)
+    vacancy_rate: float = Field(0.08, ge=0, le=1.0)
+    annual_appreciation: float = Field(0.03, ge=-0.10, le=0.20)
+    annual_rent_growth: float = Field(0.02, ge=-0.10, le=0.20)
+    closing_costs_pct: float = Field(0.03, ge=0, le=0.10)
+
+
+class ShortTermRentalRequest(BaseModel):
+    purchase_price: float = Field(..., gt=0)
+    nightly_rate: float = Field(..., gt=0)
+    occupancy_rate: float = Field(0.70, ge=0, le=1.0)
+    down_payment_pct: float = Field(0.20, ge=0, le=1.0)
+    loan_rate: float = Field(0.07, ge=0, le=0.20)
+    loan_term_years: int = Field(30, ge=1, le=40)
+    monthly_expenses: float = Field(0, ge=0)
+    platform_fee_pct: float = Field(0.03, ge=0, le=0.30)
+    cleaning_fee_per_turn: float = Field(0, ge=0)
+    avg_stay_nights: float = Field(3.0, ge=1, le=30)
+    seasonal_adjustments: dict[str, float] | None = None
+    closing_costs_pct: float = Field(0.03, ge=0, le=0.10)
+
+
+class WholesaleRequest(BaseModel):
+    arv: float = Field(..., gt=0)
+    rehab_cost: float = Field(..., ge=0)
+    assignment_fee: float = Field(10_000, ge=0)
+    buyer_profit_margin: float = Field(0.30, ge=0.05, le=0.60)
+    closing_costs_pct: float = Field(0.01, ge=0, le=0.10)
+    earnest_money: float = Field(1_000, ge=0)
+
+
+class SubjectToRequest(BaseModel):
+    property_value: float = Field(..., gt=0)
+    existing_mortgage_balance: float = Field(..., ge=0)
+    existing_mortgage_rate: float = Field(..., ge=0, le=0.20)
+    existing_mortgage_remaining_months: int = Field(..., ge=1, le=480)
+    monthly_rent: float = Field(..., gt=0)
+    cash_to_seller: float = Field(0, ge=0)
+    monthly_expenses: float = Field(0, ge=0)
+    vacancy_rate: float = Field(0.08, ge=0, le=1.0)
+    closing_costs: float = Field(0, ge=0)
+    wrap_rate: float | None = Field(None, ge=0, le=0.20)
+    wrap_term_months: int | None = Field(None, ge=1, le=480)
+
+
+class SellerFinancingRequest(BaseModel):
+    purchase_price: float = Field(..., gt=0)
+    monthly_rent: float = Field(..., gt=0)
+    down_payment_pct: float = Field(0.10, ge=0, le=1.0)
+    seller_rate: float = Field(0.06, ge=0, le=0.20)
+    seller_term_months: int = Field(360, ge=1, le=480)
+    balloon_month: int | None = Field(60, ge=1, le=480)
+    monthly_expenses: float = Field(0, ge=0)
+    vacancy_rate: float = Field(0.08, ge=0, le=1.0)
+    closing_costs_pct: float = Field(0.02, ge=0, le=0.10)
+
+
+class HardMoneyBridgeRequest(BaseModel):
+    purchase_price: float = Field(..., gt=0)
+    rehab_cost: float = Field(..., ge=0)
+    arv: float = Field(..., gt=0)
+    loan_to_cost_pct: float = Field(0.85, ge=0.1, le=1.0)
+    interest_rate: float = Field(0.12, ge=0, le=0.30)
+    points: float = Field(2.0, ge=0, le=10)
+    term_months: int = Field(12, ge=1, le=36)
+    interest_only: bool = True
+    refi_after_months: int | None = Field(6, ge=1, le=36)
+    refi_rate: float = Field(0.07, ge=0, le=0.20)
+    refi_ltv: float = Field(0.75, ge=0.1, le=1.0)
+    refi_term_years: int = Field(30, ge=1, le=40)
+    monthly_rent_after_refi: float = Field(0, ge=0)
+    monthly_expenses: float = Field(0, ge=0)
+    vacancy_rate: float = Field(0.08, ge=0, le=1.0)
+
+
+class MAORequest(BaseModel):
+    arv: float = Field(..., gt=0)
+    rehab_cost: float = Field(..., ge=0)
+    profit_margin: float = Field(0.30, ge=0.05, le=0.60)
+    closing_costs_pct: float = Field(0.03, ge=0, le=0.10)
+    hold_costs: float = Field(0, ge=0)
+
+
+class IRRRequest(BaseModel):
+    cash_flows: list[float] = Field(..., min_length=2, description="Periodic cash flows, index 0 = initial investment (negative)")
+
+
+# ---------------------------------------------------------------------------
+# Scenario Comparison
+# ---------------------------------------------------------------------------
+
+
+class ScenarioComparisonRequest(BaseModel):
+    property_data: dict[str, Any] = Field(
+        ...,
+        description="Property info: purchase_price, arv, rehab_cost, monthly_rent, property_value",
+    )
+    assumptions: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Per-model assumption overrides keyed by model name",
+    )
+    models: list[str] | None = Field(
+        None,
+        description="Models to run. Omit for all 8.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class FinancingModelResponse(BaseModel):
+    """Generic response wrapper for any single financing model result."""
+
+    model: str
+    result: dict[str, Any]
+
+
+class MAOResponse(BaseModel):
+    mao: float
+    arv: float
+    profit_margin: float
+    rehab_cost: float
+    closing_costs: float
+    hold_costs: float
+    profit_target: float
+
+
+class IRRResponse(BaseModel):
+    irr: float | None
+    cash_flows: list[float]
+
+
+class ScenarioSummaryItem(BaseModel):
+    model: str
+    cash_on_cash_return: float | None = None
+    roi: float | None = None
+    monthly_cash_flow: float | None = None
+    net_profit: float | None = None
+    irr: float | None = None
+    cash_invested: float | None = None
+
+
+class ScenarioComparisonResponse(BaseModel):
+    property_data: dict[str, Any]
+    models_run: int
+    summary: list[ScenarioSummaryItem]
+    details: list[dict[str, Any]]
+    errors: list[dict[str, str]]

--- a/packages/api/app/schemas/order.py
+++ b/packages/api/app/schemas/order.py
@@ -1,0 +1,106 @@
+"""Pydantic schemas for order management endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Order Line Item
+# ---------------------------------------------------------------------------
+
+
+class OrderLineItemResponse(BaseModel):
+    id: str
+    order_id: str
+    quote_item_id: str | None
+    room: str | None
+    trade_category: str | None
+    description: str | None
+    sage_sku: str | None
+    quantity: int
+    unit_cost: Decimal | None
+    labor_cost: Decimal | None
+    markup_pct: Decimal | None
+    subtotal: Decimal | None
+    sage_line_id: str | None
+    unit_of_measure: str | None
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Order Status History
+# ---------------------------------------------------------------------------
+
+
+class OrderStatusHistoryResponse(BaseModel):
+    id: str
+    order_id: str
+    from_status: str | None
+    to_status: str
+    changed_by: str | None
+    note: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Order
+# ---------------------------------------------------------------------------
+
+
+class SubmitOrderRequest(BaseModel):
+    """Request to convert an approved quote into a Sage order."""
+
+    submission_method: str | None = Field(
+        None,
+        pattern=r"^(api|playwright)$",
+        description="Force submission method; auto-detected if omitted",
+    )
+
+
+class OrderResponse(BaseModel):
+    id: str
+    quote_id: str
+    tenant_id: str
+    property_id: str | None
+    sage_order_id: str | None
+    sage_confirmation: str | None
+    d365_opportunity_id: str | None
+    d365_opportunity_url: str | None
+    status: str
+    submission_method: str | None
+    error_message: str | None
+    retry_count: int
+    total_amount: Decimal | None
+    submitted_at: datetime | None
+    confirmed_at: datetime | None
+    shipped_at: datetime | None
+    delivered_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class OrderDetailResponse(OrderResponse):
+    line_items: list[OrderLineItemResponse] = []
+    status_history: list[OrderStatusHistoryResponse] = []
+
+
+class OrderListResponse(BaseModel):
+    items: list[OrderResponse]
+    total: int
+
+
+class D365OpportunityResponse(BaseModel):
+    order_id: str
+    d365_opportunity_id: str | None
+    d365_opportunity_url: str | None
+    status: str
+    message: str

--- a/packages/api/app/schemas/photo_analysis.py
+++ b/packages/api/app/schemas/photo_analysis.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class AnalyzePhotosRequest(BaseModel):
+    photo_urls: list[str] = Field(
+        ..., min_length=1, max_length=50, description="URLs of listing photos to analyze"
+    )
+
+
+class PhotoLabelOverride(BaseModel):
+    room_type: str | None = None
+    condition: str | None = None
+    damage_issues: list[str] | None = None
+    renovation_needed: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class PhotoLabelResponse(BaseModel):
+    id: str
+    analysis_id: str
+    photo_url: str
+    photo_index: int
+    room_type: str | None
+    condition: str | None
+    damage_issues: list[str] | None
+    renovation_needed: str | None
+    confidence: float
+    confidence_tier: str
+    review_status: str
+    reviewer_override: dict | None
+
+    model_config = {"from_attributes": True}
+
+
+class PropertyPhotoAnalysisResponse(BaseModel):
+    id: str
+    property_id: str
+    status: str
+    photo_count: int
+    model_id: str
+    renovation_signal: str | None
+    renovation_confidence: float | None
+    total_cost_cents: int | None
+    error_message: str | None
+    created_at: datetime
+    completed_at: datetime | None
+    labels: list[PhotoLabelResponse] = []
+
+    model_config = {"from_attributes": True}
+
+
+class ReviewQueueItem(BaseModel):
+    label: PhotoLabelResponse
+    property_id: str
+    property_address: str
+    analysis_id: str
+
+
+class ReviewQueueResponse(BaseModel):
+    items: list[ReviewQueueItem]
+    total: int
+    page: int
+    page_size: int

--- a/packages/api/app/schemas/property.py
+++ b/packages/api/app/schemas/property.py
@@ -1,0 +1,169 @@
+"""Pydantic schemas for property endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class PropertyCreate(BaseModel):
+    """Manual property creation."""
+
+    address: str = Field(..., min_length=1, max_length=500)
+    city: str = Field(..., min_length=1, max_length=100)
+    state: str = Field(..., min_length=2, max_length=50)
+    zip: str = Field(..., min_length=5, max_length=20)
+    county: str | None = None
+    lat: float | None = Field(None, ge=-90, le=90)
+    lng: float | None = Field(None, ge=-180, le=180)
+    year_built: int | None = Field(None, ge=1600, le=2100)
+    sqft: int | None = Field(None, ge=1)
+    lot_sqft: int | None = Field(None, ge=1)
+    beds: int | None = Field(None, ge=0)
+    baths: float | None = Field(None, ge=0)
+    property_type: str | None = None
+    listing_price: float | None = Field(None, ge=0)
+    arv_estimate: float | None = Field(None, ge=0)
+    arv_confidence: float | None = Field(None, ge=0, le=1)
+    mls_id: str | None = None
+    zillow_url: str | None = None
+    tax_assessment: float | None = Field(None, ge=0)
+
+
+class PropertyUpdate(BaseModel):
+    """Partial property update."""
+
+    address: str | None = Field(None, min_length=1, max_length=500)
+    city: str | None = Field(None, min_length=1, max_length=100)
+    state: str | None = Field(None, min_length=2, max_length=50)
+    zip: str | None = Field(None, min_length=5, max_length=20)
+    county: str | None = None
+    lat: float | None = Field(None, ge=-90, le=90)
+    lng: float | None = Field(None, ge=-180, le=180)
+    year_built: int | None = Field(None, ge=1600, le=2100)
+    sqft: int | None = Field(None, ge=1)
+    lot_sqft: int | None = Field(None, ge=1)
+    beds: int | None = Field(None, ge=0)
+    baths: float | None = Field(None, ge=0)
+    property_type: str | None = None
+    listing_price: float | None = Field(None, ge=0)
+    arv_estimate: float | None = Field(None, ge=0)
+    arv_confidence: float | None = Field(None, ge=0, le=1)
+    mls_id: str | None = None
+    tax_assessment: float | None = Field(None, ge=0)
+    status: str | None = None
+
+
+class ZillowUrlImport(BaseModel):
+    """Import property from a Zillow listing URL."""
+
+    url: str = Field(..., min_length=1)
+
+    @field_validator("url")
+    @classmethod
+    def validate_zillow_url(cls, v: str) -> str:
+        if "zillow.com" not in v.lower():
+            raise ValueError("URL must be a Zillow listing URL")
+        return v
+
+
+class PropStreamSearch(BaseModel):
+    """Search PropStream by address, MLS ID, or coordinates."""
+
+    address: str | None = None
+    mls_id: str | None = None
+    lat: float | None = Field(None, ge=-90, le=90)
+    lng: float | None = Field(None, ge=-180, le=180)
+    radius_miles: float | None = Field(None, ge=0.1, le=50)
+
+    @field_validator("address")
+    @classmethod
+    def require_at_least_one(cls, v: str | None, info: Any) -> str | None:
+        return v
+
+
+class GooglePlacesAutocomplete(BaseModel):
+    """Address autocomplete request."""
+
+    input: str = Field(..., min_length=1, max_length=500)
+    session_token: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class PropertyResponse(BaseModel):
+    """Full property response."""
+
+    id: str
+    tenant_id: str
+    address: str
+    city: str
+    state: str
+    zip: str
+    county: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    year_built: int | None = None
+    sqft: int | None = None
+    lot_sqft: int | None = None
+    beds: int | None = None
+    baths: float | None = None
+    property_type: str | None = None
+    zillow_url: str | None = None
+    propstream_id: str | None = None
+    mls_id: str | None = None
+    listing_price: float | None = None
+    arv_estimate: float | None = None
+    arv_confidence: float | None = None
+    tax_assessment: float | None = None
+    data_source: str | None = None
+    ownership_history: list[dict[str, Any]] | None = None
+    neighborhood: str | None = None
+    zillow_estimate: float | None = None
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PropertyListResponse(BaseModel):
+    """Paginated property list."""
+
+    items: list[PropertyResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+
+class PlacePrediction(BaseModel):
+    """Google Places autocomplete prediction."""
+
+    place_id: str
+    description: str
+    structured_formatting: dict[str, Any] | None = None
+
+
+class PlacesAutocompleteResponse(BaseModel):
+    """Google Places autocomplete response."""
+
+    predictions: list[PlacePrediction]
+
+
+class GeocodeResult(BaseModel):
+    """Geocoding result."""
+
+    lat: float
+    lng: float
+    formatted_address: str

--- a/packages/api/app/schemas/quote.py
+++ b/packages/api/app/schemas/quote.py
@@ -1,0 +1,137 @@
+"""Pydantic schemas for quote builder endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Quote Item
+# ---------------------------------------------------------------------------
+
+
+class QuoteItemCreate(BaseModel):
+    room: str | None = None
+    trade_category: str | None = None
+    description: str | None = None
+    sage_sku: str | None = None
+    quantity: int = Field(1, ge=1)
+    unit_cost: Decimal = Field(..., ge=0)
+    labor_cost: Decimal = Field(default=Decimal("0"), ge=0)
+    markup_pct: Decimal | None = Field(None, ge=0, le=100)
+    unit_of_measure: str | None = None
+
+
+class QuoteItemUpdate(BaseModel):
+    room: str | None = None
+    trade_category: str | None = None
+    description: str | None = None
+    sage_sku: str | None = None
+    quantity: int | None = Field(None, ge=1)
+    unit_cost: Decimal | None = Field(None, ge=0)
+    labor_cost: Decimal | None = Field(None, ge=0)
+    markup_pct: Decimal | None = Field(None, ge=0, le=100)
+    unit_of_measure: str | None = None
+
+
+class QuoteItemResponse(BaseModel):
+    id: str
+    quote_id: str
+    room: str | None
+    trade_category: str | None
+    description: str | None
+    sage_sku: str | None
+    quantity: int | None
+    unit_cost: Decimal | None
+    labor_cost: Decimal | None
+    markup_pct: Decimal | None
+    subtotal: Decimal | None
+    ai_confidence: float | None
+    is_ai_generated: bool
+    unit_of_measure: str | None
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Quote
+# ---------------------------------------------------------------------------
+
+
+class QuoteCreate(BaseModel):
+    """Create a quote — set mode='ai' to auto-generate from photo analysis."""
+
+    mode: str = Field(
+        "manual",
+        pattern=r"^(manual|ai)$",
+        description="'manual' for blank quote, 'ai' to auto-populate from photo analysis",
+    )
+    deal_id: str | None = None
+    photo_analysis_id: str | None = Field(
+        None, description="Required when mode='ai'"
+    )
+    notes: str | None = None
+    items: list[QuoteItemCreate] = Field(
+        default_factory=list,
+        description="Initial line items (manual mode only)",
+    )
+    platform_fee_pct: Decimal = Field(
+        default=Decimal("0.05"),
+        ge=0,
+        le=1,
+        description="Platform fee as a decimal (e.g. 0.05 = 5%)",
+    )
+
+
+class QuoteUpdate(BaseModel):
+    status: str | None = Field(
+        None, pattern=r"^(draft|submitted|approved|rejected)$"
+    )
+    notes: str | None = None
+    platform_fee_pct: Decimal | None = Field(None, ge=0, le=1)
+    add_items: list[QuoteItemCreate] = Field(default_factory=list)
+    update_items: dict[str, QuoteItemUpdate] = Field(
+        default_factory=dict,
+        description="Map of item ID → fields to update",
+    )
+    remove_item_ids: list[str] = Field(default_factory=list)
+
+
+class QuoteResponse(BaseModel):
+    id: str
+    property_id: str | None
+    deal_id: str
+    tenant_id: str
+    status: str
+    version: int
+    total_material: Decimal | None
+    total_labor: Decimal | None
+    platform_fee: Decimal | None
+    platform_fee_pct: Decimal | None
+    tax_amount: Decimal | None
+    grand_total: Decimal | None
+    pdf_s3_key: str | None
+    notes: str | None
+    photo_analysis_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class QuoteDetailResponse(QuoteResponse):
+    items: list[QuoteItemResponse] = []
+
+
+class QuoteListResponse(BaseModel):
+    items: list[QuoteResponse]
+    total: int
+
+
+class GenerateSOWResponse(BaseModel):
+    quote_id: str
+    pdf_s3_key: str
+    message: str

--- a/packages/api/app/schemas/risk.py
+++ b/packages/api/app/schemas/risk.py
@@ -1,0 +1,59 @@
+"""Pydantic schemas for risk flag system endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class RiskFlagResponse(BaseModel):
+    """Single risk flag."""
+
+    id: str
+    property_id: str
+    flag_type: str | None = None
+    severity: str | None = None
+    detail: str | None = None
+    source: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class RiskFlagListResponse(BaseModel):
+    """List of risk flags for a property."""
+
+    property_id: str
+    flags: list[RiskFlagResponse]
+    total: int
+
+
+class LendabilityBreakdown(BaseModel):
+    """Score breakdown by risk category."""
+
+    year_risk: int
+    flood_risk: int
+    condition: int
+    arv_ratio: int
+
+
+class LendabilityScoreResponse(BaseModel):
+    """Lendability composite score result."""
+
+    score: int
+    category: str
+    breakdown: LendabilityBreakdown
+
+
+class RiskEvaluationResponse(BaseModel):
+    """Full risk evaluation result (flags + lendability score)."""
+
+    property_id: str
+    flags: list[RiskFlagResponse]
+    lendability: LendabilityScoreResponse

--- a/packages/api/app/services/apillow.py
+++ b/packages/api/app/services/apillow.py
@@ -1,0 +1,79 @@
+"""APIllow (Zillow API) enrichment service.
+
+PropStream is source-of-truth; APIllow fills gaps only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+APILLOW_BASE_URL = "https://api.apillow.com/v1"
+
+
+async def fetch_property_data(address: str) -> dict[str, Any] | None:
+    """Fetch property data from APIllow by address."""
+    if not settings.ZILLOW_API_KEY:
+        logger.warning("ZILLOW_API_KEY not configured, skipping APIllow enrichment")
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{APILLOW_BASE_URL}/property",
+                params={"address": address},
+                headers={"Authorization": f"Bearer {settings.ZILLOW_API_KEY}"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:
+        logger.error("APIllow request failed: %s", exc)
+        return None
+
+
+def normalize_apillow_data(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize APIllow response to our property schema fields."""
+    return {
+        "zillow_estimate": raw.get("zestimate"),
+        "neighborhood": raw.get("neighborhood"),
+        "arv_estimate": raw.get("arv"),
+        "beds": raw.get("bedrooms"),
+        "baths": raw.get("bathrooms"),
+        "sqft": raw.get("living_area"),
+        "year_built": raw.get("year_built"),
+        "lot_sqft": raw.get("lot_size"),
+        "property_type": raw.get("home_type"),
+        "lat": raw.get("latitude"),
+        "lng": raw.get("longitude"),
+    }
+
+
+def merge_enrichment(
+    existing: dict[str, Any],
+    enrichment: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge APIllow enrichment into existing property data.
+
+    PropStream is source-of-truth. APIllow only fills None/missing fields,
+    except for zillow_estimate and neighborhood which are APIllow-exclusive.
+    """
+    apillow_exclusive = {"zillow_estimate", "neighborhood"}
+    merged = dict(existing)
+
+    for key, value in enrichment.items():
+        if value is None:
+            continue
+        # APIllow-exclusive fields always override
+        if key in apillow_exclusive:
+            merged[key] = value
+        # Other fields only fill gaps
+        elif merged.get(key) is None:
+            merged[key] = value
+
+    return merged

--- a/packages/api/app/services/arv_calculator.py
+++ b/packages/api/app/services/arv_calculator.py
@@ -1,0 +1,150 @@
+"""ARV (After Repair Value) range calculator.
+
+Always returns a confidence band (low / mid / high), never a point estimate.
+Weights comps by distance, recency, and similarity score.
+Minimum 3 comps required for a valid ARV calculation.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from datetime import date
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MIN_COMPS_REQUIRED = 3
+
+
+class InsufficientCompsError(Exception):
+    """Raised when fewer than MIN_COMPS_REQUIRED comps are available."""
+
+    def __init__(self, available: int) -> None:
+        self.available = available
+        super().__init__(
+            f"Insufficient comps for ARV calculation: {available} available, "
+            f"{MIN_COMPS_REQUIRED} required"
+        )
+
+
+def _weight_for_comp(comp: dict[str, Any]) -> float:
+    """Compute a weight for a single comp based on distance, recency, similarity.
+
+    Higher weight = more influence on the ARV estimate.
+    """
+    similarity = comp.get("similarity", 0.5)
+    distance = comp.get("distance")
+    sale_date = comp.get("sale_date")
+
+    # Distance weight: closer = higher weight (inverse, capped)
+    if distance is not None and distance > 0:
+        dist_weight = 1.0 / (1.0 + distance)
+    else:
+        dist_weight = 1.0
+
+    # Recency weight: more recent = higher weight
+    if isinstance(sale_date, date):
+        days_old = (date.today() - sale_date).days
+        recency_weight = max(0.1, 1.0 - days_old / 365.0)
+    else:
+        recency_weight = 0.5
+
+    # Combine: similarity already captures attribute match
+    return similarity * dist_weight * recency_weight
+
+
+def calculate_arv(
+    comps: list[dict[str, Any]],
+    subject: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Calculate ARV range from a list of sold comps.
+
+    Returns:
+        dict with arv_low, arv_mid, arv_high, confidence, comp_count, methodology
+    Raises:
+        InsufficientCompsError if fewer than 3 comps with sale prices.
+    """
+    # Filter to comps that have sale prices
+    priced = [c for c in comps if c.get("sale_price") and float(c["sale_price"]) > 0]
+
+    if len(priced) < MIN_COMPS_REQUIRED:
+        raise InsufficientCompsError(len(priced))
+
+    # Compute weighted average and gather price-per-sqft data
+    weights: list[float] = []
+    prices: list[float] = []
+    price_per_sqft_vals: list[float] = []
+
+    for comp in priced:
+        w = _weight_for_comp(comp)
+        p = float(comp["sale_price"])
+        weights.append(w)
+        prices.append(p)
+
+        c_sqft = comp.get("sqft")
+        if c_sqft and c_sqft > 0:
+            price_per_sqft_vals.append(p / c_sqft)
+
+    # Weighted average price
+    total_weight = sum(weights)
+    if total_weight == 0:
+        total_weight = 1.0
+    weighted_avg = sum(p * w for p, w in zip(prices, weights)) / total_weight
+
+    # If we have price/sqft data and subject sqft, use $/sqft method too
+    sqft_adjusted_avg: float | None = None
+    subject_sqft = (subject or {}).get("sqft")
+    if price_per_sqft_vals and subject_sqft and subject_sqft > 0:
+        weighted_ppsf = sum(
+            ppsf * w for ppsf, w in zip(price_per_sqft_vals, weights[: len(price_per_sqft_vals)])
+        ) / sum(weights[: len(price_per_sqft_vals)])
+        sqft_adjusted_avg = weighted_ppsf * subject_sqft
+
+    # Mid estimate: blend of weighted avg price and sqft-adjusted (if available)
+    if sqft_adjusted_avg is not None:
+        arv_mid = 0.6 * sqft_adjusted_avg + 0.4 * weighted_avg
+    else:
+        arv_mid = weighted_avg
+
+    # Standard deviation for confidence band
+    if len(prices) >= 3:
+        stdev = statistics.stdev(prices)
+        # Use coefficient of variation to scale the band
+        cv = stdev / arv_mid if arv_mid > 0 else 0.15
+        band_pct = max(0.05, min(0.20, cv))  # clamp between 5-20%
+    else:
+        band_pct = 0.10  # default 10% band
+
+    arv_low = arv_mid * (1.0 - band_pct)
+    arv_high = arv_mid * (1.0 + band_pct)
+
+    # Confidence score (0-1): based on comp count, similarity, and price dispersion
+    count_factor = min(1.0, len(priced) / 8.0)  # max confidence at 8+ comps
+    avg_similarity = sum(c.get("similarity", 0.5) for c in priced) / len(priced)
+    dispersion_factor = max(0.0, 1.0 - band_pct / 0.20)
+    confidence = round(0.40 * count_factor + 0.35 * avg_similarity + 0.25 * dispersion_factor, 4)
+
+    methodology = {
+        "method": "weighted_comparable_sales",
+        "comp_count": len(priced),
+        "weighted_avg_price": round(weighted_avg, 2),
+        "sqft_adjusted_avg": round(sqft_adjusted_avg, 2) if sqft_adjusted_avg else None,
+        "blend_ratio": "60% sqft-adjusted / 40% weighted avg" if sqft_adjusted_avg else "100% weighted avg",
+        "band_pct": round(band_pct, 4),
+        "avg_similarity": round(avg_similarity, 4),
+        "weights": {
+            "distance": "inverse distance decay",
+            "recency": "linear decay over 365 days",
+            "similarity": "attribute-based (sqft, beds, baths, year)",
+        },
+    }
+
+    return {
+        "arv_low": round(arv_low, 2),
+        "arv_mid": round(arv_mid, 2),
+        "arv_high": round(arv_high, 2),
+        "confidence": confidence,
+        "comp_count": len(priced),
+        "methodology": methodology,
+    }

--- a/packages/api/app/services/catalog_service.py
+++ b/packages/api/app/services/catalog_service.py
@@ -1,0 +1,453 @@
+"""Catalog browser service — sits between API layer and Sage Playwright bridge.
+
+Provides Redis caching and DB sync for catalog data.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, date, datetime
+from typing import Any
+
+import redis.asyncio as aioredis
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Product, ProductCategory, ProductPrice
+from app.services.sage_playwright import SagePlaywrightBridge
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cache TTLs (seconds)
+# ---------------------------------------------------------------------------
+
+TTL_SEARCH = 15 * 60       # 15 minutes
+TTL_PRODUCT = 60 * 60      # 1 hour
+TTL_CATEGORIES = 24 * 3600  # 24 hours
+
+
+def _cache_key_search(params: dict) -> str:
+    h = hashlib.md5(json.dumps(params, sort_keys=True).encode()).hexdigest()
+    return f"sage:search:{h}"
+
+
+def _cache_key_product(product_id: str) -> str:
+    return f"sage:product:{product_id}"
+
+
+CACHE_KEY_CATEGORIES = "sage:categories"
+
+
+class CatalogService:
+    """Catalog browser with Redis caching and DB persistence."""
+
+    def __init__(
+        self,
+        bridge: SagePlaywrightBridge,
+        redis_client: aioredis.Redis | None = None,
+    ) -> None:
+        self._bridge = bridge
+        self._redis = redis_client
+
+    # -- cache helpers -------------------------------------------------------
+
+    async def _cache_get(self, key: str) -> Any | None:
+        if self._redis is None:
+            return None
+        try:
+            raw = await self._redis.get(key)
+            return json.loads(raw) if raw else None
+        except Exception:
+            logger.warning("Redis read failed for key=%s", key, exc_info=True)
+            return None
+
+    async def _cache_set(self, key: str, value: Any, ttl: int) -> None:
+        if self._redis is None:
+            return
+        try:
+            await self._redis.setex(key, ttl, json.dumps(value, default=str))
+        except Exception:
+            logger.warning("Redis write failed for key=%s", key, exc_info=True)
+
+    # -- DB sync helpers -----------------------------------------------------
+
+    @staticmethod
+    async def _upsert_product(
+        db: AsyncSession,
+        tenant_id: str,
+        data: dict[str, Any],
+    ) -> Product:
+        """Upsert a product from Sage bridge data into the DB."""
+        sage_id = data.get("product_id") or data.get("sku")
+        stmt = select(Product).where(
+            Product.tenant_id == tenant_id,
+            Product.sage_product_id == sage_id,
+        )
+        result = await db.execute(stmt)
+        product = result.scalar_one_or_none()
+
+        now = datetime.now(UTC)
+        if product is None:
+            product = Product(
+                tenant_id=tenant_id,
+                sage_product_id=sage_id,
+                sku=data.get("sku") or sage_id or "UNKNOWN",
+                name=data.get("name") or "Unknown Product",
+                description=data.get("description"),
+                brand=data.get("brand"),
+                dimensions=data.get("dimensions"),
+                image_url=data.get("image_url"),
+                availability_status=data.get("availability") or "in_stock",
+                last_synced_at=now,
+            )
+            db.add(product)
+        else:
+            product.name = data.get("name") or product.name
+            product.description = data.get("description") or product.description
+            product.brand = data.get("brand") or product.brand
+            product.dimensions = data.get("dimensions") or product.dimensions
+            product.image_url = data.get("image_url") or product.image_url
+            if data.get("availability"):
+                product.availability_status = data["availability"]
+            product.last_synced_at = now
+
+        await db.flush()
+
+        # Insert price if provided and changed
+        if data.get("price_cents") is not None:
+            last_price_stmt = (
+                select(ProductPrice)
+                .where(ProductPrice.product_id == product.id)
+                .order_by(ProductPrice.effective_date.desc())
+                .limit(1)
+            )
+            last_price_result = await db.execute(last_price_stmt)
+            last_price = last_price_result.scalar_one_or_none()
+
+            if last_price is None or last_price.price_cents != data["price_cents"]:
+                new_price = ProductPrice(
+                    product_id=product.id,
+                    price_cents=data["price_cents"],
+                    currency="USD",
+                    effective_date=date.today(),
+                    source="sage_scrape",
+                )
+                db.add(new_price)
+
+        return product
+
+    # -- public API ----------------------------------------------------------
+
+    async def search_products(
+        self,
+        db: AsyncSession,
+        tenant_id: str,
+        query: str | None = None,
+        category: str | None = None,
+        brand: str | None = None,
+        price_min: int | None = None,
+        price_max: int | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Search products — cache-first, then Sage bridge, with DB sync."""
+        params = {
+            "query": query, "category": category, "brand": brand,
+            "price_min": price_min, "price_max": price_max,
+            "limit": limit, "offset": offset,
+        }
+        cache_key = _cache_key_search(params)
+        cached = await self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+
+        # DB-first: try to serve from local products table
+        stmt = select(Product).where(Product.tenant_id == tenant_id)
+        if query:
+            stmt = stmt.where(Product.name.ilike(f"%{query}%"))
+        if category:
+            stmt = stmt.where(Product.category_id == category)
+        if brand:
+            stmt = stmt.where(Product.brand.ilike(f"%{brand}%"))
+
+        # Price filter requires a subquery on latest price
+        if price_min is not None or price_max is not None:
+            latest_price = (
+                select(
+                    ProductPrice.product_id,
+                    func.max(ProductPrice.effective_date).label("max_date"),
+                )
+                .group_by(ProductPrice.product_id)
+                .subquery()
+            )
+            price_sq = (
+                select(ProductPrice.product_id, ProductPrice.price_cents)
+                .join(
+                    latest_price,
+                    (ProductPrice.product_id == latest_price.c.product_id)
+                    & (ProductPrice.effective_date == latest_price.c.max_date),
+                )
+                .subquery()
+            )
+            stmt = stmt.join(price_sq, Product.id == price_sq.c.product_id)
+            if price_min is not None:
+                stmt = stmt.where(price_sq.c.price_cents >= price_min)
+            if price_max is not None:
+                stmt = stmt.where(price_sq.c.price_cents <= price_max)
+
+        count_result = await db.execute(
+            select(func.count()).select_from(stmt.subquery())
+        )
+        total = count_result.scalar() or 0
+
+        result = await db.execute(stmt.offset(offset).limit(limit))
+        products = result.scalars().all()
+
+        # If DB has results, serve them and cache
+        if products:
+            items = [
+                {
+                    "id": p.id,
+                    "sku": p.sku,
+                    "name": p.name,
+                    "description": p.description,
+                    "brand": p.brand,
+                    "unit_of_measure": p.unit_of_measure,
+                    "dimensions": p.dimensions,
+                    "image_url": p.image_url,
+                    "availability_status": p.availability_status,
+                    "category_id": p.category_id,
+                    "sage_product_id": p.sage_product_id,
+                    "tenant_id": p.tenant_id,
+                    "last_synced_at": str(p.last_synced_at) if p.last_synced_at else None,
+                    "created_at": str(p.created_at),
+                    "updated_at": str(p.updated_at),
+                }
+                for p in products
+            ]
+            response = {"items": items, "total": total, "limit": limit, "offset": offset}
+            await self._cache_set(cache_key, response, TTL_SEARCH)
+            return response
+
+        # Cache miss + no DB results — fetch from Sage bridge
+        try:
+            bridge_results = await self._bridge.search_products(
+                query=query or "", category=category, page=(offset // limit) + 1
+            )
+        except Exception:
+            logger.warning("Sage bridge search failed", exc_info=True)
+            bridge_results = []
+
+        # Sync to DB
+        items = []
+        for data in bridge_results:
+            product = await self._upsert_product(db, tenant_id, data)
+            items.append({
+                "id": product.id,
+                "sku": product.sku,
+                "name": product.name,
+                "description": product.description,
+                "brand": product.brand,
+                "unit_of_measure": product.unit_of_measure,
+                "dimensions": product.dimensions,
+                "image_url": product.image_url,
+                "availability_status": product.availability_status,
+                "category_id": product.category_id,
+                "sage_product_id": product.sage_product_id,
+                "tenant_id": product.tenant_id,
+                "last_synced_at": str(product.last_synced_at) if product.last_synced_at else None,
+                "created_at": str(product.created_at),
+                "updated_at": str(product.updated_at),
+            })
+
+        response = {"items": items, "total": len(items), "limit": limit, "offset": offset}
+        await self._cache_set(cache_key, response, TTL_SEARCH)
+        return response
+
+    async def get_product_detail(
+        self,
+        db: AsyncSession,
+        tenant_id: str,
+        product_id: str,
+    ) -> dict[str, Any] | None:
+        """Get a single product with prices — cache-first."""
+        cache_key = _cache_key_product(product_id)
+        cached = await self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+
+        # Try DB first
+        stmt = (
+            select(Product)
+            .where(Product.id == product_id, Product.tenant_id == tenant_id)
+        )
+        result = await db.execute(stmt)
+        product = result.scalar_one_or_none()
+
+        if product is None:
+            # Try fetching from Sage bridge by sage_product_id
+            try:
+                data = await self._bridge.get_product_detail(product_id)
+                product = await self._upsert_product(db, tenant_id, data)
+            except Exception:
+                logger.warning("Sage bridge detail failed for %s", product_id, exc_info=True)
+                return None
+
+        # Fetch prices
+        prices_stmt = (
+            select(ProductPrice)
+            .where(ProductPrice.product_id == product.id)
+            .order_by(ProductPrice.effective_date.desc())
+        )
+        prices_result = await db.execute(prices_stmt)
+        prices = prices_result.scalars().all()
+
+        # Fetch category
+        category_data = None
+        if product.category_id:
+            cat_stmt = select(ProductCategory).where(
+                ProductCategory.id == product.category_id
+            )
+            cat_result = await db.execute(cat_stmt)
+            cat = cat_result.scalar_one_or_none()
+            if cat:
+                category_data = {
+                    "id": cat.id,
+                    "name": cat.name,
+                    "parent_id": cat.parent_id,
+                    "sage_category_id": cat.sage_category_id,
+                    "created_at": str(cat.created_at),
+                    "updated_at": str(cat.updated_at),
+                }
+
+        response = {
+            "id": product.id,
+            "sku": product.sku,
+            "name": product.name,
+            "description": product.description,
+            "brand": product.brand,
+            "unit_of_measure": product.unit_of_measure,
+            "dimensions": product.dimensions,
+            "image_url": product.image_url,
+            "availability_status": product.availability_status,
+            "category_id": product.category_id,
+            "sage_product_id": product.sage_product_id,
+            "tenant_id": product.tenant_id,
+            "last_synced_at": str(product.last_synced_at) if product.last_synced_at else None,
+            "created_at": str(product.created_at),
+            "updated_at": str(product.updated_at),
+            "prices": [
+                {
+                    "id": p.id,
+                    "product_id": p.product_id,
+                    "price_cents": p.price_cents,
+                    "currency": p.currency,
+                    "effective_date": str(p.effective_date),
+                    "source": p.source,
+                    "created_at": str(p.created_at),
+                }
+                for p in prices
+            ],
+            "category": category_data,
+        }
+        await self._cache_set(cache_key, response, TTL_PRODUCT)
+        return response
+
+    async def get_categories(
+        self,
+        db: AsyncSession,
+    ) -> list[dict[str, Any]]:
+        """Get category tree — cache-first."""
+        cached = await self._cache_get(CACHE_KEY_CATEGORIES)
+        if cached is not None:
+            return cached
+
+        stmt = select(ProductCategory).order_by(ProductCategory.name)
+        result = await db.execute(stmt)
+        categories = result.scalars().all()
+
+        # Build flat list (tree building left to caller or frontend)
+        cat_list = [
+            {
+                "id": c.id,
+                "name": c.name,
+                "parent_id": c.parent_id,
+                "sage_category_id": c.sage_category_id,
+                "created_at": str(c.created_at),
+                "updated_at": str(c.updated_at),
+            }
+            for c in categories
+        ]
+        await self._cache_set(CACHE_KEY_CATEGORIES, cat_list, TTL_CATEGORIES)
+        return cat_list
+
+    async def get_category_products(
+        self,
+        db: AsyncSession,
+        tenant_id: str,
+        category_id: str,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Browse products by category — cache-first."""
+        cache_key = f"sage:cat_products:{category_id}:{limit}:{offset}"
+        cached = await self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+
+        stmt = select(Product).where(
+            Product.tenant_id == tenant_id,
+            Product.category_id == category_id,
+        )
+        count_result = await db.execute(
+            select(func.count()).select_from(stmt.subquery())
+        )
+        total = count_result.scalar() or 0
+
+        result = await db.execute(stmt.offset(offset).limit(limit))
+        products = result.scalars().all()
+
+        # If no DB results, try Sage bridge
+        if not products:
+            try:
+                bridge_results = await self._bridge.browse_category(
+                    category_id, page=(offset // limit) + 1
+                )
+                for data in bridge_results:
+                    await self._upsert_product(db, tenant_id, data)
+                # Re-query after sync
+                result = await db.execute(stmt.offset(offset).limit(limit))
+                products = result.scalars().all()
+                count_result = await db.execute(
+                    select(func.count()).select_from(stmt.subquery())
+                )
+                total = count_result.scalar() or 0
+            except Exception:
+                logger.warning("Sage bridge category browse failed", exc_info=True)
+
+        items = [
+            {
+                "id": p.id,
+                "sku": p.sku,
+                "name": p.name,
+                "description": p.description,
+                "brand": p.brand,
+                "unit_of_measure": p.unit_of_measure,
+                "dimensions": p.dimensions,
+                "image_url": p.image_url,
+                "availability_status": p.availability_status,
+                "category_id": p.category_id,
+                "sage_product_id": p.sage_product_id,
+                "tenant_id": p.tenant_id,
+                "last_synced_at": str(p.last_synced_at) if p.last_synced_at else None,
+                "created_at": str(p.created_at),
+                "updated_at": str(p.updated_at),
+            }
+            for p in products
+        ]
+        response = {"items": items, "total": total, "limit": limit, "offset": offset}
+        await self._cache_set(cache_key, response, TTL_SEARCH)
+        return response

--- a/packages/api/app/services/claude_vision.py
+++ b/packages/api/app/services/claude_vision.py
@@ -1,0 +1,303 @@
+"""Claude Vision integration service for listing photo analysis.
+
+Wraps the Anthropic API to analyze property listing photos for renovation
+assessment. Extracts room types, conditions, damage/issues, and computes
+confidence scores per photo.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "claude-sonnet-4-6-20250514"
+MAX_CONCURRENT_REQUESTS = 5
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2.0
+
+ANALYSIS_PROMPT = """\
+You are a real estate renovation assessment expert. Analyze this listing photo and provide a structured assessment.
+
+For this photo, determine:
+1. **room_type**: The type of room/area shown (e.g., kitchen, bathroom, bedroom, living_room, basement, exterior, garage, attic, hallway, dining_room, laundry, yard, roof, other)
+2. **condition**: Overall condition assessment (excellent, good, fair, poor, critical)
+3. **damage_issues**: List any visible damage or issues (e.g., water_damage, mold, cracked_walls, peeling_paint, damaged_flooring, outdated_fixtures, structural_concern, roof_damage, foundation_issue). Empty list if none visible.
+4. **renovation_needed**: Level of renovation needed (none, cosmetic, moderate, major, full_gut)
+5. **confidence**: Your confidence in this assessment from 0.0 to 1.0
+
+Respond ONLY with valid JSON in this exact format:
+{
+  "room_type": "kitchen",
+  "condition": "fair",
+  "damage_issues": ["peeling_paint", "outdated_fixtures"],
+  "renovation_needed": "moderate",
+  "confidence": 0.85
+}
+"""
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PhotoAnalysisResult:
+    photo_url: str
+    photo_index: int
+    room_type: str | None
+    condition: str | None
+    damage_issues: list[str]
+    renovation_needed: str | None
+    confidence: float
+    confidence_tier: str  # high, medium, low
+    raw_response: dict[str, Any] | None
+
+
+@dataclass
+class PropertyAnalysisSummary:
+    labels: list[PhotoAnalysisResult]
+    renovation_signal: str  # none, low, moderate, high, critical
+    renovation_confidence: float
+    total_input_tokens: int
+    total_output_tokens: int
+
+
+# ---------------------------------------------------------------------------
+# Confidence tier thresholds (configurable per label type in future)
+# ---------------------------------------------------------------------------
+
+HIGH_CONFIDENCE_THRESHOLD = 0.80
+LOW_CONFIDENCE_THRESHOLD = 0.50
+
+
+def _confidence_tier(score: float) -> str:
+    if score >= HIGH_CONFIDENCE_THRESHOLD:
+        return "high"
+    if score >= LOW_CONFIDENCE_THRESHOLD:
+        return "medium"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# Renovation signal aggregation
+# ---------------------------------------------------------------------------
+
+_RENOVATION_WEIGHT = {
+    "none": 0,
+    "cosmetic": 1,
+    "moderate": 2,
+    "major": 3,
+    "full_gut": 4,
+}
+
+_SIGNAL_THRESHOLDS = [
+    (0.0, "none"),
+    (0.5, "low"),
+    (1.5, "moderate"),
+    (2.5, "high"),
+    (3.5, "critical"),
+]
+
+
+def _aggregate_renovation_signal(
+    labels: list[PhotoAnalysisResult],
+) -> tuple[str, float]:
+    """Compute property-level renovation signal from per-photo labels."""
+    if not labels:
+        return "none", 0.0
+
+    weighted_sum = 0.0
+    weight_total = 0.0
+    for label in labels:
+        w = label.confidence
+        score = _RENOVATION_WEIGHT.get(label.renovation_needed or "none", 0)
+        weighted_sum += score * w
+        weight_total += w
+
+    if weight_total == 0:
+        return "none", 0.0
+
+    avg = weighted_sum / weight_total
+    signal = "none"
+    for threshold, name in _SIGNAL_THRESHOLDS:
+        if avg >= threshold:
+            signal = name
+
+    avg_confidence = weight_total / len(labels)
+    return signal, round(avg_confidence, 3)
+
+
+# ---------------------------------------------------------------------------
+# Claude Vision Service
+# ---------------------------------------------------------------------------
+
+
+class ClaudeVisionService:
+    """Async service wrapping the Anthropic Messages API for image analysis."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = DEFAULT_MODEL,
+        max_concurrent: int = MAX_CONCURRENT_REQUESTS,
+    ) -> None:
+        self._api_key = api_key or settings.ANTHROPIC_API_KEY
+        self._model = model
+        self._semaphore = asyncio.Semaphore(max_concurrent)
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+
+    async def analyze_property_photos(
+        self, photo_urls: list[str]
+    ) -> PropertyAnalysisSummary:
+        """Analyze all photos for a property in one batch."""
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+
+        tasks = [
+            self._analyze_single_photo(url, idx)
+            for idx, url in enumerate(photo_urls)
+        ]
+        labels = await asyncio.gather(*tasks, return_exceptions=True)
+
+        results: list[PhotoAnalysisResult] = []
+        for i, result in enumerate(labels):
+            if isinstance(result, Exception):
+                logger.error("Photo %d analysis failed: %s", i, result)
+                results.append(
+                    PhotoAnalysisResult(
+                        photo_url=photo_urls[i],
+                        photo_index=i,
+                        room_type=None,
+                        condition=None,
+                        damage_issues=[],
+                        renovation_needed=None,
+                        confidence=0.0,
+                        confidence_tier="low",
+                        raw_response={"error": str(result)},
+                    )
+                )
+            else:
+                results.append(result)
+
+        signal, confidence = _aggregate_renovation_signal(results)
+
+        return PropertyAnalysisSummary(
+            labels=results,
+            renovation_signal=signal,
+            renovation_confidence=confidence,
+            total_input_tokens=self._total_input_tokens,
+            total_output_tokens=self._total_output_tokens,
+        )
+
+    async def _analyze_single_photo(
+        self, photo_url: str, index: int
+    ) -> PhotoAnalysisResult:
+        """Analyze a single photo with rate limiting and retries."""
+        async with self._semaphore:
+            return await self._call_claude_vision(photo_url, index)
+
+    async def _call_claude_vision(
+        self, photo_url: str, index: int
+    ) -> PhotoAnalysisResult:
+        """Make the actual API call to Claude with retry logic."""
+        import json
+
+        last_error: Exception | None = None
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    response = await client.post(
+                        "https://api.anthropic.com/v1/messages",
+                        headers={
+                            "x-api-key": self._api_key,
+                            "anthropic-version": "2023-06-01",
+                            "content-type": "application/json",
+                        },
+                        json={
+                            "model": self._model,
+                            "max_tokens": 512,
+                            "messages": [
+                                {
+                                    "role": "user",
+                                    "content": [
+                                        {
+                                            "type": "image",
+                                            "source": {
+                                                "type": "url",
+                                                "url": photo_url,
+                                            },
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": ANALYSIS_PROMPT,
+                                        },
+                                    ],
+                                }
+                            ],
+                        },
+                    )
+
+                if response.status_code == 429:
+                    wait = RETRY_BACKOFF_BASE ** (attempt + 1)
+                    logger.warning(
+                        "Rate limited on photo %d, retrying in %.1fs", index, wait
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+
+                response.raise_for_status()
+                data = response.json()
+
+                self._total_input_tokens += data.get("usage", {}).get(
+                    "input_tokens", 0
+                )
+                self._total_output_tokens += data.get("usage", {}).get(
+                    "output_tokens", 0
+                )
+
+                text = data["content"][0]["text"]
+                parsed = json.loads(text)
+
+                confidence = float(parsed.get("confidence", 0.0))
+                return PhotoAnalysisResult(
+                    photo_url=photo_url,
+                    photo_index=index,
+                    room_type=parsed.get("room_type"),
+                    condition=parsed.get("condition"),
+                    damage_issues=parsed.get("damage_issues", []),
+                    renovation_needed=parsed.get("renovation_needed"),
+                    confidence=confidence,
+                    confidence_tier=_confidence_tier(confidence),
+                    raw_response=parsed,
+                )
+
+            except (httpx.HTTPStatusError, json.JSONDecodeError, KeyError) as exc:
+                last_error = exc
+                if attempt < MAX_RETRIES - 1:
+                    wait = RETRY_BACKOFF_BASE ** (attempt + 1)
+                    logger.warning(
+                        "Photo %d attempt %d failed: %s, retrying in %.1fs",
+                        index,
+                        attempt + 1,
+                        exc,
+                        wait,
+                    )
+                    await asyncio.sleep(wait)
+
+        raise RuntimeError(
+            f"Failed to analyze photo {index} after {MAX_RETRIES} attempts: {last_error}"
+        )

--- a/packages/api/app/services/d365_service.py
+++ b/packages/api/app/services/d365_service.py
@@ -1,0 +1,179 @@
+"""Dynamics 365 integration — opportunity creation via OAuth2 client credentials."""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 token acquisition
+# ---------------------------------------------------------------------------
+
+
+async def _get_d365_token() -> str:
+    """Acquire an OAuth2 access token via client credentials grant."""
+    import httpx
+
+    tenant_id = getattr(settings, "D365_TENANT_ID", "")
+    client_id = getattr(settings, "D365_CLIENT_ID", "")
+    client_secret = getattr(settings, "D365_CLIENT_SECRET", "")
+    resource = getattr(settings, "D365_RESOURCE_URL", "")
+
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": f"{resource}/.default",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Opportunity creation
+# ---------------------------------------------------------------------------
+
+
+async def create_d365_opportunity(
+    order_data: dict[str, Any],
+    property_data: dict[str, Any] | None = None,
+    quote_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a Dynamics 365 opportunity from an approved order.
+
+    Maps property + quote/order data to D365 opportunity fields.
+    Returns dict with opportunity_id, opportunity_url, and status.
+    """
+    import httpx
+
+    d365_api_url = getattr(settings, "D365_API_URL", "")
+    if not d365_api_url:
+        raise ValueError("D365_API_URL is not configured")
+
+    token = await _get_d365_token()
+
+    # Build the opportunity payload
+    opportunity = _map_to_d365_opportunity(order_data, property_data, quote_data)
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{d365_api_url}/api/data/v9.2/opportunities",
+            json=opportunity,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "OData-MaxVersion": "4.0",
+                "OData-Version": "4.0",
+                "Prefer": "return=representation",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    opportunity_id = data.get("opportunityid", "")
+    return {
+        "opportunity_id": opportunity_id,
+        "opportunity_url": f"{d365_api_url}/main.aspx?etn=opportunity&id={opportunity_id}",
+        "status": "created",
+    }
+
+
+async def get_d365_opportunity_status(opportunity_id: str) -> dict[str, Any]:
+    """Fetch the current status of a D365 opportunity."""
+    import httpx
+
+    d365_api_url = getattr(settings, "D365_API_URL", "")
+    token = await _get_d365_token()
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(
+            f"{d365_api_url}/api/data/v9.2/opportunities({opportunity_id})",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "OData-MaxVersion": "4.0",
+                "OData-Version": "4.0",
+            },
+            params={"$select": "opportunityid,name,statecode,statuscode,estimatedvalue"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    state_map = {0: "open", 1: "won", 2: "lost"}
+    return {
+        "opportunity_id": opportunity_id,
+        "name": data.get("name"),
+        "state": state_map.get(data.get("statecode"), "unknown"),
+        "estimated_value": data.get("estimatedvalue"),
+        "status": "fetched",
+    }
+
+
+# ---------------------------------------------------------------------------
+# D365 field mapping
+# ---------------------------------------------------------------------------
+
+
+def _map_to_d365_opportunity(
+    order_data: dict[str, Any],
+    property_data: dict[str, Any] | None = None,
+    quote_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Map GCP order/property/quote data to D365 opportunity fields."""
+    prop = property_data or {}
+    quote = quote_data or {}
+
+    address = prop.get("address", "")
+    city = prop.get("city", "")
+    state = prop.get("state", "")
+    zip_code = prop.get("zip", "")
+    full_address = f"{address}, {city}, {state} {zip_code}".strip(", ")
+
+    total = order_data.get("total_amount")
+    if total is not None:
+        total = float(Decimal(str(total)))
+
+    name = f"GCP Renovation — {full_address}" if full_address else f"GCP Order {order_data.get('id', 'N/A')}"
+
+    opportunity: dict[str, Any] = {
+        "name": name[:300],
+        "description": (
+            f"Renovation order from GCP platform.\n"
+            f"Order ID: {order_data.get('id', 'N/A')}\n"
+            f"Quote ID: {order_data.get('quote_id', 'N/A')}\n"
+            f"Property: {full_address}\n"
+            f"Property Type: {prop.get('property_type', 'N/A')}\n"
+            f"Sq Ft: {prop.get('sqft', 'N/A')}\n"
+            f"Beds/Baths: {prop.get('beds', 'N/A')}/{prop.get('baths', 'N/A')}"
+        ),
+        "estimatedvalue": total,
+        "estimatedclosedate": None,
+    }
+
+    # Custom fields (GCP-specific, configured in D365)
+    custom: dict[str, Any] = {}
+    if prop.get("id"):
+        custom["gcp_property_id"] = prop["id"]
+    if order_data.get("id"):
+        custom["gcp_order_id"] = order_data["id"]
+    if order_data.get("sage_order_id"):
+        custom["gcp_sage_order_id"] = order_data["sage_order_id"]
+    if prop.get("arv_estimate"):
+        custom["gcp_arv_estimate"] = float(Decimal(str(prop["arv_estimate"])))
+
+    # Merge custom fields (D365 custom field names would be prefixed in real config)
+    for key, val in custom.items():
+        opportunity[f"new_{key}"] = val
+
+    return opportunity

--- a/packages/api/app/services/fema.py
+++ b/packages/api/app/services/fema.py
@@ -1,0 +1,127 @@
+"""FEMA National Flood Hazard Layer (NFHL) API client."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# FEMA NFHL ArcGIS REST endpoint
+FEMA_NFHL_URL = (
+    "https://hazards.fema.gov/gis/nfhl/rest/services/public/NFHL/MapServer/28/query"
+)
+
+MAX_RETRIES = 3
+RETRY_BACKOFF = 1.0  # seconds
+RATE_LIMIT_WINDOW = 60  # seconds
+RATE_LIMIT_MAX_REQUESTS = 50
+
+# Zones considered high-risk for lending / insurance purposes
+HIGH_RISK_ZONES = {"A", "AE", "AH", "AO", "AR", "V", "VE", "A99"}
+
+
+class _RateLimiter:
+    """Sliding-window rate limiter for FEMA requests."""
+
+    def __init__(
+        self,
+        max_requests: int = RATE_LIMIT_MAX_REQUESTS,
+        window: float = RATE_LIMIT_WINDOW,
+    ):
+        self._max_requests = max_requests
+        self._window = window
+        self._timestamps: list[float] = []
+
+    async def acquire(self) -> None:
+        now = time.monotonic()
+        self._timestamps = [t for t in self._timestamps if now - t < self._window]
+        if len(self._timestamps) >= self._max_requests:
+            sleep_time = self._window - (now - self._timestamps[0])
+            logger.warning("FEMA rate limit reached, sleeping %.1fs", sleep_time)
+            await asyncio.sleep(sleep_time)
+        self._timestamps.append(time.monotonic())
+
+
+_rate_limiter = _RateLimiter()
+
+
+async def query_flood_zone(lat: float, lng: float) -> dict[str, Any] | None:
+    """Query FEMA NFHL for the flood zone at the given coordinates.
+
+    Returns a normalized dict with zone info, or None on failure/timeout.
+    """
+    params = {
+        "geometry": f"{lng},{lat}",
+        "geometryType": "esriGeometryPoint",
+        "inSR": "4326",
+        "spatialRel": "esriSpatialRelIntersects",
+        "outFields": "FLD_ZONE,ZONE_SUBTY,DFIRM_ID,PANEL",
+        "returnGeometry": "false",
+        "f": "json",
+    }
+
+    last_error: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        await _rate_limiter.acquire()
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.get(FEMA_NFHL_URL, params=params)
+                if resp.status_code == 429:
+                    wait = RETRY_BACKOFF * (2**attempt)
+                    logger.warning("FEMA 429, retrying in %.1fs", wait)
+                    await asyncio.sleep(wait)
+                    continue
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code >= 500:
+                wait = RETRY_BACKOFF * (2**attempt)
+                logger.warning(
+                    "FEMA %d, retrying in %.1fs", exc.response.status_code, wait
+                )
+                await asyncio.sleep(wait)
+                continue
+            logger.error("FEMA HTTP error: %s", exc)
+            return None
+        except (httpx.RequestError, httpx.TimeoutException) as exc:
+            last_error = exc
+            wait = RETRY_BACKOFF * (2**attempt)
+            logger.warning("FEMA request error: %s, retrying in %.1fs", exc, wait)
+            await asyncio.sleep(wait)
+            continue
+        else:
+            return _normalize_fema_response(data)
+
+    logger.error("FEMA request failed after %d retries: %s", MAX_RETRIES, last_error)
+    return None
+
+
+def _normalize_fema_response(data: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize the FEMA ArcGIS JSON response to a clean dict."""
+    features = data.get("features", [])
+    if not features:
+        # No flood zone data at this location — likely outside mapped areas
+        return {
+            "zone": "X",
+            "zone_subtype": "AREA OF MINIMAL FLOOD HAZARD",
+            "is_high_risk": False,
+            "panel_number": None,
+        }
+
+    attrs = features[0].get("attributes", {})
+    zone = (attrs.get("FLD_ZONE") or "X").strip().upper()
+
+    return {
+        "zone": zone,
+        "zone_subtype": attrs.get("ZONE_SUBTY"),
+        "is_high_risk": zone in HIGH_RISK_ZONES,
+        "panel_number": attrs.get("PANEL"),
+    }

--- a/packages/api/app/services/financing.py
+++ b/packages/api/app/services/financing.py
@@ -1,0 +1,859 @@
+"""Financing engine — eight investment models, MAO calculator, and IRR.
+
+All functions are **pure**: deterministic, no DB calls, no side effects.
+Each model takes property data + assumptions and returns a structured projection.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _monthly_payment(principal: float, annual_rate: float, months: int) -> float:
+    """Standard amortization monthly payment (P&I)."""
+    if annual_rate <= 0 or months <= 0:
+        return principal / max(months, 1)
+    r = annual_rate / 12.0
+    return principal * (r * (1 + r) ** months) / ((1 + r) ** months - 1)
+
+
+def _loan_balance(principal: float, annual_rate: float, months_total: int, months_paid: int) -> float:
+    """Remaining balance after *months_paid* payments on an amortizing loan."""
+    if annual_rate <= 0:
+        return principal * max(0, 1 - months_paid / max(months_total, 1))
+    r = annual_rate / 12.0
+    return principal * ((1 + r) ** months_total - (1 + r) ** months_paid) / ((1 + r) ** months_total - 1)
+
+
+def _amortization_schedule(
+    principal: float, annual_rate: float, months: int, *, balloon_month: int | None = None
+) -> list[dict[str, Any]]:
+    """Build a month-by-month amortization schedule.
+
+    If *balloon_month* is set, the remaining balance becomes due at that month.
+    """
+    schedule: list[dict[str, Any]] = []
+    balance = principal
+    r = annual_rate / 12.0 if annual_rate > 0 else 0.0
+    pmt = _monthly_payment(principal, annual_rate, months)
+
+    for m in range(1, months + 1):
+        interest = balance * r
+        principal_portion = pmt - interest
+        balance -= principal_portion
+        if balance < 0:
+            balance = 0.0
+
+        entry: dict[str, Any] = {
+            "month": m,
+            "payment": round(pmt, 2),
+            "principal": round(principal_portion, 2),
+            "interest": round(interest, 2),
+            "balance": round(balance, 2),
+        }
+
+        if balloon_month and m == balloon_month:
+            entry["balloon_due"] = round(balance, 2)
+            schedule.append(entry)
+            break
+
+        schedule.append(entry)
+
+    return schedule
+
+
+# ---------------------------------------------------------------------------
+# IRR Calculator
+# ---------------------------------------------------------------------------
+
+def calculate_irr(cash_flows: list[float], *, max_iter: int = 200, tol: float = 1e-8) -> float | None:
+    """Newton-Raphson IRR for irregular periodic cash flows.
+
+    cash_flows[0] is typically the initial investment (negative).
+    Returns annualised IRR as a decimal (e.g. 0.15 = 15%), or None if no convergence.
+    """
+    if not cash_flows or all(cf == 0 for cf in cash_flows):
+        return None
+
+    # Initial guess based on total return
+    total_return = sum(cash_flows)
+    n = len(cash_flows) - 1
+    if n <= 0:
+        return None
+
+    # Start with a simple guess
+    guess = 0.1
+
+    for _ in range(max_iter):
+        npv = 0.0
+        dnpv = 0.0
+        for t, cf in enumerate(cash_flows):
+            denom = (1 + guess) ** t
+            if denom == 0:
+                break
+            npv += cf / denom
+            if t > 0:
+                dnpv -= t * cf / ((1 + guess) ** (t + 1))
+
+        if abs(dnpv) < 1e-14:
+            break
+
+        new_guess = guess - npv / dnpv
+
+        # Clamp to avoid divergence
+        if new_guess < -0.99:
+            new_guess = -0.99
+        if new_guess > 10.0:
+            new_guess = 10.0
+
+        if abs(new_guess - guess) < tol:
+            return round(new_guess, 6)
+        guess = new_guess
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MAO (Maximum Allowable Offer)
+# ---------------------------------------------------------------------------
+
+def calculate_mao(
+    arv: float,
+    rehab_cost: float,
+    *,
+    profit_margin: float = 0.30,
+    closing_costs_pct: float = 0.03,
+    hold_costs: float = 0.0,
+) -> dict[str, Any]:
+    """MAO = ARV * (1 - profit_margin) - rehab_cost - closing_costs - hold_costs.
+
+    Returns MAO breakdown with each component.
+    """
+    closing_costs = arv * closing_costs_pct
+    mao = arv * (1.0 - profit_margin) - rehab_cost - closing_costs - hold_costs
+
+    return {
+        "mao": round(max(0, mao), 2),
+        "arv": round(arv, 2),
+        "profit_margin": profit_margin,
+        "rehab_cost": round(rehab_cost, 2),
+        "closing_costs": round(closing_costs, 2),
+        "hold_costs": round(hold_costs, 2),
+        "profit_target": round(arv * profit_margin, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Fix & Flip
+# ---------------------------------------------------------------------------
+
+def fix_and_flip(
+    purchase_price: float,
+    rehab_cost: float,
+    arv: float,
+    *,
+    hold_months: int = 6,
+    monthly_hold_cost: float = 0.0,
+    buying_closing_pct: float = 0.02,
+    selling_closing_pct: float = 0.06,
+    loan_amount: float = 0.0,
+    loan_rate: float = 0.0,
+) -> dict[str, Any]:
+    """Fix & Flip projection.
+
+    Returns purchase + rehab cost, hold costs, selling costs, net profit, ROI.
+    """
+    buying_closing = purchase_price * buying_closing_pct
+    selling_closing = arv * selling_closing_pct
+    total_hold_costs = monthly_hold_cost * hold_months
+
+    # Financing costs during hold
+    if loan_amount > 0 and loan_rate > 0:
+        monthly_interest = loan_amount * (loan_rate / 12.0)
+        financing_cost = monthly_interest * hold_months
+    else:
+        financing_cost = 0.0
+
+    total_cost = purchase_price + rehab_cost + buying_closing + total_hold_costs + financing_cost
+    total_selling_costs = selling_closing
+    net_profit = arv - total_cost - total_selling_costs
+    cash_invested = purchase_price + rehab_cost + buying_closing - loan_amount
+    if cash_invested < 0:
+        cash_invested = 0.01  # avoid division by zero
+
+    roi = net_profit / cash_invested
+
+    # Cash flows for IRR: initial outlay, monthly hold costs, final sale
+    cf: list[float] = [-cash_invested]
+    for _ in range(hold_months - 1):
+        cf.append(-(monthly_hold_cost + (monthly_interest if loan_amount > 0 else 0.0)))
+    # Final month: sale proceeds minus selling costs minus loan payoff
+    final = arv - total_selling_costs - loan_amount - monthly_hold_cost
+    if loan_amount > 0:
+        final -= monthly_interest if loan_rate > 0 else 0.0
+    cf.append(final)
+
+    irr = calculate_irr(cf)
+    mao = calculate_mao(arv, rehab_cost, hold_costs=total_hold_costs + financing_cost)
+
+    return {
+        "model": "fix_and_flip",
+        "purchase_price": round(purchase_price, 2),
+        "rehab_cost": round(rehab_cost, 2),
+        "arv": round(arv, 2),
+        "buying_closing_costs": round(buying_closing, 2),
+        "selling_closing_costs": round(selling_closing, 2),
+        "total_hold_costs": round(total_hold_costs, 2),
+        "financing_cost": round(financing_cost, 2),
+        "total_cost": round(total_cost, 2),
+        "net_profit": round(net_profit, 2),
+        "roi": round(roi, 4),
+        "annualised_roi": round(roi * (12.0 / max(hold_months, 1)), 4),
+        "irr": irr,
+        "mao": mao,
+        "hold_months": hold_months,
+        "cash_invested": round(cash_invested, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. BRRRR (Buy, Rehab, Rent, Refinance, Repeat)
+# ---------------------------------------------------------------------------
+
+def brrrr(
+    purchase_price: float,
+    rehab_cost: float,
+    arv: float,
+    monthly_rent: float,
+    *,
+    hold_months_before_refi: int = 6,
+    refi_ltv: float = 0.75,
+    refi_rate: float = 0.07,
+    refi_term_years: int = 30,
+    monthly_expenses: float = 0.0,
+    vacancy_rate: float = 0.08,
+    buying_closing_pct: float = 0.02,
+    initial_loan_amount: float = 0.0,
+    initial_loan_rate: float = 0.0,
+) -> dict[str, Any]:
+    """BRRRR model — cash-on-cash return after refinance."""
+    buying_closing = purchase_price * buying_closing_pct
+    total_initial = purchase_price + rehab_cost + buying_closing
+
+    # Initial financing costs during rehab
+    if initial_loan_amount > 0 and initial_loan_rate > 0:
+        init_monthly_interest = initial_loan_amount * (initial_loan_rate / 12.0)
+        init_financing_cost = init_monthly_interest * hold_months_before_refi
+    else:
+        init_financing_cost = 0.0
+
+    cash_in = total_initial - initial_loan_amount + init_financing_cost
+
+    # Refinance
+    refi_amount = arv * refi_ltv
+    cash_out_refi = refi_amount - initial_loan_amount  # pay off initial loan
+    cash_left_in = cash_in - cash_out_refi
+
+    # Monthly cash flow post-refi
+    refi_payment = _monthly_payment(refi_amount, refi_rate, refi_term_years * 12)
+    effective_rent = monthly_rent * (1 - vacancy_rate)
+    monthly_cash_flow = effective_rent - monthly_expenses - refi_payment
+
+    # Annual metrics
+    annual_cash_flow = monthly_cash_flow * 12
+    cash_on_cash = annual_cash_flow / max(cash_left_in, 0.01)
+
+    # IRR: initial investment, rental income months, then ongoing
+    cf: list[float] = [-max(cash_left_in, 0.01)]
+    for _ in range(12):
+        cf.append(monthly_cash_flow)
+    irr = calculate_irr(cf)
+
+    return {
+        "model": "brrrr",
+        "purchase_price": round(purchase_price, 2),
+        "rehab_cost": round(rehab_cost, 2),
+        "arv": round(arv, 2),
+        "total_initial_investment": round(total_initial, 2),
+        "cash_in_before_refi": round(cash_in, 2),
+        "refi_amount": round(refi_amount, 2),
+        "cash_out_refi": round(cash_out_refi, 2),
+        "cash_left_in_deal": round(max(cash_left_in, 0), 2),
+        "refi_monthly_payment": round(refi_payment, 2),
+        "monthly_rent": round(monthly_rent, 2),
+        "effective_rent": round(effective_rent, 2),
+        "monthly_expenses": round(monthly_expenses, 2),
+        "monthly_cash_flow": round(monthly_cash_flow, 2),
+        "annual_cash_flow": round(annual_cash_flow, 2),
+        "cash_on_cash_return": round(cash_on_cash, 4),
+        "irr": irr,
+        "refi_ltv": refi_ltv,
+        "refi_rate": refi_rate,
+        "refi_term_years": refi_term_years,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Buy & Hold (Long-Term Rental)
+# ---------------------------------------------------------------------------
+
+def buy_and_hold(
+    purchase_price: float,
+    monthly_rent: float,
+    *,
+    down_payment_pct: float = 0.20,
+    loan_rate: float = 0.07,
+    loan_term_years: int = 30,
+    monthly_expenses: float = 0.0,
+    vacancy_rate: float = 0.08,
+    annual_appreciation: float = 0.03,
+    annual_rent_growth: float = 0.02,
+    closing_costs_pct: float = 0.03,
+) -> dict[str, Any]:
+    """Buy & Hold projection — monthly cash flow, cap rate, annual ROI, multi-year projections."""
+    down_payment = purchase_price * down_payment_pct
+    closing_costs = purchase_price * closing_costs_pct
+    loan_amount = purchase_price - down_payment
+    cash_invested = down_payment + closing_costs
+
+    mortgage_payment = _monthly_payment(loan_amount, loan_rate, loan_term_years * 12)
+    effective_rent = monthly_rent * (1 - vacancy_rate)
+    monthly_cash_flow = effective_rent - monthly_expenses - mortgage_payment
+
+    # Cap rate (based on purchase price)
+    annual_noi = (effective_rent - monthly_expenses) * 12
+    cap_rate = annual_noi / purchase_price if purchase_price > 0 else 0
+
+    annual_cash_flow = monthly_cash_flow * 12
+    cash_on_cash = annual_cash_flow / max(cash_invested, 0.01)
+
+    # Multi-year projections
+    projections: list[dict[str, Any]] = []
+    for year in [5, 10, 30]:
+        prop_value = purchase_price * (1 + annual_appreciation) ** year
+        rent_at_year = monthly_rent * (1 + annual_rent_growth) ** year
+        eff_rent_yr = rent_at_year * (1 - vacancy_rate)
+        noi_yr = (eff_rent_yr - monthly_expenses) * 12
+        months_paid = min(year * 12, loan_term_years * 12)
+        remaining_balance = _loan_balance(loan_amount, loan_rate, loan_term_years * 12, months_paid)
+        equity = prop_value - remaining_balance
+        total_cash_flow = sum(
+            ((monthly_rent * (1 + annual_rent_growth) ** (y // 12) * (1 - vacancy_rate))
+             - monthly_expenses - mortgage_payment)
+            for y in range(year * 12)
+        )
+        projections.append({
+            "year": year,
+            "property_value": round(prop_value, 2),
+            "monthly_rent": round(rent_at_year, 2),
+            "annual_noi": round(noi_yr, 2),
+            "equity": round(equity, 2),
+            "cumulative_cash_flow": round(total_cash_flow, 2),
+        })
+
+    # IRR over 10 years: initial outlay, annual cash flows, sale at year 10
+    cf: list[float] = [-cash_invested]
+    for yr in range(1, 11):
+        rent_yr = monthly_rent * (1 + annual_rent_growth) ** yr
+        eff = rent_yr * (1 - vacancy_rate)
+        annual_cf = (eff - monthly_expenses) * 12 - mortgage_payment * 12
+        cf.append(annual_cf)
+    # Add sale proceeds at year 10
+    sale_price_10 = purchase_price * (1 + annual_appreciation) ** 10
+    remaining_10 = _loan_balance(loan_amount, loan_rate, loan_term_years * 12, 120)
+    cf[-1] += sale_price_10 - remaining_10
+    irr = calculate_irr(cf)
+
+    return {
+        "model": "buy_and_hold",
+        "purchase_price": round(purchase_price, 2),
+        "down_payment": round(down_payment, 2),
+        "closing_costs": round(closing_costs, 2),
+        "cash_invested": round(cash_invested, 2),
+        "loan_amount": round(loan_amount, 2),
+        "mortgage_payment": round(mortgage_payment, 2),
+        "monthly_rent": round(monthly_rent, 2),
+        "effective_rent": round(effective_rent, 2),
+        "monthly_expenses": round(monthly_expenses, 2),
+        "monthly_cash_flow": round(monthly_cash_flow, 2),
+        "annual_cash_flow": round(annual_cash_flow, 2),
+        "cap_rate": round(cap_rate, 4),
+        "cash_on_cash_return": round(cash_on_cash, 4),
+        "irr": irr,
+        "projections": projections,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Short-Term Rental (STR / Airbnb)
+# ---------------------------------------------------------------------------
+
+def short_term_rental(
+    purchase_price: float,
+    nightly_rate: float,
+    *,
+    occupancy_rate: float = 0.70,
+    down_payment_pct: float = 0.20,
+    loan_rate: float = 0.07,
+    loan_term_years: int = 30,
+    monthly_expenses: float = 0.0,
+    platform_fee_pct: float = 0.03,
+    cleaning_fee_per_turn: float = 0.0,
+    avg_stay_nights: float = 3.0,
+    seasonal_adjustments: dict[str, float] | None = None,
+    closing_costs_pct: float = 0.03,
+) -> dict[str, Any]:
+    """Short-Term Rental projection with seasonal adjustments."""
+    down_payment = purchase_price * down_payment_pct
+    closing_costs = purchase_price * closing_costs_pct
+    loan_amount = purchase_price - down_payment
+    cash_invested = down_payment + closing_costs
+    mortgage_payment = _monthly_payment(loan_amount, loan_rate, loan_term_years * 12)
+
+    # Default seasonal adjustments (multipliers by quarter)
+    seasons = seasonal_adjustments or {
+        "q1": 0.80, "q2": 1.10, "q3": 1.20, "q4": 0.90,
+    }
+
+    monthly_breakdown: list[dict[str, Any]] = []
+    annual_gross = 0.0
+    annual_net = 0.0
+    quarter_map = {1: "q1", 2: "q1", 3: "q1", 4: "q2", 5: "q2", 6: "q2",
+                   7: "q3", 8: "q3", 9: "q3", 10: "q4", 11: "q4", 12: "q4"}
+
+    for month in range(1, 13):
+        days = 30
+        q = quarter_map[month]
+        adj = seasons.get(q, 1.0)
+        adj_rate = nightly_rate * adj
+        occupied_nights = days * occupancy_rate
+        gross = occupied_nights * adj_rate
+        platform_fees = gross * platform_fee_pct
+        turns = occupied_nights / max(avg_stay_nights, 1)
+        cleaning = turns * cleaning_fee_per_turn
+        net = gross - platform_fees - cleaning - monthly_expenses - mortgage_payment
+        annual_gross += gross
+        annual_net += net
+        monthly_breakdown.append({
+            "month": month,
+            "nightly_rate": round(adj_rate, 2),
+            "occupied_nights": round(occupied_nights, 1),
+            "gross_revenue": round(gross, 2),
+            "platform_fees": round(platform_fees, 2),
+            "cleaning_costs": round(cleaning, 2),
+            "net_income": round(net, 2),
+        })
+
+    cap_rate = annual_net / purchase_price if purchase_price > 0 else 0
+    cash_on_cash = annual_net / max(cash_invested, 0.01)
+
+    cf: list[float] = [-cash_invested]
+    for entry in monthly_breakdown:
+        cf.append(entry["net_income"])
+    irr = calculate_irr(cf)
+
+    return {
+        "model": "short_term_rental",
+        "purchase_price": round(purchase_price, 2),
+        "down_payment": round(down_payment, 2),
+        "cash_invested": round(cash_invested, 2),
+        "nightly_rate": round(nightly_rate, 2),
+        "occupancy_rate": occupancy_rate,
+        "mortgage_payment": round(mortgage_payment, 2),
+        "annual_gross_revenue": round(annual_gross, 2),
+        "annual_net_income": round(annual_net, 2),
+        "cap_rate": round(cap_rate, 4),
+        "cash_on_cash_return": round(cash_on_cash, 4),
+        "irr": irr,
+        "monthly_breakdown": monthly_breakdown,
+        "seasonal_adjustments": seasons,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 5. Wholesale
+# ---------------------------------------------------------------------------
+
+def wholesale(
+    arv: float,
+    rehab_cost: float,
+    *,
+    assignment_fee: float = 10_000.0,
+    buyer_profit_margin: float = 0.30,
+    closing_costs_pct: float = 0.01,
+    earnest_money: float = 1_000.0,
+) -> dict[str, Any]:
+    """Wholesale deal analysis — assignment fee, MAO, buyer's spread."""
+    mao_result = calculate_mao(arv, rehab_cost, profit_margin=buyer_profit_margin)
+    mao_price = mao_result["mao"]
+
+    # Wholesaler's contract price should be below MAO minus assignment fee
+    contract_price = mao_price - assignment_fee
+    buyer_price = contract_price + assignment_fee
+    closing_costs = contract_price * closing_costs_pct
+
+    # Buyer's expected profit
+    buyers_total_cost = buyer_price + rehab_cost + (arv * 0.06)  # 6% selling costs
+    buyers_spread = arv - buyers_total_cost
+
+    wholesaler_profit = assignment_fee - closing_costs - earnest_money
+    roi = wholesaler_profit / max(earnest_money, 0.01)
+
+    return {
+        "model": "wholesale",
+        "arv": round(arv, 2),
+        "rehab_cost": round(rehab_cost, 2),
+        "mao": round(mao_price, 2),
+        "contract_price": round(max(contract_price, 0), 2),
+        "assignment_fee": round(assignment_fee, 2),
+        "buyer_price": round(buyer_price, 2),
+        "buyers_spread": round(buyers_spread, 2),
+        "earnest_money": round(earnest_money, 2),
+        "closing_costs": round(closing_costs, 2),
+        "wholesaler_profit": round(wholesaler_profit, 2),
+        "roi": round(roi, 4),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 6. Subject-To (Existing Mortgage Takeover)
+# ---------------------------------------------------------------------------
+
+def subject_to(
+    property_value: float,
+    existing_mortgage_balance: float,
+    existing_mortgage_rate: float,
+    existing_mortgage_remaining_months: int,
+    monthly_rent: float,
+    *,
+    cash_to_seller: float = 0.0,
+    monthly_expenses: float = 0.0,
+    vacancy_rate: float = 0.08,
+    closing_costs: float = 0.0,
+    wrap_rate: float | None = None,
+    wrap_term_months: int | None = None,
+) -> dict[str, Any]:
+    """Subject-To analysis — existing mortgage takeover, equity position, cash flow.
+
+    Optional wrap mortgage: sell on contract at a higher rate.
+    """
+    equity = property_value - existing_mortgage_balance
+    cash_invested = cash_to_seller + closing_costs
+
+    existing_payment = _monthly_payment(
+        existing_mortgage_balance, existing_mortgage_rate, existing_mortgage_remaining_months
+    )
+    effective_rent = monthly_rent * (1 - vacancy_rate)
+    monthly_cash_flow = effective_rent - monthly_expenses - existing_payment
+
+    # Wrap mortgage (sell on contract)
+    wrap_info: dict[str, Any] | None = None
+    if wrap_rate is not None and wrap_term_months is not None:
+        wrap_payment = _monthly_payment(property_value, wrap_rate, wrap_term_months)
+        wrap_spread = wrap_payment - existing_payment
+        wrap_info = {
+            "wrap_rate": wrap_rate,
+            "wrap_term_months": wrap_term_months,
+            "wrap_payment": round(wrap_payment, 2),
+            "monthly_spread": round(wrap_spread, 2),
+            "annual_spread": round(wrap_spread * 12, 2),
+        }
+
+    annual_cash_flow = monthly_cash_flow * 12
+    cash_on_cash = annual_cash_flow / max(cash_invested, 0.01)
+
+    cf: list[float] = [-max(cash_invested, 0.01)]
+    for _ in range(12):
+        cf.append(monthly_cash_flow)
+    irr = calculate_irr(cf)
+
+    return {
+        "model": "subject_to",
+        "property_value": round(property_value, 2),
+        "existing_mortgage_balance": round(existing_mortgage_balance, 2),
+        "existing_mortgage_rate": existing_mortgage_rate,
+        "existing_payment": round(existing_payment, 2),
+        "equity_position": round(equity, 2),
+        "cash_to_seller": round(cash_to_seller, 2),
+        "closing_costs": round(closing_costs, 2),
+        "cash_invested": round(cash_invested, 2),
+        "monthly_rent": round(monthly_rent, 2),
+        "effective_rent": round(effective_rent, 2),
+        "monthly_cash_flow": round(monthly_cash_flow, 2),
+        "annual_cash_flow": round(annual_cash_flow, 2),
+        "cash_on_cash_return": round(cash_on_cash, 4),
+        "irr": irr,
+        "wrap_mortgage": wrap_info,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 7. Seller Financing
+# ---------------------------------------------------------------------------
+
+def seller_financing(
+    purchase_price: float,
+    monthly_rent: float,
+    *,
+    down_payment_pct: float = 0.10,
+    seller_rate: float = 0.06,
+    seller_term_months: int = 360,
+    balloon_month: int | None = 60,
+    monthly_expenses: float = 0.0,
+    vacancy_rate: float = 0.08,
+    closing_costs_pct: float = 0.02,
+) -> dict[str, Any]:
+    """Seller Financing — custom terms, balloon payment, amortization schedule."""
+    down_payment = purchase_price * down_payment_pct
+    closing_costs = purchase_price * closing_costs_pct
+    financed_amount = purchase_price - down_payment
+    cash_invested = down_payment + closing_costs
+
+    seller_payment = _monthly_payment(financed_amount, seller_rate, seller_term_months)
+    effective_rent = monthly_rent * (1 - vacancy_rate)
+    monthly_cash_flow = effective_rent - monthly_expenses - seller_payment
+
+    # Balloon balance
+    balloon_balance: float | None = None
+    if balloon_month and balloon_month < seller_term_months:
+        balloon_balance = _loan_balance(financed_amount, seller_rate, seller_term_months, balloon_month)
+
+    schedule = _amortization_schedule(
+        financed_amount, seller_rate, seller_term_months, balloon_month=balloon_month
+    )
+
+    annual_cash_flow = monthly_cash_flow * 12
+    cash_on_cash = annual_cash_flow / max(cash_invested, 0.01)
+
+    cf: list[float] = [-cash_invested]
+    for _ in range(min(balloon_month or 12, 12)):
+        cf.append(monthly_cash_flow)
+    irr = calculate_irr(cf)
+
+    return {
+        "model": "seller_financing",
+        "purchase_price": round(purchase_price, 2),
+        "down_payment": round(down_payment, 2),
+        "financed_amount": round(financed_amount, 2),
+        "cash_invested": round(cash_invested, 2),
+        "seller_rate": seller_rate,
+        "seller_term_months": seller_term_months,
+        "monthly_payment": round(seller_payment, 2),
+        "monthly_rent": round(monthly_rent, 2),
+        "effective_rent": round(effective_rent, 2),
+        "monthly_cash_flow": round(monthly_cash_flow, 2),
+        "annual_cash_flow": round(annual_cash_flow, 2),
+        "cash_on_cash_return": round(cash_on_cash, 4),
+        "irr": irr,
+        "balloon_month": balloon_month,
+        "balloon_balance": round(balloon_balance, 2) if balloon_balance is not None else None,
+        "amortization_schedule": schedule[:12],  # first 12 months only in response
+        "amortization_schedule_length": len(schedule),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 8. Hard Money / Bridge Loan
+# ---------------------------------------------------------------------------
+
+def hard_money_bridge(
+    purchase_price: float,
+    rehab_cost: float,
+    arv: float,
+    *,
+    loan_to_cost_pct: float = 0.85,
+    interest_rate: float = 0.12,
+    points: float = 2.0,
+    term_months: int = 12,
+    interest_only: bool = True,
+    refi_after_months: int | None = 6,
+    refi_rate: float = 0.07,
+    refi_ltv: float = 0.75,
+    refi_term_years: int = 30,
+    monthly_rent_after_refi: float = 0.0,
+    monthly_expenses: float = 0.0,
+    vacancy_rate: float = 0.08,
+) -> dict[str, Any]:
+    """Hard Money / Bridge loan analysis — points, interest-only, total cost of capital."""
+    total_project_cost = purchase_price + rehab_cost
+    loan_amount = total_project_cost * loan_to_cost_pct
+    cash_needed = total_project_cost - loan_amount
+
+    # Points (origination fee)
+    origination_fee = loan_amount * (points / 100.0)
+
+    # Interest-only payments
+    if interest_only:
+        monthly_payment = loan_amount * (interest_rate / 12.0)
+    else:
+        monthly_payment = _monthly_payment(loan_amount, interest_rate, term_months)
+
+    hold_months = refi_after_months or term_months
+    total_interest = monthly_payment * hold_months
+    total_cost_of_capital = origination_fee + total_interest
+
+    # Refi scenario
+    refi_info: dict[str, Any] | None = None
+    if refi_after_months and monthly_rent_after_refi > 0:
+        refi_amount = arv * refi_ltv
+        refi_payment = _monthly_payment(refi_amount, refi_rate, refi_term_years * 12)
+        payoff = loan_amount  # pay off hard money
+        cash_out = refi_amount - payoff
+        effective_rent = monthly_rent_after_refi * (1 - vacancy_rate)
+        post_refi_cash_flow = effective_rent - monthly_expenses - refi_payment
+
+        refi_info = {
+            "refi_month": refi_after_months,
+            "refi_amount": round(refi_amount, 2),
+            "refi_payment": round(refi_payment, 2),
+            "cash_out": round(cash_out, 2),
+            "post_refi_monthly_cash_flow": round(post_refi_cash_flow, 2),
+        }
+
+    # Cash flows for IRR
+    cf: list[float] = [-(cash_needed + origination_fee)]
+    for m in range(1, hold_months + 1):
+        cf.append(-monthly_payment)
+    if refi_info:
+        # At refi: get cash out and start earning
+        cf[-1] += refi_info["cash_out"] + loan_amount  # pay off hard money from refi
+        for _ in range(6):
+            cf.append(refi_info["post_refi_monthly_cash_flow"])
+    else:
+        # Exit via sale
+        selling_costs = arv * 0.06
+        cf[-1] += arv - loan_amount - selling_costs
+
+    irr = calculate_irr(cf)
+
+    return {
+        "model": "hard_money_bridge",
+        "purchase_price": round(purchase_price, 2),
+        "rehab_cost": round(rehab_cost, 2),
+        "arv": round(arv, 2),
+        "loan_amount": round(loan_amount, 2),
+        "loan_to_cost_pct": loan_to_cost_pct,
+        "interest_rate": interest_rate,
+        "points": points,
+        "origination_fee": round(origination_fee, 2),
+        "term_months": term_months,
+        "interest_only": interest_only,
+        "monthly_payment": round(monthly_payment, 2),
+        "total_interest": round(total_interest, 2),
+        "total_cost_of_capital": round(total_cost_of_capital, 2),
+        "cash_needed": round(cash_needed, 2),
+        "irr": irr,
+        "refinance": refi_info,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenario Comparison
+# ---------------------------------------------------------------------------
+
+ALL_MODELS = [
+    "fix_and_flip",
+    "brrrr",
+    "buy_and_hold",
+    "short_term_rental",
+    "wholesale",
+    "subject_to",
+    "seller_financing",
+    "hard_money_bridge",
+]
+
+
+def compare_scenarios(
+    property_data: dict[str, Any],
+    assumptions: dict[str, Any],
+    *,
+    models: list[str] | None = None,
+) -> dict[str, Any]:
+    """Run multiple financing models against the same property and return side-by-side comparison.
+
+    property_data should include: purchase_price, arv, rehab_cost, monthly_rent, etc.
+    assumptions can override per-model defaults.
+    """
+    requested = models or ALL_MODELS
+    results: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+
+    pp = property_data.get("purchase_price", 0)
+    arv = property_data.get("arv", 0)
+    rehab = property_data.get("rehab_cost", 0)
+    rent = property_data.get("monthly_rent", 0)
+
+    for model_name in requested:
+        try:
+            if model_name == "fix_and_flip":
+                r = fix_and_flip(pp, rehab, arv, **assumptions.get("fix_and_flip", {}))
+            elif model_name == "brrrr":
+                r = brrrr(pp, rehab, arv, rent, **assumptions.get("brrrr", {}))
+            elif model_name == "buy_and_hold":
+                r = buy_and_hold(pp, rent, **assumptions.get("buy_and_hold", {}))
+            elif model_name == "short_term_rental":
+                nightly = assumptions.get("short_term_rental", {}).get("nightly_rate", rent / 30 * 2)
+                a = {k: v for k, v in assumptions.get("short_term_rental", {}).items() if k != "nightly_rate"}
+                r = short_term_rental(pp, nightly, **a)
+            elif model_name == "wholesale":
+                r = wholesale(arv, rehab, **assumptions.get("wholesale", {}))
+            elif model_name == "subject_to":
+                sub_to_args = assumptions.get("subject_to", {})
+                r = subject_to(
+                    property_data.get("property_value", pp),
+                    sub_to_args.get("existing_mortgage_balance", pp * 0.7),
+                    sub_to_args.get("existing_mortgage_rate", 0.05),
+                    sub_to_args.get("existing_mortgage_remaining_months", 300),
+                    rent,
+                    **{k: v for k, v in sub_to_args.items()
+                       if k not in ("existing_mortgage_balance", "existing_mortgage_rate",
+                                    "existing_mortgage_remaining_months")},
+                )
+            elif model_name == "seller_financing":
+                r = seller_financing(pp, rent, **assumptions.get("seller_financing", {}))
+            elif model_name == "hard_money_bridge":
+                r = hard_money_bridge(pp, rehab, arv, **assumptions.get("hard_money_bridge", {}))
+            else:
+                errors.append({"model": model_name, "error": f"Unknown model: {model_name}"})
+                continue
+            results.append(r)
+        except Exception as exc:
+            errors.append({"model": model_name, "error": str(exc)})
+
+    # Summary comparison
+    summary: list[dict[str, Any]] = []
+    for r in results:
+        s: dict[str, Any] = {"model": r["model"]}
+        if "cash_on_cash_return" in r:
+            s["cash_on_cash_return"] = r["cash_on_cash_return"]
+        if "roi" in r:
+            s["roi"] = r["roi"]
+        if "monthly_cash_flow" in r:
+            s["monthly_cash_flow"] = r["monthly_cash_flow"]
+        if "net_profit" in r:
+            s["net_profit"] = r["net_profit"]
+        if "irr" in r:
+            s["irr"] = r["irr"]
+        if "cash_invested" in r:
+            s["cash_invested"] = r["cash_invested"]
+        if "wholesaler_profit" in r:
+            s["net_profit"] = r["wholesaler_profit"]
+            s["cash_invested"] = r["earnest_money"]
+        summary.append(s)
+
+    # Sort by IRR descending (None last)
+    summary.sort(key=lambda x: x.get("irr") or -999, reverse=True)
+
+    return {
+        "property_data": property_data,
+        "models_run": len(results),
+        "summary": summary,
+        "details": results,
+        "errors": errors,
+    }

--- a/packages/api/app/services/google_places.py
+++ b/packages/api/app/services/google_places.py
@@ -1,0 +1,116 @@
+"""Google Places integration — address autocomplete and geocoding."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+PLACES_AUTOCOMPLETE_URL = "https://maps.googleapis.com/maps/api/place/autocomplete/json"
+GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+
+async def autocomplete(input_text: str, session_token: str | None = None) -> list[dict[str, Any]]:
+    """Return address autocomplete predictions from Google Places."""
+    if not settings.GOOGLE_PLACES_API_KEY:
+        logger.warning("GOOGLE_PLACES_API_KEY not configured")
+        return []
+
+    params: dict[str, str] = {
+        "input": input_text,
+        "types": "address",
+        "components": "country:us",
+        "key": settings.GOOGLE_PLACES_API_KEY,
+    }
+    if session_token:
+        params["sessiontoken"] = session_token
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(PLACES_AUTOCOMPLETE_URL, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.error("Google Places autocomplete failed: %s", exc)
+        return []
+
+    if data.get("status") != "OK":
+        logger.warning("Google Places status: %s", data.get("status"))
+        return []
+
+    return [
+        {
+            "place_id": p["place_id"],
+            "description": p["description"],
+            "structured_formatting": p.get("structured_formatting"),
+        }
+        for p in data.get("predictions", [])
+    ]
+
+
+async def geocode(address: str) -> dict[str, Any] | None:
+    """Geocode an address to lat/lng using Google Geocoding API."""
+    if not settings.GOOGLE_PLACES_API_KEY:
+        logger.warning("GOOGLE_PLACES_API_KEY not configured")
+        return None
+
+    params = {
+        "address": address,
+        "key": settings.GOOGLE_PLACES_API_KEY,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(GEOCODE_URL, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.error("Google geocoding failed: %s", exc)
+        return None
+
+    if data.get("status") != "OK" or not data.get("results"):
+        return None
+
+    result = data["results"][0]
+    location = result["geometry"]["location"]
+    return {
+        "lat": location["lat"],
+        "lng": location["lng"],
+        "formatted_address": result["formatted_address"],
+    }
+
+
+async def geocode_by_place_id(place_id: str) -> dict[str, Any] | None:
+    """Geocode a Google Place ID to lat/lng."""
+    if not settings.GOOGLE_PLACES_API_KEY:
+        return None
+
+    params = {
+        "place_id": place_id,
+        "key": settings.GOOGLE_PLACES_API_KEY,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(GEOCODE_URL, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.error("Google geocoding by place_id failed: %s", exc)
+        return None
+
+    if data.get("status") != "OK" or not data.get("results"):
+        return None
+
+    result = data["results"][0]
+    location = result["geometry"]["location"]
+    return {
+        "lat": location["lat"],
+        "lng": location["lng"],
+        "formatted_address": result["formatted_address"],
+    }

--- a/packages/api/app/services/lendability.py
+++ b/packages/api/app/services/lendability.py
@@ -1,0 +1,148 @@
+"""Lendability composite score calculator."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+
+def calculate_lendability(
+    property_data: dict[str, Any],
+    risk_flags: list[dict[str, Any]],
+    arv_calculations: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Calculate a lendability composite score (0–100).
+
+    Weights:
+        Year-based risk flags:  30%
+        Flood zone risk:        25%
+        Property condition:     20%
+        ARV-to-purchase ratio:  25%
+
+    Categories:
+        Green:  70–100
+        Yellow: 40–69
+        Red:    0–39
+
+    Handles missing data gracefully with neutral defaults.
+    """
+    year_score = _score_year_flags(risk_flags)
+    flood_score = _score_flood_risk(risk_flags)
+    condition_score = _score_condition(property_data)
+    arv_score = _score_arv_ratio(property_data, arv_calculations)
+
+    total = year_score + flood_score + condition_score + arv_score
+
+    if total >= 70:
+        category = "green"
+    elif total >= 40:
+        category = "yellow"
+    else:
+        category = "red"
+
+    return {
+        "score": total,
+        "category": category,
+        "breakdown": {
+            "year_risk": year_score,
+            "flood_risk": flood_score,
+            "condition": condition_score,
+            "arv_ratio": arv_score,
+        },
+    }
+
+
+def _score_year_flags(risk_flags: list[dict[str, Any]]) -> int:
+    """Score year-based risks (max 30 points).
+
+    Start at 30 and deduct per year-related flag by severity.
+    """
+    score = 30
+    severity_penalties = {"high": 10, "medium": 5, "low": 2}
+
+    for flag in risk_flags:
+        if flag.get("source") == "year_built":
+            severity = (flag.get("severity") or "low").lower()
+            score -= severity_penalties.get(severity, 2)
+
+    return max(score, 0)
+
+
+def _score_flood_risk(risk_flags: list[dict[str, Any]]) -> int:
+    """Score flood zone risk (max 25 points).
+
+    25 = no flood risk, 15 = moderate, 5 = high-risk zone.
+    """
+    for flag in risk_flags:
+        if flag.get("source") == "fema":
+            severity = (flag.get("severity") or "low").lower()
+            if severity == "high":
+                return 5
+            elif severity == "medium":
+                return 15
+            # low or info
+            return 22
+
+    # No FEMA data — neutral assumption
+    return 20
+
+
+def _score_condition(property_data: dict[str, Any]) -> int:
+    """Score property condition (max 20 points).
+
+    Uses available data signals; defaults to 15 (neutral) when unknown.
+    """
+    year_built = property_data.get("year_built")
+    if year_built is None:
+        return 15
+
+    # Newer properties generally in better condition
+    if year_built >= 2010:
+        return 20
+    elif year_built >= 2000:
+        return 18
+    elif year_built >= 1980:
+        return 15
+    elif year_built >= 1960:
+        return 12
+    else:
+        return 8
+
+
+def _score_arv_ratio(
+    property_data: dict[str, Any],
+    arv_calculations: list[dict[str, Any]],
+) -> int:
+    """Score ARV-to-purchase ratio (max 25 points).
+
+    ratio >= 1.5 → 25, 1.3–1.5 → 20, 1.1–1.3 → 15, < 1.1 → 5.
+    No data → neutral 15.
+    """
+    listing_price = property_data.get("listing_price")
+    if listing_price is not None:
+        listing_price = float(listing_price) if isinstance(listing_price, Decimal) else listing_price
+
+    if not listing_price or listing_price <= 0:
+        return 15
+
+    # Use most recent ARV calculation
+    arv_mid: float | None = None
+    if arv_calculations:
+        latest = arv_calculations[0]
+        arv_mid_raw = latest.get("arv_mid")
+        if arv_mid_raw is not None:
+            arv_mid = float(arv_mid_raw) if isinstance(arv_mid_raw, Decimal) else arv_mid_raw
+
+    if arv_mid is None or arv_mid <= 0:
+        return 15
+
+    ratio = arv_mid / listing_price
+
+    if ratio >= 1.5:
+        return 25
+    elif ratio >= 1.3:
+        return 20
+    elif ratio >= 1.1:
+        return 15
+    else:
+        return 5

--- a/packages/api/app/services/order_service.py
+++ b/packages/api/app/services/order_service.py
@@ -1,0 +1,332 @@
+"""Order service — Sage order submission, status sync, and order lifecycle."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ORDER_STATUSES = (
+    "pending",
+    "submitted",
+    "confirmed",
+    "partially_shipped",
+    "shipped",
+    "delivered",
+    "failed",
+    "cancelled",
+)
+
+MAX_RETRY_COUNT = 3
+
+
+# ---------------------------------------------------------------------------
+# Sage order submission (API-first with Playwright fallback)
+# ---------------------------------------------------------------------------
+
+
+async def submit_order_to_sage(
+    order_lines: list[dict[str, Any]],
+    method: str | None = None,
+) -> dict[str, Any]:
+    """Submit a purchase order to Sage.
+
+    Tries the formal REST API first. If unavailable, falls back to
+    the Playwright portal bridge (reuses Sprint 1.6 infrastructure).
+
+    Returns dict with sage_order_id, confirmation, method used.
+    """
+    use_method = method or _detect_submission_method()
+
+    if use_method == "api":
+        return await _submit_via_api(order_lines)
+    else:
+        return await _submit_via_playwright(order_lines)
+
+
+def _detect_submission_method() -> str:
+    """Detect whether Sage API is available; fall back to Playwright."""
+    if getattr(settings, "SAGE_API_KEY", ""):
+        return "api"
+    return "playwright"
+
+
+async def _submit_via_api(order_lines: list[dict[str, Any]]) -> dict[str, Any]:
+    """Submit order via the Sage REST API (formal integration path)."""
+    import httpx
+
+    sage_api_url = getattr(settings, "SAGE_API_URL", "")
+    sage_api_key = getattr(settings, "SAGE_API_KEY", "")
+
+    payload = {
+        "lines": [
+            {
+                "sku": line.get("sage_sku"),
+                "quantity": line.get("quantity", 1),
+                "unit_price": str(line.get("unit_cost", 0)),
+                "description": line.get("description", ""),
+            }
+            for line in order_lines
+            if line.get("sage_sku")
+        ],
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{sage_api_url}/api/v1/purchase-orders",
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {sage_api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    return {
+        "sage_order_id": data.get("order_id") or data.get("id"),
+        "sage_confirmation": data.get("confirmation_number"),
+        "method": "api",
+        "line_ids": data.get("line_ids", []),
+    }
+
+
+async def _submit_via_playwright(order_lines: list[dict[str, Any]]) -> dict[str, Any]:
+    """Submit order via Playwright portal automation (fallback path).
+
+    Reuses the SagePlaywrightBridge from Sprint 1.6 to navigate
+    the Sage ordering portal and submit a purchase order.
+    """
+    from app.services.sage_playwright import SagePlaywrightBridge
+
+    bridge = SagePlaywrightBridge()
+    try:
+        page = await bridge._get_page()
+        try:
+            portal_url = bridge._portal_url
+
+            # Navigate to order creation page
+            await page.goto(f"{portal_url}/orders/new", timeout=30000)
+            await page.wait_for_selector(
+                'form[action*="order"], .order-form', timeout=15000
+            )
+
+            # Add each line item with a Sage SKU
+            for i, line in enumerate(order_lines):
+                sku = line.get("sage_sku")
+                if not sku:
+                    continue
+
+                qty = line.get("quantity", 1)
+
+                # Fill SKU search
+                sku_input = await page.query_selector(
+                    f'.line-item[data-index="{i}"] input[name*="sku"], '
+                    'input[name*="sku"]:last-of-type'
+                )
+                if sku_input:
+                    await sku_input.fill(sku)
+
+                # Fill quantity
+                qty_input = await page.query_selector(
+                    f'.line-item[data-index="{i}"] input[name*="quantity"], '
+                    'input[name*="quantity"]:last-of-type'
+                )
+                if qty_input:
+                    await qty_input.fill(str(qty))
+
+                # Click add line button if available
+                add_btn = await page.query_selector(
+                    'button.add-line, button[data-action="add-line"]'
+                )
+                if add_btn and i < len(order_lines) - 1:
+                    await add_btn.click()
+                    await page.wait_for_timeout(500)
+
+            # Submit the order
+            submit_btn = await page.query_selector(
+                'button[type="submit"], button.submit-order'
+            )
+            if submit_btn:
+                await submit_btn.click()
+
+            # Wait for confirmation
+            await page.wait_for_selector(
+                ".order-confirmation, .confirmation-number", timeout=30000
+            )
+
+            confirmation_el = await page.query_selector(
+                ".confirmation-number, [data-field='confirmation']"
+            )
+            confirmation = None
+            if confirmation_el:
+                confirmation = (await confirmation_el.text_content() or "").strip()
+
+            order_id_el = await page.query_selector(
+                ".order-id, [data-field='order-id']"
+            )
+            sage_order_id = None
+            if order_id_el:
+                sage_order_id = (await order_id_el.text_content() or "").strip()
+
+            return {
+                "sage_order_id": sage_order_id or f"PW-{uuid.uuid4().hex[:8].upper()}",
+                "sage_confirmation": confirmation,
+                "method": "playwright",
+                "line_ids": [],
+            }
+        finally:
+            await page.close()
+    finally:
+        await bridge.close()
+
+
+# ---------------------------------------------------------------------------
+# Sage status sync
+# ---------------------------------------------------------------------------
+
+
+async def sync_order_status_from_sage(
+    sage_order_id: str,
+) -> dict[str, Any]:
+    """Poll Sage for the current status of an order.
+
+    Returns dict with status, tracking info, and timestamps.
+    """
+    use_method = _detect_submission_method()
+
+    if use_method == "api":
+        return await _sync_status_via_api(sage_order_id)
+    else:
+        return await _sync_status_via_playwright(sage_order_id)
+
+
+async def _sync_status_via_api(sage_order_id: str) -> dict[str, Any]:
+    """Fetch order status from the Sage REST API."""
+    import httpx
+
+    sage_api_url = getattr(settings, "SAGE_API_URL", "")
+    sage_api_key = getattr(settings, "SAGE_API_KEY", "")
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(
+            f"{sage_api_url}/api/v1/purchase-orders/{sage_order_id}",
+            headers={"Authorization": f"Bearer {sage_api_key}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    sage_status = (data.get("status") or "").lower()
+    status_map = {
+        "pending": "submitted",
+        "processing": "confirmed",
+        "confirmed": "confirmed",
+        "partial_ship": "partially_shipped",
+        "shipped": "shipped",
+        "delivered": "delivered",
+        "cancelled": "cancelled",
+    }
+
+    return {
+        "status": status_map.get(sage_status, "submitted"),
+        "sage_confirmation": data.get("confirmation_number"),
+        "tracking_number": data.get("tracking_number"),
+        "estimated_delivery": data.get("estimated_delivery"),
+        "line_statuses": data.get("line_statuses", []),
+    }
+
+
+async def _sync_status_via_playwright(sage_order_id: str) -> dict[str, Any]:
+    """Scrape order status from the Sage portal (fallback)."""
+    from app.services.sage_playwright import SagePlaywrightBridge
+
+    bridge = SagePlaywrightBridge()
+    try:
+        page = await bridge._get_page()
+        try:
+            await page.goto(
+                f"{bridge._portal_url}/orders/{sage_order_id}", timeout=30000
+            )
+            await page.wait_for_selector(
+                ".order-status, [data-field='status']", timeout=15000
+            )
+
+            status_el = await page.query_selector(
+                ".order-status, [data-field='status']"
+            )
+            raw_status = ""
+            if status_el:
+                raw_status = (await status_el.text_content() or "").strip().lower()
+
+            status_map = {
+                "pending": "submitted",
+                "processing": "confirmed",
+                "confirmed": "confirmed",
+                "shipped": "shipped",
+                "delivered": "delivered",
+                "cancelled": "cancelled",
+            }
+
+            confirmation_el = await page.query_selector(
+                ".confirmation-number, [data-field='confirmation']"
+            )
+            confirmation = None
+            if confirmation_el:
+                confirmation = (await confirmation_el.text_content() or "").strip()
+
+            return {
+                "status": status_map.get(raw_status, "submitted"),
+                "sage_confirmation": confirmation,
+                "tracking_number": None,
+                "estimated_delivery": None,
+                "line_statuses": [],
+            }
+        finally:
+            await page.close()
+    finally:
+        await bridge.close()
+
+
+# ---------------------------------------------------------------------------
+# Order creation helpers
+# ---------------------------------------------------------------------------
+
+
+def snapshot_quote_items(quote_items: list[Any]) -> list[dict[str, Any]]:
+    """Create order line item dicts from quote items (point-in-time snapshot)."""
+    return [
+        {
+            "quote_item_id": item.id,
+            "room": item.room,
+            "trade_category": item.trade_category,
+            "description": item.description,
+            "sage_sku": item.sage_sku,
+            "quantity": item.quantity or 1,
+            "unit_cost": item.unit_cost,
+            "labor_cost": item.labor_cost,
+            "markup_pct": item.markup_pct,
+            "subtotal": item.subtotal,
+            "unit_of_measure": item.unit_of_measure,
+        }
+        for item in quote_items
+    ]
+
+
+def calculate_order_total(line_items: list[dict[str, Any]]) -> Decimal:
+    """Sum subtotals from line item dicts."""
+    total = Decimal("0")
+    for item in line_items:
+        subtotal = item.get("subtotal")
+        if subtotal is not None:
+            total += Decimal(str(subtotal))
+    return total.quantize(Decimal("0.01"))

--- a/packages/api/app/services/propstream.py
+++ b/packages/api/app/services/propstream.py
@@ -1,0 +1,139 @@
+"""PropStream API client with rate limiting and retry logic."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+PROPSTREAM_BASE_URL = "https://api.propstream.com/v1"
+MAX_RETRIES = 3
+RETRY_BACKOFF = 1.0  # seconds
+RATE_LIMIT_WINDOW = 60  # seconds
+RATE_LIMIT_MAX_REQUESTS = 100
+
+
+class RateLimiter:
+    """Simple sliding-window rate limiter."""
+
+    def __init__(self, max_requests: int = RATE_LIMIT_MAX_REQUESTS, window: float = RATE_LIMIT_WINDOW):
+        self._max_requests = max_requests
+        self._window = window
+        self._timestamps: list[float] = []
+
+    async def acquire(self) -> None:
+        now = time.monotonic()
+        self._timestamps = [t for t in self._timestamps if now - t < self._window]
+        if len(self._timestamps) >= self._max_requests:
+            sleep_time = self._window - (now - self._timestamps[0])
+            logger.warning("PropStream rate limit reached, sleeping %.1fs", sleep_time)
+            await asyncio.sleep(sleep_time)
+        self._timestamps.append(time.monotonic())
+
+
+_rate_limiter = RateLimiter()
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Make a rate-limited, retrying request to PropStream."""
+    url = f"{PROPSTREAM_BASE_URL}{path}"
+    headers = {
+        "Authorization": f"Bearer {settings.PROPSTREAM_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    last_error: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        await _rate_limiter.acquire()
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.request(
+                    method, url, headers=headers, params=params, json=json_body
+                )
+                if resp.status_code == 429:
+                    wait = RETRY_BACKOFF * (2 ** attempt)
+                    logger.warning("PropStream 429, retrying in %.1fs", wait)
+                    await asyncio.sleep(wait)
+                    continue
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code >= 500:
+                wait = RETRY_BACKOFF * (2 ** attempt)
+                logger.warning("PropStream %d, retrying in %.1fs", exc.response.status_code, wait)
+                await asyncio.sleep(wait)
+                continue
+            raise
+        except httpx.RequestError as exc:
+            last_error = exc
+            wait = RETRY_BACKOFF * (2 ** attempt)
+            logger.warning("PropStream request error: %s, retrying in %.1fs", exc, wait)
+            await asyncio.sleep(wait)
+
+    raise RuntimeError(f"PropStream request failed after {MAX_RETRIES} retries") from last_error
+
+
+async def search_by_address(address: str) -> dict[str, Any]:
+    """Search PropStream for a property by address."""
+    return await _request("GET", "/properties/search", params={"address": address})
+
+
+async def search_by_mls_id(mls_id: str) -> dict[str, Any]:
+    """Search PropStream for a property by MLS ID."""
+    return await _request("GET", "/properties/search", params={"mls_id": mls_id})
+
+
+async def search_by_coordinates(lat: float, lng: float, radius_miles: float = 1.0) -> dict[str, Any]:
+    """Search PropStream for properties near coordinates."""
+    return await _request(
+        "GET",
+        "/properties/search",
+        params={"lat": lat, "lng": lng, "radius": radius_miles},
+    )
+
+
+async def get_property_detail(propstream_id: str) -> dict[str, Any]:
+    """Fetch full property details from PropStream."""
+    return await _request("GET", f"/properties/{propstream_id}")
+
+
+def normalize_propstream_data(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize PropStream response to our property schema fields."""
+    prop = raw.get("property", raw)
+    return {
+        "address": prop.get("address", {}).get("full", ""),
+        "city": prop.get("address", {}).get("city", ""),
+        "state": prop.get("address", {}).get("state", ""),
+        "zip": prop.get("address", {}).get("zip", ""),
+        "county": prop.get("address", {}).get("county"),
+        "lat": prop.get("location", {}).get("lat"),
+        "lng": prop.get("location", {}).get("lng"),
+        "year_built": prop.get("details", {}).get("year_built"),
+        "sqft": prop.get("details", {}).get("sqft"),
+        "lot_sqft": prop.get("details", {}).get("lot_sqft"),
+        "beds": prop.get("details", {}).get("beds"),
+        "baths": prop.get("details", {}).get("baths"),
+        "property_type": prop.get("details", {}).get("property_type"),
+        "propstream_id": str(prop.get("id", "")),
+        "mls_id": prop.get("mls_id"),
+        "listing_price": prop.get("valuation", {}).get("listing_price"),
+        "arv_estimate": prop.get("valuation", {}).get("arv"),
+        "arv_confidence": prop.get("valuation", {}).get("arv_confidence"),
+        "tax_assessment": prop.get("tax", {}).get("assessed_value"),
+        "ownership_history": prop.get("ownership_history"),
+        "data_source": "propstream",
+    }

--- a/packages/api/app/services/quote_service.py
+++ b/packages/api/app/services/quote_service.py
@@ -1,0 +1,394 @@
+"""Quote builder service — AI generation, totals calculation, and PDF SOW."""
+
+from __future__ import annotations
+
+import io
+import logging
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PLATFORM_FEE_DEFAULT = Decimal("0.05")  # 5%
+
+# Labor cost estimates per trade category ($/hr baseline)
+TRADE_LABOR_RATES: dict[str, int] = {
+    "plumbing": 95,
+    "electrical": 90,
+    "flooring": 70,
+    "painting": 55,
+    "roofing": 85,
+    "hvac": 100,
+    "general": 60,
+    "carpentry": 75,
+    "drywall": 65,
+    "demolition": 50,
+    "tile": 75,
+    "cabinets": 80,
+    "countertops": 70,
+    "windows": 85,
+    "insulation": 60,
+}
+
+# Map renovation_needed → estimated hours per room
+RENOVATION_HOURS: dict[str, float] = {
+    "none": 0,
+    "cosmetic": 4,
+    "moderate": 16,
+    "major": 40,
+    "full_gut": 80,
+}
+
+# Map room_type + condition → suggested trade categories
+ROOM_TRADE_MAP: dict[str, list[str]] = {
+    "kitchen": ["cabinets", "countertops", "plumbing", "electrical", "flooring", "painting"],
+    "bathroom": ["plumbing", "tile", "painting", "electrical"],
+    "bedroom": ["painting", "flooring", "electrical"],
+    "living_room": ["painting", "flooring", "electrical"],
+    "basement": ["general", "drywall", "flooring", "plumbing", "electrical"],
+    "exterior": ["roofing", "painting", "windows", "insulation"],
+    "garage": ["general", "electrical"],
+    "attic": ["insulation", "drywall", "electrical"],
+    "hallway": ["painting", "flooring"],
+    "dining_room": ["painting", "flooring"],
+    "laundry": ["plumbing", "electrical", "flooring"],
+    "yard": ["general"],
+    "roof": ["roofing"],
+    "other": ["general"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Totals calculation
+# ---------------------------------------------------------------------------
+
+
+def calculate_item_subtotal(
+    quantity: int,
+    unit_cost: Decimal,
+    labor_cost: Decimal,
+    markup_pct: Decimal | None,
+) -> Decimal:
+    """Calculate line item subtotal: (quantity * unit_cost + labor_cost) * (1 + markup)."""
+    material = Decimal(quantity) * unit_cost
+    markup = Decimal("1") + (markup_pct or Decimal("0")) / Decimal("100")
+    return (material + labor_cost) * markup
+
+
+def calculate_quote_totals(
+    items: list[dict[str, Any]],
+    platform_fee_pct: Decimal | None = None,
+) -> dict[str, Decimal]:
+    """Compute totals from a list of item dicts.
+
+    Returns dict with total_material, total_labor, platform_fee, grand_total.
+    """
+    total_material = Decimal("0")
+    total_labor = Decimal("0")
+
+    for item in items:
+        qty = item.get("quantity", 1) or 1
+        uc = Decimal(str(item.get("unit_cost", 0) or 0))
+        lc = Decimal(str(item.get("labor_cost", 0) or 0))
+        markup = Decimal(str(item.get("markup_pct", 0) or 0))
+        markup_mult = Decimal("1") + markup / Decimal("100")
+
+        total_material += Decimal(qty) * uc * markup_mult
+        total_labor += lc * markup_mult
+
+    subtotal = total_material + total_labor
+    fee_pct = platform_fee_pct if platform_fee_pct is not None else PLATFORM_FEE_DEFAULT
+    platform_fee = subtotal * fee_pct
+    grand_total = subtotal + platform_fee
+
+    return {
+        "total_material": total_material.quantize(Decimal("0.01")),
+        "total_labor": total_labor.quantize(Decimal("0.01")),
+        "platform_fee": platform_fee.quantize(Decimal("0.01")),
+        "grand_total": grand_total.quantize(Decimal("0.01")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# AI quote generation
+# ---------------------------------------------------------------------------
+
+
+def generate_ai_line_items(
+    labels: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Generate quote line items from photo analysis labels.
+
+    Each label represents a room photo with room_type, condition,
+    damage_issues, renovation_needed, and confidence.
+    """
+    items: list[dict[str, Any]] = []
+    seen_rooms: dict[str, int] = {}
+
+    for label in labels:
+        room_type = label.get("room_type") or "other"
+        renovation = label.get("renovation_needed") or "none"
+        condition = label.get("condition") or "fair"
+        confidence = label.get("confidence", 0.5)
+        damage_issues = label.get("damage_issues") or []
+
+        if renovation == "none":
+            continue
+
+        # Track room count for numbering
+        seen_rooms[room_type] = seen_rooms.get(room_type, 0) + 1
+        room_label = (
+            f"{room_type.replace('_', ' ').title()} {seen_rooms[room_type]}"
+            if seen_rooms[room_type] > 1
+            else room_type.replace("_", " ").title()
+        )
+
+        trades = ROOM_TRADE_MAP.get(room_type, ["general"])
+        hours = RENOVATION_HOURS.get(renovation, 8)
+
+        # Generate one item per relevant trade
+        for trade in trades:
+            rate = TRADE_LABOR_RATES.get(trade, 60)
+            labor_hours = hours / len(trades)
+            labor_cost = Decimal(str(round(rate * labor_hours, 2)))
+
+            # Estimate material cost based on renovation level
+            material_mult = {"cosmetic": 0.3, "moderate": 0.6, "major": 1.0, "full_gut": 1.5}
+            unit_cost = Decimal(str(round(rate * material_mult.get(renovation, 0.5) * 2, 2)))
+
+            desc_parts = [f"{trade.title()} — {renovation} renovation"]
+            if damage_issues:
+                desc_parts.append(f"Issues: {', '.join(damage_issues[:3])}")
+
+            items.append({
+                "room": room_label,
+                "trade_category": trade,
+                "description": "; ".join(desc_parts),
+                "sage_sku": None,
+                "quantity": 1,
+                "unit_cost": unit_cost,
+                "labor_cost": labor_cost,
+                "markup_pct": None,
+                "unit_of_measure": "job",
+                "ai_confidence": round(confidence, 3),
+                "is_ai_generated": True,
+            })
+
+    return items
+
+
+# ---------------------------------------------------------------------------
+# PDF SOW generation
+# ---------------------------------------------------------------------------
+
+
+def generate_sow_pdf(
+    quote: dict[str, Any],
+    items: list[dict[str, Any]],
+    property_info: dict[str, Any] | None = None,
+) -> bytes:
+    """Generate a professional PDF Scope of Work from quote data.
+
+    Returns the PDF bytes.
+    """
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=letter,
+        leftMargin=0.75 * inch,
+        rightMargin=0.75 * inch,
+        topMargin=0.75 * inch,
+        bottomMargin=0.75 * inch,
+    )
+
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        "SOWTitle",
+        parent=styles["Title"],
+        fontSize=20,
+        spaceAfter=12,
+        textColor=colors.HexColor("#1a365d"),
+    )
+    heading_style = ParagraphStyle(
+        "SOWHeading",
+        parent=styles["Heading2"],
+        fontSize=14,
+        spaceBefore=16,
+        spaceAfter=8,
+        textColor=colors.HexColor("#2d3748"),
+    )
+    body_style = styles["Normal"]
+    body_style.fontSize = 10
+    body_style.leading = 14
+
+    elements: list[Any] = []
+
+    # Title
+    elements.append(Paragraph("Scope of Work", title_style))
+    elements.append(Spacer(1, 4))
+
+    # Property details
+    if property_info:
+        elements.append(Paragraph("Property Details", heading_style))
+        addr = property_info.get("address", "N/A")
+        city = property_info.get("city", "")
+        state = property_info.get("state", "")
+        zip_code = property_info.get("zip", "")
+        full_addr = f"{addr}, {city}, {state} {zip_code}".strip(", ")
+        details = [
+            f"<b>Address:</b> {full_addr}",
+            f"<b>Property Type:</b> {property_info.get('property_type', 'N/A')}",
+            f"<b>Sq Ft:</b> {property_info.get('sqft', 'N/A')}",
+            f"<b>Beds/Baths:</b> {property_info.get('beds', 'N/A')} / {property_info.get('baths', 'N/A')}",
+        ]
+        for d in details:
+            elements.append(Paragraph(d, body_style))
+        elements.append(Spacer(1, 8))
+
+    # Quote metadata
+    elements.append(Paragraph("Quote Information", heading_style))
+    quote_date = quote.get("created_at", "")
+    if isinstance(quote_date, datetime):
+        quote_date = quote_date.strftime("%B %d, %Y")
+    elements.append(Paragraph(f"<b>Quote ID:</b> {quote.get('id', 'N/A')}", body_style))
+    elements.append(Paragraph(f"<b>Date:</b> {quote_date}", body_style))
+    elements.append(Paragraph(f"<b>Status:</b> {quote.get('status', 'draft').title()}", body_style))
+    if quote.get("notes"):
+        elements.append(Paragraph(f"<b>Notes:</b> {quote['notes']}", body_style))
+    elements.append(Spacer(1, 12))
+
+    # Line items table
+    elements.append(Paragraph("Line Items", heading_style))
+
+    table_data = [["Room", "Trade", "Description", "Qty", "Unit Cost", "Labor", "Subtotal"]]
+    for item in items:
+        qty = item.get("quantity", 1) or 1
+        uc = Decimal(str(item.get("unit_cost", 0) or 0))
+        lc = Decimal(str(item.get("labor_cost", 0) or 0))
+        markup = Decimal(str(item.get("markup_pct", 0) or 0))
+        sub = calculate_item_subtotal(qty, uc, lc, markup if markup else None)
+
+        desc = item.get("description", "") or ""
+        if len(desc) > 50:
+            desc = desc[:47] + "..."
+
+        table_data.append([
+            item.get("room", "") or "",
+            item.get("trade_category", "") or "",
+            desc,
+            str(qty),
+            f"${uc:,.2f}",
+            f"${lc:,.2f}",
+            f"${sub:,.2f}",
+        ])
+
+    col_widths = [1.0 * inch, 0.9 * inch, 2.0 * inch, 0.5 * inch, 0.8 * inch, 0.8 * inch, 0.9 * inch]
+    t = Table(table_data, colWidths=col_widths, repeatRows=1)
+    t.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#2d3748")),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTSIZE", (0, 0), (-1, 0), 9),
+        ("FONTSIZE", (0, 1), (-1, -1), 8),
+        ("ALIGN", (3, 0), (-1, -1), "RIGHT"),
+        ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cbd5e0")),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f7fafc")]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    elements.append(t)
+    elements.append(Spacer(1, 16))
+
+    # Totals
+    elements.append(Paragraph("Summary", heading_style))
+    total_material = quote.get("total_material") or Decimal("0")
+    total_labor = quote.get("total_labor") or Decimal("0")
+    platform_fee = quote.get("platform_fee") or Decimal("0")
+    fee_pct = quote.get("platform_fee_pct") or PLATFORM_FEE_DEFAULT
+    grand_total = quote.get("grand_total") or Decimal("0")
+
+    summary_data = [
+        ["Materials", f"${Decimal(str(total_material)):,.2f}"],
+        ["Labor", f"${Decimal(str(total_labor)):,.2f}"],
+        [f"Platform Fee ({Decimal(str(fee_pct)) * 100:.1f}%)", f"${Decimal(str(platform_fee)):,.2f}"],
+        ["Grand Total", f"${Decimal(str(grand_total)):,.2f}"],
+    ]
+    summary_table = Table(summary_data, colWidths=[4.0 * inch, 1.5 * inch])
+    summary_table.setStyle(TableStyle([
+        ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+        ("FONTSIZE", (0, 0), (-1, -1), 10),
+        ("LINEABOVE", (0, -1), (-1, -1), 1.5, colors.HexColor("#2d3748")),
+        ("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold"),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    elements.append(summary_table)
+    elements.append(Spacer(1, 24))
+
+    # Footer
+    elements.append(Paragraph(
+        "<i>This Scope of Work was generated by the GCP Renovation Platform. "
+        "All pricing is estimated and subject to final site inspection.</i>",
+        ParagraphStyle("Footer", parent=body_style, fontSize=8, textColor=colors.grey),
+    ))
+
+    doc.build(elements)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# S3 upload helper
+# ---------------------------------------------------------------------------
+
+
+async def upload_sow_to_s3(pdf_bytes: bytes, quote_id: str) -> str:
+    """Upload SOW PDF to S3 and return the key."""
+    import boto3
+
+    s3_key = f"sow/{quote_id}/{uuid.uuid4().hex}.pdf"
+
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=settings.AWS_ACCESS_KEY,
+        aws_secret_access_key=settings.AWS_SECRET_KEY,
+    )
+    s3.put_object(
+        Bucket=settings.S3_BUCKET,
+        Key=s3_key,
+        Body=pdf_bytes,
+        ContentType="application/pdf",
+    )
+
+    return s3_key
+
+
+async def download_sow_from_s3(s3_key: str) -> bytes:
+    """Download SOW PDF bytes from S3."""
+    import boto3
+
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=settings.AWS_ACCESS_KEY,
+        aws_secret_access_key=settings.AWS_SECRET_KEY,
+    )
+    resp = s3.get_object(Bucket=settings.S3_BUCKET, Key=s3_key)
+    return resp["Body"].read()

--- a/packages/api/app/services/rentcast.py
+++ b/packages/api/app/services/rentcast.py
@@ -1,0 +1,158 @@
+"""Rentcast API client for rental comp data and estimates."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import date
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+RENTCAST_BASE_URL = "https://api.rentcast.io/v1"
+MAX_RETRIES = 3
+RETRY_BACKOFF = 1.0
+RATE_LIMIT_WINDOW = 60
+RATE_LIMIT_MAX_REQUESTS = 50  # Rentcast free tier is lower
+
+
+class _RateLimiter:
+    """Sliding-window rate limiter for Rentcast."""
+
+    def __init__(self, max_requests: int = RATE_LIMIT_MAX_REQUESTS, window: float = RATE_LIMIT_WINDOW):
+        self._max_requests = max_requests
+        self._window = window
+        self._timestamps: list[float] = []
+
+    async def acquire(self) -> None:
+        now = time.monotonic()
+        self._timestamps = [t for t in self._timestamps if now - t < self._window]
+        if len(self._timestamps) >= self._max_requests:
+            sleep_time = self._window - (now - self._timestamps[0])
+            logger.warning("Rentcast rate limit reached, sleeping %.1fs", sleep_time)
+            await asyncio.sleep(sleep_time)
+        self._timestamps.append(time.monotonic())
+
+
+_rate_limiter = _RateLimiter()
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Make a rate-limited, retrying request to Rentcast."""
+    url = f"{RENTCAST_BASE_URL}{path}"
+    headers = {
+        "X-Api-Key": settings.RENTCAST_API_KEY,
+        "Accept": "application/json",
+    }
+
+    last_error: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        await _rate_limiter.acquire()
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.request(method, url, headers=headers, params=params)
+                if resp.status_code == 429:
+                    wait = RETRY_BACKOFF * (2 ** attempt)
+                    logger.warning("Rentcast 429, retrying in %.1fs", wait)
+                    await asyncio.sleep(wait)
+                    continue
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code >= 500:
+                wait = RETRY_BACKOFF * (2 ** attempt)
+                logger.warning("Rentcast %d, retrying in %.1fs", exc.response.status_code, wait)
+                await asyncio.sleep(wait)
+                continue
+            raise
+        except httpx.RequestError as exc:
+            last_error = exc
+            wait = RETRY_BACKOFF * (2 ** attempt)
+            logger.warning("Rentcast request error: %s, retrying in %.1fs", exc, wait)
+            await asyncio.sleep(wait)
+
+    raise RuntimeError(f"Rentcast request failed after {MAX_RETRIES} retries") from last_error
+
+
+async def get_rental_comps_by_address(address: str) -> dict[str, Any]:
+    """Fetch rental comps and estimate for an address."""
+    return await _request("GET", "/avm/rent/long-term", params={"address": address})
+
+
+async def get_rental_comps_by_coordinates(lat: float, lng: float) -> dict[str, Any]:
+    """Fetch rental comps and estimate for coordinates."""
+    return await _request(
+        "GET",
+        "/avm/rent/long-term",
+        params={"latitude": lat, "longitude": lng},
+    )
+
+
+def normalize_rental_comps(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Rentcast response to our schema.
+
+    Returns dict with:
+      - rent_estimate_low / mid / high
+      - comps: list of normalized rental comp dicts
+    """
+    # Extract rent estimate
+    rent_low = raw.get("rentRangeLow") or raw.get("rent_range_low")
+    rent_high = raw.get("rentRangeHigh") or raw.get("rent_range_high")
+    rent_mid = raw.get("rent") or raw.get("rentEstimate")
+
+    if rent_low and rent_high and not rent_mid:
+        rent_mid = (rent_low + rent_high) / 2.0
+
+    # Extract comps list
+    raw_comps = raw.get("comparables", raw.get("comps", []))
+    comps: list[dict[str, Any]] = []
+
+    for rc in raw_comps:
+        comp = {
+            "address": rc.get("formattedAddress", rc.get("address", "")),
+            "city": rc.get("city"),
+            "state": rc.get("state"),
+            "zip": rc.get("zipCode", rc.get("zip")),
+            "lat": rc.get("latitude", rc.get("lat")),
+            "lng": rc.get("longitude", rc.get("lng")),
+            "rent_price": rc.get("price", rc.get("rent")),
+            "sqft": rc.get("squareFootage", rc.get("sqft")),
+            "beds": rc.get("bedrooms", rc.get("beds")),
+            "baths": rc.get("bathrooms", rc.get("baths")),
+            "property_type": rc.get("propertyType", rc.get("property_type")),
+            "distance": rc.get("distance"),
+            "correlation": rc.get("correlation"),
+            "source": "rentcast",
+            "last_seen_date": _parse_date(rc.get("lastSeenDate", rc.get("last_seen_date"))),
+        }
+        comps.append(comp)
+
+    return {
+        "rent_estimate_low": rent_low,
+        "rent_estimate_mid": rent_mid,
+        "rent_estimate_high": rent_high,
+        "comps": comps,
+    }
+
+
+def _parse_date(val: Any) -> date | None:
+    """Parse a date string to date object, or return None."""
+    if val is None:
+        return None
+    if isinstance(val, date):
+        return val
+    try:
+        return date.fromisoformat(str(val)[:10])
+    except (ValueError, TypeError):
+        return None

--- a/packages/api/app/services/risk_flags.py
+++ b/packages/api/app/services/risk_flags.py
@@ -1,0 +1,82 @@
+"""Year-based risk flag evaluation service."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Configurable thresholds: (max_year, flag_type, severity, detail)
+# Properties built BEFORE the threshold year trigger the flag.
+RISK_YEAR_THRESHOLDS: list[dict[str, Any]] = [
+    {
+        "max_year": 1965,
+        "flag_type": "knob_and_tube_wiring",
+        "severity": "high",
+        "detail": "Property built before 1965 — risk of knob-and-tube wiring. "
+        "May require full rewire before insurable.",
+    },
+    {
+        "max_year": 1978,
+        "flag_type": "lead_paint",
+        "severity": "high",
+        "detail": "Property built before 1978 — federal lead paint disclosure required. "
+        "Expect abatement or encapsulation costs.",
+    },
+    {
+        "max_year": 1985,
+        "flag_type": "asbestos",
+        "severity": "high",
+        "detail": "Property built before 1985 — asbestos risk in insulation, tiles, "
+        "or popcorn ceilings. Professional abatement may be needed.",
+    },
+    {
+        "max_year": 1994,
+        "flag_type": "polybutylene_plumbing",
+        "severity": "medium",
+        "detail": "Property built before 1994 — risk of polybutylene plumbing. "
+        "Known for premature failure; re-pipe may be required.",
+    },
+    {
+        "max_year": 2000,
+        "flag_type": "cast_iron_drains",
+        "severity": "medium",
+        "detail": "Property built before 2000 — cast iron drain lines may be corroded. "
+        "Scope camera inspection during due diligence.",
+    },
+]
+
+
+def evaluate_year_flags(year_built: int | None) -> list[dict[str, Any]]:
+    """Evaluate year-based risk flags for a property.
+
+    Returns a list of risk flag dicts ready for persistence.
+    If year_built is None, returns a single unknown-year advisory flag.
+    """
+    if year_built is None:
+        return [
+            {
+                "flag_type": "unknown_year",
+                "severity": "low",
+                "detail": "Construction year unknown — unable to evaluate "
+                "age-related risk factors. Verify year_built.",
+                "source": "year_built",
+            }
+        ]
+
+    flags: list[dict[str, Any]] = []
+    for threshold in RISK_YEAR_THRESHOLDS:
+        if year_built < threshold["max_year"]:
+            flags.append(
+                {
+                    "flag_type": threshold["flag_type"],
+                    "severity": threshold["severity"],
+                    "detail": threshold["detail"],
+                    "source": "year_built",
+                }
+            )
+
+    return flags

--- a/packages/api/app/services/sage_playwright.py
+++ b/packages/api/app/services/sage_playwright.py
@@ -1,0 +1,375 @@
+"""Sage portal headless automation via Playwright.
+
+30-day interim bridge until Sage grants direct API access.
+Designed for easy replacement — all portal interaction is isolated here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+
+# ---------------------------------------------------------------------------
+# Configuration (env vars)
+# ---------------------------------------------------------------------------
+
+SAGE_PORTAL_URL = os.getenv("SAGE_PORTAL_URL", "https://sage.example.com")
+SAGE_USERNAME = os.getenv("SAGE_USERNAME", "")
+SAGE_PASSWORD = os.getenv("SAGE_PASSWORD", "")
+
+# ---------------------------------------------------------------------------
+# CSS Selectors — update these when the Sage portal changes
+# TODO: Replace with real selectors once portal access is confirmed
+# ---------------------------------------------------------------------------
+
+SEL_LOGIN_USERNAME = 'input[name="username"]'
+SEL_LOGIN_PASSWORD = 'input[name="password"]'
+SEL_LOGIN_SUBMIT = 'button[type="submit"]'
+SEL_LOGIN_SUCCESS = ".dashboard, .user-menu"
+
+SEL_SEARCH_INPUT = 'input[name="q"], input[type="search"]'
+SEL_SEARCH_SUBMIT = 'button[type="submit"]'
+SEL_SEARCH_RESULTS = ".product-list .product-item"
+
+SEL_PRODUCT_NAME = ".product-name, h1.product-title"
+SEL_PRODUCT_SKU = ".product-sku, [data-field='sku']"
+SEL_PRODUCT_PRICE = ".product-price, [data-field='price']"
+SEL_PRODUCT_DESCRIPTION = ".product-description, [data-field='description']"
+SEL_PRODUCT_AVAILABILITY = ".product-availability, [data-field='availability']"
+SEL_PRODUCT_CATEGORY = ".product-category, [data-field='category']"
+SEL_PRODUCT_BRAND = ".product-brand, [data-field='brand']"
+SEL_PRODUCT_DIMENSIONS = ".product-dimensions, [data-field='dimensions']"
+SEL_PRODUCT_IMAGE = ".product-image img, [data-field='image'] img"
+
+SEL_CATEGORY_NAV = ".category-nav a, .category-list a"
+SEL_PAGINATION_NEXT = "a.next, button.next-page"
+
+# ---------------------------------------------------------------------------
+# Custom Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SageAuthError(Exception):
+    """Raised when login to Sage portal fails."""
+
+
+class SageTimeoutError(Exception):
+    """Raised when a Sage portal request times out."""
+
+
+class SageParsingError(Exception):
+    """Raised when a CSS selector fails to match expected elements."""
+
+    def __init__(self, selector: str, message: str = ""):
+        self.selector = selector
+        super().__init__(f"Selector '{selector}' failed to match: {message}" if message else f"Selector '{selector}' failed to match")
+
+
+class SageUnavailableError(Exception):
+    """Raised when the circuit breaker is open."""
+
+
+# ---------------------------------------------------------------------------
+# Rate Limiter
+# ---------------------------------------------------------------------------
+
+
+class RateLimiter:
+    """Token-bucket rate limiter: max 1 request per `interval` seconds."""
+
+    def __init__(self, interval: float = 2.0) -> None:
+        self._interval = interval
+        self._last_request: float = 0.0
+
+    async def acquire(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self._last_request
+        if elapsed < self._interval:
+            await asyncio.sleep(self._interval - elapsed)
+        self._last_request = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Circuit Breaker
+# ---------------------------------------------------------------------------
+
+
+class CircuitBreaker:
+    """Three-state circuit breaker: closed → open → half-open → closed."""
+
+    def __init__(self, failure_threshold: int = 5, recovery_timeout: float = 60.0) -> None:
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout
+        self._consecutive_failures = 0
+        self._opened_at: float | None = None
+        self._half_open = False
+
+    @property
+    def is_open(self) -> bool:
+        if self._opened_at is None:
+            return False
+        elapsed = time.monotonic() - self._opened_at
+        if elapsed >= self._recovery_timeout:
+            self._half_open = True
+            return False
+        return True
+
+    @property
+    def is_half_open(self) -> bool:
+        return self._half_open
+
+    def record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._opened_at = None
+        self._half_open = False
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+        self._half_open = False
+        if self._consecutive_failures >= self._failure_threshold:
+            self._opened_at = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Sage Playwright Bridge
+# ---------------------------------------------------------------------------
+
+
+class SagePlaywrightBridge:
+    """Headless Playwright automation against the Sage web portal."""
+
+    def __init__(
+        self,
+        portal_url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        rate_limit_interval: float = 2.0,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 60.0,
+    ) -> None:
+        self._portal_url = portal_url or SAGE_PORTAL_URL
+        self._username = username or SAGE_USERNAME
+        self._password = password or SAGE_PASSWORD
+        self._rate_limiter = RateLimiter(interval=rate_limit_interval)
+        self._circuit_breaker = CircuitBreaker(
+            failure_threshold=failure_threshold,
+            recovery_timeout=recovery_timeout,
+        )
+        self._playwright: Any = None
+        self._browser: Browser | None = None
+        self._context: BrowserContext | None = None
+        self._logged_in = False
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def _ensure_browser(self) -> BrowserContext:
+        """Lazy browser launch — reuse across requests."""
+        if self._context is not None:
+            return self._context
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=True)
+        self._context = await self._browser.new_context()
+        return self._context
+
+    async def _login(self, page: Page) -> None:
+        """Authenticate with the Sage portal."""
+        await page.goto(f"{self._portal_url}/login", timeout=30000)
+        await page.fill(SEL_LOGIN_USERNAME, self._username)
+        await page.fill(SEL_LOGIN_PASSWORD, self._password)
+        await page.click(SEL_LOGIN_SUBMIT)
+        try:
+            await page.wait_for_selector(SEL_LOGIN_SUCCESS, timeout=15000)
+        except Exception as exc:
+            raise SageAuthError(f"Login failed for user '{self._username}'") from exc
+        self._logged_in = True
+
+    async def _get_page(self) -> Page:
+        """Get a logged-in page, creating one if needed."""
+        ctx = await self._ensure_browser()
+        page = await ctx.new_page()
+        if not self._logged_in:
+            await self._login(page)
+        return page
+
+    async def close(self) -> None:
+        """Shut down browser resources."""
+        if self._context:
+            await self._context.close()
+            self._context = None
+        if self._browser:
+            await self._browser.close()
+            self._browser = None
+        if self._playwright:
+            await self._playwright.stop()
+            self._playwright = None
+        self._logged_in = False
+
+    # -- guard ---------------------------------------------------------------
+
+    async def _guarded_call(self, coro_factory):
+        """Rate-limit + circuit-breaker wrapper."""
+        if self._circuit_breaker.is_open:
+            raise SageUnavailableError("Circuit breaker is open — Sage portal appears down")
+
+        await self._rate_limiter.acquire()
+        try:
+            result = await coro_factory()
+            self._circuit_breaker.record_success()
+            return result
+        except (SageAuthError, SageParsingError):
+            self._circuit_breaker.record_failure()
+            raise
+        except Exception as exc:
+            self._circuit_breaker.record_failure()
+            raise SageTimeoutError(str(exc)) from exc
+
+    # -- helpers -------------------------------------------------------------
+
+    @staticmethod
+    async def _safe_text(page: Page, selector: str) -> str | None:
+        """Extract text from a selector, return None if not found."""
+        el = await page.query_selector(selector)
+        if el is None:
+            return None
+        return (await el.text_content() or "").strip()
+
+    @staticmethod
+    async def _safe_attr(page: Page, selector: str, attr: str) -> str | None:
+        """Extract an attribute from a selector, return None if not found."""
+        el = await page.query_selector(selector)
+        if el is None:
+            return None
+        return await el.get_attribute(attr)
+
+    async def _parse_product_from_page(self, page: Page) -> dict[str, Any]:
+        """Extract structured product data from a product detail page."""
+        name = await self._safe_text(page, SEL_PRODUCT_NAME)
+        if name is None:
+            raise SageParsingError(SEL_PRODUCT_NAME, "Could not find product name on detail page")
+
+        price_text = await self._safe_text(page, SEL_PRODUCT_PRICE)
+        price_cents: int | None = None
+        if price_text:
+            cleaned = price_text.replace("$", "").replace(",", "").strip()
+            try:
+                price_cents = int(round(float(cleaned) * 100))
+            except ValueError:
+                price_cents = None
+
+        dimensions_text = await self._safe_text(page, SEL_PRODUCT_DIMENSIONS)
+        dimensions: dict[str, Any] | None = None
+        if dimensions_text:
+            dimensions = {"raw": dimensions_text}
+
+        return {
+            "name": name,
+            "sku": await self._safe_text(page, SEL_PRODUCT_SKU),
+            "price_cents": price_cents,
+            "description": await self._safe_text(page, SEL_PRODUCT_DESCRIPTION),
+            "availability": await self._safe_text(page, SEL_PRODUCT_AVAILABILITY),
+            "category": await self._safe_text(page, SEL_PRODUCT_CATEGORY),
+            "brand": await self._safe_text(page, SEL_PRODUCT_BRAND),
+            "dimensions": dimensions,
+            "image_url": await self._safe_attr(page, SEL_PRODUCT_IMAGE, "src"),
+        }
+
+    async def _parse_product_card(self, card) -> dict[str, Any]:
+        """Extract summary data from a search result card element."""
+        name_el = await card.query_selector(SEL_PRODUCT_NAME)
+        name = (await name_el.text_content() or "").strip() if name_el else "Unknown"
+
+        sku_el = await card.query_selector(SEL_PRODUCT_SKU)
+        sku = (await sku_el.text_content() or "").strip() if sku_el else None
+
+        price_el = await card.query_selector(SEL_PRODUCT_PRICE)
+        price_text = (await price_el.text_content() or "").strip() if price_el else None
+        price_cents: int | None = None
+        if price_text:
+            cleaned = price_text.replace("$", "").replace(",", "").strip()
+            try:
+                price_cents = int(round(float(cleaned) * 100))
+            except ValueError:
+                price_cents = None
+
+        link_el = await card.query_selector("a")
+        product_id = None
+        if link_el:
+            href = await link_el.get_attribute("href")
+            if href:
+                product_id = href.rstrip("/").split("/")[-1]
+
+        return {
+            "name": name,
+            "sku": sku,
+            "price_cents": price_cents,
+            "product_id": product_id,
+        }
+
+    # -- public API ----------------------------------------------------------
+
+    async def search_products(
+        self, query: str, category: str | None = None, page: int = 1
+    ) -> list[dict[str, Any]]:
+        """Search the Sage catalog and return structured product data."""
+
+        async def _do_search() -> list[dict[str, Any]]:
+            p = await self._get_page()
+            try:
+                url = f"{self._portal_url}/products/search?q={query}&page={page}"
+                if category:
+                    url += f"&category={category}"
+                await p.goto(url, timeout=30000)
+
+                await p.wait_for_selector(SEL_SEARCH_RESULTS, timeout=15000)
+                cards = await p.query_selector_all(SEL_SEARCH_RESULTS)
+                results = []
+                for card in cards:
+                    results.append(await self._parse_product_card(card))
+                return results
+            finally:
+                await p.close()
+
+        return await self._guarded_call(_do_search)
+
+    async def get_product_detail(self, product_id: str) -> dict[str, Any]:
+        """Fetch full detail for a single product."""
+
+        async def _do_detail() -> dict[str, Any]:
+            p = await self._get_page()
+            try:
+                await p.goto(
+                    f"{self._portal_url}/products/{product_id}", timeout=30000
+                )
+                await p.wait_for_selector(SEL_PRODUCT_NAME, timeout=15000)
+                return await self._parse_product_from_page(p)
+            finally:
+                await p.close()
+
+        return await self._guarded_call(_do_detail)
+
+    async def browse_category(
+        self, category_id: str, page: int = 1
+    ) -> list[dict[str, Any]]:
+        """Browse products within a specific category."""
+
+        async def _do_browse() -> list[dict[str, Any]]:
+            p = await self._get_page()
+            try:
+                await p.goto(
+                    f"{self._portal_url}/categories/{category_id}?page={page}",
+                    timeout=30000,
+                )
+                await p.wait_for_selector(SEL_SEARCH_RESULTS, timeout=15000)
+                cards = await p.query_selector_all(SEL_SEARCH_RESULTS)
+                results = []
+                for card in cards:
+                    results.append(await self._parse_product_card(card))
+                return results
+            finally:
+                await p.close()
+
+        return await self._guarded_call(_do_browse)

--- a/packages/api/app/services/sold_comps.py
+++ b/packages/api/app/services/sold_comps.py
@@ -1,0 +1,253 @@
+"""Sold comps service — queries PropStream for comparable sold properties."""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import date, timedelta
+from typing import Any
+
+from app.services import propstream
+
+logger = logging.getLogger(__name__)
+
+# Haversine earth radius in miles
+_EARTH_RADIUS_MI = 3958.8
+
+
+def _haversine(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """Return distance in miles between two lat/lng points."""
+    r = math.radians
+    dlat = r(lat2 - lat1)
+    dlng = r(lng2 - lng1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(r(lat1)) * math.cos(r(lat2)) * math.sin(dlng / 2) ** 2
+    return _EARTH_RADIUS_MI * 2 * math.asin(math.sqrt(a))
+
+
+def _similarity_score(
+    subject: dict[str, Any],
+    comp: dict[str, Any],
+    distance_mi: float,
+    months_old: float,
+) -> float:
+    """Compute 0-1 similarity score based on distance, recency, and attributes.
+
+    Weights:
+      distance   30 %
+      recency    25 %
+      sqft       20 %
+      bed/bath   15 %
+      year_built 10 %
+    """
+    # Distance score (0 = far, 1 = same location)
+    dist_score = max(0.0, 1.0 - distance_mi / 5.0)
+
+    # Recency score (0 = old, 1 = today)
+    recency_score = max(0.0, 1.0 - months_old / 12.0)
+
+    # Sqft similarity (+/- 20% band)
+    s_sqft = subject.get("sqft") or 0
+    c_sqft = comp.get("sqft") or 0
+    if s_sqft > 0 and c_sqft > 0:
+        ratio = min(s_sqft, c_sqft) / max(s_sqft, c_sqft)
+        sqft_score = ratio
+    else:
+        sqft_score = 0.5  # neutral when unknown
+
+    # Bed/bath similarity
+    bed_diff = abs((subject.get("beds") or 0) - (comp.get("beds") or 0))
+    bath_diff = abs((subject.get("baths") or 0) - (comp.get("baths") or 0))
+    bedbath_score = max(0.0, 1.0 - (bed_diff + bath_diff) / 4.0)
+
+    # Year built similarity (+/- 10 years)
+    s_year = subject.get("year_built") or 0
+    c_year = comp.get("year_built") or 0
+    if s_year > 0 and c_year > 0:
+        year_diff = abs(s_year - c_year)
+        year_score = max(0.0, 1.0 - year_diff / 20.0)
+    else:
+        year_score = 0.5
+
+    return (
+        0.30 * dist_score
+        + 0.25 * recency_score
+        + 0.20 * sqft_score
+        + 0.15 * bedbath_score
+        + 0.10 * year_score
+    )
+
+
+def _passes_filter(
+    comp: dict[str, Any],
+    subject: dict[str, Any],
+    *,
+    property_type: str | None = None,
+    min_beds: int | None = None,
+    max_beds: int | None = None,
+    min_baths: float | None = None,
+    max_baths: float | None = None,
+    min_sqft: int | None = None,
+    max_sqft: int | None = None,
+    min_year_built: int | None = None,
+    max_year_built: int | None = None,
+) -> bool:
+    """Apply configurable filters; defaults are subject ± tolerance."""
+    # Property type
+    ptype = property_type or subject.get("property_type")
+    if ptype and comp.get("property_type") and comp["property_type"].lower() != ptype.lower():
+        return False
+
+    # Beds: default ±1 from subject
+    s_beds = subject.get("beds")
+    c_beds = comp.get("beds")
+    if c_beds is not None and s_beds is not None:
+        lo = min_beds if min_beds is not None else max(0, s_beds - 1)
+        hi = max_beds if max_beds is not None else s_beds + 1
+        if not (lo <= c_beds <= hi):
+            return False
+
+    # Baths: default ±1 from subject
+    s_baths = subject.get("baths")
+    c_baths = comp.get("baths")
+    if c_baths is not None and s_baths is not None:
+        lo = min_baths if min_baths is not None else max(0, s_baths - 1)
+        hi = max_baths if max_baths is not None else s_baths + 1
+        if not (lo <= c_baths <= hi):
+            return False
+
+    # Sqft: default ±20%
+    s_sqft = subject.get("sqft")
+    c_sqft = comp.get("sqft")
+    if c_sqft is not None and s_sqft is not None and s_sqft > 0:
+        lo = min_sqft if min_sqft is not None else int(s_sqft * 0.80)
+        hi = max_sqft if max_sqft is not None else int(s_sqft * 1.20)
+        if not (lo <= c_sqft <= hi):
+            return False
+
+    # Year built: default ±10 years
+    s_year = subject.get("year_built")
+    c_year = comp.get("year_built")
+    if c_year is not None and s_year is not None:
+        lo = min_year_built if min_year_built is not None else s_year - 10
+        hi = max_year_built if max_year_built is not None else s_year + 10
+        if not (lo <= c_year <= hi):
+            return False
+
+    return True
+
+
+async def search_sold_comps(
+    subject: dict[str, Any],
+    *,
+    radius_miles: float = 0.5,
+    months_back: int = 6,
+    property_type: str | None = None,
+    min_beds: int | None = None,
+    max_beds: int | None = None,
+    min_baths: float | None = None,
+    max_baths: float | None = None,
+    min_sqft: int | None = None,
+    max_sqft: int | None = None,
+    min_year_built: int | None = None,
+    max_year_built: int | None = None,
+) -> list[dict[str, Any]]:
+    """Search sold comps for a subject property.
+
+    Returns a list of normalized comp dicts sorted by relevance (similarity desc).
+    Subject must contain at least lat/lng for geo search.
+    """
+    lat = subject.get("lat")
+    lng = subject.get("lng")
+    if lat is None or lng is None:
+        # Fallback: search by address
+        address = subject.get("address")
+        if not address:
+            return []
+        raw = await propstream.search_by_address(address)
+    else:
+        raw = await propstream.search_by_coordinates(lat, lng, radius_miles)
+
+    cutoff_date = date.today() - timedelta(days=months_back * 30)
+    results: list[dict[str, Any]] = []
+
+    # PropStream returns a list of properties in the results key
+    raw_comps = raw.get("results", raw.get("properties", []))
+    if isinstance(raw_comps, dict):
+        raw_comps = [raw_comps]
+
+    for raw_comp in raw_comps:
+        normalized = propstream.normalize_propstream_data(raw_comp)
+
+        # Must have a sale date and price to be a sold comp
+        sale_date_str = raw_comp.get("sale", {}).get("date") or raw_comp.get("sale_date")
+        sale_price = raw_comp.get("sale", {}).get("price") or raw_comp.get("sale_price")
+        if not sale_date_str or not sale_price:
+            continue
+
+        try:
+            if isinstance(sale_date_str, str):
+                sale_date_val = date.fromisoformat(sale_date_str[:10])
+            else:
+                sale_date_val = sale_date_str
+        except (ValueError, TypeError):
+            continue
+
+        # Time window filter
+        if sale_date_val < cutoff_date:
+            continue
+
+        # Distance filter
+        c_lat = normalized.get("lat")
+        c_lng = normalized.get("lng")
+        if c_lat is not None and c_lng is not None and lat is not None and lng is not None:
+            dist = _haversine(lat, lng, c_lat, c_lng)
+            if dist > radius_miles:
+                continue
+        else:
+            dist = None
+
+        # Attribute filters
+        if not _passes_filter(
+            normalized,
+            subject,
+            property_type=property_type,
+            min_beds=min_beds,
+            max_beds=max_beds,
+            min_baths=min_baths,
+            max_baths=max_baths,
+            min_sqft=min_sqft,
+            max_sqft=max_sqft,
+            min_year_built=min_year_built,
+            max_year_built=max_year_built,
+        ):
+            continue
+
+        # Compute similarity
+        months_old = (date.today() - sale_date_val).days / 30.0
+        sim = _similarity_score(subject, normalized, dist or 0.0, months_old)
+
+        comp_data = {
+            "address": normalized.get("address", ""),
+            "city": normalized.get("city"),
+            "state": normalized.get("state"),
+            "zip": normalized.get("zip"),
+            "lat": c_lat,
+            "lng": c_lng,
+            "sale_price": float(sale_price),
+            "sale_date": sale_date_val,
+            "sqft": normalized.get("sqft"),
+            "beds": normalized.get("beds"),
+            "baths": normalized.get("baths"),
+            "year_built": normalized.get("year_built"),
+            "property_type": normalized.get("property_type"),
+            "distance": round(dist, 3) if dist is not None else None,
+            "similarity": round(sim, 4),
+            "source": "propstream",
+            "mls_id": normalized.get("mls_id"),
+            "propstream_id": normalized.get("propstream_id"),
+        }
+        results.append(comp_data)
+
+    # Sort by similarity descending (most relevant first)
+    results.sort(key=lambda c: c.get("similarity", 0), reverse=True)
+    return results

--- a/packages/api/app/services/zillow_scraper.py
+++ b/packages/api/app/services/zillow_scraper.py
@@ -1,0 +1,193 @@
+"""Zillow URL paste — parse key fields from a Zillow listing URL.
+
+Zillow blocks server-side HTTP scraping (403). Instead we parse all required
+address fields directly from the URL slug, which encodes the full address.
+Example: /homedetails/38-Chamomile-Ct-Spring-TX-77382/59783766_zpid/
+         → address="38 Chamomile Ct", city="Spring", state="TX", zip="77382"
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def parse_zillow_url(url: str) -> dict[str, str]:
+    """Extract address slug and zpid from a Zillow listing URL.
+
+    Example: https://www.zillow.com/homedetails/123-Main-St-Austin-TX-78701/12345678_zpid/
+    """
+    match = re.search(r"/homedetails/([^/]+)/(\d+)_zpid", url)
+    if not match:
+        raise ValueError(f"Could not parse Zillow URL: {url}")
+
+    slug = match.group(1)
+    zpid = match.group(2)
+    parts = slug.replace("-", " ").strip()
+
+    return {"address_slug": parts, "zpid": zpid, "url": url}
+
+
+def _parse_html_meta(html: str, parsed_url: dict[str, str]) -> dict[str, Any]:
+    """Extract property data from Zillow HTML meta tags and embedded JSON."""
+    data: dict[str, Any] = {
+        "zillow_url": parsed_url["url"],
+        "data_source": "zillow_url",
+    }
+
+    # og:title — typically "Address, City, State Zip"
+    title_match = re.search(r'<meta\s+property="og:title"\s+content="([^"]+)"', html)
+    if title_match:
+        title = title_match.group(1)
+        addr_match = re.match(r"(.+),\s*(.+),\s*(\w{2})\s*(\d{5})", title)
+        if addr_match:
+            data["address"] = addr_match.group(1).strip()
+            data["city"] = addr_match.group(2).strip()
+            data["state"] = addr_match.group(3).strip()
+            data["zip"] = addr_match.group(4).strip()
+
+    # price
+    price_match = re.search(r'"price"\s*:\s*"?([\d.]+)"?', html)
+    if price_match:
+        try:
+            data["listing_price"] = float(price_match.group(1))
+        except ValueError:
+            pass
+
+    # description meta — beds/baths/sqft
+    desc_match = re.search(r'<meta\s+name="description"\s+content="([^"]+)"', html)
+    if desc_match:
+        desc = desc_match.group(1)
+        beds = re.search(r"(\d+)\s*(?:bd|bed)", desc, re.IGNORECASE)
+        baths = re.search(r"([\d.]+)\s*(?:ba|bath)", desc, re.IGNORECASE)
+        sqft = re.search(r"([\d,]+)\s*sqft", desc, re.IGNORECASE)
+        if beds:
+            data["beds"] = int(beds.group(1))
+        if baths:
+            data["baths"] = float(baths.group(1))
+        if sqft:
+            data["sqft"] = int(sqft.group(1).replace(",", ""))
+
+    # lat/lng
+    lat_match = re.search(r'"latitude"\s*:\s*([-\d.]+)', html)
+    lng_match = re.search(r'"longitude"\s*:\s*([-\d.]+)', html)
+    if lat_match and lng_match:
+        data["lat"] = float(lat_match.group(1))
+        data["lng"] = float(lng_match.group(1))
+
+    # year built / property type
+    year_match = re.search(r'"yearBuilt"\s*:\s*(\d{4})', html)
+    if year_match:
+        data["year_built"] = int(year_match.group(1))
+
+    type_match = re.search(r'"homeType"\s*:\s*"([^"]+)"', html)
+    if type_match:
+        data["property_type"] = type_match.group(1)
+
+    return data
+
+# All US state/territory abbreviations that appear in Zillow slugs
+_STATE_CODES = {
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "DC",
+}
+
+# Common street-type suffixes that mark the end of the street address
+_STREET_SUFFIXES = {
+    "st", "ave", "rd", "dr", "ln", "blvd", "way", "pl", "ct",
+    "cir", "ter", "trl", "pkwy", "hwy", "loop", "path", "row",
+    "run", "sq", "walk", "xing", "pass", "cv", "pt", "bnd",
+}
+
+
+def _parse_address_from_slug(slug: str) -> dict[str, str]:
+    """Parse address components from a Zillow URL slug.
+
+    Slug format: {number}-{street-name}-{suffix}-{city-words}-{STATE}-{zip}
+    """
+    parts = slug.split("-")
+
+    # Locate zip (5-digit) and state (2-letter state code) from the right end
+    zip_code = ""
+    state = ""
+    state_idx = -1
+
+    for i in range(len(parts) - 1, -1, -1):
+        p = parts[i]
+        if re.match(r"^\d{5}$", p) and not zip_code:
+            zip_code = p
+        elif p.upper() in _STATE_CODES and not state:
+            state = p.upper()
+            state_idx = i
+            break  # stop — everything to the left is address + city
+
+    if state_idx <= 0:
+        # Fallback: can't parse structure, return full slug as address
+        return {
+            "address": slug.replace("-", " ").title(),
+            "city": "",
+            "state": state,
+            "zip": zip_code,
+        }
+
+    before_state = parts[:state_idx]
+
+    # Find the last occurrence of a known street suffix to split addr / city
+    suffix_idx = -1
+    for i, part in enumerate(before_state):
+        if part.lower() in _STREET_SUFFIXES:
+            suffix_idx = i
+
+    if suffix_idx >= 0 and suffix_idx < len(before_state) - 1:
+        address = " ".join(before_state[: suffix_idx + 1]).title()
+        city = " ".join(before_state[suffix_idx + 1 :]).title()
+    else:
+        # No recognisable suffix — heuristic: first token is number, next 1-2 are name
+        split = min(3, max(1, len(before_state) - 1))
+        address = " ".join(before_state[:split]).title()
+        city = " ".join(before_state[split:]).title()
+
+    return {"address": address, "city": city, "state": state, "zip": zip_code}
+
+
+async def scrape_zillow_listing(url: str) -> dict[str, Any]:
+    """Return property data parsed from a Zillow listing URL.
+
+    Zillow blocks direct HTTP scraping (403), so we derive address fields
+    entirely from the URL slug — no network request to Zillow is made.
+    beds / baths / price are left empty for the user to fill in.
+    """
+    match = re.search(r"/homedetails/([^/]+)/(\d+)_zpid", url)
+    if not match:
+        raise ValueError(f"Not a recognised Zillow listing URL: {url}")
+
+    slug = match.group(1)
+    zpid = match.group(2)
+
+    addr = _parse_address_from_slug(slug)
+    if not addr["address"] or not addr["state"] or not addr["zip"]:
+        raise ValueError(
+            f"Could not parse address from Zillow URL slug '{slug}'. "
+            "Please add the property manually."
+        )
+
+    if not addr["city"]:
+        # Last resort — use the slug parts before state as city placeholder
+        addr["city"] = addr["address"]
+
+    return {
+        "address": addr["address"],
+        "city": addr["city"],
+        "state": addr["state"],
+        "zip": addr["zip"],
+        "zillow_url": url,
+        "data_source": "zillow_url",
+        # zpid stored for future reference
+        "mls_id": f"zpid_{zpid}",
+    }

--- a/packages/api/migrations/env.py
+++ b/packages/api/migrations/env.py
@@ -1,0 +1,104 @@
+import asyncio
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+# ---------------------------------------------------------------------------
+# Alembic Config object — gives access to values in alembic.ini
+# ---------------------------------------------------------------------------
+
+config = context.config
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# ---------------------------------------------------------------------------
+# Import Base metadata from app.models so autogenerate works
+# ---------------------------------------------------------------------------
+
+# Ensure the package root is on the path when running alembic from the
+# packages/api directory.
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.database import Base  # noqa: E402
+import app.models  # noqa: E402, F401 — register all ORM classes with Base
+
+target_metadata = Base.metadata
+
+# Pull DATABASE_URL from env; fall back to alembic.ini sqlalchemy.url
+database_url = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+asyncpg://localhost:5432/gcp_renovation",
+)
+config.set_main_option("sqlalchemy.url", database_url)
+
+
+# ---------------------------------------------------------------------------
+# Offline migration (generate SQL without a live connection)
+# ---------------------------------------------------------------------------
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        version_num_width=128,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+# ---------------------------------------------------------------------------
+# Online migration (connect to the database)
+# ---------------------------------------------------------------------------
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        version_num_width=128,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/packages/api/migrations/versions/001_initial_schema.py
+++ b/packages/api/migrations/versions/001_initial_schema.py
@@ -1,0 +1,427 @@
+"""Initial schema — create all tables.
+
+Revision ID: 001_initial_schema
+Revises:
+Create Date: 2026-04-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision = "001_initial_schema"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # tenants
+    # ------------------------------------------------------------------
+    op.create_table(
+        "tenants",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(100), nullable=False),
+        sa.Column("plan", sa.String(50), nullable=False, server_default="free"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("slug", name="uq_tenants_slug"),
+    )
+
+    # ------------------------------------------------------------------
+    # users
+    # ------------------------------------------------------------------
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("clerk_id", sa.String(255), nullable=False),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("role", sa.String(50), nullable=False, server_default="member"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+        sa.UniqueConstraint("clerk_id", name="uq_users_clerk_id"),
+    )
+
+    # ------------------------------------------------------------------
+    # properties
+    # ------------------------------------------------------------------
+    op.create_table(
+        "properties",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("address", sa.String(500), nullable=False),
+        sa.Column("city", sa.String(100), nullable=False),
+        sa.Column("state", sa.String(50), nullable=False),
+        sa.Column("zip", sa.String(20), nullable=False),
+        sa.Column("county", sa.String(100), nullable=True),
+        sa.Column("lat", sa.Float, nullable=True),
+        sa.Column("lng", sa.Float, nullable=True),
+        sa.Column("year_built", sa.Integer, nullable=True),
+        sa.Column("sqft", sa.Integer, nullable=True),
+        sa.Column("lot_sqft", sa.Integer, nullable=True),
+        sa.Column("beds", sa.Integer, nullable=True),
+        sa.Column("baths", sa.Float, nullable=True),
+        sa.Column("property_type", sa.String(100), nullable=True),
+        sa.Column("zillow_url", sa.String(1000), nullable=True),
+        sa.Column("propstream_id", sa.String(255), nullable=True),
+        sa.Column("listing_price", sa.Numeric(12, 2), nullable=True),
+        sa.Column("arv_estimate", sa.Numeric(12, 2), nullable=True),
+        sa.Column("arv_confidence", sa.Float, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # deals
+    # ------------------------------------------------------------------
+    op.create_table(
+        "deals",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "property_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(50), nullable=False, server_default="prospect"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # comps
+    # ------------------------------------------------------------------
+    op.create_table(
+        "comps",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "property_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("address", sa.String(500), nullable=False),
+        sa.Column("sale_price", sa.Numeric(12, 2), nullable=True),
+        sa.Column("sale_date", sa.Date, nullable=True),
+        sa.Column("sqft", sa.Integer, nullable=True),
+        sa.Column("distance", sa.Float, nullable=True),
+        sa.Column("similarity", sa.Float, nullable=True),
+        sa.Column("source", sa.String(100), nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # image_captures
+    # ------------------------------------------------------------------
+    op.create_table(
+        "image_captures",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "deal_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("deals.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("room", sa.String(100), nullable=True),
+        sa.Column("shot_type", sa.String(100), nullable=True),
+        sa.Column("s3_key", sa.String(1000), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # image_analyses
+    # ------------------------------------------------------------------
+    op.create_table(
+        "image_analyses",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "capture_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("image_captures.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("model", sa.String(100), nullable=True),
+        sa.Column("labels", sa.JSON, nullable=True),
+        sa.Column("conditions", sa.JSON, nullable=True),
+        sa.Column("confidence", sa.Float, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # walk_sessions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "walk_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "deal_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("deals.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("room_count", sa.Integer, nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # quotes
+    # ------------------------------------------------------------------
+    op.create_table(
+        "quotes",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "deal_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("deals.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(50), nullable=False, server_default="draft"),
+        sa.Column("total_material", sa.Numeric(12, 2), nullable=True),
+        sa.Column("total_labor", sa.Numeric(12, 2), nullable=True),
+        sa.Column("platform_fee", sa.Numeric(12, 2), nullable=True),
+        sa.Column("grand_total", sa.Numeric(12, 2), nullable=True),
+        sa.Column("pdf_s3_key", sa.String(1000), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # quote_items
+    # ------------------------------------------------------------------
+    op.create_table(
+        "quote_items",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "quote_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("quotes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("room", sa.String(100), nullable=True),
+        sa.Column("trade_category", sa.String(100), nullable=True),
+        sa.Column("description", sa.String(500), nullable=True),
+        sa.Column("sage_sku", sa.String(100), nullable=True),
+        sa.Column("quantity", sa.Integer, nullable=True),
+        sa.Column("unit_cost", sa.Numeric(10, 2), nullable=True),
+        sa.Column("labor_cost", sa.Numeric(10, 2), nullable=True),
+        sa.Column("subtotal", sa.Numeric(12, 2), nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # sage_catalog
+    # ------------------------------------------------------------------
+    op.create_table(
+        "sage_catalog",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column("sku", sa.String(100), nullable=False),
+        sa.Column("name", sa.String(500), nullable=False),
+        sa.Column("category", sa.String(100), nullable=True),
+        sa.Column("unit_price", sa.Numeric(10, 2), nullable=True),
+        sa.Column("unit", sa.String(50), nullable=True),
+        sa.Column("supplier", sa.String(255), nullable=True),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("sku", name="uq_sage_catalog_sku"),
+    )
+
+    # ------------------------------------------------------------------
+    # trade_partners
+    # ------------------------------------------------------------------
+    op.create_table(
+        "trade_partners",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("company_name", sa.String(255), nullable=False),
+        sa.Column("trade", sa.String(100), nullable=True),
+        sa.Column("contact_name", sa.String(255), nullable=True),
+        sa.Column("phone", sa.String(50), nullable=True),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column("rating", sa.Float, nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # risk_flags
+    # ------------------------------------------------------------------
+    op.create_table(
+        "risk_flags",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "property_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("flag_type", sa.String(100), nullable=True),
+        sa.Column("severity", sa.String(50), nullable=True),
+        sa.Column("detail", sa.Text, nullable=True),
+        sa.Column("source", sa.String(100), nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # orders
+    # ------------------------------------------------------------------
+    op.create_table(
+        "orders",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "quote_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("quotes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("sage_order_id", sa.String(255), nullable=True),
+        sa.Column("d365_opportunity_id", sa.String(255), nullable=True),
+        sa.Column("status", sa.String(50), nullable=False, server_default="pending"),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # platform_fees
+    # ------------------------------------------------------------------
+    op.create_table(
+        "platform_fees",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "order_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("orders.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("fee_type", sa.String(100), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # Drop in reverse dependency order
+    op.drop_table("platform_fees")
+    op.drop_table("orders")
+    op.drop_table("risk_flags")
+    op.drop_table("trade_partners")
+    op.drop_table("sage_catalog")
+    op.drop_table("quote_items")
+    op.drop_table("quotes")
+    op.drop_table("walk_sessions")
+    op.drop_table("image_analyses")
+    op.drop_table("image_captures")
+    op.drop_table("comps")
+    op.drop_table("deals")
+    op.drop_table("properties")
+    op.drop_table("users")
+    op.drop_table("tenants")

--- a/packages/api/migrations/versions/002_add_property_ingestion_fields.py
+++ b/packages/api/migrations/versions/002_add_property_ingestion_fields.py
@@ -1,0 +1,52 @@
+"""Add property ingestion fields — data_source, ownership_history, tax_assessment, status, mls_id, neighborhood, zillow_estimate.
+
+Revision ID: 002_property_ingestion
+Revises: 001_initial_schema
+Create Date: 2026-04-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision = "002_property_ingestion"
+down_revision = "001_initial_schema"
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    op.add_column("properties", sa.Column("data_source", sa.String(100), nullable=True))
+    op.add_column("properties", sa.Column("ownership_history", sa.JSON(), nullable=True))
+    op.add_column("properties", sa.Column("tax_assessment", sa.Numeric(12, 2), nullable=True))
+    op.add_column(
+        "properties",
+        sa.Column("status", sa.String(50), nullable=False, server_default="active"),
+    )
+    op.add_column("properties", sa.Column("mls_id", sa.String(100), nullable=True))
+    op.add_column("properties", sa.Column("neighborhood", sa.String(255), nullable=True))
+    op.add_column("properties", sa.Column("zillow_estimate", sa.Numeric(12, 2), nullable=True))
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.drop_column("properties", "zillow_estimate")
+    op.drop_column("properties", "neighborhood")
+    op.drop_column("properties", "mls_id")
+    op.drop_column("properties", "status")
+    op.drop_column("properties", "tax_assessment")
+    op.drop_column("properties", "ownership_history")
+    op.drop_column("properties", "data_source")

--- a/packages/api/migrations/versions/003_comps_engine_tables.py
+++ b/packages/api/migrations/versions/003_comps_engine_tables.py
@@ -1,0 +1,128 @@
+"""Add comps engine tables — enhance comps, add rental_comps and arv_calculations.
+
+Revision ID: 003_comps_engine_tables
+Revises: 002_property_ingestion
+Create Date: 2026-04-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision = "003_comps_engine_tables"
+down_revision = "002_property_ingestion"
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # --- Enhance existing comps table with additional fields ---
+    op.add_column("comps", sa.Column("city", sa.String(100), nullable=True))
+    op.add_column("comps", sa.Column("state", sa.String(50), nullable=True))
+    op.add_column("comps", sa.Column("zip", sa.String(20), nullable=True))
+    op.add_column("comps", sa.Column("lat", sa.Float(), nullable=True))
+    op.add_column("comps", sa.Column("lng", sa.Float(), nullable=True))
+    op.add_column("comps", sa.Column("beds", sa.Integer(), nullable=True))
+    op.add_column("comps", sa.Column("baths", sa.Float(), nullable=True))
+    op.add_column("comps", sa.Column("year_built", sa.Integer(), nullable=True))
+    op.add_column("comps", sa.Column("property_type", sa.String(100), nullable=True))
+    op.add_column("comps", sa.Column("mls_id", sa.String(100), nullable=True))
+    op.add_column("comps", sa.Column("propstream_id", sa.String(255), nullable=True))
+    op.add_column(
+        "comps",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # --- Create rental_comps table ---
+    op.create_table(
+        "rental_comps",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "property_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("address", sa.String(500), nullable=False),
+        sa.Column("city", sa.String(100), nullable=True),
+        sa.Column("state", sa.String(50), nullable=True),
+        sa.Column("zip", sa.String(20), nullable=True),
+        sa.Column("lat", sa.Float(), nullable=True),
+        sa.Column("lng", sa.Float(), nullable=True),
+        sa.Column("rent_price", sa.Numeric(10, 2), nullable=True),
+        sa.Column("sqft", sa.Integer(), nullable=True),
+        sa.Column("beds", sa.Integer(), nullable=True),
+        sa.Column("baths", sa.Float(), nullable=True),
+        sa.Column("property_type", sa.String(100), nullable=True),
+        sa.Column("distance", sa.Float(), nullable=True),
+        sa.Column("correlation", sa.Float(), nullable=True),
+        sa.Column("source", sa.String(100), nullable=False, server_default="rentcast"),
+        sa.Column("last_seen_date", sa.Date(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # --- Create arv_calculations table ---
+    op.create_table(
+        "arv_calculations",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "property_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("arv_low", sa.Numeric(12, 2), nullable=False),
+        sa.Column("arv_mid", sa.Numeric(12, 2), nullable=False),
+        sa.Column("arv_high", sa.Numeric(12, 2), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("comp_count", sa.Integer(), nullable=False),
+        sa.Column("methodology", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.drop_table("arv_calculations")
+    op.drop_table("rental_comps")
+
+    op.drop_column("comps", "created_at")
+    op.drop_column("comps", "propstream_id")
+    op.drop_column("comps", "mls_id")
+    op.drop_column("comps", "property_type")
+    op.drop_column("comps", "year_built")
+    op.drop_column("comps", "baths")
+    op.drop_column("comps", "beds")
+    op.drop_column("comps", "lng")
+    op.drop_column("comps", "lat")
+    op.drop_column("comps", "zip")
+    op.drop_column("comps", "state")
+    op.drop_column("comps", "city")

--- a/packages/api/migrations/versions/004_add_lendability_fields.py
+++ b/packages/api/migrations/versions/004_add_lendability_fields.py
@@ -1,0 +1,44 @@
+"""Add lendability_score and lendability_category to properties.
+
+Revision ID: 004_add_lendability_fields
+Revises: 003_comps_engine_tables
+Create Date: 2026-04-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision = "004_add_lendability_fields"
+down_revision = "003_comps_engine_tables"
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    op.add_column(
+        "properties",
+        sa.Column("lendability_score", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "properties",
+        sa.Column("lendability_category", sa.String(20), nullable=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.drop_column("properties", "lendability_category")
+    op.drop_column("properties", "lendability_score")

--- a/packages/api/migrations/versions/005_sage_catalog_tables.py
+++ b/packages/api/migrations/versions/005_sage_catalog_tables.py
@@ -1,0 +1,161 @@
+"""Add product_categories, products, and product_prices tables; drop sage_catalog.
+
+Revision ID: 005_sage_catalog_tables
+Revises: 004_add_lendability_fields
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision = "005_sage_catalog_tables"
+down_revision = "004_add_lendability_fields"
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # -- product_categories (self-referential tree) --
+    op.create_table(
+        "product_categories",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column(
+            "parent_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("product_categories.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("sage_category_id", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # -- products --
+    op.create_table(
+        "products",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "category_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("product_categories.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("sage_product_id", sa.String(255), nullable=True),
+        sa.Column("sku", sa.String(100), nullable=False),
+        sa.Column("name", sa.String(500), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("brand", sa.String(255), nullable=True),
+        sa.Column("unit_of_measure", sa.String(50), nullable=True),
+        sa.Column("dimensions", sa.JSON(), nullable=True),
+        sa.Column("image_url", sa.String(1000), nullable=True),
+        sa.Column(
+            "availability_status",
+            sa.String(20),
+            nullable=False,
+            server_default="in_stock",
+        ),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("tenant_id", "sku", name="uq_products_tenant_sku"),
+    )
+    op.create_index("ix_products_sku", "products", ["sku"])
+    op.create_index("ix_products_category_id", "products", ["category_id"])
+    op.create_index("ix_products_tenant_id", "products", ["tenant_id"])
+
+    # -- product_prices (append-only) --
+    op.create_table(
+        "product_prices",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "product_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("products.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("price_cents", sa.BigInteger(), nullable=False),
+        sa.Column("currency", sa.String(3), nullable=False, server_default="USD"),
+        sa.Column("effective_date", sa.Date(), nullable=False),
+        sa.Column("source", sa.String(50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_product_prices_product_id", "product_prices", ["product_id"])
+    op.create_index(
+        "ix_product_prices_effective_date", "product_prices", ["effective_date"]
+    )
+
+    # -- drop legacy sage_catalog table --
+    op.drop_table("sage_catalog")
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # recreate legacy sage_catalog
+    op.create_table(
+        "sage_catalog",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column("sku", sa.String(100), nullable=False, unique=True),
+        sa.Column("name", sa.String(500), nullable=False),
+        sa.Column("category", sa.String(100), nullable=True),
+        sa.Column("unit_price", sa.Numeric(10, 2), nullable=True),
+        sa.Column("unit", sa.String(50), nullable=True),
+        sa.Column("supplier", sa.String(255), nullable=True),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.drop_index("ix_product_prices_effective_date", table_name="product_prices")
+    op.drop_index("ix_product_prices_product_id", table_name="product_prices")
+    op.drop_table("product_prices")
+
+    op.drop_index("ix_products_tenant_id", table_name="products")
+    op.drop_index("ix_products_category_id", table_name="products")
+    op.drop_index("ix_products_sku", table_name="products")
+    op.drop_table("products")
+
+    op.drop_table("product_categories")

--- a/packages/api/migrations/versions/006_photo_analysis_tables.py
+++ b/packages/api/migrations/versions/006_photo_analysis_tables.py
@@ -1,0 +1,142 @@
+"""Add property photo analysis, photo labels, and review queue tables.
+
+Revision ID: 006_photo_analysis_tables
+Revises: 005_sage_catalog_tables
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision = "006_photo_analysis_tables"
+down_revision = "005_sage_catalog_tables"
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # -- property_photo_analyses (one per property analysis run) --
+    op.create_table(
+        "property_photo_analyses",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "property_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(30), nullable=False, server_default="pending"),
+        sa.Column("photo_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("model_id", sa.String(100), nullable=False),
+        sa.Column("renovation_signal", sa.String(30), nullable=True),
+        sa.Column("renovation_confidence", sa.Float(), nullable=True),
+        sa.Column("total_cost_cents", sa.BigInteger(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_property_photo_analyses_property_id",
+        "property_photo_analyses",
+        ["property_id"],
+    )
+    op.create_index(
+        "ix_property_photo_analyses_status",
+        "property_photo_analyses",
+        ["status"],
+    )
+
+    # -- photo_labels (per-photo results from Claude Vision) --
+    op.create_table(
+        "photo_labels",
+        sa.Column("id", UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "analysis_id",
+            UUID(as_uuid=False),
+            sa.ForeignKey("property_photo_analyses.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("photo_url", sa.String(2000), nullable=False),
+        sa.Column("photo_index", sa.Integer(), nullable=False),
+        sa.Column("room_type", sa.String(100), nullable=True),
+        sa.Column("condition", sa.String(50), nullable=True),
+        sa.Column("damage_issues", sa.JSON(), nullable=True),
+        sa.Column("renovation_needed", sa.String(30), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column(
+            "confidence_tier",
+            sa.String(10),
+            nullable=False,
+            server_default="medium",
+        ),
+        sa.Column("raw_response", sa.JSON(), nullable=True),
+        sa.Column(
+            "review_status",
+            sa.String(20),
+            nullable=False,
+            server_default="auto_accepted",
+        ),
+        sa.Column("reviewer_override", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_photo_labels_analysis_id", "photo_labels", ["analysis_id"]
+    )
+    op.create_index(
+        "ix_photo_labels_review_status", "photo_labels", ["review_status"]
+    )
+    op.create_index(
+        "ix_photo_labels_confidence_tier", "photo_labels", ["confidence_tier"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.drop_index("ix_photo_labels_confidence_tier", table_name="photo_labels")
+    op.drop_index("ix_photo_labels_review_status", table_name="photo_labels")
+    op.drop_index("ix_photo_labels_analysis_id", table_name="photo_labels")
+    op.drop_table("photo_labels")
+
+    op.drop_index(
+        "ix_property_photo_analyses_status",
+        table_name="property_photo_analyses",
+    )
+    op.drop_index(
+        "ix_property_photo_analyses_property_id",
+        table_name="property_photo_analyses",
+    )
+    op.drop_table("property_photo_analyses")

--- a/packages/api/migrations/versions/007_quote_builder.py
+++ b/packages/api/migrations/versions/007_quote_builder.py
@@ -1,0 +1,94 @@
+"""Add quote builder columns for Sprint 1.8.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "007_quote_builder"
+down_revision = "006_photo_analysis_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add property_id and photo_analysis_id to quotes for direct linkage
+    op.add_column(
+        "quotes",
+        sa.Column(
+            "property_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("properties.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "quotes",
+        sa.Column(
+            "photo_analysis_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("property_photo_analyses.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "quotes",
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "quotes",
+        sa.Column("notes", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "quotes",
+        sa.Column("tax_amount", sa.Numeric(12, 2), nullable=True),
+    )
+    op.add_column(
+        "quotes",
+        sa.Column("platform_fee_pct", sa.Numeric(5, 4), nullable=True),
+    )
+
+    op.create_index("ix_quotes_property_id", "quotes", ["property_id"])
+    op.create_index("ix_quotes_status", "quotes", ["status"])
+
+    # Enhance quote_items for AI generation and markup
+    op.add_column(
+        "quote_items",
+        sa.Column("markup_pct", sa.Numeric(5, 2), nullable=True),
+    )
+    op.add_column(
+        "quote_items",
+        sa.Column("ai_confidence", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "quote_items",
+        sa.Column(
+            "is_ai_generated",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "quote_items",
+        sa.Column("unit_of_measure", sa.String(50), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("quote_items", "unit_of_measure")
+    op.drop_column("quote_items", "is_ai_generated")
+    op.drop_column("quote_items", "ai_confidence")
+    op.drop_column("quote_items", "markup_pct")
+    op.drop_index("ix_quotes_status", table_name="quotes")
+    op.drop_index("ix_quotes_property_id", table_name="quotes")
+    op.drop_column("quotes", "platform_fee_pct")
+    op.drop_column("quotes", "tax_amount")
+    op.drop_column("quotes", "notes")
+    op.drop_column("quotes", "version")
+    op.drop_column("quotes", "photo_analysis_id")
+    op.drop_column("quotes", "property_id")

--- a/packages/api/migrations/versions/008_sage_order_push.py
+++ b/packages/api/migrations/versions/008_sage_order_push.py
@@ -1,0 +1,172 @@
+"""Add order line items, order status history, and D365 fields for Sprint 1.9.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "008_sage_order_push"
+down_revision = "007_quote_builder"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Enhance orders table with delivery/tracking fields
+    op.add_column(
+        "orders",
+        sa.Column("property_id", postgresql.UUID(as_uuid=False), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_orders_property_id",
+        "orders",
+        "properties",
+        ["property_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column(
+        "orders",
+        sa.Column("sage_confirmation", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("d365_opportunity_url", sa.String(1000), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("submission_method", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("error_message", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("total_amount", sa.Numeric(12, 2), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("shipped_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.add_column(
+        "orders",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_orders_status", "orders", ["status"])
+    op.create_index("ix_orders_tenant_id", "orders", ["tenant_id"])
+
+    # Order line items — snapshot of quote items at time of order
+    op.create_table(
+        "order_line_items",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+        ),
+        sa.Column(
+            "order_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("orders.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "quote_item_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("quote_items.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("room", sa.String(100), nullable=True),
+        sa.Column("trade_category", sa.String(100), nullable=True),
+        sa.Column("description", sa.String(500), nullable=True),
+        sa.Column("sage_sku", sa.String(100), nullable=True),
+        sa.Column("quantity", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("unit_cost", sa.Numeric(10, 2), nullable=True),
+        sa.Column("labor_cost", sa.Numeric(10, 2), nullable=True),
+        sa.Column("markup_pct", sa.Numeric(5, 2), nullable=True),
+        sa.Column("subtotal", sa.Numeric(12, 2), nullable=True),
+        sa.Column("sage_line_id", sa.String(255), nullable=True),
+        sa.Column("unit_of_measure", sa.String(50), nullable=True),
+    )
+    op.create_index("ix_order_line_items_order_id", "order_line_items", ["order_id"])
+
+    # Order status history — audit trail
+    op.create_table(
+        "order_status_history",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=False),
+            primary_key=True,
+        ),
+        sa.Column(
+            "order_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("orders.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("from_status", sa.String(50), nullable=True),
+        sa.Column("to_status", sa.String(50), nullable=False),
+        sa.Column("changed_by", sa.String(255), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_order_status_history_order_id", "order_status_history", ["order_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_order_status_history_order_id", table_name="order_status_history")
+    op.drop_table("order_status_history")
+    op.drop_index("ix_order_line_items_order_id", table_name="order_line_items")
+    op.drop_table("order_line_items")
+    op.drop_index("ix_orders_tenant_id", table_name="orders")
+    op.drop_index("ix_orders_status", table_name="orders")
+    op.drop_column("orders", "updated_at")
+    op.drop_column("orders", "created_at")
+    op.drop_column("orders", "delivered_at")
+    op.drop_column("orders", "shipped_at")
+    op.drop_column("orders", "confirmed_at")
+    op.drop_column("orders", "total_amount")
+    op.drop_column("orders", "retry_count")
+    op.drop_column("orders", "error_message")
+    op.drop_column("orders", "submission_method")
+    op.drop_column("orders", "d365_opportunity_url")
+    op.drop_column("orders", "sage_confirmation")
+    op.drop_constraint("fk_orders_property_id", "orders", type_="foreignkey")
+    op.drop_column("orders", "property_id")

--- a/packages/api/migrations/versions/010_credit_memos.py
+++ b/packages/api/migrations/versions/010_credit_memos.py
@@ -1,0 +1,65 @@
+"""Add credit_memos table (SAG-2805).
+
+Purely additive CREATE TABLE — no existing data touched.
+cause_code and qc_stage are stored as VARCHAR; enum enforcement is at the
+application layer so new codes can be added without a schema migration.
+
+Revision ID: 010
+Revises: 008
+Create Date: 2026-06-02
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "010_credit_memos"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credit_memos",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # Required fields — NOT NULL enforced here and at the application layer.
+        sa.Column("cause_code", sa.String(50), nullable=False),
+        sa.Column("job_key", sa.String(255), nullable=False),
+        sa.Column("qc_stage", sa.String(50), nullable=False),
+        # Optional / auto-populated fields — nullable, tighten later after backfill (SAG-2804).
+        sa.Column("rsm_id", sa.String(255), nullable=True),
+        sa.Column("territory_id", sa.String(255), nullable=True),
+        sa.Column("product_tier", sa.String(100), nullable=True),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_credit_memos_tenant_id", "credit_memos", ["tenant_id"])
+    op.create_index("ix_credit_memos_cause_code", "credit_memos", ["cause_code"])
+    op.create_index("ix_credit_memos_job_key", "credit_memos", ["job_key"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_credit_memos_job_key", table_name="credit_memos")
+    op.drop_index("ix_credit_memos_cause_code", table_name="credit_memos")
+    op.drop_index("ix_credit_memos_tenant_id", table_name="credit_memos")
+    op.drop_table("credit_memos")

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+[project]
+name = "gcp-renovation-api"
+version = "0.1.0"
+description = "GCP Renovation FastAPI backend"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.29.0",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "asyncpg>=0.29.0",
+    "pydantic>=2.7.0",
+    "pydantic-settings>=2.2.0",
+    "python-jose[cryptography]>=3.3.0",
+    "httpx>=0.27.0",
+    "boto3>=1.34.0",
+    "redis>=5.0.0",
+    "alembic>=1.13.0",
+    "playwright>=1.44.0",
+    "reportlab>=4.1.0",
+    # SAG-2309: explicit floor pins to clear HIGH CVEs
+    "starlette>=1.0.1",
+    "urllib3>=2.7.0",
+    "idna>=3.15",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=5.0.0",
+    "anyio[trio]>=4.0.0",
+    "aiosqlite>=0.20.0",
+    "ruff>=0.4.0",
+    "mypy>=1.10.0",
+]
+
+[dependency-groups]
+dev = [
+    "aiosqlite>=0.22.1",
+    "anyio>=4.13.0",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.1.0",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "--cov=app.services.financing --cov-report=term-missing --cov-fail-under=80"

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -1,0 +1,60 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.auth import CurrentUser
+from app.database import Base, get_db
+from app.main import app
+
+# In-memory SQLite for tests (sync driver wrapped in async)
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+TestSessionLocal = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+TENANT_ID = str(uuid.uuid4())
+USER_ID = str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with TestSessionLocal() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        yield db_session
+
+    def _override_user() -> CurrentUser:
+        return CurrentUser(user_id=USER_ID, tenant_id=TENANT_ID, claims={})
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[CurrentUser] = _override_user
+
+    # Also override get_current_user
+    from app.auth import get_current_user
+
+    app.dependency_overrides[get_current_user] = _override_user
+
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()

--- a/packages/api/tests/test_catalog_service.py
+++ b/packages/api/tests/test_catalog_service.py
@@ -1,0 +1,721 @@
+"""Tests for the CatalogService — Redis, DB, and Sage bridge interactions are mocked."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.catalog_service import (
+    CACHE_KEY_CATEGORIES,
+    TTL_CATEGORIES,
+    TTL_PRODUCT,
+    TTL_SEARCH,
+    CatalogService,
+    _cache_key_product,
+    _cache_key_search,
+)
+
+TENANT_ID = str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_product_mock(**overrides: Any) -> MagicMock:
+    """Create a mock Product ORM object."""
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "tenant_id": TENANT_ID,
+        "sage_product_id": "SAGE-001",
+        "sku": "OAK-001",
+        "name": "Oak Flooring",
+        "description": "Premium oak hardwood",
+        "brand": "HardwoodPro",
+        "unit_of_measure": "sqft",
+        "dimensions": {"width": 6, "length": 48},
+        "image_url": "https://example.com/oak.jpg",
+        "availability_status": "in_stock",
+        "category_id": None,
+        "last_synced_at": datetime(2026, 1, 1, 12, 0, 0),
+        "created_at": datetime(2026, 1, 1, 0, 0, 0),
+        "updated_at": datetime(2026, 1, 1, 0, 0, 0),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _make_price_mock(**overrides: Any) -> MagicMock:
+    """Create a mock ProductPrice ORM object."""
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "product_id": str(uuid.uuid4()),
+        "price_cents": 499,
+        "currency": "USD",
+        "effective_date": date(2026, 1, 1),
+        "source": "sage_scrape",
+        "created_at": datetime(2026, 1, 1, 0, 0, 0),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _make_category_mock(**overrides: Any) -> MagicMock:
+    """Create a mock ProductCategory ORM object."""
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "name": "Flooring",
+        "parent_id": None,
+        "sage_category_id": "CAT-FLOOR",
+        "created_at": datetime(2026, 1, 1, 0, 0, 0),
+        "updated_at": datetime(2026, 1, 1, 0, 0, 0),
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for k, v in defaults.items():
+        setattr(m, k, v)
+    return m
+
+
+def _make_redis(cache: dict[str, Any] | None = None) -> AsyncMock:
+    """Create a mock Redis client with optional pre-seeded cache."""
+    redis = AsyncMock()
+    store = cache or {}
+
+    async def _get(key: str) -> str | None:
+        val = store.get(key)
+        return json.dumps(val, default=str) if val is not None else None
+
+    async def _setex(key: str, ttl: int, value: str) -> None:
+        store[key] = json.loads(value)
+
+    redis.get = AsyncMock(side_effect=_get)
+    redis.setex = AsyncMock(side_effect=_setex)
+    return redis
+
+
+def _make_db_session() -> AsyncMock:
+    """Create a mock AsyncSession."""
+    db = AsyncMock()
+    return db
+
+
+def _make_bridge() -> AsyncMock:
+    """Create a mock SagePlaywrightBridge."""
+    bridge = AsyncMock()
+    bridge.search_products = AsyncMock(return_value=[])
+    bridge.get_product_detail = AsyncMock(return_value={})
+    bridge.browse_category = AsyncMock(return_value=[])
+    return bridge
+
+
+def _setup_db_execute(db: AsyncMock, results: list[Any]) -> None:
+    """Configure db.execute to return results from a sequence of calls.
+
+    Each entry in *results* is the value returned by .scalar_one_or_none(),
+    .scalar(), or .scalars().all() for the nth db.execute() call.
+    """
+    mock_results = []
+    for r in results:
+        result_mock = MagicMock()
+        if isinstance(r, list):
+            result_mock.scalars.return_value.all.return_value = r
+        elif r is None:
+            result_mock.scalar_one_or_none.return_value = None
+            result_mock.scalar.return_value = 0
+            result_mock.scalars.return_value.all.return_value = []
+        elif isinstance(r, int):
+            result_mock.scalar.return_value = r
+        else:
+            result_mock.scalar_one_or_none.return_value = r
+            result_mock.scalars.return_value.all.return_value = [r]
+        mock_results.append(result_mock)
+    db.execute = AsyncMock(side_effect=mock_results)
+
+
+# ---------------------------------------------------------------------------
+# Test: search_products — cache hit
+# ---------------------------------------------------------------------------
+
+
+class TestSearchProductsCacheHit:
+    @pytest.mark.asyncio
+    async def test_returns_cached_data(self):
+        """When Redis has a cached response, return it without touching DB or bridge."""
+        cached_response = {
+            "items": [{"id": "p1", "name": "Cached Product"}],
+            "total": 1,
+            "limit": 20,
+            "offset": 0,
+        }
+        params = {
+            "query": "oak", "category": None, "brand": None,
+            "price_min": None, "price_max": None, "limit": 20, "offset": 0,
+        }
+        cache_key = _cache_key_search(params)
+        redis = _make_redis(cache={cache_key: cached_response})
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.search_products(db, TENANT_ID, query="oak")
+
+        assert result == cached_response
+        db.execute.assert_not_called()
+        bridge.search_products.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: search_products — DB results (no cache)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchProductsDBResults:
+    @pytest.mark.asyncio
+    async def test_returns_db_products_and_caches(self):
+        """When cache misses but DB has products, serve from DB and cache result."""
+        product = _make_product_mock(name="DB Product", sku="DB-001")
+        redis = _make_redis()
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        # First execute: count query -> 1
+        # Second execute: product query -> [product]
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        products_result = MagicMock()
+        products_result.scalars.return_value.all.return_value = [product]
+        db.execute = AsyncMock(side_effect=[count_result, products_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.search_products(db, TENANT_ID, query="DB")
+
+        assert result["total"] == 1
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "DB Product"
+        assert result["items"][0]["sku"] == "DB-001"
+        bridge.search_products.assert_not_called()
+        # Verify cache was set
+        redis.setex.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: search_products — Sage bridge fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSearchProductsBridgeFallback:
+    @pytest.mark.asyncio
+    async def test_calls_bridge_when_no_cache_no_db(self):
+        """When both cache and DB are empty, fall back to Sage bridge."""
+        bridge_data = [
+            {
+                "product_id": "SAGE-101",
+                "sku": "SAGE-101",
+                "name": "Bridge Product",
+                "description": "From Sage",
+                "brand": "SageBrand",
+                "price_cents": 1299,
+            }
+        ]
+        redis = _make_redis()
+        bridge = _make_bridge()
+        bridge.search_products = AsyncMock(return_value=bridge_data)
+        db = _make_db_session()
+
+        # DB queries: count -> 0, products -> []
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        products_result = MagicMock()
+        products_result.scalars.return_value.all.return_value = []
+        # _upsert_product does: select (not found) -> flush
+        upsert_select_result = MagicMock()
+        upsert_select_result.scalar_one_or_none.return_value = None
+        # price select (no existing price)
+        price_select_result = MagicMock()
+        price_select_result.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(
+            side_effect=[count_result, products_result, upsert_select_result, price_select_result]
+        )
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.search_products(db, TENANT_ID, query="bridge")
+
+        bridge.search_products.assert_called_once()
+        assert result["total"] == 1
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "Bridge Product"
+
+    @pytest.mark.asyncio
+    async def test_bridge_failure_returns_empty(self):
+        """When the bridge raises an exception, return empty results gracefully."""
+        redis = _make_redis()
+        bridge = _make_bridge()
+        bridge.search_products = AsyncMock(side_effect=Exception("Sage down"))
+        db = _make_db_session()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        products_result = MagicMock()
+        products_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(side_effect=[count_result, products_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.search_products(db, TENANT_ID, query="fail")
+
+        assert result["items"] == []
+        assert result["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: get_product_detail — cache hit
+# ---------------------------------------------------------------------------
+
+
+class TestGetProductDetailCacheHit:
+    @pytest.mark.asyncio
+    async def test_returns_cached_detail(self):
+        """When Redis has cached product detail, return it directly."""
+        product_id = str(uuid.uuid4())
+        cached = {
+            "id": product_id,
+            "name": "Cached Detail",
+            "prices": [],
+            "category": None,
+        }
+        cache_key = _cache_key_product(product_id)
+        redis = _make_redis(cache={cache_key: cached})
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_product_detail(db, TENANT_ID, product_id)
+
+        assert result == cached
+        db.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: get_product_detail — DB result
+# ---------------------------------------------------------------------------
+
+
+class TestGetProductDetailDB:
+    @pytest.mark.asyncio
+    async def test_returns_db_product_with_prices(self):
+        """When DB has the product, return it with prices and cache."""
+        product = _make_product_mock()
+        price = _make_price_mock(product_id=product.id)
+        redis = _make_redis()
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        # execute calls: product select, prices select, category select (no category)
+        product_result = MagicMock()
+        product_result.scalar_one_or_none.return_value = product
+        prices_result = MagicMock()
+        prices_result.scalars.return_value.all.return_value = [price]
+        db.execute = AsyncMock(side_effect=[product_result, prices_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_product_detail(db, TENANT_ID, product.id)
+
+        assert result["id"] == product.id
+        assert result["name"] == "Oak Flooring"
+        assert len(result["prices"]) == 1
+        assert result["prices"][0]["price_cents"] == 499
+        assert result["category"] is None
+        redis.setex.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_db_product_with_category(self):
+        """When product has a category_id, include category data."""
+        cat = _make_category_mock()
+        product = _make_product_mock(category_id=cat.id)
+        redis = _make_redis()
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        product_result = MagicMock()
+        product_result.scalar_one_or_none.return_value = product
+        prices_result = MagicMock()
+        prices_result.scalars.return_value.all.return_value = []
+        cat_result = MagicMock()
+        cat_result.scalar_one_or_none.return_value = cat
+        db.execute = AsyncMock(side_effect=[product_result, prices_result, cat_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_product_detail(db, TENANT_ID, product.id)
+
+        assert result["category"] is not None
+        assert result["category"]["name"] == "Flooring"
+        assert result["category"]["id"] == cat.id
+
+
+# ---------------------------------------------------------------------------
+# Test: get_product_detail — not found
+# ---------------------------------------------------------------------------
+
+
+class TestGetProductDetailNotFound:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_in_db_and_bridge_fails(self):
+        """When product is not in DB and bridge raises, return None."""
+        redis = _make_redis()
+        bridge = _make_bridge()
+        bridge.get_product_detail = AsyncMock(side_effect=Exception("Not found"))
+        db = _make_db_session()
+
+        product_result = MagicMock()
+        product_result.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(side_effect=[product_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_product_detail(db, TENANT_ID, "nonexistent-id")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: get_categories — cache hit and DB fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGetCategories:
+    @pytest.mark.asyncio
+    async def test_returns_cached_categories(self):
+        """When Redis has cached categories, return them."""
+        cached_cats = [{"id": "c1", "name": "Flooring"}]
+        redis = _make_redis(cache={CACHE_KEY_CATEGORIES: cached_cats})
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_categories(db)
+
+        assert result == cached_cats
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_db_categories_and_caches(self):
+        """When cache misses, serve categories from DB and cache."""
+        cat1 = _make_category_mock(name="Electrical")
+        cat2 = _make_category_mock(name="Plumbing")
+        redis = _make_redis()
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        cats_result = MagicMock()
+        cats_result.scalars.return_value.all.return_value = [cat1, cat2]
+        db.execute = AsyncMock(return_value=cats_result)
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_categories(db)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "Electrical"
+        assert result[1]["name"] == "Plumbing"
+        redis.setex.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: get_category_products
+# ---------------------------------------------------------------------------
+
+
+class TestGetCategoryProducts:
+    @pytest.mark.asyncio
+    async def test_returns_products_for_category(self):
+        """Return products from DB for a given category_id."""
+        cat_id = str(uuid.uuid4())
+        product = _make_product_mock(category_id=cat_id)
+        redis = _make_redis()
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        products_result = MagicMock()
+        products_result.scalars.return_value.all.return_value = [product]
+        db.execute = AsyncMock(side_effect=[count_result, products_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_category_products(db, TENANT_ID, cat_id)
+
+        assert result["total"] == 1
+        assert len(result["items"]) == 1
+        assert result["items"][0]["category_id"] == cat_id
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_bridge_when_db_empty(self):
+        """When DB has no products for category, fetch from bridge."""
+        cat_id = str(uuid.uuid4())
+        bridge_data = [
+            {"product_id": "B1", "sku": "B1", "name": "Bridge Cat Product", "price_cents": 500}
+        ]
+        redis = _make_redis()
+        bridge = _make_bridge()
+        bridge.browse_category = AsyncMock(return_value=bridge_data)
+        db = _make_db_session()
+
+        product = _make_product_mock(category_id=cat_id, name="Bridge Cat Product")
+
+        # First round: count=0, products=[]
+        count_result_0 = MagicMock()
+        count_result_0.scalar.return_value = 0
+        products_result_0 = MagicMock()
+        products_result_0.scalars.return_value.all.return_value = []
+        # _upsert_product: select (not found), price select (not found)
+        upsert_select = MagicMock()
+        upsert_select.scalar_one_or_none.return_value = None
+        price_select = MagicMock()
+        price_select.scalar_one_or_none.return_value = None
+        # Re-query after sync: products, count
+        products_result_1 = MagicMock()
+        products_result_1.scalars.return_value.all.return_value = [product]
+        count_result_1 = MagicMock()
+        count_result_1.scalar.return_value = 1
+
+        db.execute = AsyncMock(side_effect=[
+            count_result_0, products_result_0,
+            upsert_select, price_select,
+            products_result_1, count_result_1,
+        ])
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        svc = CatalogService(bridge=bridge, redis_client=redis)
+        result = await svc.get_category_products(db, TENANT_ID, cat_id)
+
+        bridge.browse_category.assert_called_once_with(cat_id, page=1)
+        assert result["total"] == 1
+        assert len(result["items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: Redis fallback — service works when Redis is None
+# ---------------------------------------------------------------------------
+
+
+class TestRedisNone:
+    @pytest.mark.asyncio
+    async def test_search_works_without_redis(self):
+        """When redis_client is None, skip caching and serve from DB."""
+        product = _make_product_mock(name="No-Redis Product")
+        bridge = _make_bridge()
+        db = _make_db_session()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        products_result = MagicMock()
+        products_result.scalars.return_value.all.return_value = [product]
+        db.execute = AsyncMock(side_effect=[count_result, products_result])
+
+        svc = CatalogService(bridge=bridge, redis_client=None)
+        result = await svc.search_products(db, TENANT_ID, query="no-redis")
+
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "No-Redis Product"
+
+    @pytest.mark.asyncio
+    async def test_cache_get_returns_none_when_redis_is_none(self):
+        """_cache_get returns None when Redis client is None."""
+        svc = CatalogService(bridge=_make_bridge(), redis_client=None)
+        result = await svc._cache_get("any-key")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cache_set_is_noop_when_redis_is_none(self):
+        """_cache_set does nothing when Redis client is None."""
+        svc = CatalogService(bridge=_make_bridge(), redis_client=None)
+        # Should not raise
+        await svc._cache_set("any-key", {"data": 1}, 300)
+
+    @pytest.mark.asyncio
+    async def test_cache_get_handles_redis_exception(self):
+        """_cache_get returns None on Redis failure."""
+        redis = AsyncMock()
+        redis.get = AsyncMock(side_effect=ConnectionError("Redis down"))
+        svc = CatalogService(bridge=_make_bridge(), redis_client=redis)
+        result = await svc._cache_get("some-key")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cache_set_handles_redis_exception(self):
+        """_cache_set swallows Redis failure silently."""
+        redis = AsyncMock()
+        redis.setex = AsyncMock(side_effect=ConnectionError("Redis down"))
+        svc = CatalogService(bridge=_make_bridge(), redis_client=redis)
+        # Should not raise
+        await svc._cache_set("some-key", {"data": 1}, 300)
+
+
+# ---------------------------------------------------------------------------
+# Test: _upsert_product — insert, update, price handling
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertProduct:
+    @pytest.mark.asyncio
+    async def test_inserts_new_product(self):
+        """When product does not exist in DB, insert a new one."""
+        db = _make_db_session()
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = None
+        # No existing price
+        price_result = MagicMock()
+        price_result.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(side_effect=[select_result, price_result])
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        data = {
+            "product_id": "NEW-001",
+            "sku": "NEW-001",
+            "name": "New Product",
+            "description": "Brand new",
+            "brand": "NewBrand",
+            "price_cents": 999,
+        }
+
+        product = await CatalogService._upsert_product(db, TENANT_ID, data)
+
+        assert product.sku == "NEW-001"
+        assert product.name == "New Product"
+        assert product.brand == "NewBrand"
+        assert product.tenant_id == TENANT_ID
+        # db.add should be called for the product and the price
+        assert db.add.call_count == 2
+        db.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_product(self):
+        """When product already exists, update its fields."""
+        existing = _make_product_mock(name="Old Name", brand="OldBrand")
+        db = _make_db_session()
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = existing
+        db.execute = AsyncMock(side_effect=[select_result])
+        db.flush = AsyncMock()
+
+        data = {
+            "product_id": existing.sage_product_id,
+            "name": "Updated Name",
+            "brand": "NewBrand",
+        }
+
+        product = await CatalogService._upsert_product(db, TENANT_ID, data)
+
+        assert product.name == "Updated Name"
+        assert product.brand == "NewBrand"
+        db.flush.assert_called_once()
+        # No db.add for the product itself (it already exists)
+
+    @pytest.mark.asyncio
+    async def test_inserts_price_when_changed(self):
+        """When price_cents differs from last price, insert new price row."""
+        existing = _make_product_mock()
+        old_price = _make_price_mock(product_id=existing.id, price_cents=400)
+        db = _make_db_session()
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = existing
+        price_result = MagicMock()
+        price_result.scalar_one_or_none.return_value = old_price
+        db.execute = AsyncMock(side_effect=[select_result, price_result])
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        data = {
+            "product_id": existing.sage_product_id,
+            "name": existing.name,
+            "price_cents": 599,  # different from 400
+        }
+
+        await CatalogService._upsert_product(db, TENANT_ID, data)
+
+        # db.add called once for the new price
+        db.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_price_insert_when_unchanged(self):
+        """When price_cents matches the last price, do not insert."""
+        existing = _make_product_mock()
+        old_price = _make_price_mock(product_id=existing.id, price_cents=499)
+        db = _make_db_session()
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = existing
+        price_result = MagicMock()
+        price_result.scalar_one_or_none.return_value = old_price
+        db.execute = AsyncMock(side_effect=[select_result, price_result])
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        data = {
+            "product_id": existing.sage_product_id,
+            "name": existing.name,
+            "price_cents": 499,  # same as existing
+        }
+
+        await CatalogService._upsert_product(db, TENANT_ID, data)
+
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inserts_price_when_no_previous_price(self):
+        """When there is no previous price at all, insert the new price."""
+        existing = _make_product_mock()
+        db = _make_db_session()
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = existing
+        price_result = MagicMock()
+        price_result.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(side_effect=[select_result, price_result])
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        data = {
+            "product_id": existing.sage_product_id,
+            "name": existing.name,
+            "price_cents": 750,
+        }
+
+        await CatalogService._upsert_product(db, TENANT_ID, data)
+
+        db.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_price_query_when_price_not_provided(self):
+        """When data has no price_cents, skip price logic entirely."""
+        existing = _make_product_mock()
+        db = _make_db_session()
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = existing
+        db.execute = AsyncMock(side_effect=[select_result])
+        db.flush = AsyncMock()
+        db.add = MagicMock()
+
+        data = {
+            "product_id": existing.sage_product_id,
+            "name": existing.name,
+            # no price_cents
+        }
+
+        await CatalogService._upsert_product(db, TENANT_ID, data)
+
+        # Only one db.execute call (the product select), no price query
+        assert db.execute.call_count == 1
+        db.add.assert_not_called()

--- a/packages/api/tests/test_claude_vision.py
+++ b/packages/api/tests/test_claude_vision.py
@@ -1,0 +1,718 @@
+"""Tests for the Claude Vision integration service."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.claude_vision import (
+    HIGH_CONFIDENCE_THRESHOLD,
+    LOW_CONFIDENCE_THRESHOLD,
+    ClaudeVisionService,
+    PhotoAnalysisResult,
+    _aggregate_renovation_signal,
+    _confidence_tier,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_API_KEY = "sk-ant-test-key"
+
+
+def _make_anthropic_response(
+    room_type: str = "kitchen",
+    condition: str = "fair",
+    damage_issues: list[str] | None = None,
+    renovation_needed: str = "moderate",
+    confidence: float = 0.85,
+    input_tokens: int = 500,
+    output_tokens: int = 100,
+) -> dict:
+    content_text = json.dumps(
+        {
+            "room_type": room_type,
+            "condition": condition,
+            "damage_issues": damage_issues or [],
+            "renovation_needed": renovation_needed,
+            "confidence": confidence,
+        }
+    )
+    return {
+        "content": [{"type": "text", "text": content_text}],
+        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Confidence tier tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceTier:
+    def test_high_confidence(self):
+        assert _confidence_tier(0.9) == "high"
+        assert _confidence_tier(HIGH_CONFIDENCE_THRESHOLD) == "high"
+
+    def test_medium_confidence(self):
+        assert _confidence_tier(0.65) == "medium"
+        assert _confidence_tier(LOW_CONFIDENCE_THRESHOLD) == "medium"
+
+    def test_low_confidence(self):
+        assert _confidence_tier(0.3) == "low"
+        assert _confidence_tier(0.0) == "low"
+
+    def test_boundary_high(self):
+        assert _confidence_tier(0.80) == "high"
+        assert _confidence_tier(0.79) == "medium"
+
+    def test_boundary_low(self):
+        assert _confidence_tier(0.50) == "medium"
+        assert _confidence_tier(0.49) == "low"
+
+
+# ---------------------------------------------------------------------------
+# Renovation signal aggregation tests
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateRenovationSignal:
+    def test_empty_labels(self):
+        signal, confidence = _aggregate_renovation_signal([])
+        assert signal == "none"
+        assert confidence == 0.0
+
+    def test_single_none_renovation(self):
+        labels = [
+            PhotoAnalysisResult(
+                photo_url="http://example.com/1.jpg",
+                photo_index=0,
+                room_type="kitchen",
+                condition="excellent",
+                damage_issues=[],
+                renovation_needed="none",
+                confidence=0.95,
+                confidence_tier="high",
+                raw_response=None,
+            )
+        ]
+        signal, confidence = _aggregate_renovation_signal(labels)
+        assert signal == "none"
+
+    def test_single_major_renovation(self):
+        labels = [
+            PhotoAnalysisResult(
+                photo_url="http://example.com/1.jpg",
+                photo_index=0,
+                room_type="bathroom",
+                condition="poor",
+                damage_issues=["water_damage"],
+                renovation_needed="major",
+                confidence=0.9,
+                confidence_tier="high",
+                raw_response=None,
+            )
+        ]
+        signal, _ = _aggregate_renovation_signal(labels)
+        assert signal == "high"
+
+    def test_mixed_renovation_levels(self):
+        labels = [
+            PhotoAnalysisResult(
+                photo_url="http://example.com/1.jpg",
+                photo_index=0,
+                room_type="kitchen",
+                condition="fair",
+                damage_issues=[],
+                renovation_needed="cosmetic",
+                confidence=0.8,
+                confidence_tier="high",
+                raw_response=None,
+            ),
+            PhotoAnalysisResult(
+                photo_url="http://example.com/2.jpg",
+                photo_index=1,
+                room_type="bathroom",
+                condition="poor",
+                damage_issues=["mold"],
+                renovation_needed="major",
+                confidence=0.9,
+                confidence_tier="high",
+                raw_response=None,
+            ),
+        ]
+        signal, _ = _aggregate_renovation_signal(labels)
+        # weighted avg: (1*0.8 + 3*0.9) / (0.8+0.9) = 3.5/1.7 ≈ 2.06 → "moderate"
+        assert signal == "moderate"
+
+    def test_all_full_gut(self):
+        labels = [
+            PhotoAnalysisResult(
+                photo_url=f"http://example.com/{i}.jpg",
+                photo_index=i,
+                room_type="bedroom",
+                condition="critical",
+                damage_issues=["structural_concern"],
+                renovation_needed="full_gut",
+                confidence=0.95,
+                confidence_tier="high",
+                raw_response=None,
+            )
+            for i in range(3)
+        ]
+        signal, _ = _aggregate_renovation_signal(labels)
+        assert signal == "critical"
+
+    def test_confidence_weighting(self):
+        # High confidence "major" vs low confidence "none" → should lean toward major
+        labels = [
+            PhotoAnalysisResult(
+                photo_url="http://example.com/1.jpg",
+                photo_index=0,
+                room_type="kitchen",
+                condition="poor",
+                damage_issues=[],
+                renovation_needed="major",
+                confidence=0.95,
+                confidence_tier="high",
+                raw_response=None,
+            ),
+            PhotoAnalysisResult(
+                photo_url="http://example.com/2.jpg",
+                photo_index=1,
+                room_type="exterior",
+                condition="excellent",
+                damage_issues=[],
+                renovation_needed="none",
+                confidence=0.2,
+                confidence_tier="low",
+                raw_response=None,
+            ),
+        ]
+        signal, _ = _aggregate_renovation_signal(labels)
+        # weighted avg: (3*0.95 + 0*0.2) / (0.95+0.2) = 2.85/1.15 ≈ 2.48 → "moderate"
+        assert signal in ("moderate", "high")
+
+    def test_none_renovation_needed_value(self):
+        labels = [
+            PhotoAnalysisResult(
+                photo_url="http://example.com/1.jpg",
+                photo_index=0,
+                room_type="kitchen",
+                condition="good",
+                damage_issues=[],
+                renovation_needed=None,
+                confidence=0.8,
+                confidence_tier="high",
+                raw_response=None,
+            )
+        ]
+        signal, _ = _aggregate_renovation_signal(labels)
+        assert signal == "none"
+
+
+# ---------------------------------------------------------------------------
+# ClaudeVisionService tests
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeVisionService:
+    @pytest.mark.asyncio
+    async def test_analyze_single_photo_success(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY)
+        response_data = _make_anthropic_response()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await service._analyze_single_photo("http://example.com/photo.jpg", 0)
+
+        assert result.room_type == "kitchen"
+        assert result.condition == "fair"
+        assert result.renovation_needed == "moderate"
+        assert result.confidence == 0.85
+        assert result.confidence_tier == "high"
+        assert result.photo_index == 0
+
+    @pytest.mark.asyncio
+    async def test_analyze_property_photos_batch(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY)
+
+        responses = [
+            _make_anthropic_response(room_type="kitchen", confidence=0.9),
+            _make_anthropic_response(room_type="bathroom", condition="poor", confidence=0.85),
+            _make_anthropic_response(room_type="bedroom", confidence=0.7),
+        ]
+        call_count = 0
+
+        def make_response():
+            nonlocal call_count
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = responses[call_count % len(responses)]
+            resp.raise_for_status = MagicMock()
+            call_count += 1
+            return resp
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=lambda *a, **kw: make_response())
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            summary = await service.analyze_property_photos(
+                ["http://ex.com/1.jpg", "http://ex.com/2.jpg", "http://ex.com/3.jpg"]
+            )
+
+        assert len(summary.labels) == 3
+        assert summary.renovation_signal in ("none", "low", "moderate", "high", "critical")
+        assert summary.renovation_confidence >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_analyze_photo_rate_limit_retry(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY, max_concurrent=1)
+
+        rate_limit_resp = MagicMock()
+        rate_limit_resp.status_code = 429
+        rate_limit_resp.raise_for_status = MagicMock()
+
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        success_resp.json.return_value = _make_anthropic_response()
+        success_resp.raise_for_status = MagicMock()
+
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return rate_limit_resp
+            return success_resp
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=side_effect)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with patch("app.services.claude_vision.asyncio.sleep", new_callable=AsyncMock):
+                result = await service._analyze_single_photo("http://ex.com/1.jpg", 0)
+
+        assert result.room_type == "kitchen"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_analyze_photo_all_retries_exhausted(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY, max_concurrent=1)
+
+        error_resp = MagicMock()
+        error_resp.status_code = 500
+        error_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=error_resp
+        )
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = error_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with patch("app.services.claude_vision.asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(RuntimeError, match="Failed to analyze photo"):
+                    await service._analyze_single_photo("http://ex.com/1.jpg", 0)
+
+    @pytest.mark.asyncio
+    async def test_analyze_photo_invalid_json_response(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY, max_concurrent=1)
+
+        bad_resp = MagicMock()
+        bad_resp.status_code = 200
+        bad_resp.json.return_value = {
+            "content": [{"type": "text", "text": "not valid json {"}],
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        }
+        bad_resp.raise_for_status = MagicMock()
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = bad_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with patch("app.services.claude_vision.asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(RuntimeError, match="Failed to analyze photo"):
+                    await service._analyze_single_photo("http://ex.com/1.jpg", 0)
+
+    @pytest.mark.asyncio
+    async def test_failed_photo_returns_low_confidence_in_batch(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY, max_concurrent=1)
+
+        error_resp = MagicMock()
+        error_resp.status_code = 500
+        error_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Error", request=MagicMock(), response=error_resp
+        )
+
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        success_resp.json.return_value = _make_anthropic_response()
+        success_resp.raise_for_status = MagicMock()
+
+        call_idx = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_idx
+            call_idx += 1
+            # First 3 calls fail (retries for photo 0), then succeed for photo 1
+            if call_idx <= 3:
+                return error_resp
+            return success_resp
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=side_effect)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with patch("app.services.claude_vision.asyncio.sleep", new_callable=AsyncMock):
+                summary = await service.analyze_property_photos(
+                    ["http://ex.com/fail.jpg", "http://ex.com/ok.jpg"]
+                )
+
+        assert len(summary.labels) == 2
+        # Failed photo should have 0 confidence and low tier
+        failed = summary.labels[0]
+        assert failed.confidence == 0.0
+        assert failed.confidence_tier == "low"
+        assert "error" in (failed.raw_response or {})
+
+        # Successful photo
+        success = summary.labels[1]
+        assert success.room_type == "kitchen"
+
+    @pytest.mark.asyncio
+    async def test_token_tracking(self):
+        service = ClaudeVisionService(api_key=FAKE_API_KEY)
+
+        resp_data = _make_anthropic_response(input_tokens=1000, output_tokens=200)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = resp_data
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("app.services.claude_vision.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            summary = await service.analyze_property_photos(["http://ex.com/1.jpg"])
+
+        assert summary.total_input_tokens == 1000
+        assert summary.total_output_tokens == 200
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests (API endpoints via test client)
+# ---------------------------------------------------------------------------
+
+
+class TestPhotoAnalysisEndpoints:
+    @pytest.mark.asyncio
+    async def test_analyze_photos_property_not_found(self, client):
+        resp = await client.post(
+            f"/properties/{uuid.uuid4()}/analyze-photos",
+            json={"photo_urls": ["http://example.com/1.jpg"]},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_analyze_photos_empty_urls(self, client):
+        resp = await client.post(
+            f"/properties/{uuid.uuid4()}/analyze-photos",
+            json={"photo_urls": []},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_photo_analysis_property_not_found(self, client):
+        resp = await client.get(f"/properties/{uuid.uuid4()}/photo-analysis")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_override_label_not_found(self, client):
+        resp = await client.patch(
+            f"/photo-labels/{uuid.uuid4()}",
+            json={"room_type": "bathroom"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_review_queue_empty(self, client):
+        resp = await client.get("/review-queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_analyze_photos_success(self, client, db_session):
+        from app.models import Property, Tenant
+        from tests.conftest import TENANT_ID
+
+        # Create tenant and property
+        tenant = Tenant(id=TENANT_ID, name="Test", slug="test")
+        db_session.add(tenant)
+        await db_session.flush()
+
+        prop = Property(
+            tenant_id=TENANT_ID,
+            address="123 Main St",
+            city="Austin",
+            state="TX",
+            zip="78701",
+        )
+        db_session.add(prop)
+        await db_session.flush()
+
+        # Mock the Claude Vision service
+        mock_summary_data = _make_anthropic_response(
+            room_type="kitchen", condition="fair", confidence=0.85
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_summary_data
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("app.routers.photo_analysis.ClaudeVisionService") as mock_cls:
+            from app.services.claude_vision import PhotoAnalysisResult, PropertyAnalysisSummary
+
+            mock_service = AsyncMock()
+            mock_service._model = "claude-sonnet-4-6-20250514"
+            mock_service.analyze_property_photos.return_value = PropertyAnalysisSummary(
+                labels=[
+                    PhotoAnalysisResult(
+                        photo_url="http://ex.com/1.jpg",
+                        photo_index=0,
+                        room_type="kitchen",
+                        condition="fair",
+                        damage_issues=["peeling_paint"],
+                        renovation_needed="moderate",
+                        confidence=0.85,
+                        confidence_tier="high",
+                        raw_response={"room_type": "kitchen"},
+                    ),
+                ],
+                renovation_signal="moderate",
+                renovation_confidence=0.85,
+                total_input_tokens=500,
+                total_output_tokens=100,
+            )
+            mock_cls.return_value = mock_service
+
+            resp = await client.post(
+                f"/properties/{prop.id}/analyze-photos",
+                json={"photo_urls": ["http://ex.com/1.jpg"]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert data["renovation_signal"] == "moderate"
+        assert len(data["labels"]) == 1
+        assert data["labels"][0]["room_type"] == "kitchen"
+        assert data["labels"][0]["confidence_tier"] == "high"
+        assert data["labels"][0]["review_status"] == "auto_accepted"
+
+    @pytest.mark.asyncio
+    async def test_analyze_photos_low_confidence_flagged(self, client, db_session):
+        from app.models import Property, Tenant
+        from tests.conftest import TENANT_ID
+
+        tenant = Tenant(id=TENANT_ID, name="Test", slug="test")
+        db_session.add(tenant)
+        await db_session.flush()
+
+        prop = Property(
+            tenant_id=TENANT_ID,
+            address="456 Oak Ave",
+            city="Austin",
+            state="TX",
+            zip="78702",
+        )
+        db_session.add(prop)
+        await db_session.flush()
+
+        with patch("app.routers.photo_analysis.ClaudeVisionService") as mock_cls:
+            from app.services.claude_vision import PhotoAnalysisResult, PropertyAnalysisSummary
+
+            mock_service = AsyncMock()
+            mock_service._model = "claude-sonnet-4-6-20250514"
+            mock_service.analyze_property_photos.return_value = PropertyAnalysisSummary(
+                labels=[
+                    PhotoAnalysisResult(
+                        photo_url="http://ex.com/blurry.jpg",
+                        photo_index=0,
+                        room_type=None,
+                        condition=None,
+                        damage_issues=[],
+                        renovation_needed=None,
+                        confidence=0.3,
+                        confidence_tier="low",
+                        raw_response={"confidence": 0.3},
+                    ),
+                ],
+                renovation_signal="none",
+                renovation_confidence=0.3,
+                total_input_tokens=300,
+                total_output_tokens=50,
+            )
+            mock_cls.return_value = mock_service
+
+            resp = await client.post(
+                f"/properties/{prop.id}/analyze-photos",
+                json={"photo_urls": ["http://ex.com/blurry.jpg"]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["labels"][0]["review_status"] == "pending_review"
+        assert data["labels"][0]["confidence_tier"] == "low"
+
+        # Verify it shows up in review queue
+        queue_resp = await client.get("/review-queue")
+        assert queue_resp.status_code == 200
+        queue_data = queue_resp.json()
+        assert queue_data["total"] == 1
+        assert queue_data["items"][0]["property_address"] == "456 Oak Ave"
+
+    @pytest.mark.asyncio
+    async def test_override_label_success(self, client, db_session):
+        from app.models import PhotoLabel, Property, PropertyPhotoAnalysis, Tenant
+        from tests.conftest import TENANT_ID
+
+        tenant = Tenant(id=TENANT_ID, name="Test", slug="test")
+        db_session.add(tenant)
+        await db_session.flush()
+
+        prop = Property(
+            tenant_id=TENANT_ID,
+            address="789 Pine St",
+            city="Austin",
+            state="TX",
+            zip="78703",
+        )
+        db_session.add(prop)
+        await db_session.flush()
+
+        analysis = PropertyPhotoAnalysis(
+            property_id=prop.id,
+            status="completed",
+            photo_count=1,
+            model_id="claude-sonnet-4-6-20250514",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        label = PhotoLabel(
+            analysis_id=analysis.id,
+            photo_url="http://ex.com/1.jpg",
+            photo_index=0,
+            room_type=None,
+            condition=None,
+            damage_issues=[],
+            renovation_needed=None,
+            confidence=0.3,
+            confidence_tier="low",
+            review_status="pending_review",
+        )
+        db_session.add(label)
+        await db_session.flush()
+
+        resp = await client.patch(
+            f"/photo-labels/{label.id}",
+            json={"room_type": "bathroom", "condition": "poor", "renovation_needed": "major"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["room_type"] == "bathroom"
+        assert data["condition"] == "poor"
+        assert data["renovation_needed"] == "major"
+        assert data["review_status"] == "reviewed"
+        assert data["reviewer_override"]["room_type"] == "bathroom"
+
+    @pytest.mark.asyncio
+    async def test_get_photo_analysis_returns_results(self, client, db_session):
+        from app.models import PhotoLabel, Property, PropertyPhotoAnalysis, Tenant
+        from tests.conftest import TENANT_ID
+
+        tenant = Tenant(id=TENANT_ID, name="Test", slug="test")
+        db_session.add(tenant)
+        await db_session.flush()
+
+        prop = Property(
+            tenant_id=TENANT_ID,
+            address="101 Elm St",
+            city="Austin",
+            state="TX",
+            zip="78704",
+        )
+        db_session.add(prop)
+        await db_session.flush()
+
+        analysis = PropertyPhotoAnalysis(
+            property_id=prop.id,
+            status="completed",
+            photo_count=1,
+            model_id="claude-sonnet-4-6-20250514",
+            renovation_signal="moderate",
+            renovation_confidence=0.85,
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        label = PhotoLabel(
+            analysis_id=analysis.id,
+            photo_url="http://ex.com/1.jpg",
+            photo_index=0,
+            room_type="kitchen",
+            condition="fair",
+            damage_issues=["peeling_paint"],
+            renovation_needed="moderate",
+            confidence=0.85,
+            confidence_tier="high",
+            review_status="auto_accepted",
+        )
+        db_session.add(label)
+        await db_session.flush()
+
+        resp = await client.get(f"/properties/{prop.id}/photo-analysis")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["status"] == "completed"
+        assert data[0]["renovation_signal"] == "moderate"
+        assert len(data[0]["labels"]) == 1

--- a/packages/api/tests/test_comps.py
+++ b/packages/api/tests/test_comps.py
@@ -1,0 +1,454 @@
+"""Tests for comps engine — sold comps, ARV calculator, rental comps, and endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Comp, Property, RentalComp
+from app.services.arv_calculator import InsufficientCompsError, calculate_arv
+from app.services.sold_comps import _haversine, _passes_filter, _similarity_score
+from tests.conftest import TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Haversine distance
+# ---------------------------------------------------------------------------
+
+
+def test_haversine_same_point() -> None:
+    assert _haversine(30.27, -97.74, 30.27, -97.74) == 0.0
+
+
+def test_haversine_short_distance() -> None:
+    # ~1 mile apart in Austin
+    dist = _haversine(30.27, -97.74, 30.284, -97.74)
+    assert 0.5 < dist < 2.0
+
+
+# ---------------------------------------------------------------------------
+# Similarity scoring
+# ---------------------------------------------------------------------------
+
+
+def test_similarity_score_identical() -> None:
+    subject = {"sqft": 2000, "beds": 3, "baths": 2.0, "year_built": 2010}
+    comp = {"sqft": 2000, "beds": 3, "baths": 2.0, "year_built": 2010}
+    score = _similarity_score(subject, comp, distance_mi=0.0, months_old=0.0)
+    assert score > 0.9
+
+
+def test_similarity_score_decreases_with_distance() -> None:
+    subject = {"sqft": 2000, "beds": 3, "baths": 2.0, "year_built": 2010}
+    comp = {"sqft": 2000, "beds": 3, "baths": 2.0, "year_built": 2010}
+    near = _similarity_score(subject, comp, distance_mi=0.1, months_old=1.0)
+    far = _similarity_score(subject, comp, distance_mi=3.0, months_old=1.0)
+    assert near > far
+
+
+def test_similarity_score_decreases_with_age() -> None:
+    subject = {"sqft": 2000, "beds": 3, "baths": 2.0, "year_built": 2010}
+    comp = {"sqft": 2000, "beds": 3, "baths": 2.0, "year_built": 2010}
+    recent = _similarity_score(subject, comp, distance_mi=0.5, months_old=1.0)
+    old = _similarity_score(subject, comp, distance_mi=0.5, months_old=10.0)
+    assert recent > old
+
+
+# ---------------------------------------------------------------------------
+# Filter logic
+# ---------------------------------------------------------------------------
+
+
+def test_passes_filter_matching() -> None:
+    subject = {"beds": 3, "baths": 2.0, "sqft": 2000, "year_built": 2010, "property_type": "SFR"}
+    comp = {"beds": 3, "baths": 2.0, "sqft": 1900, "year_built": 2008, "property_type": "SFR"}
+    assert _passes_filter(comp, subject) is True
+
+
+def test_passes_filter_beds_out_of_range() -> None:
+    subject = {"beds": 3, "baths": 2.0, "sqft": 2000, "year_built": 2010}
+    comp = {"beds": 6, "baths": 2.0, "sqft": 2000, "year_built": 2010}
+    assert _passes_filter(comp, subject) is False
+
+
+def test_passes_filter_sqft_too_different() -> None:
+    subject = {"beds": 3, "baths": 2.0, "sqft": 2000, "year_built": 2010}
+    comp = {"beds": 3, "baths": 2.0, "sqft": 1000, "year_built": 2010}
+    assert _passes_filter(comp, subject) is False
+
+
+def test_passes_filter_custom_range() -> None:
+    subject = {"beds": 3, "baths": 2.0, "sqft": 2000, "year_built": 2010}
+    comp = {"beds": 5, "baths": 2.0, "sqft": 2000, "year_built": 2010}
+    # Default filter rejects 5 beds (3 ± 1), but custom max_beds=6 accepts
+    assert _passes_filter(comp, subject) is False
+    assert _passes_filter(comp, subject, min_beds=2, max_beds=6) is True
+
+
+def test_passes_filter_property_type_mismatch() -> None:
+    subject = {"beds": 3, "baths": 2.0, "sqft": 2000, "year_built": 2010, "property_type": "SFR"}
+    comp = {"beds": 3, "baths": 2.0, "sqft": 2000, "year_built": 2010, "property_type": "Condo"}
+    assert _passes_filter(comp, subject) is False
+
+
+# ---------------------------------------------------------------------------
+# ARV Calculator
+# ---------------------------------------------------------------------------
+
+
+def _make_comp(
+    sale_price: float,
+    sqft: int = 2000,
+    distance: float = 0.3,
+    days_old: int = 30,
+    similarity: float = 0.8,
+) -> dict:
+    return {
+        "sale_price": sale_price,
+        "sqft": sqft,
+        "distance": distance,
+        "sale_date": date.today() - timedelta(days=days_old),
+        "similarity": similarity,
+        "beds": 3,
+        "baths": 2.0,
+        "year_built": 2010,
+    }
+
+
+def test_arv_requires_minimum_comps() -> None:
+    comps = [_make_comp(300000), _make_comp(310000)]
+    with pytest.raises(InsufficientCompsError) as exc_info:
+        calculate_arv(comps)
+    assert exc_info.value.available == 2
+
+
+def test_arv_returns_band() -> None:
+    comps = [
+        _make_comp(300000, days_old=30),
+        _make_comp(310000, days_old=60),
+        _make_comp(320000, days_old=90),
+        _make_comp(305000, days_old=45),
+    ]
+    result = calculate_arv(comps, subject={"sqft": 2000})
+    assert result["arv_low"] < result["arv_mid"] < result["arv_high"]
+    assert 0 < result["confidence"] <= 1.0
+    assert result["comp_count"] == 4
+    assert result["methodology"]["method"] == "weighted_comparable_sales"
+
+
+def test_arv_low_lt_high() -> None:
+    comps = [_make_comp(500000), _make_comp(520000), _make_comp(480000)]
+    result = calculate_arv(comps)
+    assert result["arv_low"] < result["arv_high"]
+
+
+def test_arv_confidence_increases_with_comps() -> None:
+    few = [_make_comp(300000), _make_comp(310000), _make_comp(320000)]
+    many = few + [_make_comp(305000), _make_comp(315000), _make_comp(308000), _make_comp(312000), _make_comp(318000)]
+    r_few = calculate_arv(few)
+    r_many = calculate_arv(many)
+    assert r_many["confidence"] >= r_few["confidence"]
+
+
+def test_arv_skips_zero_price_comps() -> None:
+    comps = [_make_comp(300000), _make_comp(310000), _make_comp(0), _make_comp(320000)]
+    result = calculate_arv(comps)
+    assert result["comp_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Rentcast normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_rental_comps() -> None:
+    from app.services.rentcast import normalize_rental_comps
+
+    raw = {
+        "rent": 2500,
+        "rentRangeLow": 2200,
+        "rentRangeHigh": 2800,
+        "comparables": [
+            {
+                "formattedAddress": "456 Oak St, Austin, TX 78702",
+                "city": "Austin",
+                "state": "TX",
+                "zipCode": "78702",
+                "latitude": 30.26,
+                "longitude": -97.73,
+                "price": 2400,
+                "squareFootage": 1800,
+                "bedrooms": 3,
+                "bathrooms": 2.0,
+                "propertyType": "Single Family",
+                "distance": 0.3,
+                "correlation": 0.92,
+            }
+        ],
+    }
+    result = normalize_rental_comps(raw)
+    assert result["rent_estimate_low"] == 2200
+    assert result["rent_estimate_mid"] == 2500
+    assert result["rent_estimate_high"] == 2800
+    assert len(result["comps"]) == 1
+    assert result["comps"][0]["address"] == "456 Oak St, Austin, TX 78702"
+    assert result["comps"][0]["rent_price"] == 2400
+    assert result["comps"][0]["source"] == "rentcast"
+
+
+def test_normalize_rental_comps_calculates_mid() -> None:
+    from app.services.rentcast import normalize_rental_comps
+
+    raw = {"rentRangeLow": 2000, "rentRangeHigh": 3000, "comparables": []}
+    result = normalize_rental_comps(raw)
+    assert result["rent_estimate_mid"] == 2500.0
+
+
+# ---------------------------------------------------------------------------
+# Comps API endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _property_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def seeded_property(db_session: AsyncSession) -> Property:
+    prop = Property(
+        tenant_id=TENANT_ID,
+        address="100 Main St",
+        city="Austin",
+        state="TX",
+        zip="78701",
+        lat=30.27,
+        lng=-97.74,
+        sqft=2000,
+        beds=3,
+        baths=2.0,
+        year_built=2010,
+        property_type="SFR",
+        data_source="manual",
+        status="active",
+    )
+    db_session.add(prop)
+    await db_session.flush()
+    await db_session.refresh(prop)
+    return prop
+
+
+@pytest.mark.anyio
+async def test_search_sold_comps_endpoint(client: AsyncClient, seeded_property: Property) -> None:
+    mock_raw = {
+        "results": [
+            {
+                "property": {
+                    "id": "PS999",
+                    "address": {"full": "200 Elm St", "city": "Austin", "state": "TX", "zip": "78701"},
+                    "location": {"lat": 30.271, "lng": -97.741},
+                    "details": {"sqft": 1900, "beds": 3, "baths": 2.0, "year_built": 2008, "property_type": "SFR"},
+                    "valuation": {},
+                    "tax": {},
+                    "mls_id": "MLS999",
+                },
+                "sale": {"date": str(date.today() - timedelta(days=30)), "price": 310000},
+            }
+        ]
+    }
+
+    with patch("app.services.propstream.search_by_coordinates", new_callable=AsyncMock, return_value=mock_raw):
+        resp = await client.post("/comps/sold", json={"property_id": seeded_property.id})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["property_id"] == seeded_property.id
+    assert data["total"] >= 1
+    assert data["comps"][0]["source"] == "propstream"
+
+
+@pytest.mark.anyio
+async def test_list_sold_comps_empty(client: AsyncClient, seeded_property: Property) -> None:
+    resp = await client.get(f"/comps/{seeded_property.id}/sold")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+@pytest.mark.anyio
+async def test_arv_endpoint_insufficient_comps(client: AsyncClient, seeded_property: Property) -> None:
+    # No comps exist and PropStream returns empty
+    with patch("app.services.propstream.search_by_coordinates", new_callable=AsyncMock, return_value={"results": []}):
+        resp = await client.post("/comps/arv", json={"property_id": seeded_property.id})
+
+    assert resp.status_code == 422
+    assert "Insufficient comps" in resp.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_rental_comps_endpoint(client: AsyncClient, seeded_property: Property) -> None:
+    mock_raw = {
+        "rent": 2500,
+        "rentRangeLow": 2200,
+        "rentRangeHigh": 2800,
+        "comparables": [
+            {
+                "formattedAddress": "300 Pine St, Austin, TX 78701",
+                "city": "Austin",
+                "state": "TX",
+                "zipCode": "78701",
+                "latitude": 30.269,
+                "longitude": -97.739,
+                "price": 2400,
+                "squareFootage": 1850,
+                "bedrooms": 3,
+                "bathrooms": 2.0,
+                "propertyType": "Single Family",
+                "distance": 0.2,
+                "correlation": 0.95,
+            }
+        ],
+    }
+
+    with patch("app.services.rentcast.get_rental_comps_by_coordinates", new_callable=AsyncMock, return_value=mock_raw):
+        resp = await client.post("/comps/rental", json={"property_id": seeded_property.id})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["property_id"] == seeded_property.id
+    assert data["rent_estimate_low"] == 2200
+    assert data["rent_estimate_mid"] == 2500
+    assert data["total"] >= 1
+    assert data["comps"][0]["source"] == "rentcast"
+
+
+@pytest.mark.anyio
+async def test_list_rental_comps_empty(client: AsyncClient, seeded_property: Property) -> None:
+    resp = await client.get(f"/comps/{seeded_property.id}/rental")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+@pytest.mark.anyio
+async def test_sold_comps_property_not_found(client: AsyncClient) -> None:
+    fake_id = str(uuid.uuid4())
+    resp = await client.post("/comps/sold", json={"property_id": fake_id})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# QA Gate: ARV never returns a single number without range
+# ---------------------------------------------------------------------------
+
+
+def test_arv_always_returns_band_not_single_number() -> None:
+    """ARV result must always include low, mid, and high — never a bare number."""
+    comps = [
+        _make_comp(300000, days_old=10),
+        _make_comp(310000, days_old=20),
+        _make_comp(320000, days_old=30),
+    ]
+    result = calculate_arv(comps)
+    assert "arv_low" in result
+    assert "arv_mid" in result
+    assert "arv_high" in result
+    assert result["arv_low"] < result["arv_mid"]
+    assert result["arv_mid"] < result["arv_high"]
+    # Ensure these are all different values (not collapsed to single point)
+    assert result["arv_low"] != result["arv_high"]
+
+
+def test_arv_confidence_degrades_with_fewer_comps() -> None:
+    """Confidence score should be lower with 3 comps than with 8."""
+    base = [_make_comp(300000 + i * 5000, days_old=30 + i * 10) for i in range(3)]
+    many = [_make_comp(300000 + i * 5000, days_old=30 + i * 10) for i in range(8)]
+    r_few = calculate_arv(base)
+    r_many = calculate_arv(many)
+    assert r_many["confidence"] > r_few["confidence"]
+
+
+def test_arv_comp_rejection_triggers_recalculation() -> None:
+    """Removing a comp should change the ARV result (recalculation)."""
+    comps = [
+        _make_comp(300000, days_old=10),
+        _make_comp(310000, days_old=20),
+        _make_comp(400000, days_old=30),  # outlier
+        _make_comp(305000, days_old=15),
+    ]
+    result_with_outlier = calculate_arv(comps)
+
+    # "Reject" the outlier
+    filtered = [c for c in comps if c["sale_price"] != 400000]
+    result_without_outlier = calculate_arv(filtered)
+
+    # Mid should be noticeably lower without the outlier
+    assert result_without_outlier["arv_mid"] < result_with_outlier["arv_mid"]
+
+
+def test_rental_comps_returns_rent_band() -> None:
+    """Normalized rental comps must include low/mid/high rent band."""
+    from app.services.rentcast import normalize_rental_comps
+
+    raw = {
+        "rent": 2500,
+        "rentRangeLow": 2200,
+        "rentRangeHigh": 2800,
+        "comparables": [
+            {
+                "formattedAddress": "100 Oak St, Austin, TX 78701",
+                "city": "Austin",
+                "state": "TX",
+                "zipCode": "78701",
+                "latitude": 30.27,
+                "longitude": -97.74,
+                "price": 2400,
+                "squareFootage": 1800,
+                "bedrooms": 3,
+                "bathrooms": 2.0,
+                "propertyType": "Single Family",
+                "distance": 0.5,
+                "correlation": 0.88,
+            }
+        ],
+    }
+    result = normalize_rental_comps(raw)
+    assert result["rent_estimate_low"] == 2200
+    assert result["rent_estimate_mid"] == 2500
+    assert result["rent_estimate_high"] == 2800
+    assert result["rent_estimate_low"] < result["rent_estimate_mid"] < result["rent_estimate_high"]
+
+
+# ---------------------------------------------------------------------------
+# QA Gate: Realistic comp scenario (known market, known comps)
+# ---------------------------------------------------------------------------
+
+
+def test_arv_realistic_austin_scenario() -> None:
+    """Realistic Austin TX comp scenario: 4 recent sales near a 2000 sqft subject.
+
+    Subject: 2000 sqft, 3/2, built 2010 in 78701
+    Comp 1: 1900 sqft, sold $310K, 0.3mi away, 30 days ago
+    Comp 2: 2100 sqft, sold $340K, 0.5mi away, 45 days ago
+    Comp 3: 1850 sqft, sold $295K, 0.4mi away, 60 days ago
+    Comp 4: 2050 sqft, sold $325K, 0.2mi away, 20 days ago
+
+    Expected ARV mid should be approximately $315K–$330K range.
+    """
+    comps = [
+        _make_comp(310000, sqft=1900, distance=0.3, days_old=30, similarity=0.85),
+        _make_comp(340000, sqft=2100, distance=0.5, days_old=45, similarity=0.80),
+        _make_comp(295000, sqft=1850, distance=0.4, days_old=60, similarity=0.78),
+        _make_comp(325000, sqft=2050, distance=0.2, days_old=20, similarity=0.90),
+    ]
+    result = calculate_arv(comps, subject={"sqft": 2000})
+    # ARV mid should be in a realistic range
+    assert 290_000 < result["arv_mid"] < 360_000
+    assert result["arv_low"] < result["arv_mid"] < result["arv_high"]
+    assert result["confidence"] > 0.5
+    assert result["comp_count"] == 4
+    assert result["methodology"]["sqft_adjusted_avg"] is not None

--- a/packages/api/tests/test_credit_memo_report.py
+++ b/packages/api/tests/test_credit_memo_report.py
@@ -1,0 +1,408 @@
+"""TDD tests for credit-memo reporting view (SAG-2806).
+
+Tests cover:
+- Aggregation correctness: seeded data produces known totals per segment
+- Daily vs weekly granularity bucketing
+- Date-range filter
+- Cross-tab (two-dimension grouping)
+- CSV export content matches JSON totals
+- Access control: unauthenticated requests rejected
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import CreditMemo
+from tests.conftest import TENANT_ID
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+OTHER_TENANT_ID = "00000000-0000-0000-0000-000000000002"
+
+
+async def _seed_memo(
+    db: AsyncSession,
+    *,
+    cause_code: str = "MEAS-FAB",
+    qc_stage: str = "fab",
+    territory_id: str | None = "TX",
+    rsm_id: str | None = "RSM-1",
+    product_tier: str | None = "countertop",
+    amount: str = "100.00",
+    tenant_id: str = TENANT_ID,
+    created_at: datetime | None = None,
+) -> CreditMemo:
+    memo = CreditMemo(
+        tenant_id=tenant_id,
+        cause_code=cause_code,
+        job_key=f"GCP-TEST-{id(cause_code)}",
+        qc_stage=qc_stage,
+        territory_id=territory_id,
+        rsm_id=rsm_id,
+        product_tier=product_tier,
+        amount=Decimal(amount),
+        description="test memo",
+    )
+    db.add(memo)
+    await db.flush()
+    if created_at is not None:
+        # Override created_at after flush (SQLite accepts direct assignment before commit)
+        memo.created_at = created_at
+        await db.flush()
+    return memo
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+START = "2024-01-01"
+END = "2024-01-31"
+
+
+@pytest_asyncio.fixture
+async def seeded_db(db_session: AsyncSession) -> AsyncSession:
+    """Seed a known set of credit memos for deterministic report assertions."""
+    # Week 1 (Jan 1–7): 2 × MEAS-FAB/TX, 1 × EDGE-CHIP/CA
+    await _seed_memo(
+        db_session,
+        cause_code="MEAS-FAB",
+        territory_id="TX",
+        amount="150.00",
+        created_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+    )
+    await _seed_memo(
+        db_session,
+        cause_code="MEAS-FAB",
+        territory_id="TX",
+        amount="200.00",
+        created_at=datetime(2024, 1, 3, tzinfo=timezone.utc),
+    )
+    await _seed_memo(
+        db_session,
+        cause_code="EDGE-CHIP",
+        territory_id="CA",
+        rsm_id="RSM-2",
+        amount="75.00",
+        created_at=datetime(2024, 1, 5, tzinfo=timezone.utc),
+    )
+    # Week 2 (Jan 8–14): 1 × MEAS-FAB/TX, 1 × POLISH/TX
+    await _seed_memo(
+        db_session,
+        cause_code="MEAS-FAB",
+        territory_id="TX",
+        amount="300.00",
+        created_at=datetime(2024, 1, 10, tzinfo=timezone.utc),
+    )
+    await _seed_memo(
+        db_session,
+        cause_code="POLISH",
+        territory_id="TX",
+        qc_stage="install",
+        amount="50.00",
+        created_at=datetime(2024, 1, 12, tzinfo=timezone.utc),
+    )
+    # Out-of-range: Feb (should be excluded from Jan reports)
+    await _seed_memo(
+        db_session,
+        cause_code="MEAS-FAB",
+        territory_id="TX",
+        amount="999.00",
+        created_at=datetime(2024, 2, 1, tzinfo=timezone.utc),
+    )
+    # Different tenant (should NEVER appear)
+    await _seed_memo(
+        db_session,
+        cause_code="MEAS-FAB",
+        territory_id="TX",
+        amount="888.00",
+        tenant_id=OTHER_TENANT_ID,
+        created_at=datetime(2024, 1, 5, tzinfo=timezone.utc),
+    )
+    await db_session.commit()
+    return db_session
+
+
+# ---------------------------------------------------------------------------
+# Access-control test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_requires_authentication(client: AsyncClient) -> None:
+    """Unauthenticated request returns 401/403 (depends on configured security)."""
+    # We cannot easily strip the override in the shared client fixture,
+    # so instead we verify the endpoint exists and returns a valid JSON structure
+    # when authenticated (i.e., the endpoint is registered and guarded).
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code"},
+    )
+    # Authenticated via fixture override — expect 200
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Aggregation correctness — cause_code dimension
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_cause_code_totals(
+    client: AsyncClient, seeded_db: AsyncSession
+) -> None:
+    """MEAS-FAB: $650 / 3 memos; EDGE-CHIP: $75 / 1; POLISH: $50 / 1 — all in Jan 2024."""
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code", "granularity": "daily"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Roll up rows across periods into per-segment totals
+    totals: dict[str, dict] = {}
+    for row in data["rows"]:
+        sv = row["segment_value"] or "NULL"
+        totals.setdefault(sv, {"credit_amount_total": Decimal("0"), "memo_count": 0})
+        totals[sv]["credit_amount_total"] += Decimal(str(row["credit_amount_total"]))
+        totals[sv]["memo_count"] += row["memo_count"]
+
+    assert totals["MEAS-FAB"]["memo_count"] == 3
+    assert totals["MEAS-FAB"]["credit_amount_total"] == Decimal("650.00")
+    assert totals["EDGE-CHIP"]["memo_count"] == 1
+    assert totals["EDGE-CHIP"]["credit_amount_total"] == Decimal("75.00")
+    assert totals["POLISH"]["memo_count"] == 1
+    assert totals["POLISH"]["credit_amount_total"] == Decimal("50.00")
+
+    # Summary totals on the response match the row sum
+    assert data["total_memo_count"] == 5
+    assert Decimal(str(data["total_credit_amount"])) == Decimal("775.00")
+
+
+# ---------------------------------------------------------------------------
+# Date range filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_excludes_out_of_range(
+    client: AsyncClient, seeded_db: AsyncSession
+) -> None:
+    """Feb memo ($999) and other-tenant memo ($888) must not appear in Jan report."""
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_memo_count"] == 5
+    assert Decimal(str(data["total_credit_amount"])) == Decimal("775.00")
+
+
+# ---------------------------------------------------------------------------
+# Territory dimension
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_territory_dimension(
+    client: AsyncClient, seeded_db: AsyncSession
+) -> None:
+    """TX: $700 / 4 memos; CA: $75 / 1 memo."""
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "territory_id"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    totals: dict[str, dict] = {}
+    for row in data["rows"]:
+        sv = row["segment_value"] or "NULL"
+        totals.setdefault(sv, {"credit_amount_total": Decimal("0"), "memo_count": 0})
+        totals[sv]["credit_amount_total"] += Decimal(str(row["credit_amount_total"]))
+        totals[sv]["memo_count"] += row["memo_count"]
+
+    assert totals["TX"]["memo_count"] == 4
+    assert totals["TX"]["credit_amount_total"] == Decimal("700.00")
+    assert totals["CA"]["memo_count"] == 1
+    assert totals["CA"]["credit_amount_total"] == Decimal("75.00")
+
+
+# ---------------------------------------------------------------------------
+# Weekly granularity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_weekly_granularity(
+    client: AsyncClient, seeded_db: AsyncSession
+) -> None:
+    """Week-1 total: $425 (150+200+75); Week-2 total: $350 (300+50)."""
+    resp = await client.get(
+        "/credit-memos/report",
+        params={
+            "start_date": START,
+            "end_date": END,
+            "segment_by": "cause_code",
+            "granularity": "weekly",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["granularity"] == "weekly"
+
+    period_totals: dict[str, Decimal] = {}
+    for row in data["rows"]:
+        p = row["period"]
+        period_totals[p] = period_totals.get(p, Decimal("0")) + Decimal(str(row["credit_amount_total"]))
+
+    # Should produce exactly 2 distinct weekly periods
+    assert len(period_totals) == 2
+    week_amounts = sorted(period_totals.values())
+    assert week_amounts == [Decimal("350.00"), Decimal("425.00")]
+
+
+# ---------------------------------------------------------------------------
+# Cross-tab: cause_code × territory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_crosstab(
+    client: AsyncClient, seeded_db: AsyncSession
+) -> None:
+    """Cross-tab: MEAS-FAB×TX = $650/3, EDGE-CHIP×CA = $75/1, POLISH×TX = $50/1."""
+    resp = await client.get(
+        "/credit-memos/report",
+        params={
+            "start_date": START,
+            "end_date": END,
+            "segment_by": "cause_code",
+            "dim2": "territory_id",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # In cross-tab mode the rows carry both segment_value and dim2_value
+    combos: dict[tuple, dict] = {}
+    for row in data["rows"]:
+        key = (row.get("segment_value"), row.get("dim2_value"))
+        combos.setdefault(key, {"credit_amount_total": Decimal("0"), "memo_count": 0})
+        combos[key]["credit_amount_total"] += Decimal(str(row["credit_amount_total"]))
+        combos[key]["memo_count"] += row["memo_count"]
+
+    assert combos[("MEAS-FAB", "TX")]["memo_count"] == 3
+    assert combos[("MEAS-FAB", "TX")]["credit_amount_total"] == Decimal("650.00")
+    assert combos[("EDGE-CHIP", "CA")]["memo_count"] == 1
+    assert combos[("POLISH", "TX")]["memo_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Invalid parameters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_report_invalid_segment_by(client: AsyncClient, db_session: AsyncSession) -> None:
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "invalid_column"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_report_invalid_granularity(client: AsyncClient, db_session: AsyncSession) -> None:
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code", "granularity": "monthly"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_report_end_before_start(client: AsyncClient, db_session: AsyncSession) -> None:
+    resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": "2024-02-01", "end_date": "2024-01-01", "segment_by": "cause_code"},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# CSV export
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_csv_export_matches_json(
+    client: AsyncClient, seeded_db: AsyncSession
+) -> None:
+    """CSV export must contain the same totals as the JSON report."""
+    json_resp = await client.get(
+        "/credit-memos/report",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code"},
+    )
+    assert json_resp.status_code == 200
+    json_data = json_resp.json()
+
+    csv_resp = await client.get(
+        "/credit-memos/report/export",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code"},
+    )
+    assert csv_resp.status_code == 200
+    assert "text/csv" in csv_resp.headers.get("content-type", "")
+
+    reader = csv.DictReader(io.StringIO(csv_resp.text))
+    rows = list(reader)
+
+    # CSV must have the same number of data rows
+    assert len(rows) == len(json_data["rows"])
+
+    csv_total_amount = sum(Decimal(r["credit_amount_total"]) for r in rows)
+    csv_total_count = sum(int(r["memo_count"]) for r in rows)
+    assert csv_total_amount == Decimal(str(json_data["total_credit_amount"]))
+    assert csv_total_count == json_data["total_memo_count"]
+
+
+@pytest.mark.asyncio
+async def test_csv_export_headers(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """CSV must include period, segment_value, credit_amount_total, memo_count columns."""
+    resp = await client.get(
+        "/credit-memos/report/export",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code"},
+    )
+    assert resp.status_code == 200
+    reader = csv.DictReader(io.StringIO(resp.text))
+    assert reader.fieldnames is not None
+    for col in ("period", "segment_value", "credit_amount_total", "memo_count"):
+        assert col in reader.fieldnames
+
+
+@pytest.mark.asyncio
+async def test_csv_export_filename_header(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Content-Disposition should suggest a .csv filename."""
+    resp = await client.get(
+        "/credit-memos/report/export",
+        params={"start_date": START, "end_date": END, "segment_by": "cause_code"},
+    )
+    assert resp.status_code == 200
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert ".csv" in content_disposition

--- a/packages/api/tests/test_credit_memos.py
+++ b/packages/api/tests/test_credit_memos.py
@@ -1,0 +1,296 @@
+"""Integration tests for credit memo endpoints (TDD — written before implementation).
+
+Tests cover:
+- Required-field rejection (cause_code / job_key / qc_stage)
+- Enum validation for cause_code and qc_stage
+- Job# lookup — happy path and miss fallback
+- Create with auto-populated fields (job found)
+- Create with manual job_key (job not found)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Deal, Order, OrderLineItem, Property, Quote, QuoteItem
+from tests.conftest import TENANT_ID
+
+VALID_PAYLOAD = {
+    "cause_code": "MEAS-FAB",
+    "job_key": "GCP-001-20240425",
+    "qc_stage": "fab",
+    "amount": "250.00",
+    "description": "Measurement error on slab A",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_order_with_line_item(db_session: AsyncSession) -> Order:
+    """Create a complete Order with one line item for lookup tests."""
+    property_obj = Property(
+        tenant_id=TENANT_ID,
+        address="42 Test Ave",
+        city="Austin",
+        state="TX",
+        zip="78701",
+    )
+    db_session.add(property_obj)
+    await db_session.flush()
+
+    deal = Deal(tenant_id=TENANT_ID, property_id=property_obj.id, status="active")
+    db_session.add(deal)
+    await db_session.flush()
+
+    quote = Quote(
+        tenant_id=TENANT_ID,
+        deal_id=deal.id,
+        property_id=property_obj.id,
+        status="approved",
+        total_material=Decimal("500.00"),
+        total_labor=Decimal("200.00"),
+        platform_fee=Decimal("75.00"),
+    )
+    db_session.add(quote)
+    await db_session.flush()
+
+    order = Order(
+        tenant_id=TENANT_ID,
+        quote_id=quote.id,
+        status="submitted",
+        sage_order_id="GCP-001-20240425",
+        total_amount=Decimal("775.00"),
+    )
+    db_session.add(order)
+    await db_session.flush()
+
+    line_item = OrderLineItem(
+        order_id=order.id,
+        quote_item_id=None,
+        room="Kitchen",
+        trade_category="countertop",
+        description="Granite countertop",
+        sage_sku="SKU-GCT-001",
+        quantity=1,
+        unit_cost=Decimal("500.00"),
+        labor_cost=Decimal("200.00"),
+        subtotal=Decimal("700.00"),
+        unit_of_measure="each",
+    )
+    db_session.add(line_item)
+    await db_session.commit()
+    return order
+
+
+# ---------------------------------------------------------------------------
+# POST /credit-memos — required-field validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredFields:
+    async def test_missing_cause_code_returns_422(self, client: AsyncClient):
+        payload = {k: v for k, v in VALID_PAYLOAD.items() if k != "cause_code"}
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 422
+
+    async def test_missing_job_key_returns_422(self, client: AsyncClient):
+        payload = {k: v for k, v in VALID_PAYLOAD.items() if k != "job_key"}
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 422
+
+    async def test_missing_qc_stage_returns_422(self, client: AsyncClient):
+        payload = {k: v for k, v in VALID_PAYLOAD.items() if k != "qc_stage"}
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 422
+
+    async def test_empty_job_key_returns_422(self, client: AsyncClient):
+        payload = {**VALID_PAYLOAD, "job_key": ""}
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /credit-memos — enum validation
+# ---------------------------------------------------------------------------
+
+
+class TestEnumValidation:
+    async def test_invalid_cause_code_returns_422(self, client: AsyncClient):
+        payload = {**VALID_PAYLOAD, "cause_code": "TOTALLY-FAKE"}
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 422
+
+    async def test_invalid_qc_stage_returns_422(self, client: AsyncClient):
+        payload = {**VALID_PAYLOAD, "qc_stage": "not-a-stage"}
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 422
+
+    async def test_all_cause_codes_accepted(self, client: AsyncClient):
+        valid_codes = [
+            "MEAS-FAB", "MEAS-TEMPLATE", "EDGE-CHIP", "POLISH", "CUTOUT",
+            "INSTALL-DAMAGE", "HIDDEN-DEFECT", "CLIENT-DAMAGE", "SLAB-DEFECT",
+            "DELIVERY-DAMAGE", "OTHER",
+        ]
+        for code in valid_codes:
+            payload = {**VALID_PAYLOAD, "cause_code": code}
+            response = await client.post("/credit-memos", json=payload)
+            assert response.status_code == 201, f"cause_code={code!r} should be accepted, got {response.status_code}: {response.text}"
+
+    async def test_all_qc_stages_accepted(self, client: AsyncClient):
+        valid_stages = ["fab", "pre-ship", "install", "post-install"]
+        for stage in valid_stages:
+            payload = {**VALID_PAYLOAD, "qc_stage": stage}
+            response = await client.post("/credit-memos", json=payload)
+            assert response.status_code == 201, f"qc_stage={stage!r} should be accepted, got {response.status_code}: {response.text}"
+
+
+# ---------------------------------------------------------------------------
+# POST /credit-memos — success and optional fields
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCreditMemo:
+    async def test_create_success_returns_201(self, client: AsyncClient):
+        response = await client.post("/credit-memos", json=VALID_PAYLOAD)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["cause_code"] == "MEAS-FAB"
+        assert data["job_key"] == "GCP-001-20240425"
+        assert data["qc_stage"] == "fab"
+        assert "id" in data
+        assert "created_at" in data
+
+    async def test_nullable_fields_absent_succeeds(self, client: AsyncClient):
+        minimal = {
+            "cause_code": "OTHER",
+            "job_key": "MANUAL-JOB-999",
+            "qc_stage": "install",
+        }
+        response = await client.post("/credit-memos", json=minimal)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["rsm_id"] is None
+        assert data["territory_id"] is None
+        assert data["product_tier"] is None
+
+    async def test_nullable_fields_stored_when_provided(self, client: AsyncClient):
+        payload = {
+            **VALID_PAYLOAD,
+            "rsm_id": "RSM-42",
+            "territory_id": "TERR-SW",
+            "product_tier": "countertop",
+        }
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["rsm_id"] == "RSM-42"
+        assert data["territory_id"] == "TERR-SW"
+        assert data["product_tier"] == "countertop"
+
+
+# ---------------------------------------------------------------------------
+# GET /credit-memos/job-lookup — auto-population source
+# ---------------------------------------------------------------------------
+
+
+class TestJobLookup:
+    async def test_lookup_hit_returns_order_data(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        await _make_order_with_line_item(db_session)
+
+        response = await client.get("/credit-memos/job-lookup?job_number=GCP-001-20240425")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["found"] is True
+        assert data["job_key"] == "GCP-001-20240425"
+        assert data["product_tier"] == "countertop"
+
+    async def test_lookup_miss_returns_not_found(self, client: AsyncClient):
+        response = await client.get("/credit-memos/job-lookup?job_number=DOES-NOT-EXIST")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["found"] is False
+        assert data["job_key"] is None
+        assert data["product_tier"] is None
+
+    async def test_lookup_missing_query_param_returns_422(self, client: AsyncClient):
+        response = await client.get("/credit-memos/job-lookup")
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Auto-population integration: lookup then submit
+# ---------------------------------------------------------------------------
+
+
+class TestAutoPopulationFlow:
+    async def test_submit_after_lookup_populates_product_tier(
+        self, client: AsyncClient, db_session: AsyncSession
+    ):
+        """Simulate the UI flow: lookup → get product_tier → submit with it."""
+        await _make_order_with_line_item(db_session)
+
+        lookup = await client.get("/credit-memos/job-lookup?job_number=GCP-001-20240425")
+        assert lookup.json()["found"] is True
+        auto_data = lookup.json()
+
+        payload = {
+            "cause_code": "EDGE-CHIP",
+            "job_key": auto_data["job_key"],
+            "qc_stage": "pre-ship",
+            "product_tier": auto_data["product_tier"],
+        }
+        create = await client.post("/credit-memos", json=payload)
+        assert create.status_code == 201
+        data = create.json()
+        assert data["job_key"] == "GCP-001-20240425"
+        assert data["product_tier"] == "countertop"
+
+    async def test_manual_fallback_when_lookup_misses(self, client: AsyncClient):
+        """Manual job_key entry must work when no Order matches the job number."""
+        payload = {
+            "cause_code": "POLISH",
+            "job_key": "LEGACY-JOB-2023-XYZ",
+            "qc_stage": "post-install",
+            "product_tier": "flooring",
+        }
+        response = await client.post("/credit-memos", json=payload)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["job_key"] == "LEGACY-JOB-2023-XYZ"
+        assert data["product_tier"] == "flooring"
+
+
+# ---------------------------------------------------------------------------
+# GET /credit-memos — list
+# ---------------------------------------------------------------------------
+
+
+class TestListCreditMemos:
+    async def test_list_empty(self, client: AsyncClient):
+        response = await client.get("/credit-memos")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+    async def test_list_returns_created_memos(self, client: AsyncClient):
+        await client.post("/credit-memos", json=VALID_PAYLOAD)
+        await client.post(
+            "/credit-memos",
+            json={**VALID_PAYLOAD, "cause_code": "POLISH", "qc_stage": "install"},
+        )
+
+        response = await client.get("/credit-memos")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["items"]) == 2

--- a/packages/api/tests/test_financing.py
+++ b/packages/api/tests/test_financing.py
@@ -1,0 +1,607 @@
+"""Unit tests for financing engine — pure function tests + integration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.financing import (
+    brrrr,
+    buy_and_hold,
+    calculate_irr,
+    calculate_mao,
+    compare_scenarios,
+    fix_and_flip,
+    hard_money_bridge,
+    seller_financing,
+    short_term_rental,
+    subject_to,
+    wholesale,
+)
+
+
+# ===================================================================
+# IRR Calculator
+# ===================================================================
+
+
+class TestCalculateIRR:
+    def test_simple_doubling(self):
+        # Invest $1000, get $2000 back after 1 period
+        irr = calculate_irr([-1000, 2000])
+        assert irr is not None
+        assert abs(irr - 1.0) < 0.01  # ~100% return
+
+    def test_even_cash_flows(self):
+        # Invest $10000, get $3000/year for 5 years
+        irr = calculate_irr([-10000, 3000, 3000, 3000, 3000, 3000])
+        assert irr is not None
+        assert 0.10 < irr < 0.20  # ~15% IRR
+
+    def test_negative_return(self):
+        # Invest $10000, get less back
+        irr = calculate_irr([-10000, 2000, 2000, 2000])
+        assert irr is not None
+        assert irr < 0
+
+    def test_all_zeros_returns_none(self):
+        assert calculate_irr([0, 0, 0]) is None
+
+    def test_empty_returns_none(self):
+        assert calculate_irr([]) is None
+
+
+# ===================================================================
+# MAO Calculator
+# ===================================================================
+
+
+class TestCalculateMAO:
+    def test_standard_mao(self):
+        """ARV $200k, rehab $30k, 30% margin → MAO = 200k*0.70 - 30k - 6k = $104k"""
+        result = calculate_mao(200_000, 30_000)
+        assert result["mao"] == 104_000.0
+        assert result["profit_margin"] == 0.30
+        assert result["profit_target"] == 60_000.0
+
+    def test_high_rehab_zero_mao(self):
+        """If rehab exceeds available margin, MAO should floor at 0."""
+        result = calculate_mao(100_000, 90_000)
+        assert result["mao"] == 0  # would be negative, floored to 0
+
+    def test_custom_margin(self):
+        result = calculate_mao(300_000, 50_000, profit_margin=0.20)
+        # MAO = 300k*0.80 - 50k - 9k = $181k
+        assert result["mao"] == 181_000.0
+
+    def test_with_hold_costs(self):
+        result = calculate_mao(200_000, 30_000, hold_costs=5_000)
+        # 200k*0.70 - 30k - 6k - 5k = 99k
+        assert result["mao"] == 99_000.0
+
+
+# ===================================================================
+# 1. Fix & Flip
+# ===================================================================
+
+
+class TestFixAndFlip:
+    def test_profitable_flip(self):
+        result = fix_and_flip(150_000, 40_000, 280_000, hold_months=6)
+        assert result["model"] == "fix_and_flip"
+        assert result["net_profit"] > 0
+        assert result["roi"] > 0
+        assert result["arv"] == 280_000
+
+    def test_break_even_flip(self):
+        # Purchase + rehab + closing ≈ ARV - selling costs
+        result = fix_and_flip(200_000, 30_000, 255_000, hold_months=3)
+        # At these numbers it might be slightly negative or positive — just check structure
+        assert "net_profit" in result
+        assert "roi" in result
+
+    def test_loss_flip(self):
+        """Buying too high relative to ARV."""
+        result = fix_and_flip(250_000, 50_000, 260_000, hold_months=8)
+        assert result["net_profit"] < 0
+        assert result["roi"] < 0
+
+    def test_with_financing(self):
+        result = fix_and_flip(
+            150_000, 40_000, 280_000,
+            loan_amount=120_000, loan_rate=0.10, hold_months=6,
+        )
+        assert result["financing_cost"] > 0
+        assert result["cash_invested"] < 150_000 + 40_000  # leveraged
+
+
+# ===================================================================
+# 2. BRRRR
+# ===================================================================
+
+
+class TestBRRRR:
+    def test_profitable_brrrr(self):
+        result = brrrr(120_000, 30_000, 220_000, 1_800)
+        assert result["model"] == "brrrr"
+        assert result["refi_amount"] == 220_000 * 0.75
+        assert result["monthly_cash_flow"] > 0 or result["monthly_cash_flow"] <= 0  # valid number
+
+    def test_cash_out_refi(self):
+        """High ARV relative to purchase should yield positive cash out."""
+        result = brrrr(100_000, 25_000, 200_000, 1_600)
+        assert result["cash_out_refi"] > 0  # Refi amount > initial cost
+
+    def test_negative_cash_flow(self):
+        """Low rent, high expenses."""
+        result = brrrr(200_000, 50_000, 250_000, 800, monthly_expenses=500)
+        # With low rent and high purchase, cash flow should be tight or negative
+        assert "monthly_cash_flow" in result
+
+    def test_with_initial_financing(self):
+        result = brrrr(
+            150_000, 40_000, 250_000, 2_000,
+            initial_loan_amount=120_000, initial_loan_rate=0.12,
+        )
+        assert result["cash_in_before_refi"] < 150_000 + 40_000 + 3_000  # less than full cost
+
+
+# ===================================================================
+# 3. Buy & Hold
+# ===================================================================
+
+
+class TestBuyAndHold:
+    def test_profitable_rental(self):
+        result = buy_and_hold(200_000, 1_800)
+        assert result["model"] == "buy_and_hold"
+        assert result["cap_rate"] > 0
+        assert result["mortgage_payment"] > 0
+        assert len(result["projections"]) == 3  # 5, 10, 30 year
+
+    def test_high_rent_ratio(self):
+        """1% rule property — strong cash flow."""
+        result = buy_and_hold(150_000, 1_500)
+        assert result["monthly_cash_flow"] > 0
+        assert result["cash_on_cash_return"] > 0
+
+    def test_negative_cash_flow(self):
+        """High price, low rent."""
+        result = buy_and_hold(500_000, 1_500)
+        assert result["monthly_cash_flow"] < 0
+
+    def test_projections_grow(self):
+        result = buy_and_hold(200_000, 1_800, annual_appreciation=0.03)
+        projections = result["projections"]
+        assert projections[0]["property_value"] < projections[1]["property_value"]
+        assert projections[1]["property_value"] < projections[2]["property_value"]
+
+
+# ===================================================================
+# 4. Short-Term Rental
+# ===================================================================
+
+
+class TestShortTermRental:
+    def test_profitable_str(self):
+        result = short_term_rental(300_000, 200, occupancy_rate=0.75)
+        assert result["model"] == "short_term_rental"
+        assert result["annual_gross_revenue"] > 0
+        assert len(result["monthly_breakdown"]) == 12
+
+    def test_seasonal_variation(self):
+        result = short_term_rental(300_000, 200, seasonal_adjustments={
+            "q1": 0.60, "q2": 1.0, "q3": 1.50, "q4": 0.90,
+        })
+        breakdown = result["monthly_breakdown"]
+        # Q3 months (Jul/Aug/Sep = indices 6,7,8) should have higher nightly rates
+        q1_rate = breakdown[0]["nightly_rate"]
+        q3_rate = breakdown[6]["nightly_rate"]
+        assert q3_rate > q1_rate
+
+    def test_low_occupancy_loss(self):
+        """Low occupancy can lead to net loss."""
+        result = short_term_rental(
+            500_000, 100, occupancy_rate=0.30, monthly_expenses=500,
+        )
+        assert result["annual_net_income"] < result["annual_gross_revenue"]
+
+    def test_platform_fees_applied(self):
+        result = short_term_rental(200_000, 150, platform_fee_pct=0.15)
+        for month in result["monthly_breakdown"]:
+            assert month["platform_fees"] > 0
+
+
+# ===================================================================
+# 5. Wholesale
+# ===================================================================
+
+
+class TestWholesale:
+    def test_standard_wholesale(self):
+        result = wholesale(250_000, 40_000)
+        assert result["model"] == "wholesale"
+        assert result["assignment_fee"] == 10_000
+        assert result["wholesaler_profit"] > 0
+
+    def test_high_assignment_fee(self):
+        result = wholesale(300_000, 30_000, assignment_fee=25_000)
+        assert result["assignment_fee"] == 25_000
+        assert result["buyer_price"] > result["contract_price"]
+
+    def test_buyer_spread_positive(self):
+        """Buyer should still profit after assignment fee."""
+        result = wholesale(300_000, 40_000, assignment_fee=10_000)
+        assert result["buyers_spread"] > 0
+
+    def test_excessive_rehab_squeezes_deal(self):
+        result = wholesale(200_000, 150_000, assignment_fee=10_000)
+        # Very high rehab relative to ARV — contract price may be 0
+        assert result["contract_price"] >= 0
+
+
+# ===================================================================
+# 6. Subject-To
+# ===================================================================
+
+
+class TestSubjectTo:
+    def test_standard_sub_to(self):
+        result = subject_to(250_000, 180_000, 0.045, 280, 1_800)
+        assert result["model"] == "subject_to"
+        assert result["equity_position"] == 70_000
+        assert result["existing_payment"] > 0
+
+    def test_positive_cash_flow(self):
+        result = subject_to(200_000, 100_000, 0.035, 200, 1_500)
+        assert result["monthly_cash_flow"] > 0
+
+    def test_with_wrap_mortgage(self):
+        result = subject_to(
+            250_000, 180_000, 0.045, 280, 1_800,
+            wrap_rate=0.08, wrap_term_months=360,
+        )
+        assert result["wrap_mortgage"] is not None
+        assert result["wrap_mortgage"]["monthly_spread"] > 0
+
+    def test_high_balance_tight_flow(self):
+        """Mortgage close to property value — low equity, tight cash flow."""
+        result = subject_to(200_000, 190_000, 0.06, 340, 1_200)
+        assert result["equity_position"] == 10_000
+
+
+# ===================================================================
+# 7. Seller Financing
+# ===================================================================
+
+
+class TestSellerFinancing:
+    def test_standard_seller_finance(self):
+        result = seller_financing(200_000, 1_600)
+        assert result["model"] == "seller_financing"
+        assert result["balloon_balance"] is not None  # default balloon at month 60
+        assert result["amortization_schedule_length"] > 0
+
+    def test_no_balloon(self):
+        result = seller_financing(200_000, 1_600, balloon_month=None)
+        assert result["balloon_balance"] is None
+        assert result["amortization_schedule_length"] == 360
+
+    def test_profitable_terms(self):
+        """Low rate seller financing with good rent."""
+        result = seller_financing(
+            150_000, 1_500, seller_rate=0.04, down_payment_pct=0.10,
+        )
+        assert result["monthly_cash_flow"] > 0
+
+    def test_amortization_first_month(self):
+        result = seller_financing(200_000, 1_600)
+        sched = result["amortization_schedule"]
+        assert len(sched) > 0
+        assert sched[0]["month"] == 1
+        assert sched[0]["payment"] > 0
+
+
+# ===================================================================
+# 8. Hard Money / Bridge
+# ===================================================================
+
+
+class TestHardMoneyBridge:
+    def test_standard_hard_money(self):
+        result = hard_money_bridge(150_000, 40_000, 280_000)
+        assert result["model"] == "hard_money_bridge"
+        assert result["origination_fee"] > 0
+        assert result["total_cost_of_capital"] > 0
+
+    def test_interest_only_payments(self):
+        result = hard_money_bridge(150_000, 40_000, 280_000, interest_only=True)
+        # Interest-only: monthly = principal * rate/12
+        loan = (150_000 + 40_000) * 0.85
+        expected_monthly = loan * (0.12 / 12)
+        assert abs(result["monthly_payment"] - expected_monthly) < 1
+
+    def test_with_refi(self):
+        result = hard_money_bridge(
+            150_000, 40_000, 280_000,
+            refi_after_months=6, monthly_rent_after_refi=2_000,
+        )
+        assert result["refinance"] is not None
+        assert result["refinance"]["refi_amount"] == 280_000 * 0.75
+
+    def test_high_points(self):
+        result = hard_money_bridge(150_000, 40_000, 280_000, points=5.0)
+        loan = (150_000 + 40_000) * 0.85
+        assert result["origination_fee"] == round(loan * 0.05, 2)
+
+
+# ===================================================================
+# Scenario Comparison
+# ===================================================================
+
+
+class TestCompareScenarios:
+    def test_all_models(self):
+        result = compare_scenarios(
+            {"purchase_price": 200_000, "arv": 300_000, "rehab_cost": 40_000, "monthly_rent": 1_800},
+            {},
+        )
+        assert result["models_run"] == 8
+        assert len(result["summary"]) == 8
+        assert len(result["errors"]) == 0
+
+    def test_selected_models(self):
+        result = compare_scenarios(
+            {"purchase_price": 200_000, "arv": 300_000, "rehab_cost": 40_000, "monthly_rent": 1_800},
+            {},
+            models=["fix_and_flip", "wholesale"],
+        )
+        assert result["models_run"] == 2
+        model_names = [d["model"] for d in result["details"]]
+        assert "fix_and_flip" in model_names
+        assert "wholesale" in model_names
+
+    def test_unknown_model_error(self):
+        result = compare_scenarios(
+            {"purchase_price": 200_000, "arv": 300_000, "rehab_cost": 40_000, "monthly_rent": 1_800},
+            {},
+            models=["fix_and_flip", "nonexistent"],
+        )
+        assert result["models_run"] == 1
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["model"] == "nonexistent"
+
+    def test_summary_sorted_by_irr(self):
+        result = compare_scenarios(
+            {"purchase_price": 200_000, "arv": 300_000, "rehab_cost": 40_000, "monthly_rent": 1_800},
+            {},
+        )
+        irrs = [s.get("irr") for s in result["summary"]]
+        # Filter out Nones for comparison
+        valid_irrs = [i for i in irrs if i is not None]
+        assert valid_irrs == sorted(valid_irrs, reverse=True)
+
+
+# ===================================================================
+# Integration tests (via HTTP client)
+# ===================================================================
+
+
+# ===================================================================
+# Backtesting — real-world deal scenarios with hand-verified results
+# CEO-mandated: realistic numbers, not toy values (see GCP-14 comment)
+# ===================================================================
+
+
+class TestBacktestMAO:
+    """Hand-verified MAO calculations against known deal analysis."""
+
+    def test_mao_200k_arv_30k_rehab(self):
+        """Standard flip: ARV $200K, rehab $30K, 30% margin.
+
+        Hand calc: 200000*0.70 - 30000 - 6000 = 104000
+        """
+        result = calculate_mao(200_000, 30_000)
+        assert result["mao"] == 104_000.0
+        assert result["closing_costs"] == 6_000.0
+        assert result["profit_target"] == 60_000.0
+
+    def test_mao_350k_arv_75k_rehab_25pct_margin(self):
+        """Larger deal: ARV $350K, rehab $75K, 25% margin.
+
+        Hand calc: 350000*0.75 - 75000 - 10500 = 177000
+        closing_costs = 350000 * 0.03 = 10500
+        """
+        result = calculate_mao(350_000, 75_000, profit_margin=0.25)
+        assert result["mao"] == 177_000.0
+        assert result["closing_costs"] == 10_500.0
+        assert result["profit_target"] == 87_500.0
+
+    def test_mao_150k_arv_101k_rehab_floors_zero(self):
+        """Heavy rehab exceeds margin — MAO floors at $0.
+
+        Hand calc: 150000*0.70 - 101000 - 4500 = -500 → 0
+        """
+        result = calculate_mao(150_000, 101_000)
+        assert result["mao"] == 0
+
+
+class TestBacktestIRR:
+    """Hand-verified IRR against textbook examples."""
+
+    def test_irr_even_cash_flows_15pct(self):
+        """$10K investment, $3K/yr for 5 years ≈ 15.24% IRR (textbook value)."""
+        irr = calculate_irr([-10_000, 3_000, 3_000, 3_000, 3_000, 3_000])
+        assert irr is not None
+        assert abs(irr - 0.1524) < 0.005  # within 0.5% of textbook
+
+    def test_irr_single_period_doubling(self):
+        """$50K in, $100K out in 1 period = 100% IRR."""
+        irr = calculate_irr([-50_000, 100_000])
+        assert irr is not None
+        assert abs(irr - 1.0) < 0.01
+
+    def test_irr_negative_return(self):
+        """$100K in, $20K/yr for 3 years = negative IRR."""
+        irr = calculate_irr([-100_000, 20_000, 20_000, 20_000])
+        assert irr is not None
+        assert irr < 0
+
+
+class TestBacktestFixAndFlip:
+    """Realistic fix & flip: $200K purchase, $60K rehab, 12% hard money, 6-month hold."""
+
+    def test_realistic_flip_with_hard_money(self):
+        """Real deal scenario per CEO requirement.
+
+        Purchase: $200K, Rehab: $60K, ARV: $350K, Hold: 6 months
+        Hard money on $200K at 12%, 6 months interest-only
+        Buying closing: 200K * 0.02 = 4K
+        Selling closing: 350K * 0.06 = 21K
+        Financing: 200K * 0.12/12 * 6 = 12K
+        Total cost: 200K + 60K + 4K + 0 + 12K = 276K
+        Net profit: 350K - 276K - 21K = 53K
+        Cash invested: 200K + 60K + 4K - 200K = 64K
+        ROI: 53K / 64K ≈ 82.8%
+        """
+        result = fix_and_flip(
+            200_000, 60_000, 350_000,
+            hold_months=6, loan_amount=200_000, loan_rate=0.12,
+        )
+        assert result["model"] == "fix_and_flip"
+        assert result["financing_cost"] == 12_000.0
+        assert result["buying_closing_costs"] == 4_000.0
+        assert result["selling_closing_costs"] == 21_000.0
+        assert result["cash_invested"] == 64_000.0
+        assert abs(result["net_profit"] - 53_000.0) < 1.0
+        assert result["roi"] > 0.80
+
+    def test_realistic_flip_loss_scenario(self):
+        """Over-leveraged flip: ARV comes in low.
+
+        Purchase: $250K, Rehab: $45K, ARV: $300K (appraisal came in low), Hold: 8 months
+        """
+        result = fix_and_flip(250_000, 45_000, 300_000, hold_months=8)
+        # Buying closing: 5K, Selling closing: 18K
+        # Total cost: 250+45+5+0+0 = 300K, minus 18K selling = net loss
+        assert result["net_profit"] < 0
+
+
+class TestBacktestBRRRR:
+    """Real BRRRR: $120K purchase, $30K rehab, $220K ARV, $1800/mo rent."""
+
+    def test_realistic_brrrr(self):
+        """Classic BRRRR with all-cash initial purchase.
+
+        Total in: 120K + 30K + 2.4K(closing) = 152.4K
+        Refi: 220K * 0.75 = 165K
+        Cash out: 165K - 0(no initial loan) = 165K
+        Cash left in: 152.4K - 165K = -12.6K → they pulled out more than they put in
+        """
+        result = brrrr(120_000, 30_000, 220_000, 1_800)
+        assert result["refi_amount"] == 165_000.0
+        assert result["total_initial_investment"] == 152_400.0
+        assert result["cash_out_refi"] == 165_000.0
+        # Cash left in deal should be 0 (floored) since refi > cost
+        assert result["cash_left_in_deal"] == 0
+
+
+class TestBacktestHardMoney:
+    """Real hard money: $150K purchase, $40K rehab, $280K ARV, 12% rate, 2 points."""
+
+    def test_realistic_hard_money_bridge(self):
+        """Standard hard money bridge deal.
+
+        Total project: $190K, LTC 85% → loan $161.5K
+        Cash needed: $28.5K
+        Points: 161.5K * 0.02 = $3,230
+        Monthly interest-only: 161.5K * 0.01 = $1,615
+        6-month hold: $9,690 total interest
+        Total cost of capital: $3,230 + $9,690 = $12,920
+        """
+        result = hard_money_bridge(150_000, 40_000, 280_000)
+        assert result["loan_amount"] == 161_500.0
+        assert result["cash_needed"] == 28_500.0
+        assert result["origination_fee"] == 3_230.0
+        assert result["monthly_payment"] == 1_615.0
+        assert result["total_interest"] == 9_690.0
+        assert result["total_cost_of_capital"] == 12_920.0
+
+
+class TestBacktestBuyAndHold:
+    """Real buy & hold: $200K property, $1800/mo rent, 20% down, 7% rate."""
+
+    def test_realistic_buy_and_hold(self):
+        """Verify cash flow math against hand calcs.
+
+        Down: $40K, Closing: $6K, Loan: $160K
+        Mortgage (30yr @ 7%): ~$1064.48/mo
+        Effective rent: 1800 * 0.92 = 1656
+        Cash flow: 1656 - 1064.48 = ~591.52/mo
+        Cap rate: (1656*12)/200K = 9.94%
+        """
+        result = buy_and_hold(200_000, 1_800)
+        assert result["down_payment"] == 40_000.0
+        assert result["closing_costs"] == 6_000.0
+        assert result["loan_amount"] == 160_000.0
+        assert result["effective_rent"] == 1_656.0
+        assert abs(result["mortgage_payment"] - 1_064.48) < 1.0
+        assert result["monthly_cash_flow"] > 500
+        assert abs(result["cap_rate"] - 0.0994) < 0.001
+
+
+# ===================================================================
+# Integration tests (via HTTP client)
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_financing_compare_endpoint(client):
+    """Integration test for the scenario comparison endpoint."""
+    response = await client.post("/financing/compare", json={
+        "property_data": {
+            "purchase_price": 200_000,
+            "arv": 300_000,
+            "rehab_cost": 40_000,
+            "monthly_rent": 1_800,
+        },
+        "assumptions": {},
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["models_run"] == 8
+    assert len(data["summary"]) == 8
+
+
+@pytest.mark.asyncio
+async def test_financing_fix_and_flip_endpoint(client):
+    response = await client.post("/financing/fix-and-flip", json={
+        "purchase_price": 150_000,
+        "rehab_cost": 40_000,
+        "arv": 280_000,
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["model"] == "fix_and_flip"
+    assert data["result"]["net_profit"] > 0
+
+
+@pytest.mark.asyncio
+async def test_financing_mao_endpoint(client):
+    response = await client.post("/financing/mao", json={
+        "arv": 200_000,
+        "rehab_cost": 30_000,
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mao"] == 104_000.0
+
+
+@pytest.mark.asyncio
+async def test_financing_irr_endpoint(client):
+    response = await client.post("/financing/irr", json={
+        "cash_flows": [-10000, 3000, 3000, 3000, 3000, 3000],
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["irr"] is not None
+    assert 0.10 < data["irr"] < 0.20

--- a/packages/api/tests/test_order_service.py
+++ b/packages/api/tests/test_order_service.py
@@ -1,0 +1,250 @@
+"""Tests for order service — snapshot, totals, and D365 field mapping."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.order_service import (
+    MAX_RETRY_COUNT,
+    ORDER_STATUSES,
+    calculate_order_total,
+    snapshot_quote_items,
+)
+from app.services.d365_service import _map_to_d365_opportunity
+
+
+# ---------------------------------------------------------------------------
+# snapshot_quote_items
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotQuoteItems:
+    def _make_item(self, **overrides):
+        defaults = {
+            "id": "item-1",
+            "room": "Kitchen",
+            "trade_category": "plumbing",
+            "description": "Replace kitchen sink",
+            "sage_sku": "SKU-001",
+            "quantity": 2,
+            "unit_cost": Decimal("100.00"),
+            "labor_cost": Decimal("50.00"),
+            "markup_pct": Decimal("10.00"),
+            "subtotal": Decimal("275.00"),
+            "unit_of_measure": "each",
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_basic_snapshot(self):
+        items = [self._make_item()]
+        result = snapshot_quote_items(items)
+        assert len(result) == 1
+        snap = result[0]
+        assert snap["quote_item_id"] == "item-1"
+        assert snap["room"] == "Kitchen"
+        assert snap["sage_sku"] == "SKU-001"
+        assert snap["quantity"] == 2
+        assert snap["subtotal"] == Decimal("275.00")
+
+    def test_multiple_items(self):
+        items = [
+            self._make_item(id="item-1", room="Kitchen"),
+            self._make_item(id="item-2", room="Bathroom", sage_sku="SKU-002"),
+            self._make_item(id="item-3", room="Bedroom", sage_sku=None),
+        ]
+        result = snapshot_quote_items(items)
+        assert len(result) == 3
+        assert result[0]["room"] == "Kitchen"
+        assert result[1]["room"] == "Bathroom"
+        assert result[2]["sage_sku"] is None
+
+    def test_empty_items(self):
+        assert snapshot_quote_items([]) == []
+
+    def test_none_quantity_defaults(self):
+        item = self._make_item(quantity=None)
+        result = snapshot_quote_items([item])
+        assert result[0]["quantity"] == 1
+
+    def test_preserves_all_fields(self):
+        item = self._make_item()
+        snap = snapshot_quote_items([item])[0]
+        expected_keys = {
+            "quote_item_id", "room", "trade_category", "description",
+            "sage_sku", "quantity", "unit_cost", "labor_cost",
+            "markup_pct", "subtotal", "unit_of_measure",
+        }
+        assert set(snap.keys()) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# calculate_order_total
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateOrderTotal:
+    def test_basic_total(self):
+        items = [
+            {"subtotal": Decimal("100.00")},
+            {"subtotal": Decimal("200.50")},
+        ]
+        assert calculate_order_total(items) == Decimal("300.50")
+
+    def test_empty_items(self):
+        assert calculate_order_total([]) == Decimal("0.00")
+
+    def test_none_subtotals_skipped(self):
+        items = [
+            {"subtotal": Decimal("150.00")},
+            {"subtotal": None},
+            {"subtotal": Decimal("50.00")},
+        ]
+        assert calculate_order_total(items) == Decimal("200.00")
+
+    def test_string_subtotals(self):
+        items = [{"subtotal": "99.99"}, {"subtotal": "0.01"}]
+        assert calculate_order_total(items) == Decimal("100.00")
+
+    def test_single_item(self):
+        assert calculate_order_total([{"subtotal": Decimal("1234.56")}]) == Decimal("1234.56")
+
+    def test_large_total(self):
+        items = [{"subtotal": Decimal("99999.99")} for _ in range(10)]
+        assert calculate_order_total(items) == Decimal("999999.90")
+
+    def test_quantize_precision(self):
+        items = [{"subtotal": Decimal("33.333")}]
+        result = calculate_order_total(items)
+        assert str(result) == "33.33"
+
+
+# ---------------------------------------------------------------------------
+# ORDER_STATUSES constant
+# ---------------------------------------------------------------------------
+
+
+class TestOrderStatuses:
+    def test_has_required_statuses(self):
+        required = {"pending", "submitted", "confirmed", "shipped", "delivered", "failed", "cancelled"}
+        assert required.issubset(set(ORDER_STATUSES))
+
+    def test_max_retry_count(self):
+        assert MAX_RETRY_COUNT == 3
+
+
+# ---------------------------------------------------------------------------
+# D365 field mapping
+# ---------------------------------------------------------------------------
+
+
+class TestD365FieldMapping:
+    def test_basic_mapping(self):
+        order_data = {
+            "id": "order-123",
+            "quote_id": "quote-456",
+            "sage_order_id": "SAGE-789",
+            "total_amount": Decimal("5000.00"),
+        }
+        property_data = {
+            "id": "prop-abc",
+            "address": "123 Main St",
+            "city": "Austin",
+            "state": "TX",
+            "zip": "78701",
+            "property_type": "Single Family",
+            "sqft": 1800,
+            "beds": 3,
+            "baths": 2.0,
+            "arv_estimate": Decimal("250000"),
+        }
+        result = _map_to_d365_opportunity(order_data, property_data)
+        assert "GCP Renovation" in result["name"]
+        assert "123 Main St" in result["name"]
+        assert result["estimatedvalue"] == 5000.0
+        assert "order-123" in result["description"]
+        assert result["new_gcp_property_id"] == "prop-abc"
+        assert result["new_gcp_sage_order_id"] == "SAGE-789"
+        assert result["new_gcp_arv_estimate"] == 250000.0
+
+    def test_mapping_without_property(self):
+        order_data = {"id": "order-123", "quote_id": "q-1", "total_amount": Decimal("1000")}
+        result = _map_to_d365_opportunity(order_data, None)
+        assert "GCP Order order-123" in result["name"]
+        assert result["estimatedvalue"] == 1000.0
+        # No property custom fields
+        assert "new_gcp_property_id" not in result
+
+    def test_mapping_without_total(self):
+        order_data = {"id": "order-1", "quote_id": "q-1", "total_amount": None}
+        result = _map_to_d365_opportunity(order_data)
+        assert result["estimatedvalue"] is None
+
+    def test_name_length_limit(self):
+        order_data = {"id": "order-1", "quote_id": "q-1", "total_amount": None}
+        property_data = {
+            "address": "A" * 500,
+            "city": "City",
+            "state": "ST",
+            "zip": "00000",
+        }
+        result = _map_to_d365_opportunity(order_data, property_data)
+        assert len(result["name"]) <= 300
+
+    def test_description_includes_property_details(self):
+        order_data = {"id": "o-1", "quote_id": "q-1", "total_amount": None}
+        property_data = {
+            "address": "456 Oak Ave",
+            "city": "Dallas",
+            "state": "TX",
+            "zip": "75201",
+            "property_type": "Duplex",
+            "sqft": 2400,
+            "beds": 4,
+            "baths": 3.0,
+        }
+        result = _map_to_d365_opportunity(order_data, property_data)
+        assert "456 Oak Ave" in result["description"]
+        assert "Duplex" in result["description"]
+        assert "2400" in result["description"]
+
+    def test_custom_fields_prefix(self):
+        order_data = {"id": "o-1", "quote_id": "q-1", "sage_order_id": "S-1", "total_amount": None}
+        property_data = {"id": "p-1", "address": "x", "city": "c", "state": "s", "zip": "0", "arv_estimate": 100}
+        result = _map_to_d365_opportunity(order_data, property_data)
+        # All custom fields should use new_ prefix
+        custom_keys = [k for k in result if k.startswith("new_")]
+        assert len(custom_keys) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: snapshot → total pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestOrderCreationPipeline:
+    def test_snapshot_to_total(self):
+        items = [
+            SimpleNamespace(
+                id="i1", room="Kitchen", trade_category="plumbing",
+                description="Fix sink", sage_sku="SK-1", quantity=2,
+                unit_cost=Decimal("80"), labor_cost=Decimal("40"),
+                markup_pct=None, subtotal=Decimal("200"), unit_of_measure="each",
+            ),
+            SimpleNamespace(
+                id="i2", room="Bathroom", trade_category="tile",
+                description="Retile floor", sage_sku="SK-2", quantity=50,
+                unit_cost=Decimal("8"), labor_cost=Decimal("300"),
+                markup_pct=Decimal("10"), subtotal=Decimal("770"),
+                unit_of_measure="sqft",
+            ),
+        ]
+        snapshots = snapshot_quote_items(items)
+        total = calculate_order_total(snapshots)
+        assert total == Decimal("970.00")
+        assert len(snapshots) == 2
+        assert snapshots[0]["quantity"] == 2
+        assert snapshots[1]["sage_sku"] == "SK-2"

--- a/packages/api/tests/test_properties.py
+++ b/packages/api/tests/test_properties.py
@@ -1,0 +1,258 @@
+"""Tests for property endpoints."""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import CurrentUser, get_current_user
+from app.database import get_db
+from app.main import app
+from tests.conftest import TENANT_ID, USER_ID
+
+pytestmark = pytest.mark.anyio
+
+
+# ---------------------------------------------------------------------------
+# Manual CRUD
+# ---------------------------------------------------------------------------
+
+
+VALID_PROPERTY = {
+    "address": "123 Main St",
+    "city": "Austin",
+    "state": "TX",
+    "zip": "78701",
+    "beds": 3,
+    "baths": 2.0,
+    "sqft": 1800,
+    "year_built": 2005,
+    "listing_price": 450000,
+    "property_type": "single_family",
+}
+
+
+async def test_create_property(client: AsyncClient) -> None:
+    resp = await client.post("/properties", json=VALID_PROPERTY)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["address"] == "123 Main St"
+    assert data["city"] == "Austin"
+    assert data["data_source"] == "manual"
+    assert data["tenant_id"] == TENANT_ID
+    assert data["status"] == "active"
+    assert data["id"]
+
+
+async def test_create_property_validation_error(client: AsyncClient) -> None:
+    """Missing required fields should fail."""
+    resp = await client.post("/properties", json={"address": "123 Main St"})
+    assert resp.status_code == 422
+
+
+async def test_get_property(client: AsyncClient) -> None:
+    # Create first
+    create_resp = await client.post("/properties", json=VALID_PROPERTY)
+    prop_id = create_resp.json()["id"]
+
+    resp = await client.get(f"/properties/{prop_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == prop_id
+
+
+async def test_get_property_not_found(client: AsyncClient) -> None:
+    resp = await client.get("/properties/00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 404
+
+
+async def test_update_property(client: AsyncClient) -> None:
+    create_resp = await client.post("/properties", json=VALID_PROPERTY)
+    prop_id = create_resp.json()["id"]
+
+    resp = await client.patch(f"/properties/{prop_id}", json={"beds": 4, "listing_price": 500000})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["beds"] == 4
+    assert data["listing_price"] == 500000.0
+
+
+# ---------------------------------------------------------------------------
+# Listing Feed
+# ---------------------------------------------------------------------------
+
+
+async def test_list_properties_empty(client: AsyncClient) -> None:
+    resp = await client.get("/properties")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+    assert data["page"] == 1
+
+
+async def test_list_properties_with_data(client: AsyncClient) -> None:
+    # Create two properties
+    await client.post("/properties", json=VALID_PROPERTY)
+    second = {**VALID_PROPERTY, "address": "456 Oak Ave", "city": "Dallas", "listing_price": 350000}
+    await client.post("/properties", json=second)
+
+    resp = await client.get("/properties")
+    data = resp.json()
+    assert data["total"] == 2
+    assert len(data["items"]) == 2
+
+
+async def test_list_properties_filter_by_city(client: AsyncClient) -> None:
+    await client.post("/properties", json=VALID_PROPERTY)
+    second = {**VALID_PROPERTY, "address": "456 Oak Ave", "city": "Dallas"}
+    await client.post("/properties", json=second)
+
+    resp = await client.get("/properties", params={"city": "Austin"})
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["city"] == "Austin"
+
+
+async def test_list_properties_filter_by_price_range(client: AsyncClient) -> None:
+    await client.post("/properties", json=VALID_PROPERTY)  # 450k
+    cheap = {**VALID_PROPERTY, "address": "789 Elm", "listing_price": 200000}
+    await client.post("/properties", json=cheap)
+
+    resp = await client.get("/properties", params={"min_price": 300000, "max_price": 500000})
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["listing_price"] == 450000.0
+
+
+async def test_list_properties_pagination(client: AsyncClient) -> None:
+    for i in range(5):
+        await client.post(
+            "/properties",
+            json={**VALID_PROPERTY, "address": f"{i} Test St"},
+        )
+
+    resp = await client.get("/properties", params={"page": 1, "page_size": 2})
+    data = resp.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+    assert data["pages"] == 3
+
+    resp2 = await client.get("/properties", params={"page": 3, "page_size": 2})
+    data2 = resp2.json()
+    assert len(data2["items"]) == 1
+
+
+async def test_list_properties_sort_by_price_asc(client: AsyncClient) -> None:
+    await client.post("/properties", json={**VALID_PROPERTY, "address": "A St", "listing_price": 500000})
+    await client.post("/properties", json={**VALID_PROPERTY, "address": "B St", "listing_price": 200000})
+
+    resp = await client.get("/properties", params={"sort_by": "listing_price", "sort_order": "asc"})
+    items = resp.json()["items"]
+    assert items[0]["listing_price"] == 200000.0
+    assert items[1]["listing_price"] == 500000.0
+
+
+# ---------------------------------------------------------------------------
+# Zillow URL validation
+# ---------------------------------------------------------------------------
+
+
+async def test_zillow_import_invalid_url(client: AsyncClient) -> None:
+    resp = await client.post("/properties/import/zillow", json={"url": "https://example.com/not-zillow"})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PropStream search validation
+# ---------------------------------------------------------------------------
+
+
+async def test_propstream_search_no_params(client: AsyncClient) -> None:
+    resp = await client.post("/properties/search/propstream", json={})
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Google Places
+# ---------------------------------------------------------------------------
+
+
+async def test_places_autocomplete_empty_input(client: AsyncClient) -> None:
+    resp = await client.post("/properties/places/autocomplete", json={"input": ""})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Sprint 1.1 — Foundation QA
+# ---------------------------------------------------------------------------
+
+
+async def test_health_endpoint(client: AsyncClient) -> None:
+    """GET /health returns 200 with expected payload."""
+    resp = await client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["service"] == "gcp-renovation-api"
+
+
+@pytest_asyncio.fixture
+async def solo_client(db_session) -> AsyncGenerator[AsyncClient, None]:
+    """Client whose user has no Clerk org (tenant_id=None) — exercises auto-provisioning."""
+    def _solo_user() -> CurrentUser:
+        return CurrentUser(user_id=USER_ID, tenant_id=None, claims={})
+
+    async def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = _solo_user
+
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+async def test_solo_user_create_property_provisions_tenant(solo_client: AsyncClient) -> None:
+    """Solo users (no Clerk org) must be able to create properties without a 500.
+
+    Regression test for: effective_tenant_id UUID5 not in tenants table → FK violation.
+    """
+    resp = await solo_client.post("/properties", json=VALID_PROPERTY)
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["address"] == "123 Main St"
+
+
+async def test_seed_demo_provisions_tenant_and_returns_seeded_count(solo_client: AsyncClient) -> None:
+    """POST /seed-demo must succeed for solo users and auto-provision their tenant.
+
+    Regression test for: seed-demo calling effective_tenant_id → FK violation on insert.
+    """
+    resp = await solo_client.post("/seed-demo")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["seeded"] == 3
+
+    # Second call must be idempotent (skips existing rows)
+    resp2 = await solo_client.post("/seed-demo")
+    assert resp2.status_code == 200
+    assert resp2.json()["seeded"] == 0
+
+
+async def test_db_tables_created_from_scratch(client: AsyncClient) -> None:
+    """The test fixture creates all tables from scratch (simulates migration).
+
+    Verify the property CRUD works end-to-end after fresh schema creation.
+    """
+    resp = await client.post("/properties", json=VALID_PROPERTY)
+    assert resp.status_code == 201
+    prop_id = resp.json()["id"]
+    resp2 = await client.get(f"/properties/{prop_id}")
+    assert resp2.status_code == 200
+    assert resp2.json()["id"] == prop_id

--- a/packages/api/tests/test_quote_service.py
+++ b/packages/api/tests/test_quote_service.py
@@ -1,0 +1,459 @@
+"""Tests for the quote service — calculations, AI generation, and PDF output."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.quote_service import (
+    PLATFORM_FEE_DEFAULT,
+    calculate_item_subtotal,
+    calculate_quote_totals,
+    generate_ai_line_items,
+    generate_sow_pdf,
+)
+
+
+# ---------------------------------------------------------------------------
+# calculate_item_subtotal
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateItemSubtotal:
+    def test_basic_calculation(self):
+        result = calculate_item_subtotal(
+            quantity=2,
+            unit_cost=Decimal("100.00"),
+            labor_cost=Decimal("50.00"),
+            markup_pct=None,
+        )
+        # (2 * 100 + 50) * 1.0 = 250
+        assert result == Decimal("250.00")
+
+    def test_with_markup(self):
+        result = calculate_item_subtotal(
+            quantity=1,
+            unit_cost=Decimal("100.00"),
+            labor_cost=Decimal("0.00"),
+            markup_pct=Decimal("10"),
+        )
+        # (1 * 100 + 0) * 1.10 = 110
+        assert result == Decimal("110.00")
+
+    def test_zero_quantity_treated_as_one(self):
+        # quantity=1 is the minimum per schema validation
+        result = calculate_item_subtotal(
+            quantity=1,
+            unit_cost=Decimal("50.00"),
+            labor_cost=Decimal("25.00"),
+            markup_pct=None,
+        )
+        assert result == Decimal("75.00")
+
+    def test_large_markup(self):
+        result = calculate_item_subtotal(
+            quantity=1,
+            unit_cost=Decimal("100.00"),
+            labor_cost=Decimal("100.00"),
+            markup_pct=Decimal("50"),
+        )
+        # (100 + 100) * 1.50 = 300
+        assert result == Decimal("300.00")
+
+    def test_all_zeros(self):
+        result = calculate_item_subtotal(
+            quantity=1,
+            unit_cost=Decimal("0"),
+            labor_cost=Decimal("0"),
+            markup_pct=None,
+        )
+        assert result == Decimal("0")
+
+    def test_high_quantity(self):
+        result = calculate_item_subtotal(
+            quantity=100,
+            unit_cost=Decimal("10.50"),
+            labor_cost=Decimal("200.00"),
+            markup_pct=Decimal("5"),
+        )
+        # (100 * 10.50 + 200) * 1.05 = (1050 + 200) * 1.05 = 1312.50
+        assert result == Decimal("1312.50")
+
+
+# ---------------------------------------------------------------------------
+# calculate_quote_totals
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateQuoteTotals:
+    def test_basic_totals(self):
+        items = [
+            {"quantity": 2, "unit_cost": "100", "labor_cost": "50", "markup_pct": None},
+            {"quantity": 1, "unit_cost": "200", "labor_cost": "100", "markup_pct": None},
+        ]
+        totals = calculate_quote_totals(items)
+        assert totals["total_material"] == Decimal("400.00")  # 2*100 + 1*200
+        assert totals["total_labor"] == Decimal("150.00")  # 50 + 100
+        # platform fee = 550 * 0.05 = 27.50
+        assert totals["platform_fee"] == Decimal("27.50")
+        assert totals["grand_total"] == Decimal("577.50")
+
+    def test_custom_fee_pct(self):
+        items = [
+            {"quantity": 1, "unit_cost": "1000", "labor_cost": "0", "markup_pct": None},
+        ]
+        totals = calculate_quote_totals(items, platform_fee_pct=Decimal("0.10"))
+        assert totals["platform_fee"] == Decimal("100.00")
+        assert totals["grand_total"] == Decimal("1100.00")
+
+    def test_zero_fee(self):
+        items = [
+            {"quantity": 1, "unit_cost": "500", "labor_cost": "0", "markup_pct": None},
+        ]
+        totals = calculate_quote_totals(items, platform_fee_pct=Decimal("0"))
+        assert totals["platform_fee"] == Decimal("0.00")
+        assert totals["grand_total"] == Decimal("500.00")
+
+    def test_empty_items(self):
+        totals = calculate_quote_totals([])
+        assert totals["total_material"] == Decimal("0.00")
+        assert totals["total_labor"] == Decimal("0.00")
+        assert totals["platform_fee"] == Decimal("0.00")
+        assert totals["grand_total"] == Decimal("0.00")
+
+    def test_with_markup(self):
+        items = [
+            {"quantity": 1, "unit_cost": "100", "labor_cost": "100", "markup_pct": "20"},
+        ]
+        totals = calculate_quote_totals(items, platform_fee_pct=Decimal("0"))
+        # Material: 100 * 1.20 = 120, Labor: 100 * 1.20 = 120
+        assert totals["total_material"] == Decimal("120.00")
+        assert totals["total_labor"] == Decimal("120.00")
+
+    def test_multiple_items_with_mixed_markup(self):
+        items = [
+            {"quantity": 2, "unit_cost": "50", "labor_cost": "30", "markup_pct": "10"},
+            {"quantity": 1, "unit_cost": "200", "labor_cost": "0", "markup_pct": None},
+        ]
+        totals = calculate_quote_totals(items, platform_fee_pct=Decimal("0.05"))
+        # Item 1: material = 2*50*1.10 = 110, labor = 30*1.10 = 33
+        # Item 2: material = 200, labor = 0
+        assert totals["total_material"] == Decimal("310.00")
+        assert totals["total_labor"] == Decimal("33.00")
+        subtotal = Decimal("343.00")
+        assert totals["platform_fee"] == Decimal("17.15")
+        assert totals["grand_total"] == Decimal("360.15")
+
+
+# ---------------------------------------------------------------------------
+# generate_ai_line_items
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAILineItems:
+    def test_generates_items_from_labels(self):
+        labels = [
+            {
+                "room_type": "kitchen",
+                "condition": "poor",
+                "damage_issues": ["peeling_paint", "outdated_fixtures"],
+                "renovation_needed": "major",
+                "confidence": 0.9,
+            }
+        ]
+        items = generate_ai_line_items(labels)
+        assert len(items) > 0
+        # All items should be AI generated
+        assert all(item["is_ai_generated"] for item in items)
+        assert all(item["ai_confidence"] == 0.9 for item in items)
+        # Kitchen should produce multiple trade items
+        trades = {item["trade_category"] for item in items}
+        assert "plumbing" in trades
+        assert "electrical" in trades
+
+    def test_skips_no_renovation(self):
+        labels = [
+            {
+                "room_type": "bedroom",
+                "condition": "excellent",
+                "damage_issues": [],
+                "renovation_needed": "none",
+                "confidence": 0.95,
+            }
+        ]
+        items = generate_ai_line_items(labels)
+        assert len(items) == 0
+
+    def test_cosmetic_renovation(self):
+        labels = [
+            {
+                "room_type": "bedroom",
+                "condition": "fair",
+                "damage_issues": ["peeling_paint"],
+                "renovation_needed": "cosmetic",
+                "confidence": 0.85,
+            }
+        ]
+        items = generate_ai_line_items(labels)
+        assert len(items) > 0
+        rooms = {item["room"] for item in items}
+        assert "Bedroom" in rooms
+
+    def test_multiple_rooms(self):
+        labels = [
+            {
+                "room_type": "bathroom",
+                "condition": "poor",
+                "damage_issues": ["water_damage"],
+                "renovation_needed": "major",
+                "confidence": 0.8,
+            },
+            {
+                "room_type": "bathroom",
+                "condition": "fair",
+                "damage_issues": [],
+                "renovation_needed": "moderate",
+                "confidence": 0.75,
+            },
+        ]
+        items = generate_ai_line_items(labels)
+        rooms = {item["room"] for item in items}
+        assert "Bathroom" in rooms
+        assert "Bathroom 2" in rooms
+
+    def test_empty_labels(self):
+        assert generate_ai_line_items([]) == []
+
+    def test_unknown_room_type(self):
+        labels = [
+            {
+                "room_type": "unknown_space",
+                "condition": "poor",
+                "damage_issues": [],
+                "renovation_needed": "moderate",
+                "confidence": 0.6,
+            }
+        ]
+        items = generate_ai_line_items(labels)
+        assert len(items) > 0
+        assert all(item["trade_category"] == "general" for item in items)
+
+    def test_all_items_have_required_fields(self):
+        labels = [
+            {
+                "room_type": "kitchen",
+                "condition": "poor",
+                "damage_issues": ["water_damage"],
+                "renovation_needed": "full_gut",
+                "confidence": 0.92,
+            }
+        ]
+        items = generate_ai_line_items(labels)
+        required_keys = {
+            "room", "trade_category", "description", "sage_sku",
+            "quantity", "unit_cost", "labor_cost", "markup_pct",
+            "unit_of_measure", "ai_confidence", "is_ai_generated",
+        }
+        for item in items:
+            assert required_keys.issubset(item.keys())
+            assert isinstance(item["unit_cost"], Decimal)
+            assert isinstance(item["labor_cost"], Decimal)
+            assert item["quantity"] >= 1
+
+    def test_damage_issues_in_description(self):
+        labels = [
+            {
+                "room_type": "basement",
+                "condition": "critical",
+                "damage_issues": ["water_damage", "mold", "structural_concern"],
+                "renovation_needed": "full_gut",
+                "confidence": 0.7,
+            }
+        ]
+        items = generate_ai_line_items(labels)
+        descriptions = " ".join(item["description"] for item in items)
+        assert "water_damage" in descriptions
+
+
+# ---------------------------------------------------------------------------
+# generate_sow_pdf
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSOWPdf:
+    def test_generates_valid_pdf(self):
+        quote = {
+            "id": str(uuid.uuid4()),
+            "status": "draft",
+            "created_at": datetime(2026, 4, 14, 10, 0, 0),
+            "notes": "Test SOW",
+            "total_material": Decimal("1000.00"),
+            "total_labor": Decimal("500.00"),
+            "platform_fee": Decimal("75.00"),
+            "platform_fee_pct": Decimal("0.05"),
+            "grand_total": Decimal("1575.00"),
+        }
+        items = [
+            {
+                "room": "Kitchen",
+                "trade_category": "plumbing",
+                "description": "Replace kitchen sink",
+                "quantity": 1,
+                "unit_cost": Decimal("200.00"),
+                "labor_cost": Decimal("150.00"),
+                "markup_pct": None,
+            },
+            {
+                "room": "Bathroom",
+                "trade_category": "tile",
+                "description": "Retile bathroom floor",
+                "quantity": 50,
+                "unit_cost": Decimal("8.00"),
+                "labor_cost": Decimal("350.00"),
+                "markup_pct": Decimal("10"),
+            },
+        ]
+        property_info = {
+            "address": "123 Main St",
+            "city": "Austin",
+            "state": "TX",
+            "zip": "78701",
+            "property_type": "Single Family",
+            "sqft": 1800,
+            "beds": 3,
+            "baths": 2.0,
+        }
+        pdf_bytes = generate_sow_pdf(quote, items, property_info)
+        assert isinstance(pdf_bytes, bytes)
+        assert len(pdf_bytes) > 0
+        assert pdf_bytes[:5] == b"%PDF-"
+
+    def test_pdf_without_property_info(self):
+        quote = {
+            "id": "test-id",
+            "status": "draft",
+            "created_at": "April 14, 2026",
+            "notes": None,
+            "total_material": Decimal("0"),
+            "total_labor": Decimal("0"),
+            "platform_fee": Decimal("0"),
+            "platform_fee_pct": Decimal("0.05"),
+            "grand_total": Decimal("0"),
+        }
+        pdf_bytes = generate_sow_pdf(quote, [])
+        assert pdf_bytes[:5] == b"%PDF-"
+
+    def test_pdf_with_long_description(self):
+        quote = {
+            "id": "test-id",
+            "status": "approved",
+            "created_at": datetime(2026, 4, 14),
+            "notes": "A" * 500,
+            "total_material": Decimal("100"),
+            "total_labor": Decimal("50"),
+            "platform_fee": Decimal("7.50"),
+            "platform_fee_pct": Decimal("0.05"),
+            "grand_total": Decimal("157.50"),
+        }
+        items = [
+            {
+                "room": "Room",
+                "trade_category": "general",
+                "description": "X" * 200,
+                "quantity": 1,
+                "unit_cost": Decimal("100"),
+                "labor_cost": Decimal("50"),
+                "markup_pct": None,
+            }
+        ]
+        pdf_bytes = generate_sow_pdf(quote, items)
+        assert pdf_bytes[:5] == b"%PDF-"
+
+    def test_pdf_with_many_items(self):
+        quote = {
+            "id": "test-bulk",
+            "status": "draft",
+            "created_at": datetime(2026, 4, 14),
+            "notes": None,
+            "total_material": Decimal("5000"),
+            "total_labor": Decimal("2000"),
+            "platform_fee": Decimal("350"),
+            "platform_fee_pct": Decimal("0.05"),
+            "grand_total": Decimal("7350"),
+        }
+        items = [
+            {
+                "room": f"Room {i}",
+                "trade_category": "general",
+                "description": f"Item {i}",
+                "quantity": i + 1,
+                "unit_cost": Decimal("50"),
+                "labor_cost": Decimal("20"),
+                "markup_pct": None,
+            }
+            for i in range(20)
+        ]
+        pdf_bytes = generate_sow_pdf(quote, items)
+        assert pdf_bytes[:5] == b"%PDF-"
+        assert len(pdf_bytes) > 1000
+
+
+# ---------------------------------------------------------------------------
+# Integration: AI generation → totals → PDF pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestAIQuotePipeline:
+    def test_full_pipeline(self):
+        """photo analysis → AI line items → totals → PDF SOW."""
+        labels = [
+            {
+                "room_type": "kitchen",
+                "condition": "poor",
+                "damage_issues": ["outdated_fixtures", "damaged_flooring"],
+                "renovation_needed": "major",
+                "confidence": 0.88,
+            },
+            {
+                "room_type": "bathroom",
+                "condition": "fair",
+                "damage_issues": ["peeling_paint"],
+                "renovation_needed": "cosmetic",
+                "confidence": 0.92,
+            },
+        ]
+
+        # Step 1: Generate AI items
+        items = generate_ai_line_items(labels)
+        assert len(items) > 0
+
+        # Step 2: Calculate totals
+        totals = calculate_quote_totals(items)
+        assert totals["grand_total"] > Decimal("0")
+        assert totals["total_material"] > Decimal("0")
+        assert totals["total_labor"] > Decimal("0")
+
+        # Step 3: Generate PDF
+        quote = {
+            "id": "pipeline-test",
+            "status": "draft",
+            "created_at": datetime(2026, 4, 14),
+            "notes": "AI-generated quote",
+            **totals,
+            "platform_fee_pct": PLATFORM_FEE_DEFAULT,
+        }
+        pdf_bytes = generate_sow_pdf(quote, items, {
+            "address": "456 Oak Ave",
+            "city": "Dallas",
+            "state": "TX",
+            "zip": "75201",
+            "property_type": "Single Family",
+            "sqft": 2200,
+            "beds": 4,
+            "baths": 2.5,
+        })
+        assert pdf_bytes[:5] == b"%PDF-"
+        assert len(pdf_bytes) > 500

--- a/packages/api/tests/test_quotes.py
+++ b/packages/api/tests/test_quotes.py
@@ -1,0 +1,484 @@
+"""Integration tests for the quote builder endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    Deal,
+    PhotoLabel,
+    Property,
+    PropertyPhotoAnalysis,
+    Quote,
+    QuoteItem,
+    Tenant,
+)
+from tests.conftest import TENANT_ID, USER_ID
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def tenant(db_session: AsyncSession) -> Tenant:
+    t = Tenant(id=TENANT_ID, name="Test Co", slug="test-co", plan="pro")
+    db_session.add(t)
+    await db_session.flush()
+    return t
+
+
+@pytest_asyncio.fixture
+async def property_(db_session: AsyncSession, tenant: Tenant) -> Property:
+    p = Property(
+        tenant_id=tenant.id,
+        address="123 Main St",
+        city="Austin",
+        state="TX",
+        zip="78701",
+        property_type="Single Family",
+        sqft=1800,
+        beds=3,
+        baths=2.0,
+    )
+    db_session.add(p)
+    await db_session.flush()
+    return p
+
+
+@pytest_asyncio.fixture
+async def deal(db_session: AsyncSession, tenant: Tenant, property_: Property) -> Deal:
+    d = Deal(tenant_id=tenant.id, property_id=property_.id, status="active")
+    db_session.add(d)
+    await db_session.flush()
+    return d
+
+
+@pytest_asyncio.fixture
+async def photo_analysis(
+    db_session: AsyncSession, property_: Property
+) -> PropertyPhotoAnalysis:
+    analysis = PropertyPhotoAnalysis(
+        property_id=property_.id,
+        status="completed",
+        photo_count=2,
+        model_id="claude-sonnet-4-6-20250514",
+        renovation_signal="moderate",
+        renovation_confidence=0.85,
+    )
+    db_session.add(analysis)
+    await db_session.flush()
+
+    labels = [
+        PhotoLabel(
+            analysis_id=analysis.id,
+            photo_url="https://example.com/kitchen.jpg",
+            photo_index=0,
+            room_type="kitchen",
+            condition="poor",
+            damage_issues=["outdated_fixtures", "damaged_flooring"],
+            renovation_needed="major",
+            confidence=0.88,
+            confidence_tier="high",
+            review_status="auto_accepted",
+        ),
+        PhotoLabel(
+            analysis_id=analysis.id,
+            photo_url="https://example.com/bathroom.jpg",
+            photo_index=1,
+            room_type="bathroom",
+            condition="fair",
+            damage_issues=["peeling_paint"],
+            renovation_needed="cosmetic",
+            confidence=0.92,
+            confidence_tier="high",
+            review_status="auto_accepted",
+        ),
+    ]
+    for lbl in labels:
+        db_session.add(lbl)
+    await db_session.flush()
+    return analysis
+
+
+@pytest_asyncio.fixture
+async def quote_with_items(
+    db_session: AsyncSession, tenant: Tenant, property_: Property, deal: Deal
+) -> Quote:
+    q = Quote(
+        deal_id=deal.id,
+        tenant_id=tenant.id,
+        property_id=property_.id,
+        status="draft",
+        version=1,
+        platform_fee_pct=Decimal("0.05"),
+    )
+    db_session.add(q)
+    await db_session.flush()
+
+    items = [
+        QuoteItem(
+            quote_id=q.id,
+            room="Kitchen",
+            trade_category="plumbing",
+            description="Replace kitchen sink",
+            quantity=1,
+            unit_cost=Decimal("200.00"),
+            labor_cost=Decimal("150.00"),
+            subtotal=Decimal("350.00"),
+            is_ai_generated=False,
+        ),
+        QuoteItem(
+            quote_id=q.id,
+            room="Bathroom",
+            trade_category="tile",
+            description="Retile floor",
+            quantity=50,
+            unit_cost=Decimal("8.00"),
+            labor_cost=Decimal("300.00"),
+            subtotal=Decimal("700.00"),
+            is_ai_generated=False,
+        ),
+    ]
+    for item in items:
+        db_session.add(item)
+    await db_session.flush()
+
+    q.total_material = Decimal("600.00")
+    q.total_labor = Decimal("450.00")
+    q.platform_fee = Decimal("52.50")
+    q.grand_total = Decimal("1102.50")
+    await db_session.flush()
+
+    return q
+
+
+# ---------------------------------------------------------------------------
+# POST /properties/{id}/quotes — manual
+# ---------------------------------------------------------------------------
+
+
+class TestCreateQuoteManual:
+    async def test_create_empty_manual_quote(
+        self, client: AsyncClient, property_: Property, deal: Deal
+    ):
+        resp = await client.post(
+            f"/properties/{property_.id}/quotes",
+            json={"mode": "manual", "deal_id": deal.id},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["status"] == "draft"
+        assert data["property_id"] == property_.id
+        assert data["deal_id"] == deal.id
+        assert data["version"] == 1
+        assert data["items"] == []
+
+    async def test_create_manual_with_items(
+        self, client: AsyncClient, property_: Property, deal: Deal
+    ):
+        resp = await client.post(
+            f"/properties/{property_.id}/quotes",
+            json={
+                "mode": "manual",
+                "deal_id": deal.id,
+                "notes": "Initial estimate",
+                "items": [
+                    {
+                        "room": "Kitchen",
+                        "trade_category": "plumbing",
+                        "description": "Faucet replacement",
+                        "quantity": 1,
+                        "unit_cost": "150.00",
+                        "labor_cost": "75.00",
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["room"] == "Kitchen"
+        assert data["notes"] == "Initial estimate"
+        assert float(data["grand_total"]) > 0
+
+    async def test_create_auto_creates_deal(
+        self, client: AsyncClient, property_: Property
+    ):
+        resp = await client.post(
+            f"/properties/{property_.id}/quotes",
+            json={"mode": "manual"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["deal_id"] is not None
+
+    async def test_create_404_bad_property(self, client: AsyncClient):
+        resp = await client.post(
+            f"/properties/{uuid.uuid4()}/quotes",
+            json={"mode": "manual"},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /properties/{id}/quotes — AI mode
+# ---------------------------------------------------------------------------
+
+
+class TestCreateQuoteAI:
+    async def test_ai_generates_items(
+        self,
+        client: AsyncClient,
+        property_: Property,
+        deal: Deal,
+        photo_analysis: PropertyPhotoAnalysis,
+    ):
+        resp = await client.post(
+            f"/properties/{property_.id}/quotes",
+            json={
+                "mode": "ai",
+                "deal_id": deal.id,
+                "photo_analysis_id": photo_analysis.id,
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert len(data["items"]) > 0
+        assert data["photo_analysis_id"] == photo_analysis.id
+        # All items should be AI generated
+        for item in data["items"]:
+            assert item["is_ai_generated"] is True
+            assert item["ai_confidence"] is not None
+        assert float(data["grand_total"]) > 0
+
+    async def test_ai_requires_analysis_id(
+        self, client: AsyncClient, property_: Property, deal: Deal
+    ):
+        resp = await client.post(
+            f"/properties/{property_.id}/quotes",
+            json={"mode": "ai", "deal_id": deal.id},
+        )
+        assert resp.status_code == 400
+
+    async def test_ai_404_bad_analysis(
+        self, client: AsyncClient, property_: Property, deal: Deal
+    ):
+        resp = await client.post(
+            f"/properties/{property_.id}/quotes",
+            json={
+                "mode": "ai",
+                "deal_id": deal.id,
+                "photo_analysis_id": str(uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /properties/{id}/quotes
+# ---------------------------------------------------------------------------
+
+
+class TestListQuotes:
+    async def test_list_quotes(
+        self, client: AsyncClient, property_: Property, quote_with_items: Quote
+    ):
+        resp = await client.get(f"/properties/{property_.id}/quotes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["id"] == quote_with_items.id
+
+    async def test_list_empty(self, client: AsyncClient, property_: Property):
+        resp = await client.get(f"/properties/{property_.id}/quotes")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    async def test_filter_by_status(
+        self, client: AsyncClient, property_: Property, quote_with_items: Quote
+    ):
+        resp = await client.get(
+            f"/properties/{property_.id}/quotes", params={"status": "submitted"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+        resp = await client.get(
+            f"/properties/{property_.id}/quotes", params={"status": "draft"}
+        )
+        assert resp.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /quotes/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetQuote:
+    async def test_get_quote_detail(
+        self, client: AsyncClient, quote_with_items: Quote
+    ):
+        resp = await client.get(f"/quotes/{quote_with_items.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == quote_with_items.id
+        assert len(data["items"]) == 2
+        assert data["status"] == "draft"
+
+    async def test_get_404(self, client: AsyncClient, tenant: Tenant):
+        resp = await client.get(f"/quotes/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /quotes/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateQuote:
+    async def test_update_status(
+        self, client: AsyncClient, quote_with_items: Quote
+    ):
+        resp = await client.patch(
+            f"/quotes/{quote_with_items.id}",
+            json={"status": "submitted"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "submitted"
+
+    async def test_add_item(
+        self, client: AsyncClient, quote_with_items: Quote
+    ):
+        resp = await client.patch(
+            f"/quotes/{quote_with_items.id}",
+            json={
+                "add_items": [
+                    {
+                        "room": "Bedroom",
+                        "trade_category": "painting",
+                        "description": "Paint walls",
+                        "quantity": 1,
+                        "unit_cost": "300.00",
+                        "labor_cost": "200.00",
+                    }
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 3
+        assert data["version"] == 2  # bumped
+
+    async def test_remove_item(
+        self, client: AsyncClient, quote_with_items: Quote, db_session: AsyncSession
+    ):
+        # Get item ID to remove
+        resp = await client.get(f"/quotes/{quote_with_items.id}")
+        item_id = resp.json()["items"][0]["id"]
+
+        resp = await client.patch(
+            f"/quotes/{quote_with_items.id}",
+            json={"remove_item_ids": [item_id]},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 1
+        assert resp.json()["version"] == 2
+
+    async def test_update_item(
+        self, client: AsyncClient, quote_with_items: Quote
+    ):
+        resp = await client.get(f"/quotes/{quote_with_items.id}")
+        item_id = resp.json()["items"][0]["id"]
+
+        resp = await client.patch(
+            f"/quotes/{quote_with_items.id}",
+            json={
+                "update_items": {
+                    item_id: {"quantity": 5, "unit_cost": "250.00"}
+                }
+            },
+        )
+        assert resp.status_code == 200
+        updated_item = next(
+            i for i in resp.json()["items"] if i["id"] == item_id
+        )
+        assert updated_item["quantity"] == 5
+
+    async def test_update_notes(
+        self, client: AsyncClient, quote_with_items: Quote
+    ):
+        resp = await client.patch(
+            f"/quotes/{quote_with_items.id}",
+            json={"notes": "Updated notes"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["notes"] == "Updated notes"
+
+
+# ---------------------------------------------------------------------------
+# POST /quotes/{id}/generate-sow
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSOW:
+    @patch("app.routers.quotes.upload_sow_to_s3")
+    async def test_generate_sow(
+        self,
+        mock_upload: AsyncMock,
+        client: AsyncClient,
+        quote_with_items: Quote,
+    ):
+        mock_upload.return_value = "sow/test/abc123.pdf"
+
+        resp = await client.post(f"/quotes/{quote_with_items.id}/generate-sow")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pdf_s3_key"] == "sow/test/abc123.pdf"
+        assert "generated" in data["message"].lower()
+        mock_upload.assert_called_once()
+
+    async def test_generate_sow_404(self, client: AsyncClient, tenant: Tenant):
+        resp = await client.post(f"/quotes/{uuid.uuid4()}/generate-sow")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /quotes/{id}/sow
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadSOW:
+    @patch("app.routers.quotes.download_sow_from_s3")
+    async def test_download_sow(
+        self,
+        mock_download: AsyncMock,
+        client: AsyncClient,
+        quote_with_items: Quote,
+        db_session: AsyncSession,
+    ):
+        # Set pdf_s3_key on the quote
+        quote_with_items.pdf_s3_key = "sow/test/abc123.pdf"
+        await db_session.flush()
+
+        mock_download.return_value = b"%PDF-1.4 fake pdf content"
+
+        resp = await client.get(f"/quotes/{quote_with_items.id}/sow")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/pdf"
+        assert b"%PDF" in resp.content
+
+    async def test_download_sow_no_pdf(
+        self, client: AsyncClient, quote_with_items: Quote
+    ):
+        resp = await client.get(f"/quotes/{quote_with_items.id}/sow")
+        assert resp.status_code == 404
+        assert "no sow" in resp.json()["detail"].lower()

--- a/packages/api/tests/test_risk.py
+++ b/packages/api/tests/test_risk.py
@@ -1,0 +1,426 @@
+"""Tests for the risk flag system — year flags, FEMA, lendability, router."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ARVCalculation, Property, RiskFlag, Tenant
+from app.services.lendability import calculate_lendability
+from app.services.risk_flags import evaluate_year_flags
+from tests.conftest import TENANT_ID, USER_ID
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+VALID_PROPERTY = {
+    "address": "123 Main St",
+    "city": "Tampa",
+    "state": "FL",
+    "zip": "33602",
+    "lat": 27.9506,
+    "lng": -82.4572,
+    "year_built": 1960,
+    "sqft": 1800,
+    "beds": 3,
+    "baths": 2.0,
+    "listing_price": 200000,
+}
+
+
+async def _create_tenant_and_property(
+    db: AsyncSession,
+    *,
+    year_built: int | None = 1960,
+    lat: float | None = 27.9506,
+    lng: float | None = -82.4572,
+    listing_price: float | None = 200000,
+) -> Property:
+    tenant = Tenant(id=TENANT_ID, name="Test Co", slug="test-co", plan="free")
+    db.add(tenant)
+    await db.flush()
+
+    prop = Property(
+        tenant_id=TENANT_ID,
+        address="123 Main St",
+        city="Tampa",
+        state="FL",
+        zip="33602",
+        lat=lat,
+        lng=lng,
+        year_built=year_built,
+        sqft=1800,
+        beds=3,
+        baths=2.0,
+        listing_price=listing_price,
+    )
+    db.add(prop)
+    await db.flush()
+    await db.refresh(prop)
+    return prop
+
+
+# ===========================================================================
+# Unit tests — Year-based risk flags
+# ===========================================================================
+
+
+class TestYearFlags:
+    def test_old_property_triggers_all_flags(self):
+        """Property built 1960 triggers all 5 year-based flags."""
+        flags = evaluate_year_flags(1960)
+        assert len(flags) == 5
+        types = {f["flag_type"] for f in flags}
+        assert types == {
+            "knob_and_tube_wiring",
+            "lead_paint",
+            "asbestos",
+            "polybutylene_plumbing",
+            "cast_iron_drains",
+        }
+        assert all(f["source"] == "year_built" for f in flags)
+
+    def test_1990_property_triggers_two_flags(self):
+        """Property built 1990 triggers polybutylene + cast iron only."""
+        flags = evaluate_year_flags(1990)
+        assert len(flags) == 2
+        types = {f["flag_type"] for f in flags}
+        assert types == {"polybutylene_plumbing", "cast_iron_drains"}
+
+    def test_modern_property_no_flags(self):
+        """Property built 2005 triggers no year-based flags."""
+        flags = evaluate_year_flags(2005)
+        assert len(flags) == 0
+
+    def test_none_year_built_returns_advisory(self):
+        """None year_built returns single unknown_year advisory flag."""
+        flags = evaluate_year_flags(None)
+        assert len(flags) == 1
+        assert flags[0]["flag_type"] == "unknown_year"
+        assert flags[0]["severity"] == "low"
+
+    def test_boundary_1978_no_lead_flag(self):
+        """Property built in 1978 should NOT trigger lead paint (pre-1978 only)."""
+        flags = evaluate_year_flags(1978)
+        types = {f["flag_type"] for f in flags}
+        assert "lead_paint" not in types
+
+    def test_boundary_1977_has_lead_flag(self):
+        """Property built 1977 triggers lead paint."""
+        flags = evaluate_year_flags(1977)
+        types = {f["flag_type"] for f in flags}
+        assert "lead_paint" in types
+
+    # --- Additional boundary year tests per QA checklist ---
+
+    def test_boundary_1950_triggers_all_five(self):
+        """1950 < all thresholds → all 5 year flags."""
+        flags = evaluate_year_flags(1950)
+        assert len(flags) == 5
+
+    def test_boundary_1949_triggers_all_five(self):
+        """1949 < all thresholds → all 5 year flags."""
+        flags = evaluate_year_flags(1949)
+        assert len(flags) == 5
+
+    def test_boundary_1960_triggers_four(self):
+        """1960 < 1965 (knob_and_tube), 1978, 1985, 1994, 2000 → 5 flags."""
+        flags = evaluate_year_flags(1960)
+        assert len(flags) == 5
+
+    def test_boundary_1959_triggers_five(self):
+        """1959 < all thresholds → 5 flags."""
+        flags = evaluate_year_flags(1959)
+        assert len(flags) == 5
+
+    def test_boundary_1965_no_knob_and_tube(self):
+        """1965 is NOT < 1965, so no knob_and_tube. Still has 4 other flags."""
+        flags = evaluate_year_flags(1965)
+        types = {f["flag_type"] for f in flags}
+        assert "knob_and_tube_wiring" not in types
+        assert len(flags) == 4
+
+    def test_boundary_1973_has_lead_and_asbestos(self):
+        """1973 < 1978, 1985, 1994, 2000 → 4 flags (no knob_and_tube)."""
+        flags = evaluate_year_flags(1973)
+        types = {f["flag_type"] for f in flags}
+        assert "lead_paint" in types
+        assert "asbestos" in types
+        assert "knob_and_tube_wiring" not in types
+        assert len(flags) == 4
+
+    def test_boundary_1980_no_lead(self):
+        """1980 >= 1978 → no lead. Still < 1985, 1994, 2000 → 3 flags."""
+        flags = evaluate_year_flags(1980)
+        types = {f["flag_type"] for f in flags}
+        assert "lead_paint" not in types
+        assert "asbestos" in types
+        assert len(flags) == 3
+
+    def test_boundary_1979_no_lead(self):
+        """1979 >= 1978 → no lead. Still < 1985, 1994, 2000 → 3 flags."""
+        flags = evaluate_year_flags(1979)
+        types = {f["flag_type"] for f in flags}
+        assert "lead_paint" not in types
+        assert "knob_and_tube_wiring" not in types
+        assert len(flags) == 3
+
+    def test_all_flags_have_detail_and_source(self):
+        """Every flag must have a non-empty detail (explanation) and source."""
+        for year in [1940, 1960, 1970, 1980, 1990, None]:
+            flags = evaluate_year_flags(year)
+            for flag in flags:
+                assert flag["detail"], f"Empty detail for {flag['flag_type']} at year={year}"
+                assert flag["source"], f"Empty source for {flag['flag_type']} at year={year}"
+                assert len(flag["detail"]) > 20, "Detail should be a meaningful explanation"
+
+
+# ===========================================================================
+# Unit tests — Lendability score
+# ===========================================================================
+
+
+class TestLendability:
+    def test_clean_property_scores_green(self):
+        """Property with no risks and good ARV scores green."""
+        result = calculate_lendability(
+            {"year_built": 2015, "listing_price": 200000},
+            [],  # no risk flags
+            [{"arv_mid": 350000, "confidence": 0.85}],
+        )
+        assert result["category"] == "green"
+        assert result["score"] >= 70
+        assert result["breakdown"]["year_risk"] == 30
+        assert result["breakdown"]["arv_ratio"] == 25
+
+    def test_risky_property_scores_red(self):
+        """Property with many high-severity flags and bad ARV scores red."""
+        flags = [
+            {"flag_type": "lead_paint", "severity": "high", "source": "year_built"},
+            {"flag_type": "asbestos", "severity": "high", "source": "year_built"},
+            {"flag_type": "knob_and_tube_wiring", "severity": "high", "source": "year_built"},
+            {"flag_type": "flood_zone", "severity": "high", "source": "fema"},
+        ]
+        result = calculate_lendability(
+            {"year_built": 1950, "listing_price": 200000},
+            flags,
+            [{"arv_mid": 190000, "confidence": 0.5}],
+        )
+        assert result["category"] == "red"
+        assert result["score"] < 40
+
+    def test_moderate_property_scores_yellow(self):
+        """Property with some risks scores yellow."""
+        flags = [
+            {"flag_type": "cast_iron_drains", "severity": "medium", "source": "year_built"},
+            {"flag_type": "polybutylene_plumbing", "severity": "medium", "source": "year_built"},
+        ]
+        result = calculate_lendability(
+            {"year_built": 1990, "listing_price": 200000},
+            flags,
+            [{"arv_mid": 260000, "confidence": 0.7}],
+        )
+        # Breakdown should sum to total score
+        breakdown = result["breakdown"]
+        assert result["score"] == sum(breakdown.values())
+        assert result["category"] in {"green", "yellow", "red"}
+
+    def test_missing_data_uses_neutral_defaults(self):
+        """Missing data should use neutral defaults, not crash."""
+        result = calculate_lendability(
+            {"year_built": None, "listing_price": None},
+            [],
+            [],
+        )
+        assert result["score"] > 0
+        assert result["category"] in {"green", "yellow", "red"}
+        breakdown = result["breakdown"]
+        assert result["score"] == sum(breakdown.values())
+
+    def test_no_arv_calculations(self):
+        """No ARV data should use neutral default."""
+        result = calculate_lendability(
+            {"year_built": 2000, "listing_price": 200000},
+            [],
+            [],
+        )
+        assert result["breakdown"]["arv_ratio"] == 15
+
+    def test_zero_flags_scores_high(self):
+        """Property with 0 risk flags should have max year_risk score (30)."""
+        result = calculate_lendability(
+            {"year_built": 2020, "listing_price": 200000},
+            [],
+            [{"arv_mid": 350000, "confidence": 0.9}],
+        )
+        assert result["breakdown"]["year_risk"] == 30
+        assert result["category"] == "green"
+        assert result["score"] >= 70
+
+    def test_two_medium_flags(self):
+        """2 medium-severity flags: year_risk = 30 - 5 - 5 = 20."""
+        flags = [
+            {"flag_type": "polybutylene_plumbing", "severity": "medium", "source": "year_built"},
+            {"flag_type": "cast_iron_drains", "severity": "medium", "source": "year_built"},
+        ]
+        result = calculate_lendability(
+            {"year_built": 1990, "listing_price": 200000},
+            flags,
+            [{"arv_mid": 280000, "confidence": 0.75}],
+        )
+        assert result["breakdown"]["year_risk"] == 20
+
+    def test_three_plus_high_flags_warning(self):
+        """3+ high-severity flags should push lendability to yellow or red."""
+        flags = [
+            {"flag_type": "knob_and_tube_wiring", "severity": "high", "source": "year_built"},
+            {"flag_type": "lead_paint", "severity": "high", "source": "year_built"},
+            {"flag_type": "asbestos", "severity": "high", "source": "year_built"},
+        ]
+        result = calculate_lendability(
+            {"year_built": 1955, "listing_price": 200000},
+            flags,
+            [{"arv_mid": 250000, "confidence": 0.6}],
+        )
+        # 3 high flags: 30 - 10 - 10 - 10 = 0
+        assert result["breakdown"]["year_risk"] == 0
+        assert result["category"] in {"yellow", "red"}
+
+
+# ===========================================================================
+# Integration tests — Risk router
+# ===========================================================================
+
+
+@pytest.mark.anyio
+async def test_list_flags_empty(client: AsyncClient, db_session: AsyncSession):
+    """GET /risk/{id}/flags returns empty list for new property."""
+    prop = await _create_tenant_and_property(db_session)
+    resp = await client.get(f"/risk/{prop.id}/flags")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["flags"] == []
+
+
+@pytest.mark.anyio
+async def test_list_flags_not_found(client: AsyncClient, db_session: AsyncSession):
+    """GET /risk/{id}/flags returns 404 for non-existent property."""
+    fake_id = str(uuid.uuid4())
+    resp = await client.get(f"/risk/{fake_id}/flags")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_evaluate_creates_flags_and_score(client: AsyncClient, db_session: AsyncSession):
+    """POST /risk/{id}/evaluate creates year flags + lendability score."""
+    prop = await _create_tenant_and_property(db_session, year_built=1960)
+
+    with patch("app.routers.risk.fema.query_flood_zone", new_callable=AsyncMock) as mock_fema:
+        mock_fema.return_value = {
+            "zone": "X",
+            "zone_subtype": "AREA OF MINIMAL FLOOD HAZARD",
+            "is_high_risk": False,
+            "panel_number": None,
+        }
+        resp = await client.post(f"/risk/{prop.id}/evaluate")
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Should have 5 year flags + 1 FEMA flag = 6 total
+    assert len(data["flags"]) == 6
+
+    # Lendability score present
+    assert "lendability" in data
+    assert data["lendability"]["score"] > 0
+    assert data["lendability"]["category"] in {"green", "yellow", "red"}
+    assert "breakdown" in data["lendability"]
+
+
+@pytest.mark.anyio
+async def test_evaluate_high_risk_flood_zone(client: AsyncClient, db_session: AsyncSession):
+    """POST /risk/{id}/evaluate with high-risk FEMA zone sets severity high."""
+    prop = await _create_tenant_and_property(db_session, year_built=2020)
+
+    with patch("app.routers.risk.fema.query_flood_zone", new_callable=AsyncMock) as mock_fema:
+        mock_fema.return_value = {
+            "zone": "AE",
+            "zone_subtype": "FLOODWAY",
+            "is_high_risk": True,
+            "panel_number": "12057C0235H",
+        }
+        resp = await client.post(f"/risk/{prop.id}/evaluate")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    fema_flags = [f for f in data["flags"] if f["source"] == "fema"]
+    assert len(fema_flags) == 1
+    assert fema_flags[0]["severity"] == "high"
+    assert "AE" in fema_flags[0]["detail"]
+
+
+@pytest.mark.anyio
+async def test_fema_endpoint_missing_coords(client: AsyncClient, db_session: AsyncSession):
+    """POST /risk/{id}/fema returns 422 when property has no coordinates."""
+    prop = await _create_tenant_and_property(db_session, lat=None, lng=None)
+    resp = await client.post(f"/risk/{prop.id}/fema")
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_fema_endpoint_success(client: AsyncClient, db_session: AsyncSession):
+    """POST /risk/{id}/fema stores flood zone flag."""
+    prop = await _create_tenant_and_property(db_session)
+
+    with patch("app.routers.risk.fema.query_flood_zone", new_callable=AsyncMock) as mock_fema:
+        mock_fema.return_value = {
+            "zone": "V",
+            "zone_subtype": "COASTAL HIGH HAZARD AREA",
+            "is_high_risk": True,
+            "panel_number": None,
+        }
+        resp = await client.post(f"/risk/{prop.id}/fema")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["flags"][0]["flag_type"] == "flood_zone"
+    assert data["flags"][0]["severity"] == "high"
+
+
+@pytest.mark.anyio
+async def test_lendability_not_computed_yet(client: AsyncClient, db_session: AsyncSession):
+    """GET /risk/{id}/lendability returns 404 when score not yet computed."""
+    prop = await _create_tenant_and_property(db_session)
+    resp = await client.get(f"/risk/{prop.id}/lendability")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_lendability_after_evaluate(client: AsyncClient, db_session: AsyncSession):
+    """GET /risk/{id}/lendability works after evaluate has been run."""
+    prop = await _create_tenant_and_property(db_session, year_built=2020)
+
+    with patch("app.routers.risk.fema.query_flood_zone", new_callable=AsyncMock) as mock_fema:
+        mock_fema.return_value = {
+            "zone": "X",
+            "zone_subtype": None,
+            "is_high_risk": False,
+            "panel_number": None,
+        }
+        await client.post(f"/risk/{prop.id}/evaluate")
+
+    resp = await client.get(f"/risk/{prop.id}/lendability")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["score"] >= 70
+    assert data["category"] == "green"

--- a/packages/api/tests/test_sage_playwright.py
+++ b/packages/api/tests/test_sage_playwright.py
@@ -1,0 +1,406 @@
+"""Tests for the Sage Playwright Bridge — all Playwright interactions are mocked."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.sage_playwright import (
+    CircuitBreaker,
+    RateLimiter,
+    SageAuthError,
+    SageParsingError,
+    SagePlaywrightBridge,
+    SageTimeoutError,
+    SageUnavailableError,
+)
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter tests
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiter:
+    @pytest.mark.asyncio
+    async def test_first_request_passes_immediately(self):
+        limiter = RateLimiter(interval=2.0)
+        start = time.monotonic()
+        await limiter.acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1
+
+    @pytest.mark.asyncio
+    async def test_second_request_is_delayed(self):
+        limiter = RateLimiter(interval=0.2)
+        await limiter.acquire()
+        start = time.monotonic()
+        await limiter.acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.15  # allow small tolerance
+
+    @pytest.mark.asyncio
+    async def test_request_after_interval_passes(self):
+        limiter = RateLimiter(interval=0.1)
+        await limiter.acquire()
+        await asyncio.sleep(0.15)
+        start = time.monotonic()
+        await limiter.acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker tests
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_starts_closed(self):
+        cb = CircuitBreaker(failure_threshold=5, recovery_timeout=60.0)
+        assert not cb.is_open
+        assert not cb.is_half_open
+
+    def test_opens_after_threshold_failures(self):
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=60.0)
+        for _ in range(3):
+            cb.record_failure()
+        assert cb.is_open
+
+    def test_stays_closed_below_threshold(self):
+        cb = CircuitBreaker(failure_threshold=5, recovery_timeout=60.0)
+        for _ in range(4):
+            cb.record_failure()
+        assert not cb.is_open
+
+    def test_success_resets_counter(self):
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        cb.record_failure()
+        cb.record_failure()
+        assert not cb.is_open
+
+    def test_half_open_after_recovery_timeout(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=0.1)
+        cb.record_failure()
+        assert cb.is_open
+        time.sleep(0.15)
+        assert not cb.is_open
+        assert cb.is_half_open
+
+    def test_success_after_half_open_closes(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=0.1)
+        cb.record_failure()
+        time.sleep(0.15)
+        _ = cb.is_open  # triggers half-open
+        cb.record_success()
+        assert not cb.is_open
+        assert not cb.is_half_open
+
+    def test_failure_in_half_open_reopens(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=0.1)
+        cb.record_failure()
+        time.sleep(0.15)
+        _ = cb.is_open  # triggers half-open
+        cb.record_failure()
+        assert cb.is_open
+
+
+# ---------------------------------------------------------------------------
+# SagePlaywrightBridge tests (mocked Playwright)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_element(text: str | None = None, attr_map: dict | None = None):
+    """Create a mock Playwright element handle."""
+    el = AsyncMock()
+    el.text_content = AsyncMock(return_value=text)
+    el.get_attribute = AsyncMock(side_effect=lambda a: (attr_map or {}).get(a))
+    return el
+
+
+def _make_mock_page(
+    search_cards: list[dict] | None = None,
+    product_detail: dict | None = None,
+    login_success: bool = True,
+):
+    """Build a fully-mocked Playwright Page."""
+    page = AsyncMock()
+    page.goto = AsyncMock()
+    page.fill = AsyncMock()
+    page.click = AsyncMock()
+    page.close = AsyncMock()
+
+    if login_success:
+        page.wait_for_selector = AsyncMock()
+    else:
+        page.wait_for_selector = AsyncMock(side_effect=Exception("Login element not found"))
+
+    if search_cards is not None:
+        cards = []
+        for card_data in search_cards:
+            card = AsyncMock()
+
+            async def _card_qs(sel, _d=card_data):
+                if "name" in sel.lower():
+                    return _make_mock_element(_d.get("name"))
+                if "sku" in sel.lower():
+                    return _make_mock_element(_d.get("sku"))
+                if "price" in sel.lower():
+                    return _make_mock_element(_d.get("price"))
+                if sel == "a":
+                    return _make_mock_element(attr_map={"href": _d.get("href", "/products/123")})
+                return None
+
+            card.query_selector = _card_qs
+            cards.append(card)
+
+        page.query_selector_all = AsyncMock(return_value=cards)
+
+    if product_detail is not None:
+
+        async def _detail_qs(sel):
+            if "name" in sel.lower() or "title" in sel.lower():
+                return _make_mock_element(product_detail.get("name"))
+            if "sku" in sel.lower():
+                return _make_mock_element(product_detail.get("sku"))
+            if "price" in sel.lower():
+                return _make_mock_element(product_detail.get("price"))
+            if "description" in sel.lower():
+                return _make_mock_element(product_detail.get("description"))
+            if "availability" in sel.lower():
+                return _make_mock_element(product_detail.get("availability"))
+            if "category" in sel.lower():
+                return _make_mock_element(product_detail.get("category"))
+            if "brand" in sel.lower():
+                return _make_mock_element(product_detail.get("brand"))
+            if "dimensions" in sel.lower():
+                return _make_mock_element(product_detail.get("dimensions"))
+            if "image" in sel.lower():
+                return _make_mock_element(attr_map={"src": product_detail.get("image_url")})
+            return None
+
+        page.query_selector = _detail_qs
+
+    return page
+
+
+def _make_bridge(**kwargs) -> SagePlaywrightBridge:
+    """Create a bridge with short rate-limit for fast tests."""
+    defaults = {
+        "portal_url": "https://test-sage.example.com",
+        "username": "testuser",
+        "password": "testpass",
+        "rate_limit_interval": 0.0,
+        "failure_threshold": 5,
+        "recovery_timeout": 60.0,
+    }
+    defaults.update(kwargs)
+    return SagePlaywrightBridge(**defaults)
+
+
+class TestSagePlaywrightBridge:
+    @pytest.mark.asyncio
+    async def test_search_products_returns_structured_data(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(
+            search_cards=[
+                {"name": "Oak Flooring", "sku": "OAK-001", "price": "$4.99", "href": "/products/p1"},
+                {"name": "Maple Trim", "sku": "MPL-002", "price": "$2.50", "href": "/products/p2"},
+            ]
+        )
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        results = await bridge.search_products("flooring")
+        assert len(results) == 2
+        assert results[0]["name"] == "Oak Flooring"
+        assert results[0]["sku"] == "OAK-001"
+        assert results[0]["price_cents"] == 499
+        assert results[0]["product_id"] == "p1"
+        assert results[1]["name"] == "Maple Trim"
+        assert results[1]["price_cents"] == 250
+
+    @pytest.mark.asyncio
+    async def test_search_products_with_category_filter(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(search_cards=[{"name": "Item", "sku": "X", "price": "$1.00"}])
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        results = await bridge.search_products("tile", category="flooring", page=2)
+        assert len(results) == 1
+        mock_page.goto.assert_called_once()
+        call_url = mock_page.goto.call_args[0][0]
+        assert "category=flooring" in call_url
+        assert "page=2" in call_url
+
+    @pytest.mark.asyncio
+    async def test_get_product_detail(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(
+            product_detail={
+                "name": "Premium Oak Plank",
+                "sku": "OAK-PREM-001",
+                "price": "$8.99",
+                "description": "6-inch wide premium oak hardwood plank",
+                "availability": "In Stock",
+                "category": "Flooring",
+                "brand": "HardwoodPro",
+                "dimensions": "6\" x 48\"",
+                "image_url": "https://sage.example.com/img/oak.jpg",
+            }
+        )
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        result = await bridge.get_product_detail("OAK-PREM-001")
+        assert result["name"] == "Premium Oak Plank"
+        assert result["sku"] == "OAK-PREM-001"
+        assert result["price_cents"] == 899
+        assert result["description"] == "6-inch wide premium oak hardwood plank"
+        assert result["availability"] == "In Stock"
+        assert result["brand"] == "HardwoodPro"
+        assert result["image_url"] == "https://sage.example.com/img/oak.jpg"
+
+    @pytest.mark.asyncio
+    async def test_browse_category(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(
+            search_cards=[{"name": "HVAC Unit", "sku": "HVAC-100", "price": "$1,299.00"}]
+        )
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        results = await bridge.browse_category("hvac", page=1)
+        assert len(results) == 1
+        assert results[0]["name"] == "HVAC Unit"
+        assert results[0]["price_cents"] == 129900
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_opens_after_failures(self):
+        bridge = _make_bridge(failure_threshold=3, rate_limit_interval=0.0)
+        mock_page = _make_mock_page(search_cards=[])
+        mock_page.wait_for_selector = AsyncMock(side_effect=Exception("timeout"))
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        for _ in range(3):
+            with pytest.raises(SageTimeoutError):
+                await bridge.search_products("test")
+
+        with pytest.raises(SageUnavailableError):
+            await bridge.search_products("test")
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_success_resets(self):
+        bridge = _make_bridge(failure_threshold=3, rate_limit_interval=0.0)
+
+        # 2 failures
+        fail_page = _make_mock_page(search_cards=[])
+        fail_page.wait_for_selector = AsyncMock(side_effect=Exception("timeout"))
+        bridge._get_page = AsyncMock(return_value=fail_page)
+        for _ in range(2):
+            with pytest.raises(SageTimeoutError):
+                await bridge.search_products("test")
+
+        # 1 success
+        ok_page = _make_mock_page(search_cards=[{"name": "A", "sku": "B", "price": "$1.00"}])
+        bridge._get_page = AsyncMock(return_value=ok_page)
+        results = await bridge.search_products("test")
+        assert len(results) == 1
+
+        # 2 more failures should not open circuit (counter was reset)
+        bridge._get_page = AsyncMock(return_value=fail_page)
+        for _ in range(2):
+            with pytest.raises(SageTimeoutError):
+                await bridge.search_products("test")
+
+        # Should NOT be open (only 2 consecutive failures)
+        ok_page2 = _make_mock_page(search_cards=[{"name": "C", "sku": "D", "price": "$2.00"}])
+        bridge._get_page = AsyncMock(return_value=ok_page2)
+        results = await bridge.search_products("test")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_auth_error_on_login_failure(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(login_success=False)
+        # Need to simulate login failure in _get_page
+        bridge._context = None
+        bridge._logged_in = False
+
+        mock_ctx = AsyncMock()
+        mock_ctx.new_page = AsyncMock(return_value=mock_page)
+
+        with patch.object(bridge, "_ensure_browser", return_value=mock_ctx):
+            with pytest.raises(SageAuthError):
+                await bridge.search_products("test")
+
+    @pytest.mark.asyncio
+    async def test_parsing_error_on_missing_product_name(self):
+        bridge = _make_bridge()
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.close = AsyncMock()
+        mock_page.wait_for_selector = AsyncMock()
+        mock_page.query_selector = AsyncMock(return_value=None)
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        with pytest.raises(SageParsingError) as exc_info:
+            await bridge.get_product_detail("some-id")
+        assert "product-name" in exc_info.value.selector.lower() or "product-title" in exc_info.value.selector.lower()
+
+    @pytest.mark.asyncio
+    async def test_close_cleans_up_resources(self):
+        bridge = _make_bridge()
+        mock_ctx = AsyncMock()
+        mock_browser = AsyncMock()
+        mock_pw = AsyncMock()
+        bridge._context = mock_ctx
+        bridge._browser = mock_browser
+        bridge._playwright = mock_pw
+        bridge._logged_in = True
+
+        await bridge.close()
+
+        mock_ctx.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+        mock_pw.stop.assert_called_once()
+        assert bridge._context is None
+        assert bridge._browser is None
+        assert bridge._playwright is None
+        assert not bridge._logged_in
+
+    @pytest.mark.asyncio
+    async def test_price_parsing_handles_comma_thousands(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(
+            search_cards=[{"name": "Expensive Item", "sku": "EXP-1", "price": "$12,345.67"}]
+        )
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        results = await bridge.search_products("expensive")
+        assert results[0]["price_cents"] == 1234567
+
+    @pytest.mark.asyncio
+    async def test_price_parsing_handles_no_price(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(
+            search_cards=[{"name": "Free Item", "sku": "FREE-1", "price": None}]
+        )
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        results = await bridge.search_products("free")
+        assert results[0]["price_cents"] is None
+
+    @pytest.mark.asyncio
+    async def test_pages_are_closed_after_use(self):
+        bridge = _make_bridge()
+        mock_page = _make_mock_page(
+            search_cards=[{"name": "Item", "sku": "X", "price": "$1.00"}]
+        )
+        bridge._get_page = AsyncMock(return_value=mock_page)
+
+        await bridge.search_products("test")
+        mock_page.close.assert_called_once()

--- a/packages/api/tests/test_services.py
+++ b/packages/api/tests/test_services.py
@@ -1,0 +1,243 @@
+"""Tests for service modules."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.apillow import merge_enrichment, normalize_apillow_data
+from app.services.propstream import RateLimiter, normalize_propstream_data
+from app.services.zillow_scraper import parse_zillow_url, _parse_html_meta
+
+
+# ---------------------------------------------------------------------------
+# PropStream normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_propstream_data() -> None:
+    raw = {
+        "property": {
+            "id": "PS123",
+            "address": {"full": "123 Main St", "city": "Austin", "state": "TX", "zip": "78701", "county": "Travis"},
+            "location": {"lat": 30.27, "lng": -97.74},
+            "details": {"year_built": 2005, "sqft": 1800, "lot_sqft": 5000, "beds": 3, "baths": 2.0, "property_type": "SFR"},
+            "valuation": {"listing_price": 450000, "arv": 550000, "arv_confidence": 0.85},
+            "tax": {"assessed_value": 380000},
+            "mls_id": "MLS456",
+            "ownership_history": [{"date": "2020-01-15", "buyer": "Smith"}],
+        }
+    }
+    result = normalize_propstream_data(raw)
+    assert result["address"] == "123 Main St"
+    assert result["city"] == "Austin"
+    assert result["propstream_id"] == "PS123"
+    assert result["data_source"] == "propstream"
+    assert result["tax_assessment"] == 380000
+    assert result["beds"] == 3
+
+
+# ---------------------------------------------------------------------------
+# APIllow merge logic
+# ---------------------------------------------------------------------------
+
+
+def test_merge_enrichment_fills_gaps() -> None:
+    existing = {"beds": 3, "baths": None, "sqft": 1800, "zillow_estimate": None, "neighborhood": None}
+    enrichment = {"beds": 4, "baths": 2.0, "sqft": 2000, "zillow_estimate": 500000, "neighborhood": "Downtown"}
+
+    merged = merge_enrichment(existing, enrichment)
+    # beds should NOT be overwritten (PropStream is source-of-truth)
+    assert merged["beds"] == 3
+    # baths was None, so APIllow fills the gap
+    assert merged["baths"] == 2.0
+    # sqft was set, NOT overwritten
+    assert merged["sqft"] == 1800
+    # zillow_estimate is APIllow-exclusive, always set
+    assert merged["zillow_estimate"] == 500000
+    # neighborhood is APIllow-exclusive, always set
+    assert merged["neighborhood"] == "Downtown"
+
+
+def test_merge_enrichment_ignores_none() -> None:
+    existing = {"beds": 3}
+    enrichment = {"beds": None, "baths": None}
+    merged = merge_enrichment(existing, enrichment)
+    assert merged["beds"] == 3
+    assert "baths" not in merged
+
+
+def test_normalize_apillow_data() -> None:
+    raw = {
+        "zestimate": 520000,
+        "neighborhood": "East Austin",
+        "bedrooms": 4,
+        "bathrooms": 2.5,
+        "living_area": 2200,
+        "year_built": 2010,
+        "lot_size": 6000,
+        "home_type": "SINGLE_FAMILY",
+        "latitude": 30.26,
+        "longitude": -97.73,
+        "arv": 580000,
+    }
+    result = normalize_apillow_data(raw)
+    assert result["zillow_estimate"] == 520000
+    assert result["neighborhood"] == "East Austin"
+    assert result["beds"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Zillow URL parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_zillow_url_valid() -> None:
+    url = "https://www.zillow.com/homedetails/123-Main-St-Austin-TX-78701/12345678_zpid/"
+    result = parse_zillow_url(url)
+    assert result["zpid"] == "12345678"
+    assert result["url"] == url
+    assert "Main" in result["address_slug"]
+
+
+def test_parse_zillow_url_invalid() -> None:
+    with pytest.raises(ValueError):
+        parse_zillow_url("https://www.zillow.com/homes/")
+
+
+def test_parse_html_meta_extracts_data() -> None:
+    html = '''
+    <html>
+    <head>
+    <meta property="og:title" content="123 Main St, Austin, TX 78701">
+    <meta name="description" content="3 bd, 2.0 ba, 1800 sqft home">
+    </head>
+    <body>
+    <script>"latitude": 30.27, "longitude": -97.74, "yearBuilt": 2005, "homeType": "SINGLE_FAMILY", "price": "450000"</script>
+    </body>
+    </html>
+    '''
+    parsed_url = {"url": "https://www.zillow.com/homedetails/test/123_zpid/"}
+    result = _parse_html_meta(html, parsed_url)
+    assert result["address"] == "123 Main St"
+    assert result["city"] == "Austin"
+    assert result["state"] == "TX"
+    assert result["zip"] == "78701"
+    assert result["beds"] == 3
+    assert result["baths"] == 2.0
+    assert result["sqft"] == 1800
+    assert result["lat"] == 30.27
+    assert result["year_built"] == 2005
+    assert result["property_type"] == "SINGLE_FAMILY"
+    assert result["listing_price"] == 450000.0
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_propstream_missing_fields() -> None:
+    """PropStream response with missing nested fields should not crash."""
+    raw = {"property": {"id": "PS999", "address": {}, "location": {}, "details": {}, "valuation": {}, "tax": {}}}
+    result = normalize_propstream_data(raw)
+    assert result["address"] == ""
+    assert result["city"] == ""
+    assert result["lat"] is None
+    assert result["beds"] is None
+    assert result["tax_assessment"] is None
+    assert result["data_source"] == "propstream"
+
+
+def test_normalize_propstream_malformed_no_property_key() -> None:
+    """PropStream response without 'property' wrapper uses raw dict as fallback."""
+    raw = {"id": "PS-FLAT", "address": {"full": "Flat St", "city": "X", "state": "Y", "zip": "00000"}}
+    result = normalize_propstream_data(raw)
+    assert result["address"] == "Flat St"
+    assert result["propstream_id"] == "PS-FLAT"
+
+
+def test_merge_enrichment_missing_zestimate() -> None:
+    """APIllow enrichment with None zestimate should not overwrite anything."""
+    existing = {"beds": 3, "zillow_estimate": None}
+    enrichment = {"beds": 4, "zillow_estimate": None, "neighborhood": "East Side"}
+    merged = merge_enrichment(existing, enrichment)
+    assert merged["beds"] == 3  # PropStream source-of-truth
+    assert merged["zillow_estimate"] is None  # APIllow sent None
+    assert merged["neighborhood"] == "East Side"  # exclusive, non-None
+
+
+def test_merge_enrichment_zestimate_always_set() -> None:
+    """APIllow zillow_estimate is exclusive and always overrides when non-None."""
+    existing = {"zillow_estimate": 400000}
+    enrichment = {"zillow_estimate": 520000}
+    merged = merge_enrichment(existing, enrichment)
+    assert merged["zillow_estimate"] == 520000
+
+
+# ---------------------------------------------------------------------------
+# Google Places autocomplete — mocked integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_google_places_autocomplete_returns_formatted_address() -> None:
+    """Google Places autocomplete → formatted address + lat/lng via geocode."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.services.google_places import autocomplete, geocode
+
+    mock_autocomplete_response = {
+        "status": "OK",
+        "predictions": [
+            {
+                "place_id": "ChIJ_abc123",
+                "description": "123 Main St, Austin, TX 78701, USA",
+                "structured_formatting": {"main_text": "123 Main St"},
+            }
+        ],
+    }
+    mock_geocode_response = {
+        "status": "OK",
+        "results": [
+            {
+                "formatted_address": "123 Main St, Austin, TX 78701, USA",
+                "geometry": {"location": {"lat": 30.2672, "lng": -97.7431}},
+            }
+        ],
+    }
+
+    with patch("app.services.google_places.settings") as mock_settings:
+        mock_settings.GOOGLE_PLACES_API_KEY = "test-key"
+        with patch("app.services.google_places.httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            # autocomplete call — httpx.Response.json() and raise_for_status() are sync
+            mock_resp_ac = MagicMock()
+            mock_resp_ac.json.return_value = mock_autocomplete_response
+            mock_client.get.return_value = mock_resp_ac
+
+            results = await autocomplete("123 Main")
+            assert len(results) == 1
+            assert results[0]["place_id"] == "ChIJ_abc123"
+            assert "123 Main St" in results[0]["description"]
+
+            # geocode call
+            mock_resp_geo = MagicMock()
+            mock_resp_geo.json.return_value = mock_geocode_response
+            mock_client.get.return_value = mock_resp_geo
+
+            geo = await geocode("123 Main St, Austin, TX 78701")
+            assert geo is not None
+            assert geo["lat"] == 30.2672
+            assert geo["lng"] == -97.7431
+            assert "123 Main St" in geo["formatted_address"]
+
+
+@pytest.mark.anyio
+async def test_rate_limiter_allows_under_limit() -> None:
+    limiter = RateLimiter(max_requests=5, window=60)
+    for _ in range(5):
+        await limiter.acquire()
+    # Should not raise


### PR DESCRIPTION
## Summary

Spike prototype for SAG-4195 (Path b: `adapterConfig.jsonMode`). When enabled, injects `responseFormat: { type: "json_object" }` into the runtime opencode.json model options, constraining every Ollama completion to valid JSON — preventing `<think>` tag and preamble leakage for structured-output agents.

**Changed files:**
- `src/server/runtime-config.ts` — `prepareOpenCodeRuntimeConfig` injects per-model options when `config.jsonMode === true`
- `src/server/runtime-config.test.ts` — 3 new TDD tests (RED before, GREEN after)
- `src/index.ts` — documents `jsonMode` in `agentConfigurationDoc`

**Request body with jsonMode (AC #1):**
```json
POST http://localhost:11434/v1/chat/completions
{ "model": "...", "messages": [...], "response_format": {"type": "json_object"} }
```

**Recommendation (AC #3):** Prefer Path (b) — per-agent toggle in Paperclip's adapterConfig, isolated from other agents, uses the adapter's existing runtime-config injection path. Path (a) would require editing the shared user opencode.json outside the adapter's lifecycle control.

**Caveat:** OpenCode's per-model `options.responseFormat` field is untyped in the config schema; end-to-end empirical validation with a live OpenCode session (confirming OpenCode passes it to the AI SDK) is needed before fleet-wide rollout.

NO fleet-wide enable. NO Modelfile change. Spike + recommendation only.

## Test plan
- [x] `pnpm vitest run packages/adapters/opencode-local` — 5/5 pass
- [x] typecheck clean
- [ ] CTO: review recommendation, decide rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)