### PR TITLE
feat(server): direct-write monitorNextCheckAt in updateIssueSchema and PATCH route

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -433,6 +433,7 @@ export type CreateIssueLabel = z.infer<typeof createIssueLabelSchema>;
 export const updateIssueSchema = createIssueBaseSchema.partial().extend({
   requestDepth: issueRequestDepthInputSchema.optional(),
   assigneeAgentId: z.string().trim().min(1).optional().nullable(),
+  monitorNextCheckAt: z.string().datetime().optional().nullable(),
   comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
   reviewRequest: issueReviewRequestSchema.optional().nullable(),
   reopen: z.boolean().optional(),

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -401,6 +401,126 @@ describe("issue execution policy routes", () => {
     );
   });
 
+  it("persists a direct monitorNextCheckAt write to the monitor column and returns it", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1007",
+      title: "Direct monitor write",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ monitorNextCheckAt: "2026-12-05T09:00:00.000Z" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        monitorNextCheckAt: new Date("2026-12-05T09:00:00.000Z"),
+      }),
+    );
+    expect(res.body.monitorNextCheckAt).toBe("2026-12-05T09:00:00.000Z");
+  });
+
+  it("recognizes a direct monitorNextCheckAt as a scheduled-monitor review path for in_review", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Direct monitor review path",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", monitorNextCheckAt: "2026-12-05T09:00:00.000Z" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        monitorNextCheckAt: new Date("2026-12-05T09:00:00.000Z"),
+      }),
+    );
+  });
+
+  it("clears the monitor column when a direct monitorNextCheckAt is set to null", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1009",
+      title: "Direct monitor clear",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: new Date("2026-12-01T12:00:00.000Z"),
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ monitorNextCheckAt: null });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({ monitorNextCheckAt: null }),
+    );
+    expect(res.body.monitorNextCheckAt).toBeNull();
+  });
+
   it("allows board-authored in_review repair updates without a review path", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5005,12 +5005,19 @@ export function issueRoutes(
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
     const monitorChanged = monitorPoliciesEqual(previousExecutionPolicy, nextExecutionPolicy) === false;
+    const directMonitorNextCheckAtProvided = req.body.monitorNextCheckAt !== undefined;
+    const directMonitorNextCheckAt = directMonitorNextCheckAtProvided
+      ? (req.body.monitorNextCheckAt === null ? null : new Date(req.body.monitorNextCheckAt as string))
+      : undefined;
+    const directMonitorChanged =
+      directMonitorNextCheckAtProvided &&
+      (existing.monitorNextCheckAt?.getTime() ?? null) !== (directMonitorNextCheckAt?.getTime() ?? null);
     await assertCanManageIssueMonitor(
       access,
       req,
       existing.companyId,
       existing.assigneeAgentId,
-      req.body.executionPolicy !== undefined && monitorChanged,
+      (req.body.executionPolicy !== undefined && monitorChanged) || directMonitorChanged,
     );
 
     const transition = applyIssueExecutionPolicyTransition({
@@ -5043,6 +5050,14 @@ export function issueRoutes(
       };
     }
     Object.assign(updateFields, transition.patch);
+    // Direct monitorNextCheckAt write: a first-class PATCH field takes precedence over the
+    // executionPolicy-derived value and is persisted to the monitor_next_check_at column. Convert
+    // the validated ISO string to a Date so svc.update writes a proper timestamp. Applied after the
+    // transition merge so the explicit field wins, and before the in_review review-path check so the
+    // scheduled monitor is recognized as a valid disposition path.
+    if (directMonitorNextCheckAtProvided) {
+      updateFields.monitorNextCheckAt = directMonitorNextCheckAt;
+    }
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
       const existingExecutionState = parseIssueExecutionState(existing.executionState);
       if (!existingExecutionState || existingExecutionState.status !== "pending") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-execution subsystem lets agents schedule a future "monitor" wake on an issue (e.g. "check back after the external QA report lands")
> - The wake time lives in the `issues.monitor_next_check_at` column, which the heartbeat scheduler and disposition engine query directly
> - But `monitorNextCheckAt` was missing from `updateIssueSchema`, so Zod silently stripped it on every PATCH — agents could only set it indirectly through `executionPolicy.monitor.nextCheckAt`, a documented workaround
> - This pull request makes `monitorNextCheckAt` a first-class PATCH field that writes straight to the column
> - The benefit is agents can schedule/clear their next monitor check directly, without constructing a full execution policy, while the existing executionPolicy path keeps working unchanged

## Linked Issues or Issue Description

Tracked internally as BLU-10720 (routed from BLU-10283 / BLU-10281). No public GitHub issue exists, so per template path (B) the underlying bug is described below using the bug-report fields.

### Bug report

**What happened**
`PATCH /api/issues/:id` with `{"monitorNextCheckAt": "<ISO>"}` had no effect. `monitorNextCheckAt` was absent from `updateIssueSchema` (it only existed on the create base schema indirectly), so Zod stripped the key before it reached the handler. The value was never persisted and was not returned on a subsequent `GET`.

**Expected behavior**
A PATCH that sets `monitorNextCheckAt` should persist the value to the `monitor_next_check_at` column, return it on `GET`, and be honored by the disposition engine / heartbeat scheduler.

**Steps to reproduce**
1. `PATCH /api/issues/:id` with body `{"monitorNextCheckAt": "2026-12-05T09:00:00.000Z"}`.
2. `GET /api/issues/:id`.
3. Observe `monitorNextCheckAt` is `null` (silently dropped).

**Workaround (still supported)**
Send `{"executionPolicy": {"monitor": {"nextCheckAt": "<ISO>", "scheduledBy": "assignee"}}}` — routed through `applyIssueExecutionPolicyTransition`.

## What Changed

- **Schema** (`@paperclipai/shared`): add `monitorNextCheckAt: z.string().datetime().optional().nullable()` to `updateIssueSchema`.
- **PATCH route** (`server/src/routes/issues.ts`): when `monitorNextCheckAt` is present in the body, write it directly to the `monitor_next_check_at` column, converting the validated ISO string to a `Date`. Applied **after** the `applyIssueExecutionPolicyTransition` merge (so an explicit direct field wins over a policy-derived value) and **before** the `in_review` review-path check (so a directly-set future monitor is recognized as a valid `scheduled_issue_monitor` disposition path).
- **Authorization**: the direct write reuses `assertCanManageIssueMonitor`, so it carries the same "assignee agent or board user" gate as the executionPolicy path — no privilege-escalation regression.
- **GET**: no change needed — the full issue row already serializes `monitorNextCheckAt`, and `summarizeIssueMonitor` already prefers the column value.

## Verification

```
# from packages/shared
npx vitest run src/validators/issue.test.ts          # 24 passed

# from server
npx vitest run src/__tests__/issue-execution-policy-routes.test.ts   # 13 passed (3 new)
npx vitest run src/__tests__/issue-monitor-scheduler.test.ts src/__tests__/issue-execution-policy.test.ts  # 56 passed
```

New tests in `issue-execution-policy-routes.test.ts`:
- direct `monitorNextCheckAt` write persists (update called with a `Date`) and round-trips in the response body;
- a direct `monitorNextCheckAt` satisfies the `in_review` scheduled-monitor review path;
- `monitorNextCheckAt: null` clears the column.

`tsc --noEmit` is clean for the touched files (`routes/issues.ts`, `validators/issue.ts`). The only `tsc` errors in the tree are pre-existing and unrelated (`@paperclipai/plugin-sdk` dist not built).

## Risks

Low risk. Additive schema field plus a narrowly-scoped route write. The existing `executionPolicy.monitor.nextCheckAt` path is untouched and still covered by its tests. The direct field is gated by the same monitor-management authorization. No DB migration — the `monitor_next_check_at` column already exists.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server/schema only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending CI
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending review
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
