### PR TITLE
infra(db): fail-fast guard against in-process embedded-PG when standalone supervisor owns the data dir

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -400,7 +400,19 @@ export async function startServer(): Promise<StartedServer> {
   
     const runningPid = getRunningPid();
     if (runningPid) {
-      logger.warn(`Embedded PostgreSQL already running; reusing existing process (pid=${runningPid}, port=${port})`);
+      // A live postmaster owns the data dir and this process did not spawn it,
+      // so the standalone supervisor (or another paperclip server) is in charge.
+      // Racing it would lead to the rmSync below clobbering the supervisor's
+      // postmaster.pid and two postmasters fighting over the same cluster.
+      // See TSMC-10421 / TSMC-10411 for the corruption hazard this guards against.
+      const supervisorLabel = process.env.PAPERCLIP_POSTGRES_LAUNCHD_LABEL ?? "ie.thinkstack.paperclip-postgres";
+      throw new Error(
+        [
+          `Refusing to start in-process embedded PostgreSQL: data dir ${dataDir} is already owned by a live postmaster (pid=${runningPid}).`,
+          `This is the standalone supervisor (launchd label \`${supervisorLabel}\`) or another paperclip server.`,
+          `Point this server at the supervised cluster by setting DATABASE_URL=postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/paperclip (and database.mode=postgres), or stop the supervisor with \`launchctl bootout gui/$(id -u)/${supervisorLabel}\` before falling back to in-process mode.`,
+        ].join(" "),
+      );
     } else {
       const configuredAdminConnectionString = `postgres://paperclip:paperclip@127.0.0.1:${configuredPort}/postgres`;
       try {


### PR DESCRIPTION
## Summary

Follow-up to [TSMC-10411](/TSMC/issues/TSMC-10411). The standalone Postgres supervisor (`ie.thinkstack.paperclip-postgres`) owns `~/.paperclip/instances/default/db`. `DATABASE_URL` is pinned in both `launchd-start.sh` and `start-source.sh`, so today the in-process embedded path is dormant.

This PR closes the latent footgun: if a future config edit drops `DATABASE_URL` AND sets `database.mode=embedded-postgres`, the embedded branch would call `rmSync(postmaster.pid, { force: true })` on the supervisor's data dir and race a second postmaster against the supervised one.

## What changes

In `server/src/index.ts` (around the `getRunningPid()` consumer), when a live postmaster owns the data dir we now **abort with a clear error** instead of logging `"reusing existing process"` and proceeding. The error names:

- the live PID,
- the launchd label (`ie.thinkstack.paperclip-postgres`, overridable via `PAPERCLIP_POSTGRES_LAUNCHD_LABEL`),
- the two recovery paths (set `DATABASE_URL` at the supervised cluster, or `launchctl bootout gui/$(id -u)/<label>`).

## Docker / onboarding / CI preserved

The discriminator is unchanged — it's still `getRunningPid()`, which only returns a value when `process.kill(pid, 0)` reports a live process. In environments without the supervisor:

- fresh container, no pid file → `getRunningPid()` returns `null` → embedded path runs as before
- stale pid file from a prior run, dead PID → `getRunningPid()` returns `null` → existing stale-pid cleanup proceeds

So only the racing scenario the issue describes is blocked.

## Verification

- `npx tsc --noEmit` passes for `server/src/index.ts` (other pre-existing plugin-sdk resolution errors in `plugin-host-services.ts` etc. are unrelated and present on master baseline).
- Discriminator dry-run on darwin confirmed:
  - live pid (this process) → returned → would throw
  - dead pid (`999999`) → null → embedded path proceeds
  - missing pid file → null → embedded path proceeds

Scope: single change in `server/src/index.ts`. No schema, no deployment, no behavior change for currently-pinned `DATABASE_URL` setups.

## Test plan

- [ ] Manual flip in a worktree: unset `DATABASE_URL`, start `start-source.sh` while `ie.thinkstack.paperclip-postgres` is loaded → server aborts with the new message instead of clobbering `postmaster.pid`.
- [ ] Same flip with the supervisor `bootout`-ed first → embedded PG starts as before (proves the docker/CI path is unaffected).

Issue: [TSMC-10421](/TSMC/issues/TSMC-10421)
Parent context: [TSMC-10411](/TSMC/issues/TSMC-10411)