### PR TITLE
fix(acpx-local): bust warm-session cache on secret rotation

### DIFF
--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -734,6 +734,8 @@ async function buildRuntime(input: {
 }): Promise<AcpxPreparedRuntime> {
   const { runId, agent, config, context, authToken } = input.ctx;
   const workspaceContext = parseObject(context.paperclipWorkspace);
+  const secretsContext = parseObject(context.paperclipSecrets);
+  const secretManifest = Array.isArray(secretsContext.manifest) ? secretsContext.manifest : [];
   const workspaceCwd = asString(workspaceContext.cwd, "");
   const workspaceSource = asString(workspaceContext.source, "");
   const workspaceStrategy = asString(workspaceContext.strategy, "");
@@ -914,6 +916,9 @@ async function buildRuntime(input: {
           defaultMode: paperclipClaudeSettings.defaultMode,
         }
       : null,
+    // Bust the warm-session cache when any resolved secret rotates so the
+    // next spawned heartbeat picks up the new env without a harness restart.
+    secretManifestHash: shortHash(secretManifest),
   });
   const taskKey = asString(input.ctx.runtime.taskKey, "") || wakeTaskId || workspaceId || "default";
   const sessionKey = `paperclip:${agent.companyId}:${agent.id}:${taskKey}:${fingerprint}`;

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -606,7 +606,12 @@ export function secretService(db: Db) {
           .update(companySecrets)
           .set({ lastResolvedAt: new Date(), updatedAt: new Date() })
           .where(eq(companySecrets.id, secret.id))
-          .catch(() => undefined),
+          .catch((err) => {
+            logger.warn(
+              { err, companyId, secretId: secret.id },
+              "Failed to update companySecrets.lastResolvedAt",
+            );
+          }),
         recordAccessEvent({
           companyId,
           secretId: secret.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `@paperclipai/adapter-acpx-local` adapter spawns long-lived ACP runtimes ("warm sessions") and caches them across heartbeats in `defaultWarmHandles` keyed on a fingerprint built from the agent config
> - That fingerprint omits the resolved secret manifest, so after an operator rotates a secret via Settings → Secrets, the next heartbeat reuses the warm session that was spawned with the pre-rotation env and child processes keep reading the stale value
> - We hit this in production for ~6 consecutive Apify-token rotation cycles. The operator updated the token, the DB row was updated, the server resolved the new value at heartbeat time, but `acpx_local` handed the cached child process the same env it started with, so every heartbeat still authenticated with the revoked token
> - The fingerprint already discriminates on skills identity, claude settings, model, mode, etc.; secrets are the obvious missing axis
> - This pull request adds a `secretManifestHash` field to the fingerprint and converts a silent `.catch(() => undefined)` on the `lastResolvedAt` DB update into a `logger.warn` so future hot-path failures stop hiding
> - The benefit is that operators no longer have to `kill && paperclipai run` to pick up a rotated secret — the next heartbeat naturally spawns a fresh runtime with the new env

## Linked Issues or Issue Description

No upstream issue exists yet. Underlying problem:

**Bug**: After rotating a secret in Settings → Secrets, spawned acpx_local heartbeats continue to read the pre-rotation value until the `paperclipai run` host process is restarted.

**Repro**:
1. Start a `paperclipai run` host with an `acpx_local` agent bound to a company secret (e.g. an Apify token).
2. Trigger a heartbeat — the child reads the secret correctly.
3. Update the secret to a new value via Settings → Secrets.
4. Trigger another heartbeat — `defaultWarmHandles` returns the warm session from step 2 and the child still reads the old value.
5. The only workaround today is `kill <pid> && paperclipai run`.

**Root cause**: `buildRuntime` in `packages/adapters/acpx-local/src/server/execute.ts` builds a fingerprint over (acpxAgent, agentCommand, cwd, mode, permissionMode, requestedModel, skillsIdentity, paperclipClaudeSettings, …) but NOT over the resolved secret manifest. The heartbeat service already exposes `context.paperclipSecrets.manifest` from `resolveExecutionRunAdapterConfig`, and each `RuntimeSecretManifestEntry` carries a per-secret `version` that bumps on rotation. Folding that manifest into the fingerprint hash naturally invalidates the warm handle on rotation.

We also noticed `secrets.ts` silently swallows DB update failures on the `lastResolvedAt` write, which would mask cases where the rotation is happening at the application layer but the secret store is failing to record it. Replaced with a warning log.

## What Changed

- `packages/adapters/acpx-local/src/server/execute.ts`: read `context.paperclipSecrets.manifest` off the `AdapterExecutionContext` and fold `shortHash(secretManifest)` into the session fingerprint. When any secret version changes, the manifest changes → fingerprint changes → `defaultWarmHandles.get(sessionKey)` misses → fresh runtime spawned with the rotated env.
- `server/src/services/secrets.ts`: replace `.catch(() => undefined)` on the `companySecrets.lastResolvedAt` update with `logger.warn({ err, companyId, secretId }, "Failed to update companySecrets.lastResolvedAt")` so persistent DB failures surface in operator logs instead of silently dropping.

## Verification

Local:

```bash
pnpm --filter @paperclipai/adapter-acpx-local typecheck   # passes
pnpm --filter @paperclipai/server typecheck                # passes
npx vitest run packages/adapters/acpx-local/src/server/execute.test.ts   # 16/16 pass
npx vitest run server/src/__tests__/secrets-service.test.ts              # 45/45 pass
```

Behavioral (intended, to validate post-merge in a live instance):

1. Start `paperclipai run` with an `acpx_local` agent bound to a company secret.
2. Trigger a heartbeat, observe the resolved value in the child.
3. Rotate the secret via Settings → Secrets.
4. Trigger another heartbeat WITHOUT restarting the host process.
5. Expect: the child reads the rotated value (warm session is invalidated and a new ACP runtime is spawned).

## Risks

- Low risk. The change is additive: an extra discriminator on the fingerprint hash. The only observable effect for callers whose secrets did not change is identical fingerprints to before (the manifest is stable across runs when no secret rotated). The only observable effect for callers whose secrets DID change is one extra cold spawn after rotation, which is exactly what we want.
- The `secretManifest` includes failure entries from `resolveAdapterConfigForRuntime`. That means a transient resolution failure would also invalidate the fingerprint, forcing a re-spawn. This is the safe default — better to over-invalidate than under-invalidate when secrets are involved.
- The new `logger.warn` adds noise only when the `companySecrets.lastResolvedAt` update actually fails. In a healthy instance this is silent.

## Model Used

- Provider: Anthropic Claude
- Model ID: claude-opus-4-7
- Mode: standard tool-use, no extended thinking enabled for this change
- Capabilities used: code editing, repo-wide search, local typecheck + vitest runs

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge