### PR TITLE
fix(shared): accept executionState on createIssueBaseSchema

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -131,6 +131,37 @@ describe("issue validators", () => {
     ).toBe(false);
   });
 
+  it("accepts executionState on create without silently stripping it", () => {
+    expect(
+      createIssueSchema.parse({ title: "Stamp per-SHA review", executionState: null })
+        .executionState,
+    ).toBeNull();
+    expect(
+      createIssueSchema.parse({ title: "Stamp per-SHA review" }).executionState,
+    ).toBeUndefined();
+
+    const validState = {
+      status: "idle" as const,
+      currentStageId: null,
+      currentStageIndex: null,
+      currentStageType: null,
+      currentParticipant: null,
+      returnAssignee: null,
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+    };
+    const parsed = createIssueSchema.parse({
+      title: "Stamp per-SHA review",
+      executionState: validState,
+    });
+    expect(parsed.executionState).toMatchObject({
+      status: "idle",
+      currentStageId: null,
+      reviewRequest: null,
+      completedStageIds: [],
+    });
+  });
+
   it("normalizes escaped line breaks in issue comment bodies", () => {
     const parsed = addIssueCommentSchema.parse({
       body: "Progress update\\r\\n\\r\\nNext action.",

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -386,6 +386,7 @@ const createIssueBaseSchema = z.object({
   billingCode: z.string().optional().nullable(),
   assigneeAdapterOverrides: issueAssigneeAdapterOverridesSchema.optional().nullable(),
   executionPolicy: issueExecutionPolicySchema.optional().nullable(),
+  executionState: issueExecutionStateSchema.optional().nullable(),
   executionWorkspaceId: z.string().uuid().optional().nullable(),
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents create issues via `POST /api/companies/:companyId/issues`, validated by the zod schema `createIssueBaseSchema` in `packages/shared/src/validators/issue.ts`
> - That schema enumerates fields explicitly, so any property absent from the schema is silently stripped before the server route handler (`server/src/routes/issues.ts`) or service-layer `svc.create` (`server/src/services/issues.ts`) ever see it
> - `executionState` is one of the typed issue fields — it carries `targetSha`, `reviewRequest`, `completedStageIds`, etc. — and helper code on the consumer side writes `executionState.targetSha` at issue-create time
> - The field is missing from `createIssueBaseSchema` even though the matching `issueExecutionStateSchema` is already exported from the same module and the route + service layer already pass it through via `...req.body` / `...issueData`
> - This pull request adds the one-line additive zod entry — mirroring the `executionPolicy` line right above it — plus a regression test that pins the null round-trip and the full `issueExecutionStateSchema` shape
> - The benefit is that `executionState` round-trips on issue create instead of being silently dropped, removing the need for downstream client-side workarounds (body-SHA-pin guards, `--strict-execution-state` opt-ins) that exist purely because the field was being stripped

## Linked Issues or Issue Description

No public upstream issue exists for this; describing in-PR per the bug-report template:

**What happened.** `POST /api/companies/:companyId/issues` with `{ executionState: { targetSha: "abc", ... } }` returns a created issue whose `executionState` is `null`. A subsequent `GET /api/issues/:id` also returns `null`.

**What I expected.** The created and fetched issue should carry the `executionState` value that was POSTed (i.e. `executionState.targetSha === "abc"`).

**Repro steps.**

1. Run the server.
2. `POST /api/companies/:companyId/issues` with a body containing a valid `executionState` object (e.g. `{ title: "probe", status: "backlog", executionState: { targetSha: "0000000000000000000000000000000000000000" } }`).
3. Inspect the response and a follow-up `GET /api/issues/:id`. Both show `executionState: null`.

**Root cause.** `createIssueBaseSchema` in `packages/shared/src/validators/issue.ts` does not declare `executionState`. zod strips unknown fields before they reach `svc.create`, so the route handler never sees the value.

**Scope.** Only the `create` path is affected. `updateIssueSchema` is `createIssueBaseSchema.partial().extend({...})`, so the same omission propagates there as well; the additive fix below covers both.

## What Changed

- `packages/shared/src/validators/issue.ts` — added `executionState: issueExecutionStateSchema.optional().nullable()` to `createIssueBaseSchema`, mirroring the existing `executionPolicy` entry one line above. The schema is already exported from the same module, so no new import is needed.
- `packages/shared/src/validators/issue.test.ts` — added a regression case `accepts executionState on create without silently stripping it` that pins both the null round-trip and a full `issueExecutionStateSchema` shape (with `reviewRequest` / `completedStageIds` defaults applied).

Net: +32 / -0, two files, no behaviour changes outside the additive schema entry.

## Verification

- **Schema read.** Confirmed `executionState` is absent from `createIssueBaseSchema` and that `issueExecutionStateSchema` is already exported from the same module.
- **Pass-through audit.** Read `server/src/routes/issues.ts` (POST handler) and `server/src/services/issues.ts` `svc.create` — both forward arbitrary issue fields via `...req.body` / `...issueData`, so the field would reach storage if the schema accepted it.
- **Live repro before the fix.** Against a running server: `POST` with `executionState: { … }` → response and `GET` both returned `executionState: null`.
- **Live verification after the fix.** With the additive schema entry applied (built and re-published shared), the same POST round-trips the full `executionState` value.
- **Unit test.** New regression case in `packages/shared/src/validators/issue.test.ts` exercises both the null and populated `executionState` shapes through `createIssueBaseSchema.parse(...)`.

## Risks

Low risk. The change is purely additive:

- The schema now accepts an extra optional, nullable property; existing clients that omit `executionState` (or send `null`) keep their current behaviour.
- The `executionPolicy` field one line above already uses the same `.optional().nullable()` shape against an analogous typed sub-schema, so the precedent is set.
- No migration. No breaking change to API consumers — the field was already typed and exported elsewhere; the schema was the only gate dropping it.
- No behavioural change to the POST route handler or `svc.create`; both already forward the field if it survives validation.

## Model Used

Claude Opus 4.7 (Anthropic; model id `claude-opus-4-7`; extended thinking enabled). Used for: schema inspection, the additive zod entry, the regression test, and the live round-trip repro both before and after.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, shared-schema-only change
- [x] I have updated relevant documentation to reflect my changes — N/A, the schema is self-documenting via its zod type and the new regression test
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending after this description rewrite addresses the one open P2 (PR description does not follow the required template)
- [x] I will address all Greptile and reviewer comments before requesting merge
