### PR TITLE
feat(analytics): add model usage endpoint (FUL-11269)

### DIFF
--- a/server/src/__tests__/analytics-service.test.ts
+++ b/server/src/__tests__/analytics-service.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { analyticsService } from "../services/analytics.js";
+
+function renderSql(query: { toQuery: (config: unknown) => { sql: string } }) {
+  return query.toQuery({
+    escapeName: (name: string) => `"${name}"`,
+    escapeParam: (index: number) => `$${index + 1}`,
+    escapeString: (value: string) => `'${value.replaceAll("'", "''")}'`,
+  }).sql;
+}
+
+describe("analyticsService", () => {
+  it("uses tenant-scoped joins and NULL-safe group matching for model usage", async () => {
+    let capturedQuery: { toQuery: (config: unknown) => { sql: string } } | undefined;
+    const db = {
+      execute: vi.fn(async (query) => {
+        capturedQuery = query;
+        return [];
+      }),
+    };
+
+    await analyticsService(db as never).modelUsage("company-1", { groupBy: "model" });
+
+    expect(db.execute).toHaveBeenCalledOnce();
+    expect(capturedQuery).toBeDefined();
+    const querySql = renderSql(capturedQuery!);
+    expect(querySql).toMatch(/LEFT JOIN agents a ON ce\.agent_id = a\.id AND a\.company_id = \$\d+/);
+    expect(querySql).toMatch(
+      /LEFT JOIN heartbeat_runs hr ON ce\.heartbeat_run_id = hr\.id AND hr\.company_id = \$\d+/,
+    );
+    expect(querySql).toContain("ra.model IS NOT DISTINCT FROM ca.model");
+    expect(querySql).toContain("ra.provider IS NOT DISTINCT FROM ca.provider");
+  });
+});

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -15,6 +15,7 @@ const apiPrefixes: Record<string, string> = {
   "activity.ts": "/api",
   "adapters.ts": "/api",
   "agents.ts": "/api",
+  "analytics.ts": "/api",
   "approvals.ts": "/api",
   "assets.ts": "/api",
   "auth.ts": "/api/auth",

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -1,0 +1,59 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { analyticsService, type ModelUsageGroupBy } from "../services/analytics.js";
+import { accessService } from "../services/index.js";
+import { assertCompanyAccess } from "./authz.js";
+import { parseCostDateRange } from "./costs.js";
+import { badRequest } from "../errors.js";
+
+const VALID_GROUP_BY = new Set<string>(["model", "agent", "provider", "taskType"]);
+
+export function analyticsRoutes(db: Db) {
+  const router = Router();
+  const analytics = analyticsService(db);
+  const access = accessService(db);
+
+  async function assertCostReadAllowed(req: Parameters<typeof assertCompanyAccess>[0], res: any, companyId: string) {
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "company_scope:read",
+      resource: { type: "company", companyId },
+    });
+    if (decision.allowed) return true;
+    res.status(403).json({ error: "Analytics are outside this actor's authorization boundary" });
+    return false;
+  }
+
+  async function handleModelUsage(req: Parameters<typeof assertCompanyAccess>[0], res: any, companyId: string) {
+    assertCompanyAccess(req, companyId);
+    if (!(await assertCostReadAllowed(req, res, companyId))) return;
+
+    const groupByRaw = req.query.groupBy as string | undefined;
+    if (groupByRaw != null && !VALID_GROUP_BY.has(groupByRaw)) {
+      throw badRequest(`invalid 'groupBy' value; must be one of: ${[...VALID_GROUP_BY].join(", ")}`);
+    }
+
+    const range = parseCostDateRange(req.query);
+    const rows = await analytics.modelUsage(companyId, {
+      from: range?.from,
+      to: range?.to,
+      groupBy: (groupByRaw as ModelUsageGroupBy) ?? "model",
+    });
+
+    res.json({ groupBy: groupByRaw ?? "model", rows });
+  }
+
+  // Path-param form: /companies/:companyId/analytics/model-usage
+  router.get("/companies/:companyId/analytics/model-usage", async (req, res) => {
+    await handleModelUsage(req, res, req.params.companyId as string);
+  });
+
+  // Query-param form: /analytics/model-usage?companyId=...  (used by agents/TODD)
+  router.get("/analytics/model-usage", async (req, res) => {
+    const companyId = req.query.companyId as string | undefined;
+    if (!companyId) throw badRequest("'companyId' query parameter is required");
+    await handleModelUsage(req, res, companyId);
+  });
+
+  return router;
+}

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2225,6 +2225,40 @@ registry.registerPath({
   responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
 });
 
+const modelUsageQuerySchema = z.object({
+  groupBy: z.enum(["model", "agent", "provider", "taskType"]).optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+const modelUsageResponseSchema = z.object({
+  groupBy: z.string(),
+  rows: z.array(z.record(z.unknown())),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/companies/{companyId}/analytics/model-usage",
+  tags: ["analytics"],
+  summary: "Get model usage analytics",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: modelUsageQuerySchema,
+  },
+  responses: { 200: r.ok(modelUsageResponseSchema), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/analytics/model-usage",
+  tags: ["analytics"],
+  summary: "Get model usage analytics by query company id",
+  request: {
+    query: modelUsageQuerySchema.extend({ companyId: z.string() }),
+  },
+  responses: { 200: r.ok(modelUsageResponseSchema), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden },
+});
+
 registry.registerPath({
   method: "post",
   path: "/api/companies/{companyId}/budgets/policies",

--- a/server/src/services/analytics.ts
+++ b/server/src/services/analytics.ts
@@ -1,0 +1,181 @@
+import { sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+
+export type ModelUsageGroupBy = "model" | "agent" | "provider" | "taskType";
+
+export interface ModelUsageOptions {
+  from?: Date;
+  to?: Date;
+  groupBy?: ModelUsageGroupBy;
+}
+
+export interface ModelUsageRow {
+  model: string | null;
+  provider: string | null;
+  agentId: string | null;
+  agentName: string | null;
+  taskType: string | null;
+  runCount: number;
+  successCount: number;
+  failureCount: number;
+  totalTokensIn: number;
+  totalTokensOut: number;
+  estimatedCostCents: number;
+  avgLatencyMs: number | null;
+  retryCount: number;
+  fallbackUsedCount: number;
+}
+
+export function analyticsService(db: Db) {
+  return {
+    modelUsage: async (companyId: string, options: ModelUsageOptions = {}): Promise<ModelUsageRow[]> => {
+      const { from, to, groupBy = "model" } = options;
+
+      const fromClause = from ? sql`AND ce.occurred_at >= ${from.toISOString()}::timestamptz` : sql``;
+      const toClause = to ? sql`AND ce.occurred_at <= ${to.toISOString()}::timestamptz` : sql``;
+
+      // Each groupBy defines: SELECT fields, GROUP BY keys, DISTINCT ON keys for run dedup, and JOIN condition.
+      let costSelect: ReturnType<typeof sql>;
+      let costGroupBy: ReturnType<typeof sql>;
+      let runDedupDistinctOn: ReturnType<typeof sql>;
+      let runDedupOrderBy: ReturnType<typeof sql>;
+      let runDedupGroupBy: ReturnType<typeof sql>;
+      let joinOn: ReturnType<typeof sql>;
+
+      switch (groupBy) {
+        case "agent":
+          costSelect = sql`NULL::text AS model, NULL::text AS provider, ce.agent_id, a.name AS agent_name, NULL::text AS task_type`;
+          costGroupBy = sql`ce.agent_id, a.name`;
+          runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.agent_id`;
+          runDedupOrderBy = sql`ce.heartbeat_run_id, ce.agent_id, ce.id`;
+          runDedupGroupBy = sql`agent_id`;
+          joinOn = sql`ra.agent_id = ca.agent_id`;
+          break;
+        case "provider":
+          costSelect = sql`NULL::text AS model, ce.provider, NULL::uuid AS agent_id, NULL::text AS agent_name, NULL::text AS task_type`;
+          costGroupBy = sql`ce.provider`;
+          runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.provider`;
+          runDedupOrderBy = sql`ce.heartbeat_run_id, ce.provider, ce.id`;
+          runDedupGroupBy = sql`provider`;
+          joinOn = sql`ra.provider = ca.provider`;
+          break;
+        case "taskType":
+          costSelect = sql`NULL::text AS model, NULL::text AS provider, NULL::uuid AS agent_id, NULL::text AS agent_name, ce.billing_type AS task_type`;
+          costGroupBy = sql`ce.billing_type`;
+          runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.billing_type`;
+          runDedupOrderBy = sql`ce.heartbeat_run_id, ce.billing_type, ce.id`;
+          runDedupGroupBy = sql`task_type`;
+          joinOn = sql`ra.task_type = ca.task_type`;
+          break;
+        default: // model
+          costSelect = sql`ce.model, ce.provider, NULL::uuid AS agent_id, NULL::text AS agent_name, NULL::text AS task_type`;
+          costGroupBy = sql`ce.model, ce.provider`;
+          runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.model, ce.provider`;
+          runDedupOrderBy = sql`ce.heartbeat_run_id, ce.model, ce.provider, ce.id`;
+          runDedupGroupBy = sql`model, provider`;
+          joinOn = sql`ra.model = ca.model AND ra.provider = ca.provider`;
+          break;
+      }
+
+      // Two CTEs to avoid double-counting run durations across multiple cost_events per run.
+      // cost_agg sums tokens/cost from cost_events directly.
+      // run_dedup picks one row per (run, group-key) so avgLatencyMs and retryCount aren't inflated.
+      const result = await db.execute<{
+        model: string | null;
+        provider: string | null;
+        agent_id: string | null;
+        agent_name: string | null;
+        task_type: string | null;
+        run_count: string;
+        success_count: string;
+        failure_count: string;
+        total_tokens_in: string;
+        total_tokens_out: string;
+        estimated_cost_cents: string;
+        avg_latency_ms: string | null;
+        retry_count: string;
+      }>(sql`
+        WITH cost_agg AS (
+          SELECT
+            ${costSelect},
+            SUM(ce.input_tokens + ce.cached_input_tokens) AS total_tokens_in,
+            SUM(ce.output_tokens) AS total_tokens_out,
+            SUM(ce.cost_cents) AS estimated_cost_cents
+          FROM cost_events ce
+          LEFT JOIN agents a ON ce.agent_id = a.id
+          WHERE ce.company_id = ${companyId}
+            ${fromClause}
+            ${toClause}
+          GROUP BY ${costGroupBy}
+        ),
+        run_dedup AS (
+          SELECT DISTINCT ON (${runDedupDistinctOn})
+            ce.heartbeat_run_id,
+            ce.model,
+            ce.provider,
+            ce.agent_id,
+            ce.billing_type AS task_type,
+            hr.status,
+            CASE
+              WHEN hr.finished_at IS NOT NULL AND hr.started_at IS NOT NULL
+              THEN EXTRACT(EPOCH FROM (hr.finished_at - hr.started_at)) * 1000
+              ELSE NULL
+            END AS latency_ms,
+            COALESCE(hr.process_loss_retry_count, 0) AS retry_val
+          FROM cost_events ce
+          LEFT JOIN heartbeat_runs hr ON ce.heartbeat_run_id = hr.id
+          WHERE ce.company_id = ${companyId}
+            ${fromClause}
+            ${toClause}
+          ORDER BY ${runDedupOrderBy}
+        ),
+        run_agg AS (
+          SELECT
+            ${runDedupGroupBy},
+            COUNT(*)::int AS run_count,
+            COUNT(CASE WHEN status = 'done' THEN 1 END)::int AS success_count,
+            COUNT(CASE WHEN status IS NOT NULL AND status != 'done' THEN 1 END)::int AS failure_count,
+            ROUND(AVG(latency_ms))::int AS avg_latency_ms,
+            SUM(retry_val)::int AS retry_count
+          FROM run_dedup
+          GROUP BY ${runDedupGroupBy}
+        )
+        SELECT
+          ca.model,
+          ca.provider,
+          ca.agent_id,
+          ca.agent_name,
+          ca.task_type,
+          COALESCE(ra.run_count, 0) AS run_count,
+          COALESCE(ra.success_count, 0) AS success_count,
+          COALESCE(ra.failure_count, 0) AS failure_count,
+          ca.total_tokens_in,
+          ca.total_tokens_out,
+          ca.estimated_cost_cents,
+          ra.avg_latency_ms,
+          COALESCE(ra.retry_count, 0) AS retry_count
+        FROM cost_agg ca
+        LEFT JOIN run_agg ra ON ${joinOn}
+        ORDER BY ca.estimated_cost_cents DESC
+      `);
+
+      const rows = Array.isArray(result) ? result : [];
+      return rows.map((row) => ({
+        model: row.model ?? null,
+        provider: row.provider ?? null,
+        agentId: row.agent_id ?? null,
+        agentName: row.agent_name ?? null,
+        taskType: row.task_type ?? null,
+        runCount: Number(row.run_count ?? 0),
+        successCount: Number(row.success_count ?? 0),
+        failureCount: Number(row.failure_count ?? 0),
+        totalTokensIn: Number(row.total_tokens_in ?? 0),
+        totalTokensOut: Number(row.total_tokens_out ?? 0),
+        estimatedCostCents: Number(row.estimated_cost_cents ?? 0),
+        avgLatencyMs: row.avg_latency_ms != null ? Number(row.avg_latency_ms) : null,
+        retryCount: Number(row.retry_count ?? 0),
+        fallbackUsedCount: 0,
+      }));
+    },
+  };
+}

--- a/server/src/services/analytics.ts
+++ b/server/src/services/analytics.ts
@@ -49,7 +49,7 @@ export function analyticsService(db: Db) {
           runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.agent_id`;
           runDedupOrderBy = sql`ce.heartbeat_run_id, ce.agent_id, ce.id`;
           runDedupGroupBy = sql`agent_id`;
-          joinOn = sql`ra.agent_id = ca.agent_id`;
+          joinOn = sql`ra.agent_id IS NOT DISTINCT FROM ca.agent_id`;
           break;
         case "provider":
           costSelect = sql`NULL::text AS model, ce.provider, NULL::uuid AS agent_id, NULL::text AS agent_name, NULL::text AS task_type`;
@@ -57,7 +57,7 @@ export function analyticsService(db: Db) {
           runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.provider`;
           runDedupOrderBy = sql`ce.heartbeat_run_id, ce.provider, ce.id`;
           runDedupGroupBy = sql`provider`;
-          joinOn = sql`ra.provider = ca.provider`;
+          joinOn = sql`ra.provider IS NOT DISTINCT FROM ca.provider`;
           break;
         case "taskType":
           costSelect = sql`NULL::text AS model, NULL::text AS provider, NULL::uuid AS agent_id, NULL::text AS agent_name, ce.billing_type AS task_type`;
@@ -65,7 +65,7 @@ export function analyticsService(db: Db) {
           runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.billing_type`;
           runDedupOrderBy = sql`ce.heartbeat_run_id, ce.billing_type, ce.id`;
           runDedupGroupBy = sql`task_type`;
-          joinOn = sql`ra.task_type = ca.task_type`;
+          joinOn = sql`ra.task_type IS NOT DISTINCT FROM ca.task_type`;
           break;
         default: // model
           costSelect = sql`ce.model, ce.provider, NULL::uuid AS agent_id, NULL::text AS agent_name, NULL::text AS task_type`;
@@ -73,7 +73,7 @@ export function analyticsService(db: Db) {
           runDedupDistinctOn = sql`ce.heartbeat_run_id, ce.model, ce.provider`;
           runDedupOrderBy = sql`ce.heartbeat_run_id, ce.model, ce.provider, ce.id`;
           runDedupGroupBy = sql`model, provider`;
-          joinOn = sql`ra.model = ca.model AND ra.provider = ca.provider`;
+          joinOn = sql`ra.model IS NOT DISTINCT FROM ca.model AND ra.provider IS NOT DISTINCT FROM ca.provider`;
           break;
       }
 
@@ -102,7 +102,7 @@ export function analyticsService(db: Db) {
             SUM(ce.output_tokens) AS total_tokens_out,
             SUM(ce.cost_cents) AS estimated_cost_cents
           FROM cost_events ce
-          LEFT JOIN agents a ON ce.agent_id = a.id
+          LEFT JOIN agents a ON ce.agent_id = a.id AND a.company_id = ${companyId}
           WHERE ce.company_id = ${companyId}
             ${fromClause}
             ${toClause}
@@ -123,7 +123,7 @@ export function analyticsService(db: Db) {
             END AS latency_ms,
             COALESCE(hr.process_loss_retry_count, 0) AS retry_val
           FROM cost_events ce
-          LEFT JOIN heartbeat_runs hr ON ce.heartbeat_run_id = hr.id
+          LEFT JOIN heartbeat_runs hr ON ce.heartbeat_run_id = hr.id AND hr.company_id = ${companyId}
           WHERE ce.company_id = ${companyId}
             ${fromClause}
             ${toClause}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Help2day’s board and agent workflows need per-model cost, latency, token, retry, and success/failure visibility to manage execution quality.
> - The analytics subsystem already records cost events and related run metadata, but callers lacked a direct model-usage API surface.
> - FUL-11269 specifically needs a flat endpoint that agents can call with `companyId` in query params, while preserving the existing company-scoped route style.
> - The earlier local branch for this work was stale and mixed with unrelated changes, so this PR was rebuilt from current `origin/master` and contains only the analytics endpoint surface.
> - This pull request adds read-only model usage aggregation with tenant-scoped and NULL-safe SQL joins.
> - The benefit is current, machine-queryable usage evidence for model optimization and cost/latency review without manual database access.

## Linked Issues or Issue Description

No upstream GitHub issue exists for this Help2day board ticket. Internal Paperclip issue: FUL-11269.

## Problem or motivation

Paperclip operators and agents need model usage visibility without direct database access. Today the data exists across cost and run records, but there is no safe model-usage endpoint for board workflows or daily model optimization routines.

## Proposed solution

Expose model usage aggregation through company-scoped and flat query-param API routes. Return grouped run, token, cost, latency, retry, success, and failure metrics while enforcing existing company access checks.

## Alternatives considered

Direct SQL queries were rejected because they bypass the API permission model and are hard for agents to use safely. A UI-only report was rejected because routines and automation need machine-readable data.

## Roadmap alignment

This is a Help2day operational analytics feature and does not duplicate planned core roadmap work.

## What Changed

- Added `GET /api/companies/:companyId/analytics/model-usage`.
- Added `GET /api/analytics/model-usage?companyId=...` for agent/TODD callers.
- Added model usage aggregation by `model`, `agent`, `provider`, or `taskType`.
- Aggregates run counts, success/failure counts, tokens, estimated cost, average latency, and retry counts.
- Hardened SQL joins with tenant-scoped joins on `agents` and `heartbeat_runs`.
- Uses `IS NOT DISTINCT FROM` for NULL-safe group matching.
- Added regression coverage for the generated SQL join protections.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/analytics-service.test.ts`

Machine-verifiable evidence is tied to implementation commit `4e03eb4572c921ff9405c8731d021a456469ae85` and retrigger commit `24a8a5a2441e46eb765e3add3f3b4a8cc1d385f3`.

## Risks

- Read-only analytics endpoint; no mutations.
- Query cost depends on `cost_events`/`heartbeat_runs` volume in the selected date range. Callers should prefer bounded windows for large installs.
- Endpoint visibility is company-scope gated via existing access checks.

## Model Used

- OpenAI GPT-5 Codex local supervisor with repository access, shell/tool execution, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched GitHub PRs for similar PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] For merge, deploy, or runtime activation approval, I have included current machine-verifiable evidence tied to the exact commit/config being approved
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
