### PR TITLE
[codex] Suppress routine max-turn retry loops

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -139,6 +139,8 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     scheduledRetryAttempt?: number;
     runtimeConfig?: Record<string, unknown>;
     issueStatus?: string;
+    issueOriginKind?: string;
+    contextSnapshot?: Record<string, unknown>;
   }) {
     const companyId = input?.companyId ?? randomUUID();
     const agentId = input?.agentId ?? randomUUID();
@@ -194,6 +196,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       contextSnapshot: {
         issueId,
         wakeReason: "issue_assigned",
+        ...(input?.contextSnapshot ?? {}),
       },
       updatedAt: now,
       createdAt: now,
@@ -209,6 +212,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       executionRunId: runId,
       executionAgentNameKey: "claudecoder",
       executionLockedAt: now,
+      originKind: input?.issueOriginKind ?? "manual",
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
     });
@@ -421,6 +425,80 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRuns[0]?.id);
+  });
+
+  it("suppresses max-turn continuations for routine execution issues by default", async () => {
+    const { issueId, runId, now } = await seedMaxTurnFixture({
+      issueOriginKind: "routine_execution",
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+          maxTurnContinuation: {
+            enabled: true,
+            maxAttempts: 10,
+            delayMs: 1_000,
+          },
+        },
+      },
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      maxAttempts: 10,
+      delayMs: 1_000,
+    });
+
+    expect(scheduled).toMatchObject({
+      outcome: "not_scheduled",
+      errorCode: "routine_execution_auto_continuation_disabled",
+      issueId,
+    });
+
+    const retryRuns = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(retryRuns).toBe(0);
+
+    const event = await db
+      .select({
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(sql`${heartbeatRunEvents.seq} desc`)
+      .then((rows) => rows[0] ?? null);
+    expect(event?.message).toContain("routine execution issue");
+    expect(event?.payload).toMatchObject({
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      maxAttempts: 10,
+      originKind: "routine_execution",
+      optInContextKey: "allowMaxTurnContinuation",
+    });
+  });
+
+  it("allows routine max-turn continuation when the run explicitly opts in", async () => {
+    const { runId, now } = await seedMaxTurnFixture({
+      issueOriginKind: "routine_execution",
+      contextSnapshot: { allowMaxTurnContinuation: true },
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      maxAttempts: 2,
+      delayMs: 1_000,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+    expect(scheduled.attempt).toBe(1);
   });
 
   it("does not promote a duplicate max-turn continuation that does not own the issue lock", async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -220,6 +220,70 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     return { companyId, agentId, issueId, runId, now };
   }
 
+  async function seedPreexistingMaxTurnContinuation(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    sourceRunId: string;
+    dueAt: Date;
+    contextSnapshot?: Record<string, unknown>;
+  }) {
+    const retryRunId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const contextSnapshot = {
+      issueId: input.issueId,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      retryOfRunId: input.sourceRunId,
+      scheduledRetryAttempt: 1,
+      scheduledRetryAt: input.dueAt.toISOString(),
+      ...(input.contextSnapshot ?? {}),
+    };
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      payload: contextSnapshot,
+      status: "queued",
+      requestedByActorType: "system",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: retryRunId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "scheduled_retry",
+      wakeupRequestId,
+      retryOfRunId: input.sourceRunId,
+      scheduledRetryAt: input.dueAt,
+      scheduledRetryAttempt: 1,
+      scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      contextSnapshot,
+      updatedAt: input.dueAt,
+      createdAt: input.dueAt,
+    });
+    await db
+      .update(agentWakeupRequests)
+      .set({ runId: retryRunId })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+    await db
+      .update(issues)
+      .set({
+        executionRunId: retryRunId,
+        executionAgentNameKey: "claudecoder",
+        executionLockedAt: input.dueAt,
+        updatedAt: input.dueAt,
+      })
+      .where(eq(issues.id, input.issueId));
+
+    return { retryRunId, wakeupRequestId, dueAt: input.dueAt };
+  }
+
   it("schedules a retry with durable metadata and only promotes it when due", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -499,6 +563,111 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(scheduled.outcome).toBe("scheduled");
     if (scheduled.outcome !== "scheduled") return;
     expect(scheduled.attempt).toBe(1);
+  });
+
+  it("cancels a pre-existing routine max-turn scheduled retry at promotion without explicit opt-in", async () => {
+    const { companyId, agentId, issueId, runId, now } = await seedMaxTurnFixture({
+      issueOriginKind: "routine_execution",
+    });
+    const dueAt = new Date(now.getTime() + 1_000);
+    const { retryRunId, wakeupRequestId } = await seedPreexistingMaxTurnContinuation({
+      companyId,
+      agentId,
+      issueId,
+      sourceRunId: runId,
+      dueAt,
+    });
+
+    const promotion = await heartbeat.promoteDueScheduledRetries(dueAt);
+    expect(promotion).toEqual({ promoted: 0, runIds: [] });
+
+    const [retryRun, wakeupRequest, issue, event] = await Promise.all([
+      db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          error: heartbeatRuns.error,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({
+          message: heartbeatRunEvents.message,
+          payload: heartbeatRunEvents.payload,
+        })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, retryRunId))
+        .orderBy(sql`${heartbeatRunEvents.seq} desc`)
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(retryRun).toMatchObject({
+      status: "cancelled",
+      errorCode: "routine_execution_auto_continuation_disabled",
+    });
+    expect(retryRun?.error).toContain("allowMaxTurnContinuation");
+    expect(wakeupRequest).toMatchObject({
+      status: "cancelled",
+    });
+    expect(wakeupRequest?.error).toContain("allowMaxTurnContinuation");
+    expect(issue).toEqual({
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+    expect(event?.message).toContain("routine execution issue");
+    expect(event?.payload).toMatchObject({
+      issueId,
+      originKind: "routine_execution",
+      optInContextKey: "allowMaxTurnContinuation",
+      scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+    });
+  });
+
+  it("promotes a pre-existing routine max-turn scheduled retry when explicit opt-in is present", async () => {
+    const { companyId, agentId, issueId, runId, now } = await seedMaxTurnFixture({
+      issueOriginKind: "routine_execution",
+    });
+    const dueAt = new Date(now.getTime() + 1_000);
+    const { retryRunId } = await seedPreexistingMaxTurnContinuation({
+      companyId,
+      agentId,
+      issueId,
+      sourceRunId: runId,
+      dueAt,
+      contextSnapshot: { allowMaxTurnContinuation: true },
+    });
+
+    const promotion = await heartbeat.promoteDueScheduledRetries(dueAt);
+    expect(promotion).toEqual({ promoted: 1, runIds: [retryRunId] });
+
+    const retryRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(retryRun).toEqual({
+      status: "queued",
+      errorCode: null,
+    });
   });
 
   it("does not promote a duplicate max-turn continuation that does not own the issue lock", async () => {

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -470,6 +470,89 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels queued routine max-turn continuations without explicit opt-in before the run starts", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Routine max-turn continuation without opt-in",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      originKind: "routine_execution",
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      invocationSource: "automation",
+      scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      contextExtras: {
+        retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      },
+    });
+    await db
+      .update(issues)
+      .set({
+        executionRunId: runId,
+        executionAgentNameKey: "claudecoder",
+        executionLockedAt: new Date("2026-04-20T12:00:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup, issue] = await Promise.all([
+      db
+        .select({
+          status: heartbeatRuns.status,
+          errorCode: heartbeatRuns.errorCode,
+          resultJson: heartbeatRuns.resultJson,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("routine_execution_auto_continuation_disabled");
+    expect(run?.resultJson).toMatchObject({ stopReason: "routine_execution_auto_continuation_disabled" });
+    expect(wakeup?.status).toBe("skipped");
+    expect(wakeup?.error).toContain("allowMaxTurnContinuation");
+    expect(issue).toEqual({
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued max-turn continuations when another continuation owns the issue lock", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6189,7 +6189,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             | "issue_cancelled"
             | "issue_terminal_status"
             | "issue_not_in_progress"
-            | "issue_execution_lock_changed";
+            | "issue_execution_lock_changed"
+            | "routine_execution_auto_continuation_disabled";
           issueId: string | null;
           details: Record<string, unknown>;
         };
@@ -6256,6 +6257,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               status: issues.status,
               assigneeAgentId: issues.assigneeAgentId,
               executionRunId: issues.executionRunId,
+              originKind: issues.originKind,
             })
             .from(issues)
             .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -6316,6 +6318,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 issueId,
                 expectedExecutionRunId: run.id,
                 currentExecutionRunId: lockedIssue.executionRunId,
+              },
+            };
+          }
+
+          if (
+            lockedIssue.originKind === "routine_execution" &&
+            contextSnapshot.allowMaxTurnContinuation !== true
+          ) {
+            return {
+              outcome: "not_scheduled",
+              reason:
+                "Scheduled max-turn continuation suppressed for routine execution issue without explicit allowMaxTurnContinuation opt-in",
+              errorCode: "routine_execution_auto_continuation_disabled",
+              issueId,
+              details: {
+                issueId,
+                originKind: lockedIssue.originKind,
+                optInContextKey: "allowMaxTurnContinuation",
               },
             };
           }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5677,7 +5677,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
           | "issue_paused"
-          | "issue_dependencies_blocked";
+          | "issue_dependencies_blocked"
+          | "routine_execution_auto_continuation_disabled";
         issueId: string | null;
         details: Record<string, unknown>;
       };
@@ -5736,6 +5737,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        originKind: issues.originKind,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -5799,6 +5801,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           issueId,
           expectedExecutionRunId: run.id,
           currentExecutionRunId: issue.executionRunId,
+        },
+      };
+    }
+
+    if (
+      retryReason === MAX_TURN_CONTINUATION_RETRY_REASON &&
+      issue.originKind === "routine_execution" &&
+      contextSnapshot.allowMaxTurnContinuation !== true
+    ) {
+      return {
+        allowed: false,
+        reason:
+          "Scheduled max-turn continuation suppressed for routine execution issue without explicit allowMaxTurnContinuation opt-in",
+        errorCode: "routine_execution_auto_continuation_disabled",
+        issueId,
+        details: {
+          issueId,
+          originKind: issue.originKind,
+          optInContextKey: "allowMaxTurnContinuation",
         },
       };
     }
@@ -6971,7 +6992,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
-          | "issue_continuation_waiting_on_review";
+          | "issue_continuation_waiting_on_review"
+          | "routine_execution_auto_continuation_disabled";
         details: Record<string, unknown>;
       };
 
@@ -6987,6 +7009,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        originKind: issues.originKind,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -7080,6 +7103,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           issueId,
           expectedExecutionRunId: run.id,
           currentExecutionRunId: issue.executionRunId,
+        },
+      };
+    }
+
+    if (
+      retryReason === MAX_TURN_CONTINUATION_RETRY_REASON &&
+      issue.originKind === "routine_execution" &&
+      context.allowMaxTurnContinuation !== true
+    ) {
+      return {
+        stale: true,
+        errorCode: "routine_execution_auto_continuation_disabled",
+        reason:
+          "Cancelled because routine execution max-turn continuation lacks explicit allowMaxTurnContinuation opt-in before the queued run could start",
+        details: {
+          issueId,
+          originKind: issue.originKind,
+          optInContextKey: "allowMaxTurnContinuation",
         },
       };
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service owns agent wakeups, retries, queued runs, and execution locks.
> - Routine executions can be useful recurring automation, but they also have the highest risk of unattended retry loops.
> - PR #8245 already stopped newly scheduled routine max-turn continuations unless the run context explicitly opts in with `allowMaxTurnContinuation: true`.
> - The remaining gap was that pre-existing `scheduled_retry` rows and already-queued max-turn continuations could still promote or start through shared paths that did not re-check the routine opt-in.
> - This pull request makes routine max-turn continuation fail closed at scheduling, promotion, and queued-start time.
> - The benefit is that stale routine continuations cannot bypass the opt-in gate and create another retry storm.

## Linked Issues or Issue Description

Internal tracker references: LIB-504, LIB-510, LIB-513.

Bug report:

- What happened: routine execution issues that hit max-turn exhaustion could have an existing `scheduled_retry` continuation row. The original PR blocked new scheduling, but promotion of an already-existing retry row did not verify `contextSnapshot.allowMaxTurnContinuation === true`.
- Expected behavior: routine max-turn continuations must not schedule, promote, or start unless the run context explicitly sets `allowMaxTurnContinuation: true`.
- Steps to reproduce: seed a `routine_execution` issue, seed a max-turn `scheduled_retry` heartbeat run for the issue without the opt-in, and call `promoteDueScheduledRetries()` at the due time.
- Version/commit: reproduced against PR #8245 before commit `95923a22fad9ea54ebde8d7a3cce13045d1f5627`.
- Deployment mode: server heartbeat service with embedded Postgres regression coverage.
- Related PR search: searched GitHub PRs for `routine max-turn continuation`; only this PR (#8245) matched.

## What Changed

- Added `originKind` to `evaluateScheduledRetryGate()` and made routine max-turn continuations fail closed during scheduled retry promotion unless `allowMaxTurnContinuation: true` is present.
- Added the same routine opt-in guard to queued-run stale validation so a queued max-turn continuation cannot start if it somehow survived promotion.
- Added embedded Postgres regression coverage for a pre-existing routine max-turn `scheduled_retry` without opt-in, proving it is cancelled/not promoted.
- Added embedded Postgres regression coverage for a pre-existing routine max-turn `scheduled_retry` with explicit opt-in, proving it still promotes.
- Added queued-run stale invalidation coverage proving a queued routine max-turn continuation without opt-in is cancelled before adapter execution.

## Verification

- `npx pnpm@9.15.4 exec vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts` -> 1 file / 24 tests passed
- `npx pnpm@9.15.4 exec vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts` -> 1 file / 9 tests passed
- `npx pnpm@9.15.4 --filter @paperclipai/server typecheck` -> passed
- `git diff --check` -> passed

## Risks

- Low migration risk: no schema changes.
- Behavior change: existing routine max-turn continuation rows without explicit opt-in are now cancelled at promotion or queued-start time. This is intentional fail-closed behavior for the security finding.
- Routines that legitimately need max-turn continuation must explicitly set `allowMaxTurnContinuation: true` in the run context.
- Ordinary non-routine scheduled retries and non-routine max-turn continuations retain their existing behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent in a tool-enabled CLI environment with shell, git, GitHub CLI, and local test execution. Exact hosted model build identifier was not exposed in the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
