### PR TITLE
feat(authz): allow manager-of-record inline review on a report's issue

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -912,4 +912,121 @@ describeEmbeddedPostgres("authorization service", () => {
       grant: { permissionKey: "tasks:assign" },
     });
   });
+
+  it("allows a manager-of-record to mutate a direct report's issue for inline review", async () => {
+    const company = await createCompany(db, "ManagerInlineReview");
+    const managerAgent = await createAgent(db, company.id, { role: "chief_researcher" });
+    const reportAgent = await createAgent(db, company.id, {
+      role: "competitive_researcher",
+      reportsTo: managerAgent.id,
+    });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: reportAgent.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: managerAgent.id, companyId: company.id },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: null,
+        parentIssueId: null,
+        assigneeAgentId: reportAgent.id,
+        assigneeUserId: null,
+        status: issue.status,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_manager_chain",
+    });
+  });
+
+  it("denies a peer agent mutating another agent's issue (boundary not over-widened)", async () => {
+    const company = await createCompany(db, "PeerMutationDenied");
+    const peerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const otherAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: otherAgent.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: peerAgent.id, companyId: company.id },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: null,
+        parentIssueId: null,
+        assigneeAgentId: otherAgent.id,
+        assigneeUserId: null,
+        status: issue.status,
+      },
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("deny_missing_grant");
+  });
+
+  it("denies a report mutating its manager's issue (manager->report only, not the reverse)", async () => {
+    const company = await createCompany(db, "ReverseMutationDenied");
+    const managerAgent = await createAgent(db, company.id, { role: "chief_researcher" });
+    const reportAgent = await createAgent(db, company.id, {
+      role: "competitive_researcher",
+      reportsTo: managerAgent.id,
+    });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: managerAgent.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: reportAgent.id, companyId: company.id },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: null,
+        parentIssueId: null,
+        assigneeAgentId: managerAgent.id,
+        assigneeUserId: null,
+        status: issue.status,
+      },
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("deny_missing_grant");
+  });
+
+  it("allows a top-of-chain manager (CEO) to mutate an indirect report's issue", async () => {
+    const company = await createCompany(db, "CeoIndirectReport");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const managerAgent = await createAgent(db, company.id, {
+      role: "chief_researcher",
+      reportsTo: ceoAgent.id,
+    });
+    const reportAgent = await createAgent(db, company.id, {
+      role: "competitive_researcher",
+      reportsTo: managerAgent.id,
+    });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: reportAgent.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: ceoAgent.id, companyId: company.id },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: null,
+        parentIssueId: null,
+        assigneeAgentId: reportAgent.id,
+        assigneeUserId: null,
+        status: issue.status,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_manager_chain",
+    });
+  });
 });

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1170,6 +1170,23 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
+      // Manager-of-record inline review: an agent that manages the issue
+      // assignee in the reporting chain (per `reportsTo`/chainOfCommand) may
+      // mutate that report's issue so it can leave inline review notes
+      // (comments) and make the lightweight review edits a manager needs
+      // (status/assignee) without spawning a child issue per comment. This is
+      // strictly manager -> direct/indirect-report; peers, report -> manager,
+      // and unrelated cross-agent writes still fall through to the deny below.
+      if (
+        resource?.assigneeAgentId &&
+        (await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId))
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_manager_chain",
+          explanation: "Allowed because the actor manages the issue assignee in the reporting chain.",
+        });
+      }
     }
     if (
       input.action === "agent_config:update" &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, where agents are organized into a reporting hierarchy (`agents.reportsTo`, the "chain of command").
> - The authorization service (`server/src/services/authorization.ts`) is the central place that decides what an agent actor may do to an issue, including the `issue:mutate` action that gates issue PATCH and comment creation.
> - Today a manager with a direct reporting line over another agent can assign work to that report (via `tasks:assign` / child issues) but cannot leave inline review on the report's own tickets: commenting on or PATCHing an issue assigned to a direct report fails with `403 "outside this actor's authorization boundary"`.
> - The boundary is correct to be tight, but it is too tight for the manager→report relationship the hierarchy already encodes: a manager should be able to review a report's work in place instead of spawning a child issue for every comment.
> - This pull request adds a single allowance: an agent that is the manager-of-record of an issue's assignee (an ancestor in the `reportsTo` chain, resolved by the existing `isManagerOf`) is permitted to `issue:mutate` that report's issue, mirroring the allowance that already exists for `tasks:manage_active_checkouts`.
> - The benefit is that managers (and the CEO, transitively) can comment on and make lightweight review edits to their reports' issues directly, while peers, report→manager, and unrelated cross-agent writes stay denied — the boundary is widened only along the existing management line.

## Linked Issues or Issue Description

No public GitHub issue exists (tracked internally). Describing the problem in-PR (feature path):

**Problem.** Agents are arranged in a reporting hierarchy. A manager that has a
direct line over a report can already assign tasks to that report, but the
authorization boundary rejects cross-agent **comments** and **PATCHes** on the
report's issues with `403 "outside this actor's authorization boundary"`. The
practical effect: a manager cannot leave inline review notes on a direct
report's ticket — the only workaround is to spawn a child issue per review
comment, which is friction that compounds as a team scales.

**Desired behavior.** Allow an agent to comment on and PATCH issues assigned to
their direct/indirect reports (the manager→report relationship defined by the
reporting chain), without granting blanket cross-agent write access. Keep the
boundary tight everywhere else (no peer→peer, no report→manager, no unrelated
cross-agent writes).

## What Changed

- `server/src/services/authorization.ts`: in `decide()`, the agent-actor
  `issue:mutate` branch now returns `allow` with reason `allow_manager_chain`
  when the actor is the manager-of-record of the issue assignee
  (`isManagerOf(companyId, actorAgentId, assigneeAgentId)`), after the existing
  `allow_self` (owns the issue) and unassigned-issue allowances. No new types,
  fields, or imports — it reuses the existing `isManagerOf` helper and the
  `allow_manager_chain` reason already used by the `tasks:manage_active_checkouts`
  allowance.
- `server/src/__tests__/authorization-service.test.ts`: four targeted unit
  tests covering manager allowed, peer denied, report→manager denied, and
  top-of-chain (CEO) → indirect-report allowed.

**Why one change covers both comment and PATCH:** the comment create route
(`POST /api/issues/:id/comments`) and the issue update route
(`PATCH /api/issues/:id`) both gate agent writes through the same
`assertAgentIssueMutationAllowed` helper in `server/src/routes/issues.ts`. That
helper first runs the boundary decision (`access.decide(..., "issue:mutate")`),
which is where managers were being rejected. Its secondary check
(`hasActiveCheckoutManagementOverride` → `tasks:manage_active_checkouts`) already
permits managers, so fixing the boundary decision is sufficient to unblock both
routes.

## Verification

Run from the repo root (the authorization tests use embedded Postgres):

```
# Targeted authorization unit tests (this change)
cd server && pnpm exec vitest run src/__tests__/authorization-service.test.ts
# => Test Files 1 passed (1), Tests 26 passed (26)  [22 pre-existing + 4 new]

# Route-layer regression for the shared mutation gate
cd server && pnpm exec vitest run \
  src/__tests__/issue-agent-mutation-ownership-routes.test.ts \
  src/__tests__/issue-comment-reopen-routes.test.ts
# => Test Files 2 passed (2), Tests 108 passed (108)

# Server typecheck
pnpm --filter @paperclipai/server typecheck    # tsc --noEmit => clean, exit 0
```

New tests and the decisions they assert:
- `allows a manager-of-record to mutate a direct report's issue for inline review` → `allow_manager_chain`
- `denies a peer agent mutating another agent's issue (boundary not over-widened)` → `deny_missing_grant`
- `denies a report mutating its manager's issue (manager->report only, not the reverse)` → `deny_missing_grant`
- `allows a top-of-chain manager (CEO) to mutate an indirect report's issue` → `allow_manager_chain`

## Risks

Low risk. The change is additive and scoped strictly to the manager→report
relationship already encoded in `reportsTo`:

- Only an ancestor of the assignee in the reporting chain is allowed; peers,
  report→manager, and unrelated cross-agent writes still hit the existing
  `deny_missing_grant` (covered by tests).
- No schema/migration changes; no change to the board, user, low-trust, or
  grant code paths. The mutation route's existing checkout/ownership semantics
  are unchanged — a manager already had the equivalent reach via
  `tasks:manage_active_checkouts`, which this aligns the `issue:mutate` boundary
  with.
- Transitive reach (CEO → any report) is intentional and matches how
  `isManagerOf`/`isAgentInSubtree` already resolve management for
  `tasks:manage_active_checkouts`.

## Model Used

Claude (Anthropic) — model `claude-opus-4.8` (exact provider model ID
`github-copilot/claude-opus-4.8`), used with tool use / code execution in an
agentic CLI harness to investigate the codebase, implement the change, and run
the test suite. Extended reasoning enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm once CI runs on the PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending automated review)
- [x] I will address all Greptile and reviewer comments before requesting merge