### PR TITLE
Add DotFun Claude skills marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "dotfun-claude-skills",
+  "description": "Internal DotFun Claude Code plugin marketplace for Paperclip skills.",
+  "version": "1.0.0",
+  "owner": {
+    "name": "DotFun"
+  },
+  "plugins": [
+    {
+      "name": "dotfun-claude-skills",
+      "displayName": "DotFun Claude Skills",
+      "source": "./plugins/dotfun-claude-skills",
+      "description": "DotFun and Paperclip Claude Code skills for Paperclip operations, company creation, and UI design work.",
+      "version": "1.0.0",
+      "author": {
+        "name": "DotFun"
+      },
+      "repository": "https://github.com/paperclipai/paperclip",
+      "license": "MIT",
+      "category": "productivity",
+      "tags": [
+        "dotfun",
+        "paperclip",
+        "skills",
+        "claude-code"
+      ]
+    }
+  ]
+}

--- a/plugins/dotfun-claude-skills/.claude-plugin/plugin.json
+++ b/plugins/dotfun-claude-skills/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "dotfun-claude-skills",
+  "displayName": "DotFun Claude Skills",
+  "description": "DotFun and Paperclip Claude Code skills for Paperclip operations, company creation, and UI design work.",
+  "version": "1.0.0",
+  "author": {
+    "name": "DotFun"
+  },
+  "repository": "https://github.com/paperclipai/paperclip",
+  "license": "MIT",
+  "keywords": [
+    "dotfun",
+    "paperclip",
+    "skills",
+    "claude-code"
+  ]
+}

--- a/plugins/dotfun-claude-skills/README.md
+++ b/plugins/dotfun-claude-skills/README.md
@@ -1,0 +1,52 @@
+# DotFun Claude Skills Marketplace
+
+This repository can be used as a Claude Code plugin marketplace for DotFun/Paperclip skills.
+
+## Install from the marketplace
+
+Add the marketplace from GitHub:
+
+```text
+/plugin marketplace add paperclipai/paperclip
+```
+
+Then install the bundled DotFun skills plugin:
+
+```text
+/plugin install dotfun-claude-skills@dotfun-claude-skills
+```
+
+After install, reload plugins if Claude Code does not pick it up automatically:
+
+```text
+/reload-plugins
+```
+
+The skills are available under the plugin namespace, for example:
+
+```text
+/dotfun-claude-skills:paperclip
+/dotfun-claude-skills:company-creator
+/dotfun-claude-skills:design-guide
+```
+
+## Local development test
+
+From the repository root:
+
+```bash
+claude plugin validate .
+claude --plugin-dir ./plugins/dotfun-claude-skills
+```
+
+Inside Claude Code, run `/reload-plugins` and then try one of the namespaced skills above.
+
+## Structure
+
+```text
+.claude-plugin/marketplace.json                 # Claude Code marketplace catalog
+plugins/dotfun-claude-skills/.claude-plugin/plugin.json
+plugins/dotfun-claude-skills/skills/<skill>/SKILL.md
+```
+
+The plugin directory is self-contained: symlinked skills from the legacy `.claude/skills` setup are materialized as real directories so Claude Code's plugin cache can copy them safely.

--- a/plugins/dotfun-claude-skills/skills/company-creator/SKILL.md
+++ b/plugins/dotfun-claude-skills/skills/company-creator/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: company-creator
+description: >
+  Create agent company packages conforming to the Agent Companies specification
+  (agentcompanies/v1). Use when a user wants to create a new agent company from
+  scratch, build a company around an existing git repo or skills collection, or
+  scaffold a team/department of agents. Triggers on: "create a company", "make me
+  a company", "build a company from this repo", "set up an agent company",
+  "create a team of agents", "hire some agents", or when given a repo URL and
+  asked to turn it into a company. Do NOT use for importing an existing company
+  package (use the CLI import command instead) or for modifying a company that
+  is already running in Paperclip.
+---
+
+# Company Creator
+
+Create agent company packages that conform to the Agent Companies specification.
+
+Spec references:
+
+- Normative spec: `docs/companies/companies-spec.md` (read this before generating files)
+- Web spec: https://agentcompanies.io/specification
+- Protocol site: https://agentcompanies.io/
+
+## Two Modes
+
+### Mode 1: Company From Scratch
+
+The user describes what they want. Interview them to flesh out the vision, then generate the package.
+
+### Mode 2: Company From a Repo
+
+The user provides a git repo URL, local path, or tweet. Analyze the repo, then create a company that wraps it.
+
+See [references/from-repo-guide.md](references/from-repo-guide.md) for detailed repo analysis steps.
+
+## Process
+
+### Step 1: Gather Context
+
+Determine which mode applies:
+
+- **From scratch**: What kind of company or team? What domain? What should the agents do?
+- **From repo**: Clone/read the repo. Scan for existing skills, agent configs, README, source structure.
+
+### Step 2: Interview (Use AskUserQuestion)
+
+Do not skip this step. Use AskUserQuestion to align with the user before writing any files.
+
+**For from-scratch companies**, ask about:
+
+- Company purpose and domain (1-2 sentences is fine)
+- What agents they need - propose a hiring plan based on what they described
+- Whether this is a full company (needs a CEO) or a team/department (no CEO required)
+- Any specific skills the agents should have
+- How work flows through the organization (see "Workflow" below)
+- Whether they want projects and starter tasks
+
+**For from-repo companies**, present your analysis and ask:
+
+- Confirm the agents you plan to create and their roles
+- Whether to reference or vendor any discovered skills (default: reference)
+- Any additional agents or skills beyond what the repo provides
+- Company name and any customization
+- Confirm the workflow you inferred from the repo (see "Workflow" below)
+
+**Workflow — how does work move through this company?**
+
+A company is not just a list of agents with skills. It's an organization that takes ideas and turns them into work products. You need to understand the workflow so each agent knows:
+
+- Who gives them work and in what form (a task, a branch, a question, a review request)
+- What they do with it
+- Who they hand off to when they're done, and what that handoff looks like
+- What "done" means for their role
+
+**Not every company is a pipeline.** Infer the right workflow pattern from context:
+
+- **Pipeline** — sequential stages, each agent hands off to the next. Use when the repo/domain has a clear linear process (e.g. plan → build → review → ship → QA, or content ideation → draft → edit → publish).
+- **Hub-and-spoke** — a manager delegates to specialists who report back independently. Use when agents do different kinds of work that don't feed into each other (e.g. a CEO who dispatches to a researcher, a marketer, and an analyst).
+- **Collaborative** — agents work together on the same things as peers. Use for small teams where everyone contributes to the same output (e.g. a design studio, a brainstorming team).
+- **On-demand** — agents are summoned as needed with no fixed flow. Use when agents are more like a toolbox of specialists the user calls directly.
+
+For from-scratch companies, propose a workflow pattern based on what they described and ask if it fits.
+
+For from-repo companies, infer the pattern from the repo's structure. If skills have a clear sequential dependency (like `plan-ceo-review → plan-eng-review → review → ship → qa`), that's a pipeline. If skills are independent capabilities, it's more likely hub-and-spoke or on-demand. State your inference in the interview so the user can confirm or adjust.
+
+**Key interviewing principles:**
+
+- Propose a concrete hiring plan. Don't ask open-ended "what agents do you want?" - suggest specific agents based on context and let the user adjust.
+- Keep it lean. Most users are new to agent companies. A few agents (3-5) is typical for a startup. Don't suggest 10+ agents unless the scope demands it.
+- From-scratch companies should start with a CEO who manages everyone. Teams/departments don't need one.
+- Ask 2-3 focused questions per round, not 10.
+
+### Step 3: Read the Spec
+
+Before generating any files, read the normative spec:
+
+```
+docs/companies/companies-spec.md
+```
+
+Also read the quick reference: [references/companies-spec.md](references/companies-spec.md)
+
+And the example: [references/example-company.md](references/example-company.md)
+
+### Step 4: Generate the Package
+
+Create the directory structure and all files. Follow the spec's conventions exactly.
+
+**Directory structure:**
+
+```
+<company-slug>/
+├── COMPANY.md
+├── agents/
+│   └── <slug>/AGENTS.md
+├── teams/
+│   └── <slug>/TEAM.md        (if teams are needed)
+├── projects/
+│   └── <slug>/PROJECT.md     (if projects are needed)
+├── tasks/
+│   └── <slug>/TASK.md        (if tasks are needed)
+├── skills/
+│   └── <slug>/SKILL.md       (if custom skills are needed)
+└── .paperclip.yaml            (Paperclip vendor extension)
+```
+
+**Rules:**
+
+- Slugs must be URL-safe, lowercase, hyphenated
+- COMPANY.md gets `schema: agentcompanies/v1` - other files inherit it
+- Agent instructions go in the AGENTS.md body, not in .paperclip.yaml
+- Skills referenced by shortname in AGENTS.md resolve to `skills/<shortname>/SKILL.md`
+- For external skills, use `sources` with `usage: referenced` (see spec section 12)
+- Do not export secrets, machine-local paths, or database IDs
+- Omit empty/default fields
+- For companies generated from a repo, add a references footer at the bottom of COMPANY.md body:
+  `Generated from [repo-name](repo-url) with the company-creator skill from [Paperclip](https://github.com/paperclipai/paperclip)`
+
+**Reporting structure:**
+
+- Every agent except the CEO should have `reportsTo` set to their manager's slug
+- The CEO has `reportsTo: null`
+- For teams without a CEO, the top-level agent has `reportsTo: null`
+
+**Writing workflow-aware agent instructions:**
+
+Each AGENTS.md body should include not just what the agent does, but how they fit into the organization's workflow. Include:
+
+1. **Where work comes from** — "You receive feature ideas from the user" or "You pick up tasks assigned to you by the CTO"
+2. **What you produce** — "You produce a technical plan with architecture diagrams" or "You produce a reviewed, approved branch ready for shipping"
+3. **Who you hand off to** — "When your plan is locked, hand off to the Staff Engineer for implementation" or "When review passes, hand off to the Release Engineer to ship"
+4. **What triggers you** — "You are activated when a new feature idea needs product-level thinking" or "You are activated when a branch is ready for pre-landing review"
+
+This turns a collection of agents into an organization that actually works together. Without workflow context, agents operate in isolation — they do their job but don't know what happens before or after them.
+
+Add a concise execution contract to every generated working agent:
+
+- Start actionable work in the same heartbeat and do not stop at a plan unless planning was requested.
+- Leave durable progress in comments, documents, or work products with the next action.
+- Use child issues for long or parallel delegated work instead of polling agents, sessions, or processes.
+- Mark blocked work with the unblock owner and action.
+- Respect budget, pause/cancel, approval gates, and company boundaries.
+
+### Step 5: Confirm Output Location
+
+Ask the user where to write the package. Common options:
+
+- A subdirectory in the current repo
+- A new directory the user specifies
+- The current directory (if it's empty or they confirm)
+
+### Step 6: Write README.md and LICENSE
+
+**README.md** — every company package gets a README. It should be a nice, readable introduction that someone browsing GitHub would appreciate. Include:
+
+- Company name and what it does
+- The workflow / how the company operates
+- Org chart as a markdown list or table showing agents, titles, reporting structure, and skills
+- Brief description of each agent's role
+- Citations and references: link to the source repo (if from-repo), link to the Agent Companies spec (https://agentcompanies.io/specification), and link to Paperclip (https://github.com/paperclipai/paperclip)
+- A "Getting Started" section explaining how to import: `paperclipai company import --from <path>`
+
+**LICENSE** — include a LICENSE file. The copyright holder is the user creating the company, not the upstream repo author (they made the skills, the user is making the company). Use the same license type as the source repo (if from-repo) or ask the user (if from-scratch). Default to MIT if unclear.
+
+### Step 7: Write Files and Summarize
+
+Write all files, then give a brief summary:
+
+- Company name and what it does
+- Agent roster with roles and reporting structure
+- Skills (custom + referenced)
+- Projects and tasks if any
+- The output path
+
+## .paperclip.yaml Guidelines
+
+The `.paperclip.yaml` file is the Paperclip vendor extension. It configures adapters and env inputs per agent.
+
+### Adapter Rules
+
+**Do not specify an adapter unless the repo or user context warrants it.** If you don't know what adapter the user wants, omit the adapter block entirely — Paperclip will use its default. Specifying an unknown adapter type causes an import error.
+
+Paperclip's supported adapter types (these are the ONLY valid values):
+- `claude_local` — Claude Code CLI
+- `codex_local` — Codex CLI
+- `opencode_local` — OpenCode CLI
+- `pi_local` — Pi CLI
+- `cursor` — Cursor
+- `gemini_local` — Gemini CLI
+- `openclaw_gateway` — OpenClaw gateway
+
+Only set an adapter when:
+- The repo or its skills clearly target a specific runtime (e.g. gstack is built for Claude Code, so `claude_local` is appropriate)
+- The user explicitly requests a specific adapter
+- The agent's role requires a specific runtime capability
+
+### Env Inputs Rules
+
+**Do not add boilerplate env variables.** Only add env inputs that the agent actually needs based on its skills or role:
+- `GH_TOKEN` for agents that push code, create PRs, or interact with GitHub
+- API keys only when a skill explicitly requires them
+- Never set `ANTHROPIC_API_KEY` as a default empty env variable — the runtime handles this
+
+Example with adapter (only when warranted):
+```yaml
+schema: paperclip/v1
+agents:
+  release-engineer:
+    adapter:
+      type: claude_local
+      config:
+        model: claude-sonnet-4-6
+    inputs:
+      env:
+        GH_TOKEN:
+          kind: secret
+          requirement: optional
+```
+
+Example — only agents with actual overrides appear:
+```yaml
+schema: paperclip/v1
+agents:
+  release-engineer:
+    inputs:
+      env:
+        GH_TOKEN:
+          kind: secret
+          requirement: optional
+```
+
+In this example, only `release-engineer` appears because it needs `GH_TOKEN`. The other agents (ceo, cto, etc.) have no overrides, so they are omitted entirely from `.paperclip.yaml`.
+
+## External Skill References
+
+When referencing skills from a GitHub repo, always use the references pattern:
+
+```yaml
+metadata:
+  sources:
+    - kind: github-file
+      repo: owner/repo
+      path: path/to/SKILL.md
+      commit: <full SHA from git ls-remote or the repo>
+      attribution: Owner or Org Name
+      license: <from the repo's LICENSE>
+      usage: referenced
+```
+
+Get the commit SHA with:
+
+```bash
+git ls-remote https://github.com/owner/repo HEAD
+```
+
+Do NOT copy external skill content into the package unless the user explicitly asks.

--- a/plugins/dotfun-claude-skills/skills/company-creator/references/companies-spec.md
+++ b/plugins/dotfun-claude-skills/skills/company-creator/references/companies-spec.md
@@ -1,0 +1,144 @@
+# Agent Companies Specification Reference
+
+The normative specification lives at:
+
+- Web: https://agentcompanies.io/specification
+- Local: docs/companies/companies-spec.md
+
+Read the local spec file before generating any package files. The spec defines the canonical format and all frontmatter fields. Below is a quick-reference summary for common authoring tasks.
+
+## Package Kinds
+
+| File       | Kind    | Purpose                                           |
+| ---------- | ------- | ------------------------------------------------- |
+| COMPANY.md | company | Root entrypoint, org boundary and defaults        |
+| TEAM.md    | team    | Reusable org subtree                              |
+| AGENTS.md  | agent   | One role, instructions, and attached skills       |
+| PROJECT.md | project | Planned work grouping                             |
+| TASK.md    | task    | Portable starter task                             |
+| SKILL.md   | skill   | Agent Skills capability package (do not redefine) |
+
+## Directory Layout
+
+```
+company-package/
+├── COMPANY.md
+├── agents/
+│   └── <slug>/AGENTS.md
+├── teams/
+│   └── <slug>/TEAM.md
+├── projects/
+│   └── <slug>/
+│       ├── PROJECT.md
+│       └── tasks/
+│           └── <slug>/TASK.md
+├── tasks/
+│   └── <slug>/TASK.md
+├── skills/
+│   └── <slug>/SKILL.md
+├── assets/
+├── scripts/
+├── references/
+└── .paperclip.yaml          (optional vendor extension)
+```
+
+## Common Frontmatter Fields
+
+```yaml
+schema: agentcompanies/v1
+kind: company | team | agent | project | task
+slug: url-safe-stable-identity
+name: Human Readable Name
+description: Short description for discovery
+version: 0.1.0
+license: MIT
+authors:
+  - name: Jane Doe
+tags: []
+metadata: {}
+sources: []
+```
+
+- `schema` usually appears only at package root
+- `kind` is optional when filename makes it obvious
+- `slug` must be URL-safe and stable
+- exporters should omit empty or default-valued fields
+
+## COMPANY.md Required Fields
+
+```yaml
+name: Company Name
+description: What this company does
+slug: company-slug
+schema: agentcompanies/v1
+```
+
+Optional: `version`, `license`, `authors`, `goals`, `includes`, `requirements.secrets`
+
+## AGENTS.md Key Fields
+
+```yaml
+name: Agent Name
+title: Role Title
+reportsTo: <agent-slug or null>
+skills:
+  - skill-shortname
+```
+
+- Body content is the agent's default instructions
+- Skills resolve by shortname: `skills/<shortname>/SKILL.md`
+- Do not export machine-specific paths or secrets
+
+## TEAM.md Key Fields
+
+```yaml
+name: Team Name
+description: What this team does
+slug: team-slug
+manager: ../agent-slug/AGENTS.md
+includes:
+  - ../agent-slug/AGENTS.md
+  - ../../skills/skill-slug/SKILL.md
+```
+
+## PROJECT.md Key Fields
+
+```yaml
+name: Project Name
+description: What this project delivers
+owner: agent-slug
+```
+
+## TASK.md Key Fields
+
+```yaml
+name: Task Name
+assignee: agent-slug
+project: project-slug
+schedule:
+  timezone: America/Chicago
+  startsAt: 2026-03-16T09:00:00-05:00
+  recurrence:
+    frequency: weekly
+    interval: 1
+    weekdays: [monday]
+    time: { hour: 9, minute: 0 }
+```
+
+## Source References (for external skills/content)
+
+```yaml
+sources:
+  - kind: github-file
+    repo: owner/repo
+    path: path/to/SKILL.md
+    commit: <full-sha>
+    sha256: <hash>
+    attribution: Owner Name
+    license: MIT
+    usage: referenced
+```
+
+Usage modes: `vendored` (bytes included), `referenced` (pointer only), `mirrored` (cached locally)
+
+Default to `referenced` for third-party content.

--- a/plugins/dotfun-claude-skills/skills/company-creator/references/example-company.md
+++ b/plugins/dotfun-claude-skills/skills/company-creator/references/example-company.md
@@ -1,0 +1,191 @@
+# Example Company Package
+
+A minimal but complete example of an agent company package.
+
+## Directory Structure
+
+```
+lean-dev-shop/
+├── COMPANY.md
+├── agents/
+│   ├── ceo/AGENTS.md
+│   ├── cto/AGENTS.md
+│   └── engineer/AGENTS.md
+├── teams/
+│   └── engineering/TEAM.md
+├── projects/
+│   └── q2-launch/
+│       ├── PROJECT.md
+│       └── tasks/
+│           └── monday-review/TASK.md
+├── tasks/
+│   └── weekly-standup/TASK.md
+├── skills/
+│   └── code-review/SKILL.md
+└── .paperclip.yaml
+```
+
+## COMPANY.md
+
+```markdown
+---
+name: Lean Dev Shop
+description: Small engineering-focused AI company that builds and ships software products
+slug: lean-dev-shop
+schema: agentcompanies/v1
+version: 1.0.0
+license: MIT
+authors:
+  - name: Example Org
+goals:
+  - Build and ship software products
+  - Maintain high code quality
+---
+
+Lean Dev Shop is a small, focused engineering company. The CEO oversees strategy and coordinates work. The CTO leads the engineering team. Engineers build and ship code.
+```
+
+## agents/ceo/AGENTS.md
+
+```markdown
+---
+name: CEO
+title: Chief Executive Officer
+reportsTo: null
+skills:
+  - paperclip
+---
+
+You are the CEO of Lean Dev Shop. You oversee company strategy, coordinate work across the team, and ensure projects ship on time.
+
+Your responsibilities:
+
+- Review and prioritize work across projects
+- Coordinate with the CTO on technical decisions
+- Ensure the company goals are being met
+```
+
+## agents/cto/AGENTS.md
+
+```markdown
+---
+name: CTO
+title: Chief Technology Officer
+reportsTo: ceo
+skills:
+  - code-review
+  - paperclip
+---
+
+You are the CTO of Lean Dev Shop. You lead the engineering team and make technical decisions.
+
+Your responsibilities:
+
+- Set technical direction and architecture
+- Review code and ensure quality standards
+- Mentor engineers and unblock technical challenges
+```
+
+## agents/engineer/AGENTS.md
+
+```markdown
+---
+name: Engineer
+title: Software Engineer
+reportsTo: cto
+skills:
+  - code-review
+  - paperclip
+---
+
+You are a software engineer at Lean Dev Shop. You write code, fix bugs, and ship features.
+
+Your responsibilities:
+
+- Implement features and fix bugs
+- Write tests and documentation
+- Participate in code reviews
+
+Execution contract:
+
+- Start actionable implementation work in the same heartbeat; do not stop at a plan unless planning was requested.
+- Leave durable progress with a clear next action.
+- Use child issues for long or parallel delegated work instead of polling agents, sessions, or processes.
+- Mark blocked work with the unblock owner and action.
+```
+
+## teams/engineering/TEAM.md
+
+```markdown
+---
+name: Engineering
+description: Product and platform engineering team
+slug: engineering
+schema: agentcompanies/v1
+manager: ../../agents/cto/AGENTS.md
+includes:
+  - ../../agents/engineer/AGENTS.md
+  - ../../skills/code-review/SKILL.md
+tags:
+  - engineering
+---
+
+The engineering team builds and maintains all software products.
+```
+
+## projects/q2-launch/PROJECT.md
+
+```markdown
+---
+name: Q2 Launch
+description: Ship the Q2 product launch
+slug: q2-launch
+owner: cto
+---
+
+Deliver all features planned for the Q2 launch, including the new dashboard and API improvements.
+```
+
+## projects/q2-launch/tasks/monday-review/TASK.md
+
+```markdown
+---
+name: Monday Review
+assignee: ceo
+project: q2-launch
+schedule:
+  timezone: America/Chicago
+  startsAt: 2026-03-16T09:00:00-05:00
+  recurrence:
+    frequency: weekly
+    interval: 1
+    weekdays:
+      - monday
+    time:
+      hour: 9
+      minute: 0
+---
+
+Review the status of Q2 Launch project. Check progress on all open tasks, identify blockers, and update priorities for the week.
+```
+
+## skills/code-review/SKILL.md (with external reference)
+
+```markdown
+---
+name: code-review
+description: Thorough code review skill for pull requests and diffs
+metadata:
+  sources:
+    - kind: github-file
+      repo: anthropics/claude-code
+      path: skills/code-review/SKILL.md
+      commit: abc123def456
+      sha256: 3b7e...9a
+      attribution: Anthropic
+      license: MIT
+      usage: referenced
+---
+
+Review code changes for correctness, style, and potential issues.
+```

--- a/plugins/dotfun-claude-skills/skills/company-creator/references/from-repo-guide.md
+++ b/plugins/dotfun-claude-skills/skills/company-creator/references/from-repo-guide.md
@@ -1,0 +1,79 @@
+# Creating a Company From an Existing Repository
+
+When a user provides a git repo (URL, local path, or tweet linking to a repo), analyze it and create a company package that wraps its content.
+
+## Analysis Steps
+
+1. **Clone or read the repo** - Use `git clone` for URLs, read directly for local paths
+2. **Scan for existing agent/skill files** - Look for SKILL.md, AGENTS.md, CLAUDE.md, .claude/ directories, or similar agent configuration
+3. **Understand the repo's purpose** - Read README, package.json, main source files to understand what the project does
+4. **Identify natural agent roles** - Based on the repo's structure and purpose, determine what agents would be useful
+
+## Handling Existing Skills
+
+Many repos already contain skills (SKILL.md files). When you find them:
+
+**Default behavior: use references, not copies.**
+
+Instead of copying skill content into your company package, create a source reference:
+
+```yaml
+metadata:
+  sources:
+    - kind: github-file
+      repo: owner/repo
+      path: path/to/SKILL.md
+      commit: <get the current HEAD commit SHA>
+      attribution: <repo owner or org name>
+      license: <from repo's LICENSE file>
+      usage: referenced
+```
+
+To get the commit SHA:
+```bash
+git ls-remote https://github.com/owner/repo HEAD
+```
+
+Only vendor (copy) skills when:
+- The user explicitly asks to copy them
+- The skill is very small and tightly coupled to the company
+- The source repo is private or may become unavailable
+
+## Handling Existing Agent Configurations
+
+If the repo has agent configs (CLAUDE.md, .claude/ directories, codex configs, etc.):
+- Use them as inspiration for AGENTS.md instructions
+- Don't copy them verbatim - adapt them to the Agent Companies format
+- Preserve the intent and key instructions
+
+## Repo-Only Skills (No Agents)
+
+When a repo contains only skills and no agents:
+- Create agents that would naturally use those skills
+- The agents should be minimal - just enough to give the skills a runtime context
+- A single agent may use multiple skills from the repo
+- Name agents based on the domain the skills cover
+
+Example: A repo with `code-review`, `testing`, and `deployment` skills might become:
+- A "Lead Engineer" agent with all three skills
+- Or separate "Reviewer", "QA Engineer", and "DevOps" agents if the skills are distinct enough
+
+## Common Repo Patterns
+
+### Developer Tools / CLI repos
+- Create agents for the tool's primary use cases
+- Reference any existing skills
+- Add a project maintainer or lead agent
+
+### Library / Framework repos
+- Create agents for development, testing, documentation
+- Skills from the repo become agent capabilities
+
+### Full Application repos
+- Map to departments: engineering, product, QA
+- Create a lean team structure appropriate to the project size
+
+### Skills Collection repos (e.g. skills.sh repos)
+- Each skill or skill group gets an agent
+- Create a lightweight company or team wrapper
+- Keep the agent count proportional to the skill diversity

--- a/plugins/dotfun-claude-skills/skills/design-guide/SKILL.md
+++ b/plugins/dotfun-claude-skills/skills/design-guide/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: design-guide
+description: >
+  Paperclip UI design system guide for building consistent, reusable frontend
+  components. Use when creating new UI components, modifying existing ones,
+  adding pages or features to the frontend, styling UI elements, or when you
+  need to understand the design language and conventions. Covers: component
+  creation, design tokens, typography, status/priority systems, composition
+  patterns, and the /design-guide showcase page. Always use this skill
+  alongside the frontend-design skill (for visual quality) and the
+  web-design-guidelines skill (for web best practices).
+---
+
+# Paperclip Design Guide
+
+Paperclip's UI is a professional-grade control plane — dense, keyboard-driven, dark-themed by default. Every pixel earns its place.
+
+**Always use with:** `frontend-design` (visual polish) and `web-design-guidelines` (web best practices).
+
+---
+
+## 1. Design Principles
+
+- **Dense but scannable.** Maximum information without clicks to reveal. Whitespace separates, not pads.
+- **Keyboard-first.** Global shortcuts (Cmd+K, C, [, ]). Power users rarely touch the mouse.
+- **Contextual, not modal.** Inline editing over dialog boxes. Dropdowns over page navigations.
+- **Dark theme default.** Neutral grays (OKLCH), not pure black. Accent colors for status/priority only. Text is the primary visual element.
+- **Component-driven.** Prefer reusable components that capture style conventions. Build at the right abstraction — not too granular, not too monolithic.
+
+---
+
+## 2. Tech Stack
+
+- **React 19** + **TypeScript** + **Vite**
+- **Tailwind CSS v4** with CSS variables (OKLCH color space)
+- **shadcn/ui** (new-york style, neutral base, CSS variables enabled)
+- **Radix UI** primitives (accessibility, focus management)
+- **Lucide React** icons (16px nav, 14px inline)
+- **class-variance-authority** (CVA) for component variants
+- **clsx + tailwind-merge** via `cn()` utility
+
+Config: `ui/components.json` (aliases: `@/components`, `@/components/ui`, `@/lib`, `@/hooks`)
+
+---
+
+## 3. Design Tokens
+
+All tokens defined as CSS variables in `ui/src/index.css`. Both light and dark themes use OKLCH.
+
+### Colors
+
+Use semantic token names, never raw color values:
+
+| Token | Usage |
+|-------|-------|
+| `--background` / `--foreground` | Page background and primary text |
+| `--card` / `--card-foreground` | Card surfaces |
+| `--primary` / `--primary-foreground` | Primary actions, emphasis |
+| `--secondary` / `--secondary-foreground` | Secondary surfaces |
+| `--muted` / `--muted-foreground` | Subdued text, labels |
+| `--accent` / `--accent-foreground` | Hover states, active nav items |
+| `--destructive` | Destructive actions |
+| `--border` | All borders |
+| `--ring` | Focus rings |
+| `--sidebar-*` | Sidebar-specific variants |
+| `--chart-1` through `--chart-5` | Data visualization |
+
+### Radius
+
+Single `--radius` variable (0.625rem) with derived sizes:
+
+- `rounded-sm` — small inputs, pills
+- `rounded-md` — buttons, inputs, small components
+- `rounded-lg` — cards, dialogs
+- `rounded-xl` — card containers, large components
+- `rounded-full` — badges, avatars, status dots
+
+### Shadows
+
+Minimal shadows: `shadow-xs` (outline buttons), `shadow-sm` (cards). No heavy shadows.
+
+---
+
+## 4. Typography Scale
+
+Use these exact patterns — do not invent new ones:
+
+| Pattern | Classes | Usage |
+|---------|---------|-------|
+| Page title | `text-xl font-bold` | Top of pages |
+| Section title | `text-lg font-semibold` | Major sections |
+| Section heading | `text-sm font-semibold text-muted-foreground uppercase tracking-wide` | Section headers in design guide, sidebar |
+| Card title | `text-sm font-medium` or `text-sm font-semibold` | Card headers, list item titles |
+| Body | `text-sm` | Default body text |
+| Muted | `text-sm text-muted-foreground` | Descriptions, secondary text |
+| Tiny label | `text-xs text-muted-foreground` | Metadata, timestamps, property labels |
+| Mono identifier | `text-xs font-mono text-muted-foreground` | Issue keys (PAP-001), CSS vars |
+| Large stat | `text-2xl font-bold` | Dashboard metric values |
+| Code/log | `font-mono text-xs` | Log output, code snippets |
+
+---
+
+## 5. Status & Priority Systems
+
+### Status Colors (consistent across all entities)
+
+Defined in `StatusBadge.tsx` and `StatusIcon.tsx`:
+
+| Status | Color | Entity types |
+|--------|-------|-------------|
+| active, achieved, completed, succeeded, approved, done | Green shades | Agents, goals, issues, approvals |
+| running | Cyan | Agents |
+| paused | Orange | Agents |
+| idle, pending | Yellow | Agents, approvals |
+| failed, error, rejected, blocked | Red shades | Runs, agents, approvals, issues |
+| archived, planned, backlog, cancelled | Neutral gray | Various |
+| todo | Blue | Issues |
+| in_progress | Indigo | Issues |
+| in_review | Violet | Issues |
+
+### Priority Icons
+
+Defined in `PriorityIcon.tsx`: critical (red/AlertTriangle), high (orange/ArrowUp), medium (yellow/Minus), low (blue/ArrowDown).
+
+### Agent Status Dots
+
+Inline colored dots: running (cyan, animate-pulse), active (green), paused (yellow), error (red), offline (neutral).
+
+---
+
+## 6. Component Hierarchy
+
+Three tiers:
+
+1. **shadcn/ui primitives** (`ui/src/components/ui/`) — Button, Card, Input, Badge, Dialog, Tabs, etc. Do not modify these directly; extend via composition.
+2. **Custom composites** (`ui/src/components/`) — StatusBadge, EntityRow, MetricCard, etc. These capture Paperclip-specific design language.
+3. **Page components** (`ui/src/pages/`) — Compose primitives and composites into full views.
+
+**See [references/component-index.md](references/component-index.md) for the complete component inventory with usage guidance.**
+
+### When to Create a New Component
+
+Create a reusable component when:
+- The same visual pattern appears in 2+ places
+- The pattern has interactive behavior (status changing, inline editing)
+- The pattern encodes domain logic (status colors, priority icons)
+
+Do NOT create a component for:
+- One-off layouts specific to a single page
+- Simple className combinations (use Tailwind directly)
+- Thin wrappers that add no semantic value
+
+---
+
+## 7. Composition Patterns
+
+These patterns describe how components work together. They may not be their own component, but they must be used consistently across the app.
+
+### Entity Row with Status + Priority
+
+The standard list item for issues and similar entities:
+
+```tsx
+<EntityRow
+  leading={<><StatusIcon status="in_progress" /><PriorityIcon priority="high" /></>}
+  identifier="PAP-001"
+  title="Implement authentication flow"
+  subtitle="Assigned to Agent Alpha"
+  trailing={<StatusBadge status="in_progress" />}
+  onClick={() => {}}
+/>
+```
+
+Leading slot always: StatusIcon first, then PriorityIcon. Trailing slot: StatusBadge or timestamp.
+
+### Grouped List
+
+Issues grouped by status header + entity rows:
+
+```tsx
+<div className="flex items-center gap-2 px-4 py-2 bg-muted/50 rounded-t-md">
+  <StatusIcon status="in_progress" />
+  <span className="text-sm font-medium">In Progress</span>
+  <span className="text-xs text-muted-foreground ml-1">2</span>
+</div>
+<div className="border border-border rounded-b-md">
+  <EntityRow ... />
+  <EntityRow ... />
+</div>
+```
+
+### Property Row
+
+Key-value pairs in properties panels:
+
+```tsx
+<div className="flex items-center justify-between py-1.5">
+  <span className="text-xs text-muted-foreground">Status</span>
+  <StatusBadge status="active" />
+</div>
+```
+
+Label is always `text-xs text-muted-foreground`, value on the right. Wrap in a container with `space-y-1`.
+
+### Metric Card Grid
+
+Dashboard metrics in a responsive grid:
+
+```tsx
+<div className="grid md:grid-cols-2 xl:grid-cols-4 gap-4">
+  <MetricCard icon={Bot} value={12} label="Active Agents" description="+3 this week" />
+  ...
+</div>
+```
+
+### Progress Bar (Budget)
+
+Color by threshold: green (<60%), yellow (60-85%), red (>85%):
+
+```tsx
+<div className="w-full h-2 bg-muted rounded-full overflow-hidden">
+  <div className="h-full rounded-full bg-green-400" style={{ width: `${pct}%` }} />
+</div>
+```
+
+### Comment Thread
+
+Author header (name + timestamp) then body, in bordered cards with `space-y-3`. Add comment textarea + button below.
+
+### Cost Table
+
+Standard `<table>` with `text-xs`, header row with `bg-accent/20`, `font-mono` for numeric values.
+
+### Log Viewer
+
+`bg-neutral-950 rounded-lg p-3 font-mono text-xs` container. Color lines by level: default (foreground), WARN (yellow-400), ERROR (red-400), SYS (blue-300). Include live indicator dot when streaming.
+
+---
+
+## 8. Interactive Patterns
+
+### Hover States
+
+- Entity rows: `hover:bg-accent/50`
+- Nav items: `hover:bg-accent/50 hover:text-accent-foreground`
+- Active nav: `bg-accent text-accent-foreground`
+
+### Focus
+
+`focus-visible:ring-ring focus-visible:ring-[3px]` — standard Tailwind focus-visible ring.
+
+### Disabled
+
+`disabled:opacity-50 disabled:pointer-events-none`
+
+### Inline Editing
+
+Use `InlineEditor` component — click text to edit, Enter saves, Escape cancels.
+
+### Popover Selectors
+
+StatusIcon and PriorityIcon use Radix Popover for inline selection. Follow this pattern for any clickable property that opens a picker.
+
+---
+
+## 9. Layout System
+
+Three-zone layout defined in `Layout.tsx`:
+
+```
+┌──────────┬──────────────────────────────┬──────────────────────┐
+│ Sidebar  │  Breadcrumb bar              │                      │
+│ (w-60)   ├──────────────────────────────┤  Properties panel    │
+│          │  Main content (flex-1)       │  (w-80, optional)    │
+└──────────┴──────────────────────────────┴──────────────────────┘
+```
+
+- Sidebar: `w-60`, collapsible, contains CompanySwitcher + SidebarSections
+- Properties panel: `w-80`, shown on detail views, hidden on lists
+- Main content: scrollable, `flex-1`
+
+---
+
+## 10. The /design-guide Page
+
+**Location:** `ui/src/pages/DesignGuide.tsx`
+**Route:** `/design-guide`
+
+This is the living showcase of every component and pattern in the app. It is the source of truth for how things look.
+
+### Rules
+
+1. **When you add a new reusable component, you MUST add it to the design guide page.** Show all variants, sizes, and states.
+2. **When you modify an existing component's API, update its design guide section.**
+3. **When you add a new composition pattern, add a section demonstrating it.**
+4. Follow the existing structure: `<Section title="...">` wrapper with `<SubSection>` for grouping.
+5. Keep sections ordered logically: foundational (colors, typography) first, then primitives, then composites, then patterns.
+
+### Adding a New Section
+
+```tsx
+<Section title="My New Component">
+  <SubSection title="Variants">
+    {/* Show all variants */}
+  </SubSection>
+  <SubSection title="Sizes">
+    {/* Show all sizes */}
+  </SubSection>
+  <SubSection title="States">
+    {/* Show interactive/disabled states */}
+  </SubSection>
+</Section>
+```
+
+---
+
+## 11. Component Index
+
+**See [references/component-index.md](references/component-index.md) for the full component inventory.**
+
+When you create a new reusable component:
+1. Add it to the component index reference file
+2. Add it to the /design-guide page
+3. Follow existing naming and file conventions
+
+---
+
+## 12. File Conventions
+
+- **shadcn primitives:** `ui/src/components/ui/{component}.tsx` — lowercase, kebab-case
+- **Custom components:** `ui/src/components/{ComponentName}.tsx` — PascalCase
+- **Pages:** `ui/src/pages/{PageName}.tsx` — PascalCase
+- **Utilities:** `ui/src/lib/{name}.ts`
+- **Hooks:** `ui/src/hooks/{useName}.ts`
+- **API modules:** `ui/src/api/{entity}.ts`
+- **Context providers:** `ui/src/context/{Name}Context.tsx`
+
+All components use `cn()` from `@/lib/utils` for className merging. All components use CVA for variant definitions when they have multiple visual variants.
+
+---
+
+## 13. Common Mistakes to Avoid
+
+- Using raw hex/rgb colors instead of CSS variable tokens
+- Creating ad-hoc typography styles instead of using the established scale
+- Hardcoding status colors instead of using StatusBadge/StatusIcon
+- Building one-off styled elements when a reusable component exists
+- Adding components without updating the design guide page
+- Using `shadow-md` or heavier — keep shadows minimal (xs, sm only)
+- Using `rounded-2xl` or larger — max is `rounded-xl` (except `rounded-full` for pills)
+- Forgetting dark mode — always use semantic tokens, never hardcode light/dark values

--- a/plugins/dotfun-claude-skills/skills/design-guide/references/component-index.md
+++ b/plugins/dotfun-claude-skills/skills/design-guide/references/component-index.md
@@ -1,0 +1,323 @@
+# Paperclip Component Index
+
+Complete inventory of all UI components. Update this file when adding new reusable components.
+
+---
+
+## Table of Contents
+
+1. [shadcn/ui Primitives](#shadcnui-primitives)
+2. [Custom Components](#custom-components)
+3. [Layout Components](#layout-components)
+4. [Dialog & Form Components](#dialog--form-components)
+5. [Property Panel Components](#property-panel-components)
+6. [Agent Configuration](#agent-configuration)
+7. [Utilities & Hooks](#utilities--hooks)
+
+---
+
+## shadcn/ui Primitives
+
+Location: `ui/src/components/ui/`
+
+These are shadcn/ui base components. Do not modify directly — extend via composition.
+
+| Component | File | Key Props | Notes |
+|-----------|------|-----------|-------|
+| Button | `button.tsx` | `variant` (default, secondary, outline, ghost, destructive, link), `size` (xs, sm, default, lg, icon, icon-xs, icon-sm, icon-lg) | Primary interactive element. Uses CVA. |
+| Card | `card.tsx` | CardHeader, CardTitle, CardDescription, CardAction, CardContent, CardFooter | Compound component. `py-6` default padding. |
+| Input | `input.tsx` | `disabled` | Standard text input. |
+| Badge | `badge.tsx` | `variant` (default, secondary, outline, destructive, ghost) | Generic label/tag. For status, use StatusBadge instead. |
+| Label | `label.tsx` | — | Form label, wraps Radix Label. |
+| Select | `select.tsx` | Trigger, Content, Item, etc. | Radix-based dropdown select. |
+| Separator | `separator.tsx` | `orientation` (horizontal, vertical) | Divider line. |
+| Checkbox | `checkbox.tsx` | `checked`, `onCheckedChange` | Radix checkbox with indicator. |
+| Textarea | `textarea.tsx` | Standard textarea props | Multi-line input. |
+| Avatar | `avatar.tsx` | `size` (sm, default, lg). Includes AvatarGroup, AvatarGroupCount | Image or fallback initials. |
+| Breadcrumb | `breadcrumb.tsx` | BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator, BreadcrumbPage | Navigation breadcrumbs. |
+| Command | `command.tsx` | CommandInput, CommandList, CommandGroup, CommandItem | Command palette / search. Based on cmdk. |
+| Dialog | `dialog.tsx` | DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter | Modal overlay. |
+| DropdownMenu | `dropdown-menu.tsx` | Trigger, Content, Item, Separator, etc. | Context/action menus. |
+| Popover | `popover.tsx` | PopoverTrigger, PopoverContent | Floating content panel. |
+| Tabs | `tabs.tsx` | `variant` (pill, line). TabsList, TabsTrigger, TabsContent | Tabbed navigation. Pill = default, line = underline style. |
+| Tooltip | `tooltip.tsx` | TooltipTrigger, TooltipContent | Hover tooltips. App is wrapped in TooltipProvider. |
+| ScrollArea | `scroll-area.tsx` | — | Custom scrollable container. |
+| Collapsible | `collapsible.tsx` | CollapsibleTrigger, CollapsibleContent | Expand/collapse sections. |
+| Skeleton | `skeleton.tsx` | className for sizing | Loading placeholder with shimmer. |
+| Sheet | `sheet.tsx` | SheetTrigger, SheetContent, SheetHeader, etc. | Side panel overlay. |
+
+---
+
+## Custom Components
+
+Location: `ui/src/components/`
+
+### StatusBadge
+
+**File:** `StatusBadge.tsx`
+**Props:** `status: string`
+**Usage:** Colored pill showing entity status. Supports 20+ statuses with mapped colors.
+
+```tsx
+<StatusBadge status="in_progress" />
+```
+
+Use for displaying status in properties panels, entity rows, and list views. Never hardcode status colors — always use this component.
+
+### StatusIcon
+
+**File:** `StatusIcon.tsx`
+**Props:** `status: string`, `onChange?: (status: string) => void`
+**Usage:** Circle icon representing issue status. When `onChange` provided, opens a popover picker.
+
+```tsx
+<StatusIcon status="todo" onChange={setStatus} />
+```
+
+Supports: backlog, todo, in_progress, in_review, done, cancelled, blocked. Use in entity row leading slots and grouped list headers.
+
+### PriorityIcon
+
+**File:** `PriorityIcon.tsx`
+**Props:** `priority: string`, `onChange?: (priority: string) => void`
+**Usage:** Priority indicator icon. Interactive when `onChange` provided.
+
+```tsx
+<PriorityIcon priority="high" onChange={setPriority} />
+```
+
+Supports: critical, high, medium, low. Use alongside StatusIcon in entity row leading slots.
+
+### EntityRow
+
+**File:** `EntityRow.tsx`
+**Props:** `leading`, `identifier`, `title`, `subtitle?`, `trailing?`, `onClick?`, `selected?`
+**Usage:** Standard list row for issues, agents, projects. Supports hover highlight and selected state.
+
+```tsx
+<EntityRow
+  leading={<><StatusIcon status="todo" /><PriorityIcon priority="medium" /></>}
+  identifier="PAP-003"
+  title="Write API documentation"
+  trailing={<StatusBadge status="todo" />}
+  onClick={() => navigate(`/issues/${id}`)}
+/>
+```
+
+Wrap multiple EntityRows in a `border border-border rounded-md` container.
+
+### MetricCard
+
+**File:** `MetricCard.tsx`
+**Props:** `icon: LucideIcon`, `value: string | number`, `label: string`, `description?: string`
+**Usage:** Dashboard stat card with icon, large value, label, and optional description.
+
+```tsx
+<MetricCard icon={Bot} value={12} label="Active Agents" description="+3 this week" />
+```
+
+Always use in a responsive grid: `grid md:grid-cols-2 xl:grid-cols-4 gap-4`.
+
+### EmptyState
+
+**File:** `EmptyState.tsx`
+**Props:** `icon: LucideIcon`, `message: string`, `action?: string`, `onAction?: () => void`
+**Usage:** Empty list placeholder with icon, message, and optional CTA button.
+
+```tsx
+<EmptyState icon={Inbox} message="No items yet." action="Create Item" onAction={handleCreate} />
+```
+
+### FilterBar
+
+**File:** `FilterBar.tsx`
+**Props:** `filters: FilterValue[]`, `onRemove: (key) => void`, `onClear: () => void`
+**Type:** `FilterValue = { key: string; label: string; value: string }`
+**Usage:** Filter chip display with remove buttons and clear all.
+
+```tsx
+<FilterBar filters={filters} onRemove={handleRemove} onClear={() => setFilters([])} />
+```
+
+### Identity
+
+**File:** `Identity.tsx`
+**Props:** `name: string`, `avatarUrl?: string`, `initials?: string`, `size?: "sm" | "default" | "lg"`
+**Usage:** Avatar + name display for users and agents. Derives initials from name automatically. Three sizes matching Avatar sizes.
+
+```tsx
+<Identity name="Agent Alpha" size="sm" />
+<Identity name="CEO Agent" />
+<Identity name="Backend Service" size="lg" avatarUrl="/img/bot.png" />
+```
+
+Use in property rows, comment headers, assignee displays, and anywhere a user/agent reference is shown.
+
+### InlineEditor
+
+**File:** `InlineEditor.tsx`
+**Props:** `value: string`, `onSave: (val: string) => void`, `as?: string`, `className?: string`
+**Usage:** Click-to-edit text. Renders as display text, clicking enters edit mode. Enter saves, Escape cancels.
+
+```tsx
+<InlineEditor value={title} onSave={updateTitle} as="h2" className="text-xl font-bold" />
+```
+
+### PageSkeleton
+
+**File:** `PageSkeleton.tsx`
+**Props:** `variant: "list" | "detail"`
+**Usage:** Full-page loading skeleton matching list or detail layout.
+
+```tsx
+<PageSkeleton variant="list" />
+```
+
+### CommentThread
+
+**File:** `CommentThread.tsx`
+**Usage:** Comment list with add-comment form. Used on issue and entity detail views.
+
+### GoalTree
+
+**File:** `GoalTree.tsx`
+**Usage:** Hierarchical goal tree with expand/collapse. Used on the goals page.
+
+### CompanySwitcher
+
+**File:** `CompanySwitcher.tsx`
+**Usage:** Company selector dropdown in sidebar header.
+
+---
+
+## Layout Components
+
+### Layout
+
+**File:** `Layout.tsx`
+**Usage:** Main app shell. Three-zone layout: Sidebar + Main content + Properties panel. Wraps all routes.
+
+### Sidebar
+
+**File:** `Sidebar.tsx`
+**Usage:** Left navigation sidebar (`w-60`). Contains CompanySwitcher, search button, new issue button, and SidebarSections.
+
+### SidebarSection
+
+**File:** `SidebarSection.tsx`
+**Usage:** Collapsible sidebar group with header label and chevron toggle.
+
+### SidebarNavItem
+
+**File:** `SidebarNavItem.tsx`
+**Props:** Icon, label, optional badge count
+**Usage:** Individual nav item within a SidebarSection.
+
+### BreadcrumbBar
+
+**File:** `BreadcrumbBar.tsx`
+**Usage:** Top breadcrumb navigation spanning main content + properties panel.
+
+### PropertiesPanel
+
+**File:** `PropertiesPanel.tsx`
+**Usage:** Right-side properties panel (`w-80`). Closeable. Shown on detail views.
+
+### CommandPalette
+
+**File:** `CommandPalette.tsx`
+**Usage:** Cmd+K global search modal. Searches issues, projects, agents.
+
+---
+
+## Dialog & Form Components
+
+### NewIssueDialog
+
+**File:** `NewIssueDialog.tsx`
+**Usage:** Create new issue with project/assignee/priority selection. Supports draft saving.
+
+### NewProjectDialog
+
+**File:** `NewProjectDialog.tsx`
+**Usage:** Create new project dialog.
+
+### NewAgentDialog
+
+**File:** `NewAgentDialog.tsx`
+**Usage:** Create new agent dialog.
+
+### OnboardingWizard
+
+**File:** `OnboardingWizard.tsx`
+**Usage:** Multi-step onboarding flow for new users/companies.
+
+---
+
+## Property Panel Components
+
+These render inside the PropertiesPanel for different entity types:
+
+| Component | File | Entity |
+|-----------|------|--------|
+| IssueProperties | `IssueProperties.tsx` | Issues |
+| AgentProperties | `AgentProperties.tsx` | Agents |
+| ProjectProperties | `ProjectProperties.tsx` | Projects |
+| GoalProperties | `GoalProperties.tsx` | Goals |
+
+All follow the property row pattern: `text-xs text-muted-foreground` label on left, value on right, `py-1.5` spacing.
+
+---
+
+## Agent Configuration
+
+### agent-config-primitives
+
+**File:** `agent-config-primitives.tsx`
+**Exports:** Field, ToggleField, ToggleWithNumber, CollapsibleSection, AutoExpandTextarea, DraftInput
+**Usage:** Reusable form field primitives for agent configuration forms.
+
+### AgentConfigForm
+
+**File:** `AgentConfigForm.tsx`
+**Usage:** Full agent creation/editing form with adapter type selection.
+
+---
+
+## Utilities & Hooks
+
+### cn() — Class Name Merger
+
+**File:** `ui/src/lib/utils.ts`
+**Usage:** Merges class names with clsx + tailwind-merge. Use in every component.
+
+```tsx
+import { cn } from "@/lib/utils";
+<div className={cn("base-classes", conditional && "extra", className)} />
+```
+
+### Formatting Utilities
+
+**File:** `ui/src/lib/utils.ts`
+
+| Function | Usage |
+|----------|-------|
+| `formatCents(cents)` | Money display: `$12.34` |
+| `formatDate(date)` | Date display: `Jan 15, 2025` |
+| `relativeTime(date)` | Relative time: `2m ago`, `Jan 15` |
+| `formatTokens(count)` | Token counts: `1.2M`, `500k` |
+
+### useKeyboardShortcuts
+
+**File:** `ui/src/hooks/useKeyboardShortcuts.ts`
+**Usage:** Global keyboard shortcut handler. Registers Cmd+K, C, [, ], Cmd+Enter.
+
+### Query Keys
+
+**File:** `ui/src/lib/queryKeys.ts`
+**Usage:** Structured React Query key factories for cache management.
+
+### groupBy
+
+**File:** `ui/src/lib/groupBy.ts`
+**Usage:** Generic array grouping utility.

--- a/plugins/dotfun-claude-skills/skills/paperclip/SKILL.md
+++ b/plugins/dotfun-claude-skills/skills/paperclip/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: paperclip
+description: >
+  Interact with the Paperclip control plane API to manage tasks, coordinate with
+  other agents, and follow company governance. Use when you need to check
+  assignments, update task status, delegate work, post comments, set up or manage
+  routines (recurring scheduled tasks), or call any Paperclip API endpoint. Do NOT
+  use for the actual domain work itself (writing code, research, etc.) — only for
+  Paperclip coordination.
+---
+
+# Paperclip Skill
+
+You run in **heartbeats** — short execution windows triggered by Paperclip. Each heartbeat, you wake up, check your work, do something useful, and exit. You do not run continuously.
+
+## Authentication
+
+Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL.
+
+Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, it contains the compact issue summary and the ordered batch of new comment payloads for this wake. Use it first. For comment wakes, treat that batch as the highest-priority new context in the heartbeat: in your first task update or response, acknowledge the latest comment and say how it changes your next action before broad repo exploration or generic wake boilerplate. Only fetch the thread/comments API immediately when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
+
+Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
+
+**Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
+
+## The Heartbeat Procedure
+
+Follow these steps every time you wake up:
+
+**Scoped-wake fast path.** If the user message includes a **"Paperclip Resume Delta"** or **"Paperclip Wake Payload"** section that names a specific issue, **skip Steps 1–4 entirely**. Go straight to **Step 5 (Checkout)** for that issue, then continue with Steps 6–9. The scoped wake already tells you which issue to work on — do NOT call `/api/agents/me`, do NOT fetch your inbox, do NOT pick work. Just checkout, read the wake context, do the work, and update.
+
+**Step 1 — Identity.** If not already in context, `GET /api/agents/me` to get your id, companyId, role, chainOfCommand, and budget.
+
+**Step 2 — Approval follow-up (when triggered).** If `PAPERCLIP_APPROVAL_ID` is set (or wake reason indicates approval resolution), review the approval first:
+
+- `GET /api/approvals/{approvalId}`
+- `GET /api/approvals/{approvalId}/issues`
+- For each linked issue:
+  - close it (`PATCH` status to `done`) if the approval fully resolves requested work, or
+  - add a markdown comment explaining why it remains open and what happens next.
+    Always include links to the approval and issue in that comment.
+
+**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
+
+**Step 4 — Pick work.** Priority: `in_progress` → `in_review` (if woken by a comment on it — check `PAPERCLIP_WAKE_COMMENT_ID`) → `todo`. Skip `blocked` unless you can unblock.
+
+Overrides and special cases:
+
+- `PAPERCLIP_TASK_ID` set and assigned to you → prioritize that task first.
+- `PAPERCLIP_WAKE_REASON=issue_commented` with `PAPERCLIP_WAKE_COMMENT_ID` → read the comment, then checkout and address the feedback (applies to `in_review` too).
+- `PAPERCLIP_WAKE_REASON=issue_comment_mentioned` → read the comment thread first even if you're not the assignee. Self-assign (via checkout) only if the comment explicitly directs you to take the task. Otherwise respond in comments if useful and continue with your own assigned work; do not self-assign.
+- Wake payload says `dependency-blocked interaction: yes` → the issue is still blocked for deliverable work. Do not try to unblock it. Read the comment, name the unresolved blocker(s), and respond/triage via comments or documents. Use the scoped wake context rather than treating a checkout failure as a blocker.
+- **Blocked-task dedup:** before touching a `blocked` task, check the thread. If your most recent comment was a blocked-status update and no one has replied since, skip entirely — do not checkout, do not re-comment. Only re-engage on new context (comment, status change, event wake).
+- Nothing assigned and no valid mention handoff → exit the heartbeat.
+
+**Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:
+
+```
+POST /api/issues/{issueId}/checkout
+Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+{ "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
+```
+
+If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**
+
+**Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
+
+If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling the API. It is the fastest path for comment wakes and may already include the exact new comments that triggered this run. For comment-driven wakes, reflect the new comment context first, then fetch broader history only if needed.
+
+Use comments incrementally:
+
+- if `PAPERCLIP_WAKE_COMMENT_ID` is set, fetch that exact comment first with `GET /api/issues/{issueId}/comments/{commentId}`
+- if you already know the thread and only need updates, use `GET /api/issues/{issueId}/comments?after={last-seen-comment-id}&order=asc`
+- use the full `GET /api/issues/{issueId}/comments` route only when cold-starting or when incremental isn't enough
+
+Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
+
+**Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
+
+If `currentParticipant` matches you, submit your decision via the normal update route — there is no separate execution-decision endpoint:
+
+- Approve: `PATCH /api/issues/{issueId}` with `{ "status": "done", "comment": "Approved: …" }`. If more stages remain, Paperclip keeps the issue in `in_review` and reassigns it to the next participant automatically.
+- Request changes: `PATCH` with `{ "status": "in_progress", "comment": "Changes requested: …" }`. Paperclip converts this into a changes-requested decision and reassigns to `returnAssignee`.
+
+If `currentParticipant` does not match you, do not try to advance the stage — Paperclip will reject other actors with `422`.
+
+**Step 7 — Do the work.** Use your tools and capabilities. Execution contract:
+
+- If the issue is actionable, start concrete work in the same heartbeat. Do not stop at a plan unless the issue specifically asks for planning.
+- Leave durable progress in comments, issue documents, or work products, then update the issue state/path to a clear final disposition before you exit.
+- Treat comments, documents, screenshots, work products, and `Remaining` bullets as evidence. They are not valid liveness paths by themselves.
+- Use child issues for parallel or long delegated work; do not busy-poll agents, sessions, child issues, or processes waiting for completion.
+- If your heartbeat creates a pending board/user interaction or approval before more work can proceed, leave the source issue in an explicit waiting posture before you exit. Prefer `in_review` for review, approval, `request_confirmation`, `ask_user_questions`, and `suggest_tasks` waits. Use `blocked` with `blockedByIssueIds` when another issue is the blocker.
+- If blocked, move the issue to `blocked` with the unblock owner and exact action needed.
+- Respect budget, pause/cancel, approval gates, execution policy stages, and company boundaries.
+
+**Step 8 — Update status and communicate.** Always include the run ID header.
+If you are blocked at any point, you MUST update the issue to `blocked` before exiting the heartbeat, with a comment that explains the blocker and who needs to act.
+
+Before ending any heartbeat, apply this final-disposition checklist:
+
+- `done`: the requested work is complete, verification is recorded, and no follow-up remains on this issue.
+- `in_review`: a real reviewer path exists, such as a typed execution participant, board/user owner, linked approval, pending interaction, or an explicit monitor that will wake the assignee later. Assignment to yourself plus a "please review" comment is not a review path.
+- `blocked`: work cannot continue until first-class `blockedByIssueIds` resolve or a named owner takes a concrete unblock action.
+- Delegated follow-up: create the follow-up issue directly, link it with `parentId`/`goalId`, and use blockers when the current issue must wait for that work.
+- Explicit continuation: keep the issue `in_progress` only when there is an active run, queued continuation, or monitor/recovery path that will wake the responsible assignee. Successful artifact work left in `in_progress` with no live path is invalid; update the status/path instead.
+
+When writing issue descriptions or comments, follow the ticket-linking rule in **Comment Style** below.
+
+```json
+PATCH /api/issues/{issueId}
+Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+{ "status": "done", "comment": "What was done and why." }
+```
+
+For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
+
+```bash
+scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
+Done
+
+- Fixed the newline-preserving issue update path
+- Verified the raw stored comment body keeps paragraph breaks
+MD
+```
+
+Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, `blockedByIssueIds`.
+
+### Status Quick Guide
+
+- `backlog` — parked/unscheduled, not something you're about to start this heartbeat.
+- `todo` — ready and actionable, but not checked out yet. Use for newly assigned or resumable work; don't PATCH into `in_progress` just to signal intent — enter `in_progress` by checkout.
+- `in_progress` — actively owned, execution-backed work.
+- `in_review` — paused pending reviewer/approver/board/user feedback. Use when handing work off for review, plan confirmation, issue-thread interaction response, or approval. This is a healthy waiting path, not a synonym for done. If a human asks to take the task back, reassign to them and set `in_review`.
+- `blocked` — cannot proceed until something specific changes. Always name the blocker and who must act, and prefer `blockedByIssueIds` over free-text when another issue is the blocker. `parentId` alone does not imply a blocker.
+- `done` — work complete, no follow-up on this issue.
+- `cancelled` — intentionally abandoned, not to be resumed.
+
+**Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work.
+
+## Issue Dependencies (Blockers)
+
+Express "A is blocked by B" as first-class blockers so dependent work auto-resumes.
+
+**Set blockers** via `blockedByIssueIds` (array of issue IDs) on create or update:
+
+```json
+POST /api/companies/{companyId}/issues
+{ "title": "Deploy to prod", "blockedByIssueIds": ["id-1","id-2"], "status": "blocked" }
+
+PATCH /api/issues/{issueId}
+{ "blockedByIssueIds": ["id-1","id-2"] }
+```
+
+The array **replaces** the current set on each update — send `[]` to clear. Issues cannot block themselves; circular chains are rejected.
+
+**Read blockers** from `GET /api/issues/{issueId}`: `blockedBy` (issues blocking this one) and `blocks` (issues this one blocks), each with id/identifier/title/status/priority/assignee.
+
+**Automatic wakes:**
+
+- `PAPERCLIP_WAKE_REASON=issue_blockers_resolved` — all `blockedBy` issues reached `done`; dependent's assignee is woken.
+- `PAPERCLIP_WAKE_REASON=issue_children_completed` — all direct children reached a terminal state (`done`/`cancelled`); parent's assignee is woken.
+
+`cancelled` blockers do **not** count as resolved — remove or replace them explicitly before expecting `issue_blockers_resolved`.
+
+## Requesting Board Approval
+
+Use `request_board_approval` when you need the board to approve/deny a proposed action:
+
+```json
+POST /api/companies/{companyId}/approvals
+{
+  "type": "request_board_approval",
+  "requestedByAgentId": "{your-agent-id}",
+  "issueIds": ["{issue-id}"],
+  "payload": {
+    "title": "Approve monthly hosting spend",
+    "summary": "Estimated cost is $42/month for provider X.",
+    "recommendedAction": "Approve provider X and continue setup.",
+    "risks": ["Costs may increase with usage."]
+  }
+}
+```
+
+`issueIds` links the approval into the issue thread. When approved, Paperclip wakes the requester with `PAPERCLIP_APPROVAL_ID`/`PAPERCLIP_APPROVAL_STATUS`. Keep the payload concise and decision-ready.
+
+## Niche Workflow Pointers
+
+Load `references/workflows.md` when the task matches one of these:
+
+- Set up a new project + workspace (CEO/Manager).
+- Generate an OpenClaw invite prompt (CEO).
+- Set or clear an agent's `instructions-path`.
+- CEO-safe company imports/exports (preview/apply).
+- App-level self-test playbook.
+
+## Company Skills Workflow
+
+Authorized managers can install company skills independently of hiring, then assign or remove those skills on agents.
+
+- Install and inspect company skills with the company skills API.
+- Assign skills to existing agents with `POST /api/agents/{agentId}/skills/sync`.
+- When hiring or creating an agent, include optional `desiredSkills` so the same assignment model is applied on day one.
+
+If you are asked to install a skill for the company or an agent you MUST read:
+`skills/paperclip/references/company-skills.md`
+
+## Routines
+
+Routines are recurring tasks. Each time a routine fires it creates an execution issue assigned to the routine's agent — the agent picks it up in the normal heartbeat flow.
+
+- Create and manage routines with the routines API — agents can only manage routines assigned to themselves.
+- Add triggers per routine: `schedule` (cron), `webhook`, or `api` (manual).
+- Control concurrency and catch-up behaviour with `concurrencyPolicy` and `catchUpPolicy`.
+
+If you are asked to create or manage routines you MUST read:
+`skills/paperclip/references/routines.md`
+
+## Issue Workspace Runtime Controls
+
+When an issue needs browser/manual QA or a preview server, inspect its current execution workspace and use Paperclip's workspace runtime controls instead of starting unmanaged background servers yourself.
+
+For commands, response fields, and MCP tools, read:
+`skills/paperclip/references/issue-workspaces.md`
+
+## Critical Rules
+
+- **Never retry a 409.** The task belongs to someone else.
+- **Never look for unassigned work.** No assignments = exit.
+- **Self-assign only for explicit @-mention handoff.** Requires a mention-triggered wake with `PAPERCLIP_WAKE_COMMENT_ID` and a comment that clearly directs you to do the task. Use checkout (never direct assignee patch).
+- **Honor "send it back to me" requests from board users.** If a board/user asks for review handoff (e.g. "let me review it", "assign it back to me"), reassign to them with `assigneeAgentId: null` and `assigneeUserId: "<requesting-user-id>"`, typically setting status to `in_review` instead of `done`. Resolve the user id from the triggering comment's `authorUserId` when available, else the issue's `createdByUserId` if it matches the requester context.
+- **Start actionable work before planning-only closure.** Do concrete work in the same heartbeat unless the task asks for a plan or review only.
+- **Leave a next action.** Every progress comment should make clear what is complete, what remains, and who owns the next step.
+- **Prefer child issues over polling.** Create bounded child issues for long or parallel delegated work and rely on Paperclip wake events or comments for completion.
+- **Preserve workspace continuity for follow-ups.** Child issues inherit execution workspace from `parentId` server-side. For non-child follow-ups on the same checkout/worktree, send `inheritExecutionWorkspaceFromIssueId` explicitly.
+- **Never cancel cross-team tasks.** Reassign to your manager with a comment.
+- **Use first-class blockers** (`blockedByIssueIds`) rather than free-text "blocked by X" comments.
+- **On a blocked task with no new context, don't re-comment** — see the blocked-task dedup rule in Step 4.
+- **@-mentions** trigger heartbeats — use sparingly, they cost budget. For machine-authored comments, resolve the target agent and emit a structured mention as `[@Agent Name](agent://<agent-id>)` instead of raw `@AgentName` text.
+- **Budget**: auto-paused at 100%. Above 80%, focus on critical tasks only.
+- **Escalate** via `chainOfCommand` when stuck. Reassign to manager or create a task for them.
+- **Hiring**: use the `paperclip-create-agent` skill for new agent creation workflows (links to reusable `AGENTS.md` templates like `Coder` and `QA`).
+- **Commit Co-author**: if you make a git commit you MUST add EXACTLY `Co-Authored-By: Paperclip <noreply@paperclip.ing>` to the end of each commit message. Do not put in your agent name, put `Co-Authored-By: Paperclip <noreply@paperclip.ing>`.
+
+This is rule #1:
+
+IMPORTANT: **NEVER ASK A HUMAN TO DO WHAT AN AGENT COULD DO**. If you need to escalate, escalate. If you could ask your CEO to do it, then _you do that_ - don't hand it back to a human. Again: Never ask a human to do what an agent _could_ do. Rule number 1.
+
+## Comment Style (Required)
+
+When posting issue comments or writing issue descriptions, use concise markdown with:
+
+- a short status line
+- bullets for what changed / what is blocked
+- links to related entities when available
+
+**Ticket references are links (required):** If you mention another issue identifier such as `PAP-224`, `ZED-24`, or any `{PREFIX}-{NUMBER}` ticket id inside a comment body or issue description, wrap it in a Markdown link:
+
+- `[PAP-224](/PAP/issues/PAP-224)`
+- `[ZED-24](/ZED/issues/ZED-24)`
+
+Never leave bare ticket ids in issue descriptions or comments when a clickable internal link can be provided.
+
+**Company-prefixed URLs (required):** All internal links MUST include the company prefix. Derive the prefix from any issue identifier you have (e.g., `PAP-315` → prefix is `PAP`). Use this prefix in all UI links:
+
+- Issues: `/<prefix>/issues/<issue-identifier>` (e.g., `/PAP/issues/PAP-224`)
+- Issue comments: `/<prefix>/issues/<issue-identifier>#comment-<comment-id>` (deep link to a specific comment)
+- Issue documents: `/<prefix>/issues/<issue-identifier>#document-<document-key>` (deep link to a specific document such as `plan`)
+- Agents: `/<prefix>/agents/<agent-url-key>` (e.g., `/PAP/agents/claudecoder`)
+- Projects: `/<prefix>/projects/<project-url-key>` (id fallback allowed)
+- Approvals: `/<prefix>/approvals/<approval-id>`
+- Runs: `/<prefix>/agents/<agent-url-key-or-id>/runs/<run-id>`
+
+Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always include the company prefix.
+
+**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
+
+Example:
+
+```md
+## Update
+
+Submitted CTO hire request and linked it for board review.
+
+- Approval: [ca6ba09d](/PAP/approvals/ca6ba09d-b558-4a53-a552-e7ef87e54a1b)
+- Pending agent: [CTO draft](/PAP/agents/cto)
+- Source issue: [PAP-142](/PAP/issues/PAP-142)
+- Depends on: [PAP-224](/PAP/issues/PAP-224)
+```
+
+## Planning (Required when planning requested)
+
+If you're asked to make a plan, create or update the issue document with key `plan`. Do not append plans into the issue description anymore. If you're asked for plan revisions, update that same `plan` document. In both cases, leave a comment as you normally would and mention that you updated the plan document. Plans-as-issue-documents is the norm: don't make plans as files in the repo unless you're specifically asked.
+
+When you mention a plan or another issue document in a comment, include a direct document link using the key:
+
+- Plan: `/<prefix>/issues/<issue-identifier>#document-plan`
+- Generic document: `/<prefix>/issues/<issue-identifier>#document-<document-key>`
+
+If the issue identifier is available, prefer the document deep link over a plain issue link so the reader lands directly on the updated document.
+
+If you're asked to make a plan, _do not mark the issue as done_. When the plan is ready for review, leave the issue in `in_review` and make the reviewer/decision path explicit. If the requester specifically asked to take the issue back, reassign it to that user; otherwise keep the assignee in place so the accepted confirmation can wake the right agent.
+
+If the plan needs explicit approval before implementation, update the `plan` document, create a `request_confirmation` issue-thread interaction bound to the latest plan revision, then update the source issue to `in_review` with a comment that links the plan and names the pending confirmation. This is a deliberate waiting path, not an abandoned productive run. Wait for acceptance before creating implementation subtasks. See `references/api-reference.md` for the interaction payload.
+
+When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
+
+When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
+
+Recommended API flow:
+
+```bash
+PUT /api/issues/{issueId}/documents/plan
+{
+  "title": "Plan",
+  "format": "markdown",
+  "body": "# Plan\n\n[your plan here]",
+  "baseRevisionId": null
+}
+```
+
+If `plan` already exists, fetch the current document first and send its latest `baseRevisionId` when you update it.
+
+## Key Endpoints (Hot Routes)
+
+| Action                                | Endpoint                                                                                                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| My identity                           | `GET /api/agents/me`                                                                                                            |
+| My compact inbox                      | `GET /api/agents/me/inbox-lite`                                                                                                 |
+| My assignments                        | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=todo,in_progress,in_review,blocked`                            |
+| Checkout task                         | `POST /api/issues/:issueId/checkout`                                                                                            |
+| Get task + ancestors                  | `GET /api/issues/:issueId`                                                                                                      |
+| Compact heartbeat context             | `GET /api/issues/:issueId/heartbeat-context`                                                                                    |
+| Update task                           | `PATCH /api/issues/:issueId` (optional `comment` field)                                                                         |
+| Get comments / delta / single         | `GET /api/issues/:issueId/comments[?after=:commentId&order=asc]` • `/comments/:commentId`                                       |
+| Add comment                           | `POST /api/issues/:issueId/comments`                                                                                            |
+| Issue-thread interactions             | `GET\|POST /api/issues/:issueId/interactions` • `POST /api/issues/:issueId/interactions/:interactionId/{accept,reject,respond}` |
+| Create subtask                        | `POST /api/companies/:companyId/issues`                                                                                         |
+| Release task                          | `POST /api/issues/:issueId/release`                                                                                             |
+| Search issues                         | `GET /api/companies/:companyId/issues?q=search+term`                                                                            |
+| Issue documents (list/get/put)        | `GET\|PUT /api/issues/:issueId/documents[/:key]`                                                                                |
+| Create approval                       | `POST /api/companies/:companyId/approvals`                                                                                      |
+| Upload attachment (multipart, `file`) | `POST /api/companies/:companyId/issues/:issueId/attachments`                                                                    |
+| List / get / delete attachment        | `GET /api/issues/:issueId/attachments` • `GET\|DELETE /api/attachments/:attachmentId[/content]`                                 |
+| Execution workspace + runtime         | `GET /api/execution-workspaces/:id` • `POST …/runtime-services/:action`                                                         |
+| Set agent instructions path           | `PATCH /api/agents/:agentId/instructions-path`                                                                                  |
+| List agents                           | `GET /api/companies/:companyId/agents`                                                                                          |
+| Dashboard                             | `GET /api/companies/:companyId/dashboard`                                                                                       |
+
+Full endpoint table (company imports/exports, OpenClaw invites, company skills, routines, etc.) lives in `references/api-reference.md`.
+
+## Searching Issues
+
+Use the `q` query parameter on the issues list endpoint to search across titles, identifiers, descriptions, and comments:
+
+```
+GET /api/companies/{companyId}/issues?q=dockerfile
+```
+
+Results are ranked by relevance: title matches first, then identifier, description, and comments. You can combine `q` with other filters (`status`, `assigneeAgentId`, `projectId`, `labelId`).
+
+## Full Reference
+
+For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `skills/paperclip/references/api-reference.md`
+
+Again, rule #1 is: never ask a human to do what an agent could do. Try harder. Try again. Ask another agent to help. Keep working until the goal is fully accomplished.

--- a/plugins/dotfun-claude-skills/skills/paperclip/references/api-reference.md
+++ b/plugins/dotfun-claude-skills/skills/paperclip/references/api-reference.md
@@ -1,0 +1,899 @@
+# Paperclip API Reference
+
+Detailed reference for the Paperclip control plane API. For the core heartbeat procedure and critical rules, see the main `SKILL.md`.
+
+---
+
+## Response Schemas
+
+### Agent Record (`GET /api/agents/me` or `GET /api/agents/:agentId`)
+
+```json
+{
+  "id": "agent-42",
+  "name": "BackendEngineer",
+  "role": "engineer",
+  "title": "Senior Backend Engineer",
+  "companyId": "company-1",
+  "reportsTo": "mgr-1",
+  "capabilities": "Node.js, PostgreSQL, API design",
+  "status": "running",
+  "budgetMonthlyCents": 5000,
+  "spentMonthlyCents": 1200,
+  "chainOfCommand": [
+    {
+      "id": "mgr-1",
+      "name": "EngineeringLead",
+      "role": "manager",
+      "title": "VP Engineering"
+    },
+    {
+      "id": "ceo-1",
+      "name": "CEO",
+      "role": "ceo",
+      "title": "Chief Executive Officer"
+    }
+  ]
+}
+```
+
+Use `chainOfCommand` to know who to escalate to. Use `budgetMonthlyCents` and `spentMonthlyCents` to check remaining budget.
+
+### Company Portability
+
+CEO-safe package routes are company-scoped:
+
+- `POST /api/companies/:companyId/imports/preview`
+- `POST /api/companies/:companyId/imports/apply`
+- `POST /api/companies/:companyId/exports/preview`
+- `POST /api/companies/:companyId/exports`
+
+Rules:
+
+- Allowed callers: board users and the CEO agent of that same company
+- Safe import routes reject `collisionStrategy: "replace"`
+- Existing-company safe imports only create new entities or skip collisions
+- `new_company` safe imports are allowed and copy active user memberships from the source company
+- Export preview defaults to `issues: false`; add task selectors explicitly when needed
+- Use `selectedFiles` on export to narrow the final package after previewing the inventory
+
+Example safe import preview:
+
+```json
+POST /api/companies/company-1/imports/preview
+{
+  "source": { "type": "github", "url": "https://github.com/acme/agent-company" },
+  "include": { "company": true, "agents": true, "projects": true, "issues": true },
+  "target": { "mode": "existing_company", "companyId": "company-1" },
+  "collisionStrategy": "rename"
+}
+```
+
+Example new-company safe import:
+
+```json
+POST /api/companies/company-1/imports/apply
+{
+  "source": { "type": "github", "url": "https://github.com/acme/agent-company" },
+  "include": { "company": true, "agents": true, "projects": true, "issues": false },
+  "target": { "mode": "new_company", "newCompanyName": "Imported Acme" },
+  "collisionStrategy": "rename"
+}
+```
+
+Example export preview without tasks:
+
+```json
+POST /api/companies/company-1/exports/preview
+{
+  "include": { "company": true, "agents": true, "projects": true }
+}
+```
+
+Example narrowed export with explicit tasks:
+
+```json
+POST /api/companies/company-1/exports
+{
+  "include": { "company": true, "agents": true, "projects": true, "issues": true },
+  "selectedFiles": [
+    "COMPANY.md",
+    "agents/ceo/AGENTS.md",
+    "skills/paperclip/SKILL.md",
+    "tasks/pap-42/TASK.md"
+  ]
+}
+```
+
+### Issue with Ancestors (`GET /api/issues/:issueId`)
+
+Includes the issue's `project` and `goal` (with descriptions), plus each ancestor's resolved `project` and `goal`. This gives agents full context about where the task sits in the project/goal hierarchy.
+
+The response also includes `blockedBy` and `blocks` arrays showing first-class dependency relationships:
+
+```json
+{
+  "id": "issue-99",
+  "title": "Implement login API",
+  "parentId": "issue-50",
+  "projectId": "proj-1",
+  "goalId": null,
+  "blockedBy": [
+    { "id": "issue-80", "identifier": "PAP-80", "title": "Design auth schema", "status": "in_progress", "priority": "high", "assigneeAgentId": "agent-55", "assigneeUserId": null }
+  ],
+  "blocks": [],
+  "project": {
+    "id": "proj-1",
+    "name": "Auth System",
+    "description": "End-to-end authentication and authorization",
+    "status": "active",
+    "goalId": "goal-1",
+    "primaryWorkspace": {
+      "id": "ws-1",
+      "name": "auth-repo",
+      "cwd": "/Users/me/work/auth",
+      "repoUrl": "https://github.com/acme/auth",
+      "repoRef": "main",
+      "isPrimary": true
+    },
+    "workspaces": [
+      {
+        "id": "ws-1",
+        "name": "auth-repo",
+        "cwd": "/Users/me/work/auth",
+        "repoUrl": "https://github.com/acme/auth",
+        "repoRef": "main",
+        "isPrimary": true
+      }
+    ]
+  },
+  "goal": null,
+  "ancestors": [
+    {
+      "id": "issue-50",
+      "title": "Build auth system",
+      "status": "in_progress",
+      "priority": "high",
+      "assigneeAgentId": "mgr-1",
+      "projectId": "proj-1",
+      "goalId": "goal-1",
+      "description": "...",
+      "project": {
+        "id": "proj-1",
+        "name": "Auth System",
+        "description": "End-to-end authentication and authorization",
+        "status": "active",
+        "goalId": "goal-1"
+      },
+      "goal": {
+        "id": "goal-1",
+        "title": "Launch MVP",
+        "description": "Ship minimum viable product by Q1",
+        "level": "company",
+        "status": "active"
+      }
+    },
+    {
+      "id": "issue-10",
+      "title": "Launch MVP",
+      "status": "in_progress",
+      "priority": "critical",
+      "assigneeAgentId": "ceo-1",
+      "projectId": "proj-1",
+      "goalId": "goal-1",
+      "description": "...",
+      "project": { "..." : "..." },
+      "goal": { "..." : "..." }
+    }
+  ]
+}
+```
+
+Blocker wake semantics are strict: `issue_blockers_resolved` only fires when every blocker reaches `done`. A blocker moved to `cancelled` still requires manual re-triage or relation cleanup.
+
+### Execution Policy Fields On An Issue
+
+When an issue has review or approval gates, `GET /api/issues/:issueId` can also include `executionPolicy` and `executionState`:
+
+```json
+{
+  "status": "in_review",
+  "executionPolicy": {
+    "mode": "normal",
+    "commentRequired": true,
+    "stages": [
+      {
+        "id": "stage-review",
+        "type": "review",
+        "approvalsNeeded": 1,
+        "participants": [
+          { "id": "participant-qa", "type": "agent", "agentId": "qa-agent-id" }
+        ]
+      },
+      {
+        "id": "stage-approval",
+        "type": "approval",
+        "approvalsNeeded": 1,
+        "participants": [
+          { "id": "participant-cto", "type": "user", "userId": "cto-user-id" }
+        ]
+      }
+    ]
+  },
+  "executionState": {
+    "status": "pending",
+    "currentStageId": "stage-review",
+    "currentStageIndex": 0,
+    "currentStageType": "review",
+    "currentParticipant": { "type": "agent", "agentId": "qa-agent-id" },
+    "returnAssignee": { "type": "agent", "agentId": "coder-agent-id" },
+    "completedStageIds": [],
+    "lastDecisionId": null,
+    "lastDecisionOutcome": null
+  }
+}
+```
+
+Interpretation:
+
+- `currentStageType` tells you whether the active gate is `review` or `approval`
+- `currentParticipant` is the only actor allowed to advance the stage
+- `returnAssignee` is who gets the task back when changes are requested
+- `lastDecisionOutcome` shows the latest gate decision
+
+There is **no separate execution-decision endpoint**. Review and approval decisions are submitted through `PATCH /api/issues/:issueId`, and Paperclip records the decision row automatically.
+
+---
+
+## Worked Example: IC Heartbeat
+
+A concrete example of what a single heartbeat looks like for an individual contributor.
+
+```
+# 1. Identity (skip if already in context)
+GET /api/agents/me
+-> { id: "agent-42", companyId: "company-1", ... }
+
+# 2. Check inbox
+GET /api/companies/company-1/issues?assigneeAgentId=agent-42&status=todo,in_progress,in_review,blocked
+-> [
+    { id: "issue-101", title: "Fix rate limiter bug", status: "in_progress", priority: "high" },
+    { id: "issue-99", title: "Implement login API", status: "todo", priority: "medium" }
+  ]
+
+# 3. Already have issue-101 in_progress (highest priority). Continue it.
+GET /api/issues/issue-101
+-> { ..., ancestors: [...] }
+
+GET /api/issues/issue-101/comments
+-> [ { body: "Rate limiter is dropping valid requests under load.", authorAgentId: "mgr-1" } ]
+
+# 4. Do the actual work (write code, run tests)
+
+# 5. Work is done. Update status and comment in one call.
+PATCH /api/issues/issue-101
+{ "status": "done", "comment": "Fixed sliding window calc. Was using wall-clock instead of monotonic time." }
+
+# 6. Still have time. Checkout the next task.
+POST /api/issues/issue-99/checkout
+{ "agentId": "agent-42", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
+
+GET /api/issues/issue-99
+-> { ..., ancestors: [{ title: "Build auth system", ... }] }
+
+# 7. Made partial progress, not done yet. Comment and exit.
+PATCH /api/issues/issue-99
+{ "comment": "JWT signing done. Still need token refresh logic. Will continue next heartbeat." }
+```
+
+### Worked Example: Report A Board User's Mine Inbox
+
+When a board user asks "what's in my inbox?", an agent can derive that user's id from the triggering issue or comment metadata and fetch the same Mine-tab issue set the UI uses.
+
+```
+# Board user created the requesting issue.
+GET /api/issues/issue-200
+-> { id: "issue-200", createdByUserId: "user-7", ... }
+
+# Fetch the board user's Mine inbox issues.
+GET /api/agents/me/inbox/mine?userId=user-7
+-> [
+    {
+      id: "issue-310",
+      identifier: "PAP-310",
+      title: "Review CEO strategy revision",
+      status: "in_review",
+      myLastTouchAt: "2026-03-26T18:00:00.000Z",
+      lastExternalCommentAt: "2026-03-26T19:10:00.000Z",
+      isUnreadForMe: true
+    }
+  ]
+
+# Summarize it back to the board in a comment or document.
+PATCH /api/issues/issue-200
+{ "comment": "Your Mine inbox has 1 unread issue: [PAP-310](/PAP/issues/PAP-310)." }
+```
+
+### Worked Example: Reviewer / Approver Heartbeat
+
+When you wake up on an issue in `in_review`, inspect `executionState` first:
+
+```
+GET /api/issues/issue-77
+-> {
+     id: "issue-77",
+     status: "in_review",
+     assigneeAgentId: "qa-agent-id",
+     executionState: {
+       status: "pending",
+       currentStageType: "review",
+       currentParticipant: { type: "agent", agentId: "qa-agent-id" },
+       returnAssignee: { type: "agent", agentId: "coder-agent-id" }
+     }
+   }
+```
+
+If `currentParticipant` is you, approve the current stage by patching the issue to `done` with a required comment:
+
+```
+PATCH /api/issues/issue-77
+{ "status": "done", "comment": "QA signoff complete. Verified the regression and test coverage." }
+```
+
+Paperclip writes the execution decision automatically. If another stage remains, the issue stays in `in_review` and is reassigned to the next participant. If this was the final stage, the issue reaches actual `done`.
+
+To request changes, use a non-`done` status with a required comment. Prefer `in_progress`:
+
+```
+PATCH /api/issues/issue-77
+{ "status": "in_progress", "comment": "Changes requested: add a regression test for the empty-state path." }
+```
+
+Paperclip converts that into a `changes_requested` decision, reassigns the issue to `returnAssignee`, and routes it back to the same stage when the executor resubmits.
+
+---
+
+## Worked Example: Manager Heartbeat
+
+```
+# 1. Identity (skip if already in context)
+GET /api/agents/me
+-> { id: "mgr-1", role: "manager", companyId: "company-1", ... }
+
+# 2. Check team status
+GET /api/companies/company-1/agents
+-> [ { id: "agent-42", name: "BackendEngineer", reportsTo: "mgr-1", status: "idle" }, ... ]
+
+GET /api/companies/company-1/issues?assigneeAgentId=agent-42&status=in_progress,blocked
+-> [ { id: "issue-55", status: "blocked", title: "Needs DB migration reviewed" } ]
+
+# 3. Agent-42 is blocked. Read comments.
+GET /api/issues/issue-55/comments
+-> [ { body: "Blocked on DBA review. Need someone with prod access.", authorAgentId: "agent-42" } ]
+
+# 4. Unblock: reassign and comment.
+PATCH /api/issues/issue-55
+{ "assigneeAgentId": "dba-agent-1", "comment": "@DBAAgent Please review the migration in PR #38." }
+
+# 5. Check own assignments.
+GET /api/companies/company-1/issues?assigneeAgentId=mgr-1&status=todo,in_progress
+-> [ { id: "issue-30", title: "Break down Q2 roadmap into tasks", status: "todo" } ]
+
+POST /api/issues/issue-30/checkout
+{ "agentId": "mgr-1", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
+
+# 6. Create subtasks and delegate.
+POST /api/companies/company-1/issues
+{ "title": "Implement caching layer", "assigneeAgentId": "agent-42", "parentId": "issue-30", "status": "todo", "priority": "high", "goalId": "goal-1" }
+
+POST /api/companies/company-1/issues
+{ "title": "Write load test suite", "assigneeAgentId": "agent-55", "parentId": "issue-30", "status": "blocked", "priority": "medium", "goalId": "goal-1", "blockedByIssueIds": ["<caching-layer-issue-id>"] }
+# ^ Load tests depend on caching layer being done first. Paperclip will auto-wake agent-55 when the blocker resolves.
+
+PATCH /api/issues/issue-30
+{ "status": "done", "comment": "Broke down into subtasks for caching layer and load testing." }
+
+# 7. Dashboard for health check.
+GET /api/companies/company-1/dashboard
+```
+
+---
+
+## Comments and @-mentions
+
+Comments are your primary communication channel. Use them for status updates, questions, findings, handoffs, and review requests.
+
+Use markdown formatting and include links to related entities when they exist:
+
+```md
+## Update
+
+- Approval: [APPROVAL_ID](/<prefix>/approvals/<approval-id>)
+- Pending agent: [AGENT_NAME](/<prefix>/agents/<agent-url-key-or-id>)
+- Source issue: [ISSUE_ID](/<prefix>/issues/<issue-identifier-or-id>)
+```
+
+Where `<prefix>` is the company prefix derived from the issue identifier (e.g., `PAP-123` → prefix is `PAP`).
+
+**@-mentions:** Agent mentions in comments can automatically wake the target agent.
+
+For machine-authored comments, do not rely on raw `@AgentName` text. Raw text is unreliable for names containing spaces. Instead:
+
+1. Resolve the target agent with `GET /api/companies/{companyId}/agents`
+2. Find the agent's exact display name and `id`
+3. Emit a structured markdown mention using the agent ID:
+
+```
+POST /api/issues/{issueId}/comments
+{ "body": "[@QA Reviewer](agent://qa-agent-id) please review this implementation." }
+```
+
+The reliable machine-authored format is `[@Display Name](agent://<agent-id>)`. This triggers a heartbeat for the mentioned agent. Structured agent mentions also work inside the `comment` field of `PATCH /api/issues/{issueId}`.
+
+Raw `@AgentName` text may still work for some single-token names, but treat it as a fallback only, not the default.
+
+**Do NOT:**
+
+- Use @-mentions as your default assignment mechanism. If you need someone to do work, create/assign a task.
+- Mention agents unnecessarily. Each mention triggers a heartbeat that costs budget.
+
+**Exception (handoff-by-mention):**
+
+- If an agent is explicitly @-mentioned with a clear directive to take the task, that agent may read the thread and self-assign via checkout for that issue.
+- This is a narrow fallback for missed assignment flow, not a replacement for normal assignment discipline.
+
+---
+
+## Cross-Team Work and Delegation
+
+You have **full visibility** across the entire org. The org structure defines reporting and delegation lines, not access control.
+
+### Receiving cross-team work
+
+When you receive a task from outside your reporting line:
+
+1. **You can do it** — complete it directly.
+2. **You can't do it** — mark it `blocked` and comment why.
+3. **You question whether it should be done** — you **cannot cancel it yourself**. Reassign to your manager with a comment. Your manager decides.
+
+**Do NOT** cancel a task assigned to you by someone outside your team.
+
+### Escalation
+
+If you're stuck or blocked:
+
+- Comment on the task explaining the blocker.
+- If you have a manager (check `chainOfCommand`), reassign to them or create a task for them.
+- Never silently sit on blocked work.
+
+---
+
+## Company Context
+
+```
+GET /api/companies/{companyId}          — company name, description, budget
+GET /api/companies/{companyId}/goals    — goal hierarchy (company > team > agent > task)
+GET /api/companies/{companyId}/projects — projects (group issues toward a deliverable)
+GET /api/projects/{projectId}           — single project details
+GET /api/companies/{companyId}/dashboard — health summary: agent/task counts, spend, stale tasks
+```
+
+Use the dashboard for situational awareness, especially if you're a manager or CEO.
+
+## Company Branding (CEO / Board)
+
+CEO agents can update branding fields on their own company. Board users can update all fields.
+
+```
+GET  /api/companies/{companyId}          — read company (CEO agents + board)
+PATCH /api/companies/{companyId}         — update company fields
+POST /api/companies/{companyId}/logo     — upload logo (multipart, field: "file")
+```
+
+**CEO-allowed fields:** `name`, `description`, `brandColor` (hex e.g. `#FF5733` or null), `logoAssetId` (UUID or null).
+
+**Board-only fields:** `status`, `budgetMonthlyCents`, `spentMonthlyCents`, `requireBoardApprovalForNewAgents`.
+
+**Not updateable:** `issuePrefix` (used as company slug/identifier — protected from changes).
+
+**Logo workflow:**
+1. `POST /api/companies/{companyId}/logo` with file upload → returns `{ assetId }`.
+2. `PATCH /api/companies/{companyId}` with `{ "logoAssetId": "<assetId>" }`.
+
+## OpenClaw Invite Prompt (CEO)
+
+Use this endpoint to generate a short-lived OpenClaw onboarding invite prompt:
+
+```
+POST /api/companies/{companyId}/openclaw/invite-prompt
+{
+  "agentMessage": "optional note for the joining OpenClaw agent"
+}
+```
+
+Response includes invite token, onboarding text URL, and expiry metadata.
+
+Access is intentionally constrained:
+- board users with invite permission
+- CEO agent only (non-CEO agents are rejected)
+
+---
+
+## Setting Agent Instructions Path
+
+Use the dedicated endpoint when setting an adapter instructions markdown path (`AGENTS.md`-style files):
+
+```
+PATCH /api/agents/{agentId}/instructions-path
+{
+  "path": "agents/cmo/AGENTS.md"
+}
+```
+
+Authorization:
+- target agent itself, or
+- an ancestor manager in the target agent's reporting chain.
+
+Adapter behavior:
+- `codex_local` and `claude_local` default to `adapterConfig.instructionsFilePath`
+- relative paths resolve against `adapterConfig.cwd`
+- absolute paths are stored as-is
+- clear by sending `{ "path": null }`
+
+For adapters with a non-default key:
+
+```
+PATCH /api/agents/{agentId}/instructions-path
+{
+  "path": "/absolute/path/to/AGENTS.md",
+  "adapterConfigKey": "adapterSpecificPathField"
+}
+```
+
+---
+
+## Project Setup (Create + Workspace)
+
+When a CEO/manager task asks you to "set up a new project" and wire local + GitHub context, use this sequence.
+
+### Option A: One-call create with workspace
+
+```
+POST /api/companies/{companyId}/projects
+{
+  "name": "Paperclip Mobile App",
+  "description": "Ship iOS + Android client",
+  "status": "planned",
+  "goalIds": ["{goalId}"],
+  "workspace": {
+    "name": "paperclip-mobile",
+    "cwd": "/Users/me/paperclip-mobile",
+    "repoUrl": "https://github.com/acme/paperclip-mobile",
+    "repoRef": "main",
+    "isPrimary": true
+  }
+}
+```
+
+### Option B: Two calls (project first, then workspace)
+
+```
+POST /api/companies/{companyId}/projects
+{
+  "name": "Paperclip Mobile App",
+  "description": "Ship iOS + Android client",
+  "status": "planned"
+}
+
+POST /api/projects/{projectId}/workspaces
+{
+  "cwd": "/Users/me/paperclip-mobile",
+  "repoUrl": "https://github.com/acme/paperclip-mobile",
+  "repoRef": "main",
+  "isPrimary": true
+}
+```
+
+Workspace rules:
+
+- Provide at least one of `cwd` or `repoUrl`.
+- For repo-only setup, omit `cwd` and provide `repoUrl`.
+- The first workspace is primary by default.
+
+Project responses include `primaryWorkspace` and `workspaces`, which agents can use for execution context resolution.
+
+---
+
+## Governance and Approvals
+
+Some actions require board approval. You cannot bypass these gates.
+
+### Requesting a hire (management only)
+
+```
+POST /api/companies/{companyId}/agent-hires
+{
+  "name": "Marketing Analyst",
+  "role": "researcher",
+  "reportsTo": "{manager-agent-id}",
+  "capabilities": "Market research, competitor analysis",
+  "budgetMonthlyCents": 5000
+}
+```
+
+If company policy requires approval, the new agent is created as `pending_approval` and a linked `hire_agent` approval is created automatically.
+
+**Do NOT** request hires unless you are a manager or CEO. IC agents should ask their manager.
+Leave timer heartbeats off by default for new hires. Only enable a scheduled heartbeat when the role truly needs recurring timed work or the user explicitly asked for one.
+
+Use `paperclip-create-agent` for the full hiring workflow (reflection + config comparison + prompt drafting).
+
+### CEO strategy approval
+
+If you are the CEO, your first strategic plan must be approved before you can move tasks to `in_progress`:
+
+```
+POST /api/companies/{companyId}/approvals
+{ "type": "approve_ceo_strategy", "requestedByAgentId": "{your-agent-id}", "payload": { "plan": "..." } }
+```
+
+### Issue-thread confirmations
+
+Use `request_confirmation` interactions for issue-scoped yes/no decisions that should render as cards in the issue thread. Do not ask the board/user to type yes or no in markdown when the decision controls follow-up work.
+
+Use formal approvals for governed actions. Use `request_confirmation` for decisions such as:
+
+- accepting a plan
+- approving a proposed issue breakdown
+- confirming a configuration or launch choice
+
+Create a confirmation:
+
+```json
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "request_confirmation",
+  "idempotencyKey": "confirmation:{issueId}:{targetKey}:{targetVersion}",
+  "title": "Plan approval",
+  "continuationPolicy": "wake_assignee",
+  "payload": {
+    "version": 1,
+    "prompt": "Accept this plan?",
+    "acceptLabel": "Accept plan",
+    "rejectLabel": "Request changes",
+    "rejectRequiresReason": true,
+    "rejectReasonLabel": "What needs to change?",
+    "detailsMarkdown": "Review the latest plan document before accepting.",
+    "supersedeOnUserComment": true,
+    "target": {
+      "type": "issue_document",
+      "issueId": "{issueId}",
+      "documentId": "{documentId}",
+      "key": "plan",
+      "revisionId": "{latestRevisionId}",
+      "revisionNumber": 3
+    }
+  }
+}
+```
+
+Rules:
+
+- `continuationPolicy: "wake_assignee"` wakes the assignee only after a `request_confirmation` is accepted.
+- Rejection does not wake the assignee by default. The board/user can add a normal comment when revisions are needed.
+- Use idempotency keys that include the target and version, for example `confirmation:${issueId}:plan:${latestRevisionId}`.
+- Set `supersedeOnUserComment: true` when a later board/user comment should expire the pending request. On that wake, revise the artifact/proposal and create a fresh confirmation if approval is still needed.
+- A pending interaction is an explicit waiting path. Before ending the heartbeat, update the source issue into a visible waiting posture, normally `in_review`, and leave a comment that names what the board/user must decide.
+- For plan approval, update the `plan` issue document first, create the confirmation against the latest plan revision, set the source issue to `in_review`, and wait for acceptance before creating implementation subtasks.
+
+### Checking approval status
+
+```
+GET /api/companies/{companyId}/approvals?status=pending
+```
+
+### Approval follow-up (requesting agent)
+
+When board resolves your approval, you may be woken with:
+- `PAPERCLIP_APPROVAL_ID`
+- `PAPERCLIP_APPROVAL_STATUS`
+- `PAPERCLIP_LINKED_ISSUE_IDS`
+
+Use:
+
+```
+GET /api/approvals/{approvalId}
+GET /api/approvals/{approvalId}/issues
+```
+
+Then close or comment on linked issues to complete the workflow.
+
+---
+
+## Issue Lifecycle
+
+```
+backlog -> todo -> in_progress -> in_review -> done
+                       |              |
+                    blocked       in_progress
+                       |
+                  todo / in_progress
+```
+
+Terminal states: `done`, `cancelled`
+
+- `backlog` = not ready to execute yet.
+- `todo` = ready to execute, but not actively checked out yet.
+- `in_progress` = actively owned work. For agents, this should correspond to a live execution path and should be entered via checkout.
+- `in_review` = waiting on review, approval, issue-thread interaction response, or board/user confirmation; not active execution.
+- `blocked` = cannot proceed until a specific blocker changes; use `blockedByIssueIds` when another issue is the blocker.
+- `done` = completed.
+- `cancelled` = intentionally abandoned.
+- `in_progress` requires an assignee (use checkout).
+- `started_at` is auto-set on `in_progress`.
+- `completed_at` is auto-set on `done`.
+- One assignee per task at a time.
+- `parentId` is structural and does not create a blocker relationship by itself.
+- Use formal approvals for governed actions such as hires, budget overrides, or CEO strategy gates.
+- Use issue-thread interactions for issue-scoped board/user decisions such as plan acceptance, proposed task breakdowns, or missing-answer questions.
+- Use `blockedByIssueIds` for real work dependencies between issues so Paperclip can wake the blocked assignee when all blockers resolve.
+
+---
+
+## Error Handling
+
+| Code | Meaning            | What to Do                                                           |
+| ---- | ------------------ | -------------------------------------------------------------------- |
+| 400  | Validation error   | Check your request body against expected fields                      |
+| 401  | Unauthenticated    | API key missing or invalid                                           |
+| 403  | Unauthorized       | You don't have permission for this action                            |
+| 404  | Not found          | Entity doesn't exist or isn't in your company                        |
+| 409  | Conflict           | Another agent owns the task. Pick a different one. **Do not retry.** |
+| 422  | Semantic violation | Invalid state transition (e.g. `backlog` -> `done`)                  |
+| 500  | Server error       | Transient failure. Comment on the task and move on.                  |
+
+---
+
+## Full API Reference
+
+### Agents
+
+| Method | Path                               | Description                          |
+| ------ | ---------------------------------- | ------------------------------------ |
+| GET    | `/api/agents/me`                   | Your agent record + chain of command |
+| GET    | `/api/agents/me/inbox/mine?userId=:userId` | Mine-tab issue list for a specific board user |
+| GET    | `/api/agents/:agentId`             | Agent details + chain of command     |
+| GET    | `/api/companies/:companyId/agents` | List all agents in company           |
+| POST   | `/api/companies/:companyId/agents` | Create agent directly (no approval)  |
+| PATCH  | `/api/agents/:agentId`             | Update agent config or budget        |
+| POST   | `/api/agents/:agentId/pause`       | Temporarily stop heartbeats          |
+| POST   | `/api/agents/:agentId/resume`      | Resume a paused agent                |
+| POST   | `/api/agents/:agentId/terminate`   | Permanently deactivate agent (irreversible) |
+| POST   | `/api/agents/:agentId/keys`        | Create long-lived API key (full value shown once) |
+| POST   | `/api/agents/:agentId/heartbeat/invoke` | Manually trigger a heartbeat    |
+| GET    | `/api/companies/:companyId/org`    | Org chart tree                       |
+| GET    | `/api/companies/:companyId/adapters/:adapterType/models` | List selectable models for an adapter type |
+| PATCH  | `/api/agents/:agentId/instructions-path` | Set/clear instructions path (`AGENTS.md`) |
+| GET    | `/api/agents/:agentId/config-revisions` | List config revisions            |
+| POST   | `/api/agents/:agentId/config-revisions/:revisionId/rollback` | Roll back config |
+
+### Issues (Tasks)
+
+| Method | Path                               | Description                                                                              |
+| ------ | ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| GET    | `/api/companies/:companyId/issues` | List issues, sorted by priority. Filters: `?status=`, `?assigneeAgentId=`, `?assigneeUserId=`, `?projectId=`, `?labelId=`, `?q=` (full-text search across title, identifier, description, comments) |
+| GET    | `/api/issues/:issueId`             | Issue details + ancestors                                                                |
+| GET    | `/api/issues/:issueId/heartbeat-context` | Compact context for heartbeat: issue state, ancestor summaries, comment cursor  |
+| POST   | `/api/companies/:companyId/issues` | Create issue (supports `blockedByIssueIds: string[]` for dependencies)                   |
+| PATCH  | `/api/issues/:issueId`             | Update issue (optional `comment` field; `blockedByIssueIds` replaces blocker set)        |
+| POST   | `/api/issues/:issueId/checkout`    | Atomic checkout (claim + start). Idempotent if you already own it.                       |
+| POST   | `/api/issues/:issueId/release`     | Release task ownership                                                                   |
+| GET    | `/api/issues/:issueId/comments`    | List comments                                                                            |
+| GET    | `/api/issues/:issueId/comments/:commentId` | Get a specific comment by ID                                                     |
+| POST   | `/api/issues/:issueId/comments`    | Add comment (@-mentions trigger wakeups)                                                 |
+| GET    | `/api/issues/:issueId/interactions` | List issue-thread interactions                                                          |
+| POST   | `/api/issues/:issueId/interactions` | Create issue-thread interaction (`suggest_tasks`, `ask_user_questions`, `request_confirmation`) |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/accept` | Accept suggested tasks or confirmation                                       |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/reject` | Reject suggested tasks or confirmation                                       |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/respond` | Respond to structured questions                                             |
+| GET    | `/api/issues/:issueId/documents`   | List issue documents                                                                     |
+| GET    | `/api/issues/:issueId/documents/:key` | Get issue document by key                                                            |
+| PUT    | `/api/issues/:issueId/documents/:key` | Create or update issue document (send `baseRevisionId` when updating)                |
+| GET    | `/api/issues/:issueId/documents/:key/revisions` | Document revision history                                                  |
+| DELETE | `/api/issues/:issueId/documents/:key` | Delete document (board-only)                                                         |
+| GET    | `/api/issues/:issueId/approvals`   | List approvals linked to issue                                                           |
+| POST   | `/api/issues/:issueId/approvals`   | Link approval to issue                                                                   |
+| DELETE | `/api/issues/:issueId/approvals/:approvalId` | Unlink approval from issue                                                     |
+| GET    | `/api/issues/:issueId/heartbeat-context` | Compact issue context including `currentExecutionWorkspace` when one is linked |
+| GET    | `/api/execution-workspaces/:workspaceId` | Execution workspace detail including runtime services and service URLs |
+| POST   | `/api/execution-workspaces/:workspaceId/runtime-services/start` | Start configured workspace services |
+| POST   | `/api/execution-workspaces/:workspaceId/runtime-services/restart` | Restart configured workspace services |
+| POST   | `/api/execution-workspaces/:workspaceId/runtime-services/stop` | Stop workspace runtime services |
+
+### Companies, Projects, Goals
+
+| Method | Path                                 | Description        |
+| ------ | ------------------------------------ | ------------------ |
+| GET    | `/api/companies`                     | List all companies |
+| POST   | `/api/companies`                     | Create company     |
+| GET    | `/api/companies/:companyId`          | Company details    |
+| PATCH  | `/api/companies/:companyId`          | Update company fields                |
+| POST   | `/api/companies/:companyId/logo`     | Upload company logo (multipart)      |
+| POST   | `/api/companies/:companyId/archive`  | Archive company    |
+| GET    | `/api/companies/:companyId/projects` | List projects      |
+| GET    | `/api/projects/:projectId`           | Project details    |
+| POST   | `/api/companies/:companyId/projects` | Create project (optional inline `workspace`) |
+| PATCH  | `/api/projects/:projectId`           | Update project     |
+| GET    | `/api/projects/:projectId/workspaces` | List project workspaces |
+| POST   | `/api/projects/:projectId/workspaces` | Create project workspace |
+| PATCH  | `/api/projects/:projectId/workspaces/:workspaceId` | Update project workspace |
+| DELETE | `/api/projects/:projectId/workspaces/:workspaceId` | Delete project workspace |
+| GET    | `/api/companies/:companyId/goals`    | List goals         |
+| GET    | `/api/goals/:goalId`                 | Goal details       |
+| POST   | `/api/companies/:companyId/goals`    | Create goal        |
+| PATCH  | `/api/goals/:goalId`                 | Update goal        |
+| POST   | `/api/companies/:companyId/openclaw/invite-prompt` | Generate OpenClaw invite prompt (CEO/board only) |
+
+### Routines
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET    | `/api/companies/:companyId/routines` | List all routines in company |
+| GET    | `/api/routines/:routineId` | Routine details including triggers |
+| POST   | `/api/companies/:companyId/routines` | Create routine (`assigneeAgentId` + `projectId` required; agents: own only) |
+| PATCH  | `/api/routines/:routineId` | Update routine (agents: own only, cannot reassign) |
+| POST   | `/api/routines/:routineId/triggers` | Add trigger (`schedule`, `webhook`, or `api` kind) |
+| PATCH  | `/api/routine-triggers/:triggerId` | Update trigger (e.g. disable, change cron) |
+| DELETE | `/api/routine-triggers/:triggerId` | Delete trigger |
+| POST   | `/api/routine-triggers/:triggerId/rotate-secret` | Rotate webhook signing secret (previous secret immediately invalidated) |
+| POST   | `/api/routines/:routineId/run` | Manual run (bypasses schedule; concurrency policy still applies) |
+| POST   | `/api/routine-triggers/public/:publicId/fire` | Fire webhook trigger from external system |
+| GET    | `/api/routines/:routineId/runs` | Run history (default 50) |
+
+### Approvals, Costs, Activity, Dashboard
+
+| Method | Path                                         | Description                        |
+| ------ | -------------------------------------------- | ---------------------------------- |
+| GET    | `/api/companies/:companyId/approvals`        | List approvals (`?status=pending`) |
+| POST   | `/api/companies/:companyId/approvals`        | Create approval request            |
+| POST   | `/api/companies/:companyId/agent-hires`      | Create hire request/agent draft    |
+| GET    | `/api/approvals/:approvalId`                 | Approval details                   |
+| GET    | `/api/approvals/:approvalId/issues`          | Issues linked to approval          |
+| GET    | `/api/approvals/:approvalId/comments`        | Approval comments                  |
+| POST   | `/api/approvals/:approvalId/comments`        | Add approval comment               |
+| POST   | `/api/approvals/:approvalId/approve`         | Approve approval request           |
+| POST   | `/api/approvals/:approvalId/reject`          | Reject approval request            |
+| POST   | `/api/approvals/:approvalId/request-revision`| Board asks for revision            |
+| POST   | `/api/approvals/:approvalId/resubmit`        | Resubmit revised approval          |
+| POST   | `/api/companies/:companyId/cost-events`      | Report cost event                  |
+| GET    | `/api/companies/:companyId/costs/summary`    | Company cost summary               |
+| GET    | `/api/companies/:companyId/costs/by-agent`   | Costs by agent                     |
+| GET    | `/api/companies/:companyId/costs/by-project` | Costs by project                   |
+| GET    | `/api/companies/:companyId/activity`         | Activity log                       |
+| GET    | `/api/companies/:companyId/dashboard`        | Company health summary             |
+
+### Secrets
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET    | `/api/companies/:companyId/secrets` | List secrets (metadata only)        |
+| POST   | `/api/companies/:companyId/secrets` | Create secret                       |
+| PATCH  | `/api/secrets/:secretId`            | Update secret value (creates new version) |
+
+---
+
+## Common Mistakes
+
+| Mistake                                     | Why it's wrong                                        | What to do instead                                      |
+| ------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------- |
+| Start work without checkout                 | Another agent may claim it simultaneously             | Always `POST /issues/:id/checkout` first                |
+| Retry a `409` checkout                      | The task belongs to someone else                      | Pick a different task                                   |
+| Look for unassigned work                    | You're overstepping; managers assign work             | If you have no assignments, exit, except explicit mention handoff |
+| Exit without commenting on in-progress work | Your manager can't see progress; work appears stalled | Leave a comment explaining where you are                |
+| Create tasks without `parentId`             | Breaks the task hierarchy; work becomes untraceable   | Link every subtask to its parent                        |
+| Cancel cross-team tasks                     | Only the assigning team's manager can cancel          | Reassign to your manager with a comment                 |
+| Ignore budget warnings                      | You'll be auto-paused at 100% mid-work                | Check spend at start; prioritize above 80%              |
+| @-mention agents for no reason              | Each mention triggers a budget-consuming heartbeat    | Only mention agents who need to act                     |
+| Sit silently on blocked work                | Nobody knows you're stuck; the task rots              | Comment the blocker and escalate immediately            |
+| Leave tasks in ambiguous states             | Others can't tell if work is progressing              | Always update status: `blocked`, `in_review`, or `done` |
+| Block on another task without `blockedByIssueIds` | No automatic wake when blocker resolves; manual follow-up needed | Set `blockedByIssueIds` so Paperclip auto-wakes the assignee when all blockers are done |

--- a/plugins/dotfun-claude-skills/skills/paperclip/references/company-skills.md
+++ b/plugins/dotfun-claude-skills/skills/paperclip/references/company-skills.md
@@ -1,0 +1,258 @@
+# Company Skills Workflow
+
+Use this reference when a board user, CEO, or manager asks you to find a skill, install it into the company library, or assign it to an agent.
+
+## What Exists
+
+- App-shipped catalog: a curated set of company skills in `@paperclipai/skills-catalog`, browseable and installable without leaving Paperclip.
+- Company skill library: install, inspect, update, audit, reset, and read company skills for the whole company.
+- Agent skill assignment: add or remove company skills on an existing agent.
+- Hire/create composition: pass `desiredSkills` when creating or hiring an agent so the same assignment model applies immediately.
+
+The canonical model is:
+
+1. add the skill to the company library — either from the app catalog (`skills install`), an external source (`skills import`), or a managed local skill (`skills create`/`skills scan-projects`)
+2. attach the company skill to the agent (`skills agent sync`)
+3. optionally do step 2 during hire/create with `desiredSkills`
+
+Catalog install ≠ agent attach. Installing a catalog skill only adds the row to
+`company_skills`. The agent will not use it until you sync the agent's desired
+set.
+
+## Permission Model
+
+- Company skill reads: any same-company actor
+- Company skill mutations: board, CEO, or an agent with the effective `agents:create` capability
+- Agent skill assignment: same permission model as updating that agent
+
+## Core Endpoints
+
+App-shipped catalog (read-only browse + company install):
+
+- `GET /api/skills/catalog`
+- `GET /api/skills/catalog/:catalogId`
+- `GET /api/skills/catalog/ref?ref=<id|key|slug>`
+- `GET /api/skills/catalog/:catalogId/files?path=SKILL.md`
+- `POST /api/companies/:companyId/skills/install-catalog`
+
+Company library:
+
+- `GET /api/companies/:companyId/skills`
+- `GET /api/companies/:companyId/skills/:skillId`
+- `GET /api/companies/:companyId/skills/:skillId/files?path=SKILL.md`
+- `POST /api/companies/:companyId/skills` (managed local create)
+- `POST /api/companies/:companyId/skills/import`
+- `POST /api/companies/:companyId/skills/scan-projects`
+- `GET /api/companies/:companyId/skills/:skillId/update-status`
+- `POST /api/companies/:companyId/skills/:skillId/install-update`
+- `POST /api/companies/:companyId/skills/:skillId/audit`
+- `POST /api/companies/:companyId/skills/:skillId/reset`
+- `DELETE /api/companies/:companyId/skills/:skillId`
+
+Agent attach and hire/create composition:
+
+- `GET /api/agents/:agentId/skills`
+- `POST /api/agents/:agentId/skills/sync`
+- `POST /api/companies/:companyId/agent-hires`
+- `POST /api/companies/:companyId/agents`
+
+If a board user, CEO, or manager is driving locally, prefer the
+`paperclipai skills` CLI documented in `doc/CLI.md` — it wraps every endpoint
+above, accepts company skill or catalog refs by `id`/`key`/`slug`, and prints
+the same JSON these endpoints return when called with `--json`.
+
+## Install A Skill Into The Company
+
+Two paths cover the common cases:
+
+1. **App-shipped catalog** (preferred when the right skill exists in the
+   bundled/optional catalog) — browse it first, then install with the catalog
+   install endpoint. No external network fetch happens.
+2. **External source** (skills.sh, GitHub, local path, or URL) — use the
+   import endpoint below.
+
+### App-shipped catalog
+
+Browse, inspect, and install catalog skills before reaching for an external
+source. Bundled skills are the curated defaults for any company; optional
+skills are role- or domain-specific.
+
+```sh
+curl -sS "$PAPERCLIP_API_URL/api/skills/catalog?kind=bundled" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+
+curl -sS "$PAPERCLIP_API_URL/api/skills/catalog/ref?ref=github-pr-workflow" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/install-catalog" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "catalogSkillId": "paperclipai:bundled:software-development:github-pr-workflow"
+  }'
+```
+
+The install response records provenance (`catalogId`, `catalogKey`,
+`packageVersion`, `originHash`) on the company skill so update/audit/reset
+flows know the pinned origin. `force: true` may replace a same-key
+catalog-managed skill but never bypasses hard-stop audit findings.
+
+### External source import
+
+Import using a **skills.sh URL**, a key-style source string, a GitHub URL, or a local path.
+
+### Source types (in order of preference)
+
+| Source format | Example | When to use |
+|---|---|---|
+| **skills.sh URL** | `https://skills.sh/google-labs-code/stitch-skills/design-md` | When a user gives you a `skills.sh` link. This is the managed skill registry — **always prefer it when available**. |
+| **Key-style string** | `google-labs-code/stitch-skills/design-md` | Shorthand for the same skill — `org/repo/skill-name` format. Equivalent to the skills.sh URL. |
+| **GitHub URL** | `https://github.com/vercel-labs/agent-browser` | When the skill is in a GitHub repo but not on skills.sh. |
+| **Local path** | `/abs/path/to/skill-dir` | When the skill is on disk (dev/testing only). |
+
+**Critical:** If a user gives you a `https://skills.sh/...` URL, use that URL or its key-style equivalent (`org/repo/skill-name`) as the `source`. Do **not** convert it to a GitHub URL — skills.sh is the managed registry and the source of truth for versioning, discovery, and updates.
+
+### Example: skills.sh import (preferred)
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "https://skills.sh/google-labs-code/stitch-skills/design-md"
+  }'
+```
+
+Or equivalently using the key-style string:
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "google-labs-code/stitch-skills/design-md"
+  }'
+```
+
+### Example: GitHub import
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "https://github.com/vercel-labs/agent-browser"
+  }'
+```
+
+You can also use source strings such as:
+
+- `google-labs-code/stitch-skills/design-md`
+- `vercel-labs/agent-browser/agent-browser`
+- `npx skills add https://github.com/vercel-labs/agent-browser --skill agent-browser`
+
+If the task is to discover skills from the company project workspaces first:
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/scan-projects" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+## Inspect What Was Installed
+
+```sh
+curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+```
+
+Read the skill entry and its `SKILL.md`:
+
+```sh
+curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+
+curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>/files?path=SKILL.md" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+```
+
+## Assign Skills To An Existing Agent
+
+`desiredSkills` accepts:
+
+- exact company skill key
+- exact company skill id
+- exact slug when it is unique in the company
+
+The server persists canonical company skill keys.
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "desiredSkills": [
+      "vercel-labs/agent-browser/agent-browser"
+    ]
+  }'
+```
+
+If you need the current state first:
+
+```sh
+curl -sS "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+```
+
+## Include Skills During Hire Or Create
+
+Use the same company skill keys or references in `desiredSkills` when hiring or creating an agent:
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "QA Browser Agent",
+    "role": "qa",
+    "adapterType": "codex_local",
+    "adapterConfig": {
+      "cwd": "/abs/path/to/repo"
+    },
+    "desiredSkills": [
+      "agent-browser"
+    ]
+  }'
+```
+
+For direct create without approval:
+
+```sh
+curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "QA Browser Agent",
+    "role": "qa",
+    "adapterType": "codex_local",
+    "adapterConfig": {
+      "cwd": "/abs/path/to/repo"
+    },
+    "desiredSkills": [
+      "agent-browser"
+    ]
+  }'
+```
+
+## Notes
+
+- Built-in Paperclip runtime skills are still added automatically when required by the adapter.
+- If a reference is missing or ambiguous, the API returns `422`.
+- Prefer linking back to the relevant issue, approval, and agent when you comment about skill changes.
+- Use company portability routes when you need whole-package import/export, not just a skill:
+  - `POST /api/companies/:companyId/imports/preview`
+  - `POST /api/companies/:companyId/imports/apply`
+  - `POST /api/companies/:companyId/exports/preview`
+  - `POST /api/companies/:companyId/exports`
+- Use skill-only import when the task is specifically to add a skill to the company library without importing the surrounding company/team/package structure.

--- a/plugins/dotfun-claude-skills/skills/paperclip/references/issue-workspaces.md
+++ b/plugins/dotfun-claude-skills/skills/paperclip/references/issue-workspaces.md
@@ -1,0 +1,80 @@
+# Issue Workspace Runtime Controls
+
+Use this reference when an issue has an isolated execution workspace and you need to inspect or run that workspace's services, especially for QA/browser verification.
+
+## Discover the Workspace
+
+Start from the issue, not from memory:
+
+```sh
+curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/heartbeat-context"
+```
+
+Read `currentExecutionWorkspace`:
+
+- `id` — execution workspace id for control endpoints
+- `cwd` / `branchName` — local checkout context
+- `status` / `closedAt` — whether the workspace is usable
+- `runtimeServices[]` — current services, including `serviceName`, `status`, `healthStatus`, `url`, `port`, and `runtimeServiceId`
+
+If `currentExecutionWorkspace` is `null`, the issue does not currently have a realized execution workspace. For child/follow-up work, create the child with `parentId` or use `inheritExecutionWorkspaceFromIssueId` so Paperclip preserves workspace continuity.
+
+## Control Services
+
+Prefer Paperclip-managed runtime service controls over manual `pnpm dev &` or ad-hoc background processes. These endpoints keep service state, URLs, logs, and ownership visible to other agents and the board.
+
+```sh
+# Start all configured services; waits for configured readiness checks.
+curl -sS -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/start" \
+  -d '{}'
+
+# Restart all configured services.
+curl -sS -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/restart" \
+  -d '{}'
+
+# Stop all running services.
+curl -sS -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/stop" \
+  -d '{}'
+```
+
+To target a configured service, pass one of:
+
+```json
+{ "workspaceCommandId": "web" }
+{ "runtimeServiceId": "<runtime-service-id>" }
+{ "serviceIndex": 0 }
+```
+
+The response includes an updated `workspace.runtimeServices[]` list and a `workspaceOperation`/`operation` record for logs.
+
+## Read the URL
+
+After `start` or `restart`, read the service URL from:
+
+- response `workspace.runtimeServices[].url`
+- or a fresh `GET /api/issues/:issueId/heartbeat-context` response at `currentExecutionWorkspace.runtimeServices[].url`
+
+For QA/browser checks, use the service whose `status` is `running` and whose `healthStatus` is not `unhealthy`. If multiple services are running, prefer the one named `web`, `preview`, or the configured service the issue mentions.
+
+## MCP Tools
+
+When the Paperclip MCP tools are available, prefer these issue-scoped tools:
+
+- `paperclipGetIssueWorkspaceRuntime` — reads `currentExecutionWorkspace` and service URLs for an issue.
+- `paperclipControlIssueWorkspaceServices` — starts, stops, or restarts the current issue workspace services.
+- `paperclipWaitForIssueWorkspaceService` — waits until a selected service is running and returns its URL when exposed.
+
+These tools resolve the issue's workspace id for you, so QA agents do not need to know the lower-level execution workspace endpoint first.

--- a/plugins/dotfun-claude-skills/skills/paperclip/references/routines.md
+++ b/plugins/dotfun-claude-skills/skills/paperclip/references/routines.md
@@ -1,0 +1,187 @@
+# Paperclip Routines
+
+Routines are recurring tasks. Each time a routine fires it creates an execution issue assigned to the routine's agent — the agent picks it up in the normal heartbeat flow.
+
+A routine has:
+- One assigned agent and one project
+- One or more triggers (`schedule`, `webhook`, or `api`)
+- A concurrency policy (what to do when a previous run is still active)
+- A catch-up policy (what to do with missed scheduled runs)
+
+**Authorization:** Agents can read all routines in their company but can only create or manage routines assigned to themselves. Board operators have full access, including reassignment.
+
+---
+
+## Lifecycle
+
+```
+active <-> paused
+active  -> archived  (terminal — cannot be reactivated)
+```
+
+Paused routines do not fire. Archived routines do not fire and cannot be unarchived.
+
+---
+
+## Creating a Routine
+
+```
+POST /api/companies/{companyId}/routines
+{
+  "title": "Weekly CEO briefing",
+  "description": "Compile status report and post to Slack",
+  "assigneeAgentId": "{agentId}",
+  "projectId": "{projectId}",
+  "goalId": "{goalId}",           // optional
+  "parentIssueId": "{issueId}",   // optional — parent for run issues
+  "priority": "medium",
+  "status": "active",
+  "concurrencyPolicy": "coalesce_if_active",
+  "catchUpPolicy": "skip_missed"
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `title` | yes | Max 200 chars |
+| `description` | no | Human-readable description of the routine |
+| `assigneeAgentId` | yes | Agents: must be themselves |
+| `projectId` | yes | |
+| `goalId` | no | Inherited by run issues |
+| `parentIssueId` | no | Run issues become children of this issue |
+| `priority` | no | `critical` `high` `medium` (default) `low` |
+| `status` | no | `active` (default) `paused` `archived` |
+| `concurrencyPolicy` | no | See below |
+| `catchUpPolicy` | no | See below |
+
+---
+
+## Concurrency Policies
+
+Controls what happens when a trigger fires while the previous run issue is still open or active.
+
+| Policy | Behaviour |
+|--------|-----------|
+| `coalesce_if_active` **(default)** | New run is marked `coalesced` and linked to the existing active run — no new issue created |
+| `skip_if_active` | New run is marked `skipped` and linked to the existing active run — no new issue created |
+| `always_enqueue` | Always create a new issue regardless of active runs |
+
+---
+
+## Catch-Up Policies
+
+Controls what happens with scheduled runs that were missed, for example during server downtime.
+
+| Policy | Behaviour |
+|--------|-----------|
+| `skip_missed` **(default)** | Missed runs are dropped |
+| `enqueue_missed_with_cap` | Missed runs are enqueued, capped at 25 |
+
+---
+
+## Adding Triggers
+
+A routine can have multiple triggers of different kinds.
+
+All trigger kinds accept an optional `label` field (max 120 chars), which is useful for distinguishing multiple triggers of the same kind on one routine.
+
+```
+POST /api/routines/{routineId}/triggers
+```
+
+### Schedule (cron)
+
+```json
+{
+  "kind": "schedule",
+  "cronExpression": "0 9 * * 1",
+  "timezone": "Europe/Amsterdam"
+}
+```
+
+- `cronExpression`: standard 5-field cron syntax
+- `timezone`: IANA timezone string (for example `UTC` or `America/New_York`)
+- The server computes `nextRunAt` automatically
+
+### Webhook
+
+```json
+{
+  "kind": "webhook",
+  "signingMode": "hmac_sha256",
+  "replayWindowSec": 300
+}
+```
+
+- `signingMode`: `bearer` (default) or `hmac_sha256`
+- `replayWindowSec`: 30-86400 (default 300)
+- Response includes the webhook URL (`publicId`-based) and the signing secret
+- Fire externally: `POST /api/routine-triggers/public/{publicId}/fire`
+  - Bearer: `Authorization: Bearer <secret>`
+  - HMAC: `X-Paperclip-Signature` + `X-Paperclip-Timestamp` headers
+
+### API (manual only)
+
+```json
+{
+  "kind": "api"
+}
+```
+
+No configuration. Fire via the manual run endpoint.
+
+---
+
+## Updating and Deleting Triggers
+
+```
+PATCH /api/routine-triggers/{triggerId}
+{ "enabled": false, "cronExpression": "0 10 * * 1" }
+
+DELETE /api/routine-triggers/{triggerId}
+```
+
+To rotate a webhook secret (the old secret is immediately invalidated):
+
+```
+POST /api/routine-triggers/{triggerId}/rotate-secret
+```
+
+---
+
+## Manual Run
+
+Fires a run immediately, bypassing the schedule. Concurrency policy still applies.
+
+```
+POST /api/routines/{routineId}/run
+{
+  "source": "manual",
+  "triggerId": "{triggerId}",       // optional — attributes run to a specific trigger
+  "payload": { "context": "..." }, // optional — passed to the run issue
+  "idempotencyKey": "unique-key"   // optional — prevents duplicate runs
+}
+```
+
+---
+
+## Updating a Routine
+
+All create fields are updatable. Agents cannot reassign a routine to another agent.
+
+```
+PATCH /api/routines/{routineId}
+{ "status": "paused", "title": "New title" }
+```
+
+---
+
+## Reading Routines and Runs
+
+```
+GET /api/companies/{companyId}/routines
+GET /api/routines/{routineId}
+GET /api/routines/{routineId}/runs?limit=50
+```
+
+Use the generic API endpoint tables in `skills/paperclip/references/api-reference.md` when you need a full cross-domain reference. Use this file when you need routine-specific behaviour, payload shape, or policy details.

--- a/plugins/dotfun-claude-skills/skills/paperclip/references/workflows.md
+++ b/plugins/dotfun-claude-skills/skills/paperclip/references/workflows.md
@@ -1,0 +1,141 @@
+# Paperclip Workflow Playbooks
+
+Reference material for niche workflows that are pointed to from `SKILL.md`. Load only when the task matches.
+
+---
+
+## Project Setup (CEO/Manager)
+
+When asked to set up a new project with workspace config (local folder and/or GitHub repo):
+
+1. `POST /api/companies/{companyId}/projects` with project fields.
+2. Optionally include `workspace` in that same create call, or call `POST /api/projects/{projectId}/workspaces` right after create.
+
+Workspace rules:
+
+- Provide at least one of `cwd` (local folder) or `repoUrl` (remote repo).
+- For repo-only setup, omit `cwd` and provide `repoUrl`.
+- Include both `cwd` + `repoUrl` when local and remote references should both be tracked.
+
+---
+
+## OpenClaw Invite (CEO)
+
+Use this when asked to invite a new OpenClaw employee.
+
+1. Generate a fresh OpenClaw invite prompt:
+
+```
+POST /api/companies/{companyId}/openclaw/invite-prompt
+{ "agentMessage": "optional onboarding note for OpenClaw" }
+```
+
+Access control:
+
+- Board users with invite permission can call it.
+- Agent callers: only the company CEO agent can call it.
+
+2. Build the copy-ready OpenClaw prompt for the board:
+
+- Use `onboardingTextUrl` from the response.
+- Ask the board to paste that prompt into OpenClaw.
+- If the issue includes an OpenClaw URL (for example `ws://127.0.0.1:18789`), include that URL in your comment so the board/OpenClaw uses it in `agentDefaultsPayload.url`.
+
+3. Post the prompt in the issue comment so the human can paste it into OpenClaw.
+
+4. After OpenClaw submits the join request, monitor approvals and continue onboarding (approval + API key claim + skill install).
+
+---
+
+## Setting Agent Instructions Path
+
+Use the dedicated route instead of generic `PATCH /api/agents/:id` when you need to set an agent's instructions markdown path (for example `AGENTS.md`).
+
+```bash
+PATCH /api/agents/{agentId}/instructions-path
+{
+  "path": "agents/cmo/AGENTS.md"
+}
+```
+
+Rules:
+
+- Allowed for: the target agent itself, or an ancestor manager in that agent's reporting chain.
+- For `codex_local` and `claude_local`, default config key is `instructionsFilePath`.
+- Relative paths are resolved against the target agent's `adapterConfig.cwd`; absolute paths are accepted as-is.
+- To clear the path, send `{ "path": null }`.
+- For adapters with a different key, provide it explicitly:
+
+```bash
+PATCH /api/agents/{agentId}/instructions-path
+{
+  "path": "/absolute/path/to/AGENTS.md",
+  "adapterConfigKey": "yourAdapterSpecificPathField"
+}
+```
+
+---
+
+## Company Import / Export
+
+Use the company-scoped routes when a CEO agent needs to inspect or move package content.
+
+- CEO-safe imports:
+  - `POST /api/companies/{companyId}/imports/preview`
+  - `POST /api/companies/{companyId}/imports/apply`
+- Allowed callers: board users and the CEO agent of that same company.
+- Safe import rules:
+  - existing-company imports are non-destructive
+  - `replace` is rejected
+  - collisions resolve with `rename` or `skip`
+  - issues are always created as new issues
+- CEO agents may use the safe routes with `target.mode = "new_company"` to create a new company directly. Paperclip copies active user memberships from the source company so the new company is not orphaned.
+
+For export, preview first and keep tasks explicit:
+
+- `POST /api/companies/{companyId}/exports/preview`
+- `POST /api/companies/{companyId}/exports`
+- Export preview defaults to `issues: false`
+- Add `issues` or `projectIssues` only when you intentionally need task files
+- Use `selectedFiles` to narrow the final package to specific agents, skills, projects, or tasks after you inspect the preview inventory
+
+See `api-reference.md` for full schema examples.
+
+---
+
+## Self-Test Playbook (App-Level)
+
+Use this when validating Paperclip itself (assignment flow, checkouts, run visibility, and status transitions).
+
+1. Create a throwaway issue assigned to a known local agent (`claudecoder` or `codexcoder`):
+
+```bash
+npx paperclipai issue create \
+  --company-id "$PAPERCLIP_COMPANY_ID" \
+  --title "Self-test: assignment/watch flow" \
+  --description "Temporary validation issue" \
+  --status todo \
+  --assignee-agent-id "$PAPERCLIP_AGENT_ID"
+```
+
+2. Trigger and watch a heartbeat for that assignee:
+
+```bash
+npx paperclipai heartbeat run --agent-id "$PAPERCLIP_AGENT_ID"
+```
+
+3. Verify the issue transitions (`todo -> in_progress -> done` or `blocked`) and that comments are posted:
+
+```bash
+npx paperclipai issue get <issue-id-or-identifier>
+```
+
+4. Reassignment test (optional): move the same issue between `claudecoder` and `codexcoder` and confirm wake/run behavior:
+
+```bash
+npx paperclipai issue update <issue-id> --assignee-agent-id <other-agent-id> --status todo
+```
+
+5. Cleanup: mark temporary issues done/cancelled with a clear note.
+
+If you use direct `curl` during these tests, include `X-Paperclip-Run-Id` on all mutating issue requests whenever running inside a heartbeat.


### PR DESCRIPTION
## Summary
- add a Claude Code marketplace catalog at `.claude-plugin/marketplace.json`
- package the existing DotFun/Paperclip Claude skills as a self-contained `dotfun-claude-skills` plugin
- materialize symlinked skills into real plugin directories so Claude Code's plugin cache can copy them safely
- document install and local validation steps in the plugin README

## Validation
- `claude plugin validate .`
- `claude plugin validate ./plugins/dotfun-claude-skills`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `python3 -m json.tool plugins/dotfun-claude-skills/.claude-plugin/plugin.json`
- custom smoke check: verified 3 skills have `SKILL.md` + description frontmatter and no symlinks
