### PR TITLE
feat(claude-local): add disablePaperclipBridge to skip the callback bridge for direct-reachable remote targets

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -45,6 +45,7 @@ Core fields:
 - dangerouslySkipPermissions (boolean, optional, default true): pass --dangerously-skip-permissions to claude; defaults to true because Paperclip runs Claude in headless --print mode where interactive permission prompts cannot be answered
 - command (string, optional): defaults to "claude"
 - extraArgs (string[], optional): additional CLI args
+- disablePaperclipBridge (boolean, optional, default false): for remote execution targets, skip the sandbox callback bridge and let Claude reach the Paperclip control plane directly. Only enable when the remote can reach the control plane URL itself; set PAPERCLIP_API_URL in `env` accordingly
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats

--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -213,6 +213,75 @@ describe("claude remote execution", () => {
     }));
   });
 
+  it("skips the Paperclip callback bridge when disablePaperclipBridge is set and points Claude at the env API URL", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-remote-nobridge-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const instructionsPath = path.join(rootDir, "instructions.md");
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(instructionsPath, "Use the remote workspace.\n", "utf8");
+
+    await execute({
+      runId: "run-2",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "claude",
+        instructionsFilePath: instructionsPath,
+        disablePaperclipBridge: true,
+        env: {
+          PAPERCLIP_API_URL: "http://control-plane.example:3100",
+        },
+      },
+      authToken: "direct-agent-token",
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+          workspaceId: "workspace-1",
+          repoUrl: "https://github.com/paperclipai/paperclip.git",
+          repoRef: "main",
+          worktreePath: workspaceDir,
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(startAdapterExecutionTargetPaperclipBridge).not.toHaveBeenCalled();
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    // Bridge skipped: Claude keeps the operator-provided control-plane URL and
+    // the real agent token, with no queue bridge mode injected.
+    expect(call?.[3].env.PAPERCLIP_API_URL).toBe("http://control-plane.example:3100");
+    expect(call?.[3].env.PAPERCLIP_API_KEY).toBe("direct-agent-token");
+    expect(call?.[3].env.PAPERCLIP_API_BRIDGE_MODE).toBeUndefined();
+  });
+
   it("does not resume saved Claude sessions for remote SSH execution without a matching remote identity", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-remote-resume-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -379,6 +379,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  // When the remote execution target can reach the Paperclip control plane
+  // directly (e.g. a trusted host on the same private network/VPN), the sandbox
+  // callback bridge is unnecessary overhead and its launch/readiness handshake
+  // can be fragile on some remote shells. Operators can opt out per agent and
+  // instead point Claude at the control plane via PAPERCLIP_API_URL in `env`.
+  const disablePaperclipBridge = asBoolean(config.disablePaperclipBridge, false);
   const configEnv = parseObject(config.env);
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -568,7 +574,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
   }
   let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
-  if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(runtimeExecutionTarget)) {
+  if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(runtimeExecutionTarget) && !disablePaperclipBridge) {
     paperclipBridge = await startAdapterExecutionTargetPaperclipBridge({
       runId,
       target: runtimeExecutionTarget,


### PR DESCRIPTION
## Summary

Adds an opt-in `disablePaperclipBridge` flag to the `claude_local` adapter config. When set, remote execution targets skip the sandbox callback bridge and let Claude talk to the Paperclip control plane directly.

**Default is `false` — no behavior change for existing setups.**

## Motivation

For remote (`ssh`) execution targets, Claude's Paperclip API calls are always routed through the sandbox callback bridge (`adapterExecutionTargetUsesPaperclipBridge` returns true for every remote target). That bridge exists for sandbox containers that *cannot* reach the control plane, but it's unnecessary when the remote host can reach it directly (e.g. a trusted box on the same VPN / private network).

It's also fragile on some remote shells. On **Windows OpenSSH** specifically, the bridge launch is the hard blocker:

- `startSandboxCallbackBridgeServer` launches the bridge with `nohup … node … >> log 2>&1 < /dev/null &` and then polls up to ~10s for `ready.json`.
- On Windows OpenSSH the **launch ssh exec never returns** — a backgrounded/detached child keeps the session's stdout/stderr open, so the channel doesn't close. The bridge process actually starts and writes `ready.json` in ~0.3s, but the launch call hangs for minutes; the readiness wait times out (`start sandbox callback bridge timed out`) and the run is reaped before Claude is ever launched.

Claude itself runs fine over that same SSH channel — the only thing standing between a working remote agent and a hung run is the bridge handshake.

## What this PR does

- `execute.ts`: read `disablePaperclipBridge` (default `false`) and add it to the bridge gate. When enabled the bridge is not started, so `env.PAPERCLIP_API_URL` (operator-provided via `env`) and `env.PAPERCLIP_API_KEY` (the run `authToken`) are passed through to Claude unchanged.
- `index.ts`: document the new config option.
- `execute.remote.test.ts`: test that with the flag set the bridge is not started and the env API URL/token survive (no `queue_v1` bridge mode injected).

## Usage

```jsonc
// agent adapterConfig
{
  "disablePaperclipBridge": true,
  "env": { "PAPERCLIP_API_URL": "http://<control-plane-reachable-from-remote>:3100" }
}
```

## Verification

Verified end-to-end against a live Windows (`drogon`) SSH executor with the control plane on a Mac mini over Tailscale: with the bridge bypassed, a smoke run completed normally (`status=succeeded, exitCode=0`) — Claude launched, ran tools, posted a comment via the direct API, and closed the task. Direct control-plane reachability from the remote was ~17ms.

> Note: I was unable to run the package test suite locally (partial checkout without installed workspace deps), so CI is the source of truth for the added test. The runtime change is small and gated behind a default-off flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
