### PR TITLE
fix(recovery): exempt perpetual trackers from stranded-recovery flip — by label + future monitorNextCheckAt (BLU-15638, BLU-16005)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -580,6 +580,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     assignToUser?: boolean;
     activePauseHold?: boolean;
     perpetualTracker?: boolean;
+    monitorNextCheckAt?: Date | null;
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
@@ -684,6 +685,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
+        monitorNextCheckAt: input.monitorNextCheckAt ?? null,
       },
     ]);
 
@@ -2808,6 +2810,58 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(0);
+  });
+
+  it("does not flip issues with a future scheduled monitor to blocked (BLU-16005)", async () => {
+    // A scheduled monitor (monitorNextCheckAt in the future) is a live
+    // continuation path: the monitor scheduler will wake the assignee at that
+    // time. Without honoring it, perpetual-tracker EPICs (e.g. SOC 2 BLU-9829)
+    // that sit idle between scheduled checks get flipped to `blocked` every
+    // recovery cycle. No perpetual-tracker label here — the nextCheckAt guard
+    // must protect the issue on its own.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.companyId, companyId));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("still flips a stranded issue once its scheduled monitor is overdue (BLU-16005)", async () => {
+    // Guard is bounded to *future* checks: a monitor whose nextCheckAt has
+    // already elapsed is not a live path, so genuine strandings are still
+    // recovered.
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      monitorNextCheckAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
   });
 
   it("redacts error-code-only stranded recovery failures in issue copy", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -24,6 +24,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueLabels,
   issuePlanDecompositions,
   issueRecoveryActions,
   issueRelations,
@@ -32,6 +33,7 @@ import {
   issueTreeHolds,
   issueWorkProducts,
   issues,
+  labels,
   projects,
   projectWorkspaces,
   workspaceOperations,
@@ -577,6 +579,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     runSource?: string | null;
     assignToUser?: boolean;
     activePauseHold?: boolean;
+    perpetualTracker?: boolean;
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
@@ -692,6 +695,21 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         status: "active",
         reason: "pause recovery subtree",
         releasePolicy: { strategy: "manual" },
+      });
+    }
+
+    if (input.perpetualTracker) {
+      const labelId = randomUUID();
+      await db.insert(labels).values({
+        id: labelId,
+        companyId,
+        name: "perpetual-tracker",
+        color: "#888888",
+      });
+      await db.insert(issueLabels).values({
+        issueId,
+        labelId,
+        companyId,
       });
     }
 
@@ -2760,6 +2778,36 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry failure details were withheld from the issue thread");
     expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction.id}\``);
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
+  });
+
+  it("does not flip perpetual-tracker issues to blocked (BLU-15638)", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      perpetualTracker: true,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    // The perpetual-tracker label must keep the issue out of the candidate
+    // set entirely: no escalation, no requeue, nothing touched.
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.assigneeAgentId).toBe(agentId);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.companyId, companyId));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
   });
 
   it("redacts error-code-only stranded recovery failures in issue copy", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -554,7 +554,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
-    const [run, deferredWake] = await Promise.all([
+    const now = new Date();
+    const [run, deferredWake, scheduledMonitor] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -579,9 +580,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         )
         .limit(1)
         .then((rows) => rows[0] ?? null),
+      // BLU-16005: a scheduled monitor whose next-check is still in the future
+      // is a live continuation path — the monitor scheduler will wake the
+      // assignee at monitorNextCheckAt. Perpetual-tracker EPICs (e.g. SOC 2
+      // BLU-9829) sit idle between scheduled checks with no heartbeat run and
+      // no deferred wake; without this they look stranded and the recovery
+      // sweep flips them to `blocked` + reassigns on every cycle. Bounded to
+      // future checks so a genuinely overdue/abandoned monitor is still
+      // recovered.
+      db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.id, issueId),
+            gt(issues.monitorNextCheckAt, now),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return Boolean(run || deferredWake || scheduledMonitor);
   }
 
   async function hasPendingWakeInteraction(companyId: string, issueId: string) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -19,10 +19,12 @@ import {
   issueAttachments,
   issueComments,
   issueApprovals,
+  issueLabels,
   issueRecoveryActions,
   issueRelations,
   issueThreadInteractions,
   issues,
+  labels,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -2652,6 +2654,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           isNull(issues.assigneeUserId),
           inArray(issues.status, ["todo", "in_progress"]),
           sql`${issues.assigneeAgentId} is not null`,
+          // BLU-15638: perpetual-tracker issues (long-lived SOC 2 / ops
+          // EPICs) are intentionally assigned with no live execution path,
+          // so the stranded-recovery sweep would otherwise flip them to
+          // `blocked` and reassign on every run. Exempt them here — same
+          // intent as the BLU-10337 disposition-flip exemption, applied to
+          // the source-scoped recovery path.
+          sql`not exists (
+            select 1
+            from ${issueLabels} il
+            inner join ${labels} l on l.id = il.label_id
+            where il.issue_id = ${issues.id} and l.name = 'perpetual-tracker'
+          )`,
         ),
       );
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The fleet executor runs a stranded-recovery sweep (`reconcileStrandedAssignedIssues`) that flips agent-assigned issues with no live execution path to `blocked` and reassigns them to the recovery owner
> - Long-lived "perpetual-tracker" EPICs are intentionally idle between scheduled monitor checks, so the sweep mistook them for stranded work and flipped them ~every 25 min, each flip firing a spurious manager wake
> - This needs addressing because the loop burns budget, spams managers, and corrupts the status of legitimately-parked tracker epics (e.g. the SOC 2 epic BLU-9829)
> - This pull request adds two complementary guards so monitored / labeled trackers are recognized as having a live continuation path
> - The benefit is that the recovery sweep stops false-flipping idle-but-healthy trackers while still recovering genuinely stranded work

## Linked Issues or Issue Description

No GitHub issue exists; tracked in Paperclip as BLU-16005 (and the companion label prong BLU-15638). Describing the bug in-PR per `bug_report.yml`:

**What happened?**

`reconcileStrandedAssignedIssues` flipped perpetual-tracker EPIC BLU-9829 from its parked state to `blocked` and reassigned it to the recovery owner (Cosmo) repeatedly — about every 25 minutes — each flip firing a spurious manager wake.

**Expected behavior**

An issue with a future scheduled monitor (`monitorNextCheckAt`) — or carrying the `perpetual-tracker` label — should be treated as having a live continuation path and left untouched by the stranded-recovery sweep.

**Steps to reproduce**

1. Assign an agent a long-lived EPIC with the `perpetual-tracker` label and a future `monitorNextCheckAt`.
2. Leave it idle (no active heartbeat run) between scheduled monitor checks.
3. Observe `reconcileStrandedAssignedIssues` flip it to `blocked` and reassign to the recovery owner on each sweep (~25 min cadence). Evidence: system comments `908030f8` and `3eeb9a29` on BLU-9829, 25 minutes apart.

**Paperclip version or commit**

`master` (head of `paperclipai/paperclip` as of this PR).

**Deployment mode**

Self-hosted control plane (BOD fleet executor).

**Severity:** High — tight self-wake loop spamming manager wakes and corrupting tracker status.

## What Changed

- **Label exemption (BLU-15638):** `reconcileStrandedAssignedIssues` candidate query now excludes issues carrying the `perpetual-tracker` label, covering trackers that have no monitor scheduled yet.
- **Honor `monitorNextCheckAt` (BLU-16005):** `hasActiveExecutionPath` now treats a scheduled monitor whose next-check is still in the future as a live continuation path — added as a third source alongside the active-heartbeat-run and deferred-wakeup checks. Bounded to future checks so a genuinely overdue/abandoned monitor is still recovered.

## Verification

- New tests in `heartbeat-process-recovery.test.ts`:
  - `does not flip perpetual-tracker issues to blocked (BLU-15638)`
  - `does not flip issues with a future scheduled monitor to blocked (BLU-16005)`
  - `still flips a stranded issue once its scheduled monitor is overdue (BLU-16005)`
- Full `heartbeat-process-recovery.test.ts` suite: 59 passed, no regressions.
- `General tests (server)`: 1674 passed (the earlier single failure was a known flaky `environment-service.test.ts` dedup test, green on re-run).

## Risks

Low/additive. Touches the live fleet executor's recovery path, but the change is purely additive — more issues are recognized as having a live path, so fewer false flips. Existing flip behavior for genuinely stranded work is preserved (covered by the overdue-monitor test). Needs a controlled control-plane deploy to take effect; not self-merging.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use (Claude Code / Paperclip heartbeat harness).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I searched the open GitHub PR list for similar/duplicate PRs before opening this one (none found touching `reconcileStrandedAssignedIssues` / `hasActiveExecutionPath`)
