### PR TITLE
fix(recovery): skip stalled-issue escalation on org quota exhaustion (SAG-1807)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2371,6 +2371,45 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  it("keeps assigned todo quota exhaustion quiet during recovery cooldown", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+      runErrorCode: "claude_transient_upstream",
+      runError: "You've hit your org's monthly usage limit",
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        finishedAt: new Date("2030-03-19T00:05:00.000Z"),
+        updatedAt: new Date("2030-03-19T00:05:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toEqual([runId]);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "todo",
@@ -2818,6 +2857,120 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
     expect(runs).toHaveLength(2);
     const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
+      issueId,
+      retryReason: "issue_continuation_needed",
+      source: "issue.continuation_recovery",
+    });
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  it("keeps quota-exhausted continuation retries quiet during transient backoff", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "claude_transient_upstream",
+      runError: "You've hit your org's monthly usage limit",
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        finishedAt: new Date("2030-03-19T00:05:00.000Z"),
+        updatedAt: new Date("2030-03-19T00:05:00.000Z"),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toEqual([runId]);
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+  });
+
+  it("keeps retrying quota-exhausted continuation after cooldown without escalating", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "claude_transient_upstream",
+      runError: "You've hit your org's monthly usage limit",
+    });
+    // Backfill enough consecutive quota failures to prove quota exhaustion does not
+    // use the normal transient cap to create a recovery action.
+    const olderTimestamps = [
+      new Date("2026-03-18T23:45:00.000Z"),
+      new Date("2026-03-18T23:50:00.000Z"),
+      new Date("2026-03-18T23:55:00.000Z"),
+    ];
+    for (const finishedAt of olderTimestamps) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+        },
+        errorCode: "claude_transient_upstream",
+        error: "You've hit your org's monthly usage limit",
+        startedAt: finishedAt,
+        finishedAt,
+        createdAt: finishedAt,
+        updatedAt: finishedAt,
+      });
+    }
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    const retryRun = runs.find((row) => {
+      const ctx = row.contextSnapshot as Record<string, unknown> | null;
+      return row.id !== runId &&
+        row.errorCode === null &&
+        ctx?.retryReason === "issue_continuation_needed" &&
+        ctx?.source === "issue.continuation_recovery";
+    });
     expect(retryRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
       issueId,
       retryReason: "issue_continuation_needed",

--- a/server/src/services/recovery/run-error-guards.ts
+++ b/server/src/services/recovery/run-error-guards.ts
@@ -1,0 +1,19 @@
+type RunWithErrorFields = {
+  errorCode: string | null;
+  error: string | null;
+};
+
+/**
+ * Returns true when the run failed because the org's Claude API quota was
+ * exhausted ("You've hit your org's monthly usage limit").  These failures
+ * are an external billing constraint, not an agent failure, so they must not
+ * trigger "Recover stalled issues" escalation tickets.
+ */
+export function isQuotaLimitExhaustionRun(run: RunWithErrorFields | null): boolean {
+  if (!run) return false;
+  return (
+    run.errorCode === "claude_transient_upstream" &&
+    typeof run.error === "string" &&
+    run.error.toLowerCase().includes("monthly usage limit")
+  );
+}

--- a/server/src/services/recovery/service.test.ts
+++ b/server/src/services/recovery/service.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { isQuotaLimitExhaustionRun } from "./run-error-guards.js";
+
+describe("isQuotaLimitExhaustionRun", () => {
+  const base = {
+    id: "run-1",
+    agentId: "agent-1",
+    status: "failed" as const,
+    error: null,
+    errorCode: null,
+    contextSnapshot: null,
+    livenessState: null,
+  };
+
+  it("returns false for null run", () => {
+    expect(isQuotaLimitExhaustionRun(null)).toBe(false);
+  });
+
+  it("returns true for claude_transient_upstream with monthly usage limit message", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "You've hit your org's monthly usage limit",
+      }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive on the error message", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "You've hit your org's Monthly Usage Limit",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when errorCode is not claude_transient_upstream", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "adapter_failed",
+        error: "monthly usage limit exceeded",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when error message does not contain monthly usage limit", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "Claude API rate limit exceeded, retry after 60s",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when error is null even with matching errorCode", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for genuine transient upstream without quota message", () => {
+    expect(
+      isQuotaLimitExhaustionRun({
+        ...base,
+        errorCode: "claude_transient_upstream",
+        error: "overloaded_error: The API is temporarily overloaded",
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -62,6 +62,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { isQuotaLimitExhaustionRun } from "./run-error-guards.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -2741,23 +2742,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
-          const failureSummary = summarizeRunFailureForIssueComment(latestRun);
-          const updated = await escalateStrandedAssignedIssue({
-            issue,
-            previousStatus: "todo",
-            latestRun,
-            comment:
-              "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
-              `but it still has no live execution path.${failureSummary ?? ""} ` +
-              "Moving it to `blocked` so it is visible for intervention.",
-          });
-          if (updated) {
-            result.escalated += 1;
-            result.issueIds.push(issue.id);
-          } else {
-            result.skipped += 1;
+          if (!isQuotaLimitExhaustionRun(latestRun)) {
+            const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+            const updated = await escalateStrandedAssignedIssue({
+              issue,
+              previousStatus: "todo",
+              latestRun,
+              comment:
+                "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
+                `but it still has no live execution path.${failureSummary ?? ""} ` +
+                "Moving it to `blocked` so it is visible for intervention.",
+            });
+            if (updated) {
+              result.escalated += 1;
+              result.issueIds.push(issue.id);
+            } else {
+              result.skipped += 1;
+            }
+            continue;
           }
-          continue;
+          // Quota exhaustion: do not create a recovery ticket; fall through to re-enqueue
+          // so the issue retries on the next recovery cron cycle once quota is restored.
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
@@ -2869,7 +2874,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
         continue;
       }
-      if (isUnsuccessfulTerminalIssueRun(latestRun)) {
+      if (isUnsuccessfulTerminalIssueRun(latestRun) && !isQuotaLimitExhaustionRun(latestRun)) {
         const classification = classifyContinuationFailure(latestRun);
 
         if (classification.kind === "non_retryable") {
@@ -2932,6 +2937,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             }
           }
         }
+        // Quota exhaustion: isQuotaLimitExhaustionRun guard above skips this block entirely;
+        // fall through to re-enqueue so the issue retries once quota is restored.
       }
 
       if (await isInvocationBudgetBlocked(issue, agentId)) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -113,7 +113,7 @@ type RecoveryWakeup = (
 
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
-  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
+  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState" | "finishedAt"
 > | null;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
@@ -196,6 +196,7 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const QUOTA_LIMIT_RECOVERY_BASE_BACKOFF_MS = CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS;
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -491,6 +492,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        finishedAt: heartbeatRuns.finishedAt,
       })
       .from(heartbeatRuns)
       .where(
@@ -504,9 +506,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
-  async function summarizeRecentContinuationRetries(
+  async function summarizeRecentIssueRetries(
     companyId: string,
     issueId: string,
+    retryReasonToMatch: "assignment_recovery" | "issue_continuation_needed",
     errorCodeToMatch: string | null,
   ) {
     const rows = await db
@@ -532,7 +535,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     for (const row of rows) {
       const ctx = parseObject(row.contextSnapshot);
       const retryReason = readNonEmptyString(ctx.retryReason);
-      if (retryReason !== "issue_continuation_needed") break;
+      if (retryReason !== retryReasonToMatch) break;
       if (
         !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
           row.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
@@ -550,6 +553,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (latestFinishedAt === null) latestFinishedAt = row.finishedAt ?? null;
     }
     return { consecutive, latestFinishedAt };
+  }
+
+  async function summarizeRecentContinuationRetries(
+    companyId: string,
+    issueId: string,
+    errorCodeToMatch: string | null,
+  ) {
+    return summarizeRecentIssueRetries(
+      companyId,
+      issueId,
+      "issue_continuation_needed",
+      errorCodeToMatch,
+    );
+  }
+
+  function shouldDelayQuotaLimitRetry(input: {
+    latestFinishedAt: Date | null;
+    consecutive: number;
+  }) {
+    if (!input.latestFinishedAt) return false;
+    const elapsed = Date.now() - input.latestFinishedAt.getTime();
+    const requiredDelay = QUOTA_LIMIT_RECOVERY_BASE_BACKOFF_MS *
+      Math.pow(2, Math.max(0, input.consecutive - 1));
+    return elapsed < requiredDelay;
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
@@ -2742,7 +2769,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
-          if (!isQuotaLimitExhaustionRun(latestRun)) {
+          const isQuotaLimitExhaustion = isQuotaLimitExhaustionRun(latestRun);
+          if (!isQuotaLimitExhaustion) {
             const failureSummary = summarizeRunFailureForIssueComment(latestRun);
             const updated = await escalateStrandedAssignedIssue({
               issue,
@@ -2761,8 +2789,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             }
             continue;
           }
-          // Quota exhaustion: do not create a recovery ticket; fall through to re-enqueue
-          // so the issue retries on the next recovery cron cycle once quota is restored.
+
+          const retrySummary = await summarizeRecentIssueRetries(
+            issue.companyId,
+            issue.id,
+            "assignment_recovery",
+            readNonEmptyString(latestRun.errorCode),
+          );
+          if (shouldDelayQuotaLimitRetry(retrySummary)) {
+            result.skipped += 1;
+            continue;
+          }
         }
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
@@ -2874,10 +2911,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
         continue;
       }
-      if (isUnsuccessfulTerminalIssueRun(latestRun) && !isQuotaLimitExhaustionRun(latestRun)) {
+      if (isUnsuccessfulTerminalIssueRun(latestRun)) {
+        const isQuotaLimitExhaustion = isQuotaLimitExhaustionRun(latestRun);
         const classification = classifyContinuationFailure(latestRun);
 
-        if (classification.kind === "non_retryable") {
+        if (!isQuotaLimitExhaustion && classification.kind === "non_retryable") {
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -2903,7 +2941,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             issue.id,
             classification.errorCode,
           );
-          if (consecutive >= classification.maxAttempts) {
+          if (!isQuotaLimitExhaustion && consecutive >= classification.maxAttempts) {
             const failureSummary = summarizeRunFailureForIssueComment(latestRun);
             const attemptCopy = consecutive <= 1 ? "" : ` (${consecutive}× attempts)`;
             const causeCopy = classification.errorCode
@@ -2927,9 +2965,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             continue;
           }
 
-          if (classification.baseBackoffMs > 0 && latestFinishedAt) {
+          const baseBackoffMs = isQuotaLimitExhaustion
+            ? QUOTA_LIMIT_RECOVERY_BASE_BACKOFF_MS
+            : classification.baseBackoffMs;
+          if (baseBackoffMs > 0 && latestFinishedAt) {
             const elapsed = Date.now() - latestFinishedAt.getTime();
-            const requiredDelay = classification.baseBackoffMs *
+            const requiredDelay = baseBackoffMs *
               Math.pow(2, Math.max(0, consecutive - 1));
             if (elapsed < requiredDelay) {
               result.skipped += 1;
@@ -2937,8 +2978,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             }
           }
         }
-        // Quota exhaustion: isQuotaLimitExhaustionRun guard above skips this block entirely;
-        // fall through to re-enqueue so the issue retries once quota is restored.
       }
 
       if (await isInvocationBudgetBlocked(issue, agentId)) {


### PR DESCRIPTION
## Thinking Path

SAG-1807 covers Claude org quota exhaustion during heartbeat/recovery runs. The relevant failure signature is `errorCode === "claude_transient_upstream"` plus an error message containing `monthly usage limit`.

Quota exhaustion is an external billing/provider constraint, not evidence that the assigned agent failed the task. The recovery handler should therefore avoid creating noisy "Recover stalled issues" artifacts for quota exhaustion while still preserving the existing retry/backoff cadence so the recovery cron cannot re-enqueue every cycle while quota remains exhausted.

## What Changed

- Added/kept the isolated `isQuotaLimitExhaustionRun` predicate for the SAG-1807 quota signature.
- Changed assigned `todo` recovery so a quota-failed `assignment_recovery` attempt suppresses escalation and observes an exponential cooldown before another recovery enqueue.
- Changed `in_progress` continuation recovery so quota failures enter the existing transient retry/backoff path instead of bypassing it, while suppressing recovery-action/escalation creation for the quota-specific case.
- Kept non-quota transient and non-retryable continuation behavior unchanged.
- Added focused heartbeat recovery tests for quiet quota exhaustion, cooldown/backoff, repeated quota retries after cooldown, and no recovery-action/comment creation.

## Verification

- `pnpm install --frozen-lockfile`
- `npx vitest run server/src/services/recovery/service.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts` -> 2 files passed, 66 tests passed

## Risks

- Quota exhaustion now retries quietly with exponential cooldown; if quota remains exhausted for a long period, the source issue remains assigned/in its current state rather than creating a recovery ticket.
- The cooldown uses the same 60s base as existing transient continuation recovery and grows exponentially for consecutive quota recovery failures.

## Model Used

- Codex Code Executor (gpt-5.5)

## Checklist

- [x] Public issue context included: [SAG-1807](/SAG/issues/SAG-1807)
- [x] Quota exhaustion does not create noisy stalled-issue recovery artifacts
- [x] Quota exhaustion preserves retry/backoff/cooldown behavior
- [x] Genuine non-quota transient failures still trigger existing recovery behavior
- [x] Focused tests run and passing

Closes [SAG-1807](/SAG/issues/SAG-1807)
