### PR TITLE
Stabilize stale run recovery and compiled runtime

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -85,6 +85,7 @@
 - [ ] I have added or updated tests where applicable
 - [ ] If this change affects the UI, I have included before/after screenshots
 - [ ] I have updated relevant documentation to reflect my changes
+- [ ] For merge, deploy, or runtime activation approval, I have included current machine-verifiable evidence tied to the exact commit/config being approved
 - [ ] I have considered and documented any risks above
 - [ ] All Paperclip CI gates are green
 - [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups

--- a/docs/deploy/help2day-dedicated-ops.md
+++ b/docs/deploy/help2day-dedicated-ops.md
@@ -32,6 +32,29 @@ Before touching runtime, service, or database settings:
 
 Never print database URLs, passwords, tokens, cookies, or webhook URLs in logs or issue comments.
 
+## Approval Evidence Gate
+
+No Help2day or Paperclip agent may request human approval for a merge, deploy, service restart, database restart, or runtime activation unless it can present current, machine-verifiable evidence tied to the exact commit and configuration being approved.
+
+Before requesting approval, provide:
+
+- exact git branch and commit SHA,
+- upstream comparison showing whether the branch is ahead or behind,
+- tracked working-tree state,
+- changed-file summary for the approval scope,
+- relevant local validation commands and results,
+- live service health for runtime changes,
+- database target and PostgreSQL pending-restart state for database changes,
+- rollback path.
+
+Use the local evidence helper when possible:
+
+```bash
+node scripts/approval-evidence-report.mjs --require-clean
+```
+
+If the working tree is intentionally dirty, the approval request must name the dirty files and explain why they are excluded from the approval scope. Approval requests without current evidence should be treated as incomplete, not ready for a human decision.
+
 ## Agent Concurrency Levels
 
 Use the global premium/local adapter cap as the primary safety valve. Per-agent limits are secondary and should prevent one agent from monopolizing the host.

--- a/docs/deploy/help2day-dedicated-ops.md
+++ b/docs/deploy/help2day-dedicated-ops.md
@@ -55,6 +55,57 @@ node scripts/approval-evidence-report.mjs --require-clean
 
 If the working tree is intentionally dirty, the approval request must name the dirty files and explain why they are excluded from the approval scope. Approval requests without current evidence should be treated as incomplete, not ready for a human decision.
 
+## Repository And Posting Identity
+
+Before opening, updating, or commenting on GitHub/Vercel work, prove the exact target:
+
+- Help2day product work belongs in the active Help2day repository/worktree.
+- Paperclip platform/runtime work belongs in the Paperclip platform repository.
+- Do not add Help2day workflows or app code to the Paperclip platform repository, or Paperclip cron/runtime workflows to the Help2day app repository, unless the issue explicitly requires cross-repo work and the runtime schema proves that target.
+
+Use the Help2day/Paperclip posting identity:
+
+- GitHub user: `gboyles2paperclipAI`
+- Commit author email: `285433492+gboyles2paperclipAI@users.noreply.github.com`
+- Vercel account: `gboyles2paperclipai`
+
+Before posting or pushing:
+
+```bash
+git remote -v
+git branch --show-current
+git status --short --untracked-files=no
+git config user.name
+git config user.email
+gh auth status -h github.com
+```
+
+If a PR is authored from the wrong account, wrong repository, wrong branch base, or a disjoint dependency tree, do not ask Grant to approve it. Close or supersede it with a clean branch from the verified base.
+
+## Runtime Target Verification
+
+When an issue asks for cron, routine, database seed, deploy, or runtime activation, verify the implementation surface before changing files:
+
+- current service host and service unit,
+- active database host and database name without printing credentials,
+- relevant table/schema names from the running database,
+- existing scripts, routes, and scheduler paths in the current repo,
+- exact branch/commit being deployed or tested.
+
+The default for local Paperclip platform automation is a host-level script with locking and log evidence when the product runtime has no matching built-in scheduler route. Do not invent GitHub Actions as a fallback without proving the target repository and secrets model are correct.
+
+## Permanent Watcher Issues
+
+Issues with `executionPolicy.permanentWatcher=true` are long-running monitor/watchdog records. Their valid steady state is usually `in_progress`, not `done`.
+
+Recovery logic must not treat a successful maintenance run on a permanent watcher as a missing disposition. If a permanent watcher is mistakenly blocked:
+
+- verify `executionPolicy.permanentWatcher=true`,
+- verify there is no customer-impacting failure behind the block,
+- resolve the recovery action as restored,
+- return the issue to its designated watcher owner,
+- leave a comment with the exact recovery-action id and code/test evidence.
+
 ## Agent Concurrency Levels
 
 Use the global premium/local adapter cap as the primary safety valve. Per-agent limits are secondary and should prevent one agent from monopolizing the host.
@@ -180,3 +231,27 @@ If queued work rises while running count stays below cap, check:
 - scheduler/watchdog logs,
 - database connectivity,
 - service restarts.
+
+## Board Triage Rules
+
+Use first-class blockers only for dependencies that really prevent completion. Do not keep an issue blocked because of stale comments after the dependency is done.
+
+For every blocked issue, the current comment or blocker must identify:
+
+- exact blocker issue, PR, deployment, credential, or provider action,
+- current machine-verifiable evidence,
+- who can remove the blocker,
+- the next safe action,
+- why an agent cannot complete it independently.
+
+For KB publishing work, separate repository readiness from production publishing readiness. If code/content is merged but the deployed app cannot access the production database, mark the publishing ticket blocked on the Vercel/database access gate instead of repeatedly asking for generic approval.
+
+After any supervisor board repair, immediately check live and queued runs for the repaired issue ids. Cancel stale queued/running runs whose instructions were generated before the repair, especially when:
+
+- an issue was just moved to `done`,
+- an issue was just moved to `blocked`,
+- the assignee was cleared,
+- a blocker chain was corrected,
+- the run is about to perform deploy/restart/database work based on stale evidence.
+
+Do not trust the board state until a second read-back confirms no stale run rewrote the status after the repair.

--- a/docs/deploy/help2day-dedicated-ops.md
+++ b/docs/deploy/help2day-dedicated-ops.md
@@ -1,0 +1,159 @@
+# Help2day Dedicated Paperclip Operations
+
+This runbook records the dedicated Help2day deployment model and the safe operating protocol for agent concurrency, Paperclip app runtime, and PostgreSQL tuning.
+
+## Topology
+
+- `paperclip01` runs the Paperclip app and local agent adapter processes.
+- `paperclipdb1` runs the active PostgreSQL database.
+- Help2day traffic should use PostgreSQL on `paperclipdb1`, not the loopback PostgreSQL cluster on `paperclip01`.
+- `paperclip01` may still have a local PostgreSQL package installed for tooling or historical repair work. Treat it as unused unless live connections or config prove otherwise.
+
+## Pre-Change Checks
+
+Before touching runtime, service, or database settings:
+
+1. Confirm host and path.
+   - `hostname`
+   - `pwd`
+   - expected path: `/home/paperclipadmin/.paperclip/instances/default`
+2. Confirm active company is Help2day.
+3. Confirm current run pressure.
+   - Active work below 5 is the preferred gate for restarts.
+   - Do not restart or mass-cancel while active work is above that gate unless this is an outage recovery.
+4. Confirm database target.
+   - Paperclip config should be in `postgres` mode.
+   - Established app connections should point from `paperclip01` to `paperclipdb1`.
+5. Capture before-state.
+   - Paperclip service state and PID.
+   - live run counts.
+   - DB settings being changed.
+   - host load and available memory.
+
+Never print database URLs, passwords, tokens, cookies, or webhook URLs in logs or issue comments.
+
+## Agent Concurrency Levels
+
+Use the global premium/local adapter cap as the primary safety valve. Per-agent limits are secondary and should prevent one agent from monopolizing the host.
+
+Recommended levels for `paperclip01`:
+
+- 3 premium/local runs: conservative stable default.
+- 4-5 premium/local runs: normal steady-state target after a clean observation window.
+- 6-7 premium/local runs: supervised backlog drain only.
+- 8+ premium/local runs: warning zone; do not leave unattended without fresh evidence.
+- 20 premium/local runs: not a steady-state cap for this host. Use 20 as queue depth or theoretical upper bound only.
+
+Back down immediately if any of these occur:
+
+- active run count exceeds the configured cap,
+- service restarts unexpectedly,
+- active runs stop producing output for the watchdog window,
+- API health fails,
+- database connections or waits spike,
+- sustained system load exceeds CPU capacity,
+- available memory falls below 4 GiB.
+
+## Stale Run Failure Mode
+
+Observed failure mode on 2026-06-17:
+
+- A run stayed `running` for hours with no process metadata and no output.
+- The watchdog created recovery/evaluation work but did not terminate the source run.
+- Because global premium concurrency was effectively 1, queued work accumulated behind that run.
+
+Durable behavior:
+
+- Critical silent runs with no process metadata, no process PID/group, no output, and no log metadata should be auto-cancelled by the watchdog.
+- Cancelling must release the issue execution lock.
+- The agent should be finalized back to idle/cancelled state.
+- The scheduler should promote the next queued run for that agent when safe.
+
+## Safe PostgreSQL Reload Tuning
+
+These settings can be changed with `ALTER SYSTEM` plus `pg_reload_conf()` and do not require a PostgreSQL restart:
+
+- `effective_cache_size = '10GB'`
+- `work_mem = '16MB'`
+- `maintenance_work_mem = '512MB'`
+- `track_io_timing = 'on'`
+- `random_page_cost = '1.1'`
+- `effective_io_concurrency = '200'`
+- `checkpoint_timeout = '15min'`
+- `max_wal_size = '4GB'`
+- `min_wal_size = '512MB'`
+- `jit = 'off'`
+
+Validate afterward:
+
+- `pg_settings.pending_restart` should remain false for these settings.
+- Paperclip API health should be OK.
+- live run counts should remain within cap.
+- PostgreSQL active/idle connections should remain normal.
+
+Rollback:
+
+Use `ALTER SYSTEM RESET <setting>; SELECT pg_reload_conf();` for each reload-only setting, or set the previous explicit values and reload.
+
+## Restart-Gated PostgreSQL Tuning
+
+Do these only during a planned window, preferably when active work is below 5 and a current backup has been verified:
+
+- Increase `shared_buffers` from the small package default to an app-appropriate value, starting at `2GB`.
+- Add `pg_stat_statements` to `shared_preload_libraries`.
+- Restart PostgreSQL.
+- Create the extension in the `paperclip` database if needed.
+
+Validation after restart:
+
+- PostgreSQL service is active.
+- Paperclip API health is OK.
+- Paperclip connects to `paperclipdb1`.
+- `pg_settings.pending_restart` is false.
+- `pg_stat_statements` is available.
+- run queue resumes without a spike.
+
+Rollback:
+
+- Restore prior `shared_buffers` and `shared_preload_libraries`.
+- Restart PostgreSQL.
+- Verify API health and database connectivity.
+
+## Paperclip App Runtime
+
+The preferred steady state on a dedicated app host is a compiled server process, not a source `tsx` runtime.
+
+Before switching:
+
+- Ensure the repository builds cleanly.
+- Resolve unrelated typecheck blockers.
+- Confirm the service unit points to the intended working tree or release artifact.
+- Keep a rollback path to the previous `ExecStart`.
+
+Do not switch the service to compiled runtime while active work is above the restart gate unless it is needed for outage recovery.
+
+## Backup Expectations
+
+- `paperclipdb1` should have a current PostgreSQL backup path and timer.
+- `paperclip01` guarded backup should continue to provide app-level safety evidence.
+- Before restart-gated database changes, verify the latest backup timestamp and that the target backup volume has enough free space.
+
+## Routine Stability Checks
+
+During active operation, sample:
+
+- Paperclip API health.
+- `paperclip.service` active state, PID, and restart count.
+- Help2day live run counts.
+- active run `lastOutputAt` freshness.
+- host load and memory on `paperclip01`.
+- PostgreSQL active/idle connection counts and wait events on `paperclipdb1`.
+
+If queued work rises while running count stays below cap, check:
+
+- global premium/local cap,
+- per-agent concurrency policy,
+- stuck active runs,
+- scheduler/watchdog logs,
+- database connectivity,
+- service restarts.

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -13,8 +13,18 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "production": "./dist/*.js",
+      "types": "./src/*.ts",
+      "import": "./src/*.ts",
+      "default": "./src/*.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/acpx-local/package.json
+++ b/packages/adapters/acpx-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/cursor-cloud/package.json
+++ b/packages/adapters/cursor-cloud/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/cursor-local/package.json
+++ b/packages/adapters/cursor-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/gemini-local/package.json
+++ b/packages/adapters/gemini-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/grok-local/package.json
+++ b/packages/adapters/grok-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/openclaw-gateway/package.json
+++ b/packages/adapters/openclaw-gateway/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/adapters/pi-local/package.json
+++ b/packages/adapters/pi-local/package.json
@@ -13,10 +13,30 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server/index.ts",
-    "./ui": "./src/ui/index.ts",
-    "./cli": "./src/cli/index.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./server": {
+      "production": "./dist/server/index.js",
+      "types": "./src/server/index.ts",
+      "import": "./src/server/index.ts",
+      "default": "./src/server/index.ts"
+    },
+    "./ui": {
+      "production": "./dist/ui/index.js",
+      "types": "./src/ui/index.ts",
+      "import": "./src/ui/index.ts",
+      "default": "./src/ui/index.ts"
+    },
+    "./cli": {
+      "production": "./dist/cli/index.js",
+      "types": "./src/cli/index.ts",
+      "import": "./src/cli/index.ts",
+      "default": "./src/cli/index.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,8 +13,18 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "production": "./dist/*.js",
+      "types": "./src/*.ts",
+      "import": "./src/*.ts",
+      "default": "./src/*.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,9 +13,24 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./telemetry": "./src/telemetry/index.ts",
-    "./*": "./src/*.ts"
+    ".": {
+      "production": "./dist/index.js",
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./telemetry": {
+      "production": "./dist/telemetry/index.js",
+      "types": "./src/telemetry/index.ts",
+      "import": "./src/telemetry/index.ts",
+      "default": "./src/telemetry/index.ts"
+    },
+    "./*": {
+      "production": "./dist/*.js",
+      "types": "./src/*.ts",
+      "import": "./src/*.ts",
+      "default": "./src/*.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -92,6 +92,25 @@ describe("issue validators", () => {
     ).toBe(false);
   });
 
+  it("allows restored recovery resolutions to intentionally park the source issue in backlog", () => {
+    expect(
+      resolveIssueRecoveryActionSchema.parse({
+        outcome: "restored",
+        sourceIssueStatus: "backlog",
+      }),
+    ).toMatchObject({
+      outcome: "restored",
+      sourceIssueStatus: "backlog",
+    });
+
+    expect(
+      resolveIssueRecoveryActionSchema.safeParse({
+        outcome: "false_positive",
+        sourceIssueStatus: "backlog",
+      }).success,
+    ).toBe(false);
+  });
+
   it("allows cancelled recovery resolutions to atomically restore the source issue status", () => {
     expect(
       resolveIssueRecoveryActionSchema.parse({

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -279,18 +279,19 @@ const RESOLVE_ISSUE_RECOVERY_ACTION_OUTCOMES = [
 export const resolveIssueRecoveryActionSchema = z.object({
   actionId: z.string().uuid().optional(),
   outcome: z.enum(RESOLVE_ISSUE_RECOVERY_ACTION_OUTCOMES),
-  sourceIssueStatus: z.enum(["todo", "done", "in_review", "blocked"]),
+  sourceIssueStatus: z.enum(["backlog", "todo", "done", "in_review", "blocked"]),
   resolutionNote: multilineTextSchema.optional().nullable(),
 }).strict().superRefine((value, ctx) => {
   if (value.outcome === "restored") {
     if (
       value.sourceIssueStatus !== "todo" &&
+      value.sourceIssueStatus !== "backlog" &&
       value.sourceIssueStatus !== "done" &&
       value.sourceIssueStatus !== "in_review"
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Restored recovery actions must move the source issue to todo, done, or in_review",
+        message: "Restored recovery actions must move the source issue to backlog, todo, done, or in_review",
         path: ["sourceIssueStatus"],
       });
     }

--- a/scripts/approval-evidence-report.mjs
+++ b/scripts/approval-evidence-report.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const args = {
+    requireClean: false,
+    healthUrl: process.env.PAPERCLIP_HEALTH_URL ?? "http://127.0.0.1:3100/api/health",
+    liveRunsUrl: process.env.PAPERCLIP_LIVE_RUNS_URL ?? "",
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--require-clean") {
+      args.requireClean = true;
+      continue;
+    }
+    if (arg === "--health-url") {
+      args.healthUrl = argv[++i] ?? "";
+      continue;
+    }
+    if (arg === "--live-runs-url") {
+      args.liveRunsUrl = argv[++i] ?? "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+      continue;
+    }
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+  return args;
+}
+
+function usage() {
+  return [
+    "usage: node scripts/approval-evidence-report.mjs [--require-clean] [--health-url <url>] [--live-runs-url <url>]",
+    "",
+    "Prints machine-verifiable evidence for merge/deploy/runtime approval requests.",
+    "Does not print secrets or environment variables.",
+  ].join("\n");
+}
+
+function run(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      ...options,
+    }).trim();
+  } catch (error) {
+    if (options.optional) return "";
+    throw error;
+  }
+}
+
+async function fetchJson(url) {
+  if (!url) return null;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    return { ok: false, status: response.status, statusText: response.statusText };
+  }
+  const json = await response.json();
+  return { ok: true, status: response.status, body: json };
+}
+
+function parseAheadBehind(output) {
+  const [behind = "0", ahead = "0"] = output.split(/\s+/);
+  return { ahead: Number(ahead), behind: Number(behind) };
+}
+
+function trackedDirtyFiles() {
+  const status = run("git", ["status", "--porcelain=v1", "--untracked-files=no"]);
+  return status ? status.split("\n") : [];
+}
+
+function changedFiles() {
+  const diff = run("git", ["diff", "--name-status", "HEAD"], { optional: true });
+  return diff ? diff.split("\n") : [];
+}
+
+function systemctlShow(unit, properties) {
+  const output = run("systemctl", ["show", unit, `--property=${properties.join(",")}`, "--no-pager"], { optional: true });
+  if (!output) return null;
+  const result = {};
+  for (const line of output.split("\n")) {
+    const index = line.indexOf("=");
+    if (index > 0) result[line.slice(0, index)] = line.slice(index + 1);
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const branch = run("git", ["branch", "--show-current"]);
+  const head = run("git", ["rev-parse", "HEAD"]);
+  const upstream = run("git", ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], { optional: true });
+  const upstreamHead = upstream ? run("git", ["rev-parse", upstream], { optional: true }) : "";
+  const aheadBehind = upstream ? parseAheadBehind(run("git", ["rev-list", "--left-right", "--count", `${upstream}...HEAD`])) : null;
+  const dirtyTracked = trackedDirtyFiles();
+  const changed = changedFiles();
+  const health = await fetchJson(args.healthUrl);
+  const liveRuns = await fetchJson(args.liveRunsUrl);
+
+  const report = {
+    schemaVersion: 1,
+    kind: "paperclip.approval_evidence",
+    capturedAt: new Date().toISOString(),
+    git: {
+      branch,
+      head,
+      upstream: upstream || null,
+      upstreamHead: upstreamHead || null,
+      aheadBehind,
+      trackedWorkingTreeClean: dirtyTracked.length === 0,
+      dirtyTrackedFiles: dirtyTracked,
+      changedFiles: changed,
+    },
+    runtime: {
+      paperclipService: systemctlShow("paperclip.service", [
+        "ActiveState",
+        "SubState",
+        "MainPID",
+        "NRestarts",
+        "ExecStart",
+        "WorkingDirectory",
+      ]),
+      health,
+      liveRuns,
+    },
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (args.requireClean && dirtyTracked.length > 0) {
+    console.error("approval evidence failed: tracked working tree is not clean");
+    process.exit(2);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/approval-evidence-report.mjs
+++ b/scripts/approval-evidence-report.mjs
@@ -65,6 +65,21 @@ async function fetchJson(url) {
   return { ok: true, status: response.status, body: json };
 }
 
+function summarizeLiveRuns(response) {
+  if (!response?.ok || !Array.isArray(response.body)) return response;
+  const counts = response.body.reduce((acc, run) => {
+    const status = typeof run?.status === "string" ? run.status : "unknown";
+    acc[status] = (acc[status] ?? 0) + 1;
+    return acc;
+  }, {});
+  return {
+    ...response,
+    runningObserved: counts.running ?? 0,
+    queuedObserved: counts.queued ?? 0,
+    statusCounts: counts,
+  };
+}
+
 function parseAheadBehind(output) {
   const [behind = "0", ahead = "0"] = output.split(/\s+/);
   return { ahead: Number(ahead), behind: Number(behind) };
@@ -106,7 +121,7 @@ async function main() {
   const dirtyTracked = trackedDirtyFiles();
   const changed = changedFiles();
   const health = await fetchJson(args.healthUrl);
-  const liveRuns = await fetchJson(args.liveRunsUrl);
+  const liveRuns = summarizeLiveRuns(await fetchJson(args.liveRunsUrl));
 
   const report = {
     schemaVersion: 1,

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -203,7 +203,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       lastOutputSeq: opts.withOutput ? 3 : 0,
       lastOutputStream: opts.withOutput ? "stdout" : null,
       contextSnapshot: { issueId },
-      stdoutExcerpt: "OPENAI_API_KEY=sk-test-secret-value should not leak",
+      stdoutExcerpt: opts.noProcessMetadata ? null : "OPENAI_API_KEY=sk-test-secret-value should not leak",
       logBytes: 0,
     });
     if (opts.logChunk) {

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -131,6 +131,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
+    noProcessMetadata?: boolean;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -197,7 +198,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       invocationSource: "assignment",
       triggerDetail: "system",
       startedAt,
-      processStartedAt: startedAt,
+      processStartedAt: opts.noProcessMetadata ? null : startedAt,
       lastOutputAt,
       lastOutputSeq: opts.withOutput ? 3 : 0,
       lastOutputStream: opts.withOutput ? "stdout" : null,
@@ -321,9 +322,9 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       now,
       ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
     });
-    const heartbeat = heartbeatService(db);
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
 
-    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const result = await recovery.scanSilentActiveRuns({ now, companyId });
 
     expect(result.created).toBe(1);
     const [evaluation] = await db
@@ -342,6 +343,51 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
     expect(source?.status).not.toBe("blocked");
+  });
+
+  it("auto-cancels critical silent runs that never acquired process or log metadata", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      noProcessMetadata: true,
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+
+    const result = await recovery.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({ created: 0, autoCancelled: 1, skipped: 0 });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("watchdog_no_process_output_silence");
+    expect(run?.finishedAt?.toISOString()).toBe(now.toISOString());
+    expect(run?.resultJson).toMatchObject({
+      activeRunWatchdogAutoCancel: {
+        sourceIssueId: issueId,
+        processStartedAt: null,
+        processPid: null,
+        processGroupId: null,
+        lastOutputAt: null,
+        lastOutputSeq: 0,
+        cleanup: { outcome: "no_process_metadata" },
+      },
+    });
+
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.executionRunId).toBeNull();
+    const [agent] = await db.select().from(agents).where(eq(agents.id, coderId));
+    expect(agent?.status).toBe("idle");
+    const [event] = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(event?.message).toContain("auto-cancelled no-process silent run");
   });
 
   it("emits the source-issue escalation comment only once across repeated critical scans", async () => {

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -658,7 +658,11 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       expect(secondRunWhileFirstRunning?.status).toBe("queued");
       expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
     } finally {
-      process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS = originalPremiumCap;
+      if (originalPremiumCap === undefined) {
+        delete process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS;
+      } else {
+        process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS = originalPremiumCap;
+      }
       finishFirstRun();
     }
   }, 40_000);

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -545,6 +545,124 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     }
   }, 40_000);
 
+  it("honors the premium managed global cap across different agents", async () => {
+    const originalPremiumCap = process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS;
+    process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS = "1";
+    const companyId = randomUUID();
+    const firstAgentId = randomUUID();
+    const secondAgentId = randomUUID();
+    const firstIssueId = randomUUID();
+    const secondIssueId = randomUUID();
+    let finishFirstRun!: () => void;
+    const firstRunFinished = new Promise<void>((resolve) => {
+      finishFirstRun = resolve;
+    });
+
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await firstRunFinished;
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "First premium run completed.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: firstAgentId,
+        companyId,
+        name: "FirstPremiumAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "claude_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+      {
+        id: secondAgentId,
+        companyId,
+        name: "SecondPremiumAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "claude_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: firstIssueId,
+        companyId,
+        title: "First premium assignment",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: firstAgentId,
+      },
+      {
+        id: secondIssueId,
+        companyId,
+        title: "Second premium assignment",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: secondAgentId,
+      },
+    ]);
+
+    try {
+      const firstWake = await heartbeat.wakeup(firstAgentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId: firstIssueId },
+        contextSnapshot: { issueId: firstIssueId, wakeReason: "issue_assigned" },
+      });
+      expect(firstWake).not.toBeNull();
+
+      const firstRunStarted = await waitForCondition(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstWake!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+      expect(firstRunStarted).toBe(true);
+      expect(await waitForCondition(async () => mockAdapterExecute.mock.calls.length === 1, 30_000)).toBe(true);
+
+      const secondWake = await heartbeat.wakeup(secondAgentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId: secondIssueId },
+        contextSnapshot: { issueId: secondIssueId, wakeReason: "issue_assigned" },
+      });
+      expect(secondWake).not.toBeNull();
+
+      const secondRunWhileFirstRunning = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, secondWake!.id))
+        .then((rows) => rows[0] ?? null);
+      expect(secondRunWhileFirstRunning?.status).toBe("queued");
+      expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+    } finally {
+      process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS = originalPremiumCap;
+      finishFirstRun();
+    }
+  }, 40_000);
+
   it("cancels stale queued runs when issue blockers are still unresolved", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2207,6 +2207,40 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("skips assignment_recovery requeue for a todo issue whose run was operator-pruned (cancelled with no errorCode)", async () => {
+    // An operator cancelling a queued run during incident recovery sets status=cancelled
+    // with no errorCode. Recovery should NOT immediately requeue as assignment_recovery
+    // — that would undo the operator's queue pruning and worsen the incident.
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "cancelled",
+      runErrorCode: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.issueIds).not.toContain(issueId);
+  });
+
+  it("still enqueues assignment_recovery for a todo issue whose run was watchdog-cancelled (has errorCode)", async () => {
+    // Watchdog auto-cancelled runs carry errorCode "watchdog_no_process_output_silence".
+    // These are NOT operator-pruned — the issue genuinely needs a new dispatch attempt.
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "cancelled",
+      runErrorCode: "watchdog_no_process_output_silence",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(1);
+    expect(result.issueIds).toContain(issueId);
+  });
+
   it.each([
     ["failed", "adapter_failed"],
     ["failed", "process_lost"],

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -616,6 +616,56 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
   });
 
+  it("resolves an active recovery action by intentionally parking the source issue in backlog without wakeup", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: managerId, assigneeUserId: null })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "issue_graph_liveness",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "issue_graph_liveness",
+      fingerprint: "graph-liveness:intentional-backlog",
+      evidence: { latestIssueStatus: "blocked" },
+      nextAction: "Restore a live execution path.",
+      wakePolicy: { type: "manual" },
+    });
+    const app = createApp();
+
+    const resolved = await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "restored",
+        sourceIssueStatus: "backlog",
+        resolutionNote: "Operator intentionally parked the source issue.",
+      })
+      .expect(200);
+
+    expect(resolved.body.issue).toMatchObject({
+      id: sourceIssueId,
+      status: "backlog",
+      activeRecoveryAction: null,
+    });
+    expect(resolved.body.recoveryAction).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "restored",
+      resolutionNote: "Operator intentionally parked the source issue.",
+    });
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakeups).toHaveLength(0);
+  });
+
   it("marks a recovery action stale when a blocked source issue is manually moved to todo", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from "express";
 import type { IncomingHttpHeaders } from "node:http";
 import { betterAuth } from "better-auth";
+import type { BetterAuthOptions } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { toNodeHandler } from "better-auth/node";
 import type { Db } from "@paperclipai/db";
@@ -130,7 +131,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
     publicUrl,
   });
 
-  const authConfig = {
+  const authConfig: BetterAuthOptions = {
     baseURL: baseUrl,
     secret,
     trustedOrigins,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -217,6 +217,17 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+const PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_DEFAULT = 3;
+const PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_MIN = 1;
+const PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_MAX = 20;
+const PREMIUM_MANAGED_ADAPTER_TYPES = new Set([
+  "acpx_local",
+  "claude_local",
+  "codex_local",
+  "cursor",
+  "cursor_cloud",
+  "gemini_local",
+]);
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -1369,6 +1380,26 @@ function normalizeMaxConcurrentRuns(value: unknown) {
   const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
   return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_MIN, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+}
+
+function normalizePremiumManagedMaxConcurrentRuns(value: unknown) {
+  const parsedValue = typeof value === "string" && value.trim().length > 0
+    ? Number(value)
+    : asNumber(value, PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_DEFAULT);
+  const parsed = Math.floor(parsedValue);
+  if (!Number.isFinite(parsed)) return PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_DEFAULT;
+  return Math.max(
+    PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_MIN,
+    Math.min(PREMIUM_MANAGED_MAX_CONCURRENT_RUNS_MAX, parsed),
+  );
+}
+
+function premiumManagedMaxConcurrentRuns() {
+  return normalizePremiumManagedMaxConcurrentRuns(process.env.PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS);
+}
+
+function isPremiumManagedAdapter(adapterType: string | null | undefined) {
+  return PREMIUM_MANAGED_ADAPTER_TYPES.has(adapterType?.trim() ?? "");
 }
 
 interface WakeupOptions {
@@ -3128,7 +3159,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     cancelWorkForScope: cancelBudgetScopeWork,
   };
   const budgets = budgetService(db, budgetHooks);
-  const recovery = recoveryService(db, { enqueueWakeup });
+  const recovery = recoveryService(db, {
+    enqueueWakeup,
+    onWatchdogAutoCancelled: async (run) => {
+      await releaseIssueExecutionAndPromote(run);
+      await finalizeAgentStatus(run.agentId, "cancelled");
+      await startNextQueuedRunForAgent(run.agentId);
+    },
+  });
   const productivityReviews = productivityReviewService(db, { enqueueWakeup });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
 
@@ -6741,6 +6779,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
+  async function countRunningPremiumManagedRuns() {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(and(
+        eq(heartbeatRuns.status, "running"),
+        inArray(agents.adapterType, [...PREMIUM_MANAGED_ADAPTER_TYPES]),
+      ));
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -6764,6 +6814,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (budgetBlock) {
       await cancelRunInternal(run.id, budgetBlock.reason);
       return null;
+    }
+
+    const policy = parseHeartbeatPolicy(agent);
+    const runningCount = await countRunningRunsForAgent(agent.id);
+    if (runningCount >= policy.maxConcurrentRuns) {
+      return null;
+    }
+    if (isPremiumManagedAdapter(agent.adapterType)) {
+      const premiumRunningCount = await countRunningPremiumManagedRuns();
+      if (premiumRunningCount >= premiumManagedMaxConcurrentRuns()) {
+        return null;
+      }
     }
 
     const issueId = readNonEmptyString(context.issueId);
@@ -7676,7 +7738,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      let availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
+      if (isPremiumManagedAdapter(agent.adapterType)) {
+        const premiumAvailableSlots = Math.max(
+          0,
+          premiumManagedMaxConcurrentRuns() - await countRunningPremiumManagedRuns(),
+        );
+        availableSlots = Math.min(availableSlots, premiumAvailableSlots);
+      }
       if (availableSlots <= 0) return [];
 
       const queuedRuns = await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3163,6 +3163,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     enqueueWakeup,
     onWatchdogAutoCancelled: async (run) => {
       await releaseIssueExecutionAndPromote(run);
+      await releaseEnvironmentLeasesForRun({
+        runId: run.id,
+        companyId: run.companyId,
+        agentId: run.agentId,
+        status: run.status,
+        failureReason: run.error ?? undefined,
+      });
+      await releaseRuntimeServicesForRun(run.id).catch(() => undefined);
       await finalizeAgentStatus(run.agentId, "cancelled");
       await startNextQueuedRunForAgent(run.agentId);
     },
@@ -6783,7 +6791,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)` })
       .from(heartbeatRuns)
-      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .innerJoin(agents, and(eq(heartbeatRuns.agentId, agents.id), eq(heartbeatRuns.companyId, agents.companyId)))
       .where(and(
         eq(heartbeatRuns.status, "running"),
         inArray(agents.adapterType, [...PREMIUM_MANAGED_ADAPTER_TYPES]),
@@ -6821,13 +6829,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (runningCount >= policy.maxConcurrentRuns) {
       return null;
     }
-    if (isPremiumManagedAdapter(agent.adapterType)) {
-      const premiumRunningCount = await countRunningPremiumManagedRuns();
-      if (premiumRunningCount >= premiumManagedMaxConcurrentRuns()) {
-        return null;
-      }
-    }
-
     const issueId = readNonEmptyString(context.issueId);
     if (issueId) {
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
@@ -6881,18 +6882,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const claimedAt = new Date();
-    const claimed = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "running",
-        startedAt: run.startedAt ?? claimedAt,
-        updatedAt: claimedAt,
-      })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "queued")))
-      .returning()
-      .then((rows) => rows[0] ?? null);
+    const claimWithAdmission = async () => {
+      if (isPremiumManagedAdapter(agent.adapterType)) {
+        const premiumRunningCount = await countRunningPremiumManagedRuns();
+        if (premiumRunningCount >= premiumManagedMaxConcurrentRuns()) {
+          return null;
+        }
+      }
+      const claimedAt = new Date();
+      return db
+        .update(heartbeatRuns)
+        .set({
+          status: "running",
+          startedAt: run.startedAt ?? claimedAt,
+          updatedAt: claimedAt,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.companyId, run.companyId), eq(heartbeatRuns.status, "queued")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+    };
+    const claimed = isPremiumManagedAdapter(agent.adapterType)
+      ? await withAgentStartLock("__premium_managed_global__", claimWithAdmission)
+      : await claimWithAdmission();
     if (!claimed) return null;
+    const claimedAt = claimed.startedAt ?? new Date();
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -7739,13 +7752,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const policy = parseHeartbeatPolicy(agent);
       const runningCount = await countRunningRunsForAgent(agentId);
       let availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
-      if (isPremiumManagedAdapter(agent.adapterType)) {
-        const premiumAvailableSlots = Math.max(
-          0,
-          premiumManagedMaxConcurrentRuns() - await countRunningPremiumManagedRuns(),
-        );
-        availableSlots = Math.min(availableSlots, premiumAvailableSlots);
-      }
       if (availableSlots <= 0) return [];
 
       const queuedRuns = await db

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -884,6 +884,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; o
       !runningProcesses.has(run.id) &&
       !run.lastOutputAt &&
       (run.lastOutputSeq ?? 0) === 0 &&
+      !run.lastOutputStream &&
+      (run.lastOutputBytes ?? 0) === 0 &&
+      !run.stdoutExcerpt &&
+      !run.stderrExcerpt &&
       !run.logStore &&
       !run.logRef &&
       (run.logBytes ?? 0) === 0;
@@ -1250,7 +1254,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; o
           resultJson,
           updatedAt: input.now,
         })
-        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.companyId, input.run.companyId), eq(heartbeatRuns.status, "running")))
+        .where(and(
+          eq(heartbeatRuns.id, input.run.id),
+          eq(heartbeatRuns.companyId, input.run.companyId),
+          eq(heartbeatRuns.status, "running"),
+        ))
         .returning();
       if (!updatedRun) return null;
 
@@ -1392,7 +1400,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; o
           resultJson,
           updatedAt: input.now,
         })
-        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.companyId, input.run.companyId), eq(heartbeatRuns.status, "running")))
+        .where(and(
+          eq(heartbeatRuns.id, input.run.id),
+          eq(heartbeatRuns.companyId, input.run.companyId),
+          eq(heartbeatRuns.status, "running"),
+          isNull(heartbeatRuns.processStartedAt),
+          isNull(heartbeatRuns.processPid),
+          isNull(heartbeatRuns.processGroupId),
+          isNull(heartbeatRuns.lastOutputAt),
+          sql`coalesce(${heartbeatRuns.lastOutputSeq}, 0) = 0`,
+          isNull(heartbeatRuns.lastOutputStream),
+          sql`coalesce(${heartbeatRuns.lastOutputBytes}, 0) = 0`,
+          isNull(heartbeatRuns.stdoutExcerpt),
+          isNull(heartbeatRuns.stderrExcerpt),
+          isNull(heartbeatRuns.logStore),
+          isNull(heartbeatRuns.logRef),
+          sql`coalesce(${heartbeatRuns.logBytes}, 0) = 0`,
+        ))
         .returning();
       if (!updatedRun) return null;
 
@@ -1463,8 +1487,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; o
         cleanup,
       },
     });
-    await finalizeAgentAfterSourceResolvedRun(finalizedRun, "cancelled");
-    await deps.onWatchdogAutoCancelled?.(finalizedRun);
+    if (deps.onWatchdogAutoCancelled) {
+      await deps.onWatchdogAutoCancelled(finalizedRun);
+    } else {
+      await finalizeAgentAfterSourceResolvedRun(finalizedRun, "cancelled");
+    }
     return { kind: "auto_cancelled" as const, runId: finalizedRun.id, evaluationIssueId: input.existingEvaluation?.id ?? null };
   }
 
@@ -1717,16 +1744,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; o
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     const silenceAgeMs = silenceAgeMsForRun(input.run, input.now);
-    if (isNoProcessCriticalSilentRun(input.run, input.now)) {
-      return autoCancelNoProcessSilentRun({
-        run: input.run,
-        runningAgent,
-        sourceIssue,
-        existingEvaluation: existing,
-        silenceAgeMs,
-        now: input.now,
-      });
-    }
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
       await logActivity(db, {
         companyId: input.run.companyId,
@@ -1768,16 +1785,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; o
       }
     }
 
+    // Dedup: if a reviewer has dismissed this run's silence as a false positive, don't
+    // auto-cancel or re-file. Terminal same-run evidence is folded first so resolved
+    // source issues can still close their existing watchdog work idempotently.
+    if (await hasDismissedFalsePositiveDecision(input.run.companyId, input.run.id)) {
+      return { kind: "skipped" as const };
+    }
+
+    if (isNoProcessCriticalSilentRun(input.run, input.now)) {
+      return autoCancelNoProcessSilentRun({
+        run: input.run,
+        runningAgent,
+        sourceIssue,
+        existingEvaluation: existing,
+        silenceAgeMs,
+        now: input.now,
+      });
+    }
+
     // Idle output is expected when the source issue is blocked — skip ticket creation entirely.
     if (sourceIssue?.status === "blocked") return { kind: "skipped" as const };
 
     // Dedup: if a reviewer has dismissed this run's silence as a false positive, don't re-file.
     // A "continue" decision with a snooze window is allowed to re-arm normally — only an
     // explicit dismissed_false_positive blocks all further alerts for this run.
-    if (await hasDismissedFalsePositiveDecision(input.run.companyId, input.run.id)) {
-      return { kind: "skipped" as const };
-    }
-
     // Dedup: if a prior evaluation issue for this run was closed `done` on the board
     // without going through the watchdog decision API, no dismissed_false_positive record exists
     // and the watchdog would re-fire every cycle. Auto-record the suppression now so future

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -110,6 +110,8 @@ type RecoveryWakeup = (
   opts?: RecoveryWakeupOptions,
 ) => Promise<typeof heartbeatRuns.$inferSelect | null>;
 
+type RecoveryFinalizedRunHook = (run: typeof heartbeatRuns.$inferSelect) => Promise<void>;
+
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
   "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
@@ -460,7 +462,7 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
-export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
+export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup; onWatchdogAutoCancelled?: RecoveryFinalizedRunHook }) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -871,6 +873,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   function silenceAgeMsForRun(run: Pick<typeof heartbeatRuns.$inferSelect, "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">, now = new Date()) {
     const startedAt = silenceStartedAtForRun(run);
     return startedAt ? Math.max(0, now.getTime() - startedAt.getTime()) : null;
+  }
+
+  function isNoProcessCriticalSilentRun(run: typeof heartbeatRuns.$inferSelect, now: Date) {
+    return run.status === "running" &&
+      (silenceAgeMsForRun(run, now) ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS &&
+      !run.processStartedAt &&
+      typeof run.processPid !== "number" &&
+      typeof run.processGroupId !== "number" &&
+      !runningProcesses.has(run.id) &&
+      !run.lastOutputAt &&
+      (run.lastOutputSeq ?? 0) === 0 &&
+      !run.logStore &&
+      !run.logRef &&
+      (run.logBytes ?? 0) === 0;
   }
 
   async function latestActiveOutputQuietUntilDecision(companyId: string, runId: string, now = new Date()) {
@@ -1337,6 +1353,121 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation?.id ?? null };
   }
 
+  async function autoCancelNoProcessSilentRun(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    existingEvaluation: Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>;
+    silenceAgeMs: number | null;
+    now: Date;
+  }) {
+    const cleanup = await cleanupSourceResolvedRunProcess({ run: input.run, runningAgent: input.runningAgent });
+    const reason = "Auto-cancelled by active-run watchdog: critical output silence with no process, log, or output metadata.";
+    const resultJson = {
+      ...parseObject(input.run.resultJson),
+      activeRunWatchdogAutoCancel: {
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        sourceIssueIdentifier: input.sourceIssue?.identifier ?? null,
+        silenceAgeMs: input.silenceAgeMs,
+        silenceStartedAt: silenceStartedAtForRun(input.run)?.toISOString() ?? null,
+        lastOutputAt: input.run.lastOutputAt?.toISOString() ?? null,
+        lastOutputSeq: input.run.lastOutputSeq ?? 0,
+        processStartedAt: input.run.processStartedAt?.toISOString() ?? null,
+        processPid: input.run.processPid ?? null,
+        processGroupId: input.run.processGroupId ?? null,
+        evaluationIssueId: input.existingEvaluation?.id ?? null,
+        evaluationIssueIdentifier: input.existingEvaluation?.identifier ?? null,
+        cleanup,
+      },
+    };
+
+    const finalizedRun = await db.transaction(async (tx) => {
+      const [updatedRun] = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          finishedAt: input.now,
+          error: reason,
+          errorCode: "watchdog_no_process_output_silence",
+          resultJson,
+          updatedAt: input.now,
+        })
+        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.companyId, input.run.companyId), eq(heartbeatRuns.status, "running")))
+        .returning();
+      if (!updatedRun) return null;
+
+      if (input.run.wakeupRequestId) {
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            status: "cancelled",
+            finishedAt: input.now,
+            error: reason,
+            updatedAt: input.now,
+          })
+          .where(and(eq(agentWakeupRequests.id, input.run.wakeupRequestId), eq(agentWakeupRequests.companyId, input.run.companyId)));
+      }
+
+      if (input.sourceIssue) {
+        await tx
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: input.now,
+          })
+          .where(
+            and(
+              eq(issues.id, input.sourceIssue.id),
+              eq(issues.companyId, input.run.companyId),
+              eq(issues.executionRunId, input.run.id),
+            ),
+          );
+      }
+
+      return updatedRun;
+    });
+    if (!finalizedRun) return { kind: "skipped" as const };
+
+    if (input.existingEvaluation && !isTerminalIssueStatus(input.existingEvaluation.status)) {
+      await issuesSvc.update(input.existingEvaluation.id, { status: "done" });
+      await issuesSvc.addComment(input.existingEvaluation.id, [
+        "Watchdog auto-cancelled the source run.",
+        "",
+        `- Run: \`${input.run.id}\``,
+        `- Silent for: ${formatDuration(input.silenceAgeMs)}`,
+        "- Reason: critical output silence with no process, log, or output metadata.",
+      ].join("\n"), { runId: input.run.id });
+    }
+
+    await appendRecoveryRunEvent(finalizedRun, {
+      level: "warn",
+      message: "Active-run watchdog auto-cancelled no-process silent run",
+      payload: resultJson.activeRunWatchdogAutoCancel,
+    });
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_auto_cancelled",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        sourceIssueIdentifier: input.sourceIssue?.identifier ?? null,
+        silenceAgeMs: input.silenceAgeMs,
+        cleanup,
+      },
+    });
+    await finalizeAgentAfterSourceResolvedRun(finalizedRun, "cancelled");
+    await deps.onWatchdogAutoCancelled?.(finalizedRun);
+    return { kind: "auto_cancelled" as const, runId: finalizedRun.id, evaluationIssueId: input.existingEvaluation?.id ?? null };
+  }
+
   async function resolveStaleRunOwnerAgentId(input: {
     run: typeof heartbeatRuns.$inferSelect;
     runningAgent: typeof agents.$inferSelect;
@@ -1585,6 +1716,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
+    const silenceAgeMs = silenceAgeMsForRun(input.run, input.now);
+    if (isNoProcessCriticalSilentRun(input.run, input.now)) {
+      return autoCancelNoProcessSilentRun({
+        run: input.run,
+        runningAgent,
+        sourceIssue,
+        existingEvaluation: existing,
+        silenceAgeMs,
+        now: input.now,
+      });
+    }
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
       await logActivity(db, {
         companyId: input.run.companyId,
@@ -1620,7 +1762,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           evidence: terminalEvidence,
           existingEvaluation: existing,
           silenceStartedAt,
-          silenceAgeMs: silenceAgeMsForRun(input.run, input.now),
+          silenceAgeMs,
           now: input.now,
         });
       }
@@ -1828,6 +1970,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       existing: 0,
       escalated: 0,
       folded: 0,
+      autoCancelled: 0,
       snoozed: 0,
       skipped: 0,
       evaluationIssueIds: [] as string[],
@@ -1843,6 +1986,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       else if (outcome.kind === "existing") result.existing += 1;
       else if (outcome.kind === "escalated") result.escalated += 1;
       else if (outcome.kind === "folded") result.folded += 1;
+      else if (outcome.kind === "auto_cancelled") result.autoCancelled += 1;
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {
         result.evaluationIssueIds.push(outcome.evaluationIssueId);
@@ -2736,6 +2880,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (latestRun.status === "succeeded") {
+          result.skipped += 1;
+          continue;
+        }
+
+        // Operator-pruned detection: a cancelled run with no errorCode was not terminated
+        // by an execution failure path. Watchdog auto-cancels set errorCode
+        // "watchdog_no_process_output_silence"; adapter failures set other codes.
+        // A null errorCode is characteristic of an operator cancelling a queued run during
+        // incident recovery. Skip assignment_recovery requeue so the operator's queue
+        // pruning is not immediately undone; the issue stays todo until re-dispatched by
+        // assignment, routine cycle, or manual trigger.
+        if (latestRun.status === "cancelled" && !latestRun.errorCode) {
           result.skipped += 1;
           continue;
         }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent execution health depends on stale-run recovery, queue promotion, runtime startup, and operator-visible deployment evidence
> - A silent running assignment with no useful process state can hold an execution lock and leave later work queued even when capacity exists
> - The dedicated Help2day deployment also needs to run from compiled workspace packages so service restarts exercise the same build artifacts that were validated
> - Merge, deploy, and runtime activation decisions need current machine-verifiable evidence tied to the exact commit or config being approved
> - This pull request makes stale critical runs recoverable, adds a managed premium-run cap, supports compiled workspace execution, and documents the dedicated operations path
> - The benefit is a more stable Paperclip runtime with less manual queue intervention and a durable evidence standard for future approvals

## Linked Issues or Issue Description

Bug report: stale agent run can block queue progress on a dedicated Paperclip instance.

What happened:
A Help2day dedicated Paperclip assignment run remained `running` for hours without useful process/output evidence. Because the run still held execution state, later work stayed queued even though the operator expected multiple runs to proceed.

Expected behavior:
Critical silent no-process runs should be safely cancelled by recovery, their source issue lock should be released, environment/runtime resources should be released, the owning agent should be finalized, and queued work should be promoted within the configured concurrency cap.

Steps to reproduce:
1. Create a managed assignment run with stale critical output silence.
2. Ensure the run has no active process metadata and no durable output/log evidence.
3. Keep the source issue execution lock pointed at that run.
4. Run the heartbeat recovery path.
5. Observe that, before this fix, the run could remain active and queue promotion did not recover capacity.

Environment:
- Paperclip version/commit observed: Help2day dedicated instance before this branch.
- Fixed commit: `73985755561ed66a8e75488114cb670d7ab378bd`.
- Deployment mode: `local_trusted` / private dedicated service.

Related operational tickets: Help2day FUL incident work for agent queue/run recovery and dedicated runtime stabilization. No public GitHub issue exists for this private Help2day operations incident.

## What Changed

- Added critical silent-run auto-cancel recovery for no-process/no-output assignment runs, including source issue execution-lock release and agent status finalization.
- Promoted queued work after stale-run auto-cancel instead of leaving capacity unused.
- Added environment lease and runtime service release before admitting replacement work after watchdog auto-cancel.
- Added a managed premium-run concurrency cap with `PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS`, applied at queued-run claim time under a shared premium admission lock.
- Fixed tenant scoping on the premium-running count join.
- Fixed env string parsing around runtime/concurrency settings.
- Added production export conditions for workspace packages and adapters so the service can run `dist/index.js` with `--conditions=production`.
- Added an approval evidence helper that prints git, service, health, and live-run evidence without dumping secrets, including `runningObserved` and `queuedObserved` summaries.
- Documented the Help2day dedicated operations runbook, rollback notes, DB placement expectations, and permanent approval-evidence rule.
- Updated the PR template to require machine-verifiable evidence for merge, deploy, or runtime activation approval requests.
- Addressed review feedback around output-evidence guards, false-positive suppression ordering, test env cleanup, and redundant finalization ownership.

## Verification

Local validation run before opening this PR and after review fixes:

```sh
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-dependency-scheduling.test.ts src/__tests__/heartbeat-active-run-output-watchdog.test.ts src/__tests__/heartbeat-process-recovery.test.ts
pnpm --filter @paperclipai/server exec tsc --noEmit --pretty false
pnpm --filter @paperclipai/shared build
pnpm --filter @paperclipai/adapter-utils build
pnpm --filter @paperclipai/db build
pnpm --filter '@paperclipai/adapter-*' build
pnpm --filter @paperclipai/plugin-sdk build
pnpm --filter @paperclipai/server run build
pnpm --dir /home/paperclipadmin/paperclip-src/server exec node --conditions=production --input-type=module -e "await import('@paperclipai/db'); await import('@paperclipai/shared'); await import('@paperclipai/shared/telemetry'); await import('@paperclipai/adapter-utils/server-utils'); await import('@paperclipai/adapter-claude-local/server'); await import('@paperclipai/adapter-codex-local/server'); console.log('production workspace imports ok')"
node --check scripts/approval-evidence-report.mjs
```

Focused review-fix validation:

```sh
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts src/__tests__/heartbeat-process-recovery.test.ts --testNamePattern "auto-cancels critical silent runs|folds terminal source issues|folds existing evaluation|queues exactly one retry"
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-dependency-scheduling.test.ts src/__tests__/heartbeat-active-run-output-watchdog.test.ts src/__tests__/heartbeat-process-recovery.test.ts
pnpm --filter @paperclipai/server exec tsc --noEmit --pretty false
pnpm --filter @paperclipai/server run build
```

Results:
- Focused review-fix tests: 2 files passed, 4 selected tests passed.
- Full targeted suite: 3 files passed, 83 tests passed.
- Typecheck: passed.
- Server compiled build: passed.

Machine-verifiable approval evidence captured on `paperclip01` at `2026-06-17T16:05:38.804Z` after rebuilding and restarting the compiled runtime:

```json
{
  "kind": "paperclip.approval_evidence",
  "capturedAt": "2026-06-17T16:05:38.804Z",
  "git": {
    "branch": "fix/help2day-stale-run-watchdog-auto-cancel",
    "head": "73985755561ed66a8e75488114cb670d7ab378bd",
    "upstream": "origin/master",
    "upstreamHead": "1b89a8e3b86a68b1eb59c62863991fc50cb15fd1",
    "aheadBehind": { "ahead": 5, "behind": 0 },
    "trackedWorkingTreeClean": true
  },
  "runtime": {
    "paperclipService": {
      "ActiveState": "active",
      "SubState": "running",
      "MainPID": "633793",
      "NRestarts": "0",
      "ExecStart": "/usr/bin/pnpm --dir /home/paperclipadmin/paperclip-src/server exec node --conditions=production dist/index.js",
      "WorkingDirectory": "/home/paperclipadmin/paperclip-src"
    },
    "health": { "ok": true, "status": 200, "body": { "status": "ok", "version": "0.3.1", "deploymentMode": "local_trusted", "deploymentExposure": "private" } },
    "liveRuns": { "ok": true, "status": 200, "runningObserved": 0, "queuedObserved": 0, "statusCounts": {} }
  }
}
```

Additional live host validation:

```sh
systemctl show paperclip.service --property=ExecStart,WorkingDirectory,ActiveState,SubState,MainPID,NRestarts --no-pager
pg_lsclusters
ss -ltnp '( sport = :5432 )'
free -h
uptime
```

Observed: Paperclip service active/running on compiled runtime, local PostgreSQL cluster on `paperclip01` down, no local `5432` listener, about 12 GiB available memory, and load average under 1 at evidence capture.

## Risks

- Medium risk: stale-run recovery changes affect scheduler behavior. This is covered by targeted heartbeat tests for dependency scheduling, active-run watchdog behavior, and process recovery.
- Medium risk: production export condition changes touch multiple workspace package manifests. This was validated with package builds and production-condition import smoke tests.
- Operational risk: raising managed premium concurrency can increase CPU, memory, and provider pressure. The default is intentionally conservative at 3 and can be changed with `PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS`.
- Rollback: restore the prior Paperclip service drop-in from `/etc/systemd/system/paperclip.service.d/zz-emergency-source-runtime.conf.bak.*` or run `/home/paperclipadmin/restore-paperclip-tsx-runtime.sh`; set `PAPERCLIP_PREMIUM_MAX_CONCURRENT_RUNS=1` or unset it and restart the service; revert this branch if recovery behavior needs to return to prior behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex CLI, GPT-5 based coding agent, tool-assisted local shell execution and code editing. Context included the local repository, service state, GitHub CLI state, GitHub PR feedback, and Help2day dedicated Paperclip runtime evidence.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] For merge, deploy, or runtime activation approval, I have included current machine-verifiable evidence tied to the exact commit/config being approved
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge