### PR TITLE
test(cli): kill the whole server process group in company import/export e2e teardown

### DIFF
--- a/cli/src/__tests__/company-import-export-e2e.test.ts
+++ b/cli/src/__tests__/company-import-export-e2e.test.ts
@@ -186,15 +186,67 @@ function collectTextFiles(root: string, current: string, files: Record<string, s
   }
 }
 
+// The server is spawned via `pnpm paperclipai run`. `pnpm` is only a wrapper:
+// the process that actually binds the HTTP port is a node grandchild. Signalling
+// the pnpm child alone (`child.kill`) leaves that grandchild orphaned, where it
+// keeps squatting its port — and once afterAll() removes the temp data dir, it
+// becomes a DB-less server that poisons later runs. We therefore spawn the child
+// `detached` (making it a process-group leader) and signal the whole group.
+const activeServerPids = new Set<number>();
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    // Negative pid → deliver to every process in the group (pnpm + node server).
+    process.kill(-pid, signal);
+  } catch {
+    // Group already gone; fall back to the direct child in case it survived.
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already dead — nothing to do.
+    }
+  }
+}
+
+// Backstop: if a run is interrupted (SIGINT/SIGTERM) or exits before afterAll,
+// reap any server groups we started so we never leak orphaned servers.
+function reapAllServers(): void {
+  for (const pid of activeServerPids) {
+    signalProcessGroup(pid, "SIGKILL");
+  }
+  activeServerPids.clear();
+}
+
+process.once("exit", reapAllServers);
+for (const interrupt of ["SIGINT", "SIGTERM"] as const) {
+  process.once(interrupt, () => {
+    reapAllServers();
+    process.exit(interrupt === "SIGINT" ? 130 : 143);
+  });
+}
+
 async function stopServerProcess(child: ServerProcess | null) {
   if (!child || child.exitCode !== null) return;
-  child.kill("SIGTERM");
+  const pid = child.pid;
+  if (typeof pid !== "number") {
+    child.kill("SIGTERM");
+    return;
+  }
+  signalProcessGroup(pid, "SIGTERM");
   await new Promise<void>((resolve) => {
-    child.once("exit", () => resolve());
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      activeServerPids.delete(pid);
+      resolve();
+    };
+    child.once("exit", finish);
     setTimeout(() => {
       if (child.exitCode === null) {
-        child.kill("SIGKILL");
+        signalProcessGroup(pid, "SIGKILL");
       }
+      finish();
     }, 5_000);
   });
 }
@@ -306,9 +358,15 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
           shellHome: cliShellHome,
         }),
         stdio: ["ignore", "pipe", "pipe"],
+        // Become a process-group leader so teardown can signal the whole tree
+        // (pnpm wrapper + the node server grandchild that binds the port).
+        detached: true,
       },
     );
     serverProcess = child;
+    if (typeof child.pid === "number") {
+      activeServerPids.add(child.pid);
+    }
     child.stdout?.on("data", (chunk) => {
       output.stdout.push(String(chunk));
     });


### PR DESCRIPTION
## Problem

The company import/export e2e test (`cli/src/__tests__/company-import-export-e2e.test.ts`) starts the control plane with `spawn("pnpm", ["paperclipai", "run", ...])`. `pnpm` is only a wrapper — the process that actually binds the HTTP port is a **node grandchild**.

Teardown called `child.kill("SIGTERM")`, which signals **only the pnpm wrapper**. The node server is left orphaned (reparented to pid 1) and keeps squatting its port. Then `afterAll()` runs `rmSync(tempRoot)` and deletes the server's temp data dir, turning it into a **DB-less server that answers `500` / `database_unreachable`**.

Impact observed on this machine: 4+ leaked `cli/src/index.ts run --config /tmp/paperclip-company-cli-e2e-*` servers accumulated over days (some 5 days old). These leaked servers shadow ports later handed to live processes — repeatedly poisoning Paperclip agent heartbeats whose injected `$PAPERCLIP_API_URL` pointed at a leaked, data-dir-deleted server.

## Fix

- `spawn` the server **`detached`** so it leads its own process group (pnpm wrapper + node server grandchild share the group).
- Signal the **entire group** in teardown: `process.kill(-pid, "SIGTERM")`, then `SIGKILL` after a 5s grace period. Falls back to a direct child kill if the group is already gone.
- Add a module-level reaper on `process` `exit` / `SIGINT` / `SIGTERM`, so an **interrupted** vitest run still reaps every server group it started (the previous code leaked the whole tree on interrupt).

## Scope

This is the only CLI test that spawns a long-running `pnpm paperclipai run` server; `http.test.ts` and the other CLI tests do not, so no other teardown needs the same change.

## Verification

- esbuild transpile of the edited file: passes (syntax valid).
- Behavioral validation is the e2e test itself under CI: after the run there must be **no surviving** `paperclip-company-cli-e2e-*` server process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)