### PR TITLE
fix(shared): store multiline text verbatim, stop eating \r/\n escapes (RENA-14562)

### DIFF
--- a/packages/shared/src/validators/approval.test.ts
+++ b/packages/shared/src/validators/approval.test.ts
@@ -20,12 +20,12 @@ describe("approval validators", () => {
     expect(requestApprovalRevisionSchema.parse({}).decisionNote).toBeUndefined();
   });
 
-  it("normalizes escaped line breaks in approval comments and decision notes", () => {
+  it("preserves literal backslash sequences in approval comments and decision notes (RENA-14562)", () => {
     expect(addApprovalCommentSchema.parse({ body: "Looks good\\n\\nApproved." }).body)
-      .toBe("Looks good\n\nApproved.");
+      .toBe("Looks good\\n\\nApproved.");
     expect(resolveApprovalSchema.parse({ decisionNote: "Decision\\n\\nApproved." }).decisionNote)
-      .toBe("Decision\n\nApproved.");
-    expect(requestApprovalRevisionSchema.parse({ decisionNote: "Decision\\r\\nRevise." }).decisionNote)
-      .toBe("Decision\nRevise.");
+      .toBe("Decision\\n\\nApproved.");
+    expect(requestApprovalRevisionSchema.parse({ decisionNote: "Path C:\\register\\new" }).decisionNote)
+      .toBe("Path C:\\register\\new");
   });
 });

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -31,21 +31,21 @@ describe("issue validators", () => {
       .toBeUndefined();
   });
 
-  it("normalizes JSON-escaped line breaks in issue descriptions", () => {
+  it("preserves literal backslash sequences in issue descriptions (RENA-14562)", () => {
     const parsed = createIssueSchema.parse({
       title: "Follow up PR",
       description: "PR: https://example.com/pr/1\\n\\nShip the follow-up.",
     });
 
-    expect(parsed.description).toBe("PR: https://example.com/pr/1\n\nShip the follow-up.");
+    expect(parsed.description).toBe("PR: https://example.com/pr/1\\n\\nShip the follow-up.");
   });
 
-  it("normalizes escaped line breaks in issue update comments", () => {
+  it("preserves literal backslash sequences in issue update comments (RENA-14562)", () => {
     const parsed = updateIssueSchema.parse({
-      comment: "Done\\n\\n- Verified the route",
+      comment: "Done\\n\\n- Verified C:\\register",
     });
 
-    expect(parsed.comment).toBe("Done\n\n- Verified the route");
+    expect(parsed.comment).toBe("Done\\n\\n- Verified C:\\register");
   });
 
   it("allows false-positive recovery resolutions to atomically restore the source issue status", () => {
@@ -131,12 +131,24 @@ describe("issue validators", () => {
     ).toBe(false);
   });
 
-  it("normalizes escaped line breaks in issue comment bodies", () => {
+  it("preserves literal backslash sequences in issue comment bodies (RENA-14562)", () => {
     const parsed = addIssueCommentSchema.parse({
       body: "Progress update\\r\\n\\r\\nNext action.",
     });
 
-    expect(parsed.body).toBe("Progress update\n\nNext action.");
+    expect(parsed.body).toBe("Progress update\\r\\n\\r\\nNext action.");
+  });
+
+  it("roundtrips Windows paths and escape sequences byte-for-byte (RENA-14562)", () => {
+    // Exact acceptance-criteria probe: literal backslash+r/n/t must survive untouched.
+    const body = "\\register \\new \\team";
+    expect(addIssueCommentSchema.parse({ body }).body).toBe(body);
+
+    const winPath = "BUG-TEST: path is C:\\Claude\\register-task.ps1 and \\node_modules and C:\\new";
+    expect(addIssueCommentSchema.parse({ body: winPath }).body).toBe(winPath);
+
+    // Real newlines (already decoded by the JSON parser) still pass through unchanged.
+    expect(addIssueCommentSchema.parse({ body: "Line 1\nLine 2" }).body).toBe("Line 1\nLine 2");
   });
 
   it("accepts structured issue comment presentation and metadata", () => {
@@ -181,17 +193,17 @@ describe("issue validators", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("normalizes escaped line breaks in generated task drafts", () => {
+  it("preserves literal backslash sequences in generated task drafts (RENA-14562)", () => {
     const parsed = suggestedTaskDraftSchema.parse({
       clientKey: "task-1",
       title: "Follow up",
       description: "Line 1\\n\\nLine 2",
     });
 
-    expect(parsed.description).toBe("Line 1\n\nLine 2");
+    expect(parsed.description).toBe("Line 1\\n\\nLine 2");
   });
 
-  it("normalizes escaped line breaks in thread summaries and documents", () => {
+  it("preserves literal backslash sequences in thread summaries and documents (RENA-14562)", () => {
     const response = respondIssueThreadInteractionSchema.parse({
       answers: [],
       summaryMarkdown: "Summary\\n\\nNext action",
@@ -201,8 +213,8 @@ describe("issue validators", () => {
       body: "# Plan\\n\\nShip it",
     });
 
-    expect(response.summaryMarkdown).toBe("Summary\n\nNext action");
-    expect(document.body).toBe("# Plan\n\nShip it");
+    expect(response.summaryMarkdown).toBe("Summary\\n\\nNext action");
+    expect(document.body).toBe("# Plan\\n\\nShip it");
   });
 
   it("clamps oversized requestDepth values on create", () => {

--- a/packages/shared/src/validators/text.test.ts
+++ b/packages/shared/src/validators/text.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { multilineTextSchema } from "./text.js";
+
+describe("multilineTextSchema (RENA-14562)", () => {
+  it("stores literal backslash escape sequences verbatim", () => {
+    for (const value of ["\\r", "\\n", "\\r\\n", "\\t", "\\register", "\\new", "\\repos", "C:\\node_modules"]) {
+      expect(multilineTextSchema.parse(value)).toBe(value);
+    }
+  });
+
+  it("does not alter real (already-decoded) line breaks", () => {
+    expect(multilineTextSchema.parse("a\nb\r\nc")).toBe("a\nb\r\nc");
+  });
+
+  it("leaves arbitrary backslash sequences untouched", () => {
+    expect(multilineTextSchema.parse("\\C \\t \\x \\\\")).toBe("\\C \\t \\x \\\\");
+  });
+});

--- a/packages/shared/src/validators/text.ts
+++ b/packages/shared/src/validators/text.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
-export function normalizeEscapedLineBreaks(value: string): string {
-  return value
-    .replace(/\\r\\n/g, "\n")
-    .replace(/\\n/g, "\n")
-    .replace(/\\r/g, "\n");
-}
-
-export const multilineTextSchema = z.string().transform(normalizeEscapedLineBreaks);
+// Free-form multiline text fields are stored verbatim. JSON already encodes real
+// line breaks via the "\n" string escape, which the JSON parser decodes before the
+// value reaches this schema. We must NOT re-interpret literal backslash sequences
+// here: replacing literal "\n"/"\r" with LF destroys legitimate data such as Windows
+// paths (C:\new, \register, \repos, \node_modules). See RENA-14562.
+export const multilineTextSchema = z.string();


### PR DESCRIPTION
## Summary

Fixes the Comment-API bug documented in RENA-14562.

**Root Cause:** Zod transform in packages/shared/src/validators/text.ts was stripping \r\n line endings from multiline text fields (introduced in PR #4444).

**Fix:** Store multiline text verbatim without transform — lossless. Removes the problematic escape normalization.

**Tests:** Vitest tests in 	ext.test.ts, issue.test.ts, pproval.test.ts validate the fix (commit cherry-picked from 5cc0d6).

**Impact:** Without this source fix, a future 
pm update paperclipai would reactivate the bug because the current hotfix only patches the compiled bundle on the running instance.

## Files Changed
- packages/shared/src/validators/text.ts — remove escape normalization
- packages/shared/src/validators/text.test.ts — new test file
- packages/shared/src/validators/issue.test.ts — updated tests
- packages/shared/src/validators/approval.test.ts — updated tests

Fixes: RENA-14562