### PR TITLE
feat: add shared write-path permission infrastructure

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -13,12 +13,14 @@ import {
   materializePaperclipSkillCopy,
   refreshPaperclipWorkspaceEnvForExecution,
   renderPaperclipWakePrompt,
+  renderDeniedWritePathsNote,
   runningProcesses,
   runChildProcess,
   sanitizeSshRemoteEnv,
   shapePaperclipWorkspaceEnvForExecution,
   rewriteWorkspaceCwdEnvVarsForExecution,
   stringifyPaperclipWakePayload,
+  validateDeniedWritePaths,
 } from "./server-utils.js";
 
 function isPidAlive(pid: number) {
@@ -1159,5 +1161,57 @@ describe("appendWithByteCap", () => {
     expect(output).not.toContain("\uFFFD");
     expect(Buffer.from(output, "utf8").toString("utf8")).toBe(output);
     expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("validateDeniedWritePaths", () => {
+  it("allows paths not in denied list", () => {
+    expect(validateDeniedWritePaths("/home/user", ["/paperclip"])).toEqual({ allowed: true });
+  });
+
+  it("denies paths under a denied prefix", () => {
+    expect(validateDeniedWritePaths("/paperclip/config.json", ["/paperclip"])).toEqual({
+      allowed: false,
+      errorMessage: "Write access to /paperclip/config.json is denied (under /paperclip).",
+    });
+  });
+
+  it("denies exact match of a denied prefix", () => {
+    expect(validateDeniedWritePaths("/paperclip", ["/paperclip"])).toEqual({
+      allowed: false,
+      errorMessage: "Write access to /paperclip is denied (under /paperclip).",
+    });
+  });
+
+  it("allows paths under agent workspace even if parent is denied", () => {
+    const workspaceCwd = "/paperclip/instances/default/workspaces/agent-1";
+    expect(validateDeniedWritePaths(workspaceCwd, ["/paperclip"], workspaceCwd)).toEqual({ allowed: true });
+    expect(validateDeniedWritePaths(workspaceCwd + "/src", ["/paperclip"], workspaceCwd)).toEqual({ allowed: true });
+  });
+
+  it("denies other paths under denied parent even if workspace is also under it", () => {
+    const workspaceCwd = "/paperclip/instances/default/workspaces/agent-1";
+    expect(validateDeniedWritePaths("/paperclip/instances/default/config.json", ["/paperclip"], workspaceCwd)).toEqual({
+      allowed: false,
+      errorMessage: "Write access to /paperclip/instances/default/config.json is denied (under /paperclip).",
+    });
+  });
+
+  it("denies paths in a differently named sibling directory", () => {
+    expect(validateDeniedWritePaths("/paperclip-backup", ["/paperclip"])).toEqual({ allowed: true });
+  });
+});
+
+describe("renderDeniedWritePathsNote", () => {
+  it("returns empty string for empty list", () => {
+    expect(renderDeniedWritePathsNote([])).toBe("");
+    expect(renderDeniedWritePathsNote(undefined)).toBe("");
+  });
+
+  it("renders a list of paths with header", () => {
+    const note = renderDeniedWritePathsNote(["/paperclip", "/etc"]);
+    expect(note).toContain("Denied Write Paths:");
+    expect(note).toContain("- /paperclip");
+    expect(note).toContain("- /etc");
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -7,9 +7,12 @@ import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
 import type {
+  AdapterAgent,
   AdapterSkillEntry,
   AdapterSkillSnapshot,
 } from "./types.js";
+
+export const DEFAULT_DENIED_WRITE_PATHS = ["/paperclip"];
 
 export interface RunProcessResult {
   exitCode: number | null;
@@ -110,6 +113,59 @@ export function resolvePaperclipInstanceRootForAdapter(input: {
   return path.resolve(homeDir, "instances", instanceId);
 }
 
+/**
+ * Validates if the given cwd is allowed for writing based on denied paths.
+ * Exempts the agent's own workspace cwd.
+ */
+export function validateDeniedWritePaths(
+  cwd: string,
+  deniedPaths: string[],
+  workspaceCwd?: string,
+): { allowed: true } | { allowed: false; errorMessage: string } {
+  for (const denied of deniedPaths) {
+    const relative = path.relative(denied, cwd);
+    const isUnderDenied =
+      relative === "" ||
+      (!relative.startsWith("..") && !path.isAbsolute(relative));
+
+    if (isUnderDenied) {
+      if (workspaceCwd) {
+        // Exempt if the denied path is exactly our workspace prefix.
+        if (path.resolve(denied) === path.resolve(workspaceCwd)) {
+          continue;
+        }
+        // Also exempt if the cwd is under our own workspace.
+        const relToWorkspace = path.relative(workspaceCwd, cwd);
+        const isUnderWorkspace =
+          relToWorkspace === "" ||
+          (!relToWorkspace.startsWith("..") && !path.isAbsolute(relToWorkspace));
+        if (isUnderWorkspace) {
+          continue;
+        }
+      }
+
+      return {
+        allowed: false,
+        errorMessage: `Write access to ${cwd} is denied (under ${denied}).`,
+      };
+    }
+  }
+  return { allowed: true };
+}
+
+/**
+ * Renders the "Denied Write Paths" section for the agent prompt.
+ */
+export function renderDeniedWritePathsNote(deniedPaths?: string[]): string {
+  if (!deniedPaths || deniedPaths.length === 0) return "";
+  return [
+    "Denied Write Paths:",
+    "The following paths are read-only. You MUST NOT attempt to modify, delete, or write any files under these prefixes:",
+    ...deniedPaths.map((p) => `- ${p}`),
+    "",
+  ].join("\n");
+}
+
 export const DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE = [
   "You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.",
   "",
@@ -127,6 +183,7 @@ export const DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE = [
   "- For plan approval, update the plan document first, then create request_confirmation targeting the latest plan revision with idempotencyKey confirmation:{issueId}:plan:{revisionId}. Wait for acceptance before creating implementation subtasks, and create a fresh confirmation after superseding board/user comments if approval is still needed.",
   "- If blocked, mark the issue blocked and name the unblock owner and action.",
   "- Respect budget, pause/cancel, approval gates, and company boundaries.",
+  "{{deniedWritePaths}}",
 ].join("\n");
 
 export interface PaperclipSkillEntry {
@@ -935,7 +992,11 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
-export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+export function buildPaperclipEnv(agent: {
+  id: string;
+  companyId: string;
+  deniedWritePaths?: string[];
+}): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
@@ -946,6 +1007,9 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     PAPERCLIP_AGENT_ID: agent.id,
     PAPERCLIP_COMPANY_ID: agent.companyId,
   };
+  if (agent.deniedWritePaths && agent.deniedWritePaths.length > 0) {
+    vars.PAPERCLIP_AGENT_DENIED_WRITE_PATHS = agent.deniedWritePaths.join(",");
+  }
   const runtimeHost = resolveHostForUrl(
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -11,6 +11,7 @@ export interface AdapterAgent {
   name: string;
   adapterType: string | null;
   adapterConfig: unknown;
+  deniedWritePaths?: string[];
 }
 
 export interface AdapterRuntime {
@@ -503,6 +504,7 @@ export interface CreateConfigValues {
   maxTurnsPerRun: number;
   heartbeatEnabled: boolean;
   intervalSec: number;
+  deniedWritePaths?: string[];
   /** Arbitrary key-value pairs populated by schema-driven config fields. */
   adapterSchemaValues?: Record<string, unknown>;
   // openclaw_gateway adapter fields

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -19,6 +19,7 @@ export interface AgentPermissions extends Record<string, unknown> {
   canCreateAgents: boolean;
   trustPreset?: TrustPreset;
   authorizationPolicy?: TrustAuthorizationPolicy;
+  deniedWritePaths?: string[];
 }
 
 export interface AgentModelProfileConfig {
@@ -90,6 +91,7 @@ export interface Agent {
   capabilities: string | null;
   adapterType: AgentAdapterType;
   adapterConfig: Record<string, unknown>;
+  deniedWritePaths?: string[];
   runtimeConfig: AgentRuntimeConfig;
   defaultEnvironmentId?: string | null;
   budgetMonthlyCents: number;


### PR DESCRIPTION
## Summary
- Add `deniedWritePaths` to adapter and agent types
- Implement `validateDeniedWritePaths` and `renderDeniedWritePathsNote` utilities in `@paperclipai/adapter-utils`
- Update `buildPaperclipEnv` to expose `PAPERCLIP_AGENT_DENIED_WRITE_PATHS`
- Update default agent prompt template with `{{deniedWritePaths}}` placeholder

Closes [GRI-685](/GRI/issues/GRI-685)