### PR TITLE
feat(secrets): reject secret_ref bindings for PAPERCLIP_* env keys at save time (FUL-11382)

### DIFF
--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -94,7 +94,7 @@ describeEmbeddedPostgres("secretService", () => {
     ).rejects.toThrow(/same company/i);
   });
 
-  it("rejects Paperclip runtime env keys backed by secret refs during env normalization", async () => {
+  it("rejects Paperclip runtime env keys backed by non-plain bindings during env normalization", async () => {
     const companyId = await seedCompany();
     const svc = secretService(db);
 
@@ -107,7 +107,7 @@ describeEmbeddedPostgres("secretService", () => {
         },
       }),
     ).rejects.toThrow(
-      'Environment key "PAPERCLIP_AGENT_ID" is reserved by the Paperclip runtime and cannot be overridden via a secret_ref binding.',
+      'Environment key "PAPERCLIP_AGENT_ID" is reserved by the Paperclip runtime and cannot be overridden via a non-plain binding.',
     );
   });
 

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -94,6 +94,42 @@ describeEmbeddedPostgres("secretService", () => {
     ).rejects.toThrow(/same company/i);
   });
 
+  it("rejects Paperclip runtime env keys backed by secret refs during env normalization", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+
+    await expect(
+      svc.normalizeEnvBindingsForPersistence(companyId, {
+        PAPERCLIP_AGENT_ID: {
+          type: "secret_ref",
+          secretId: randomUUID(),
+          version: "latest",
+        },
+      }),
+    ).rejects.toThrow(
+      'Environment key "PAPERCLIP_AGENT_ID" is reserved by the Paperclip runtime and cannot be overridden via a secret_ref binding.',
+    );
+  });
+
+  it("allows Paperclip runtime env keys backed by plain bindings during env normalization", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+
+    await expect(
+      svc.normalizeEnvBindingsForPersistence(companyId, {
+        PAPERCLIP_AGENT_ID: {
+          type: "plain",
+          value: "agent-1",
+        },
+      }),
+    ).resolves.toEqual({
+      PAPERCLIP_AGENT_ID: {
+        type: "plain",
+        value: "agent-1",
+      },
+    });
+  });
+
   it("prevents duplicate bindings for a target config path", async () => {
     const companyId = await seedCompany();
     const svc = secretService(db);

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -686,9 +686,9 @@ export function secretService(db: Db) {
         continue;
       }
 
-      if (binding.type === "secret_ref" && key.startsWith("PAPERCLIP_")) {
+      if (key.startsWith("PAPERCLIP_")) {
         throw unprocessable(
-          `Environment key "${key}" is reserved by the Paperclip runtime and cannot be overridden via a secret_ref binding.`,
+          `Environment key "${key}" is reserved by the Paperclip runtime and cannot be overridden via a non-plain binding.`,
         );
       }
 

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -686,6 +686,12 @@ export function secretService(db: Db) {
         continue;
       }
 
+      if (binding.type === "secret_ref" && key.startsWith("PAPERCLIP_")) {
+        throw unprocessable(
+          `Environment key "${key}" is reserved by the Paperclip runtime and cannot be overridden via a secret_ref binding.`,
+        );
+      }
+
       await assertSecretInCompany(companyId, binding.secretId);
       normalized[key] = {
         type: "secret_ref",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent, project, and routine environment settings can include plain values or secret-backed bindings.
> - Reserved `PAPERCLIP_*` keys are injected by the runtime and should not be shadowed through saved secret references.
> - FUL-11366 added a startup warning for this misconfiguration, but the warning happens after the bad config has already been persisted.
> - `normalizeEnvConfig()` is the shared save-time choke point for these environment writes.
> - This pull request rejects any non-plain binding for reserved `PAPERCLIP_*` keys before secret lookup.
> - The benefit is an immediate 422 validation error instead of a later runtime warning or confused-deputy shadowing path.

## Linked Issues or Issue Description

No GitHub issue exists for this internal Paperclip board issue. This PR addresses Paperclip board issue `FUL-11382` using the feature request template fields below.

### Subsystem affected

server/ — REST API & orchestration services

### Problem or motivation

Saved environment configs can currently persist a `secret_ref` binding for a reserved `PAPERCLIP_*` runtime key. That allows persisted config to shadow runtime-injected values until a later startup warning catches it. The validation should happen before the config is saved.

### Proposed solution

Reject reserved `PAPERCLIP_*` keys when they are backed by any non-plain binding in `normalizeEnvConfig()`, before secret lookup. Keep plain bindings accepted so existing local trusted and test workflows can still provide explicit non-secret values.

### Alternatives considered

Route-level validation was considered, but agent, project, and routine writes already share `normalizeEnvConfig()`. A single normalization guard avoids route drift.

### Roadmap alignment

No direct roadmap item found. This is a security hardening and validation improvement for existing environment binding behavior.

### Additional context

Acceptance criteria: `PAPERCLIP_AGENT_ID` with a non-plain binding rejects with a descriptive validation error, while a plain binding for the same key remains accepted.

## What Changed

- `server/src/services/secrets.ts`: rejects any non-plain binding for env keys prefixed with `PAPERCLIP_` during normalization.
- `server/src/__tests__/secrets-service.test.ts`: adds focused regression coverage for rejected non-plain runtime-key bindings and allowed plain runtime-key bindings.

## Verification

- `pnpm --dir /home/paperclipadmin/paperclip-pr-8239 exec vitest run server/src/__tests__/secrets-service.test.ts` - passed, 47 tests.
- `pnpm --dir /home/paperclipadmin/paperclip-pr-8239 --filter @paperclipai/server typecheck` - passed.

## Risks

Low. The change intentionally rejects a previously accepted misconfiguration: a reserved `PAPERCLIP_*` key backed by a non-plain binding. Plain bindings are unchanged, and the rejection happens before secret lookup.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex via local CLI, normal reasoning mode, with shell/code execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Co-Authored-By: Paperclip <noreply@paperclip.ing>
