### PR TITLE
fix(claude-local): treat subtype=success as success despite non-zero CLI exit

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -53,6 +53,7 @@ import {
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
   isClaudeTransientUpstreamError,
+  isClaudeSuccessResult,
   isClaudeUnknownSessionError,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
@@ -878,7 +879,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const poisonedPreviousMessageId = isClaudePoisonedPreviousMessageIdError(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    // The Claude CLI's own `result` event is the authoritative outcome. A
+    // non-zero process exit *after* a `subtype=success` result (e.g. SIGTERM
+    // during the grace window, or EPIPE once the log consumer closes on long
+    // runs) must not flip a successful run to failed — otherwise the harness
+    // records "Claude run failed: subtype=success" and eventually errors the agent.
+    const claudeReportedSuccess = isClaudeSuccessResult(parsed);
+    const failed =
+      !claudeReportedSuccess && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
     // session id; if the last entry contains a non-`msg_`-prefixed
@@ -944,7 +952,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
 
     return {
-      exitCode: proc.exitCode,
+      exitCode: claudeReportedSuccess ? 0 : proc.exitCode,
       signal: proc.signal,
       timedOut: false,
       errorMessage,

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -164,6 +164,15 @@ export function describeClaudeFailure(parsed: Record<string, unknown>): string |
   return parts.length > 1 ? parts.join(": ") : null;
 }
 
+export function isClaudeSuccessResult(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+
+  const subtype = asString(parsed.subtype, "").trim().toLowerCase();
+  if (subtype !== "success") return false;
+
+  return parsed.is_error !== true;
+}
+
 export function isClaudeMaxTurnsResult(parsed: Record<string, unknown> | null | undefined): boolean {
   if (!parsed) return false;
 

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -197,6 +197,17 @@ console.log(JSON.stringify({ type: "result", session_id: "22222222-2222-4222-822
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeFakeClaudeSuccessThenNonZeroExitCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }));
+console.log(JSON.stringify({ type: "assistant", session_id: "claude-session-1", message: { content: [{ type: "text", text: "hello" }] } }));
+console.log(JSON.stringify({ type: "result", subtype: "success", is_error: false, session_id: "claude-session-1", result: "all done", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
+process.exit(143);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 async function setupExecuteEnv(
   root: string,
   options?: { commandWriter?: (commandPath: string) => Promise<void> },
@@ -563,6 +574,43 @@ describe("claude execute", () => {
       expect(result.errorCode).not.toBe("max_turns_exhausted");
       expect(result.resultJson?.stopReason).not.toBe("max_turns_exhausted");
       expect(result.clearSession).toBe(false);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats subtype=success as a successful run even when the CLI exits non-zero", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-success-"));
+    const { workspace, commandPath, restore } = await setupExecuteEnv(root, {
+      commandWriter: writeFakeClaudeSuccessThenNonZeroExitCommand,
+    });
+    try {
+      const result = await execute({
+        runId: "run-success-nonzero",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {},
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+        onMeta: async () => {},
+      });
+
+      expect(result.errorMessage).toBeNull();
+      expect(result.exitCode).toBe(0);
+      expect(result.summary).toBe("all done");
     } finally {
       restore();
       await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; agents execute through pluggable adapters.
> - The `claude_local` adapter runs the Claude CLI as a child process and translates its outcome into a run result the harness records.
> - Success was decided **solely from the process exit code**: the adapter ignored the CLI's own `result` event and trusted only `exitCode === 0`.
> - On long heartbeats the CLI emits `subtype=success` and then the process exits non-zero (SIGTERM during the grace window, or EPIPE once the log consumer closes), so genuinely-successful turns were recorded `failed`.
> - Repeated false failures drive `finalizeAgentStatus` to flip the agent to `error`, making it unassignable (reassign → 403) and burning runs/budget.
> - This PR makes the CLI's `result` event authoritative so a successful turn is never failed by a spurious non-zero exit, while leaving genuine failures classified as failures.
> - The benefit is resilient `claude_local` capacity that does not self-destruct under normal grace-window/EPIPE exits.

## Linked Issues or Issue Description

No public GitHub issue. Describing inline (bug):

**What happened:** The `claude_local` adapter records successful Claude CLI runs as failed. The CLI emits a `result` event with `subtype=success`, but if the process subsequently exits non-zero, the adapter calls `describeClaudeFailure()` and stores the run body as `Claude run failed: subtype=success: …` with a non-zero exit code.

**Expected:** A turn that produced `subtype=success` (and `is_error !== true`) should be recorded as a successful run regardless of a late non-zero process exit.

**Impact:** After repeated false failures the harness flips the agent's runtime status to `error`; the agent becomes unassignable (reassign → 403) and runs/budget are wasted.

**Repro:** Run a `claude_local` heartbeat long enough that the process receives SIGTERM during the grace window (or hits EPIPE) after the CLI has already emitted `subtype=success`. The run is recorded `failed`.

Related open PRs addressing the same root cause (dedup): #7284, #8077, #5553, #5124, #4335, #1114, #8028. This PR differs by normalizing the outcome in `execute.ts` via an explicit `isClaudeSuccessResult()` predicate plus a server-side regression test; maintainers may prefer to consolidate these into one.

## What Changed

- Added `isClaudeSuccessResult(parsed)` — true when `subtype === "success"` and `is_error !== true`.
- In `packages/adapters/claude-local/src/server/execute.ts`, when the parsed result reports success, normalize the outcome to `exitCode: 0` / `errorMessage: null` even if the process exited non-zero.
- Genuine failures are unchanged: non-zero exit with no success result, `is_error: true`, and `error_*` subtypes still fail; legacy exit-0 success with no subtype still succeeds.
- Added a server-side execute regression test: fake CLI emits `subtype=success` then `process.exit(143)`.

## Verification

- [x] New regression test asserts `errorMessage === null`, `exitCode === 0`, and summary preserved on `subtype=success` + `exit 143`.
- [x] Existing `claude-local-execute.test.ts` (clean exit-0 success) still passes.
- [x] Verified the outcome truth table locally (6/6): success+exit0, success+exit143, is_error+success, error_max_turns, non-zero-no-result, legacy-exit0.
- [ ] Full repo CI typecheck + vitest (run by CI; local contributing env did not have all deps installed).

## Risks

Low risk. The change only *upgrades* a recorded outcome from failure→success when the CLI itself reported `subtype=success && is_error !== true`; it never downgrades a real failure. Worst case is masking a post-success crash that occurs after the result event, which is preferable to discarding completed work and erroring the agent.

## Model Used

Claude (Anthropic), `claude-opus-4-8`, extended thinking, with tool use / code execution in the Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
