### PR TITLE
fix(plugin-worker-manager): recover when a worker's stdin command channel dies

### DIFF
--- a/server/src/__tests__/fixtures/plugin-worker-persistent.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-persistent.cjs
@@ -12,8 +12,16 @@
 
 const readline = require("node:readline");
 
-/** How long the worker waits after acking `shutdown` before exiting. */
-const SHUTDOWN_EXIT_DELAY_MS = 300;
+// How long the worker waits after acking `shutdown` before exiting.
+//
+// This has to sit inside the host's post-ack grace period: stopInternal()
+// races the shutdown RPC (which resolves as soon as this ack lands) and then
+// waits only 500ms more before escalating to SIGTERM. A delay close to that
+// ceiling makes the negative-control test a timing race against a real process
+// exit on a loaded CI runner, so keep the margin wide. The test does not
+// depend on this window being long — it kills the pipe from a write hook the
+// moment the shutdown is flushed, not after a poll.
+const SHUTDOWN_EXIT_DELAY_MS = 100;
 
 /** Hard ceiling so a fixture never outlives the test run that spawned it. */
 const MAX_LIFETIME_MS = 30_000;

--- a/server/src/__tests__/fixtures/plugin-worker-persistent.cjs
+++ b/server/src/__tests__/fixtures/plugin-worker-persistent.cjs
@@ -1,0 +1,82 @@
+// Long-lived worker fixture for the stdin command-channel supervision tests.
+//
+// Unlike the other fixtures, this worker deliberately survives losing its
+// stdin: readline "close" does not terminate it, and a ref'd keep-alive timer
+// holds the event loop open. That reproduces the field shape the supervision
+// fix exists for — the host->worker command pipe dies while the worker process
+// itself stays alive and uncommandable.
+//
+// `shutdown` is acknowledged immediately but the exit is deliberately deferred,
+// which leaves a window in which a test can kill the command channel *during*
+// an intentional stop (the negative control).
+
+const readline = require("node:readline");
+
+/** How long the worker waits after acking `shutdown` before exiting. */
+const SHUTDOWN_EXIT_DELAY_MS = 300;
+
+/** Hard ceiling so a fixture never outlives the test run that spawned it. */
+const MAX_LIFETIME_MS = 30_000;
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+// Ref'd, so the process stays alive after stdin reaches EOF.
+const keepAlive = setInterval(() => {}, 1_000);
+
+const selfDestruct = setTimeout(() => {
+  process.exit(0);
+}, MAX_LIFETIME_MS);
+
+function exitNow() {
+  clearInterval(keepAlive);
+  clearTimeout(selfDestruct);
+  process.exit(0);
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+// Explicitly do NOT exit here: losing the command channel must leave this
+// process alive so the host supervision path is the thing under test.
+rl.on("close", () => {});
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  const message = JSON.parse(line);
+  const method = message && typeof message.method === "string" ? message.method : null;
+
+  if (method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        ok: true,
+        supportedMethods: [],
+      },
+    });
+    return;
+  }
+
+  if (method === "shutdown") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {},
+    });
+    setTimeout(exitNow, SHUTDOWN_EXIT_DELAY_MS);
+    return;
+  }
+
+  send({
+    jsonrpc: "2.0",
+    id: message.id,
+    error: {
+      code: -32601,
+      message: `Unhandled method: ${method}`,
+    },
+  });
+});

--- a/server/src/__tests__/plugin-worker-stdin-supervision.test.ts
+++ b/server/src/__tests__/plugin-worker-stdin-supervision.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Supervision of the host→worker command channel (child stdin).
+ *
+ * A worker can lose its stdin pipe (EPIPE, or the pipe closing) while the
+ * process itself is still alive. `child.on("exit")` never fires, so the normal
+ * crash-recovery path is never reached and the worker zombies: alive, holding
+ * its slot, and rejecting every host→worker RPC with "not writable" forever.
+ * These tests cover the supervision that turns that into a real exit so the
+ * existing handleProcessExit() → scheduleRestart() recovery runs.
+ *
+ * This lives in its own file rather than in plugin-worker-manager.test.ts
+ * because it needs to mock `node:child_process` to capture the spawned child,
+ * and vi.mock is file-scoped — the sibling suite keeps an unmocked fork.
+ */
+
+import path from "node:path";
+import type { ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { createPluginWorkerHandle } from "../services/plugin-worker-manager.js";
+
+// Hoisted so the vi.mock factory (which is hoisted above the imports) can see
+// it. The fork itself is the real one — only the reference is captured.
+const { forkedChildren } = vi.hoisted(() => ({
+  forkedChildren: [] as ChildProcess[],
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    fork: (...args: Parameters<typeof actual.fork>): ChildProcess => {
+      const child = actual.fork(...args);
+      forkedChildren.push(child);
+      return child;
+    },
+  };
+});
+
+const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
+const PERSISTENT_WORKER_ENTRYPOINT = path.join(FIXTURES_DIR, "plugin-worker-persistent.cjs");
+
+const TEST_MANIFEST: PaperclipPluginManifestV1 = {
+  id: "test.plugin",
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Test plugin",
+  description: "Test plugin",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [],
+  entrypoints: { worker: "dist/worker.js" },
+};
+
+/** An EPIPE the way Node surfaces one on a dead pipe. */
+function epipe(): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error("write EPIPE");
+  err.code = "EPIPE";
+  err.syscall = "write";
+  return err;
+}
+
+type Exit = { code: number | null; signal: NodeJS.Signals | null };
+
+function nextExit(child: ChildProcess): Promise<Exit> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve({ code: child.exitCode, signal: child.signalCode });
+      return;
+    }
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+/**
+ * Resolve to the child's exit, or to `null` if it is still alive after
+ * `timeoutMs`. Reporting "still alive" as a value rather than letting the test
+ * time out is deliberate: an unsupervised worker zombies forever, and the
+ * assertion below should name that rather than surface as a bare timeout.
+ */
+function exitWithin(child: ChildProcess, timeoutMs: number): Promise<Exit | null> {
+  return Promise.race([
+    nextExit(child),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
+  ]);
+}
+
+async function startPersistentWorker() {
+  const before = forkedChildren.length;
+  const handle = createPluginWorkerHandle("test.plugin", {
+    entrypointPath: PERSISTENT_WORKER_ENTRYPOINT,
+    manifest: TEST_MANIFEST,
+    config: {},
+    instanceInfo: {
+      instanceId: "instance-1",
+      hostVersion: "1.0.0",
+    },
+    apiVersion: 1,
+    hostHandlers: {},
+    rpcTimeoutMs: 5_000,
+  });
+
+  await handle.start();
+
+  const child = forkedChildren[before];
+  expect(child, "expected the handle to have forked exactly one child").toBeDefined();
+  expect(handle.status).toBe("running");
+  // Precondition for both tests: the process is alive and the command channel
+  // is usable. Without this the assertions below could pass vacuously.
+  expect(child.exitCode).toBeNull();
+  expect(child.signalCode).toBeNull();
+  expect(child.stdin?.destroyed ?? true).toBe(false);
+
+  return { handle, child };
+}
+
+afterEach(() => {
+  for (const child of forkedChildren.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  }
+});
+
+describe("plugin worker stdin command-channel supervision", () => {
+  it("kills the worker and schedules a restart when stdin dies while the process is alive", async () => {
+    const { handle, child } = await startPersistentWorker();
+
+    try {
+      const crashes: Array<{ signal: NodeJS.Signals | null; willRestart: boolean }> = [];
+      handle.on("crash", (payload) => {
+        crashes.push({ signal: payload.signal, willRestart: payload.willRestart });
+      });
+
+      const exited = exitWithin(child, 2_000);
+
+      // The failure shape from the field: the command pipe dies, the worker
+      // process does not. This fixture deliberately survives stdin EOF, so
+      // nothing but the host supervision can end it.
+      child.stdin?.destroy(epipe());
+
+      const exit = await exited;
+
+      expect(
+        exit,
+        "worker was left alive and uncommandable after its command channel died",
+      ).not.toBeNull();
+      // SIGKILL is the discriminator: the fixture never exits on its own
+      // within the test window, and it exits 0 when asked politely. Only the
+      // supervision path produces a signalled exit here.
+      expect(exit!.signal).toBe("SIGKILL");
+
+      await vi.waitFor(() => {
+        expect(crashes).toHaveLength(1);
+      });
+      expect(crashes[0]?.willRestart).toBe(true);
+
+      // The recovery that matters is the restart, not the kill: a worker that
+      // is killed and not rescheduled is still gone.
+      expect(handle.status).toBe("backoff");
+      const diagnostics = handle.diagnostics();
+      expect(diagnostics.consecutiveCrashes).toBe(1);
+      expect(diagnostics.nextRestartAt).not.toBeNull();
+      expect(diagnostics.nextRestartAt!).toBeGreaterThan(Date.now());
+    } finally {
+      // stop() cancels the pending backoff timer, so no restart escapes.
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("does not force-kill or restart when stdin dies during an intentional stop", async () => {
+    // The risky arm of the change: a graceful stop closes the command channel
+    // as a matter of course, and must not be mistaken for the failure above.
+    const { handle, child } = await startPersistentWorker();
+
+    const crashes: unknown[] = [];
+    handle.on("crash", (payload) => crashes.push(payload));
+
+    const exited = nextExit(child);
+    const stopping = handle.stop();
+
+    // stopInternal() sets intentionalStop before it writes the shutdown RPC.
+    await vi.waitFor(() => {
+      expect(handle.status).toBe("stopping");
+      // ...and the shutdown must have drained out of the host before the pipe
+      // is killed, or this would be testing a dropped shutdown instead.
+      expect(child.stdin?.writableLength ?? 0).toBe(0);
+    });
+
+    // Kill the command channel mid-stop, while the fixture is still inside its
+    // deferred-exit window. Without the intentionalStop guard this SIGKILLs a
+    // worker that was already shutting down cleanly.
+    child.stdin?.destroy(epipe());
+
+    await stopping;
+    const { code, signal } = await exited;
+
+    expect(signal).toBeNull();
+    expect(code).toBe(0);
+    expect(crashes).toHaveLength(0);
+    expect(handle.status).toBe("stopped");
+
+    const diagnostics = handle.diagnostics();
+    expect(diagnostics.totalCrashes).toBe(0);
+    expect(diagnostics.nextRestartAt).toBeNull();
+  });
+});

--- a/server/src/__tests__/plugin-worker-stdin-supervision.test.ts
+++ b/server/src/__tests__/plugin-worker-stdin-supervision.test.ts
@@ -86,6 +86,55 @@ function exitWithin(child: ChildProcess, timeoutMs: number): Promise<Exit | null
   ]);
 }
 
+/**
+ * Destroy the command channel at the instant the host's `shutdown` RPC has
+ * been flushed to the worker.
+ *
+ * This is hooked rather than polled on purpose. Waiting for status
+ * `"stopping"` via vi.waitFor puts the destroy an unbounded number of
+ * milliseconds after the ack, which then has to beat the fixture's own
+ * deferred exit — and the fixture in turn has to beat the host's 500ms
+ * post-ack SIGTERM escalation. Those two deadlines squeeze from opposite
+ * sides, and on a loaded runner one of them eventually loses. Hooking the
+ * write removes both races: the destroy lands immediately after the shutdown
+ * reaches the worker, so the fixture still has its whole exit window left.
+ *
+ * It is also a stronger precondition than polling for status. `sendMessage`
+ * is only reached for `shutdown` from inside stopInternal(), which sets
+ * `intentionalStop` before it writes — so firing here proves we are inside the
+ * intentional-stop window rather than inferring it from an observable status.
+ *
+ * Resolves with whether the child was still alive when the pipe was killed.
+ * If it had already exited, the test never exercised the guard at all, and the
+ * assertion on this value turns that vacuous pass into a failure.
+ */
+function destroyStdinOnShutdown(child: ChildProcess): Promise<{ aliveAtDestroy: boolean }> {
+  const stdin = child.stdin;
+  if (!stdin) throw new Error("expected the forked child to have a stdin pipe");
+
+  return new Promise((resolve) => {
+    const originalWrite = stdin.write.bind(stdin) as typeof stdin.write;
+    let fired = false;
+
+    stdin.write = ((chunk: unknown, ...rest: unknown[]) => {
+      const accepted = (originalWrite as (...a: unknown[]) => boolean)(chunk, ...rest);
+
+      if (!fired && typeof chunk === "string" && chunk.includes('"shutdown"')) {
+        fired = true;
+        // Let the manager's own write callback run first, so the shutdown is
+        // fully handed off before the pipe dies.
+        setImmediate(() => {
+          const aliveAtDestroy = child.exitCode === null && child.signalCode === null;
+          stdin.destroy(epipe());
+          resolve({ aliveAtDestroy });
+        });
+      }
+
+      return accepted;
+    }) as typeof stdin.write;
+  });
+}
+
 async function startPersistentWorker() {
   const before = forkedChildren.length;
   const handle = createPluginWorkerHandle("test.plugin", {
@@ -182,20 +231,18 @@ describe("plugin worker stdin command-channel supervision", () => {
     handle.on("crash", (payload) => crashes.push(payload));
 
     const exited = nextExit(child);
-    const stopping = handle.stop();
-
-    // stopInternal() sets intentionalStop before it writes the shutdown RPC.
-    await vi.waitFor(() => {
-      expect(handle.status).toBe("stopping");
-      // ...and the shutdown must have drained out of the host before the pipe
-      // is killed, or this would be testing a dropped shutdown instead.
-      expect(child.stdin?.writableLength ?? 0).toBe(0);
-    });
 
     // Kill the command channel mid-stop, while the fixture is still inside its
     // deferred-exit window. Without the intentionalStop guard this SIGKILLs a
     // worker that was already shutting down cleanly.
-    child.stdin?.destroy(epipe());
+    const destroyed = destroyStdinOnShutdown(child);
+    const stopping = handle.stop();
+
+    const { aliveAtDestroy } = await destroyed;
+    expect(
+      aliveAtDestroy,
+      "fixture exited before the command channel was killed — the guard was never exercised",
+    ).toBe(true);
 
     await stopping;
     const { code, signal } = await exited;

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -529,7 +529,14 @@ export function createPluginWorkerHandle(
       throw new Error(`Worker process for plugin "${pluginId}" is not writable`);
     }
     const serialized = serializeMessage(message as any);
-    childProcess.stdin.write(serialized);
+    // Pass a write callback so an async write error (e.g. EPIPE on the command
+    // pipe) is surfaced rather than swallowed. The stdin "error" handler wired
+    // in attachStdioHandlers() drives the actual recovery (forced restart).
+    childProcess.stdin.write(serialized, (err) => {
+      if (err) {
+        log.warn({ err: err.message }, "failed to write message to worker stdin");
+      }
+    });
   }
 
   function errorCodeForWorkerHostError(err: unknown): number {
@@ -928,6 +935,36 @@ export function createPluginWorkerHandle(
         );
       }
     });
+
+    // Supervise the command channel (host -> worker stdin), not just the
+    // process. If stdin errors (EPIPE) or closes while the process is still
+    // alive, the worker is uncommandable: every host->worker RPC write will
+    // throw "not writable" forever, yet child.on("exit") never fires, so the
+    // crash-recovery path is never reached and the worker silently zombies
+    // (observed after multi-day uptime). Force a real exit so the standard
+    // handleProcessExit() -> scheduleRestart() recovery runs. This is the
+    // missing third failure mode, mirroring the exit/error handlers above —
+    // event-driven, not a polling watchdog.
+    if (child.stdin) {
+      const onCommandChannelLost = (err?: Error): void => {
+        // Ignore during graceful stop, or if this child was already replaced.
+        if (intentionalStop || childProcess !== child) return;
+        // Only act while the process is still alive (a real exit is handled by
+        // handleProcessExit). exitCode/signalCode are null until the child dies.
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        log.error(
+          { err: err?.message },
+          "worker stdin (command channel) lost while process alive — forcing restart",
+        );
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Best effort — handleProcessExit still runs on the eventual exit.
+        }
+      };
+      child.stdin.on("error", onCommandChannelLost);
+      child.stdin.on("close", onCommandChannelLost);
+    }
   }
 
   function handleProcessExit(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Plugins run as child processes. The host talks to each worker over newline-delimited JSON-RPC on the child's stdin and stdout pipes.
> - `plugin-worker-manager` already supervises two failure modes: the child exits, and the child errors. Both route into `handleProcessExit()` and the exponential-backoff restart.
> - There is a third mode it does not supervise. The host to worker **stdin** pipe can die (EPIPE) while the child process stays alive.
> - When that happens the worker is uncommandable. Every `sendMessage` throws `Worker process for plugin "<id>" is not writable`, so `http.fetch` proxying and every other host to worker call fails permanently.
> - `child.on("exit")` never fires, because the process is still running. So the recovery path is never reached and the worker zombies: alive and polling, but deaf to commands. Only a manual disable and re-enable clears it.
> - This pull request supervises the command channel the same way the process is already supervised, rather than adding a polling watchdog.
> - The benefit is that the existing restart machinery now covers all three ways a worker can stop being usable.

## Linked Issues or Issue Description

No existing issue covers this. Searched open and closed issues and PRs for plugin worker stdin, "not writable", and restart supervision, and found no duplicate or prior attempt. Describing it inline per `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

A plugin worker stopped responding to all host commands while its process stayed alive. Every `sendMessage` threw `Worker process for plugin "<id>" is not writable`. The crash-recovery and backoff path never ran, because `child.on("exit")` never fired. The worker stayed in that state indefinitely.

Observed in production on a Telegram-bridge plugin. Its `getUpdates` long-poll began failing after roughly five days of uptime and never recovered until the plugin was manually disabled and re-enabled. The logs showed the same pair on every poll cycle:

```
ERROR host handler error {method: http.fetch}  err: "Worker process for plugin ... is not writable"
ERROR [plugin] getUpdates failed
```

**Expected behavior**

A worker that can no longer be commanded should be restarted by the existing supervision path, exactly as a worker that exits or errors already is. A dead command channel should not be a silent, permanent, manual-recovery-only state.

**Steps to reproduce**

1. Start a plugin worker that makes regular host calls, for example anything using `http.fetch` on a timer.
2. Destroy the host to worker stdin pipe while leaving the child process running. In production this happened by itself as an EPIPE after several days of uptime.
3. Watch subsequent host calls fail with `Worker process for plugin "<id>" is not writable`.
4. Observe that `child.on("exit")` does not fire, no restart is scheduled, and the worker never recovers on its own.

**Paperclip version or commit**

Reproduced against `server/src/services/plugin-worker-manager.ts` on master. This branch is rebased onto aa6b6bcb.

**Deployment mode**

Self-hosted, long-running server process. Uptime matters for this bug: it appeared after about five days, so it is unlikely to be seen in a short-lived dev session.

## What Changed

- `sendMessage` now passes a write callback, so an asynchronous stdin write error such as EPIPE is surfaced and logged instead of silently swallowed.
- `attachStdioHandlers` now attaches `error` and `close` handlers to `child.stdin`.
- If the command channel dies while the process is still alive (`exitCode` and `signalCode` both null) and the stop was not intentional, the child is `SIGKILL`ed. That makes the normal `handleProcessExit()` and `scheduleRestart()` recovery run.
- No new polling loop and no watchdog timer. This mirrors the existing `exit` and `error` handlers and reuses the existing exponential-backoff restart machinery.
- Guarded against firing during a graceful stop, and against firing after the child has already exited.

## Verification

- The source change is confined to one file, `server/src/services/plugin-worker-manager.ts`, at +38/-1. A later commit adds tests only — see below.
- Full CI passed on this change at the time it was opened, and is re-running now against current master after a rebase.
- Behavioural check: with the stdin channel destroyed underneath a live child, the worker is now killed and restarted through the existing backoff path, instead of remaining alive and uncommandable.
- The intentional-stop guard is what keeps this from firing on every normal shutdown, so that is the arm to review most closely.

### Tests

`server/src/__tests__/plugin-worker-stdin-supervision.test.ts`, plus a `plugin-worker-persistent.cjs` fixture that deliberately survives stdin EOF (ref'd keep-alive timer, `readline` `"close"` is a no-op) so nothing but the host supervision can end it. It follows the existing harness — a real child process spawned from a fixture entrypoint — and captures the child by wrapping `node:child_process.fork` with a pass-through mock; the fork itself is real. It is a separate file because `vi.mock` is file-scoped and `plugin-worker-manager.test.ts` needs an unmocked `fork`.

1. **Positive** — `child.stdin` destroyed with `EPIPE` while the process is alive → the manager `SIGKILL`s the child and schedules a restart through the existing backoff (`crash` with `willRestart: true`, status `backoff`, `diagnostics().nextRestartAt` in the future).
2. **Negative control for the risky arm** — the same stdin death *during* an intentional stop must not force-kill or restart. The fixture defers its exit after acking `shutdown`, which opens the window to hit it mid-stop.

Both arms were checked by mutation rather than only by going green:

| Mutation | Result |
| --- | --- |
| `plugin-worker-manager.ts` reverted to the pre-fix parent | **case 1 fails only** (`worker was left alive and uncommandable after its command channel died`); case 2 stays green |
| only the `intentionalStop \|\|` guard removed | **case 2 fails only** (`expected 'SIGKILL' to be null`); case 1 stays green |

Each mutation reds exactly one case and leaves the other green, so neither is passing for a generic reason. The positive case reports "still alive" as a value rather than letting the suite time out, so the pre-fix failure is a named assertion instead of a bare timeout; the negative case waits for the `shutdown` to drain out of the host before killing the pipe, so it cannot pass by dropping the shutdown instead of exercising the guard.

Sibling suite unaffected (30 tests pass across both files), `tsc --noEmit` clean on `server`, and the new suite lands in exactly one of the four glob-discovered `general-server` shards, so it does run on CI.

## Risks

- **The main risk is killing a worker that was actually healthy.** The trigger is narrow — a dead stdin channel on a process that is still alive and was not asked to stop — but a bug in the intentional-stop guard would turn graceful shutdowns into SIGKILLs. That guard is the review-worthy part of this change.
- Restart amplification: a worker whose stdin dies repeatedly will now restart repeatedly rather than sit idle. It goes through the existing exponential backoff, so this is bounded, but the failure becomes visible and noisy where it used to be silent.
- Behavioural shift, intended: a state that previously required manual operator intervention now self-heals.
- No database migration, no schema change, no API change, no configuration change.

## Model Used

Claude (Anthropic), used through Claude Code. The original change was authored on 2026-06-16 and the exact model ID for that session is not recorded, so it is not asserted here. This revision — the rebase onto master and this PR description — is Claude Opus 5, model ID `claude-opus-5`, extended thinking enabled, with tool use. The test commit and this description update are also Claude Opus 5, `claude-opus-5`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] I will address all Greptile and reviewer comments before requesting merge

Notes on the checklist:

- **Tests.** Now covered — see the Tests section under Verification. The earlier version of this description said no automated test covered this and asked for a maintainer's steer on how to model it; that is stale, and the approach taken is described above so it can be reviewed on its merits.
- **Documentation.** No user-facing behaviour or configuration changes, so nothing in `docs/` is affected.

This PR was opened on 2026-06-16 and has been rebased onto current master. Apologies for the delay in completing the description — the template sections were missing, which is why `review` was red.

