### PR TITLE
fix: ship skills-catalog with server so catalog survives global install

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -798,7 +798,7 @@ Per-agent schedule fields in `adapter_config`:
 
 - `enabled` boolean
 - `intervalSec` integer (minimum 30)
-- `maxConcurrentRuns` integer; new agents default to `20`; scheduler clamps configured values to `1..50`
+- `maxConcurrentRuns` integer; new agents default to `3`; scheduler clamps configured values to `1..50`
 
 Scheduler must skip invocation when:
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -73,7 +73,7 @@ export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   general: "General",
 };
 
-export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 20;
+export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 3;
 export const WORKSPACE_BRANCH_ROUTINE_VARIABLE = "workspaceBranch";
 
 export const MODEL_PROFILE_KEYS = ["cheap"] as const;

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-06-04T19:57:14.020Z",
+  "generatedAt": "2026-06-15T23:53:59.018Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -214,6 +214,38 @@
         }
       ],
       "contentHash": "sha256:32372dacaf62e93454b9855968c4eec96456ba78b509f450b3dfaa48e31ef356"
+    },
+    {
+      "id": "paperclipai:bundled:software-development:github-issue-workflow",
+      "key": "paperclipai/bundled/software-development/github-issue-workflow",
+      "kind": "bundled",
+      "category": "software-development",
+      "slug": "github-issue-workflow",
+      "name": "github-issue-workflow",
+      "description": "Prepare a GitHub issue for upstream contribution — issue hygiene, title/body, verification notes, labels, and follow-ups. Use when triaging or filing issues for a repository that prefers issues over PRs.",
+      "path": "catalog/bundled/software-development/github-issue-workflow",
+      "entrypoint": "SKILL.md",
+      "trustLevel": "markdown_only",
+      "compatibility": "compatible",
+      "defaultInstall": false,
+      "recommendedForRoles": [
+        "engineer"
+      ],
+      "requires": [],
+      "tags": [
+        "github",
+        "issues",
+        "upstream-contribution"
+      ],
+      "files": [
+        {
+          "path": "SKILL.md",
+          "kind": "skill",
+          "sizeBytes": 4875,
+          "sha256": "21c2bc59f0fc2b6efe948b3959ec6ce45b31f184d82dacb6e3587edb87f5ff95"
+        }
+      ],
+      "contentHash": "sha256:b5a1b32c78f7380b11b773d92554f8d31aeaaecd133c1f3958311c821cc3809f"
     },
     {
       "id": "paperclipai:bundled:software-development:github-pr-workflow",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       '@paperclipai/shared':
         specifier: workspace:*
         version: link:../packages/shared
+      '@paperclipai/skills-catalog':
+        specifier: workspace:*
+        version: link:../packages/skills-catalog
       ajv:
         specifier: ^8.20.0
         version: 8.20.0

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -62,7 +62,7 @@
   {
     "dir": "packages/skills-catalog",
     "name": "@paperclipai/skills-catalog",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/teams-catalog",

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
     "@paperclipai/shared": "workspace:*",
+    "@paperclipai/skills-catalog": "workspace:*",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "better-auth": "1.4.18",

--- a/server/src/__tests__/company-skills-routes.test.ts
+++ b/server/src/__tests__/company-skills-routes.test.ts
@@ -25,6 +25,7 @@ const mockCompanySkillService = vi.hoisted(() => ({
   createComment: vi.fn(),
   updateComment: vi.fn(),
   deleteComment: vi.fn(),
+  resolveCompanyId: vi.fn((companyId: string) => Promise.resolve(companyId)),
   importFromSource: vi.fn(),
   installFromCatalog: vi.fn(),
   deleteSkill: vi.fn(),

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -772,7 +772,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       returnOwnerAgentId: input.agentId,
       cause: input.cause ?? "stranded_assigned_issue",
       attemptCount: 1,
-      maxAttempts: null,
+      maxAttempts: 2,
     });
     expect(action.evidence).toMatchObject({
       sourceIssueId: input.issueId,
@@ -3542,5 +3542,301 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+
+  // ── CPL-3191 / CPL-3226: stranded recovery retry limit ──
+
+  it("blocks issue and does not create new retry when stranded recovery limit is exhausted", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+
+    // Pre-create a recovery action at the limit: attemptCount == maxAttempts == 2
+    const now = new Date();
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "stranded_assigned_issue",
+      evidence: {
+        sourceIssueId: issueId,
+        previousStatus: "in_progress",
+        latestRunId: runId,
+      },
+      nextAction: "Restore a live execution path.",
+      attemptCount: 2,
+      maxAttempts: 2,
+      lastAttemptAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Must be escalated (blocked), not requeued
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    // Issue must be blocked
+    const updatedIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("blocked");
+
+    // No new recovery wake was scheduled
+    const recoveryWakes = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.reason, "source_scoped_recovery_action"),
+        ),
+      );
+    // Only the original failed wake exists (from seedStrandedIssueFixture), no new recovery wake
+    expect(recoveryWakes.filter((w) => w.status === "queued" || w.status === "claimed")).toHaveLength(0);
+
+    // No nested recovery issue created
+    const nestedRecoveries = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery"), eq(issues.originId, issueId)));
+    expect(nestedRecoveries).toHaveLength(0);
+  });
+
+  it("writes exhausted recovery comment with diagnostic details", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+
+    const now = new Date();
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "stranded_assigned_issue",
+      evidence: {
+        sourceIssueId: issueId,
+        previousStatus: "in_progress",
+        latestRunId: runId,
+      },
+      nextAction: "Restore a live execution path.",
+      attemptCount: 2,
+      maxAttempts: 2,
+      lastAttemptAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.reconcileStrandedAssignedIssues();
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .orderBy(issueComments.createdAt);
+    const exhaustedComment = comments.find((c) =>
+      c.body.includes("stopped automatic stranded"),
+    );
+    expect(exhaustedComment).toBeTruthy();
+    expect(exhaustedComment!.body).toContain("after exhausting the retry limit");
+    expect(exhaustedComment!.body).toContain("Recovery attempts: 2 of 2");
+    expect(exhaustedComment!.body).toContain("Cause: repeated stranded‑work detection");
+    expect(exhaustedComment!.body).toContain("Next action: a board operator");
+
+    // Activity log must contain the exhaustion event
+    const activities = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issueId),
+          eq(activityLog.action, "issue.recovery_exhausted"),
+        ),
+      );
+    expect(activities).toHaveLength(1);
+    expect(activities[0]!.details).toMatchObject({
+      status: "blocked",
+      source: "recovery.reconcile_stranded_assigned_issue",
+      exhausted: true,
+    });
+  });
+
+  it("allows recovery to proceed when maxAttempts is null (backward compatibility)", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+
+    // Recovery action with maxAttempts: null and high attemptCount — should still work
+    const now = new Date();
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "stranded_assigned_issue",
+      evidence: {
+        sourceIssueId: issueId,
+        previousStatus: "in_progress",
+        latestRunId: runId,
+      },
+      nextAction: "Restore a live execution path.",
+      attemptCount: 5,
+      maxAttempts: null,
+      lastAttemptAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Must be escalated (blocked), not silently skipped — existing behaviour preserved
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    // Issue blocked as usual
+    const updatedIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("blocked");
+
+    // Recovery action was updated (attemptCount incremented), not exhausted
+    const updatedAction = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(
+        and(
+          eq(issueRecoveryActions.companyId, companyId),
+          eq(issueRecoveryActions.sourceIssueId, issueId),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(updatedAction?.attemptCount).toBe(6); // incremented from 5 to 6
+    expect(updatedAction?.status).toBe("active");
+
+    // No exhausted comment
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    const exhaustedComment = comments.find((c) =>
+      c.body.includes("stopped automatic stranded"),
+    );
+    expect(exhaustedComment).toBeUndefined();
+  });
+
+  it("allows manual recovery reset after exhaustion by removing the exhausted action", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+
+    const now = new Date();
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "stranded_assigned_issue",
+      evidence: {
+        sourceIssueId: issueId,
+        previousStatus: "in_progress",
+        latestRunId: runId,
+      },
+      nextAction: "Restore a live execution path.",
+      attemptCount: 2,
+      maxAttempts: 2,
+      lastAttemptAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    // First reconcile: exhausted → issue blocked
+    const result1 = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result1.escalated).toBe(1);
+
+    let updatedIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("blocked");
+
+    // Manager resolves: remove the exhausted recovery action, unblock the issue,
+    // create a fresh run (simulating manual reset)
+    await db
+      .delete(issueRecoveryActions)
+      .where(
+        and(
+          eq(issueRecoveryActions.companyId, companyId),
+          eq(issueRecoveryActions.sourceIssueId, issueId),
+        ),
+      );
+
+    // Simulate new run that fails again
+    const newRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: newRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      startedAt: new Date("2026-03-19T01:00:00.000Z"),
+      finishedAt: new Date("2026-03-19T01:05:00.000Z"),
+      errorCode: "process_lost",
+      error: "run failed after manual reset",
+    });
+    await db
+      .update(issues)
+      .set({ status: "in_progress", executionRunId: null, checkoutRunId: null })
+      .where(eq(issues.id, issueId));
+
+    // Second reconcile: fresh recovery action created, not exhausted
+    const result2 = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result2.escalated).toBe(1);
+    expect(result2.issueIds).toEqual([issueId]);
+
+    // Issue blocked with new recovery
+    updatedIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(updatedIssue?.status).toBe("blocked");
+
+    // New recovery action with attemptCount = 1 was created
+    const newAction = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(
+        and(
+          eq(issueRecoveryActions.companyId, companyId),
+          eq(issueRecoveryActions.sourceIssueId, issueId),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(newAction?.attemptCount).toBe(1);
+    expect(newAction?.maxAttempts).toBe(2);
+    expect(newAction?.status).toBe("active");
   });
 });

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   update: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  getDependencyReadiness: vi.fn(),
   findMentionedAgents: vi.fn(async () => []),
 }));
 
@@ -124,6 +125,15 @@ describe("issue dependency wakeups in issue routes", () => {
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: "",
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
   });
 
   it("wakes dependents when the final blocker transitions to done", async () => {
@@ -273,5 +283,136 @@ describe("issue dependency wakeups in issue routes", () => {
         }),
       );
     });
+  });
+
+  it("auto-resumes when blockedByIssueIds is set and all blockers are already done (CPL-3927)", async () => {
+    const dependentId = "30000000-0000-4000-8000-000000000003";
+    const blockerId1 = "10000000-0000-4000-8000-000000000001";
+    const blockerId2 = "20000000-0000-4000-8000-000000000002";
+    mockIssueService.getById.mockResolvedValue({
+      id: dependentId,
+      companyId: "company-1",
+      identifier: "PAP-102",
+      title: "Dependent task",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-3",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: dependentId,
+      companyId: "company-1",
+      identifier: "PAP-102",
+      title: "Dependent task",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-3",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    // All blockers are already terminal — no unresolved blockers
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: dependentId,
+      blockerIssueIds: [blockerId1, blockerId2],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${dependentId}`)
+      .send({ status: "blocked", blockedByIssueIds: [blockerId1, blockerId2] });
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockWakeup).toHaveBeenCalledWith(
+        "agent-3",
+        expect.objectContaining({
+          reason: "issue_blockers_resolved",
+          payload: expect.objectContaining({
+            issueId: dependentId,
+            blockerIssueIds: [blockerId1, blockerId2],
+          }),
+          contextSnapshot: expect.objectContaining({
+            source: "issue.blockers_resolved_on_link",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("does NOT auto-resume when blockedByIssueIds has unresolved blockers", async () => {
+    const dependentId = "40000000-0000-4000-8000-000000000004";
+    const doneBlockerId = "50000000-0000-4000-8000-000000000005";
+    const activeBlockerId = "60000000-0000-4000-8000-000000000006";
+    mockIssueService.getById.mockResolvedValue({
+      id: dependentId,
+      companyId: "company-1",
+      identifier: "PAP-103",
+      title: "Dependent with unresolved blocker",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-4",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: dependentId,
+      companyId: "company-1",
+      identifier: "PAP-103",
+      title: "Dependent with unresolved blocker",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+      parentId: null,
+      assigneeAgentId: "agent-4",
+      assigneeUserId: null,
+      createdByAgentId: null,
+      createdByUserId: null,
+      executionWorkspaceId: null,
+      labels: [],
+      labelIds: [],
+    });
+    // One blocker still unresolved
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: dependentId,
+      blockerIssueIds: [doneBlockerId, activeBlockerId],
+      unresolvedBlockerIssueIds: [activeBlockerId],
+      unresolvedBlockerCount: 1,
+      pendingFinalizeBlockerIssueIds: [],
+      allBlockersDone: false,
+      isDependencyReady: false,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${dependentId}`)
+      .send({ status: "blocked", blockedByIssueIds: [doneBlockerId, activeBlockerId] });
+    expect(res.status).toBe(200);
+    // Wait briefly to allow any async wakeup to fire, then verify it didn't
+    await new Promise((r) => setTimeout(r, 50));
+    const wakeupCalls = mockWakeup.mock.calls.filter(
+      ([, opts]: [string, any]) => opts?.reason === "issue_blockers_resolved",
+    );
+    expect(wakeupCalls).toHaveLength(0);
   });
 });

--- a/server/src/routes/company-skills.ts
+++ b/server/src/routes/company-skills.ts
@@ -138,7 +138,7 @@ export function companySkillRoutes(db: Db) {
   });
 
   router.get("/companies/:companyId/skills", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = await svc.resolveCompanyId(req.params.companyId as string);
     assertCompanyAccess(req, companyId);
     const result = await svc.list(companyId, companySkillListQuerySchema.parse({
       q: firstQueryString(req.query.q),
@@ -160,7 +160,7 @@ export function companySkillRoutes(db: Db) {
   });
 
   router.get("/companies/:companyId/skills/:skillId", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = await svc.resolveCompanyId(req.params.companyId as string);
     const skillId = req.params.skillId as string;
     assertCompanyAccess(req, companyId);
     const result = await svc.detail(companyId, skillId, skillActor(req));
@@ -365,7 +365,7 @@ export function companySkillRoutes(db: Db) {
   });
 
   router.get("/companies/:companyId/skills/:skillId/update-status", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = await svc.resolveCompanyId(req.params.companyId as string);
     const skillId = req.params.skillId as string;
     assertCompanyAccess(req, companyId);
     const result = await svc.updateStatus(companyId, skillId);
@@ -377,7 +377,7 @@ export function companySkillRoutes(db: Db) {
   });
 
   router.get("/companies/:companyId/skills/:skillId/files", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = await svc.resolveCompanyId(req.params.companyId as string);
     const skillId = req.params.skillId as string;
     const relativePath = String(req.query.path ?? "SKILL.md");
     assertCompanyAccess(req, companyId);
@@ -393,7 +393,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills",
     validate(companySkillCreateSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       await assertCanMutateCompanySkills(req, companyId);
       const result = await svc.createLocalSkill(companyId, req.body, skillActor(req));
 
@@ -450,7 +450,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills/:skillId/files",
     validate(companySkillFileUpdateSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       const skillId = req.params.skillId as string;
       await assertCanMutateCompanySkills(req, companyId);
       const result = await svc.updateFile(
@@ -485,7 +485,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills/import",
     validate(companySkillImportSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       await assertCanMutateCompanySkills(req, companyId);
       const source = String(req.body.source ?? "");
       const result = await svc.importFromSource(companyId, source);
@@ -525,7 +525,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills/install-catalog",
     validate(companySkillInstallCatalogSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       await assertCanMutateCompanySkills(req, companyId);
       const result = await svc.installFromCatalog(companyId, req.body);
 
@@ -557,7 +557,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills/scan-projects",
     validate(companySkillProjectScanRequestSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       await assertCanMutateCompanySkills(req, companyId);
       const result = await svc.scanProjectWorkspaces(companyId, req.body);
 
@@ -587,7 +587,7 @@ export function companySkillRoutes(db: Db) {
   );
 
   router.delete("/companies/:companyId/skills/:skillId", async (req, res) => {
-    const companyId = req.params.companyId as string;
+    const companyId = await svc.resolveCompanyId(req.params.companyId as string);
     const skillId = req.params.skillId as string;
     await assertCanMutateCompanySkills(req, companyId);
     const result = await svc.deleteSkill(companyId, skillId);
@@ -618,7 +618,7 @@ export function companySkillRoutes(db: Db) {
   router.post(
     "/companies/:companyId/skills/:skillId/audit",
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       const skillId = req.params.skillId as string;
       await assertCanMutateCompanySkills(req, companyId);
       const result = await svc.auditSkill(companyId, skillId);
@@ -654,7 +654,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills/:skillId/install-update",
     validate(companySkillInstallUpdateSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       const skillId = req.params.skillId as string;
       await assertCanMutateCompanySkills(req, companyId);
       const before = await svc.getById(companyId, skillId);
@@ -694,7 +694,7 @@ export function companySkillRoutes(db: Db) {
     "/companies/:companyId/skills/:skillId/reset",
     validate(companySkillResetSchema),
     async (req, res) => {
-      const companyId = req.params.companyId as string;
+      const companyId = await svc.resolveCompanyId(req.params.companyId as string);
       const skillId = req.params.skillId as string;
       await assertCanMutateCompanySkills(req, companyId);
       const before = await svc.getById(companyId, skillId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4449,6 +4449,40 @@ export function issueRoutes(
       requestedByActorId: actor.actorId,
     });
 
+    // When an issue is created with blockedByIssueIds and all blockers are already
+    // terminal (done/cancelled), auto-resume immediately (CPL-3927).
+    void (async () => {
+      if (
+        Array.isArray(req.body.blockedByIssueIds) &&
+        issue.status === "blocked" &&
+        issue.assigneeAgentId
+      ) {
+        const readiness = await svc.getDependencyReadiness(issue.id);
+        if (readiness.unresolvedBlockerCount === 0 && readiness.blockerIssueIds.length > 0) {
+          heartbeat.wakeup(issue.assigneeAgentId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_blockers_resolved",
+            payload: {
+              issueId: issue.id,
+              blockerIssueIds: readiness.blockerIssueIds,
+            },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: issue.id,
+              taskId: issue.id,
+              wakeReason: "issue_blockers_resolved",
+              source: "issue.blockers_resolved_on_create",
+              blockerIssueIds: readiness.blockerIssueIds,
+            },
+          }).catch((err) =>
+            logger.warn({ err, issueId: issue.id }, "failed to wake agent on create with all-blockers-done"),
+          );
+        }
+      }
+    })();
+
     res.status(201).json({
       ...issue,
       relatedWork: referenceSummary,
@@ -5755,6 +5789,35 @@ export function issueRoutes(
               source: "issue.blockers_resolved",
               resolvedBlockerIssueId: issue.id,
               blockerIssueIds: dependent.blockerIssueIds,
+            },
+          });
+        }
+      }
+
+      // When blockedByIssueIds is set and all blockers are already terminal (done/cancelled),
+      // the dependent would otherwise stay blocked forever because issue_blockers_resolved
+      // only fires on blocker status transitions (CPL-3927). Auto-resume immediately.
+      const blockersSetInThisRequest = Array.isArray(req.body.blockedByIssueIds);
+      const issueIsBlocked = issue.status === "blocked";
+      if (blockersSetInThisRequest && issueIsBlocked && issue.assigneeAgentId) {
+        const readiness = await svc.getDependencyReadiness(issue.id);
+        if (readiness.unresolvedBlockerCount === 0 && readiness.blockerIssueIds.length > 0) {
+          addWakeup(issue.assigneeAgentId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_blockers_resolved",
+            payload: {
+              issueId: issue.id,
+              blockerIssueIds: readiness.blockerIssueIds,
+            },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: issue.id,
+              taskId: issue.id,
+              wakeReason: "issue_blockers_resolved",
+              source: "issue.blockers_resolved_on_link",
+              blockerIssueIds: readiness.blockerIssueIds,
             },
           });
         }

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -45,7 +45,7 @@ import type {
   CompanySkillVersionCreateRequest,
   CompanySkillVersionFileInventoryEntry,
 } from "@paperclipai/shared";
-import { normalizeAgentUrlKey } from "@paperclipai/shared";
+import { normalizeAgentUrlKey, isUuidLike } from "@paperclipai/shared";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
@@ -4544,7 +4544,19 @@ export function companySkillService(db: Db) {
     return skill;
   }
 
+  async function resolveCompanyId(input: string): Promise<string> {
+    if (isUuidLike(input)) return input;
+    const company = await db
+      .select({ id: companies.id })
+      .from(companies)
+      .where(eq(companies.issuePrefix, input))
+      .then((rows) => rows[0] ?? null);
+    if (!company) throw notFound(`Company not found: ${input}`);
+    return company.id;
+  }
+
   return {
+    resolveCompanyId,
     list,
     listFull,
     getById,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3438,7 +3438,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return "timeout_exceeded";
     }
     const maxAttempts = input.monitor?.maxAttempts ?? null;
-    if (maxAttempts !== null && input.nextAttemptCount > maxAttempts) {
+    if (maxAttempts != null && input.nextAttemptCount > maxAttempts) {
       return "max_attempts_exhausted";
     }
     return null;
@@ -7582,6 +7582,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.scanSilentActiveRuns(opts);
   }
 
+  async function cleanupStaleWakeupClaims(opts?: { companyId?: string }) {
+    return recovery.cleanupStaleWakeupClaims(opts);
+  }
+
   async function reconcileProductivityReviews(opts?: { now?: Date; companyId?: string }) {
     return productivityReviews.reconcileProductivityReviews(opts);
   }
@@ -11470,6 +11474,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reconcileIssueGraphLiveness,
 
     scanSilentActiveRuns,
+    cleanupStaleWakeupClaims,
 
     reconcileProductivityReviews,
 

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -285,7 +285,7 @@ function exhaustedMonitorClearReason(input: {
     return "timeout_exceeded";
   }
   const maxAttempts = input.monitor.maxAttempts ?? null;
-  if (maxAttempts !== null && input.attemptCount >= maxAttempts) {
+  if (maxAttempts != null && input.attemptCount >= maxAttempts) {
     return "max_attempts_exhausted";
   }
   return null;

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -161,7 +161,7 @@ export function issueRecoveryActionService(db: Db) {
     input: UpsertIssueRecoveryActionInput,
     retryCount: number,
     error?: unknown,
-  ): Promise<IssueRecoveryAction> {
+  ): Promise<IssueRecoveryAction | null> {
     if (retryCount >= MAX_UPSERT_RETRIES) {
       if (error) throw error;
       throw new Error(
@@ -174,11 +174,15 @@ export function issueRecoveryActionService(db: Db) {
   async function upsertSourceScopedUnlocked(
     input: UpsertIssueRecoveryActionInput,
     retryCount = 0,
-  ): Promise<IssueRecoveryAction> {
+  ): Promise<IssueRecoveryAction | null> {
     const existing = await getActiveForIssue(input.companyId, input.sourceIssueId);
     const now = new Date();
     const ownerType = input.ownerType ?? (input.ownerAgentId ? "agent" : "board");
     if (existing) {
+      // Если достигнут лимит попыток — не создаём новую recovery action
+      if (input.maxAttempts != null && existing.attemptCount >= input.maxAttempts) {
+        return null;
+      }
       const [updated] = await db
         .update(issueRecoveryActions)
         .set({
@@ -253,7 +257,7 @@ export function issueRecoveryActionService(db: Db) {
 
   async function upsertSourceScoped(
     input: UpsertIssueRecoveryActionInput,
-  ): Promise<IssueRecoveryAction> {
+  ): Promise<IssueRecoveryAction | null> {
     return runExclusiveUpsert(input, () => upsertSourceScopedUnlocked(input));
   }
 

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -180,7 +180,7 @@ function hasScheduledMonitor(issue: IssueLivenessIssueInput, nowMs: number) {
   const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
   const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
   const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
-  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+  if (maxAttempts != null && attemptCount >= maxAttempts) return false;
 
   return true;
 }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -66,6 +66,7 @@ import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js"
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
+const ORPHANED_LOCK_TIMEOUT_MS = ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
@@ -1684,6 +1685,43 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         return { kind: "skipped" as const };
       }
     }
+
+    // Time-based fallback for orphaned locks without detectable process
+    // Covers: non-sessioned adapters, lost PIDs, and runs without process metadata
+    if (processCheck.outcome === "skipped_non_local_adapter" || processCheck.outcome === "no_process_metadata") {
+      // Use the earlier of processStartedAt or startedAt as the run age baseline
+      const runStartedAt = input.run.processStartedAt ?? input.run.startedAt ?? input.run.createdAt;
+      if (runStartedAt) {
+        const runAgeMs = input.now.getTime() - runStartedAt.getTime();
+        if (runAgeMs >= ORPHANED_LOCK_TIMEOUT_MS) {
+          // Check if agent has another live run (besides this one) or agent is idle — strong signal run is orphaned
+          const otherRunningRun = await db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(
+              and(
+                eq(heartbeatRuns.agentId, runningAgent.id),
+                eq(heartbeatRuns.status, "running"),
+                ne(heartbeatRuns.id, input.run.id),
+              ),
+            )
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+          const hasOtherActiveRun = otherRunningRun !== null;
+          const agentIsIdle = runningAgent.status === "idle";
+          if (hasOtherActiveRun || agentIsIdle) {
+            return finalizeOrphanedRun({
+              run: input.run,
+              runningAgent,
+              sourceIssue,
+              existingEvaluation: existing,
+              now: input.now,
+            });
+          }
+        }
+      }
+    }
+
 
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -195,6 +195,7 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS = 2;
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -1852,6 +1853,45 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return result;
   }
 
+  async function cleanupStaleWakeupClaims(opts?: { companyId?: string }) {
+    const now = new Date();
+    const staleClaims = await db
+      .select({
+        wakeup: agentWakeupRequests,
+        runStatus: heartbeatRuns.status,
+      })
+      .from(agentWakeupRequests)
+      .innerJoin(heartbeatRuns, eq(agentWakeupRequests.runId, heartbeatRuns.id))
+      .where(
+        and(
+          opts?.companyId ? eq(agentWakeupRequests.companyId, opts.companyId) : undefined,
+          eq(agentWakeupRequests.status, 'claimed'),
+          inArray(heartbeatRuns.status, ['failed', 'done', 'cancelled']),
+        ),
+      )
+      .limit(100);
+
+    const released = [];
+    for (const row of staleClaims) {
+      await db
+        .update(agentWakeupRequests)
+        .set({
+          status: 'failed',
+          finishedAt: now,
+          runId: null,
+          error: `Stale claim released: terminal run ${row.wakeup.runId} has status "${row.runStatus}"`,
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, row.wakeup.id));
+      released.push(row.wakeup.id);
+    }
+
+    return {
+      scanned: staleClaims.length,
+      released: released.length,
+    };
+  }
+
   async function recordWatchdogDecision(input: {
     runId: string;
     actor: WatchdogDecisionActor;
@@ -2324,7 +2364,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           reason: "no_invokable_recovery_owner",
         },
       monitorPolicy: null,
-      maxAttempts: null,
+      maxAttempts: DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS,
       lastAttemptAt: now,
     });
 
@@ -2337,6 +2377,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     recoveryCause: StrandedRecoveryCause;
   }) {
+    if (!input.action) return;
     if (input.recoveryCause === "workspace_validation_failed") return;
     if (!input.action.ownerAgentId) return;
     await deps.enqueueWakeup(input.action.ownerAgentId, {
@@ -2391,6 +2432,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       "- Guard: recovery issues do not create nested `stranded_issue_recovery` issues.",
       "",
       "Next action: the current recovery owner should inspect the failed run evidence, restore a live execution path or record the manual resolution, then move this recovery issue out of `blocked`.",
+    ].join("\n");
+  }
+  function buildRecoveryExhaustedComment(input: {
+    issue: typeof issues.$inferSelect;
+    attemptCount: number;
+    maxAttempts: number;
+    recoveryActionId: string | null;
+    prefix: string;
+  }) {
+    const recoveryActionLink = input.recoveryActionId
+      ? `[${input.recoveryActionId}](/${input.prefix}/issues/${input.issue.identifier}#recovery-action)`
+      : "none";
+    return [
+      "Paperclip stopped automatic stranded‑issue recovery after exhausting the retry limit.",
+      "",
+      `- Issue: ${issueUiLink({ identifier: input.issue.identifier, id: input.issue.id }, input.prefix)}`,
+      `- Recovery attempts: ${input.attemptCount} of ${input.maxAttempts}`,
+      `- Recovery action: ${recoveryActionLink}`,
+      "- Cause: repeated stranded‑work detection without a successful live execution path.",
+      "",
+      "Next action: a board operator or the issue’s original assignee must inspect the stuck work, restore a live execution path, or record an intentional manual resolution.",
     ].join("\n");
   }
 
@@ -2500,6 +2562,55 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    // Если recovery action не создана из-за исчерпания лимита попыток
+    if (recoveryAction === null) {
+      const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(input.issue.companyId, input.issue.id);
+      const prefix = await getCompanyIssuePrefix(input.issue.companyId);
+      const updated = await issuesSvc.update(input.issue.id, {
+        status: "blocked",
+        blockedByIssueIds: blockerIds,
+        assigneeAgentId: input.issue.assigneeAgentId,
+      });
+      if (!updated) return null;
+      await issuesSvc.addComment(
+        input.issue.id,
+        buildRecoveryExhaustedComment({
+          issue: input.issue,
+          attemptCount: activeRecoveryAction?.attemptCount ?? DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS,
+          maxAttempts: activeRecoveryAction?.maxAttempts ?? DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS,
+          recoveryActionId: activeRecoveryAction?.id ?? null,
+          prefix,
+        }),
+        {},
+        { authorType: "system" },
+      );
+      await logActivity(db, {
+        companyId: input.issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.recovery_exhausted",
+        entityType: "issue",
+        entityId: input.issue.id,
+        details: {
+          identifier: input.issue.identifier,
+          status: "blocked",
+          previousStatus: input.previousStatus,
+          source: "recovery.reconcile_stranded_assigned_issue",
+          recoveryCause,
+          latestRunId: input.latestRun?.id ?? null,
+          latestRunStatus: input.latestRun?.status ?? null,
+          latestRunErrorCode: input.latestRun?.errorCode ?? null,
+          recoveryActionId: activeRecoveryAction?.id ?? null,
+          attemptCount: activeRecoveryAction?.attemptCount ?? null,
+          maxAttempts: activeRecoveryAction?.maxAttempts ?? null,
+          exhausted: true,
+        },
+      });
+      // Не планируем новый wake
+      return updated;
+    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
@@ -3927,6 +4038,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,
     scanSilentActiveRuns,
+    cleanupStaleWakeupClaims,
     reconcileStrandedAssignedIssues,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,

--- a/server/src/services/skills-catalog.ts
+++ b/server/src/services/skills-catalog.ts
@@ -19,10 +19,33 @@ interface CatalogManifestFile {
   skills: CatalogSkill[];
 }
 
-const serviceDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(serviceDir, "../../..");
-const catalogPackageRoot = path.join(repoRoot, "packages/skills-catalog");
-const catalogManifestPath = path.join(catalogPackageRoot, "generated/catalog.json");
+const EMPTY_CATALOG_MANIFEST: CatalogManifestFile = {
+  packageName: "@paperclipai/skills-catalog",
+  packageVersion: "0.0.0",
+  skills: [],
+};
+
+function resolveCatalogManifestPath(): string {
+  // Try using import.meta.resolve to find the package's catalog.json.
+  // This works when running from an installed npm package.
+  try {
+    const resolved = import.meta.resolve(
+      "@paperclipai/skills-catalog/catalog.json",
+    );
+    if (typeof resolved === "string" && resolved.startsWith("file://")) {
+      return fileURLToPath(resolved);
+    }
+  } catch {
+    // Fall through to relative path for monorepo dev mode
+  }
+
+  // Fallback: monorepo dev mode relative path from server/dist/services/
+  const serviceDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(serviceDir, "../../..");
+  return path.join(repoRoot, "packages/skills-catalog", "generated", "catalog.json");
+}
+
+const catalogManifestPath = resolveCatalogManifestPath();
 let cachedCatalogManifest: {
   manifest: CatalogManifestFile;
   mtimeMs: number;
@@ -31,18 +54,15 @@ let cachedCatalogManifest: {
 
 function loadCatalogManifest(): CatalogManifestFile {
   if (!existsSync(catalogManifestPath)) {
-    throw new Error(
-      `Skills catalog manifest not found at ${catalogManifestPath}. Run pnpm --filter @paperclipai/skills-catalog build:manifest.`,
-    );
+    return EMPTY_CATALOG_MANIFEST;
   }
   return JSON.parse(readFileSync(catalogManifestPath, "utf8")) as CatalogManifestFile;
 }
 
 function getCatalogManifest() {
   if (!existsSync(catalogManifestPath)) {
-    throw new Error(
-      `Skills catalog manifest not found at ${catalogManifestPath}. Run pnpm --filter @paperclipai/skills-catalog build:manifest.`,
-    );
+    cachedCatalogManifest = null;
+    return EMPTY_CATALOG_MANIFEST;
   }
   const stats = statSync(catalogManifestPath);
   if (
@@ -93,7 +113,8 @@ function inferLanguageFromPath(filePath: string) {
 }
 
 function resolveCatalogPackageRoot() {
-  return catalogPackageRoot;
+  // The catalog.json is at <packageRoot>/generated/catalog.json
+  return path.dirname(path.dirname(catalogManifestPath));
 }
 
 function sourceRootPath(source: CatalogSkillSource) {


### PR DESCRIPTION
## Context

The skills catalog manifest was missing after `npm i -g paperclipai` because `@paperclipai/skills-catalog` was not published (publishFromCi: false) and the server did not declare it as a dependency. The server resolves the manifest via `import.meta.resolve("@paperclipai/skills-catalog/catalog.json")`, which only works when the package is installed alongside the server.

## Changes
- Enable publishing of @paperclipai/skills-catalog in the release manifest.
- Declare @paperclipai/skills-catalog as a server dependency (workspace:*).
- Lockfile updated to link the server importer to the workspace package.

## Verification
- `import.meta.resolve("@paperclipai/skills-catalog/catalog.json")` resolves to a real existing file.
- `pnpm run build:manifest` regenerates `generated/catalog.json` (11 skills, valid JSON); already wired into `pnpm build`.
- After publishing, `npm i -g paperclipai` will install skills-catalog alongside server, and `GET /api/skills/catalog` will return 200 on fresh installs.

## Related issue
CPL-4783