### PR TITLE
Harden telemetry privacy boundaries

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -832,6 +832,19 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `agent.sessions.send`
 - `agent.sessions.close`
 
+### Telemetry privacy
+
+`telemetry.track` is an external telemetry egress capability. Plugin telemetry
+dimensions are fail-closed at the host boundary: safe dimensions are limited to
+bounded primitive counts, booleans, and short low-cardinality slug strings. Raw
+identifiers, emails, URLs, paths, tokens, prompts, messages, names, and
+free-form text are rejected before egress.
+
+Stable/private references must use the hashed private-ref path exposed by the
+SDK (`ctx.telemetry.track(event, dimensions, privateRefs)`). The host hashes raw
+refs with `TelemetryClient.hashPrivateRef()` and forwards only `<key>_hashed`
+and `<key>_is_hashed: true` dimensions.
+
 ### Plugin State
 
 - `plugin.state.read`

--- a/packages/plugins/examples/plugin-kitchen-sink-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-kitchen-sink-example/src/worker.ts
@@ -407,7 +407,7 @@ async function registerActionHandlers(ctx: PluginContext): Promise<void> {
     await ctx.metrics.write("demo.events.emitted", 1, { source: "manual" });
     await ctx.telemetry.track("demo_event", {
       source: "manual",
-      has_company: Boolean(companyId),
+      configured: Boolean(companyId),
     });
     pushRecord({
       level: "info",

--- a/packages/plugins/sdk/README.md
+++ b/packages/plugins/sdk/README.md
@@ -372,6 +372,26 @@ Declare in `manifest.capabilities`. Grouped by scope:
 
 Full list in code: import `PLUGIN_CAPABILITIES` from `@paperclipai/plugin-sdk`.
 
+### Plugin telemetry privacy contract
+
+Plugins with `telemetry.track` may emit only low-cardinality primitive
+dimensions: bounded numbers, booleans, and short slug-like enum/status strings.
+Raw identifiers, emails, URLs, file paths, tokens, prompts, messages, names, and
+other free-form text are rejected by the host before telemetry egress.
+
+Stable or private references must be passed as the third `privateRefs` argument:
+
+```ts
+await ctx.telemetry.track(
+  "sync_completed",
+  { source: "manual", success: true },
+  { company_id: companyId },
+);
+```
+
+The host hashes each private ref with the instance telemetry salt and forwards
+only `<key>_hashed` plus `<key>_is_hashed: true` dimensions.
+
 ### Restricted Database Namespace
 
 Trusted orchestration plugins can declare a host-owned PostgreSQL namespace:

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -846,7 +846,11 @@ export interface WorkerToHostMethods {
 
   // Telemetry
   "telemetry.track": [
-    params: { eventName: string; dimensions?: Record<string, string | number | boolean> },
+    params: {
+      eventName: string;
+      dimensions?: Record<string, string | number | boolean>;
+      privateRefs?: Record<string, string>;
+    },
     result: void,
   ];
 

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -128,7 +128,11 @@ export interface TestHarness {
   logs: TestHarnessLogEntry[];
   activity: Array<{ message: string; entityType?: string; entityId?: string; metadata?: Record<string, unknown> }>;
   metrics: Array<{ name: string; value: number; tags?: Record<string, string> }>;
-  telemetry: Array<{ eventName: string; dimensions?: Record<string, string | number | boolean> }>;
+  telemetry: Array<{
+    eventName: string;
+    dimensions?: Record<string, string | number | boolean>;
+    privateRefs?: Record<string, string>;
+  }>;
   dbQueries: Array<{ sql: string; params?: unknown[] }>;
   dbExecutes: Array<{ sql: string; params?: unknown[] }>;
 }
@@ -2301,9 +2305,9 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
     },
     telemetry: {
-      async track(eventName, dimensions) {
+      async track(eventName, dimensions, privateRefs) {
         requireCapability(manifest, capabilitySet, "telemetry.track");
-        telemetry.push({ eventName, dimensions });
+        telemetry.push({ eventName, dimensions, privateRefs });
       },
     },
     logger: {

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -1033,6 +1033,12 @@ export interface PluginMetricsClient {
   write(name: string, value: number, tags?: Record<string, string>): Promise<void>;
 }
 
+export type PluginTelemetryDimensionValue = string | number | boolean;
+
+export type PluginTelemetryDimensions = Record<string, PluginTelemetryDimensionValue>;
+
+export type PluginTelemetryPrivateRefs = Record<string, string>;
+
 /**
  * `ctx.telemetry` — emit plugin-scoped telemetry to the host's external
  * telemetry pipeline.
@@ -1044,14 +1050,18 @@ export interface PluginTelemetryClient {
    * Track a plugin telemetry event.
    *
    * The host prefixes the final event name as `plugin.<pluginId>.<eventName>`
-   * before forwarding it to the shared telemetry client.
+   * before forwarding it to the shared telemetry client. Dimension keys and
+   * values must be low-cardinality primitives; stable/private identifiers must
+   * be sent through `privateRefs` so the host hashes them before egress.
    *
    * @param eventName - Bare plugin event slug (for example `"sync_completed"`)
-   * @param dimensions - Optional structured dimensions
+   * @param dimensions - Optional safe primitive dimensions
+   * @param privateRefs - Optional raw private references to hash server-side
    */
   track(
     eventName: string,
-    dimensions?: Record<string, string | number | boolean>,
+    dimensions?: PluginTelemetryDimensions,
+    privateRefs?: PluginTelemetryPrivateRefs,
   ): Promise<void>;
 }
 

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -1255,8 +1255,9 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
         async track(
           eventName: string,
           dimensions?: Record<string, string | number | boolean>,
+          privateRefs?: Record<string, string>,
         ): Promise<void> {
-          await callHost("telemetry.track", { eventName, dimensions });
+          await callHost("telemetry.track", { eventName, dimensions, privateRefs });
         },
       },
 

--- a/packages/shared/src/telemetry/events.ts
+++ b/packages/shared/src/telemetry/events.ts
@@ -1,5 +1,14 @@
 import type { TelemetryClient } from "./client.js";
 
+function hashedAgentIdDimensions(
+  client: TelemetryClient,
+  agentId: string | undefined,
+): { agent_id_hashed: string; agent_id_is_hashed: true } | Record<string, never> {
+  return agentId
+    ? { agent_id_hashed: client.hashPrivateRef(agentId), agent_id_is_hashed: true }
+    : {};
+}
+
 export function trackInstallStarted(client: TelemetryClient): void {
   client.track("install.started");
 }
@@ -54,9 +63,7 @@ export function trackAgentCreated(
 ): void {
   client.track("agent.created", {
     agent_role: dims.agentRole,
-    ...(dims.agentId
-      ? { agent_id_hashed: client.hashPrivateRef(dims.agentId), agent_id_is_hashed: true }
-      : {}),
+    ...hashedAgentIdDimensions(client, dims.agentId),
   });
 }
 
@@ -76,9 +83,7 @@ export function trackAgentFirstHeartbeat(
 ): void {
   client.track("agent.first_heartbeat", {
     agent_role: dims.agentRole,
-    ...(dims.agentId
-      ? { agent_id_hashed: client.hashPrivateRef(dims.agentId), agent_id_is_hashed: true }
-      : {}),
+    ...hashedAgentIdDimensions(client, dims.agentId),
   });
 }
 
@@ -88,9 +93,7 @@ export function trackAgentTaskCompleted(
 ): void {
   client.track("agent.task_completed", {
     agent_role: dims.agentRole,
-    ...(dims.agentId
-      ? { agent_id_hashed: client.hashPrivateRef(dims.agentId), agent_id_is_hashed: true }
-      : {}),
+    ...hashedAgentIdDimensions(client, dims.agentId),
     ...(dims.adapterType ? { adapter_type: dims.adapterType } : {}),
     ...(dims.model ? { model: dims.model } : {}),
   });

--- a/packages/shared/src/telemetry/events.ts
+++ b/packages/shared/src/telemetry/events.ts
@@ -54,7 +54,9 @@ export function trackAgentCreated(
 ): void {
   client.track("agent.created", {
     agent_role: dims.agentRole,
-    ...(dims.agentId ? { agent_id: dims.agentId } : {}),
+    ...(dims.agentId
+      ? { agent_id_hashed: client.hashPrivateRef(dims.agentId), agent_id_is_hashed: true }
+      : {}),
   });
 }
 
@@ -74,7 +76,9 @@ export function trackAgentFirstHeartbeat(
 ): void {
   client.track("agent.first_heartbeat", {
     agent_role: dims.agentRole,
-    ...(dims.agentId ? { agent_id: dims.agentId } : {}),
+    ...(dims.agentId
+      ? { agent_id_hashed: client.hashPrivateRef(dims.agentId), agent_id_is_hashed: true }
+      : {}),
   });
 }
 
@@ -84,7 +88,9 @@ export function trackAgentTaskCompleted(
 ): void {
   client.track("agent.task_completed", {
     agent_role: dims.agentRole,
-    ...(dims.agentId ? { agent_id: dims.agentId } : {}),
+    ...(dims.agentId
+      ? { agent_id_hashed: client.hashPrivateRef(dims.agentId), agent_id_is_hashed: true }
+      : {}),
     ...(dims.adapterType ? { adapter_type: dims.adapterType } : {}),
     ...(dims.model ? { model: dims.model } : {}),
   });

--- a/server/src/__tests__/plugin-telemetry-bridge.test.ts
+++ b/server/src/__tests__/plugin-telemetry-bridge.test.ts
@@ -25,16 +25,20 @@ describe("plugin telemetry bridge", () => {
     mockGetTelemetryClient.mockReset();
   });
 
-  it("prefixes plugin telemetry events before forwarding them to the telemetry client", async () => {
-    const track = vi.fn();
-    mockGetTelemetryClient.mockReturnValue({ track });
-
-    const services = buildHostServices(
+  function createTelemetryServices() {
+    return buildHostServices(
       {} as never,
       "plugin-record-id",
       "linear",
       createEventBusStub(),
     );
+  }
+
+  it("prefixes plugin telemetry events before forwarding them to the telemetry client", async () => {
+    const track = vi.fn();
+    mockGetTelemetryClient.mockReturnValue({ track });
+
+    const services = createTelemetryServices();
     const handlers = createHostClientHandlers({
       pluginId: "linear",
       capabilities: ["telemetry.track"],
@@ -55,12 +59,7 @@ describe("plugin telemetry bridge", () => {
   it("rejects invalid bare telemetry event names before prefixing", async () => {
     mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
 
-    const services = buildHostServices(
-      {} as never,
-      "plugin-record-id",
-      "linear",
-      createEventBusStub(),
-    );
+    const services = createTelemetryServices();
 
     await expect(
       services.telemetry.track({ eventName: "sync.completed" }),
@@ -70,12 +69,7 @@ describe("plugin telemetry bridge", () => {
   });
 
   it("rejects telemetry tracking when the plugin lacks the capability", async () => {
-    const services = buildHostServices(
-      {} as never,
-      "plugin-record-id",
-      "linear",
-      createEventBusStub(),
-    );
+    const services = createTelemetryServices();
     const handlers = createHostClientHandlers({
       pluginId: "linear",
       capabilities: [],
@@ -92,12 +86,7 @@ describe("plugin telemetry bridge", () => {
   });
 
   it("passes telemetry requests through when the plugin declares the capability", async () => {
-    const services = buildHostServices(
-      {} as never,
-      "plugin-record-id",
-      "linear",
-      createEventBusStub(),
-    );
+    const services = createTelemetryServices();
     const handlers = createHostClientHandlers({
       pluginId: "linear",
       capabilities: ["telemetry.track"],
@@ -110,5 +99,103 @@ describe("plugin telemetry bridge", () => {
     });
 
     expect(mockGetTelemetryClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects raw private dimension keys before telemetry egress", async () => {
+    const track = vi.fn();
+    mockGetTelemetryClient.mockReturnValue({ track });
+    const services = createTelemetryServices();
+    const rejectedKeys = [
+      "company_id",
+      "agentId",
+      "issue_url",
+      "email",
+      "token",
+      "path",
+      "prompt",
+      "message",
+      "userid",
+      "companyid",
+      "hostname",
+    ];
+
+    for (const key of rejectedKeys) {
+      await expect(
+        services.telemetry.track({
+          eventName: "sync_completed",
+          dimensions: { [key]: "manual" },
+        }),
+      ).rejects.toThrow(/Plugin telemetry dimension|lowercase snake_case/);
+    }
+
+    expect(mockGetTelemetryClient).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("rejects suspicious dimension values before telemetry egress", async () => {
+    const track = vi.fn();
+    mockGetTelemetryClient.mockReturnValue({ track });
+    const services = createTelemetryServices();
+    const rejectedValues = [
+      "2f3f5a65-48c8-42f8-967e-b67d4e77f1d2",
+      "user@example.com",
+      "https://example.com/issues/123",
+      "/tmp/paperclip/workspace",
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ",
+      "0123456789abcdef0123456789abcdef",
+    ];
+
+    for (const value of rejectedValues) {
+      await expect(
+        services.telemetry.track({
+          eventName: "sync_completed",
+          dimensions: { source: value },
+        }),
+      ).rejects.toThrow(/must be a short low-cardinality slug|must be 1-64 characters/);
+    }
+
+    expect(mockGetTelemetryClient).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("hashes declared private refs server-side before forwarding telemetry", async () => {
+    const track = vi.fn();
+    const hashPrivateRef = vi.fn((value: string) => `hashed-${value}`);
+    mockGetTelemetryClient.mockReturnValue({ track, hashPrivateRef });
+    const services = createTelemetryServices();
+
+    await services.telemetry.track({
+      eventName: "sync_completed",
+      dimensions: { source: "manual", attempts: 2, success: true },
+      privateRefs: { company_id: "company-123" },
+    });
+
+    expect(hashPrivateRef).toHaveBeenCalledWith("company-123");
+    expect(track).toHaveBeenCalledWith("plugin.linear.sync_completed", {
+      source: "manual",
+      attempts: 2,
+      success: true,
+      company_id_hashed: "hashed-company-123",
+      company_id_is_hashed: true,
+    });
+  });
+
+  it("rejects telemetry events with too many outgoing dimensions", async () => {
+    const track = vi.fn();
+    mockGetTelemetryClient.mockReturnValue({ track });
+    const services = createTelemetryServices();
+    const dimensions = Object.fromEntries(
+      Array.from({ length: 21 }, (_, index) => [`flag_${index}`, true]),
+    );
+
+    await expect(
+      services.telemetry.track({
+        eventName: "sync_completed",
+        dimensions,
+      }),
+    ).rejects.toThrow("Plugin telemetry events may include at most 20 outgoing dimensions.");
+
+    expect(mockGetTelemetryClient).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/plugin-telemetry-bridge.test.ts
+++ b/server/src/__tests__/plugin-telemetry-bridge.test.ts
@@ -132,6 +132,29 @@ describe("plugin telemetry bridge", () => {
     expect(track).not.toHaveBeenCalled();
   });
 
+  it("allows safe dimension keys that contain sensitive substrings inside unrelated words", async () => {
+    const track = vi.fn();
+    mockGetTelemetryClient.mockReturnValue({ track });
+    const services = createTelemetryServices();
+
+    await services.telemetry.track({
+      eventName: "sync_completed",
+      dimensions: {
+        script_type: "manual",
+        zip_code: "enabled",
+        description_mode: "summary",
+        hidden: true,
+      },
+    });
+
+    expect(track).toHaveBeenCalledWith("plugin.linear.sync_completed", {
+      script_type: "manual",
+      zip_code: "enabled",
+      description_mode: "summary",
+      hidden: true,
+    });
+  });
+
   it("rejects suspicious dimension values before telemetry egress", async () => {
     const track = vi.fn();
     mockGetTelemetryClient.mockReturnValue({ track });

--- a/server/src/__tests__/plugin-telemetry-bridge.test.ts
+++ b/server/src/__tests__/plugin-telemetry-bridge.test.ts
@@ -203,6 +203,23 @@ describe("plugin telemetry bridge", () => {
     });
   });
 
+  it("rejects private refs that generate colliding telemetry output keys", async () => {
+    const track = vi.fn();
+    const hashPrivateRef = vi.fn((value: string) => `hashed-${value}`);
+    mockGetTelemetryClient.mockReturnValue({ track, hashPrivateRef });
+    const services = createTelemetryServices();
+
+    await expect(
+      services.telemetry.track({
+        eventName: "sync_completed",
+        privateRefs: { foo: "v1", foo_is: "v2" },
+      }),
+    ).rejects.toThrow('Plugin telemetry private ref "foo_is" collides with existing dimensions.');
+
+    expect(hashPrivateRef).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
   it("rejects telemetry events with too many outgoing dimensions", async () => {
     const track = vi.fn();
     mockGetTelemetryClient.mockReturnValue({ track });

--- a/server/src/__tests__/shared-telemetry-events.test.ts
+++ b/server/src/__tests__/shared-telemetry-events.test.ts
@@ -92,17 +92,25 @@ describe("shared telemetry agent events", () => {
     const client = createClient();
 
     trackAgentCreated(client, { agentRole: "engineer" });
+    trackAgentFirstHeartbeat(client, { agentRole: "coder" });
+    trackAgentTaskCompleted(client, { agentRole: "qa" });
 
-    expect(client.track).toHaveBeenCalledWith("agent.created", {
-      agent_role: "engineer",
-    });
-    expect(client.track).not.toHaveBeenCalledWith(
-      "agent.created",
-      expect.objectContaining({
-        agent_id_hashed: expect.any(String),
-        agent_id_is_hashed: expect.any(Boolean),
-      }),
-    );
+    for (const [eventName, agentRole] of [
+      ["agent.created", "engineer"],
+      ["agent.first_heartbeat", "coder"],
+      ["agent.task_completed", "qa"],
+    ]) {
+      expect(client.track).toHaveBeenCalledWith(eventName, {
+        agent_role: agentRole,
+      });
+      expect(client.track).not.toHaveBeenCalledWith(
+        eventName,
+        expect.objectContaining({
+          agent_id_hashed: expect.any(String),
+          agent_id_is_hashed: expect.any(Boolean),
+        }),
+      );
+    }
     expect(client.hashPrivateRef).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/shared-telemetry-events.test.ts
+++ b/server/src/__tests__/shared-telemetry-events.test.ts
@@ -7,54 +7,103 @@ import {
 } from "@paperclipai/shared/telemetry";
 import type { TelemetryClient } from "@paperclipai/shared/telemetry";
 
+const HASHES_BY_AGENT_ID = new Map([
+  ["11111111-1111-4111-8111-111111111111", "1719c104ec07b03e"],
+  ["22222222-2222-4222-8222-222222222222", "d80e1b8ab30d1931"],
+  ["33333333-3333-4333-8333-333333333333", "24810192f01670c5"],
+]);
+
 function createClient(): TelemetryClient {
   return {
     track: vi.fn(),
-    hashPrivateRef: vi.fn((value: string) => `hashed:${value}`),
+    hashPrivateRef: vi.fn((value: string) => {
+      const hash = HASHES_BY_AGENT_ID.get(value);
+      if (!hash) throw new Error(`Unexpected test agent id: ${value}`);
+      return hash;
+    }),
   } as unknown as TelemetryClient;
 }
 
 describe("shared telemetry agent events", () => {
-  it("includes agent_id for agent.created", () => {
+  it("hashes agent_id for agent.created", () => {
     const client = createClient();
+    const agentId = "11111111-1111-4111-8111-111111111111";
 
     trackAgentCreated(client, {
       agentRole: "engineer",
-      agentId: "11111111-1111-4111-8111-111111111111",
+      agentId,
     });
 
     expect(client.track).toHaveBeenCalledWith("agent.created", {
       agent_role: "engineer",
-      agent_id: "11111111-1111-4111-8111-111111111111",
+      agent_id_hashed: "1719c104ec07b03e",
+      agent_id_is_hashed: true,
     });
+    expect(client.track).not.toHaveBeenCalledWith(
+      "agent.created",
+      expect.objectContaining({ agent_id: agentId }),
+    );
+    expect(client.hashPrivateRef).toHaveBeenCalledWith(agentId);
   });
 
-  it("includes agent_id for agent.first_heartbeat", () => {
+  it("hashes agent_id for agent.first_heartbeat", () => {
     const client = createClient();
+    const agentId = "22222222-2222-4222-8222-222222222222";
 
     trackAgentFirstHeartbeat(client, {
       agentRole: "coder",
-      agentId: "22222222-2222-4222-8222-222222222222",
+      agentId,
     });
 
     expect(client.track).toHaveBeenCalledWith("agent.first_heartbeat", {
       agent_role: "coder",
-      agent_id: "22222222-2222-4222-8222-222222222222",
+      agent_id_hashed: "d80e1b8ab30d1931",
+      agent_id_is_hashed: true,
     });
+    expect(client.track).not.toHaveBeenCalledWith(
+      "agent.first_heartbeat",
+      expect.objectContaining({ agent_id: agentId }),
+    );
+    expect(client.hashPrivateRef).toHaveBeenCalledWith(agentId);
   });
 
-  it("includes agent_id for agent.task_completed", () => {
+  it("hashes agent_id for agent.task_completed", () => {
     const client = createClient();
+    const agentId = "33333333-3333-4333-8333-333333333333";
 
     trackAgentTaskCompleted(client, {
       agentRole: "qa",
-      agentId: "33333333-3333-4333-8333-333333333333",
+      agentId,
     });
 
     expect(client.track).toHaveBeenCalledWith("agent.task_completed", {
       agent_role: "qa",
-      agent_id: "33333333-3333-4333-8333-333333333333",
+      agent_id_hashed: "24810192f01670c5",
+      agent_id_is_hashed: true,
     });
+    expect(client.track).not.toHaveBeenCalledWith(
+      "agent.task_completed",
+      expect.objectContaining({ agent_id: agentId }),
+    );
+    expect(client.hashPrivateRef).toHaveBeenCalledWith(agentId);
+  });
+
+  it("omits agent hash dimensions when agent_id is absent", () => {
+    const client = createClient();
+
+    trackAgentCreated(client, { agentRole: "engineer" });
+
+    expect(client.track).toHaveBeenCalledWith("agent.created", {
+      agent_role: "engineer",
+    });
+    expect(client.track).not.toHaveBeenCalledWith(
+      "agent.created",
+      expect.objectContaining({
+        agent_id_hashed: expect.any(String),
+        agent_id_is_hashed: expect.any(Boolean),
+      }),
+    );
+    expect(client.hashPrivateRef).not.toHaveBeenCalled();
   });
 
   it("keeps non-agent event dimensions unchanged", () => {

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -89,6 +89,167 @@ const DNS_LOOKUP_TIMEOUT_MS = 5_000;
 /** Only these protocols are allowed for plugin HTTP requests. */
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 const TELEMETRY_EVENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/;
+const PLUGIN_TELEMETRY_MAX_DIMENSIONS = 20;
+const PLUGIN_TELEMETRY_MAX_STRING_LENGTH = 64;
+const PLUGIN_TELEMETRY_MAX_PRIVATE_REF_LENGTH = 512;
+const PLUGIN_TELEMETRY_MAX_NUMBER_ABS = 1_000_000_000;
+const PLUGIN_TELEMETRY_DIMENSION_KEY_REGEX = /^[a-z][a-z0-9_]{0,39}$/;
+const PLUGIN_TELEMETRY_SAFE_STRING_REGEX = /^[a-z0-9][a-z0-9_.:-]{0,63}$/;
+const PLUGIN_TELEMETRY_FORBIDDEN_KEY_PARTS = new Set([
+  "id",
+  "uuid",
+  "email",
+  "user",
+  "agent",
+  "company",
+  "project",
+  "issue",
+  "task",
+  "run",
+  "session",
+  "token",
+  "secret",
+  "key",
+  "url",
+  "uri",
+  "path",
+  "ref",
+  "name",
+  "title",
+  "message",
+  "prompt",
+  "content",
+  "query",
+  "search",
+  "ip",
+  "host",
+  "domain",
+]);
+
+type PluginTelemetryDimensionValue = string | number | boolean;
+
+type ValidatedPluginTelemetryInput = {
+  dimensions: Record<string, PluginTelemetryDimensionValue>;
+  privateRefs: Array<{ key: string; value: string }>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normaliseTelemetryKey(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function assertPluginTelemetryKey(key: string, kind: "dimension" | "private ref"): void {
+  if (!PLUGIN_TELEMETRY_DIMENSION_KEY_REGEX.test(key)) {
+    throw new Error(
+      `Plugin telemetry ${kind} keys must be lowercase snake_case slugs up to 40 characters.`,
+    );
+  }
+  if (key.endsWith("_hashed") || key.endsWith("_is_hashed")) {
+    throw new Error(`Plugin telemetry ${kind} keys may not use reserved hash marker suffixes.`);
+  }
+}
+
+function assertSafePluginTelemetryDimensionKey(key: string): void {
+  assertPluginTelemetryKey(key, "dimension");
+  const normalisedKey = normaliseTelemetryKey(key);
+  const parts = normalisedKey.split("_");
+  const forbidden = Array.from(PLUGIN_TELEMETRY_FORBIDDEN_KEY_PARTS).find((part) =>
+    parts.includes(part) || normalisedKey.includes(part),
+  );
+  if (forbidden) {
+    throw new Error(
+      `Plugin telemetry dimension "${key}" is not allowed; send private identifiers through privateRefs so the host can hash them.`,
+    );
+  }
+}
+
+function looksSensitivePluginTelemetryValue(value: string): boolean {
+  return (
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value) ||
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ||
+    /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ||
+    /(^\/|^~\/|^[A-Za-z]:\\|[\\/])/.test(value) ||
+    /^[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}$/.test(value) ||
+    /^[a-f0-9]{32,}$/i.test(value) ||
+    /^[A-Za-z0-9+/_=-]{32,}$/.test(value) ||
+    /^(bearer|sk|pk|ghp|github_pat|glpat|xox[baprs])[-_]/i.test(value)
+  );
+}
+
+function assertSafePluginTelemetryDimensionValue(key: string, value: unknown): PluginTelemetryDimensionValue {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || Math.abs(value) > PLUGIN_TELEMETRY_MAX_NUMBER_ABS) {
+      throw new Error(`Plugin telemetry dimension "${key}" must be a finite bounded number.`);
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    if (value.length === 0 || value.length > PLUGIN_TELEMETRY_MAX_STRING_LENGTH) {
+      throw new Error(
+        `Plugin telemetry string dimension "${key}" must be 1-${PLUGIN_TELEMETRY_MAX_STRING_LENGTH} characters.`,
+      );
+    }
+    if (looksSensitivePluginTelemetryValue(value) || !PLUGIN_TELEMETRY_SAFE_STRING_REGEX.test(value)) {
+      throw new Error(
+        `Plugin telemetry string dimension "${key}" must be a short low-cardinality slug and must not contain identifiers or sensitive data.`,
+      );
+    }
+    return value;
+  }
+  throw new Error(`Plugin telemetry dimension "${key}" must be a string, number, or boolean.`);
+}
+
+function validatePluginTelemetryInput(
+  dimensions: unknown,
+  privateRefs: unknown,
+): ValidatedPluginTelemetryInput {
+  if (dimensions !== undefined && !isRecord(dimensions)) {
+    throw new Error("Plugin telemetry dimensions must be an object when provided.");
+  }
+  if (privateRefs !== undefined && !isRecord(privateRefs)) {
+    throw new Error("Plugin telemetry privateRefs must be an object when provided.");
+  }
+
+  const safeDimensions: Record<string, PluginTelemetryDimensionValue> = {};
+  const privateRefEntries: Array<{ key: string; value: string }> = [];
+  const dimensionEntries = Object.entries(dimensions ?? {});
+  const privateEntries = Object.entries(privateRefs ?? {});
+  const outgoingDimensionCount = dimensionEntries.length + privateEntries.length * 2;
+  if (outgoingDimensionCount > PLUGIN_TELEMETRY_MAX_DIMENSIONS) {
+    throw new Error(
+      `Plugin telemetry events may include at most ${PLUGIN_TELEMETRY_MAX_DIMENSIONS} outgoing dimensions.`,
+    );
+  }
+
+  for (const [key, value] of dimensionEntries) {
+    assertSafePluginTelemetryDimensionKey(key);
+    safeDimensions[key] = assertSafePluginTelemetryDimensionValue(key, value);
+  }
+
+  for (const [key, value] of privateEntries) {
+    assertPluginTelemetryKey(key, "private ref");
+    if (typeof value !== "string" || value.length === 0 || value.length > PLUGIN_TELEMETRY_MAX_PRIVATE_REF_LENGTH) {
+      throw new Error(
+        `Plugin telemetry private ref "${key}" must be a non-empty string up to ${PLUGIN_TELEMETRY_MAX_PRIVATE_REF_LENGTH} characters.`,
+      );
+    }
+    const hashKey = `${key}_hashed`;
+    const markerKey = `${key}_is_hashed`;
+    if (
+      Object.prototype.hasOwnProperty.call(safeDimensions, hashKey) ||
+      Object.prototype.hasOwnProperty.call(safeDimensions, markerKey)
+    ) {
+      throw new Error(`Plugin telemetry private ref "${key}" collides with existing dimensions.`);
+    }
+    privateRefEntries.push({ key, value });
+  }
+
+  return { dimensions: safeDimensions, privateRefs: privateRefEntries };
+}
 
 /**
  * Check if an IP address is in a private/reserved range (RFC 1918, loopback,
@@ -1292,9 +1453,17 @@ export function buildHostServices(
             'Plugin telemetry event names must be lowercase slugs using letters, numbers, "_" or "-".',
           );
         }
+        const telemetryInput = validatePluginTelemetryInput(params.dimensions, params.privateRefs);
         const telemetryClient = getTelemetryClient();
         if (!telemetryClient) return;
-        telemetryClient.track(`plugin.${pluginKey}.${eventName}`, params.dimensions);
+        const dimensions: Record<string, PluginTelemetryDimensionValue> = {
+          ...telemetryInput.dimensions,
+        };
+        for (const { key, value } of telemetryInput.privateRefs) {
+          dimensions[`${key}_hashed`] = telemetryClient.hashPrivateRef(value);
+          dimensions[`${key}_is_hashed`] = true;
+        }
+        telemetryClient.track(`plugin.${pluginKey}.${eventName}`, dimensions);
       },
     },
 

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -125,6 +125,7 @@ const PLUGIN_TELEMETRY_FORBIDDEN_KEY_PARTS = new Set([
   "host",
   "domain",
 ]);
+const PLUGIN_TELEMETRY_FORBIDDEN_COMPACT_KEYS = new Set(["companyid", "userid", "hostname"]);
 
 type PluginTelemetryDimensionValue = string | number | boolean;
 
@@ -157,9 +158,9 @@ function assertSafePluginTelemetryDimensionKey(key: string): void {
   const normalisedKey = normaliseTelemetryKey(key);
   const parts = normalisedKey.split("_");
   const forbidden = Array.from(PLUGIN_TELEMETRY_FORBIDDEN_KEY_PARTS).find((part) =>
-    parts.includes(part) || normalisedKey.includes(part),
+    parts.includes(part),
   );
-  if (forbidden) {
+  if (forbidden || PLUGIN_TELEMETRY_FORBIDDEN_COMPACT_KEYS.has(normalisedKey)) {
     throw new Error(
       `Plugin telemetry dimension "${key}" is not allowed; send private identifiers through privateRefs so the host can hash them.`,
     );

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -231,6 +231,7 @@ function validatePluginTelemetryInput(
     safeDimensions[key] = assertSafePluginTelemetryDimensionValue(key, value);
   }
 
+  const allocatedOutputKeys = new Set(Object.keys(safeDimensions));
   for (const [key, value] of privateEntries) {
     assertPluginTelemetryKey(key, "private ref");
     if (typeof value !== "string" || value.length === 0 || value.length > PLUGIN_TELEMETRY_MAX_PRIVATE_REF_LENGTH) {
@@ -240,12 +241,11 @@ function validatePluginTelemetryInput(
     }
     const hashKey = `${key}_hashed`;
     const markerKey = `${key}_is_hashed`;
-    if (
-      Object.prototype.hasOwnProperty.call(safeDimensions, hashKey) ||
-      Object.prototype.hasOwnProperty.call(safeDimensions, markerKey)
-    ) {
+    if (allocatedOutputKeys.has(hashKey) || allocatedOutputKeys.has(markerKey)) {
       throw new Error(`Plugin telemetry private ref "${key}" collides with existing dimensions.`);
     }
+    allocatedOutputKeys.add(hashKey);
+    allocatedOutputKeys.add(markerKey);
     privateRefEntries.push({ key, value });
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Telemetry helps maintainers understand agent lifecycle, task-completion, and plugin behavior across installs.
> - Telemetry dimensions cross an external egress boundary, so raw operational identifiers and plugin-supplied free-form values need a stricter privacy contract.
> - Shared telemetry already supports private-reference hashing, and plugin telemetry can use the same boundary instead of forwarding raw references.
> - This pull request hashes agent telemetry identifiers and adds a fail-closed plugin telemetry dimension contract with host-side private ref hashing.
> - The benefit is maintainers keep aggregate, low-cardinality telemetry while reducing the risk that raw ids, paths, tokens, prompts, or similar sensitive values leave an instance.

## Linked Issues or Issue Description

No public GitHub issue was found for this targeted telemetry privacy hardening change.

### Subsystem affected

Telemetry privacy across shared agent telemetry helpers and the plugin host/SDK telemetry bridge.

### Problem or motivation

Agent telemetry previously emitted raw agent ids, and plugin telemetry dimensions were forwarded from plugins to the host telemetry client without a host-enforced privacy contract. That allowed plugin-supplied raw identifiers or sensitive-looking values to cross the telemetry egress boundary unchanged.

### Proposed solution

Hash agent identifiers before egress and require plugin telemetry to use low-cardinality primitive dimensions. Stable or private plugin references now flow through a `privateRefs` SDK argument, where the host hashes each raw ref and forwards only `<key>_hashed` plus `<key>_is_hashed: true` dimensions.

### Alternatives considered

Dropping identifiers entirely would avoid sending raw ids, but it would remove useful aggregate continuity. Relying only on plugin authors to sanitize dimensions was rejected because the host should enforce the privacy boundary.

### Roadmap alignment

This is a narrow telemetry and plugin runtime hardening change. It does not duplicate a roadmap-level core feature.

### Additional context

The plugin telemetry validator rejects sensitive key forms including compressed names such as `userid`, `companyid`, and `hostname`, in addition to explicit snake_case forms.

## What Changed

- Updated shared agent telemetry events to send `agent_id_hashed` instead of raw `agent_id`, plus an explicit `agent_id_is_hashed` marker.
- Added fail-closed plugin telemetry dimension validation in the host service: bounded dimensions, low-cardinality slug-like string values, suspicious value rejection, max outgoing dimension count, reserved hash marker protection, and private-ref output collision detection.
- Added the plugin SDK `privateRefs` telemetry contract through public types, protocol, worker RPC host, and testing harness.
- Hash plugin private refs server-side with the telemetry client before forwarding external telemetry.
- Updated plugin telemetry documentation and the kitchen sink example to avoid identifier-shaped dimensions.
- Added regression coverage for safe plugin dimensions, rejected raw/suspicious dimensions, private ref hashing, dimension caps, false-positive key filtering, collision rejection, and compressed sensitive-key bypass prevention.

## Verification

- `git diff --check`
- `pnpm vitest run server/src/__tests__/shared-telemetry-events.test.ts`
- `pnpm vitest run server/src/__tests__/plugin-telemetry-bridge.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/plugin-sdk typecheck`
- GitHub PR checks are green on `33282fe05c2c1d56ab3d54cd44d4a927f2a7650b`, including `verify`, `Build`, `e2e`, `General tests`, serialized server shards, security scans, and release dry run.
- Greptile Review is 5/5 with no files requiring attention on `33282fe05c2c1d56ab3d54cd44d4a927f2a7650b`.

## Risks

Downstream telemetry consumers that expected raw `agent_id` or unrestricted plugin dimensions need to migrate to hashed dimensions and low-cardinality plugin telemetry. The behavior is intentionally stricter at the plugin telemetry egress boundary, so plugins sending identifier-like dimensions will now receive validation errors until they move those values to `privateRefs`.

## Model Used

OpenAI GPT-5 Codex coding agent, API-based coding workflow with terminal/tool use and repository inspection.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge