### PR TITLE
test(ui): stabilize IssueProperties model-options assertion

### DIFF
--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -1059,9 +1059,13 @@ describe("IssueProperties", () => {
     expect(container.textContent).toContain("Custom · gpt-5.4 · high");
     expect(container.textContent).toContain("Model lane");
 
-    const modelButton = Array.from(container.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("GPT-5.5"));
-    expect(modelButton).not.toBeUndefined();
+    // Wait for the adapter-models query to resolve so the model options render.
+    let modelButton: HTMLButtonElement | undefined;
+    await waitForAssertion(() => {
+      modelButton = Array.from(container.querySelectorAll("button"))
+        .find((button) => button.textContent?.includes("GPT-5.5"));
+      expect(modelButton).not.toBeUndefined();
+    });
 
     await act(async () => {
       modelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The board UI test suite protects issue editing behavior, including assignee model options in `IssueProperties`.
> - A Storybook-related dependency bump exposed a brittle async wait in one `IssueProperties` test.
> - The test was waiting for model options with a fixed number of flush ticks instead of waiting for the React Query-backed options to render.
> - This pull request makes that lookup use the existing polling assertion helper used elsewhere in the same file.
> - The benefit is that the test now tracks the UI state it actually needs, without changing product behavior.

## Linked Issues or Issue Description

Refs #7746

Bug fix:

- What happened: after the `@storybook/react-vite` 10.4.2 update path, the `IssueProperties` test `edits existing custom assignee model options from the properties pane` could fail while looking for the `GPT-5.5` model option.
- Expected behavior: the test should wait for the async adapter-model options to render before interacting with them.
- Steps to reproduce: run `cd ui && pnpm vitest run src/components/IssueProperties.test.tsx` against the affected dependency state.
- Paperclip version/commit: based on `0936990a58ce819da8fd5e8ceb2e9a5b4d4a70ad`.
- Deployment mode: local development test run; no runtime deployment mode involved.

## What Changed

- Replaced the fixed-tick model-button lookup in `IssueProperties.test.tsx` with the existing `waitForAssertion` helper.
- Left application code unchanged; this is a test-only stabilization.

## Verification

- `cd ui && pnpm vitest run src/components/IssueProperties.test.tsx` -> 1 test file passed, 25 tests passed.

## Risks

Low risk. The change only affects a test wait path and uses an existing helper already used elsewhere in the same test file. The main risk is masking a real missing-option regression, but the assertion still requires the `GPT-5.5` button to render before the test can continue.

## Model Used

OpenAI Codex based on GPT-5, with code editing, terminal command execution, Git/GitHub CLI operation, and repository context inspection capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge