### PR TITLE
[codex] sanitize agent worktree branch names

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -866,6 +866,94 @@ describe("realizeExecutionWorkspace", () => {
     expect(canonicalRealized.branchName).toBe("feature/rollout-apr-3-api-2");
   });
 
+  it("keeps untitled issue fallbacks unique to the issue identifier", async () => {
+    const repoRoot = await createTempRepo();
+
+    const nullTitleRealized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "feature/{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-template-untitled-null",
+        identifier: "PAP-996",
+        title: null,
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    const blankTitleRealized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "feature/{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-template-untitled-blank",
+        identifier: "PAP-997",
+        title: "   ",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    const defaultTemplateRealized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+        },
+      },
+      issue: {
+        id: "issue-template-untitled-default",
+        identifier: "PAP-998",
+        title: "",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(nullTitleRealized.branchName).toBe("feature/pap-996");
+    expect(blankTitleRealized.branchName).toBe("feature/pap-997");
+    expect(defaultTemplateRealized.branchName).toBe("pap-998");
+  });
+
   it("runs a configured provision command inside the derived worktree", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -403,7 +403,7 @@ describe("realizeExecutionWorkspace", () => {
 
     expect(first.strategy).toBe("git_worktree");
     expect(first.created).toBe(true);
-    expect(first.branchName).toBe("PAP-447-add-worktree-support");
+    expect(first.branchName).toBe("add-worktree-support");
     expect(first.cwd).toContain(path.join(".paperclip", "worktrees"));
     await expect(fs.stat(path.join(first.cwd, ".git"))).resolves.toBeTruthy();
 
@@ -510,7 +510,7 @@ describe("realizeExecutionWorkspace", () => {
 
   it("rejects reusing an empty directory that only looks like a worktree because it sits inside the repo", async () => {
     const repoRoot = await createTempRepo();
-    const branchName = "PAP-447-add-worktree-support";
+    const branchName = "add-worktree-support";
     const poisonedPath = path.join(repoRoot, ".paperclip", "worktrees", branchName);
     await fs.mkdir(poisonedPath, { recursive: true });
 
@@ -546,7 +546,7 @@ describe("realizeExecutionWorkspace", () => {
 
   it("reuses the current linked worktree instead of nesting another worktree inside it", async () => {
     const repoRoot = await createTempRepo();
-    const branchName = "PAP-1355-worktree-reuse";
+    const branchName = "worktree-reuse";
     const currentWorktree = path.join(repoRoot, ".paperclip", "worktrees", branchName);
 
     await fs.mkdir(path.dirname(currentWorktree), { recursive: true });
@@ -644,12 +644,12 @@ describe("realizeExecutionWorkspace", () => {
           companyId: "company-1",
         },
       }),
-    ).rejects.toThrow(/not a reusable git worktree \(worktree HEAD is on "unexpected-branch" instead of "PAP-447-add-worktree-support"\)\./);
+    ).rejects.toThrow(/not a reusable git worktree \(worktree HEAD is on "unexpected-branch" instead of "add-worktree-support"\)\./);
   });
 
   it("reuses an already checked out branch from git worktree metadata even when the target path differs", async () => {
     const repoRoot = await createTempRepo();
-    const branchName = "PAP-1355-worktree-reuse";
+    const branchName = "worktree-reuse";
     const existingWorktree = path.join(repoRoot, ".paperclip", "worktrees", branchName);
     const { recorder, operations } = createWorkspaceOperationRecorderDouble();
 
@@ -730,7 +730,7 @@ describe("realizeExecutionWorkspace", () => {
     });
 
     expect(realized.branchName).toBe(
-      "PAP-991-there-should-be-a-setting-for-the-allowance-of-thumbs-up-thumbs-down-data-rm-rf",
+      "there-should-be-a-setting-for-the-allowance-of-thumbs-up-thumbs-down-data-rm-rf",
     );
     expect(realized.branchName?.includes("/")).toBe(false);
     expect(path.basename(realized.cwd)).toBe(realized.branchName);
@@ -766,8 +766,42 @@ describe("realizeExecutionWorkspace", () => {
       },
     });
 
-    expect(realized.branchName).toBe("release/PAP-992.hotfix-april-1");
-    expect(path.basename(realized.cwd)).toBe("PAP-992.hotfix-april-1");
+    expect(realized.branchName).toBe("release/hotfix-april-1");
+    expect(path.basename(realized.cwd)).toBe("hotfix-april-1");
+  });
+
+  it("strips issue identifiers from branch template output and slug text", async () => {
+    const repoRoot = await createTempRepo();
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "feature/{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-template-strip",
+        identifier: "pap-993",
+        title: "pap-993 hotfix rollout",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(realized.branchName).toBe("feature/hotfix-rollout");
+    expect(path.basename(realized.cwd)).toBe("hotfix-rollout");
   });
 
   it("runs a configured provision command inside the derived worktree", async () => {
@@ -816,7 +850,7 @@ describe("realizeExecutionWorkspace", () => {
     });
 
     await expect(fs.readFile(path.join(workspace.cwd, ".paperclip-provision-branch"), "utf8")).resolves.toBe(
-      "PAP-448-run-provision-command\n",
+      "run-provision-command\n",
     );
     await expect(fs.readFile(path.join(workspace.cwd, ".paperclip-provision-base"), "utf8")).resolves.toBe(
       `${repoRoot}\n`,
@@ -1073,7 +1107,7 @@ describe("realizeExecutionWorkspace", () => {
       const envContents = await fs.readFile(envPath, "utf8");
       const configContents = JSON.parse(await fs.readFile(configPath, "utf8"));
       const configStats = await fs.lstat(configPath);
-      const expectedInstanceId = "pap-885-show-worktree-banner";
+      const expectedInstanceId = "show-worktree-banner";
       const expectedInstanceRoot = path.join(
         isolatedWorktreeHome,
         "instances",
@@ -1093,7 +1127,7 @@ describe("realizeExecutionWorkspace", () => {
       expect(envVars.PAPERCLIP_INSTANCE_ID).toBe(expectedInstanceId);
       expect(await fs.realpath(envVars.PAPERCLIP_CONFIG!)).toBe(await fs.realpath(configPath));
       expect(envVars.PAPERCLIP_IN_WORKTREE).toBe("true");
-      expect(envVars.PAPERCLIP_WORKTREE_NAME).toBe("PAP-885-show-worktree-banner");
+      expect(envVars.PAPERCLIP_WORKTREE_NAME).toBe("show-worktree-banner");
 
       process.chdir(workspace.cwd);
       expect(resolvePaperclipConfigPath()).toBe(configPath);
@@ -1599,7 +1633,7 @@ describe("realizeExecutionWorkspace", () => {
     ]);
     expect(operations[0]?.command).toContain("git worktree add");
     expect(operations[0]?.metadata).toMatchObject({
-      branchName: "PAP-540-record-workspace-operations",
+      branchName: "record-workspace-operations",
       created: true,
     });
     expect(operations[1]?.command).toBe("bash ./scripts/provision.sh");
@@ -1658,7 +1692,7 @@ describe("realizeExecutionWorkspace", () => {
 
   it("reuses an existing branch without resetting it when recreating a missing worktree", async () => {
     const repoRoot = await createTempRepo();
-    const branchName = "PAP-450-recreate-missing-worktree";
+    const branchName = "recreate-missing-worktree";
 
     await runGit(repoRoot, ["checkout", "-b", branchName]);
     await fs.writeFile(path.join(repoRoot, "feature.txt"), "preserve me\n", "utf8");
@@ -1702,7 +1736,7 @@ describe("realizeExecutionWorkspace", () => {
 
   it("reattaches a missing persisted git worktree before manual control starts it", async () => {
     const repoRoot = await createTempRepo();
-    const branchName = "PAP-451-restore-persisted-worktree";
+    const branchName = "restore-persisted-worktree";
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
     await fs.writeFile(
       path.join(repoRoot, "scripts", "restore.sh"),
@@ -2312,7 +2346,7 @@ describe("ensureRuntimeServicesForRun", () => {
 
   it("does not reuse project-scoped shared services across different workspace launch contexts", async () => {
     const primaryWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-primary-"));
-    const worktreeWorkspaceRoot = path.join(primaryWorkspaceRoot, ".paperclip", "worktrees", "PAP-874-chat-speed-issues");
+    const worktreeWorkspaceRoot = path.join(primaryWorkspaceRoot, ".paperclip", "worktrees", "chat-speed-issues");
     await fs.mkdir(worktreeWorkspaceRoot, { recursive: true });
 
     const primaryWorkspace = buildWorkspace(primaryWorkspaceRoot);
@@ -2321,7 +2355,7 @@ describe("ensureRuntimeServicesForRun", () => {
       source: "task_session",
       strategy: "git_worktree",
       cwd: worktreeWorkspaceRoot,
-      branchName: "PAP-874-chat-speed-issues",
+      branchName: "chat-speed-issues",
       worktreePath: worktreeWorkspaceRoot,
     };
     const serviceCommand =

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -804,6 +804,68 @@ describe("realizeExecutionWorkspace", () => {
     expect(path.basename(realized.cwd)).toBe("hotfix-rollout");
   });
 
+  it("preserves ordinary slug segments while stripping canonical issue identifiers", async () => {
+    const repoRoot = await createTempRepo();
+
+    const titledRealized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "feature/{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-template-preserve",
+        identifier: "PAP-994",
+        title: "Deploy hotfix may 2025 in 2024 for 1",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(titledRealized.branchName).toBe("feature/deploy-hotfix-may-2025-in-2024-for-1");
+
+    const canonicalRealized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "feature/{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-template-uppercase-strip",
+        identifier: "PAP-995",
+        title: "PAP-995 rollout apr 3 api 2",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(canonicalRealized.branchName).toBe("feature/rollout-apr-3-api-2");
+  });
+
   it("runs a configured provision command inside the derived worktree", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -362,7 +362,12 @@ function sanitizeSlugPart(
   fallback: string,
   issueIdentifier?: string | null,
 ): string {
-  const raw = stripPaperclipIssueIdentifiers(value ?? "", issueIdentifier).trim().toLowerCase();
+  const raw = stripPaperclipIssueIdentifiers(value ?? "", issueIdentifier).trim();
+  return normalizeSlugPart(raw, fallback);
+}
+
+function normalizeSlugPart(value: string, fallback: string): string {
+  const raw = value.trim().toLowerCase();
   const normalized = raw
     .replace(/[^a-z0-9_-]+/g, "-")
     .replace(/-+/g, "-")
@@ -399,15 +404,16 @@ function renderWorkspaceTemplate(template: string, input: {
   repoRef: string | null;
 }) {
   const issueIdentifier = input.issue?.identifier ?? input.issue?.id ?? "issue";
+  const hasIssueTitle = typeof input.issue?.title === "string" && input.issue.title.trim().length > 0;
   const slug = sanitizeSlugPart(
     input.issue?.title,
-    sanitizeSlugPart(issueIdentifier, "issue", issueIdentifier),
+    normalizeSlugPart(issueIdentifier, "issue"),
     issueIdentifier,
   );
   return renderTemplate(template, {
     issue: {
       id: input.issue?.id ?? "",
-      identifier: input.issue?.identifier ?? "",
+      identifier: hasIssueTitle ? (input.issue?.identifier ?? "") : "",
       title: input.issue?.title ?? "",
     },
     agent: {
@@ -1159,7 +1165,8 @@ export async function realizeExecutionWorkspace(input: {
     projectId: input.base.projectId,
     repoRef: input.base.repoRef,
   });
-  const branchName = sanitizeBranchName(renderedBranch, input.issue?.identifier);
+  const hasIssueTitle = typeof input.issue?.title === "string" && input.issue.title.trim().length > 0;
+  const branchName = sanitizeBranchName(renderedBranch, hasIssueTitle ? input.issue?.identifier : null);
   const configuredParentDir = asString(rawStrategy.worktreeParentDir, "");
   const worktreeParentDir = configuredParentDir
     ? resolveConfiguredPath(configuredParentDir, repoRoot)

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -357,8 +357,12 @@ function toRuntimeServiceRef(record: RuntimeServiceRecord, overrides?: Partial<R
   };
 }
 
-function sanitizeSlugPart(value: string | null | undefined, fallback: string): string {
-  const raw = stripPaperclipIssueIdentifiers(value ?? "").trim().toLowerCase();
+function sanitizeSlugPart(
+  value: string | null | undefined,
+  fallback: string,
+  issueIdentifier?: string | null,
+): string {
+  const raw = stripPaperclipIssueIdentifiers(value ?? "", issueIdentifier).trim().toLowerCase();
   const normalized = raw
     .replace(/[^a-z0-9_-]+/g, "-")
     .replace(/-+/g, "-")
@@ -366,15 +370,26 @@ function sanitizeSlugPart(value: string | null | undefined, fallback: string): s
   return normalized.length > 0 ? normalized : fallback;
 }
 
-function stripPaperclipIssueIdentifiers(value: string): string {
+function stripPaperclipIssueIdentifiers(value: string, issueIdentifier?: string | null): string {
+  const normalizedIdentifier = issueIdentifier?.trim().toUpperCase() ?? null;
   return value
     .split("/")
     .map((segment) => segment
-      .replace(/(^|[._-])[a-z][a-z0-9]{1,3}-\d+(?=$|[._-])/gi, "$1")
+      .replace(
+        normalizedIdentifier
+          ? new RegExp(`(^|[._-])${escapeRegExp(normalizedIdentifier)}(?=$|[._-])`, "gi")
+          : /$^/,
+        "$1",
+      )
+      .replace(/(^|[._-])[A-Z][A-Z0-9]{1,3}-\d+(?=$|[._-])/g, "$1")
       .replace(/[._-]{2,}/g, "-")
       .replace(/^[._-]+|[._-]+$/g, ""))
     .filter((segment) => segment.length > 0)
     .join("/");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function renderWorkspaceTemplate(template: string, input: {
@@ -384,7 +399,11 @@ function renderWorkspaceTemplate(template: string, input: {
   repoRef: string | null;
 }) {
   const issueIdentifier = input.issue?.identifier ?? input.issue?.id ?? "issue";
-  const slug = sanitizeSlugPart(input.issue?.title, sanitizeSlugPart(issueIdentifier, "issue"));
+  const slug = sanitizeSlugPart(
+    input.issue?.title,
+    sanitizeSlugPart(issueIdentifier, "issue", issueIdentifier),
+    issueIdentifier,
+  );
   return renderTemplate(template, {
     issue: {
       id: input.issue?.id ?? "",
@@ -405,8 +424,8 @@ function renderWorkspaceTemplate(template: string, input: {
   });
 }
 
-function sanitizeBranchName(value: string): string {
-  const sanitized = stripPaperclipIssueIdentifiers(value.trim())
+function sanitizeBranchName(value: string, issueIdentifier?: string | null): string {
+  const sanitized = stripPaperclipIssueIdentifiers(value.trim(), issueIdentifier)
     .split("/")
     .map((segment) => segment
       .replace(/[^A-Za-z0-9._-]+/g, "-")
@@ -1140,7 +1159,7 @@ export async function realizeExecutionWorkspace(input: {
     projectId: input.base.projectId,
     repoRef: input.base.repoRef,
   });
-  const branchName = sanitizeBranchName(renderedBranch);
+  const branchName = sanitizeBranchName(renderedBranch, input.issue?.identifier);
   const configuredParentDir = asString(rawStrategy.worktreeParentDir, "");
   const worktreeParentDir = configuredParentDir
     ? resolveConfiguredPath(configuredParentDir, repoRoot)

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -358,12 +358,23 @@ function toRuntimeServiceRef(record: RuntimeServiceRecord, overrides?: Partial<R
 }
 
 function sanitizeSlugPart(value: string | null | undefined, fallback: string): string {
-  const raw = (value ?? "").trim().toLowerCase();
+  const raw = stripPaperclipIssueIdentifiers(value ?? "").trim().toLowerCase();
   const normalized = raw
     .replace(/[^a-z0-9_-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^[-_]+|[-_]+$/g, "");
   return normalized.length > 0 ? normalized : fallback;
+}
+
+function stripPaperclipIssueIdentifiers(value: string): string {
+  return value
+    .split("/")
+    .map((segment) => segment
+      .replace(/(^|[._-])[a-z][a-z0-9]{1,3}-\d+(?=$|[._-])/gi, "$1")
+      .replace(/[._-]{2,}/g, "-")
+      .replace(/^[._-]+|[._-]+$/g, ""))
+    .filter((segment) => segment.length > 0)
+    .join("/");
 }
 
 function renderWorkspaceTemplate(template: string, input: {
@@ -395,12 +406,17 @@ function renderWorkspaceTemplate(template: string, input: {
 }
 
 function sanitizeBranchName(value: string): string {
-  return value
-    .trim()
-    .replace(/[^A-Za-z0-9._/-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^[-/.]+|[-/.]+$/g, "")
-    .slice(0, 120) || "paperclip-work";
+  const sanitized = stripPaperclipIssueIdentifiers(value.trim())
+    .split("/")
+    .map((segment) => segment
+      .replace(/[^A-Za-z0-9._-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/\.{2,}/g, ".")
+      .replace(/^[-._]+|[-._]+$/g, ""))
+    .filter((segment) => segment.length > 0)
+    .join("/")
+    .slice(0, 120);
+  return sanitized || "paperclip-work";
 }
 
 function isAbsolutePath(value: string) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses git worktrees to give agent runs isolated execution paths inside a repository.
> - The worktree runtime is responsible for turning issue context into a branch name before any branch is created or reused.
> - That branch name can be derived from templates, identifiers, and title slugs, so any leak at this layer becomes persistent GitHub branch and pull request metadata.
> - The current behavior keeps issue-style identifiers in generated branch names, which is undesirable once the branch is pushed upstream.
> - The safest fix is to strip those identifiers both when slug parts are derived and at the final branch-name sanitization boundary.
> - This pull request adds that guardrail and regression coverage so future worktree branches stay descriptive without carrying identifier prefixes.

## Linked Issues or Issue Description

Fixes #8259

## What Changed

- Stripped issue-style identifiers before slug normalization so title-derived branch names no longer inherit them.
- Added a final branch-name sanitization pass that removes issue-style identifiers from template output while preserving intentional `/` and `.` structure.
- Updated worktree runtime tests to expect identifier-free branch names and added a regression for template-derived leakage.

## Verification

- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t 'strips issue identifiers|preserves intentional slashes and dots|slugifies unsafe issue titles|creates and reuses a git worktree|rejects reusing a linked worktree whose branch drifted|reuses an already checked out branch from git worktree metadata even when the target path differs'`
- `pnpm --filter @paperclipai/server typecheck`
- `gh pr list --repo paperclipai/paperclip --state open --limit 20 --json number,title,headRefName,author`

## Risks

- Low behavioral risk: generated worktree branch names become shorter because identifier prefixes are removed.
- Historical branches and already-open pull requests are unchanged; this only protects future branch creation and reuse.
- The sanitization regex is intentionally scoped to issue-style prefixes, so review should confirm it does not remove meaningful non-identifier text.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex via Paperclip `codex_local`, GPT-5-class coding model with shell and GitHub tool use. The exact runtime snapshot and context-window setting were not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
