### PR TITLE
fix: reserve timer wakeup source for scheduler

### DIFF
--- a/cli/src/__tests__/heartbeat-run.test.ts
+++ b/cli/src/__tests__/heartbeat-run.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { heartbeatRun } from "../commands/heartbeat-run.js";
+
+const ORIGINAL_EXIT_CODE = process.exitCode;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = ORIGINAL_EXIT_CODE;
+});
+
+describe("heartbeat run command", () => {
+  it("fails loudly for invalid wakeup sources", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await heartbeatRun({
+      agentId: "agent-1",
+      source: "timer",
+      trigger: "manual",
+      timeoutMs: "0",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("Invalid heartbeat source: timer");
+  });
+});

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -721,7 +721,7 @@ export function registerAgentCommands(program: Command): void {
       .description("Request a heartbeat wakeup for an agent")
       .argument("<agentRef>", "Agent ID or shortname/url-key")
       .option("-C, --company-id <id>", "Company ID for shortname/url-key lookup")
-      .option("--source <source>", "Invocation source (timer, assignment, on_demand, automation)", "on_demand")
+      .option("--source <source>", "Invocation source (assignment, on_demand, automation)", "on_demand")
       .option("--trigger <trigger>", "Trigger detail (manual, ping, callback, system)", "manual")
       .option("--reason <text>", "Wakeup reason")
       .option("--payload <json>", "JSON object payload")

--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -4,7 +4,7 @@ import type { Agent, HeartbeatRun, HeartbeatRunEvent, HeartbeatRunStatus } from 
 import { getCLIAdapter } from "../adapters/index.js";
 import { resolveCommandContext } from "./client/common.js";
 
-const HEARTBEAT_SOURCES = ["timer", "assignment", "on_demand", "automation"] as const;
+const HEARTBEAT_SOURCES = ["assignment", "on_demand", "automation"] as const;
 const HEARTBEAT_TRIGGERS = ["manual", "ping", "callback", "system"] as const;
 const TERMINAL_STATUSES = new Set<HeartbeatRunStatus>(["succeeded", "failed", "cancelled", "timed_out"]);
 const POLL_INTERVAL_MS = 200;

--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -59,9 +59,12 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
   const debug = Boolean(opts.debug);
   const parsedTimeout = Number.parseInt(opts.timeoutMs, 10);
   const timeoutMs = Number.isFinite(parsedTimeout) ? parsedTimeout : 0;
-  const source = HEARTBEAT_SOURCES.includes(opts.source as HeartbeatSource)
-    ? (opts.source as HeartbeatSource)
-    : "on_demand";
+  if (!HEARTBEAT_SOURCES.includes(opts.source as HeartbeatSource)) {
+    console.error(pc.red(`Invalid heartbeat source: ${opts.source}`));
+    console.error(pc.gray(`Allowed sources: ${HEARTBEAT_SOURCES.join(", ")}`));
+    return;
+  }
+  const source = opts.source as HeartbeatSource;
   const triggerDetail = HEARTBEAT_TRIGGERS.includes(opts.trigger as HeartbeatTrigger)
     ? (opts.trigger as HeartbeatTrigger)
     : "manual";

--- a/cli/src/commands/heartbeat-run.ts
+++ b/cli/src/commands/heartbeat-run.ts
@@ -62,6 +62,7 @@ export async function heartbeatRun(opts: HeartbeatRunOptions): Promise<void> {
   if (!HEARTBEAT_SOURCES.includes(opts.source as HeartbeatSource)) {
     console.error(pc.red(`Invalid heartbeat source: ${opts.source}`));
     console.error(pc.gray(`Allowed sources: ${HEARTBEAT_SOURCES.join(", ")}`));
+    process.exitCode = 1;
     return;
   }
   const source = opts.source as HeartbeatSource;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -148,7 +148,7 @@ heartbeat
   .option("--api-key <token>", "Bearer token for agent-authenticated calls")
   .option(
     "--source <source>",
-    "Invocation source (timer | assignment | on_demand | automation)",
+    "Invocation source (assignment | on_demand | automation)",
     "on_demand",
   )
   .option("--trigger <trigger>", "Trigger detail (manual | ping | callback | system)", "manual")

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -127,7 +127,7 @@ export const agentMineInboxQuerySchema = z.object({
 export type AgentMineInboxQuery = z.infer<typeof agentMineInboxQuerySchema>;
 
 export const wakeAgentSchema = z.object({
-  source: z.enum(["timer", "assignment", "on_demand", "automation"]).optional().default("on_demand"),
+  source: z.enum(["assignment", "on_demand", "automation"]).optional().default("on_demand"),
   triggerDetail: z.enum(["manual", "ping", "callback", "system"]).optional(),
   reason: z.string().optional().nullable(),
   payload: z.record(z.string(), z.unknown()).optional().nullable(),

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -586,6 +586,22 @@ describe("agent live run routes", () => {
     });
   });
 
+  it("rejects client supplied timer wakeup source before heartbeat policy", async () => {
+    const res = await requestApp(
+      await createApp(),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          source: "timer",
+          triggerDetail: "ping",
+          reason: "client_timer_ping",
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
   it("calls heartbeat.wakeup with the legacy minimal shape when the body is empty", async () => {
     const res = await requestApp(
       await createApp(),

--- a/server/src/__tests__/heartbeat-archived-company-guard.test.ts
+++ b/server/src/__tests__/heartbeat-archived-company-guard.test.ts
@@ -1,13 +1,11 @@
 import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
-  agentRuntimeState,
   agentWakeupRequests,
   companies,
-  companySkills,
   createDb,
-  heartbeatRunEvents,
   heartbeatRuns,
   issues,
 } from "@paperclipai/db";
@@ -30,20 +28,39 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
 
+  async function waitForRunToFinish(
+    heartbeat: ReturnType<typeof heartbeatService>,
+    runId: string,
+    timeoutMs = 5_000,
+  ) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const run = await heartbeat.getRun(runId);
+      if (run && !["queued", "running"].includes(run.status)) return run;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return await heartbeat.getRun(runId);
+  }
+
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-archived-company-guard-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
 
   afterEach(async () => {
-    await db.delete(heartbeatRunEvents);
-    await db.delete(heartbeatRuns);
-    await db.delete(agentWakeupRequests);
-    await db.delete(issues);
-    await db.delete(agentRuntimeState);
-    await db.delete(agents);
-    await db.delete(companySkills);
-    await db.delete(companies);
+    await db.execute(sql.raw(`
+      TRUNCATE TABLE
+        "heartbeat_run_events",
+        "heartbeat_runs",
+        "agent_wakeup_requests",
+        "issues",
+        "agent_runtime_state",
+        "company_skill_versions",
+        "company_skills",
+        "agents",
+        "companies"
+      RESTART IDENTITY CASCADE
+    `));
   });
 
   afterAll(async () => {
@@ -263,12 +280,14 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
 
     const run = await db
       .select({
+        id: heartbeatRuns.id,
         agentId: heartbeatRuns.agentId,
         invocationSource: heartbeatRuns.invocationSource,
       })
       .from(heartbeatRuns)
       .then((rows) => rows.find((row) => row.agentId === agentId) ?? null);
     expect(run).toMatchObject({ invocationSource: "timer" });
+    await waitForRunToFinish(heartbeat, run!.id);
   });
 
   it("skips background wakeups for non-active companies with a company.inactive reason", async () => {

--- a/server/src/__tests__/heartbeat-archived-company-guard.test.ts
+++ b/server/src/__tests__/heartbeat-archived-company-guard.test.ts
@@ -5,6 +5,7 @@ import {
   agentRuntimeState,
   agentWakeupRequests,
   companies,
+  companySkills,
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -41,6 +42,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
     await db.delete(issues);
     await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(companySkills);
     await db.delete(companies);
   });
 

--- a/server/src/__tests__/heartbeat-archived-company-guard.test.ts
+++ b/server/src/__tests__/heartbeat-archived-company-guard.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
+  agentRuntimeState,
   agentWakeupRequests,
   companies,
   createDb,
@@ -38,6 +39,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(issues);
+    await db.delete(agentRuntimeState);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -133,6 +135,45 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
     return { companyId, managerId, childId };
   }
 
+  async function insertActiveTimerAgent(input: {
+    createdAt: Date;
+    lastHeartbeatAt: Date | null;
+    intervalSec: number;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Timer Co",
+      status: "active",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: input.intervalSec,
+          wakeOnDemand: true,
+        },
+      },
+      lastHeartbeatAt: input.lastHeartbeatAt,
+      createdAt: input.createdAt,
+      permissions: {},
+    });
+
+    return { companyId, agentId };
+  }
+
   it("does not iterate archived-company agents in tickTimers", async () => {
     const { agentId } = await insertArchivedAgent();
 
@@ -150,6 +191,82 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
       .from(heartbeatRuns)
       .then((rows) => rows.filter((row) => row.agentId === agentId).length);
     expect(runCount).toBe(0);
+  });
+
+  it("respects heartbeat interval before enqueuing scheduler timer wakeups", async () => {
+    const now = new Date("2026-06-04T00:10:00Z");
+    const { agentId } = await insertActiveTimerAgent({
+      createdAt: new Date("2026-06-04T00:00:00Z"),
+      lastHeartbeatAt: new Date("2026-06-04T00:09:30Z"),
+      intervalSec: 60,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.tickTimers(now);
+
+    expect(result).toMatchObject({
+      checked: 1,
+      enqueued: 0,
+      skipped: 0,
+    });
+
+    const runCount = await db
+      .select()
+      .from(heartbeatRuns)
+      .then((rows) => rows.filter((row) => row.agentId === agentId).length);
+    const wakeupCount = await db
+      .select()
+      .from(agentWakeupRequests)
+      .then((rows) => rows.filter((row) => row.agentId === agentId).length);
+    expect(runCount).toBe(0);
+    expect(wakeupCount).toBe(0);
+  });
+
+  it("uses the scheduler as the trusted timer wakeup source after the interval elapses", async () => {
+    const now = new Date("2026-06-04T00:10:00Z");
+    const { agentId } = await insertActiveTimerAgent({
+      createdAt: new Date("2026-06-04T00:00:00Z"),
+      lastHeartbeatAt: new Date("2026-06-04T00:08:59Z"),
+      intervalSec: 60,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.tickTimers(now);
+
+    expect(result).toMatchObject({
+      checked: 1,
+      enqueued: 1,
+      skipped: 0,
+    });
+
+    const wakeup = await db
+      .select({
+        source: agentWakeupRequests.source,
+        triggerDetail: agentWakeupRequests.triggerDetail,
+        reason: agentWakeupRequests.reason,
+        requestedByActorType: agentWakeupRequests.requestedByActorType,
+        requestedByActorId: agentWakeupRequests.requestedByActorId,
+        status: agentWakeupRequests.status,
+      })
+      .from(agentWakeupRequests)
+      .then((rows) => rows.find((row) => row.source === "timer") ?? null);
+    expect(wakeup).toMatchObject({
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat_scheduler",
+      status: "claimed",
+    });
+
+    const run = await db
+      .select({
+        agentId: heartbeatRuns.agentId,
+        invocationSource: heartbeatRuns.invocationSource,
+      })
+      .from(heartbeatRuns)
+      .then((rows) => rows.find((row) => row.agentId === agentId) ?? null);
+    expect(run).toMatchObject({ invocationSource: "timer" });
   });
 
   it("skips background wakeups for non-active companies with a company.inactive reason", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3159,7 +3159,8 @@ export function agentRoutes(
   // Shared handler body for the wakeup-style endpoints. The two routes differ
   // only in:
   //  - `source` — the modern /wakeup endpoint reads it from the request body
-  //    (timer|assignment|on_demand|automation) while the legacy
+  //    (assignment|on_demand|automation; timer is reserved for the server
+  //    scheduler) while the legacy
   //    /heartbeat/invoke endpoint hardcodes "on_demand", since it has only
   //    ever produced on-demand invocations.
   //  - skipped-response shape — the modern endpoint surfaces the rich

--- a/ui/src/api/agents.ts
+++ b/ui/src/api/agents.ts
@@ -75,7 +75,7 @@ export interface AgentPermissionUpdate {
 }
 
 export interface AgentWakeRequest {
-  source?: "timer" | "assignment" | "on_demand" | "automation";
+  source?: "assignment" | "on_demand" | "automation";
   triggerDetail?: "manual" | "ping" | "callback" | "system";
   reason?: string | null;
   payload?: Record<string, unknown> | null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The relevant subsystem is agent wakeup scheduling: client/API wakeups and the server heartbeat scheduler both enqueue heartbeat runs.
> - The problem is that a client-origin `/agents/:id/wakeup` request could submit `source: "timer"`, making an external wake look like a native scheduler tick.
> - Timer-sourced runs are policy-significant because they represent the heartbeat interval path, while client wakes should be explicit on-demand/assignment/automation requests.
> - The safer boundary is to reserve `timer` for the trusted server scheduler and reject it at the public wakeup schema.
> - This pull request narrows accepted client wakeup sources and keeps the scheduler path explicitly system-authored.
> - The benefit is clearer attribution and regression coverage so client/user-origin wakeups cannot masquerade as scheduler timer pings.

## Linked Issues or Issue Description

No GitHub issue exists for this bug, so the bug report is described inline.

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest `master` branch for this change.
- [x] I have confirmed the error originates in Paperclip itself — not in an agent adapter, API provider, or local configuration.

### What happened?

The public agent wakeup endpoint accepted a client/API body with `source: "timer"` and `triggerDetail: "ping"`. That let an externally initiated wakeup carry the same source value as a native heartbeat scheduler tick in wakeup/run metadata.

### Expected behavior

Only the server heartbeat scheduler should be able to create timer-sourced wakeups. Client/API wakeups should use `assignment`, `on_demand`, or `automation`, and invalid source values should be rejected rather than silently coerced.

### Steps to reproduce

1. Start Paperclip from `master`.
2. POST to `/api/agents/:id/wakeup` with `{ "source": "timer", "triggerDetail": "ping" }` as an authenticated client/operator.
3. Observe that the request reaches the wakeup path as a timer source instead of being rejected.

### Paperclip version or commit

Reproduced against current `master` before this PR.

### Deployment mode

Local dev / self-hosted server.

### Installation method

Built from source.

### Agent adapter(s) involved

Not adapter-specific (core bug).

### Database mode

Not database-related.

### Access context

Board/operator API request path.

## What Changed

- Removed `timer` from the public `wakeAgentSchema` accepted source enum.
- Updated CLI source validation/help text to stop advertising client-supplied timer wakeups.
- Changed the heartbeat debug CLI to reject invalid sources loudly instead of silently falling back to `on_demand`.
- Clarified the server route comment that `timer` is reserved for the scheduler.
- Added route regression coverage proving client-supplied `source: "timer"` is rejected before `heartbeat.wakeup` runs.
- Added scheduler regression coverage proving timer wakeups still respect heartbeat interval policy and are created as trusted system scheduler wakeups after the interval elapses.

## Verification

- `pnpm vitest run server/src/__tests__/agent-live-run-routes.test.ts server/src/__tests__/heartbeat-archived-company-guard.test.ts`
- `pnpm --filter paperclipai typecheck`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low-to-medium behavior change: any external caller that intentionally used `source: "timer"` must switch to `on_demand`, `assignment`, or `automation`.
- Scheduler behavior is preserved and covered by tests.
- No database migration, UI change, or deploy/restart is included.

## Model Used

- Nous Hermes Agent using OpenAI GPT-5.5 with tool-assisted code inspection, testing, and GitHub/Paperclip operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
