### PR TITLE
chore: add @nickyleach to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,18 @@
 # Replace @cryppadotta if a different maintainer or team should own release infrastructure.
 
-.github/** @cryppadotta @devinfoley
-scripts/release*.sh @cryppadotta @devinfoley
-scripts/release-*.mjs @cryppadotta @devinfoley
-scripts/create-github-release.sh @cryppadotta @devinfoley
-scripts/rollback-latest.sh @cryppadotta @devinfoley
-doc/RELEASING.md @cryppadotta @devinfoley
-doc/PUBLISHING.md @cryppadotta @devinfoley
-doc/RELEASE-AUTOMATION-SETUP.md @cryppadotta @devinfoley
-skills/** @cryppadotta @devinfoley
+.github/** @cryppadotta @devinfoley @nickyleach
+scripts/release*.sh @cryppadotta @devinfoley @nickyleach
+scripts/release-*.mjs @cryppadotta @devinfoley @nickyleach
+scripts/create-github-release.sh @cryppadotta @devinfoley @nickyleach
+scripts/rollback-latest.sh @cryppadotta @devinfoley @nickyleach
+doc/RELEASING.md @cryppadotta @devinfoley @nickyleach
+doc/PUBLISHING.md @cryppadotta @devinfoley @nickyleach
+doc/RELEASE-AUTOMATION-SETUP.md @cryppadotta @devinfoley @nickyleach
+skills/** @cryppadotta @devinfoley @nickyleach
 
 # Package files — dependency changes require review
 # package.json matches recursively at all depths (covers root + all workspaces)
-package.json @cryppadotta @devinfoley
-pnpm-lock.yaml @cryppadotta @devinfoley
-pnpm-workspace.yaml @cryppadotta @devinfoley
-.npmrc @cryppadotta @devinfoley
+package.json @cryppadotta @devinfoley @nickyleach
+pnpm-lock.yaml @cryppadotta @devinfoley @nickyleach
+pnpm-workspace.yaml @cryppadotta @devinfoley @nickyleach
+.npmrc @cryppadotta @devinfoley @nickyleach


### PR DESCRIPTION
## Summary

- Adds `@nickyleach` as a codeowner alongside `@cryppadotta` and `@devinfoley` on all 13 existing entries
- Grants approval rights on `.github/**`, release scripts, docs, `skills/**`, and package files

## Thinking Path

The task is to give @nickyleach the same CODEOWNERS coverage as the existing owners. The simplest approach is to append `@nickyleach` to every existing entry in `.github/CODEOWNERS`. No new paths are introduced — this is a pure access grant.

## What Changed

- `.github/CODEOWNERS`: added `@nickyleach` to all 13 path patterns alongside the existing `@cryppadotta` and `@devinfoley` owners

## Verification

- Reviewed the diff: every existing CODEOWNERS line now includes `@nickyleach` as a third owner
- GitHub will enforce the new ownership on future PRs touching the covered paths

## Risks

- Low risk: CODEOWNERS is additive-only; no existing owner is removed
- The change takes effect immediately on merge — future PRs touching covered paths will require @nickyleach approval (or any of the three owners)

## Model Used

claude-sonnet-4-6

## Test plan

- [ ] Verify GitHub picks up the new CODEOWNERS entry and shows @nickyleach as a required reviewer on future PRs touching these paths

Closes PAP-61

🤖 Generated with [Claude Code](https://claude.com/claude-code)