### PR TITLE
Document OpenClaw staffing endpoints

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -59,6 +59,12 @@ Top-level `payloadTemplate` keys that are not valid OpenClaw v4 agent params are
 not sent over the gateway. Paperclip run/workspace context is provided through
 the wake message instead of as unknown wire fields.
 
+When the full Paperclip workflow is included, the wake message documents the
+issue-work endpoints and the guarded CEO / agent-creator staffing endpoints:
+list agents, create governed hire requests, directly create agents when allowed,
+and assign/update issues. The agent must first confirm its own role/permissions
+with `GET /api/agents/me`.
+
 Set `includePaperclipWorkflow=false` (or `paperclipWorkflow=false`) to send a
 lean gateway prompt without appending the full Paperclip issue-work procedure.
 This is useful for connectivity smoke checks and direct one-shot OpenClaw tasks.

--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -52,8 +52,16 @@ The agent request is built as:
   - `idempotencyKey` (Paperclip `runId`)
   - `sessionKey` (resolved strategy)
 - optional additions:
-  - all `payloadTemplate` fields merged in
+  - supported OpenClaw v4 agent fields from `payloadTemplate` merged in
   - `agentId` from config if set and not already in template
+
+Top-level `payloadTemplate` keys that are not valid OpenClaw v4 agent params are
+not sent over the gateway. Paperclip run/workspace context is provided through
+the wake message instead of as unknown wire fields.
+
+Set `includePaperclipWorkflow=false` (or `paperclipWorkflow=false`) to send a
+lean gateway prompt without appending the full Paperclip issue-work procedure.
+This is useful for connectivity smoke checks and direct one-shot OpenClaw tasks.
 
 ## Timeouts
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -420,8 +420,8 @@ function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
+  claimedApiKeyPath: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -473,6 +473,7 @@ function buildWakeText(
     "",
     "Workflow:",
     "1) GET /api/agents/me",
+    "   - If the response shows role=ceo or permissions.canCreateAgents=true, you may use the staffing endpoints listed below.",
     `2) Determine issueId: PAPERCLIP_TASK_ID if present, otherwise issue_id (${issueIdHint}).`,
     "3) If issueId exists:",
     "   - POST /api/issues/{issueId}/checkout with {\"agentId\":\"$PAPERCLIP_AGENT_ID\",\"expectedStatuses\":[\"todo\",\"backlog\",\"blocked\",\"in_review\"]}",
@@ -493,6 +494,13 @@ function buildWakeText(
     "- POST /api/issues/{issueId}/comments",
     "- PATCH /api/issues/{issueId}",
     "- POST /api/companies/{companyId}/issues (when asked to create a new issue)",
+    "",
+    "Allowlisted staffing endpoints for CEO / agent-creator work:",
+    "- GET /api/companies/{companyId}/agents (list existing agents before hiring)",
+    "- POST /api/companies/{companyId}/agent-hires (create a governed hire request; use when board approval for new agents is enabled)",
+    "- POST /api/companies/{companyId}/agents (directly create an agent only when the API allows it; if this returns 409, use agent-hires)",
+    "- PATCH /api/issues/{issueId} (assign or update work after choosing the right agent)",
+    "Only use these staffing endpoints after confirming your own role/permissions via GET /api/agents/me, and link sourceIssueId/sourceIssueIds to the issue that requested the staffing work.",
     ...(structuredWakePrompt
       ? [
           "",
@@ -1196,6 +1204,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ctx.config.includePaperclipWorkflow ?? ctx.config.paperclipWorkflow,
     true,
   );
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const wakeText = includePaperclipWorkflow
     ? buildWakeText(
@@ -1204,6 +1213,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         structuredWakeJson
           ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
           : structuredWakePrompt,
+        claimedApiKeyPath,
       )
     : buildCompactWakeText(wakePayload, structuredWakePrompt, structuredWakeJson ?? "");
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,12 +86,55 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";
 const DEFAULT_ROLE = "operator";
+
+const OPENCLAW_AGENT_PARAM_KEYS = new Set([
+  "message",
+  "agentId",
+  "provider",
+  "model",
+  "to",
+  "replyTo",
+  "sessionId",
+  "sessionKey",
+  "thinking",
+  "deliver",
+  "attachments",
+  "channel",
+  "replyChannel",
+  "accountId",
+  "replyAccountId",
+  "threadId",
+  "groupId",
+  "groupChannel",
+  "groupSpace",
+  "timeout",
+  "bestEffortDeliver",
+  "lane",
+  "cleanupBundleMcpOnRunEnd",
+  "modelRun",
+  "promptMode",
+  "extraSystemPrompt",
+  "bootstrapContextMode",
+  "bootstrapContextRunKind",
+  "acpTurnSource",
+  "internalRuntimeHandoffId",
+  "execApprovalFollowupExpectedSessionId",
+  "internalEvents",
+  "inputProvenance",
+  "suppressPromptPersistence",
+  "sessionEffects",
+  "sourceReplyDeliveryMode",
+  "disableMessageTool",
+  "voiceWakeTrigger",
+  "idempotencyKey",
+  "label",
+]);
 
 const SENSITIVE_LOG_KEY_PATTERN =
   /(^|[_-])(auth|authorization|token|secret|password|api[_-]?key|private[_-]?key)([_-]|$)|^x-openclaw-(auth|token)$/i;
@@ -303,6 +346,14 @@ function stringifyForLog(value: unknown, maxChars: number): string {
   return `${text.slice(0, maxChars)}... [truncated ${text.length - maxChars} chars]`;
 }
 
+function filterOpenClawAgentParams(value: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (OPENCLAW_AGENT_PARAM_KEYS.has(key)) out[key] = entry;
+  }
+  return out;
+}
+
 function buildWakePayload(ctx: AdapterExecutionContext): WakePayload {
   const { runId, agent, context } = ctx;
   return {
@@ -452,6 +503,33 @@ function buildWakeText(
     "Complete the workflow in this run.",
   ];
   return lines.join("\n");
+}
+
+function buildCompactWakeText(
+  payload: WakePayload,
+  structuredWakePrompt: string,
+  structuredWakeJson: string | null,
+): string {
+  const sections = [
+    "Paperclip wake event for the OpenClaw gateway adapter.",
+    `run_id=${payload.runId}`,
+    `agent_id=${payload.agentId}`,
+    `company_id=${payload.companyId}`,
+    ...(payload.taskId ? [`task_id=${payload.taskId}`] : []),
+    ...(payload.issueId ? [`issue_id=${payload.issueId}`] : []),
+    ...(payload.wakeReason ? [`wake_reason=${payload.wakeReason}`] : []),
+    ...(structuredWakePrompt ? ["", structuredWakePrompt] : []),
+    ...(structuredWakeJson
+      ? [
+          "",
+          "Structured wake payload JSON:",
+          "```json",
+          structuredWakeJson,
+          "```",
+        ]
+      : []),
+  ];
+  return sections.join("\n");
 }
 
 function appendWakeText(baseText: string, wakeText: string): string {
@@ -1114,13 +1192,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
   const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
   const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
-  const wakeText = buildWakeText(
-    wakePayload,
-    paperclipEnv,
-    structuredWakeJson
-      ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
-      : structuredWakePrompt,
+  const includePaperclipWorkflow = parseBoolean(
+    ctx.config.includePaperclipWorkflow ?? ctx.config.paperclipWorkflow,
+    true,
   );
+  const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
+  const wakeText = includePaperclipWorkflow
+    ? buildWakeText(
+        wakePayload,
+        paperclipEnv,
+        structuredWakeJson
+          ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
+          : structuredWakePrompt,
+      )
+    : buildCompactWakeText(wakePayload, structuredWakePrompt, structuredWakeJson ?? "");
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
@@ -1133,18 +1218,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     issueId: wakePayload.issueId,
   });
 
-  const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
-  const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const message = includePaperclipWorkflow
+    ? templateMessage
+      ? appendWakeText(templateMessage, wakeText)
+      : wakeText
+    : templateMessage ?? wakeText;
 
   const agentParams: Record<string, unknown> = {
-    ...payloadTemplate,
+    ...filterOpenClawAgentParams(payloadTemplate),
     message,
     sessionKey,
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;

--- a/packages/adapters/openclaw-gateway/src/server/test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/test.ts
@@ -145,8 +145,8 @@ async function probeGateway(input: {
             id: connectId,
             method: "connect",
             params: {
-              minProtocol: 3,
-              maxProtocol: 3,
+              minProtocol: 4,
+              maxProtocol: 4,
               client: {
                 id: "gateway-client",
                 version: "paperclip-probe",

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -493,6 +493,8 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("wake now");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
+      expect(String(payload?.message ?? "")).toContain("POST /api/companies/{companyId}/agent-hires");
+      expect(String(payload?.message ?? "")).toContain("permissions.canCreateAgents=true");
       expect(String(payload?.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(payload?.message ?? "")).toContain(
         "Treat this wake payload as the highest-priority change for the current heartbeat.",
@@ -505,6 +507,35 @@ describe("openclaw gateway adapter execute", () => {
       expect(payload?.paperclip).toBeUndefined();
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("uses configured claimedApiKeyPath in the wake instructions", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          claimedApiKeyPath: "~/.paperclip/custom-agent-key.json",
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const payload = gateway.getAgentPayload();
+      expect(String(payload?.message ?? "")).toContain(
+        "PAPERCLIP_API_KEY=<token from ~/.paperclip/custom-agent-key.json>",
+      );
+      expect(String(payload?.message ?? "")).toContain(
+        "Load PAPERCLIP_API_KEY from ~/.paperclip/custom-agent-key.json",
+      );
     } finally {
       await gateway.close();
     }

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -75,7 +75,7 @@ async function createMockGatewayServer(options?: {
             ok: true,
             payload: {
               type: "hello-ok",
-              protocol: 3,
+              protocol: 4,
               server: { version: "test", connId: "conn-1" },
               features: { methods: ["connect", "agent", "agent.wait"], events: ["agent"] },
               snapshot: { version: 1, ts: Date.now() },
@@ -502,14 +502,43 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+      expect(payload?.paperclip).toBeUndefined();
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("can send a lean gateway message without appending the Paperclip workflow", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          includePaperclipWorkflow: false,
+          payloadTemplate: {
+            message: "Reply exactly with: PAPERCLIP_OPENCLAW_LIVE_OK.",
+            promptMode: "minimal",
+            source: "legacy-paperclip-metadata",
+            paperclip: { runId: "legacy" },
+          },
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(payload?.message).toBe("Reply exactly with: PAPERCLIP_OPENCLAW_LIVE_OK.");
+      expect(payload?.promptMode).toBe("minimal");
+      expect(payload?.source).toBeUndefined();
+      expect(payload?.paperclip).toBeUndefined();
     } finally {
       await gateway.close();
     }


### PR DESCRIPTION
## Summary\n- document guarded CEO / agent-creator staffing endpoints in the OpenClaw gateway wake contract\n- honor configured claimedApiKeyPath in Paperclip API key wake instructions\n- add focused gateway adapter coverage\n\n## Verification\n- pnpm exec vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts\n- pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck\n- pnpm --filter @paperclipai/server typecheck\n\n## Live smoke\n- rebuilt and redeployed local paperclip-spike image\n- OPE-13 exercised the CEO staffing path successfully\n- OPE-11 is assigned to Product Prototype Lead; run dc62df46-7cd9-45c0-a2ea-b6b294593f83 was accepted by OpenClaw\n