### PR TITLE
Fix runtime worktree policy gating

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -369,10 +369,16 @@ describe("execution workspace policy helpers", () => {
     expect(issueExecutionWorkspaceModeForPersistedWorkspace(undefined)).toBe("agent_default");
   });
 
-  it("disables project execution workspace policy when the instance flag is off", () => {
+  it("honors explicit enabled project execution workspace policy even when the legacy instance flag is off", () => {
     expect(
       gateProjectExecutionWorkspacePolicy(
         { enabled: true, defaultMode: "isolated_workspace" },
+        false,
+      ),
+    ).toEqual({ enabled: true, defaultMode: "isolated_workspace" });
+    expect(
+      gateProjectExecutionWorkspacePolicy(
+        { enabled: false, defaultMode: "isolated_workspace" },
         false,
       ),
     ).toBeNull();

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -86,7 +86,12 @@ export function gateProjectExecutionWorkspacePolicy(
   projectPolicy: ProjectExecutionWorkspacePolicy | null,
   isolatedWorkspacesEnabled: boolean,
 ): ProjectExecutionWorkspacePolicy | null {
-  if (!isolatedWorkspacesEnabled) return null;
+  if (!projectPolicy) return null;
+  // Once a project has an explicit execution workspace policy, the runtime must
+  // honor it even if the legacy instance-wide UI flag is disabled. The flag is
+  // only a discovery/UI gate now; using it as a launch-time gate lets configured
+  // git_worktree projects silently fall back to the shared checkout.
+  if (!isolatedWorkspacesEnabled && !projectPolicy.enabled) return null;
   return projectPolicy;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Server-side execution workspace policy decides whether a project's agents run in an isolated git worktree or the shared managed checkout
> - The launch-time gate `gateProjectExecutionWorkspacePolicy` was short-circuiting on the legacy instance-wide `isolatedWorkspacesEnabled` UI flag, ignoring an explicit per-project `enabled: true, defaultMode: "isolated_workspace"` policy
> - This let configured `git_worktree` projects silently fall back to the shared managed checkout on the default branch when the instance flag was off, even though the project itself had opted in
> - This pull request makes the instance flag act only as a discovery/UI gate, while runtime honors an explicit enabled project policy regardless of the flag; disabled project policies remain gated off
> - The benefit is agents for projects explicitly configured for isolated worktrees no longer collide on the shared checkout

## Linked Issues or Issue Description

No public GitHub issue exists for this (tracked internally as CCS-129). Related/duplicate-search: found closed PR #8273 (`fix(workspaces): honor explicit project workspace policy`, same author, prior attempt on this issue) — superseded by this PR.

**What happened?** Projects with an explicit `execution_workspace_policy` of `{ enabled: true, defaultMode: "isolated_workspace" }` still launched agents in the shared managed checkout on the default branch when the instance-wide legacy isolated-workspaces UI flag was off.

**Expected behavior:** An explicit enabled project policy should be honored at launch time regardless of the legacy instance flag; only a disabled/absent project policy should fall back to the instance flag.

**Steps to reproduce:**
1. Set the instance-wide "isolated workspaces" UI flag to off.
2. Configure a project with `execution_workspace_policy = { enabled: true, defaultMode: "isolated_workspace" }` and a `git_worktree` runtime.
3. Launch an agent for that project.
4. Observe the agent starts in the shared managed checkout on the default branch instead of an isolated worktree.

## What Changed

- `gateProjectExecutionWorkspacePolicy` in `server/src/services/execution-workspace-policy.ts` now returns the project policy when it is explicitly `enabled: true`, even if the legacy `isolatedWorkspacesEnabled` instance flag is `false`; disabled/absent project policies still gate off as before.
- Updated `server/src/__tests__/execution-workspace-policy.test.ts` to cover both the "explicit enabled policy survives the flag being off" case and the pre-existing "disabled policy stays gated off" case.

## Verification

- `corepack pnpm --dir paperclip-ccs-129 --filter @paperclipai/server exec vitest run src/__tests__/execution-workspace-policy.test.ts`

## Risks

- Low risk: behavioral change is scoped to the launch-time gate function and only changes outcome for projects with an *explicit* `enabled: true` policy while the instance flag is off (previously silently downgraded). Disabled/absent-policy projects are unaffected. Covered by updated unit tests; no migration or schema changes.

## Model Used

None — human-authored.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
