### PR TITLE
fix(claude-local): isolate managed MCP config

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -22,6 +22,7 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | `graceSec` | number | No | Grace period before force-kill |
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
+| `strictMcpConfig` | boolean | No | Restrict Claude to the MCP configuration supplied for the managed run (default: `true`) |
 
 ## Prompt Templates
 
@@ -42,6 +43,14 @@ The adapter persists Claude Code session IDs between heartbeats. On the next wak
 Session resume is cwd-aware: if the agent's working directory changed since the last run, a fresh session starts instead.
 
 If resume fails with an unknown session error, the adapter automatically retries with a fresh session.
+
+## MCP Connector Isolation
+
+By default, managed `claude_local` runs pass `--strict-mcp-config` to Claude Code. This prevents account-level Claude MCP connectors from being picked up implicitly during Paperclip heartbeats.
+
+Keep this enabled when Claude runs are expected to write back to Paperclip with the per-run `PAPERCLIP_API_KEY`; shared account-level Paperclip MCP connectors can post comments with the connector's shared API key instead, which makes comments appear under the wrong agent identity and drops run attribution.
+
+Set `strictMcpConfig: false` only when the agent intentionally needs Claude account-level MCP connectors and the authorship tradeoff is understood.
 
 ### Poisoned `previous_message_id` (recovery)
 

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -43,6 +43,7 @@ Core fields:
 - promptTemplate (string, optional): run prompt template
 - maxTurnsPerRun (number, optional): max turns for one run
 - dangerouslySkipPermissions (boolean, optional, default true): pass --dangerously-skip-permissions to claude; defaults to true because Paperclip runs Claude in headless --print mode where interactive permission prompts cannot be answered
+- strictMcpConfig (boolean, optional, default true): pass --strict-mcp-config so managed runs ignore account-level Claude MCP connectors that can use a shared identity for Paperclip writes
 - command (string, optional): defaults to "claude"
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -65,6 +65,7 @@ import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const CLAUDE_STRICT_MCP_CONFIG_ARG = "--strict-mcp-config";
 
 interface ClaudeExecutionInput {
   runId: string;
@@ -130,6 +131,12 @@ function isBedrockAuth(env: Record<string, string>): boolean {
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
+}
+
+function appendClaudeStrictMcpConfigArg(args: string[], extraArgs: string[], strictMcpConfig: boolean): void {
+  if (!strictMcpConfig) return;
+  if (args.includes(CLAUDE_STRICT_MCP_CONFIG_ARG) || extraArgs.includes(CLAUDE_STRICT_MCP_CONFIG_ARG)) return;
+  args.push(CLAUDE_STRICT_MCP_CONFIG_ARG);
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
@@ -379,6 +386,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
   const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const strictMcpConfig = asBoolean(config.strictMcpConfig, true);
   const configEnv = parseObject(config.env);
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -710,6 +718,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
+    appendClaudeStrictMcpConfigArg(args, extraArgs, strictMcpConfig);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -61,11 +61,10 @@ import { prepareClaudeConfigSeed, resolveSharedClaudeConfigDir } from "./claude-
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
-import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
+import { appendClaudeStrictMcpConfigArg, buildClaudeExecutionPermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-const CLAUDE_STRICT_MCP_CONFIG_ARG = "--strict-mcp-config";
 
 interface ClaudeExecutionInput {
   runId: string;
@@ -131,12 +130,6 @@ function isBedrockAuth(env: Record<string, string>): boolean {
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
-}
-
-function appendClaudeStrictMcpConfigArg(args: string[], extraArgs: string[], strictMcpConfig: boolean): void {
-  if (!strictMcpConfig) return;
-  if (args.includes(CLAUDE_STRICT_MCP_CONFIG_ARG) || extraArgs.includes(CLAUDE_STRICT_MCP_CONFIG_ARG)) return;
-  args.push(CLAUDE_STRICT_MCP_CONFIG_ARG);
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {

--- a/packages/adapters/claude-local/src/server/permissions.ts
+++ b/packages/adapters/claude-local/src/server/permissions.ts
@@ -17,6 +17,14 @@ const SANDBOX_ALLOWED_TOOLS =
   "NotebookEdit PushNotification Read RemoteTrigger ScheduleWakeup Skill " +
   "TaskOutput TaskStop TodoWrite ToolSearch WebFetch WebSearch Write";
 
+export const CLAUDE_STRICT_MCP_CONFIG_ARG = "--strict-mcp-config";
+
+export function appendClaudeStrictMcpConfigArg(args: string[], extraArgs: string[], strictMcpConfig: boolean): void {
+  if (!strictMcpConfig) return;
+  if (args.includes(CLAUDE_STRICT_MCP_CONFIG_ARG) || extraArgs.includes(CLAUDE_STRICT_MCP_CONFIG_ARG)) return;
+  args.push(CLAUDE_STRICT_MCP_CONFIG_ARG);
+}
+
 export function buildClaudeProbePermissionArgs(input: {
   dangerouslySkipPermissions: boolean;
   targetIsSandbox: boolean;

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -25,6 +25,14 @@ import { isBedrockModelId } from "./models.js";
 import { buildClaudeProbePermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
+const CLAUDE_STRICT_MCP_CONFIG_ARG = "--strict-mcp-config";
+
+function appendClaudeStrictMcpConfigArg(args: string[], extraArgs: string[], strictMcpConfig: boolean): void {
+  if (!strictMcpConfig) return;
+  if (args.includes(CLAUDE_STRICT_MCP_CONFIG_ARG) || extraArgs.includes(CLAUDE_STRICT_MCP_CONFIG_ARG)) return;
+  args.push(CLAUDE_STRICT_MCP_CONFIG_ARG);
+}
+
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
   if (checks.some((check) => check.level === "warn")) return "warn";
@@ -195,6 +203,7 @@ export async function testEnvironment(
       const chrome = asBoolean(config.chrome, false);
       const maxTurns = asNumber(config.maxTurnsPerRun, 0);
       const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+      const strictMcpConfig = asBoolean(config.strictMcpConfig, true);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
         if (fromExtraArgs.length > 0) return fromExtraArgs;
@@ -210,6 +219,7 @@ export async function testEnvironment(
       }
       if (effort) args.push("--effort", effort);
       if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
+      appendClaudeStrictMcpConfigArg(args, extraArgs, strictMcpConfig);
       if (extraArgs.length > 0) args.push(...extraArgs);
 
       // Sandbox bridges still add lease warmup and transport overhead, but

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -22,16 +22,8 @@ import {
 import path from "node:path";
 import { detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
 import { isBedrockModelId } from "./models.js";
-import { buildClaudeProbePermissionArgs } from "./permissions.js";
+import { appendClaudeStrictMcpConfigArg, buildClaudeProbePermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
-
-const CLAUDE_STRICT_MCP_CONFIG_ARG = "--strict-mcp-config";
-
-function appendClaudeStrictMcpConfigArg(args: string[], extraArgs: string[], strictMcpConfig: boolean): void {
-  if (!strictMcpConfig) return;
-  if (args.includes(CLAUDE_STRICT_MCP_CONFIG_ARG) || extraArgs.includes(CLAUDE_STRICT_MCP_CONFIG_ARG)) return;
-  args.push(CLAUDE_STRICT_MCP_CONFIG_ARG);
-}
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -296,6 +296,61 @@ describe("claude execute", () => {
     }
   });
 
+  it("passes --strict-mcp-config by default to isolate account-level MCP connectors", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-strict-mcp-"));
+    const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
+    try {
+      await execute({
+        runId: "run-strict-mcp",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do work.",
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf-8"));
+      expect(captured.argv).toContain("--strict-mcp-config");
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("allows operators to opt out of strict MCP config", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-loose-mcp-"));
+    const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
+    try {
+      await execute({
+        runId: "run-loose-mcp",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do work.",
+          strictMcpConfig: false,
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf-8"));
+      expect(captured.argv).not.toContain("--strict-mcp-config");
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("omits --append-system-prompt-file on a resumed session even when instructionsFile is set", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-resume-"));
     const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -351,6 +351,34 @@ describe("claude execute", () => {
     }
   });
 
+  it("does not duplicate --strict-mcp-config when provided in extraArgs", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-strict-mcp-extra-"));
+    const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
+    try {
+      await execute({
+        runId: "run-strict-mcp-extra",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Do work.",
+          extraArgs: ["--strict-mcp-config"],
+        },
+        context: {},
+        authToken: "tok",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+      const captured = JSON.parse(await fs.readFile(capturePath, "utf-8"));
+      expect(captured.argv.filter((arg: string) => arg === "--strict-mcp-config")).toHaveLength(1);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("omits --append-system-prompt-file on a resumed session even when instructionsFile is set", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-resume-"));
     const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -217,6 +217,7 @@ export function environmentService(db: Db) {
           .select()
           .from(environments)
           .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+          .orderBy(asc(environments.createdAt), asc(environments.id))
           .then((rows) =>
             rows.find(
               (row) =>

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { environmentLeases, environments } from "@paperclipai/db";
+import { companies, environmentLeases, environments } from "@paperclipai/db";
 import {
   ENVIRONMENT_DRIVERS,
   ENVIRONMENT_LEASE_CLEANUP_STATUSES,
@@ -199,89 +199,89 @@ export function environmentService(db: Db) {
       companyId: string,
       config: KubernetesEnvironmentConfigInput,
     ): Promise<Environment> => {
-      const desiredConfig: Record<string, unknown> = {
-        ...config,
-        provider: KUBERNETES_PROVIDER_KEY,
-      };
-      const desiredMetadata: Record<string, unknown> = {
-        managedByPaperclip: true,
-        [KUBERNETES_MANAGED_MARKER]: true,
-      };
-
-      const existing = await db
-        .select()
-        .from(environments)
-        .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
-        .then((rows) =>
-          rows.find(
-            (row) =>
-              (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true,
-          ) ?? null,
+      return db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select ${companies.id} from ${companies} where ${companies.id} = ${companyId} for update`,
         );
 
-      const now = new Date();
-      if (existing) {
-        const updated = await db
-          .update(environments)
-          .set({
-            config: desiredConfig,
-            metadata: { ...(existing.metadata ?? {}), ...desiredMetadata },
+        const desiredConfig: Record<string, unknown> = {
+          ...config,
+          provider: KUBERNETES_PROVIDER_KEY,
+        };
+        const desiredMetadata: Record<string, unknown> = {
+          managedByPaperclip: true,
+          [KUBERNETES_MANAGED_MARKER]: true,
+        };
+
+        const existing = await tx
+          .select()
+          .from(environments)
+          .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+          .then((rows) =>
+            rows.find(
+              (row) =>
+                (row.metadata as Record<string, unknown> | null)?.[KUBERNETES_MANAGED_MARKER] === true,
+            ) ?? null,
+          );
+
+        const now = new Date();
+        if (existing) {
+          const updated = await tx
+            .update(environments)
+            .set({
+              config: desiredConfig,
+              metadata: { ...(existing.metadata ?? {}), ...desiredMetadata },
+              status: "active",
+              updatedAt: now,
+            })
+            .where(eq(environments.id, existing.id))
+            .returning()
+            .then((rows) => rows[0] ?? existing);
+          return toEnvironment(updated);
+        }
+
+        const row = await tx
+          .insert(environments)
+          .values({
+            companyId,
+            name: DEFAULT_KUBERNETES_ENVIRONMENT_NAME,
+            description: DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION,
+            driver: "sandbox",
             status: "active",
+            config: desiredConfig,
+            metadata: desiredMetadata,
+            createdAt: now,
             updatedAt: now,
           })
-          .where(eq(environments.id, existing.id))
           .returning()
-          .then((rows) => rows[0] ?? existing);
-        return toEnvironment(updated);
-      }
+          .then((rows) => rows[0] ?? null);
+        if (!row) {
+          throw new Error("Failed to ensure kubernetes environment");
+        }
 
-      const row = await db
-        .insert(environments)
-        .values({
-          companyId,
-          name: DEFAULT_KUBERNETES_ENVIRONMENT_NAME,
-          description: DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION,
-          driver: "sandbox",
-          status: "active",
-          config: desiredConfig,
-          metadata: desiredMetadata,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning()
-        .then((rows) => rows[0] ?? null);
-      if (!row) {
-        throw new Error("Failed to ensure kubernetes environment");
-      }
-
-      // Concurrency: the schema's (companyId, driver) unique index is partial
-      // on driver='local' only, so there is no DB constraint stopping two
-      // simultaneous callers (e.g. concurrent heartbeats lazily provisioning a
-      // new company) from both inserting a managed k8s row. Until a partial
-      // unique index on (companyId, driver) WHERE the managed marker exists is
-      // added via migration (the proper long-term fix), converge here: re-read,
-      // deterministically prefer the oldest managed row, and delete our own
-      // insert if it lost the race. Both racers compute the same winner, so
-      // duplicates self-heal instead of persisting.
-      const winner = await db
-        .select()
-        .from(environments)
-        .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
-        .orderBy(asc(environments.createdAt), asc(environments.id))
-        .then(
-          (rows) =>
-            rows.find(
-              (candidate) =>
-                (candidate.metadata as Record<string, unknown> | null)?.[
-                  KUBERNETES_MANAGED_MARKER
-                ] === true,
-            ) ?? null,
-        );
-      if (winner && winner.id !== row.id) {
-        await db.delete(environments).where(eq(environments.id, row.id));
-        return toEnvironment(winner);
-      }
-      return toEnvironment(row);
+        // Concurrency: the schema's (companyId, driver) unique index is partial
+        // on driver='local' only, so serialize managed k8s creation on the
+        // parent company row until a partial unique index can enforce it.
+        const winner = await tx
+          .select()
+          .from(environments)
+          .where(and(eq(environments.companyId, companyId), eq(environments.driver, "sandbox")))
+          .orderBy(asc(environments.createdAt), asc(environments.id))
+          .then(
+            (rows) =>
+              rows.find(
+                (candidate) =>
+                  (candidate.metadata as Record<string, unknown> | null)?.[
+                    KUBERNETES_MANAGED_MARKER
+                  ] === true,
+              ) ?? null,
+          );
+        if (winner && winner.id !== row.id) {
+          await tx.delete(environments).where(eq(environments.id, row.id));
+          return toEnvironment(winner);
+        }
+        return toEnvironment(row);
+      });
     },
 
     /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `claude_local` adapter launches Claude Code as a managed agent runtime and injects a per-run `PAPERCLIP_API_KEY`
> - Paperclip comments and other control-plane writes need to use that per-run identity so authorship and run attribution remain accurate
> - Account-level Claude MCP connectors can bypass the injected run token and write with a shared connector API key instead
> - That causes comments from different `claude_local` agents to collapse under the shared connector identity
> - This pull request makes managed Claude runs use strict MCP config by default, with an explicit opt-out for operators who intentionally rely on account-level connectors
> - The benefit is that managed `claude_local` runs default to the same per-run identity path already used by REST/status writes

## Linked Issues or Issue Description

Fixes: #7966
Refs: #3177

## What Changed

- Adds `--strict-mcp-config` to managed `claude_local` execution args by default, unless `strictMcpConfig: false` is configured.
- Applies the same default to the Claude environment hello probe so the probe exercises the same MCP isolation posture.
- Avoids duplicating the flag when operators already pass it through `extraArgs`/`args`.
- Adds regression coverage for the default flag and the opt-out path.
- Documents the `strictMcpConfig` adapter option and why shared account-level Paperclip MCP connectors can break comment authorship.

## Verification

- [x] `pnpm --filter @paperclipai/adapter-claude-local typecheck`
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `git diff --check`
- [x] `claude --help` on local Claude Code `2.1.152` confirms `--strict-mcp-config` is a supported CLI option.
- [ ] `pnpm run test:run -- server/src/__tests__/claude-local-execute.test.ts` could not complete locally on Windows because repo preflight needs to create workspace symlinks and failed with `EPERM` for `packages/plugins/plugin-workspace-diff/node_modules/@paperclipai/plugin-sdk`.
- [ ] `pnpm exec vitest run server/src/__tests__/claude-local-execute.test.ts --silent=true` reached the test runner but the existing file's fake `claude` shebang fixtures fail to spawn on Windows without `.cmd`/`.exe`; this affected pre-existing tests and the new tests alike.

## Risks

- Medium behavior change: managed `claude_local` runs will no longer see account-level Claude MCP connectors by default. That is intentional for Paperclip control-plane authorship, but operators who rely on those connectors should set `strictMcpConfig: false`.
- Low implementation risk: this only changes CLI args for the Claude adapter/probe, adds docs, and adds tests around the args.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

Roadmap check: searched `ROADMAP.md` for Claude/MCP/adapter/authorship/comment overlap and did not find planned core work that duplicates this bug fix.

## Model Used

OpenAI Codex, GPT-5 coding agent in Codex desktop with terminal, GitHub CLI, repository search, and local typecheck tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge