### PR TITLE
Fix ANA-150 productive continuation recovery loops

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3366,6 +3366,63 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  it("blocks repeated productive continuation retries when adapter context only preserves wakeReason", async () => {
+    const previousRunId = randomUUID();
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: previousRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_continuation_needed" },
+      startedAt: new Date("2026-03-18T23:50:00.000Z"),
+      finishedAt: new Date("2026-03-18T23:55:00.000Z"),
+      createdAt: new Date("2026-03-18T23:50:00.000Z"),
+      updatedAt: new Date("2026-03-18T23:55:00.000Z"),
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        retryOfRunId: previousRunId,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          taskKey: issueId,
+          wakeReason: "issue_continuation_needed",
+          wakeSource: "automation",
+          wakeTriggerDetail: "system",
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: null,
+    });
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.filter((row) => row.retryOfRunId === runId)).toHaveLength(0);
+  });
+
   it("allows one productive-terminal recovery after regular continuation recovery made progress", async () => {
     const { agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -112,7 +112,7 @@ type RecoveryWakeup = (
 
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
-  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
+  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState" | "retryOfRunId"
 > | null;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
@@ -368,8 +368,12 @@ function isProductiveContinuationRun(latestRun: LatestIssueRun) {
 
 function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIssueRun) {
   const latestContext = parseObject(latestRun.contextSnapshot);
-  return readNonEmptyString(latestContext.retryReason) === "issue_continuation_needed" &&
-    readNonEmptyString(latestContext.source) === "issue.productive_terminal_continuation_recovery" &&
+  const retryReason = readNonEmptyString(latestContext.retryReason) ?? readNonEmptyString(latestContext.wakeReason);
+  const source = readNonEmptyString(latestContext.source);
+  const hasProductiveTerminalSource = source === "issue.productive_terminal_continuation_recovery";
+  const hasAdapterPreservedRetryLink = latestRun.retryOfRunId !== null && source !== "issue.continuation_recovery";
+  return retryReason === "issue_continuation_needed" &&
+    (hasProductiveTerminalSource || hasAdapterPreservedRetryLink) &&
     isProductiveContinuationRun(latestRun);
 }
 
@@ -490,6 +494,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        retryOfRunId: heartbeatRuns.retryOfRunId,
       })
       .from(heartbeatRuns)
       .where(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, so issue state must reflect whether work has a live execution path.
> - The recovery subsystem reconciles `in_progress` assigned work when the latest heartbeat has finished but no run is alive.
> - Productive terminal continuations are useful once: they let a worker continue after making progress but leaving unfinished work.
> - A second productive-but-still-stranded continuation is different: it proves the loop is not resolving to a durable disposition.
> - The observed ANA-150 / #8210 failure mode involved adapter context that only preserved `wakeReason` plus the `retryOfRunId`, so the classifier missed it and could keep requeueing.
> - This pull request tightens repeated productive-continuation detection while preserving the normal first-retry path.
> - The benefit is faster escalation to a visible `blocked` state instead of acknowledgement/progress-looking loops.

## Linked Issues or Issue Description

- Fixes: #8210

## What Changed

- Includes `retryOfRunId` in the latest issue-run summary used by stranded issue recovery.
- Treats a successful productive continuation as already-used when either the explicit productive-terminal source is present or the adapter preserved the continuation wake reason plus retry link.
- Keeps regular `issue.continuation_recovery` productive runs eligible for one productive-terminal follow-up.
- Adds regression coverage for adapter-preserved context that only carries `wakeReason`/`retryOfRunId`.

## Verification

- `pnpm run preflight:workspace-links && pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts --no-file-parallelism --maxWorkers=1` — 51 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.

## Risks

- Low-to-medium behavioral risk: this changes recovery classification for productive continuation retries with preserved retry links. The intended effect is to block/escalate repeated stranded work sooner; the regression suite covers the first-retry and regular-continuation exceptions.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via Hermes native provider `openai-codex`, model `gpt-5.5`, high-reasoning mode, with terminal/file tool execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

