### PR TITLE
fix(execution): honor realized workspace cwd on remote leases + tolerate benign tar exit 1

### DIFF
--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
@@ -195,6 +195,81 @@ describe("sandbox managed runtime", () => {
     // And the workspace still extracts correctly into an existing target dir.
     await expect(readFile(path.join(remoteWorkspaceDir, "README.md"), "utf8")).resolves.toBe("ws\n");
     await expect(readFile(path.join(remoteWorkspaceDir, "src", "main.ts"), "utf8")).resolves.toBe("x\n");
+  });
+
+  it("tolerates a tar exit code 1 (benign 'file changed as we read it') when restoring the workspace", async () => {
+    // GNU/busybox tar returns exit code 1 for benign warnings — most commonly
+    // "file changed as we read it" when archiving a live workspace whose files
+    // mutate during the `tar -c`. That is guaranteed for an active agent run and
+    // must NOT abort the run; only exit code 2 (a real archive error) is fatal.
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-sandbox-tarexit1-"));
+    cleanupDirs.push(rootDir);
+    const localWorkspaceDir = path.join(rootDir, "local-workspace");
+    const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    const fakeBinDir = path.join(rootDir, "fakebin");
+    await mkdir(localWorkspaceDir, { recursive: true });
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(path.join(localWorkspaceDir, "README.md"), "ws\n", "utf8");
+
+    // A `tar` shim that does the real work via the system tar, then exits 1 to
+    // simulate the benign warning. Used only for the remote (client.run) tar
+    // invocations; the local helper tars still use the real system tar.
+    const realTar = (await execFile("sh", ["-c", "command -v tar"]))
+      .stdout.trim();
+    const tarShimPath = path.join(fakeBinDir, "tar");
+    await writeFile(
+      tarShimPath,
+      `#!/bin/sh\n${realTar} "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 1; fi\nexit "$status"\n`,
+      "utf8",
+    );
+    await chmod(tarShimPath, 0o755);
+
+    const client: SandboxManagedRuntimeClient = {
+      makeDir: async (remotePath) => {
+        await mkdir(remotePath, { recursive: true });
+      },
+      writeFile: async (remotePath, bytes) => {
+        await mkdir(path.dirname(remotePath), { recursive: true });
+        await writeFile(remotePath, Buffer.from(bytes));
+      },
+      readFile: async (remotePath) => await readFile(remotePath),
+      listFiles: async () => [],
+      remove: async (remotePath) => {
+        await rm(remotePath, { recursive: true, force: true });
+      },
+      // Mirror command-managed-runtime semantics: throw on any non-zero exit so
+      // the test exercises the real fatality contract. With the tar shim on PATH
+      // (so the scripts' bare `tar` resolves to it) the restore script must still
+      // exit 0 — proving the tar exit-1 tolerance is baked into the script.
+      run: async (command) => {
+        await execFile("sh", ["-c", command], {
+          maxBuffer: 32 * 1024 * 1024,
+          env: { ...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ""}` },
+        }).catch((err: NodeJS.ErrnoException & { code?: number }) => {
+          throw new Error(`run failed with exit code ${err.code ?? "null"}`);
+        });
+      },
+    };
+
+    const prepared = await prepareSandboxManagedRuntime({
+      spec: {
+        transport: "sandbox",
+        provider: "test",
+        sandboxId: "sandbox-1",
+        remoteCwd: remoteWorkspaceDir,
+        timeoutMs: 30_000,
+        apiKey: null,
+      },
+      adapterKey: "test-adapter",
+      client,
+      workspaceLocalDir: localWorkspaceDir,
+    });
+
+    await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote\n", "utf8");
+    // The restore tar exits 1 via the shim; the script must swallow that and the
+    // workspace must still round-trip back to the local dir.
+    await expect(prepared.restoreWorkspace()).resolves.toBeUndefined();
+    await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("remote\n");
   });
 
   it("creates a valid empty workspace tarball when the local workspace is empty", async () => {

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -120,13 +120,24 @@ async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>): 
 }
 
 async function execTar(args: string[]): Promise<void> {
-  await execFile("tar", args, {
-    env: {
-      ...process.env,
-      COPYFILE_DISABLE: "1",
-    },
-    maxBuffer: 32 * 1024 * 1024,
-  });
+  try {
+    await execFile("tar", args, {
+      env: {
+        ...process.env,
+        COPYFILE_DISABLE: "1",
+      },
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch (err) {
+    // tar exits 1 for benign warnings ("file changed as we read it" when
+    // archiving a live workspace, "Removing leading '/'", etc). That is not a
+    // failure for our archive/extract use — only exit code 2 is a real error.
+    // Swallow exactly exit 1; rethrow anything else (including spawn errors,
+    // which carry no numeric `code`).
+    const code = (err as { code?: unknown }).code;
+    if (code === 1) return;
+    throw err;
+  }
 }
 
 async function createTarballFromDirectory(input: {
@@ -261,6 +272,19 @@ function tarExcludeFlags(exclude: string[] | undefined): string {
   return ["._*", ...(exclude ?? [])].map((entry) => `--exclude ${shellQuote(entry)}`).join(" ");
 }
 
+// Wrap a remote `tar` invocation so a benign exit code 1 is not treated as a
+// failure. GNU/busybox tar exits 1 for warnings such as "file changed as we
+// read it" / "Removing leading '/'" / "some files differ" — guaranteed when
+// archiving a LIVE workspace whose files mutate mid-archive (every active agent
+// run hits this). Exit code 2 is a real archive error and stays fatal: `tar`
+// runs, and only an exit status of exactly 1 is rewritten to 0; any other
+// non-zero status is preserved. Portable across POSIX `sh` (no GNU-only
+// `--warning=` flag, which busybox tar rejects). The caller still composes the
+// surrounding `&&` chain; this only softens the single tar step.
+function tolerantTar(tarCommand: string): string {
+  return `{ ${tarCommand}; __pc_tar_rc=$?; [ "$__pc_tar_rc" -le 1 ]; }`;
+}
+
 export async function prepareSandboxManagedRuntime(input: {
   spec: SandboxRemoteExecutionSpec;
   adapterKey: string;
@@ -294,7 +318,7 @@ export async function prepareSandboxManagedRuntime(input: {
       `sh -c ${shellQuote(
         `mkdir -p ${shellQuote(workspaceRemoteDir)} && ` +
           `find ${shellQuote(workspaceRemoteDir)} -mindepth 1 -maxdepth 1 ${findPreserveArgs} -exec rm -rf -- {} + && ` +
-          `tar -xf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)} && ` +
+          `${tolerantTar(`tar -xf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)}`)} && ` +
           `rm -f ${shellQuote(remoteWorkspaceTar)}`,
       )}`,
       { timeoutMs: input.spec.timeoutMs },
@@ -316,7 +340,7 @@ export async function prepareSandboxManagedRuntime(input: {
         `sh -c ${shellQuote(
           `rm -rf ${shellQuote(remoteAssetDir)} && ` +
             `mkdir -p ${shellQuote(remoteAssetDir)} && ` +
-            `tar -xf ${shellQuote(remoteAssetTar)} -C ${shellQuote(remoteAssetDir)} && ` +
+            `${tolerantTar(`tar -xf ${shellQuote(remoteAssetTar)} -C ${shellQuote(remoteAssetDir)}`)} && ` +
             `rm -f ${shellQuote(remoteAssetTar)}`,
         )}`,
         { timeoutMs: input.spec.timeoutMs },
@@ -340,8 +364,10 @@ export async function prepareSandboxManagedRuntime(input: {
         await input.client.run(
           `sh -c ${shellQuote(
             `mkdir -p ${shellQuote(runtimeRootDir)} && ` +
-              `tar -cf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)} ` +
-              `${tarExcludeFlags(input.workspaceExclude)} .`,
+              tolerantTar(
+                `tar -cf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)} ` +
+                  `${tarExcludeFlags(input.workspaceExclude)} .`,
+              ),
           )}`,
           { timeoutMs: input.spec.timeoutMs },
         );

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -355,6 +355,59 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(result.persistedExecutionWorkspace).toEqual(updatedEw);
   });
 
+  it("threads the realized remoteCwd from a sandbox driver onto the lease metadata before resolving the target", async () => {
+    // Regression: a plugin-backed sandbox (e.g. the kubernetes provider) reports
+    // its in-environment cwd ("/workspace") via realizeWorkspace, but acquireLease
+    // never records it on the lease. Without persisting it here,
+    // resolveEnvironmentExecutionTarget falls back to the bounded default ("/tmp")
+    // and the adapter syncs/execs the workspace under /tmp inside the server pod.
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "kubernetes",
+      remoteCwd: "/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        // Plugin returns the realized cwd, but NO `workspaceRealization` record
+        // (matches the kubernetes plugin's onEnvironmentRealizeWorkspace shape).
+        cwd: "/workspace",
+        metadata: {
+          provider: "kubernetes",
+          remoteCwd: "/workspace",
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(
+      makeRealizeInput({
+        environment: makeEnvironment("sandbox"),
+        lease: makeLease({
+          provider: "kubernetes",
+          metadata: { driver: "sandbox", sandboxProviderPlugin: true },
+        }),
+      }),
+    );
+
+    // The realized cwd must be persisted as remoteCwd on the lease metadata...
+    expect(mockUpdateLeaseMetadata).toHaveBeenCalledWith(
+      "lease-1",
+      expect.objectContaining({ remoteCwd: "/workspace" }),
+    );
+
+    // ...and threaded into resolveEnvironmentExecutionTarget so it does NOT fall
+    // back to the bounded /tmp default.
+    expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leaseMetadata: expect.objectContaining({ remoteCwd: "/workspace" }),
+      }),
+    );
+  });
+
   it("runs a remote provision command after workspace realization when configured", async () => {
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -447,17 +447,43 @@ export function environmentRunOrchestrator(
       }
     }
 
-    // Step 3: Persist realization metadata on lease and execution workspace
-    if (Object.keys(workspaceRealization).length > 0) {
+    // Step 3: Persist realization metadata on lease and execution workspace.
+    //
+    // Thread the realized working directory through as `remoteCwd` on the lease
+    // metadata. The runtime driver (and, for plugin-backed providers, the plugin
+    // itself, e.g. the kubernetes provider) reports the authoritative in-environment
+    // cwd from realizeWorkspace (e.g. "/workspace"), but acquireLease does NOT
+    // record it on the lease. Without persisting it here,
+    // resolveEnvironmentExecutionTarget (Step 4) finds no `remoteCwd` in the lease
+    // metadata and falls back to DEFAULT_SANDBOX_REMOTE_CWD ("/tmp"), so the
+    // adapter syncs/execs the workspace under /tmp instead of the realized
+    // workspace dir. Persisting it keeps the lease the single source of truth and
+    // makes the executionTarget honor the provider's realized cwd. Generic across
+    // all remote drivers; only writes when the driver reported a non-empty cwd and
+    // the lease does not already carry the same value.
+    const realizedRemoteCwd =
+      environment.driver !== "local" &&
+      typeof realizedWorkspaceCwd === "string" &&
+      realizedWorkspaceCwd.trim().length > 0
+        ? realizedWorkspaceCwd.trim()
+        : null;
+    const shouldPersistRemoteCwd =
+      realizedRemoteCwd !== null && lease.metadata?.remoteCwd !== realizedRemoteCwd;
+    if (Object.keys(workspaceRealization).length > 0 || shouldPersistRemoteCwd) {
       const nextLeaseMetadata = {
         ...(lease.metadata ?? {}),
-        workspaceRealization,
+        ...(Object.keys(workspaceRealization).length > 0 ? { workspaceRealization } : {}),
+        ...(realizedRemoteCwd !== null ? { remoteCwd: realizedRemoteCwd } : {}),
       };
       const updatedLease = await environmentsSvc.updateLeaseMetadata(lease.id, nextLeaseMetadata);
       if (updatedLease) {
         lease = updatedLease;
+      } else {
+        // Keep the in-memory lease consistent even if the persistence layer
+        // returns no row, so Step 4 reads the realized remoteCwd.
+        lease = { ...lease, metadata: nextLeaseMetadata } as typeof lease;
       }
-      if (persistedExecutionWorkspace) {
+      if (persistedExecutionWorkspace && Object.keys(workspaceRealization).length > 0) {
         const updatedEw = await executionWorkspacesSvc.update(persistedExecutionWorkspace.id, {
           metadata: {
             ...(persistedExecutionWorkspace.metadata ?? {}),


### PR DESCRIPTION
## Problem
When running an agent on a **remote** execution environment (e.g. a kubernetes sandbox provider), two issues caused every run to fail at workspace restore:

1. **Realized workspace cwd is dropped.** A provider's `onEnvironmentRealizeWorkspace` returns the authoritative in-environment cwd (e.g. `/workspace`), but `acquireLease` does not record it and `realizeForRun` discarded it. `resolveEnvironmentExecutionTarget` then found no `remoteCwd` on the lease and fell back to `DEFAULT_SANDBOX_REMOTE_CWD` (`/tmp`), so the adapter synced/tarred the workspace under `/tmp` instead of the realized directory.
2. **`tar` exit code 1 treated as fatal.** `restoreWorkspace`'s `tar` returns exit 1 for the benign "file changed as we read it" warning, which is guaranteed when archiving a live workspace whose files mutate mid-archive. This was treated as a hard failure.

## Fix
- `environment-run-orchestrator.ts`: thread the realized cwd onto the lease metadata as `remoteCwd` (only when a non-`local` driver reports a non-empty cwd, and only if it differs), so the execution target honors it. Generic across all remote drivers.
- `sandbox-managed-runtime.ts`: a portable `tolerantTar` shell wrapper (`{ tar…; rc=$?; [ "$rc" -le 1 ]; }`, no GNU-only `--warning=` flag so busybox tar works) + a local `execTar` exit-1 swallow, applied to the create/extract steps. Exit code 2 remains fatal.

Unit tests added for both behaviors. `tsc --noEmit` clean.