### PR TITLE
feat(server): enable board chat in authenticated deployment mode (NODE-167)

### DIFF
--- a/server/src/__tests__/authz-company-access.test.ts
+++ b/server/src/__tests__/authz-company-access.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { assertBoardOrgAccess, assertCompanyAccess, hasBoardOrgAccess } from "../routes/authz.js";
+import {
+  assertBoardOrgAccess,
+  assertCompanyAccess,
+  hasBoardOrgAccess,
+  hasCompanyOwnerMembership,
+} from "../routes/authz.js";
 
 function makeReq(input: {
   method?: string;
@@ -103,6 +108,116 @@ describe("assertCompanyAccess", () => {
     });
 
     expect(() => assertCompanyAccess(req, "company-1")).not.toThrow();
+  });
+});
+
+describe("hasCompanyOwnerMembership", () => {
+  it("accepts an active owner membership on the target company", () => {
+    const req = makeReq({
+      actor: {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        companyIds: ["company-1"],
+        memberships: [
+          { companyId: "company-1", membershipRole: "owner", status: "active" },
+        ],
+        isInstanceAdmin: false,
+      },
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(true);
+  });
+
+  it("rejects non-owner roles", () => {
+    const req = makeReq({
+      actor: {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        companyIds: ["company-1"],
+        memberships: [
+          { companyId: "company-1", membershipRole: "operator", status: "active" },
+        ],
+        isInstanceAdmin: false,
+      },
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(false);
+  });
+
+  it("rejects an owner membership that is not active", () => {
+    const req = makeReq({
+      actor: {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        companyIds: ["company-1"],
+        memberships: [
+          { companyId: "company-1", membershipRole: "owner", status: "suspended" },
+        ],
+        isInstanceAdmin: false,
+      },
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(false);
+  });
+
+  it("rejects an owner membership on a different company", () => {
+    const req = makeReq({
+      actor: {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        companyIds: ["company-2"],
+        memberships: [
+          { companyId: "company-2", membershipRole: "owner", status: "active" },
+        ],
+        isInstanceAdmin: false,
+      },
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(false);
+  });
+
+  it("treats local_implicit board as owner-equivalent (loopback operator)", () => {
+    const req = makeReq({
+      actor: {
+        type: "board",
+        userId: "local-board",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+      },
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(true);
+  });
+
+  it("treats instance admins as owner-equivalent", () => {
+    const req = makeReq({
+      actor: {
+        type: "board",
+        userId: "admin-1",
+        source: "session",
+        companyIds: [],
+        memberships: [],
+        isInstanceAdmin: true,
+      },
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(true);
+  });
+
+  it("rejects non-board actors (agents)", () => {
+    const req = makeReq({
+      actor: {
+        type: "agent",
+        agentId: "agent-1",
+        companyId: "company-1",
+      } as Express.Request["actor"],
+    });
+
+    expect(hasCompanyOwnerMembership(req, "company-1")).toBe(false);
   });
 });
 

--- a/server/src/__tests__/board-chat-route-feature-flag.test.ts
+++ b/server/src/__tests__/board-chat-route-feature-flag.test.ts
@@ -11,6 +11,8 @@ const mockIssueService = vi.hoisted(() => ({
   listComments: vi.fn(),
 }));
 const mockSpawn = vi.hoisted(() => vi.fn());
+const mockHasCompanyOwnerMembership = vi.hoisted(() => vi.fn());
+const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   instanceSettingsService: () => ({ getExperimental: mockGetExperimental }),
@@ -19,9 +21,14 @@ vi.mock("../services/index.js", () => ({
 
 vi.mock("node:child_process", () => ({ spawn: mockSpawn }));
 
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
 vi.mock("../routes/authz.js", () => ({
-  getActorInfo: () => ({ actorId: "user-1", agentId: null, runId: null }),
+  getActorInfo: () => ({ actorType: "user", actorId: "user-1", agentId: null, runId: null }),
   assertCompanyAccess: () => {},
+  hasCompanyOwnerMembership: mockHasCompanyOwnerMembership,
 }));
 
 async function createApp(deploymentMode: "local_trusted" | "authenticated" = "local_trusted") {
@@ -32,9 +39,24 @@ async function createApp(deploymentMode: "local_trusted" | "authenticated" = "lo
   return app;
 }
 
+function makeFakeProc() {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  proc.exitCode = null;
+  proc.killed = false;
+  proc.kill = vi.fn(() => {
+    proc.killed = true;
+  });
+  return proc;
+}
+
 describe("POST /api/board/chat/stream feature flag guard (PAP-137)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: caller is an owner (only consulted in authenticated mode).
+    mockHasCompanyOwnerMembership.mockReturnValue(true);
   });
 
   it("returns 403 FEATURE_DISABLED when enableConferenceRoomChat is off", async () => {
@@ -55,8 +77,9 @@ describe("POST /api/board/chat/stream feature flag guard (PAP-137)", () => {
     expect(mockIssueService.create).not.toHaveBeenCalled();
   });
 
-  it("returns 403 DEPLOYMENT_MODE_UNSUPPORTED outside local_trusted even with the flag on", async () => {
+  it("returns 403 OWNER_MEMBERSHIP_REQUIRED in authenticated mode for non-owners", async () => {
     mockGetExperimental.mockResolvedValue({ enableConferenceRoomChat: true });
+    mockHasCompanyOwnerMembership.mockReturnValue(false);
     const app = await createApp("authenticated");
 
     const res = await request(app)
@@ -64,8 +87,81 @@ describe("POST /api/board/chat/stream feature flag guard (PAP-137)", () => {
       .send({ companyId: "company-1", message: "hello" });
 
     expect(res.status).toBe(403);
-    expect(res.body.code).toBe("DEPLOYMENT_MODE_UNSUPPORTED");
+    expect(res.body.code).toBe("OWNER_MEMBERSHIP_REQUIRED");
+    // No spawn, no persistence for a rejected caller.
+    expect(mockSpawn).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("admits an owner in authenticated mode (reaches the spawn)", async () => {
+    mockGetExperimental.mockResolvedValue({ enableConferenceRoomChat: true });
+    mockHasCompanyOwnerMembership.mockReturnValue(true);
+    mockIssueService.list.mockResolvedValue([
+      { id: "issue-1", title: "Board Operations", status: "todo" },
+    ]);
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1" });
+    mockIssueService.listComments.mockResolvedValue([]);
+    const fakeProc = makeFakeProc();
+    mockSpawn.mockReturnValue(fakeProc);
+    const app = await createApp("authenticated");
+
+    const req = request(app)
+      .post("/api/board/chat/stream")
+      .send({ companyId: "company-1", message: "hello" });
+    const pending = req.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+    // The privileged invocation is audited (metadata only, no content).
+    await vi.waitFor(() => expect(mockLogActivity).toHaveBeenCalled());
+    const auditCall = mockLogActivity.mock.calls[0][1];
+    expect(auditCall.action).toBe("board.chat.invoked");
+    expect(auditCall.details.messageLength).toBe("hello".length);
+    expect(JSON.stringify(auditCall)).not.toContain("hello");
+
+    fakeProc.exitCode = 0;
+    fakeProc.emit("close", 0);
+    await pending;
+  });
+
+  it("rate-limits a single actor after 10 invocations in authenticated mode", async () => {
+    mockGetExperimental.mockResolvedValue({ enableConferenceRoomChat: true });
+    mockHasCompanyOwnerMembership.mockReturnValue(true);
+    mockIssueService.list.mockResolvedValue([
+      { id: "issue-1", title: "Board Operations", status: "todo" },
+    ]);
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1" });
+    mockIssueService.listComments.mockResolvedValue([]);
+    // Reuse one app so the in-memory token bucket accumulates across requests.
+    const app = await createApp("authenticated");
+
+    for (let i = 0; i < 10; i++) {
+      const fakeProc = makeFakeProc();
+      mockSpawn.mockReturnValue(fakeProc);
+      const req = request(app)
+        .post("/api/board/chat/stream")
+        .send({ companyId: "company-1", message: `m${i}` });
+      const pending = req.then(
+        () => undefined,
+        () => undefined,
+      );
+      await vi.waitFor(() => expect(fakeProc.stdin.end).toHaveBeenCalled());
+      fakeProc.exitCode = 0;
+      fakeProc.emit("close", 0);
+      await pending;
+    }
+
+    // 11th invocation is refused before any spawn.
+    mockSpawn.mockClear();
+    const res = await request(app)
+      .post("/api/board/chat/stream")
+      .send({ companyId: "company-1", message: "over" });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe("BOARD_CHAT_RATE_LIMITED");
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 
   it("lets requests past the guard when the flag is on (400 on missing body, not 403)", async () => {
@@ -82,21 +178,9 @@ describe("POST /api/board/chat/stream feature flag guard (PAP-137)", () => {
 });
 
 describe("board-chat client disconnect", () => {
-  function makeFakeProc() {
-    const proc = new EventEmitter() as any;
-    proc.stdout = new EventEmitter();
-    proc.stderr = new EventEmitter();
-    proc.stdin = { write: vi.fn(), end: vi.fn() };
-    proc.exitCode = null;
-    proc.killed = false;
-    proc.kill = vi.fn(() => {
-      proc.killed = true;
-    });
-    return proc;
-  }
-
   it("kills the spawned subprocess when the client disconnects mid-stream", async () => {
     mockGetExperimental.mockResolvedValue({ enableConferenceRoomChat: true });
+    mockHasCompanyOwnerMembership.mockReturnValue(true);
     mockIssueService.list.mockResolvedValue([
       { id: "issue-1", title: "Board Operations", status: "todo" },
     ]);

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -50,6 +50,36 @@ export function assertInstanceAdmin(req: Request) {
   throw forbidden("Instance admin access required");
 }
 
+/**
+ * Predicate: is the requester a board user with ACTIVE OWNER membership on
+ * `companyId`? Used to gate privileged surfaces (e.g. Board Chat, which spawns
+ * the operator's `claude` CLI) in `authenticated` deployment mode, where
+ * loopback isolation no longer protects the spawn.
+ *
+ * Returns a boolean rather than throwing so callers that speak a custom
+ * response protocol (SSE / coded JSON) can emit their own error shape.
+ *
+ * - `local_implicit` board (loopback single-operator) IS the machine operator
+ *   by construction → owner-equivalent.
+ * - Instance admins are operator-level and outrank company owners.
+ * - Otherwise require an active membership with role `owner` on the company.
+ */
+export function hasCompanyOwnerMembership(req: Request, companyId: string): boolean {
+  if (req.actor.type !== "board") {
+    return false;
+  }
+  if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) {
+    return true;
+  }
+  const memberships = Array.isArray(req.actor.memberships) ? req.actor.memberships : [];
+  const membership = memberships.find((item) => item.companyId === companyId);
+  return (
+    !!membership &&
+    membership.status === "active" &&
+    membership.membershipRole === "owner"
+  );
+}
+
 export function assertCompanyAccess(req: Request, companyId: string) {
   assertAuthenticated(req);
   if (req.actor.type === "agent" && req.actor.companyId !== companyId) {

--- a/server/src/routes/board-chat.ts
+++ b/server/src/routes/board-chat.ts
@@ -6,7 +6,8 @@ import { fileURLToPath } from "node:url";
 import type { Db } from "@paperclipai/db";
 import type { DeploymentMode } from "@paperclipai/shared";
 import { instanceSettingsService, issueService } from "../services/index.js";
-import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { logActivity } from "../services/activity-log.js";
+import { assertCompanyAccess, getActorInfo, hasCompanyOwnerMembership } from "./authz.js";
 
 /**
  * Strip structured action signals (`%%ACTIONS%%{...}%%/ACTIONS%%`) from a
@@ -62,12 +63,33 @@ export function isConciergeReply(comment: {
 /** Max simultaneous `claude` subprocesses across all board-chat requests. */
 const MAX_CONCURRENT_BOARD_CHATS = 3;
 
+/** Per-actor invocation cap and sliding window for board-chat spawns. */
+const BOARD_CHAT_RATE_LIMIT = 10;
+const BOARD_CHAT_RATE_WINDOW_MS = 60 * 60 * 1000;
+
 export function boardChatRoutes(
   db: Db,
   opts: { deploymentMode: DeploymentMode },
 ) {
   const router = Router();
   let liveBoardChats = 0;
+
+  // Sliding-window invocation timestamps per actor id (in-memory, per process).
+  // The spawn exposes the operator's `claude` session, so we cap how often any
+  // one actor can trigger it independent of the concurrency gate.
+  const chatTimestampsByActor = new Map<string, number[]>();
+  function checkRateLimit(actorId: string): boolean {
+    const now = Date.now();
+    const cutoff = now - BOARD_CHAT_RATE_WINDOW_MS;
+    const recent = (chatTimestampsByActor.get(actorId) ?? []).filter((t) => t > cutoff);
+    if (recent.length >= BOARD_CHAT_RATE_LIMIT) {
+      chatTimestampsByActor.set(actorId, recent);
+      return false;
+    }
+    recent.push(now);
+    chatTimestampsByActor.set(actorId, recent);
+    return true;
+  }
 
   // The board skill is read from disk once and cached. Resolves to the
   // repo-root `skills/paperclip-board/SKILL.md` whether running from
@@ -108,13 +130,19 @@ export function boardChatRoutes(
     }
 
     // The relay spawns the operator's local `claude` CLI with permissions
-    // skipped (it must run headless), so it is only safe where the requester
-    // IS the machine operator: local_trusted is loopback-only single-operator
-    // by construction (see server/src/index.ts boot guards). Refuse everywhere
-    // else rather than lending the server's shell to remote users.
-    if (opts.deploymentMode !== "local_trusted") {
+    // skipped (it must run headless). Two deployment modes can host it safely:
+    //   - local_trusted: loopback-only single-operator by construction (see
+    //     server/src/index.ts boot guards) — the requester IS the operator.
+    //   - authenticated: CF Access + Better Auth multi-user. The spawn is only
+    //     safe for a verified company OWNER, enforced below once companyId is
+    //     known; lesser roles must not borrow the server's shell.
+    // Any other/future mode is refused.
+    if (
+      opts.deploymentMode !== "local_trusted" &&
+      opts.deploymentMode !== "authenticated"
+    ) {
       res.status(403).json({
-        error: "Board chat is only available on local single-operator instances",
+        error: "Board chat is not available in this deployment mode",
         code: "DEPLOYMENT_MODE_UNSUPPORTED",
       });
       return;
@@ -134,6 +162,30 @@ export function boardChatRoutes(
     // The body-supplied companyId must belong to the authenticated actor —
     // it scopes issue reads/writes below and is exported to the subprocess.
     assertCompanyAccess(req, companyId);
+
+    // In `authenticated` (multi-user) mode the loopback isolation that makes
+    // local_trusted safe is gone, so the privileged spawn is owner-only.
+    if (
+      opts.deploymentMode === "authenticated" &&
+      !hasCompanyOwnerMembership(req, companyId)
+    ) {
+      res.status(403).json({
+        error: "Board chat requires company owner membership",
+        code: "OWNER_MEMBERSHIP_REQUIRED",
+      });
+      return;
+    }
+
+    // Per-actor rate limit (10/hour): cap how often the operator's `claude`
+    // session can be spawned, independent of the concurrency gate below.
+    const actor = getActorInfo(req);
+    if (!checkRateLimit(actor.actorId)) {
+      res.status(429).json({
+        error: "Board chat rate limit exceeded — max 10 per hour",
+        code: "BOARD_CHAT_RATE_LIMITED",
+      });
+      return;
+    }
 
     // Back-pressure: each request holds a subprocess + SSE stream for up to
     // 2 minutes; cap simultaneous spawns instead of forking without bound.
@@ -180,12 +232,30 @@ export function boardChatRoutes(
     // Persist the user's message. Use the authenticated board/user actor so
     // attribution and author-type checks pass; "board" (the local fallback)
     // is distinct from the "board-concierge" sentinel used for replies.
-    const actor = getActorInfo(req);
     await issueSvc.addComment(resolvedIssueId, message, {
       agentId: actor.agentId ?? undefined,
       userId: actor.agentId ? undefined : actor.actorId,
       runId: actor.runId,
     });
+
+    // Audit trail for spawn abuse — record metadata only, never the message
+    // content (length alone is enough to flag anomalies). Best-effort: an
+    // audit write failure must not block the chat.
+    try {
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        action: "board.chat.invoked",
+        entityType: "issue",
+        entityId: resolvedIssueId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        details: { messageLength: message.length, taskId: taskId ?? null },
+      });
+    } catch {
+      /* best effort */
+    }
 
     // Build conversation history from recent comments (oldest first).
     const comments = await issueSvc.listComments(resolvedIssueId, { order: "asc" });


### PR DESCRIPTION
Closes NODE-167. Implements NODE-174. Board chat now allowed in `authenticated` mode, gated to company OWNERs/instance admins via hasCompanyOwnerMembership; adds per-actor 10/hr rate limit + metadata-only audit log. See commit b769ecb5 for full rationale.