### PR TITLE
Fix pnpm lockfile: add @paperclipai/shared to skills-catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,10 @@ importers:
         version: 5.9.3
 
   packages/skills-catalog:
+    dependencies:
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@types/node':
         specifier: ^24.6.0


### PR DESCRIPTION
## Summary

- Adds missing `@paperclipai/shared` workspace entry to `pnpm-lock.yaml` under `packages/skills-catalog`
- Fixes `ERR_PNPM_OUTDATED_LOCKFILE` CI failures on all PRs touching this repo
- Standalone lockfile-only change per repo policy (no other changes bundled)

## Root Cause

`packages/skills-catalog/package.json` declares `@paperclipai/shared: workspace:*` as a dependency, but the corresponding entry was absent from `pnpm-lock.yaml`, causing the frozen-lockfile CI check to fail on every PR.

## Test plan

- [x] `pnpm install --no-frozen-lockfile` ran cleanly at repo root
- [x] `pnpm install --frozen-lockfile --ignore-scripts` passed after update
- [x] `git diff --check` showed no whitespace issues
- [x] Change is exactly 4 lines added to `pnpm-lock.yaml`, no other files touched

Closes PAP-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)