### PR TITLE
fix(workspaces): honor explicit project workspace policy

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -369,13 +369,13 @@ describe("execution workspace policy helpers", () => {
     expect(issueExecutionWorkspaceModeForPersistedWorkspace(undefined)).toBe("agent_default");
   });
 
-  it("disables project execution workspace policy when the instance flag is off", () => {
+  it("keeps explicit project execution workspace policy active when the instance flag is off", () => {
     expect(
       gateProjectExecutionWorkspacePolicy(
         { enabled: true, defaultMode: "isolated_workspace" },
         false,
       ),
-    ).toBeNull();
+    ).toEqual({ enabled: true, defaultMode: "isolated_workspace" });
     expect(
       gateProjectExecutionWorkspacePolicy(
         { enabled: true, defaultMode: "isolated_workspace" },

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -86,7 +86,11 @@ export function gateProjectExecutionWorkspacePolicy(
   projectPolicy: ProjectExecutionWorkspacePolicy | null,
   isolatedWorkspacesEnabled: boolean,
 ): ProjectExecutionWorkspacePolicy | null {
-  if (!isolatedWorkspacesEnabled) return null;
+  if (!projectPolicy?.enabled) return null;
+  // A persisted project policy is an explicit operator opt-in. Keep honoring it
+  // even when the legacy instance-wide workspace UI flag is disabled, otherwise
+  // API/configured projects silently fall back to the shared checkout.
+  void isolatedWorkspacesEnabled;
   return projectPolicy;
 }
 


### PR DESCRIPTION
## Summary\n- Honor an explicit persisted project execution workspace policy even when the legacy instance-wide isolated-workspaces UI flag is off.\n- Keeps disabled/null project policies gated out, but prevents configured API/project policies from silently falling back to the shared checkout.\n- Updates policy helper coverage for the CCS Core Wholesale isolated-worktree repro.\n\n## Verification\n- Not run: this environment does not have Paperclip workspace dependencies installed; attempted targeted vitest but pnpm/vitest were unavailable in the worktree.\n\n## Context\nCore Wholesale CCS-130/Multica CCS-128 smoke showed project executionWorkspacePolicy readback enabled, but runs still landed in the managed base checkout because the project policy was gated off by the instance experimental flag.