### PR TITLE
fix(server): capture rawBody for form-encoded webhooks and bound plugin event dedup

### DIFF
--- a/server/src/__tests__/plugin-event-dedup.test.ts
+++ b/server/src/__tests__/plugin-event-dedup.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildHostServices } from "../services/plugin-host-services.js";
+
+const warn = vi.fn();
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    warn: (...args: unknown[]) => warn(...args),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    child: () => ({ warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() }),
+  },
+}));
+
+/**
+ * Fake event bus that records every handler registered through
+ * `forPlugin().subscribe()`. Tests drive delivery by invoking the captured
+ * handlers directly, simulating the real bus fanning a single domain event out
+ * to every matching subscription for the plugin.
+ */
+function createEventBus(handlers: Array<(event: unknown) => Promise<void>>) {
+  return {
+    forPlugin() {
+      return {
+        emit: vi.fn(),
+        clear: vi.fn(),
+        subscribe: (_pattern: unknown, filterOrHandler: unknown, maybeHandler?: unknown) => {
+          const handler = (typeof maybeHandler === "function" ? maybeHandler : filterOrHandler) as (
+            event: unknown,
+          ) => Promise<void>;
+          handlers.push(handler);
+        },
+      };
+    },
+  } as never;
+}
+
+function makeEvent(eventId: string | undefined) {
+  return {
+    eventId,
+    eventType: "issue.created",
+    occurredAt: "2026-06-19T00:00:00.000Z",
+    companyId: "company-1",
+    payload: {},
+  };
+}
+
+describe("plugin event delivery deduplication", () => {
+  it("notifies the worker once when overlapping subscriptions match the same event", async () => {
+    const handlers: Array<(event: unknown) => Promise<void>> = [];
+    const notifyWorker = vi.fn();
+    const services = buildHostServices(
+      {} as never,
+      "plugin-record-id",
+      "acme.slack",
+      createEventBus(handlers),
+      notifyWorker,
+    );
+
+    // A plugin that registers two ctx.events.on("issue.created", ...) handlers.
+    await services.events.subscribe({ eventPattern: "issue.created" });
+    await services.events.subscribe({ eventPattern: "issue.created" });
+    expect(handlers).toHaveLength(2);
+
+    // The bus fans one event out to both subscriptions.
+    const event = makeEvent("evt-1");
+    for (const handler of handlers) await handler(event);
+
+    expect(notifyWorker).toHaveBeenCalledTimes(1);
+    expect(notifyWorker).toHaveBeenCalledWith("onEvent", { event });
+
+    services.dispose();
+  });
+
+  it("notifies the worker once per distinct eventId", async () => {
+    const handlers: Array<(event: unknown) => Promise<void>> = [];
+    const notifyWorker = vi.fn();
+    const services = buildHostServices(
+      {} as never,
+      "plugin-record-id",
+      "acme.slack",
+      createEventBus(handlers),
+      notifyWorker,
+    );
+
+    await services.events.subscribe({ eventPattern: "issue.created" });
+    await services.events.subscribe({ eventPattern: "issue.created" });
+
+    for (const handler of handlers) await handler(makeEvent("evt-1"));
+    for (const handler of handlers) await handler(makeEvent("evt-2"));
+
+    expect(notifyWorker).toHaveBeenCalledTimes(2);
+
+    services.dispose();
+  });
+
+  it("does not deduplicate events that carry no eventId, and warns once", async () => {
+    warn.mockClear();
+    const handlers: Array<(event: unknown) => Promise<void>> = [];
+    const notifyWorker = vi.fn();
+    const services = buildHostServices(
+      {} as never,
+      "plugin-record-id",
+      "acme.slack",
+      createEventBus(handlers),
+      notifyWorker,
+    );
+
+    await services.events.subscribe({ eventPattern: "issue.created" });
+    await services.events.subscribe({ eventPattern: "issue.created" });
+
+    // Two deliveries of an eventId-less event cannot be collapsed.
+    for (const handler of handlers) await handler(makeEvent(undefined));
+
+    expect(notifyWorker).toHaveBeenCalledTimes(2);
+    // The gap is surfaced exactly once, not on every delivery.
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    services.dispose();
+  });
+});

--- a/server/src/__tests__/webhook-rawbody-urlencoded.test.ts
+++ b/server/src/__tests__/webhook-rawbody-urlencoded.test.ts
@@ -1,0 +1,74 @@
+import { createHmac } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the body-parser wiring in `server/src/app.ts`. Slack signs the *raw*
+ * request body and sends slash commands / interactivity as
+ * application/x-www-form-urlencoded. Before the urlencoded parser was added,
+ * only express.json() captured `req.rawBody`, so form-encoded webhooks left it
+ * undefined and HMAC signature verification ran against an empty buffer and
+ * always failed (mvanhorn/paperclip-plugin-slack#19).
+ *
+ * This mirrors the exact middleware order app.ts installs: json first, then
+ * urlencoded, both sharing one captureRawBody verify callback.
+ */
+function buildApp() {
+  const app = express();
+  const captureRawBody = (req: express.Request, _res: express.Response, buf: Buffer) => {
+    (req as unknown as { rawBody: Buffer }).rawBody = buf;
+  };
+  app.use(express.json({ verify: captureRawBody }));
+  app.use(express.urlencoded({ extended: false, verify: captureRawBody }));
+  app.post("/hook", (req, res) => {
+    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    res.json({
+      hasRawBody: rawBody !== undefined,
+      rawBody: rawBody ? rawBody.toString("utf8") : null,
+      parsedKeys: Object.keys(req.body ?? {}),
+    });
+  });
+  return app;
+}
+
+const SLACK_SECRET = "test-signing-secret";
+
+function slackSignature(timestamp: string, rawBody: string) {
+  const base = `v0:${timestamp}:${rawBody}`;
+  return `v0=${createHmac("sha256", SLACK_SECRET).update(base).digest("hex")}`;
+}
+
+describe("webhook raw body capture", () => {
+  it("captures rawBody for application/x-www-form-urlencoded so Slack HMAC verifies", async () => {
+    const formBody = "token=abc&command=%2Fclip&text=help&team_id=T123";
+    const timestamp = "1700000000";
+    const signature = slackSignature(timestamp, formBody);
+
+    const res = await request(buildApp())
+      .post("/hook")
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .set("X-Slack-Request-Timestamp", timestamp)
+      .set("X-Slack-Signature", signature)
+      .send(formBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.hasRawBody).toBe(true);
+    expect(res.body.rawBody).toBe(formBody);
+    // The captured rawBody reproduces Slack's signature exactly.
+    expect(slackSignature(timestamp, res.body.rawBody)).toBe(signature);
+    // The form is still parsed into req.body for handlers that want it.
+    expect(res.body.parsedKeys).toEqual(["token", "command", "text", "team_id"]);
+  });
+
+  it("still captures rawBody for application/json (no regression)", async () => {
+    const res = await request(buildApp())
+      .post("/hook")
+      .set("Content-Type", "application/json")
+      .send({ hello: "world" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.hasRawBody).toBe(true);
+    expect(JSON.parse(res.body.rawBody)).toEqual({ hello: "world" });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -174,6 +174,20 @@ export async function createApp(
     limit: DEFAULT_JSON_BODY_LIMIT,
     verify: captureRawBody,
   }));
+  // Capture rawBody for form-encoded requests (e.g. Slack slash commands and
+  // interactivity payloads). express.json() only runs for application/json, so
+  // without this middleware req.rawBody stays undefined for
+  // application/x-www-form-urlencoded bodies — and any HMAC signature check
+  // (Slack signs the raw form body) then verifies against an empty buffer and
+  // always fails. extended: false uses the built-in querystring parser, which
+  // is sufficient for the flat key/value bodies Slack sends. The two parsers
+  // are mutually exclusive by Content-Type, so reusing captureRawBody never
+  // double-captures. See mvanhorn/paperclip-plugin-slack#19.
+  app.use(express.urlencoded({
+    limit: DEFAULT_JSON_BODY_LIMIT,
+    extended: false,
+    verify: captureRawBody,
+  }));
   app.use(httpLogger);
   const privateHostnameGateEnabled = shouldEnablePrivateHostnameGuard({
     deploymentMode: opts.deploymentMode,

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -487,6 +487,15 @@ if (_logFlushInterval.unref) _logFlushInterval.unref();
 /** Maximum time (ms) to keep a session event subscription alive before forcing cleanup. */
 const SESSION_EVENT_SUBSCRIPTION_TIMEOUT_MS = 30 * 60 * 1_000; // 30 minutes
 
+/** Sliding window for de-duplicating onEvent deliveries to a plugin worker. */
+const EVENT_DEDUP_WINDOW_MS = 10_000; // 10 seconds
+/**
+ * Hard ceiling on the dedup map size. A burst of many unique events within the
+ * window would otherwise let the map grow without bound (it is only pruned by
+ * age when a new id arrives). When exceeded we evict oldest-first.
+ */
+const EVENT_DEDUP_MAX_ENTRIES = 1_000;
+
 export function buildHostServices(
   db: Db,
   pluginId: string,
@@ -544,6 +553,26 @@ export function buildHostServices(
   const budgets = budgetService(db);
   const issueApprovals = issueApprovalService(db);
   const scopedBus = eventBus.forPlugin(pluginKey);
+
+  // Deduplicate onEvent deliveries to the worker. A plugin may register multiple
+  // ctx.events.on() handlers for the same event pattern (e.g. one for
+  // notifications and one for watch-storage). Each ctx.events.on() creates an
+  // independent server-side subscription whose handler calls
+  // notifyWorker("onEvent"). Without deduplication the worker receives N copies
+  // of the same event (one per matching subscription) and re-dispatches all M of
+  // its locally registered callbacks each time — N×M invocations instead of M.
+  // Symptom: a Slack plugin with two issue.created subscriptions posted two
+  // notifications per issue.
+  //
+  // We remember recently-delivered eventIds and skip duplicate notifyWorker
+  // calls within EVENT_DEDUP_WINDOW_MS. The map is pruned by age and hard-capped
+  // at EVENT_DEDUP_MAX_ENTRIES (evicting oldest-first — Map preserves insertion
+  // order) so a burst of unique events cannot grow it without bound.
+  const recentEventIds = new Map<string, number>(); // eventId -> deliveredAt (ms)
+  // Events without an eventId cannot be deduplicated and will still fan out
+  // N×M across overlapping subscriptions. Warn once per plugin host rather than
+  // on every delivery so the gap is visible without flooding the logs.
+  let warnedMissingEventId = false;
 
   // Track active session event subscriptions for cleanup
   const activeSubscriptions = new Set<{ unsubscribe: () => void; timer: ReturnType<typeof setTimeout> }>();
@@ -1207,9 +1236,34 @@ export function buildHostServices(
       },
       async subscribe(params: { eventPattern: string; filter?: Record<string, unknown> | null }) {
         const handler = async (event: import("@paperclipai/plugin-sdk").PluginEvent) => {
-          if (notifyWorker) {
-            notifyWorker("onEvent", { event });
+          if (!notifyWorker) return;
+          if (event.eventId) {
+            const now = Date.now();
+            if (recentEventIds.has(event.eventId)) {
+              return; // Already delivered to the worker via another subscription.
+            }
+            recentEventIds.set(event.eventId, now);
+            // Prune entries that have aged out of the dedup window.
+            for (const [id, ts] of recentEventIds) {
+              if (now - ts > EVENT_DEDUP_WINDOW_MS) recentEventIds.delete(id);
+              else break; // Insertion order ⇒ remaining entries are newer.
+            }
+            // Hard cap: evict oldest-first if a burst of unique ids outpaced
+            // age-based pruning, so the map can never grow without bound.
+            while (recentEventIds.size > EVENT_DEDUP_MAX_ENTRIES) {
+              const oldest = recentEventIds.keys().next().value;
+              if (oldest === undefined) break;
+              recentEventIds.delete(oldest);
+            }
+          } else if (!warnedMissingEventId) {
+            warnedMissingEventId = true;
+            logger.warn(
+              { pluginId, pluginKey, eventPattern: params.eventPattern },
+              "Plugin event has no eventId; deliveries cannot be de-duplicated and " +
+                "may fan out across overlapping subscriptions. Ensure event sources set eventId.",
+            );
           }
+          notifyWorker("onEvent", { event });
         };
         if (params.filter) {
           scopedBus.subscribe(params.eventPattern as any, params.filter as any, handler);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work, and plugins extend it by receiving inbound webhooks and domain events.
> - The webhook ingress lives in `server/src/app.ts` (body parsing + raw-body capture) and event fan-out to plugin workers lives in `server/src/services/plugin-host-services.ts`.
> - Two bugs break the Slack plugin (and any form-encoded or multi-subscription plugin): inbound Slack webhooks fail HMAC verification, and a plugin with overlapping event subscriptions receives each event multiple times.
> - Root causes: `express.json()` is the only parser that records `req.rawBody`, so it is never set for `application/x-www-form-urlencoded`; and each `ctx.events.on()` creates an independent server-side subscription that separately notifies the worker for the same event.
> - This PR adds an `express.urlencoded()` parser sharing the same `captureRawBody` verify, and deduplicates worker notifications by `eventId`.
> - The benefit is that Slack slash commands / interactivity verify and respond correctly, and plugins stop firing duplicate side effects (e.g. double notifications) — with a dedup cache that is explicitly bounded so it is safe under event bursts.

## Linked Issues or Issue Description

Supersedes #3712 (by @riptex) — same two fixes, with the review feedback from that PR applied (bounded dedup map, `extended: false`, eventId-less warning, and tests). Credit to @riptex for the original diagnosis.

`Fixes mvanhorn/paperclip-plugin-slack#19` — "Slack signature verification always fails — `req.rawBody` undefined for form-urlencoded requests (Paperclip core bug)".

Related prior attempts at the webhook half: #3349 and #3147 (both currently conflicting).

No tracking issue exists in this repo for the duplicate-delivery bug, so it is described in full below per the bug template:

> **Bug:** A plugin that registers more than one `ctx.events.on()` handler for the same event pattern (e.g. one for notifications, one for watch-storage) receives N copies of every matching event.
> **Expected:** The worker is notified once per event; it then dispatches to all of its locally registered handlers.
> **Actual:** Each of the N server-side subscriptions independently calls `notifyWorker("onEvent")`, so the worker is notified N times and re-dispatches all M handlers each time → N×M invocations. Observed as the Slack plugin posting two notifications per issue when it held two `issue.created` subscriptions.
> **Environment:** `server/src/services/plugin-host-services.ts`, any plugin with overlapping subscriptions.

## What Changed

- **`server/src/app.ts`** — Add `express.urlencoded({ extended: false, verify: captureRawBody })` immediately after `express.json()`, reusing the existing `captureRawBody` helper. The two parsers are mutually exclusive by `Content-Type`, so `rawBody` is captured for form-encoded bodies without ever double-capturing. `extended: false` (the built-in `querystring` parser) is sufficient for Slack's flat key/value payloads.
- **`server/src/services/plugin-host-services.ts`** — Deduplicate `notifyWorker("onEvent")` calls by `event.eventId` within a 10s sliding window. The dedup map is pruned by age and **hard-capped at `EVENT_DEDUP_MAX_ENTRIES` (1000), evicting oldest-first**, so a burst of unique events cannot grow it without bound. Events with no `eventId` cannot be deduplicated, are still forwarded, and now emit a **one-time warning** so the gap is observable.
- **Tests** —
  - `server/src/__tests__/webhook-rawbody-urlencoded.test.ts`: asserts `rawBody` is captured for `application/x-www-form-urlencoded` and reproduces a real Slack v0 HMAC signature over it, plus a no-regression check for `application/json`.
  - `server/src/__tests__/plugin-event-dedup.test.ts`: asserts overlapping subscriptions collapse to one delivery, distinct `eventId`s each deliver, and eventId-less events are forwarded with a single warning.

## Verification

```bash
cd server
npx vitest run \
  src/__tests__/webhook-rawbody-urlencoded.test.ts \
  src/__tests__/plugin-event-dedup.test.ts
# 2 files, 5 tests passed
tsc --noEmit            # exit 0
```

Existing host-services suites still pass (no regression):

```bash
npx vitest run \
  src/__tests__/plugin-telemetry-bridge.test.ts \
  src/__tests__/plugin-tenant-isolation.test.ts \
  src/__tests__/plugin-access-authorization-host-services.test.ts
# 17 tests passed
```

Manually verified on a live instance: Slack `/clip` slash command, URL verification, and interactivity all pass signature verification once the rawBody fix is in place; the Slack plugin posts one notification per issue with the dedup fix.

## Risks

Low risk, additive and localized.
- The urlencoded parser only runs for `application/x-www-form-urlencoded`; JSON and all other content types are unaffected. `captureRawBody` is reused unchanged.
- Event dedup only suppresses *duplicate* deliveries of the **same** `eventId` to the **same** plugin host within 10s. Distinct events and eventId-less events are always delivered. The dedup state is per-host (per worker), in-memory, and bounded — no persistence, no cross-plugin interaction.
- No schema, migration, or public API changes.

## Model Used

AI-assisted (Opus 4.8 High). All changes were human-reviewed, type-checked with `tsc --noEmit`, and covered by the new tests above; no code was committed without review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (rawBody/Slack: #3712 superseded, #3349 / #3147 related, #3347 closed; event dedup: no existing PR)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI change
- [x] I have updated relevant documentation to reflect my changes (code comments document the new bounds; no separate docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending CI run on this PR
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending review
- [x] I will address all Greptile and reviewer comments before requesting merge

