### PR TITLE
feat(server): tasks:gate_keeper_write capability + in_review validator + review checkout

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -728,6 +728,7 @@ export const PERMISSION_KEYS = [
   "users:manage_permissions",
   "tasks:assign",
   "tasks:assign_scope",
+  "tasks:gate_keeper_write",
   "tasks:manage_active_checkouts",
   "joins:approve",
 ] as const;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -447,6 +447,7 @@ export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorks
 export const checkoutIssueSchema = z.object({
   agentId: z.string().uuid(),
   expectedStatuses: z.array(z.enum(ISSUE_STATUSES)).nonempty(),
+  checkoutType: z.enum(["execution", "review"]).optional(),
 });
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   agents,
   companies,
@@ -94,7 +95,7 @@ async function grantAgentPermission(
   db: ReturnType<typeof createDb>,
   companyId: string,
   agentId: string,
-  permissionKey: "tasks:assign" | "tasks:assign_scope",
+  permissionKey: "tasks:assign" | "tasks:assign_scope" | "tasks:gate_keeper_write",
   scope: Record<string, unknown> | null = null,
 ) {
   await db.insert(companyMemberships).values({
@@ -910,6 +911,54 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision).toMatchObject({
       allowed: true,
       grant: { permissionKey: "tasks:assign" },
+    });
+  });
+
+  it("matches gate-keeper grants by labels and revokes immediately when the grant or label is removed", async () => {
+    const company = await createCompany(db, "GateKeeperLabels");
+    const ownerAgent = await createAgent(db, company.id);
+    const gateKeeperAgent = await createAgent(db, company.id);
+    const issue = await createIssue(db, company.id, { assigneeAgentId: ownerAgent.id });
+    const svc = authorizationService(db);
+
+    await grantAgentPermission(db, company.id, gateKeeperAgent.id, "tasks:gate_keeper_write", {
+      labels: ["auditor:in-scope"],
+    });
+
+    const allowed = await svc.decide({
+      actor: { type: "agent", agentId: gateKeeperAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:gate_keeper_write",
+      resource: { type: "issue", companyId: company.id, issueId: issue.id, assigneeAgentId: ownerAgent.id },
+      scope: { labels: ["auditor:in-scope"] },
+    });
+    expect(allowed).toMatchObject({
+      allowed: true,
+      reason: "allow_explicit_grant",
+      grant: { permissionKey: "tasks:gate_keeper_write" },
+    });
+
+    const labelRemoved = await svc.decide({
+      actor: { type: "agent", agentId: gateKeeperAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:gate_keeper_write",
+      resource: { type: "issue", companyId: company.id, issueId: issue.id, assigneeAgentId: ownerAgent.id },
+      scope: { labels: [] },
+    });
+    expect(labelRemoved).toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
+    });
+
+    await db.delete(principalPermissionGrants).where(eq(principalPermissionGrants.principalId, gateKeeperAgent.id));
+
+    const grantRemoved = await svc.decide({
+      actor: { type: "agent", agentId: gateKeeperAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:gate_keeper_write",
+      resource: { type: "issue", companyId: company.id, issueId: issue.id, assigneeAgentId: ownerAgent.id },
+      scope: { labels: ["auditor:in-scope"] },
+    });
+    expect(grantRemoved).toMatchObject({
+      allowed: false,
+      reason: "deny_missing_grant",
     });
   });
 });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -13,6 +13,7 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  checkout: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   getAttachmentById: vi.fn(),
@@ -28,6 +29,8 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   findMentionedAgents: vi.fn(),
 }));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 
 const mockAccessService = vi.hoisted(() => ({
   canUser: vi.fn(),
@@ -112,7 +115,7 @@ function registerRouteMocks() {
   }));
 
   vi.doMock("../services/activity-log.js", () => ({
-    logActivity: vi.fn(async () => undefined),
+    logActivity: mockLogActivity,
   }));
 
   vi.doMock("../services/index.js", () => ({
@@ -158,7 +161,7 @@ function registerRouteMocks() {
     }),
     issueService: () => mockIssueService,
     issueThreadInteractionService: () => mockIssueThreadInteractionService,
-    logActivity: vi.fn(async () => undefined),
+    logActivity: mockLogActivity,
     projectService: () => ({}),
     routineService: () => ({
       syncRunStatusForIssue: vi.fn(async () => undefined),
@@ -342,6 +345,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockCompanyService.getById.mockReset();
     mockIssueService.addComment.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.checkout.mockReset();
     mockIssueService.create.mockReset();
     mockIssueService.createChild.mockReset();
     mockIssueService.getAttachmentById.mockReset();
@@ -461,6 +465,15 @@ describe("agent issue mutation checkout ownership", () => {
       companyId,
       body: "comment",
     });
+    mockIssueService.checkout.mockImplementation(
+      async (_id: string, agentId: string, _expectedStatuses: string[], runId: string | null, options?: { checkoutType?: "execution" | "review" }) => ({
+        ...makeIssue(),
+        assigneeAgentId: options?.checkoutType === "review" ? ownerAgentId : agentId,
+        checkoutRunId: runId,
+        executionRunId: runId,
+        status: options?.checkoutType === "review" ? "todo" : "in_progress",
+      }),
+    );
     mockIssueService.listAttachments.mockResolvedValue([]);
     mockIssueService.remove.mockResolvedValue(makeIssue({ status: "cancelled" }));
     mockIssueService.getAttachmentById.mockResolvedValue({
@@ -973,6 +986,164 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalled();
   });
 
+  it("allows gate-keeper comments and allowlisted documents on labeled issues and logs override use", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      labels: [{ name: "auditor:in-scope" }],
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed:
+        input.action === "tasks:assign" ||
+        input.action === "issue:read" ||
+        input.action === "issue:mutate" ||
+        input.action === "company_scope:read" ||
+        input.action === "tasks:gate_keeper_write",
+      action: input.action,
+      reason: input.action === "tasks:gate_keeper_write" ? "allow_explicit_grant" : "allow_explicit_grant",
+      explanation: input.action === "tasks:gate_keeper_write" ? "Allowed by gate-keeper grant." : "Allowed by test default.",
+    }));
+
+    const app = await createApp(peerActor());
+
+    await request(app).post(`/api/issues/${issueId}/comments`).send({ body: "audit note" }).expect(201);
+    await request(app).put(`/api/issues/${issueId}/documents/acceptance-criteria`).send({ format: "markdown", body: "# ok" }).expect(200);
+    await request(app).put(`/api/issues/${issueId}/documents/rollback-plan`).send({ format: "markdown", body: "# rollback" }).expect(200);
+    await request(app).put(`/api/issues/${issueId}/documents/review-evidence`).send({ format: "markdown", body: "# evidence" }).expect(200);
+
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "audit note",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalledTimes(3);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "gate_keeper_write",
+        entityId: issueId,
+        details: expect.objectContaining({
+          event: "gate_keeper_write",
+          actorAgentId: peerAgentId,
+          issueId,
+          labels: ["auditor:in-scope"],
+        }),
+      }),
+    );
+  });
+
+  it("rejects gate-keeper override use when the issue label is missing and leaves unrelated behavior unchanged", async () => {
+    const appWithoutGrant = await createApp(peerActor());
+    const baseComment = await request(appWithoutGrant).post(`/api/issues/${issueId}/comments`).send({ body: "base" });
+
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed:
+        input.action === "tasks:assign" ||
+        input.action === "issue:read" ||
+        input.action === "issue:mutate" ||
+        input.action === "company_scope:read" ||
+        input.action === "tasks:gate_keeper_write",
+      action: input.action,
+      reason: input.action === "tasks:gate_keeper_write" ? "allow_explicit_grant" : "allow_explicit_grant",
+      explanation: input.action === "tasks:gate_keeper_write" ? "Allowed by gate-keeper grant." : "Allowed by test default.",
+    }));
+
+    const appWithGrant = await createApp(peerActor());
+    const grantedComment = await request(appWithGrant).post(`/api/issues/${issueId}/comments`).send({ body: "base" });
+    const docRes = await request(appWithGrant)
+      .put(`/api/issues/${issueId}/documents/acceptance-criteria`)
+      .send({ format: "markdown", body: "# blocked" });
+
+    expect(grantedComment.status).toBe(baseComment.status);
+    expect(grantedComment.body).toEqual(baseComment.body);
+    expect(docRes.status).toBe(409);
+    expect(docRes.body.error).toBe("Issue is checked out by another agent");
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
+  });
+
+  it("keeps substance fields owner-only even for a labeled gate-keeper issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      labels: [{ name: "auditor:in-scope" }],
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed:
+        input.action === "tasks:assign" ||
+        input.action === "issue:read" ||
+        input.action === "issue:mutate" ||
+        input.action === "company_scope:read" ||
+        input.action === "tasks:gate_keeper_write",
+      action: input.action,
+      reason: "allow_explicit_grant",
+      explanation: input.action === "tasks:gate_keeper_write" ? "Allowed by gate-keeper grant." : "Allowed by test default.",
+    }));
+
+    const app = await createApp(peerActor());
+
+    await request(app).patch(`/api/issues/${issueId}`).send({ status: "done" }).expect(409);
+    await request(app).patch(`/api/issues/${issueId}`).send({ assigneeAgentId: peerAgentId }).expect(409);
+    await request(app).patch(`/api/issues/${issueId}`).send({ description: "x" }).expect(409);
+    await request(app).put(`/api/issues/${issueId}/documents/plan`).send({ format: "markdown", body: "# plan" }).expect(409);
+
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled();
+  });
+
+  it("supports review checkout only for labeled gate-keeper issues and preserves execution checkout defaults", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "todo",
+      labels: [{ name: "auditor:in-scope" }],
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed:
+        input.action === "tasks:assign" ||
+        input.action === "issue:read" ||
+        input.action === "issue:mutate" ||
+        input.action === "company_scope:read" ||
+        input.action === "tasks:gate_keeper_write",
+      action: input.action,
+      reason: "allow_explicit_grant",
+      explanation: input.action === "tasks:gate_keeper_write" ? "Allowed by gate-keeper grant." : "Allowed by test default.",
+    }));
+
+    const app = await createApp(peerActor());
+    const reviewRes = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: peerAgentId, expectedStatuses: ["todo"], checkoutType: "review" });
+
+    expect(reviewRes.status, JSON.stringify(reviewRes.body)).toBe(200);
+    expect(reviewRes.body).toMatchObject({
+      assigneeAgentId: ownerAgentId,
+      checkoutType: "review",
+    });
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      issueId,
+      peerAgentId,
+      ["todo"],
+      peerActor().runId,
+      { checkoutType: "review" },
+    );
+
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo" }));
+    const reviewDenied = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: peerAgentId, expectedStatuses: ["todo"], checkoutType: "review" });
+    expect(reviewDenied.status).toBe(403);
+    expect(reviewDenied.body.error).toContain("tasks:gate_keeper_write");
+
+    const executionRes = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId: ownerAgentId, expectedStatuses: ["in_progress"] });
+    expect(executionRes.status, JSON.stringify(executionRes.body)).toBe(200);
+    expect(executionRes.body.checkoutType).toBe("execution");
+    expect(mockIssueService.checkout).toHaveBeenLastCalledWith(
+      issueId,
+      ownerAgentId,
+      ["in_progress"],
+      ownerRunId,
+      { checkoutType: "execution" },
+    );
+  });
+
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
     ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
@@ -1005,6 +1176,7 @@ describe("agent issue mutation checkout ownership", () => {
       assigneeAgentId: null,
       title: "Claimable update",
     });
+    mockLogActivity.mockReset();
   });
 
   it("rejects peer-agent status updates that would clear a recovery action they do not own", async () => {

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -255,6 +255,68 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("accepts a gate-keeper assignee as a typed in_review path and still rejects non-gate-keepers", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1003",
+      title: "Gate keeper review path",
+      executionPolicy: null,
+      executionState: null,
+      labels: [{ name: "auditor:in-scope" }],
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { actor?: { type?: string; source?: string; agentId?: string }; action?: string }) => {
+      const allowed = input.action === "tasks:gate_keeper_write"
+        ? input.actor?.agentId === "44444444-4444-4444-8444-444444444444"
+        : input.actor?.type === "board" && input.actor.source === "local_implicit"
+          ? true
+          : input.actor?.type === "agent" && [
+              "company_scope:read",
+              "issue:read",
+              "issue:mutate",
+              "runtime:manage",
+            ].includes(input.action ?? "");
+      return {
+        allowed,
+        action: input.action,
+        reason: allowed ? "allow_explicit_grant" : "deny_missing_grant",
+        explanation: allowed ? "Allowed by test grant." : `Missing permission: ${input.action ?? "action"}`,
+      };
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    });
+
+    const allowed = await request(app)
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", assigneeAgentId: "44444444-4444-4444-8444-444444444444" });
+    expect(allowed.status, JSON.stringify(allowed.body)).toBe(200);
+
+    const denied = await request(app)
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", assigneeAgentId: "55555555-5555-4555-8555-555555555555" });
+    expect(denied.status).toBe(422);
+    expect(denied.body.details).toMatchObject({
+      code: "invalid_issue_disposition",
+      missing: "review_path",
+    });
+    expect(denied.body.details.validReviewPaths).toContain("typed_gate_keeper");
+  });
+
   it("allows an agent-authored in_review transition with a pending confirmation interaction", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4500,6 +4500,71 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       executionRunId: successorRunId,
     });
   });
+
+  it("review checkout preserves the existing assignee while recording the reviewer run lock", async () => {
+    const companyId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const reviewerAgentId = randomUUID();
+    const issueId = randomUUID();
+    const reviewRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ownerAgentId,
+        companyId,
+        name: "Owner",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: reviewerAgentId,
+        companyId,
+        name: "Reviewer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values({
+      id: reviewRunId,
+      companyId,
+      agentId: reviewerAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date("2026-06-17T03:00:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review checkout issue",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: ownerAgentId,
+    });
+
+    const updated = await svc.checkout(issueId, reviewerAgentId, ["todo"], reviewRunId, { checkoutType: "review" });
+
+    expect(updated).toMatchObject({
+      id: issueId,
+      assigneeAgentId: ownerAgentId,
+      status: "todo",
+      checkoutRunId: reviewRunId,
+      executionRunId: reviewRunId,
+    });
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -189,6 +189,65 @@ type SuccessfulRunHandoffActivityRow = {
   details: Record<string, unknown> | null;
   createdAt: Date;
 };
+type GateKeeperOverrideInput =
+  | { kind: "comment" }
+  | { kind: "document"; documentKey: string };
+
+const GATE_KEEPER_ALLOWED_DOCUMENT_KEYS = new Set([
+  "acceptance-criteria",
+  "rollback-plan",
+  "review-evidence",
+]);
+
+function issueLabelNames(issue: { labels?: Array<{ name?: string | null }> | null }) {
+  return (issue.labels ?? [])
+    .map((label) => typeof label?.name === "string" ? label.name.trim() : "")
+    .filter((label): label is string => label.length > 0);
+}
+
+function isGateKeeperScopedLabel(label: string) {
+  return label === "auditor:in-scope" || label.startsWith("gate-keeper:");
+}
+
+function gateKeeperScopedIssueLabels(issue: { labels?: Array<{ name?: string | null }> | null }) {
+  return issueLabelNames(issue).filter(isGateKeeperScopedLabel);
+}
+
+async function hasTypedGateKeeperReviewPath(input: {
+  access: {
+    decide: (
+      input: {
+        actor: { type: "agent"; agentId: string; companyId: string };
+        action: "tasks:gate_keeper_write";
+        resource: { type: "issue"; companyId: string; issueId: string; assigneeAgentId: string | null };
+        scope: { labels: string[] };
+      },
+    ) => Promise<{ allowed: boolean }>;
+  };
+  issue: {
+    id: string;
+    companyId: string;
+    assigneeAgentId?: string | null;
+    labels?: Array<{ name?: string | null }> | null;
+  };
+  nextAssigneeAgentId: string | null | undefined;
+}) {
+  if (typeof input.nextAssigneeAgentId !== "string" || input.nextAssigneeAgentId.trim().length === 0) return false;
+  const labels = gateKeeperScopedIssueLabels(input.issue);
+  if (labels.length === 0) return false;
+  const decision = await input.access.decide({
+    actor: { type: "agent", agentId: input.nextAssigneeAgentId, companyId: input.issue.companyId },
+    action: "tasks:gate_keeper_write",
+    resource: {
+      type: "issue",
+      companyId: input.issue.companyId,
+      issueId: input.issue.id,
+      assigneeAgentId: input.issue.assigneeAgentId ?? null,
+    },
+    scope: { labels },
+  });
+  return decision.allowed;
+}
 
 function applyCreateIssueStatusDefault(req: Request, res: Response, next: () => void) {
   if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
@@ -1598,9 +1657,11 @@ export function issueRoutes(
       id: string;
       companyId: string;
       status: string;
+      assigneeAgentId?: string | null;
       assigneeUserId?: string | null;
       executionState?: unknown;
       monitorNextCheckAt?: Date | null;
+      labels?: Array<{ name?: string | null }> | null;
     };
     updateFields: Record<string, unknown>;
     actorType: string;
@@ -1614,6 +1675,11 @@ export function issueRoutes(
       ? input.existing.assigneeUserId
       : input.updateFields.assigneeUserId;
     if (typeof nextAssigneeUserId === "string" && nextAssigneeUserId.trim().length > 0) return;
+    const nextAssigneeAgentId: string | null =
+      input.updateFields.assigneeAgentId === undefined
+      ? input.existing.assigneeAgentId ?? null
+      : (input.updateFields.assigneeAgentId as string | null);
+    if (await hasTypedGateKeeperReviewPath({ access, issue: input.existing, nextAssigneeAgentId })) return;
 
     const nextExecutionState = input.updateFields.executionState === undefined
       ? input.existing.executionState
@@ -1640,6 +1706,7 @@ export function issueRoutes(
         "pending_issue_thread_interaction",
         "linked_pending_approval",
         "human_assignee_user_id",
+        "typed_gate_keeper",
         "typed_execution_state_current_participant",
         "scheduled_issue_monitor",
       ],
@@ -1842,18 +1909,58 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  async function hasGateKeeperWriteOverride(
+    issue: {
+      id: string;
+      companyId: string;
+      assigneeAgentId: string | null;
+      labels?: Array<{ name?: string | null }> | null;
+    },
+    input: {
+      actorAgentId: string;
+      override: GateKeeperOverrideInput;
+    },
+  ) {
+    if (input.override.kind === "document" && !GATE_KEEPER_ALLOWED_DOCUMENT_KEYS.has(input.override.documentKey)) {
+      return null;
+    }
+    const labels = gateKeeperScopedIssueLabels(issue);
+    if (labels.length === 0) return null;
+    const decision = await access.decide({
+      actor: { type: "agent", agentId: input.actorAgentId, companyId: issue.companyId },
+      action: "tasks:gate_keeper_write",
+      resource: {
+        type: "issue",
+        companyId: issue.companyId,
+        issueId: issue.id,
+        assigneeAgentId: issue.assigneeAgentId,
+      },
+      scope: { labels },
+    });
+    if (!decision.allowed) return null;
+    return {
+      actorAgentId: input.actorAgentId,
+      labels,
+      action: input.override.kind === "comment" ? "comment" : "document_put",
+      documentKey: input.override.kind === "document" ? input.override.documentKey : null,
+    };
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
     issue: {
       id: string;
       companyId: string;
+      identifier?: string | null;
       projectId: string | null;
       parentId: string | null;
       status: string;
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
+      labels?: Array<{ name?: string | null }> | null;
     },
+    options?: { gateKeeperOverride?: GateKeeperOverrideInput },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1871,6 +1978,35 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+        return true;
+      }
+      const gateKeeperOverride = options?.gateKeeperOverride
+        ? await hasGateKeeperWriteOverride(issue, {
+          actorAgentId,
+          override: options.gateKeeperOverride,
+        })
+        : null;
+      if (gateKeeperOverride) {
+        const actor = getActorInfo(req);
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: "gate_keeper_write",
+          entityType: "issue",
+          entityId: issue.id,
+          details: {
+            event: "gate_keeper_write",
+            actorAgentId: gateKeeperOverride.actorAgentId,
+            issueId: issue.id,
+            identifier: issue.identifier ?? null,
+            action: gateKeeperOverride.action,
+            documentKey: gateKeeperOverride.documentKey,
+            labels: gateKeeperOverride.labels,
+          },
+        });
         return true;
       }
       if (issue.status === "in_progress") {
@@ -3392,13 +3528,15 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
-    if (!(await assertDeliverableMutationAllowedByRunContext(req, res, issue))) return;
     const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
     if (!keyParsed.success) {
       res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
       return;
     }
+    if (!(await assertAgentIssueMutationAllowed(req, res, issue, {
+      gateKeeperOverride: { kind: "document", documentKey: keyParsed.data },
+    }))) return;
+    if (!(await assertDeliverableMutationAllowedByRunContext(req, res, issue))) return;
 
     const actor = getActorInfo(req);
     const sourceTrust = await sourceTrustForActorWrite(issue, actor);
@@ -5078,9 +5216,15 @@ export function issueRoutes(
       typeof nextAssigneeUserId === "string" &&
       !!existing.createdByUserId &&
       nextAssigneeUserId === existing.createdByUserId;
+    const typedGateKeeperReviewAssignment =
+      req.actor.type === "agent" &&
+      (updateFields.status === "in_review" || (updateFields.status === undefined && existing.status === "in_review")) &&
+      typeof nextAssigneeAgentId === "string" &&
+      nextAssigneeUserId == null &&
+      await hasTypedGateKeeperReviewPath({ access, issue: existing, nextAssigneeAgentId });
 
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
-      if (!isAgentReturningIssueToCreator) {
+      if (!isAgentReturningIssueToCreator && !typedGateKeeperReviewAssignment) {
         await assertCanAssignTasks(req, existing.companyId, {
           issueId: existing.id,
           projectId: await resolveAssignmentProjectId({
@@ -5869,7 +6013,23 @@ export function issueRoutes(
       return;
     }
 
-    if (issue.assigneeAgentId !== req.body.agentId) {
+    const checkoutType = req.body.checkoutType === "review" ? "review" : "execution";
+    if (checkoutType === "review") {
+      if (req.actor.type !== "agent" || !req.actor.agentId) {
+        res.status(403).json({ error: "Agent authentication required for review checkout" });
+        return;
+      }
+      const reviewCheckout = await hasGateKeeperWriteOverride(issue, {
+        actorAgentId: req.actor.agentId,
+        override: { kind: "comment" },
+      });
+      if (!reviewCheckout) {
+        res.status(403).json({
+          error: "Review checkout requires a matching tasks:gate_keeper_write grant on an in-scope issue",
+        });
+        return;
+      }
+    } else if (issue.assigneeAgentId !== req.body.agentId) {
       await assertCanAssignTasks(req, issue.companyId, {
         issueId: issue.id,
         projectId: issue.projectId ?? null,
@@ -5887,7 +6047,7 @@ export function issueRoutes(
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
-    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
+    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId, { checkoutType });
     const actor = getActorInfo(req);
 
     await logActivity(db, {
@@ -5899,7 +6059,7 @@ export function issueRoutes(
       action: "issue.checked_out",
       entityType: "issue",
       entityId: issue.id,
-      details: { agentId: req.body.agentId },
+      details: { agentId: req.body.agentId, checkoutType },
     });
 
     if (
@@ -5915,7 +6075,7 @@ export function issueRoutes(
           source: "assignment",
           triggerDetail: "system",
           reason: "issue_checked_out",
-          payload: { issueId: issue.id, mutation: "checkout" },
+          payload: { issueId: issue.id, mutation: "checkout", checkoutType },
           requestedByActorType: actor.actorType,
           requestedByActorId: actor.actorId,
           contextSnapshot: { issueId: issue.id, source: "issue.checkout" },
@@ -5923,7 +6083,7 @@ export function issueRoutes(
         .catch((err) => logger.warn({ err, issueId: issue.id }, "failed to wake assignee on issue checkout"));
     }
 
-    res.json(updated);
+    res.json({ ...updated, checkoutType });
   });
 
   router.post("/issues/:id/release", async (req, res) => {
@@ -6624,7 +6784,9 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, issue, {
+      gateKeeperOverride: { kind: "comment" },
+    }))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -151,6 +151,12 @@ function scopeIncludesId(ids: string[], id: string | null | undefined) {
   return Boolean(id && ids.includes(id));
 }
 
+function scopeIncludesAnyValue(allowedValues: string[], requestedValues: string[]) {
+  if (requestedValues.length === 0) return false;
+  const allowed = new Set(allowedValues);
+  return requestedValues.some((value) => allowed.has(value));
+}
+
 function isSimpleAssignableAgentStatus(status: string | null | undefined) {
   return status !== "pending_approval" && status !== "terminated";
 }
@@ -329,6 +335,7 @@ async function scopeAllows(
         ? requestedScope.targetAgentId
         : null;
   const requestedProjectId = typeof requestedScope.projectId === "string" ? requestedScope.projectId : null;
+  const requestedLabels = scopeValueList(requestedScope.labels);
   let constrained = false;
 
   const projectIds = [
@@ -382,6 +389,15 @@ async function scopeAllows(
       }
     }
     if (!matchesSubtree) return false;
+  }
+
+  const labelNames = [
+    ...scopeValuesForKeys(grantScope, ["label", "labels"]),
+    ...prefixedScopeValues(grantScope, "label:"),
+  ];
+  if (labelNames.length > 0) {
+    constrained = true;
+    if (!scopeIncludesAnyValue(labelNames, requestedLabels)) return false;
   }
 
   // Unknown metadata keys do not constrain the grant. Recognized constraints

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5477,7 +5477,13 @@ export function issueService(db: Db) {
         return enriched;
       }),
 
-    checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+    checkout: async (
+      id: string,
+      agentId: string,
+      expectedStatuses: string[],
+      checkoutRunId: string | null,
+      options?: { checkoutType?: "execution" | "review" },
+    ) => {
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
@@ -5503,6 +5509,37 @@ export function issueService(db: Db) {
 
       await clearExecutionRunIfTerminal(id);
       await clearCheckoutRunIfTerminal(id);
+
+      if (options?.checkoutType === "review") {
+        const checkoutRunMatches = checkoutRunId === null
+          ? isNull(issues.checkoutRunId)
+          : or(isNull(issues.checkoutRunId), eq(issues.checkoutRunId, checkoutRunId));
+        const executionRunMatches = checkoutRunId === null
+          ? isNull(issues.executionRunId)
+          : or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId));
+        const reviewUpdated = await db
+          .update(issues)
+          .set({
+            checkoutRunId,
+            executionRunId: checkoutRunId,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, id),
+              inArray(issues.status, expectedStatuses),
+              checkoutRunMatches,
+              executionRunMatches,
+            ),
+          )
+          .returning()
+          .then((rows) => rows[0] ?? null);
+
+        if (reviewUpdated) {
+          const [enriched] = await withIssueLabels(db, [reviewUpdated]);
+          return enriched;
+        }
+      }
 
       const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
       const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue ownership, review routing, and audit logging all run through the server issue-control-plane surfaces.
> - The current mutation model assumes either the assignee or a broad assignment authority is making cross-agent issue writes.
> - That breaks a narrow QA gate flow where a designated gate-keeper needs to comment, publish review docs, and claim a review run on another agent's labeled issue without taking substantive ownership.
> - The missing pieces were a label-scoped permission, a typed `in_review` path for that permission, and a review-only checkout mode that preserves the assignee.
> - This pull request adds those narrow gate-keeper paths while keeping status/assignee/description mutations owner-only and logging every override use.
> - The benefit is that scoped reviewers can participate in issue review workflows without widening general cross-agent write permissions.

## Linked Issues or Issue Description

Feature request context from ThinkStack MC:

- Refs: TSMC implementation issue `TSMC-10381`.
- Refs: approved design/work plan `TSMC-10048`.
- Problem: a designated gate-keeper agent could not comment on, write review documents to, transition into `in_review`, or perform a review checkout on another agent's in-scope issue without broader ownership/assignment permissions.
- Expected behavior: a label-scoped `tasks:gate_keeper_write` grant should allow comment/write/review checkout behavior on explicitly labeled issues, while substantive issue mutations remain denied.

## Problem or motivation

A designated gate-keeper agent (Auditor) could not comment on, write review documents to, transition into `in_review`, or perform a review checkout on another agent's in-scope issue without broader cross-agent ownership or assignment permissions. The control plane's mutation model treated review-side participation as substantive ownership, which forced widening write authority every time a scoped reviewer needed to act.

## Proposed solution

Introduce a narrow, label-scoped `tasks:gate_keeper_write` permission key with:

- Authorization decision branch in `authorization.ts` that matches grant scope labels against issue labels.
- Mutation override in `routes/issues.ts` limited to comments and an explicit document-key allowlist (`acceptance-criteria`, `rollback-plan`, `review-evidence`); substance fields (`status`, `assigneeAgentId`, `description`, etc.) remain owner-only.
- `checkoutType: "review"` on `POST /api/issues/:id/checkout` that locks the run for review without rotating `assigneeAgentId`.
- Typed `in_review` validator path that accepts assignment to a registered gate-keeper for any label on the issue and appends `typed_gate_keeper` to `validReviewPaths`.
- Structured audit-log entry on every override use.

## Alternatives considered

- **Broaden `tasks:manage_active_checkouts`** — rejected: that capability already exists as an escape hatch for owners; widening it would silently grant substantive write authority and defeat the substance-protection invariant that this work depends on.
- **Reassign the issue to the gate-keeper for the review window** — rejected: rotating `assigneeAgentId` loses owner context, would race with the original agent's heartbeats, and would also require a clean way back which the existing in_review validator does not provide.
- **A separate side-channel review API** — rejected: it would fragment the issue thread and force every reviewer client to learn a new surface, when the actual blocker is just three narrow write paths on the existing endpoints.

## Roadmap alignment

Unblocks the [PLATFORM] meta-gate flow described in `qa-gate-scope` (TSMC-10032 §1/§5/§7) by allowing the Auditor role to be granted scoped review-write capability without changing the issue assignee. No new public-API surface area beyond the documented four touch points; reversible via `DELETE FROM principal_permission_grants WHERE permission_key = 'tasks:gate_keeper_write'`.

## What Changed

- Added `tasks:gate_keeper_write` to shared permission keys and extended checkout validation with optional `checkoutType: "review"`.
- Extended authorization scope matching so grant scope labels can match requested issue labels via `label`, `labels`, or `label:`-prefixed scope entries.
- Added route-level gate-keeper helpers in `server/src/routes/issues.ts` for scoped-label detection, allowlisted document writes, typed `in_review` validation, and audit-log entries on override use.
- Added review checkout handling in `server/src/services/issues.ts` that records the reviewer run lock without changing `assigneeAgentId` or forcing execution-checkout blocker semantics.
- Added focused server coverage for label-scoped authz, cross-agent comment/document behavior, typed gate-keeper review routing, and review checkout persistence.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `pnpm exec vitest run server/src/__tests__/authorization-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts server/src/__tests__/issues-service.test.ts`
- Result on rebased head: `Test Files  4 passed (4)` / `Tests  166 passed (166)`.

## Risks

- Low to moderate: this changes issue mutation authorization and `in_review` routing, so regressions would most likely show up in cross-agent review handoffs.
- The blast radius is limited by requiring an explicit `tasks:gate_keeper_write` grant plus matching gate-keeper labels on the issue.
- Rollback is straightforward: revert the PR or remove the permission grant rows; the new path is read live from grants/labels and does not require a schema migration.

## Model Used

- OpenAI GPT-5 Codex via Codex local agent tooling.
- Model family: GPT-5 / Codex coding agent with tool use, shell execution, file editing, and test execution.
- Exact runtime model ID was not exposed in the local Paperclip worktree, but this change was produced through the Codex engineer lane with iterative test/typecheck repair.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

