### PR TITLE
Automate PR review child issue lifecycle

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -834,6 +834,67 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.createChild).not.toHaveBeenCalled();
   });
 
+  it("auto-closes an existing pull request review child when PR work product reaches closed", async () => {
+    mockWorkProductService.getById.mockResolvedValueOnce({
+      id: "product-pr-4",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #124",
+      url: "https://github.com/paperclipai/paperclip/pull/124",
+      status: "ready_for_review",
+      metadata: { paperclipPullRequestReviewChildIssueId: "review-child-3" },
+    });
+    mockWorkProductService.update.mockResolvedValueOnce({
+      id: "product-pr-4",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #124",
+      url: "https://github.com/paperclipai/paperclip/pull/124",
+      status: "closed",
+      metadata: { paperclipPullRequestReviewChildIssueId: "review-child-3" },
+    });
+    mockIssueService.getById
+      .mockResolvedValueOnce(makeIssue())
+      .mockResolvedValueOnce({
+        ...makeIssue({
+          id: "review-child-3",
+          parentId: issueId,
+          status: "todo",
+          assigneeAgentId: null,
+        }),
+      });
+
+    const app = await createApp(ownerActor());
+    const res = await request(app)
+      .patch("/api/work-products/product-pr-4")
+      .send({ status: "closed" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "review-child-3",
+      expect.objectContaining({
+        status: "done",
+        actorAgentId: ownerAgentId,
+        actorUserId: null,
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "review-child-3",
+      expect.stringContaining("Pull request work product `PR #124` reached `closed`."),
+      expect.objectContaining({ runId: ownerRunId }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "review-child-3",
+      expect.stringContaining("terminal status `closed`"),
+      expect.objectContaining({ runId: ownerRunId }),
+    );
+    expect(mockIssueService.createChild).not.toHaveBeenCalled();
+  });
+
   it("preserves board mutations on active checkouts", async () => {
     const app = await createApp(boardActor());
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -20,6 +20,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getRelationSummaries: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
+  list: vi.fn(),
   listAttachments: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   remove: vi.fn(),
@@ -299,6 +300,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.getById.mockReset();
     mockIssueService.getRelationSummaries.mockReset();
     mockIssueService.getWakeableParentAfterChildCompletion.mockReset();
+    mockIssueService.list.mockReset();
     mockIssueService.listAttachments.mockReset();
     mockIssueService.listWakeableBlockedDependents.mockReset();
     mockIssueRecoveryActionService.getActiveForIssue.mockReset();
@@ -396,6 +398,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.list.mockResolvedValue([]);
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue(),
@@ -454,6 +457,7 @@ describe("agent issue mutation checkout ownership", () => {
       companyId,
       type: "artifact",
       title: "Updated",
+      metadata: null,
     });
     mockWorkProductService.remove.mockResolvedValue({
       id: "product-1",
@@ -675,6 +679,159 @@ describe("agent issue mutation checkout ownership", () => {
     );
     expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalled();
     expect(mockWorkProductService.update).toHaveBeenCalledWith("product-1", { title: "Updated product" });
+  });
+
+  it("auto-creates one blocking review child for a pull request work product and stores linkage metadata", async () => {
+    mockWorkProductService.createForIssue.mockResolvedValueOnce({
+      id: "product-pr-1",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #42",
+      url: "https://github.com/paperclipai/paperclip/pull/42",
+      status: "ready_for_review",
+      metadata: null,
+    });
+    mockWorkProductService.update.mockResolvedValueOnce({
+      id: "product-pr-1",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #42",
+      url: "https://github.com/paperclipai/paperclip/pull/42",
+      status: "ready_for_review",
+      metadata: { paperclipPullRequestReviewChildIssueId: "99999999-9999-4999-8999-999999999999" },
+    });
+
+    const app = await createApp(ownerActor());
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/work-products`)
+      .send({
+        type: "pull_request",
+        provider: "github",
+        title: "PR #42",
+        url: "https://github.com/paperclipai/paperclip/pull/42",
+        status: "ready_for_review",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.createChild).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.createChild).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        title: "Review PR: PR #42",
+        blockParentUntilDone: true,
+      }),
+    );
+    expect(mockWorkProductService.update).toHaveBeenCalledWith(
+      "product-pr-1",
+      expect.objectContaining({
+        metadata: { paperclipPullRequestReviewChildIssueId: "99999999-9999-4999-8999-999999999999" },
+      }),
+    );
+  });
+
+  it("keeps pull request review child creation idempotent via linked metadata on update", async () => {
+    mockWorkProductService.getById.mockResolvedValueOnce({
+      id: "product-pr-2",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #99",
+      url: "https://github.com/paperclipai/paperclip/pull/99",
+      status: "ready_for_review",
+      metadata: { paperclipPullRequestReviewChildIssueId: "review-child-1" },
+    });
+    mockWorkProductService.update.mockResolvedValueOnce({
+      id: "product-pr-2",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #99 updated",
+      url: "https://github.com/paperclipai/paperclip/pull/99",
+      status: "ready_for_review",
+      metadata: { paperclipPullRequestReviewChildIssueId: "review-child-1" },
+    });
+    mockIssueService.getById
+      .mockResolvedValueOnce(makeIssue())
+      .mockResolvedValueOnce({
+        ...makeIssue({
+          id: "review-child-1",
+          parentId: issueId,
+          status: "todo",
+          assigneeAgentId: null,
+        }),
+      });
+
+    const app = await createApp(ownerActor());
+    const res = await request(app)
+      .patch("/api/work-products/product-pr-2")
+      .send({ title: "PR #99 updated" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.createChild).not.toHaveBeenCalled();
+    expect(mockWorkProductService.update).toHaveBeenCalledTimes(1);
+    expect(mockWorkProductService.update).toHaveBeenCalledWith("product-pr-2", { title: "PR #99 updated" });
+  });
+
+  it("auto-closes an existing pull request review child when PR work product reaches merged", async () => {
+    mockWorkProductService.getById.mockResolvedValueOnce({
+      id: "product-pr-3",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #123",
+      url: "https://github.com/paperclipai/paperclip/pull/123",
+      status: "ready_for_review",
+      metadata: { paperclipPullRequestReviewChildIssueId: "review-child-2" },
+    });
+    mockWorkProductService.update.mockResolvedValueOnce({
+      id: "product-pr-3",
+      issueId,
+      companyId,
+      type: "pull_request",
+      provider: "github",
+      title: "PR #123",
+      url: "https://github.com/paperclipai/paperclip/pull/123",
+      status: "merged",
+      metadata: { paperclipPullRequestReviewChildIssueId: "review-child-2" },
+    });
+    mockIssueService.getById
+      .mockResolvedValueOnce(makeIssue())
+      .mockResolvedValueOnce({
+        ...makeIssue({
+          id: "review-child-2",
+          parentId: issueId,
+          status: "todo",
+          assigneeAgentId: null,
+        }),
+      });
+
+    const app = await createApp(ownerActor());
+    const res = await request(app)
+      .patch("/api/work-products/product-pr-3")
+      .send({ status: "merged" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "review-child-2",
+      expect.objectContaining({
+        status: "done",
+        actorAgentId: ownerAgentId,
+        actorUserId: null,
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "review-child-2",
+      expect.stringContaining("Pull request work product `PR #123` reached `merged`."),
+      expect.objectContaining({ runId: ownerRunId }),
+    );
+    expect(mockIssueService.createChild).not.toHaveBeenCalled();
   });
 
   it("preserves board mutations on active checkouts", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -199,6 +199,63 @@ function inferVideoContentTypeFromFilename(filename: string | null | undefined):
   return null;
 }
 
+const PULL_REQUEST_REVIEW_MARKER_PREFIX = "<!-- paperclip:pull-request-review:";
+const PULL_REQUEST_REVIEW_TERMINAL_STATUSES = new Set(["merged", "closed", "failed", "archived"]);
+const PULL_REQUEST_REVIEW_CHILD_ISSUE_ID_META_KEY = "paperclipPullRequestReviewChildIssueId";
+
+function buildPullRequestReviewMarker(workProductId: string) {
+  return `${PULL_REQUEST_REVIEW_MARKER_PREFIX}${workProductId} -->`;
+}
+
+function pullRequestReviewChildTitle(productTitle: string) {
+  return `Review PR: ${productTitle}`;
+}
+
+function pullRequestReviewChildDescription(input: {
+  workProductId: string;
+  title: string;
+  url: string | null;
+  status: string;
+}) {
+  const pullRequestUrl = input.url ? `- Pull request: ${input.url}` : "- Pull request: URL not recorded";
+  return [
+    buildPullRequestReviewMarker(input.workProductId),
+    "",
+    "This review task was auto-created from a pull request work product.",
+    "",
+    `- Pull request title: ${input.title}`,
+    pullRequestUrl,
+    `- Current PR status: \`${input.status}\``,
+    "",
+    "Close this task only after review is complete and the branch is merged back into the base branch.",
+  ].join("\n");
+}
+
+function shouldCreatePullRequestReviewTask(product: {
+  type: string;
+  status: string;
+}) {
+  return product.type === "pull_request" && !PULL_REQUEST_REVIEW_TERMINAL_STATUSES.has(product.status);
+}
+
+function getPullRequestReviewChildIssueIdFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+) {
+  if (!metadata || typeof metadata !== "object") return null;
+  const childIssueId = metadata[PULL_REQUEST_REVIEW_CHILD_ISSUE_ID_META_KEY];
+  return typeof childIssueId === "string" && childIssueId.length > 0 ? childIssueId : null;
+}
+
+function buildPullRequestReviewMetadataPatch(
+  metadata: Record<string, unknown> | null | undefined,
+  reviewChildIssueId: string,
+) {
+  return {
+    ...(metadata ?? {}),
+    [PULL_REQUEST_REVIEW_CHILD_ISSUE_ID_META_KEY]: reviewChildIssueId,
+  };
+}
+
 function resolveAttachmentResponseContentType(input: {
   storedContentType: string | null | undefined;
   objectContentType?: string | null;
@@ -937,6 +994,151 @@ export function issueRoutes(
   };
   const feedbackExportService = opts?.feedbackExportService;
   const environmentsSvc = environmentService(db);
+
+  async function findExistingPullRequestReviewChild(issue: {
+    id: string;
+    companyId: string;
+  }, product: {
+    id: string;
+    metadata?: Record<string, unknown> | null;
+  }) {
+    const linkedChildIssueId = getPullRequestReviewChildIssueIdFromMetadata(product.metadata);
+    if (linkedChildIssueId) {
+      const child = await svc.getById(linkedChildIssueId);
+      if (child && child.companyId === issue.companyId && child.parentId === issue.id) {
+        return child;
+      }
+    }
+
+    const workProductId = product.id;
+    const marker = buildPullRequestReviewMarker(workProductId);
+    const children = await svc.list(issue.companyId, { parentId: issue.id });
+    return children.find((child) => typeof child.description === "string" && child.description.includes(marker)) ?? null;
+  }
+
+  async function resolveDefaultPullRequestReviewerAgentId(companyId: string) {
+    const agents = await agentsSvc.list(companyId);
+    return agents.find((agent) => agent.role === "qa" && agent.status !== "terminated")?.id ?? null;
+  }
+
+  async function persistPullRequestReviewLinkage(product: {
+    id: string;
+    metadata?: Record<string, unknown> | null;
+  }, reviewChildIssueId: string) {
+    const updated = await workProductsSvc.update(product.id, {
+      metadata: buildPullRequestReviewMetadataPatch(product.metadata, reviewChildIssueId),
+    });
+    if (!updated) {
+      throw notFound("Work product not found");
+    }
+    return updated;
+  }
+
+  async function ensurePullRequestReviewTask(input: {
+    issue: typeof issueRows.$inferSelect;
+    product: {
+      id: string;
+      type: string;
+      title: string;
+      url: string | null;
+      status: string;
+      metadata?: Record<string, unknown> | null;
+    };
+    actor: ReturnType<typeof getActorInfo>;
+  }) {
+    if (input.product.type !== "pull_request") return;
+
+    const existing = await findExistingPullRequestReviewChild(input.issue, input.product);
+    if (!shouldCreatePullRequestReviewTask(input.product)) {
+      if (input.product.status === "merged" && existing && existing.status !== "done") {
+        await svc.update(existing.id, {
+          status: "done",
+          actorAgentId: input.actor.agentId,
+          actorUserId: input.actor.actorType === "user" ? input.actor.actorId : null,
+        });
+        await svc.addComment(existing.id, [
+          `Pull request work product \`${input.product.title}\` reached \`merged\`.`,
+          "",
+          "Paperclip closed this review task automatically because the PR is now merged.",
+        ].join("\n"), { runId: input.actor.runId ?? null });
+      }
+      return;
+    }
+
+    if (existing) {
+      const linkedChildIssueId = getPullRequestReviewChildIssueIdFromMetadata(input.product.metadata);
+      if (linkedChildIssueId !== existing.id) {
+        await persistPullRequestReviewLinkage(input.product, existing.id);
+      }
+      return;
+    }
+
+    const reviewerAgentId = await resolveDefaultPullRequestReviewerAgentId(input.issue.companyId);
+    const { issue: reviewIssue, parentBlockerAdded } = await svc.createChild(input.issue.id, {
+      title: pullRequestReviewChildTitle(input.product.title),
+      description: pullRequestReviewChildDescription({
+        workProductId: input.product.id,
+        title: input.product.title,
+        url: input.product.url,
+        status: input.product.status,
+      }),
+      status: "todo",
+      workMode: "standard",
+      priority: "high",
+      assigneeAgentId: reviewerAgentId ?? undefined,
+      acceptanceCriteria: [
+        "Review the pull request and record approval or requested changes in this task.",
+        "Merge the branch back into the base branch only after the review path is closed.",
+      ],
+      blockParentUntilDone: true,
+      createdByAgentId: input.actor.agentId,
+      createdByUserId: input.actor.actorType === "user" ? input.actor.actorId : null,
+      actorAgentId: input.actor.agentId,
+      actorUserId: input.actor.actorType === "user" ? input.actor.actorId : null,
+    });
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: input.actor.actorType,
+      actorId: input.actor.actorId,
+      agentId: input.actor.agentId,
+      runId: input.actor.runId,
+      action: "issue.child_created",
+      entityType: "issue",
+      entityId: reviewIssue.id,
+      details: {
+        parentId: input.issue.id,
+        identifier: reviewIssue.identifier,
+        title: reviewIssue.title,
+        inheritedExecutionWorkspaceFromIssueId: input.issue.id,
+        parentBlockerAdded,
+        sourceWorkProductId: input.product.id,
+        sourceWorkProductType: input.product.type,
+      },
+    });
+
+    if (reviewerAgentId) {
+      void queueIssueAssignmentWakeup({
+        heartbeat,
+        issue: reviewIssue,
+        reason: "issue_assigned",
+        mutation: "create",
+        contextSource: "issue.pull_request_review_child_create",
+        requestedByActorType: input.actor.actorType,
+        requestedByActorId: input.actor.actorId,
+      });
+    }
+
+    await persistPullRequestReviewLinkage(input.product, reviewIssue.id);
+
+    await svc.addComment(input.issue.id, [
+      `Auto-created review child ${reviewIssue.identifier ?? reviewIssue.id} for pull request \`${input.product.title}\`.`,
+      "",
+      reviewerAgentId
+        ? "The review task is assigned to QA and blocks this issue until review closure."
+        : "The review task blocks this issue until review closure.",
+    ].join("\n"), { runId: input.actor.runId ?? null });
+  }
 
   async function cancelScheduledRetrySupersededByComment(input: {
     scheduledRetryRunId: string | null | undefined;
@@ -3327,6 +3529,11 @@ export function issueRoutes(
       entityId: issue.id,
       details: { workProductId: product.id, type: product.type, provider: product.provider },
     });
+    await ensurePullRequestReviewTask({
+      issue,
+      product,
+      actor,
+    });
     await revalidateActiveSourceRecoveryAfterCommittedWrite({
       issue,
       trigger: "work_product",
@@ -3379,6 +3586,11 @@ export function issueRoutes(
       entityType: "issue",
       entityId: existing.issueId,
       details: { workProductId: product.id, changedKeys: Object.keys(req.body).sort() },
+    });
+    await ensurePullRequestReviewTask({
+      issue,
+      product,
+      actor,
     });
     await revalidateActiveSourceRecoveryAfterCommittedWrite({
       issue,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -238,6 +238,13 @@ function shouldCreatePullRequestReviewTask(product: {
   return product.type === "pull_request" && !PULL_REQUEST_REVIEW_TERMINAL_STATUSES.has(product.status);
 }
 
+function pullRequestTerminalStatusClosureMessage(status: string) {
+  if (status === "merged") {
+    return "Paperclip closed this review task automatically because the PR is now merged.";
+  }
+  return `Paperclip closed this review task automatically because the PR reached terminal status \`${status}\`.`;
+}
+
 function getPullRequestReviewChildIssueIdFromMetadata(
   metadata: Record<string, unknown> | null | undefined,
 ) {
@@ -1050,16 +1057,16 @@ export function issueRoutes(
 
     const existing = await findExistingPullRequestReviewChild(input.issue, input.product);
     if (!shouldCreatePullRequestReviewTask(input.product)) {
-      if (input.product.status === "merged" && existing && existing.status !== "done") {
+      if (existing && existing.status !== "done") {
         await svc.update(existing.id, {
           status: "done",
           actorAgentId: input.actor.agentId,
           actorUserId: input.actor.actorType === "user" ? input.actor.actorId : null,
         });
         await svc.addComment(existing.id, [
-          `Pull request work product \`${input.product.title}\` reached \`merged\`.`,
+          `Pull request work product \`${input.product.title}\` reached \`${input.product.status}\`.`,
           "",
-          "Paperclip closed this review task automatically because the PR is now merged.",
+          pullRequestTerminalStatusClosureMessage(input.product.status),
         ].join("\n"), { runId: input.actor.runId ?? null });
       }
       return;


### PR DESCRIPTION
Fixes #8267

## Thinking Path

> - Paperclip orchestrates agent work and relies on issue state transitions being explicit and unblockable.
> - Pull request work products are part of that execution trail because they connect implementation work to review and merge outcomes.
> - The missing behavior here was that recording a PR on an issue did not create a durable, first-class review task path on the issue tree.
> - `API-42` added that automation, but the initial PR path stalled and also left a lifecycle gap for non-merged terminal PR states.
> - When a PR is closed, failed, or archived, leaving the review child open keeps the parent blocked indefinitely even though the PR lifecycle is already over.
> - This pull request lands the review-child automation with durable linkage metadata and closes the linked review child whenever the PR reaches any terminal state.
> - The benefit is that PR work products now produce a review path that is both explicit and self-cleaning instead of creating stuck parent issues.

## What Changed

- auto-create a blocking review child issue when a `pull_request` work product is recorded on an issue
- persist `paperclipPullRequestReviewChildIssueId` metadata so repeated updates stay idempotent without title matching
- auto-close the linked review child when the PR reaches a terminal status, including `merged` and non-merged terminal states such as `closed`
- add focused route tests for create, idempotent update, merged close, and closed-state close behavior

## Verification

- `pnpm -C /home/mike/paperclip exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- Result: `1` file passed, `33` tests passed

## Risks

- Low risk. The change is scoped to pull request work-product lifecycle handling in the issue routes and is covered by focused backend tests.

## Model Used

- OpenAI GPT-5 Codex via Codex local adapter
- Tool-using coding agent with shell execution and repository mutation support
- Context drawn from the local `paperclip` checkout and GitHub API responses during implementation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
