### PR TITLE
fix(adapter-utils): redact vendor tokens and URL passwords

### DIFF
--- a/packages/adapter-utils/src/command-redaction.test.ts
+++ b/packages/adapter-utils/src/command-redaction.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { REDACTED_COMMAND_TEXT_VALUE, redactCommandText } from "./command-redaction.js";
+
+describe("redactCommandText", () => {
+  it("redacts vendor token prefixes that are not tied to key names", () => {
+    const slackToken = "xoxb-123456789012-ABCDEFGHIJKL";
+    const supabaseToken = `sbp_${"a".repeat(40)}`;
+
+    const result = redactCommandText(`slack=${slackToken} supabase=${supabaseToken}`);
+
+    expect(result).toBe(`slack=${REDACTED_COMMAND_TEXT_VALUE} supabase=${REDACTED_COMMAND_TEXT_VALUE}`);
+  });
+
+  it("redacts URL userinfo passwords while preserving parseable URL structure", () => {
+    const result = redactCommandText(
+      "DATABASE_URL=postgres://paperclip:secret-password@db.internal:5432/app redis://default:redis-secret@localhost/0",
+    );
+
+    expect(result).toBe(
+      `DATABASE_URL=postgres://paperclip:${REDACTED_COMMAND_TEXT_VALUE}@db.internal:5432/app redis://default:${REDACTED_COMMAND_TEXT_VALUE}@localhost/0`,
+    );
+  });
+
+  it("redacts camelCase gateway secret assignments", () => {
+    const result = redactCommandText("gatewayToken=token-value gatewayPassword='password-value'");
+
+    expect(result).toBe(
+      `gatewayToken=${REDACTED_COMMAND_TEXT_VALUE} gatewayPassword='${REDACTED_COMMAND_TEXT_VALUE}'`,
+    );
+  });
+});

--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -14,6 +14,9 @@ const COMMAND_ENV_SECRET_ASSIGNMENT_RE = new RegExp(
 const COMMAND_AUTHORIZATION_BEARER_RE = /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const COMMAND_OPENAI_KEY_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const COMMAND_GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+const COMMAND_SLACK_TOKEN_RE = /\b(?:xox[abefprs]|xapp)-[A-Za-z0-9-]{10,}\b/g;
+const COMMAND_SUPABASE_ACCESS_TOKEN_RE = /\bsbp_[A-Za-z0-9]{40,}\b/g;
+const COMMAND_URL_USERINFO_PASSWORD_RE = /(\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^:/\s@]+:)[^@\s]+(@)/g;
 const COMMAND_JWT_RE =
   /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
 const COMMAND_SECRET_HINTS = [
@@ -35,6 +38,10 @@ const COMMAND_SECRET_HINTS = [
   "ghu_",
   "ghs_",
   "ghr_",
+  "xox",
+  "xapp",
+  "sbp_",
+  "://",
 ] as const;
 
 function maybeContainsSecretText(command: string) {
@@ -54,5 +61,8 @@ export function redactCommandText(command: string, redactedValue = REDACTED_COMM
     )
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
+    .replace(COMMAND_SLACK_TOKEN_RE, redactedValue)
+    .replace(COMMAND_SUPABASE_ACCESS_TOKEN_RE, redactedValue)
+    .replace(COMMAND_URL_USERINFO_PASSWORD_RE, `$1${redactedValue}$2`)
     .replace(COMMAND_JWT_RE, redactedValue);
 }

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -67,13 +67,19 @@ describe("redaction", () => {
   it("redacts common secret shapes from unstructured text", () => {
     const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     const githubToken = "ghp_1234567890abcdefghijklmnopqrstuvwxyz";
+    const slackToken = "xoxb-123456789012-ABCDEFGHIJKL";
+    const supabaseToken = `sbp_${"a".repeat(40)}`;
     const input = [
       "Authorization: Bearer live-bearer-token-value",
       `payload {"apiKey":"json-secret-value"}`,
+      `gateway {"gatewayToken":"gateway-token-value","gatewayPassword":"gateway-password-value"}`,
       `paperclip {"PAPERCLIP_API_KEY":"paperclip-json-secret"}`,
       `escaped {\\"apiKey\\":\\"escaped-json-secret\\"}`,
       `export PAPERCLIP_API_KEY='paperclip-shell-secret'`,
       `GITHUB_TOKEN=${githubToken}`,
+      `SLACK_BOT=${slackToken}`,
+      `SUPABASE_TOKEN=${supabaseToken}`,
+      `DATABASE_URL=postgres://paperclip:db-password@db.internal:5432/app`,
       `session=${jwt}`,
     ].join("\n");
 
@@ -82,11 +88,17 @@ describe("redaction", () => {
     expect(result).toContain(REDACTED_EVENT_VALUE);
     expect(result).not.toContain("live-bearer-token-value");
     expect(result).not.toContain("json-secret-value");
+    expect(result).not.toContain("gateway-token-value");
+    expect(result).not.toContain("gateway-password-value");
     expect(result).not.toContain("paperclip-json-secret");
     expect(result).not.toContain("escaped-json-secret");
     expect(result).not.toContain("paperclip-shell-secret");
     expect(result).not.toContain(githubToken);
+    expect(result).not.toContain(slackToken);
+    expect(result).not.toContain(supabaseToken);
+    expect(result).not.toContain("db-password");
     expect(result).not.toContain(jwt);
+    expect(result).toContain(`postgres://paperclip:${REDACTED_EVENT_VALUE}@db.internal`);
   });
 
   it("redacts inline secrets from command metadata without hiding safe command text", () => {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -36,6 +36,10 @@ const SECRET_TEXT_HINTS = [
   "ghu_",
   "ghs_",
   "ghr_",
+  "xox",
+  "xapp",
+  "sbp_",
+  "://",
 ] as const;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs and adapter invocations can include command text, logs, and server payloads that are persisted for auditability
> - Those durable surfaces must redact secret-shaped values before they are stored or shown
> - The consolidated redaction helper already covers common API-key, bearer, GitHub, OpenAI, and JWT shapes
> - But Slack token prefixes, Supabase `sbp_` tokens, URL userinfo passwords, and camelCase gateway secrets were still called out as uncovered patterns
> - This pull request adds those focused patterns to the shared helper and server wrapper coverage
> - The benefit is narrower secret-leak exposure without changing the surrounding run-log or event payload model

## Linked Issues or Issue Description

Fixes #8021
Refs #8027

Related/dedupe search performed:
- Reviewed open PR metadata and issue history for redaction/security work.
- Found nearby open work such as #7430, #7724, #7827, #8113, #8117, and #8119, but none was an exact duplicate of the consolidated `command-redaction.ts` / `server/src/redaction.ts` coverage for these token shapes.
- #8021 and #8027 explicitly point at this relocated helper path as the intended small follow-up surface.

## What Changed

- Added command redaction for Slack `xox*` / `xapp` tokens, Supabase `sbp_` access tokens, and URL userinfo passwords.
- Added fast-path hints so those patterns are not skipped before regex replacement.
- Reused the shared command redactor from the server redaction wrapper for the new unstructured text cases.
- Added direct adapter-utils tests plus server redaction regression coverage for JSON/text payloads and camelCase gateway secret keys.

## Verification

- `git diff --check`
- `pnpm install` (completed; emitted existing local plugin SDK bin-link warnings for unbuilt SDK dist files)
- `pnpm exec vitest run packages/adapter-utils/src/command-redaction.test.ts server/src/__tests__/redaction.test.ts` -> 2 files passed, 10 tests passed
- `pnpm --filter @paperclipai/adapter-utils typecheck` -> passed

## Risks

Low-to-medium. This changes regex-based redaction, so the main risk is overmatching unusual non-secret strings that resemble vendor tokens or URLs with userinfo. The URL replacement preserves the scheme, username, host, and path structure while only replacing the password segment.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 via Codex desktop app, with tool use, local shell execution, GitHub CLI, Codegraph, and parallel sub-agent research. Exact context window was not surfaced by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
