### PR TITLE
ci(release): pin stable publish to verified commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      verified_sha: ${{ steps.verified_ref.outputs.sha }}
 
     steps:
       - name: Checkout repository
@@ -147,6 +149,10 @@ jobs:
 
       - name: Validate release package manifest
         run: node ./scripts/release-package-map.mjs check
+
+      - name: Record verified source commit
+        id: verified_ref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -173,7 +179,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.verify_stable.outputs.verified_sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -217,7 +223,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.verify_stable.outputs.verified_sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip publishes release artifacts through GitHub Actions so users can install and update the CLI/packages reliably
> - Stable releases are manually dispatched and accept a `source_ref` that can be a branch, tag, or commit SHA
> - Branch refs such as `master` are mutable, so re-checking out `source_ref` in later jobs can resolve to a different commit than the one that passed verification
> - The release workflow already separates verification from dry-run/publish jobs, with publish jobs using `--skip-verify` because verification happened earlier
> - Therefore downstream stable jobs should consume the exact commit SHA produced by `verify_stable`, not re-resolve the original input ref
> - This PR pins stable preview/publish checkout to the verified SHA so the release runs against the commit that actually passed typecheck, tests, and build

## What Changed

- `.github/workflows/release.yml`
  - Adds a `verified_sha` output to `verify_stable`.
  - Records the verified commit with `git rev-parse HEAD` after the workflow checks out `inputs.source_ref`.
  - Checks out `needs.verify_stable.outputs.verified_sha` in `preview_stable` and `publish_stable`.

## Verification

Validated locally:

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
text = Path('.github/workflows/release.yml').read_text()
assert 'outputs:\n      verified_sha: ${{ steps.verified_ref.outputs.sha }}' in text
assert 'id: verified_ref\n        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"' in text
assert text.count('ref: ${{ needs.verify_stable.outputs.verified_sha }}') == 2
assert 'verify_stable:' in text and 'ref: ${{ inputs.source_ref }}' in text.split('verify_stable:',1)[1].split('preview_stable:',1)[0]
print('release stable verified-sha wiring check: ok')
PY
node ./scripts/release-package-map.mjs check
```

Results:

```text
release stable verified-sha wiring check: ok
Release package manifest OK: 24 enabled for CI publish, 4 disabled pending bootstrap.
```

Fork CI passed all project validation checks before upstream submission: policy, Build, Canary Dry Run, Typecheck + Release Registry, General tests, serialized server suites, e2e, and verify. The only red fork check was GitHub Dependency Review, which fails on the fork because dependency graph is not enabled there; no dependency files are changed in this PR.

## Risks

Low. This only changes the manual stable release workflow. It preserves the existing verification job and makes downstream preview/publish consume the exact verified commit instead of re-resolving a mutable input ref.

Operationally, the main risk is that a future workflow change could make `verified_sha` unavailable; in that case the downstream checkout would fail closed rather than publishing an unverified moving ref.

## Model Used

OpenAI Codex provider, model `gpt-5.5`, via Hermes Agent tool-using coding workflow. Context window size was not exposed by the runtime metadata available in this session. Tools used included `git`, GitHub CLI, repository file inspection, and local validation commands.

## Related Issue

No specific issue found. This is a release-safety hardening change discovered from the public workflow state.

## Duplicate Checks

Checked immediately before submission:

- `source_ref verified sha release workflow_dispatch`
- `stable release checkout verified commit`
- `release skip-verify publish stable`

Result: no exact duplicate PR found. Existing release hardening work appears related but not the same checkout/ref pinning issue.

## Checklist

- [x] Focused, small diff
- [x] Regression/docs validation added or not applicable
- [x] Duplicate checks completed
- [x] Validation passed
- [x] Maintainer edits enabled
