### PR TITLE
fix(recovery): skip recovery for issues with future monitorNextCheckAt

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3524,6 +3524,62 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.status).toBe("blocked");
   });
 
+  it("skips successful-run handoff when issue has a future monitorNextCheckAt", async () => {
+    const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+    await db.update(issues).set({ monitorNextCheckAt: futureDate }).where(eq(issues.id, issueId));
+
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { runId: string }) => {
+      await db.insert(issueComments).values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: ctx.runId,
+        body: "Parked post awaiting publish-runner routine.",
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Parked post awaiting publish-runner routine.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const handoffWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) => rows.filter((w) => w.reason === "finish_successful_run_handoff"));
+    expect(handoffWakeups).toHaveLength(0);
+  });
+
+  it("skips stranded sweep when issue has a future monitorNextCheckAt", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+    await db.update(issues).set({ monitorNextCheckAt: futureDate }).where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+    expect(result.escalated).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4923,6 +4923,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
         projectId: issues.projectId,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -5082,6 +5083,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       taskKey,
       hasActiveExecutionPath: Boolean(activeExecutionPath),
       hasQueuedWake: Boolean(queuedWake),
+      hasScheduledMonitor: Boolean(issue?.monitorNextCheckAt && issue.monitorNextCheckAt.getTime() > Date.now()),
       hasPendingInteractionOrApproval: Boolean(pendingInteraction || pendingApproval),
       hasExplicitBlockerPath: Boolean(explicitBlocker),
       hasOpenRecoveryIssue: Boolean(openRecoveryIssue),

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2687,6 +2687,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      if (issue.monitorNextCheckAt && issue.monitorNextCheckAt.getTime() > Date.now()) {
+        result.skipped += 1;
+        continue;
+      }
+
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -48,6 +48,7 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     taskKey: "issue-1",
     hasActiveExecutionPath: false,
     hasQueuedWake: false,
+    hasScheduledMonitor: false,
     hasPendingInteractionOrApproval: false,
     hasExplicitBlockerPath: false,
     hasOpenRecoveryIssue: false,
@@ -127,6 +128,13 @@ describe("successful run handoff decision", () => {
     expect(decide({ hasExplicitBlockerPath: true })).toEqual({
       kind: "skip",
       reason: "explicit blocker path owns the next action",
+    });
+  });
+
+  it("skips when issue has a scheduled future monitor", () => {
+    expect(decide({ hasScheduledMonitor: true })).toEqual({
+      kind: "skip",
+      reason: "issue has a scheduled future monitor",
     });
   });
 

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -338,6 +338,7 @@ export function decideSuccessfulRunHandoff(input: {
   taskKey: string | null;
   hasActiveExecutionPath: boolean;
   hasQueuedWake: boolean;
+  hasScheduledMonitor: boolean;
   hasPendingInteractionOrApproval: boolean;
   hasExplicitBlockerPath: boolean;
   hasOpenRecoveryIssue: boolean;
@@ -372,6 +373,7 @@ export function decideSuccessfulRunHandoff(input: {
   }
   if (input.hasActiveExecutionPath) return { kind: "skip", reason: "issue already has an active execution path" };
   if (input.hasQueuedWake) return { kind: "skip", reason: "issue already has a queued or deferred wake" };
+  if (input.hasScheduledMonitor) return { kind: "skip", reason: "issue has a scheduled future monitor" };
   if (input.hasPendingInteractionOrApproval) {
     return { kind: "skip", reason: "pending interaction or approval owns the next action" };
   }


### PR DESCRIPTION
﻿## Thinking Path

> - Paperclip orchestrates AI agents through issues, heartbeats, and recovery loops.
> - Non-terminal issues should stay live, but some issues intentionally wait for a scheduled monitor before the next action.
> - The recovery runner and successful-run handoff were treating those parked issues as stranded work.
> - That caused `in_progress` issues with a future `monitorNextCheckAt` to be escalated or flipped toward recovery before the monitor was due.
> - This pull request teaches the recovery paths to treat a future scheduled monitor as the active owner of the next step.
> - The benefit is that planned monitor-based workflows stay stable until their scheduled check fires.

## What Changed

- Added `monitorNextCheckAt` to the issue projection used by successful-run handoff.
- Passed a new `hasScheduledMonitor` flag into `decideSuccessfulRunHandoff`.
- Added a successful-run handoff skip when an issue has a future scheduled monitor.
- Added a stranded recovery sweep guard that skips issues with a future `monitorNextCheckAt`.
- Added unit and embedded-Postgres regression coverage for both scheduled-monitor skip paths.
- Rebuilt this branch from `upstream/master` so the PR contains only the recovery change and no manager-chain authorization changes.

## Verification

- [x] `pnpm exec vitest run server/src/services/recovery/successful-run-handoff.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts -t "scheduled future monitor|future monitorNextCheckAt"` - 3 tests passed locally.
- [x] Confirmed the rebuilt diff is limited to recovery/handoff files and tests.
- [ ] Full unfiltered `heartbeat-process-recovery.test.ts` was attempted locally on Windows but hit an unrelated existing assertion in `queues exactly one retry when the recorded local pid is dead` (`checkoutRunId` expected null, got a run id). The new monitor-specific tests pass.

## Risks

- A bad future `monitorNextCheckAt` value could delay recovery until the scheduled monitor time.
- The guard only applies when the timestamp is in the future; expired or absent monitor timestamps still flow through existing recovery logic.
- No schema, API contract, or UI changes are included.

## Issue Description

### What happened

Issues parked for a future monitor were being treated as stranded by recovery/handoff logic before the scheduled monitor time arrived.

### Expected behavior

If an issue has a future `monitorNextCheckAt`, the scheduled monitor owns the next action and recovery should not create a handoff wake or escalation for it yet.

### Steps to reproduce

1. Create or resume an agent-owned issue with `status = in_progress`.
2. Set `monitorNextCheckAt` to a future timestamp.
3. Let a successful run handoff or stranded issue sweep evaluate the issue.
4. Before this fix, recovery could enqueue/escalate despite the future monitor. After this fix, recovery skips until the monitor is due.

## Model Used

- OpenAI Codex, GPT-5 based coding agent. Exact API model ID and context-window size are not exposed by this Codex runtime. Tool use and local code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with available version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run targeted tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
- [x] I searched the GitHub PR list for similar open and closed PRs and confirmed this is not a duplicate

Fixes RR-3195
Parent RR-3194