### PR TITLE
fix: ship skills-catalog with server so catalog survives global install (CPL-4783)

### DIFF
--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-06-04T19:57:14.020Z",
+  "generatedAt": "2026-06-15T23:53:59.018Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -214,6 +214,38 @@
         }
       ],
       "contentHash": "sha256:32372dacaf62e93454b9855968c4eec96456ba78b509f450b3dfaa48e31ef356"
+    },
+    {
+      "id": "paperclipai:bundled:software-development:github-issue-workflow",
+      "key": "paperclipai/bundled/software-development/github-issue-workflow",
+      "kind": "bundled",
+      "category": "software-development",
+      "slug": "github-issue-workflow",
+      "name": "github-issue-workflow",
+      "description": "Prepare a GitHub issue for upstream contribution — issue hygiene, title/body, verification notes, labels, and follow-ups. Use when triaging or filing issues for a repository that prefers issues over PRs.",
+      "path": "catalog/bundled/software-development/github-issue-workflow",
+      "entrypoint": "SKILL.md",
+      "trustLevel": "markdown_only",
+      "compatibility": "compatible",
+      "defaultInstall": false,
+      "recommendedForRoles": [
+        "engineer"
+      ],
+      "requires": [],
+      "tags": [
+        "github",
+        "issues",
+        "upstream-contribution"
+      ],
+      "files": [
+        {
+          "path": "SKILL.md",
+          "kind": "skill",
+          "sizeBytes": 4875,
+          "sha256": "21c2bc59f0fc2b6efe948b3959ec6ce45b31f184d82dacb6e3587edb87f5ff95"
+        }
+      ],
+      "contentHash": "sha256:b5a1b32c78f7380b11b773d92554f8d31aeaaecd133c1f3958311c821cc3809f"
     },
     {
       "id": "paperclipai:bundled:software-development:github-pr-workflow",

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
-  "packageVersion": "0.3.1",
-  "generatedAt": "2026-06-15T23:53:59.018Z",
+  "packageVersion": "0.3.2",
+  "generatedAt": "2026-06-17T10:23:05.668Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",

--- a/packages/skills-catalog/package.json
+++ b/packages/skills-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/skills-catalog",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       '@paperclipai/shared':
         specifier: workspace:*
         version: link:../packages/shared
+      '@paperclipai/skills-catalog':
+        specifier: workspace:*
+        version: link:../packages/skills-catalog
       ajv:
         specifier: ^8.20.0
         version: 8.20.0

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -62,7 +62,7 @@
   {
     "dir": "packages/skills-catalog",
     "name": "@paperclipai/skills-catalog",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/teams-catalog",

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
     "@paperclipai/shared": "workspace:*",
+    "@paperclipai/skills-catalog": "workspace:*",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "better-auth": "1.4.18",

--- a/server/src/services/skills-catalog.ts
+++ b/server/src/services/skills-catalog.ts
@@ -19,10 +19,33 @@ interface CatalogManifestFile {
   skills: CatalogSkill[];
 }
 
-const serviceDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(serviceDir, "../../..");
-const catalogPackageRoot = path.join(repoRoot, "packages/skills-catalog");
-const catalogManifestPath = path.join(catalogPackageRoot, "generated/catalog.json");
+const EMPTY_CATALOG_MANIFEST: CatalogManifestFile = {
+  packageName: "@paperclipai/skills-catalog",
+  packageVersion: "0.0.0",
+  skills: [],
+};
+
+function resolveCatalogManifestPath(): string {
+  // Try using import.meta.resolve to find the package's catalog.json.
+  // This works when running from an installed npm package.
+  try {
+    const resolved = import.meta.resolve(
+      "@paperclipai/skills-catalog/catalog.json",
+    );
+    if (typeof resolved === "string" && resolved.startsWith("file://")) {
+      return fileURLToPath(resolved);
+    }
+  } catch {
+    // Fall through to relative path for monorepo dev mode
+  }
+
+  // Fallback: monorepo dev mode relative path from server/dist/services/
+  const serviceDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(serviceDir, "../../..");
+  return path.join(repoRoot, "packages/skills-catalog", "generated", "catalog.json");
+}
+
+const catalogManifestPath = resolveCatalogManifestPath();
 let cachedCatalogManifest: {
   manifest: CatalogManifestFile;
   mtimeMs: number;
@@ -31,18 +54,15 @@ let cachedCatalogManifest: {
 
 function loadCatalogManifest(): CatalogManifestFile {
   if (!existsSync(catalogManifestPath)) {
-    throw new Error(
-      `Skills catalog manifest not found at ${catalogManifestPath}. Run pnpm --filter @paperclipai/skills-catalog build:manifest.`,
-    );
+    return EMPTY_CATALOG_MANIFEST;
   }
   return JSON.parse(readFileSync(catalogManifestPath, "utf8")) as CatalogManifestFile;
 }
 
 function getCatalogManifest() {
   if (!existsSync(catalogManifestPath)) {
-    throw new Error(
-      `Skills catalog manifest not found at ${catalogManifestPath}. Run pnpm --filter @paperclipai/skills-catalog build:manifest.`,
-    );
+    cachedCatalogManifest = null;
+    return EMPTY_CATALOG_MANIFEST;
   }
   const stats = statSync(catalogManifestPath);
   if (
@@ -93,7 +113,8 @@ function inferLanguageFromPath(filePath: string) {
 }
 
 function resolveCatalogPackageRoot() {
-  return catalogPackageRoot;
+  // The catalog.json is at <packageRoot>/generated/catalog.json
+  return path.dirname(path.dirname(catalogManifestPath));
 }
 
 function sourceRootPath(source: CatalogSkillSource) {


### PR DESCRIPTION
## Summary

The skills catalog manifest (`generated/catalog.json`) was missing after `npm i -g paperclipai` because `@paperclipai/skills-catalog` was not published to npm (`publishFromCi: false`) and the server did not declare it as a dependency.

Without this fix, `GET /api/skills/catalog` returns empty results or errors after a fresh global install.

## Changes

1. **`server/src/services/skills-catalog.ts`** — Use `import.meta.resolve("@paperclipai/skills-catalog/catalog.json")` to find the manifest at runtime (works when package is installed from npm). Fall back to monorepo-relative path in dev mode. Return empty catalog instead of throwing 500 when manifest is missing.

2. **`scripts/release-package-manifest.json`** — Enable `publishFromCi: true` for `@paperclipai/skills-catalog`.

3. **`server/package.json`** — Add `@paperclipai/skills-catalog` as a production dependency (`workspace:*`).

4. **`pnpm-lock.yaml`** — Lockfile updated to link the server importer to the workspace package.

5. **`packages/skills-catalog/generated/catalog.json`** — Regenerated with latest skills (adds `github-issue-workflow` skill).

6. **`packages/skills-catalog/package.json`** — Version bumped to 0.3.2.

## Verification

- `import.meta.resolve("@paperclipai/skills-catalog/catalog.json")` resolves to a real file after `pnpm build`.
- `pnpm --filter @paperclipai/skills-catalog build:manifest` generates valid `generated/catalog.json` (11 skills) — already wired into `pnpm build`.
- Server `GET /api/skills/catalog` returns 200 with full catalog after rebuild.
- Global install (`npm i -g paperclipai`) will ship the catalog without the self-heal scripts.

## Co-authors

Co-Authored-By: Paperclip <noreply@paperclip.ing>