### PR TITLE
fix(claude-local): detect Anthropic API 401 errors as claude_auth_required

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,11 +1,77 @@
 import { describe, expect, it } from "vitest";
 import {
+  detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
   isClaudePoisonedPreviousMessageIdError,
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
 } from "./parse.js";
+
+describe("detectClaudeLoginRequired", () => {
+  const base = { parsed: null, stdout: "", stderr: "" };
+
+  it("detects subscription login prompts in stderr", () => {
+    expect(
+      detectClaudeLoginRequired({ ...base, stderr: "Please log in. Run `claude login` first." }).requiresLogin,
+    ).toBe(true);
+    expect(
+      detectClaudeLoginRequired({ ...base, stderr: "Not logged in. Please log in." }).requiresLogin,
+    ).toBe(true);
+  });
+
+  it("detects Anthropic API 401 'Failed to authenticate' in result field", () => {
+    expect(
+      detectClaudeLoginRequired({
+        parsed: {
+          is_error: true,
+          result:
+            'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"},"request_id":"req_011abc"}',
+        },
+        stdout: "",
+        stderr: "",
+      }).requiresLogin,
+    ).toBe(true);
+  });
+
+  it("detects Anthropic API 401 'authentication_error' type in result field", () => {
+    expect(
+      detectClaudeLoginRequired({
+        parsed: { is_error: true, result: 'API Error: 401 {"error":{"type":"authentication_error"}}' },
+        stdout: "",
+        stderr: "",
+      }).requiresLogin,
+    ).toBe(true);
+  });
+
+  it("detects 'Invalid authentication credentials' in stderr", () => {
+    expect(
+      detectClaudeLoginRequired({
+        ...base,
+        stderr: "Invalid authentication credentials",
+      }).requiresLogin,
+    ).toBe(true);
+  });
+
+  it("does not flag transient rate-limit errors as login-required", () => {
+    expect(
+      detectClaudeLoginRequired({
+        ...base,
+        stderr: "API Error: 429 rate_limit_error",
+      }).requiresLogin,
+    ).toBe(false);
+  });
+
+  it("does not flag unrelated errors as login-required", () => {
+    expect(
+      detectClaudeLoginRequired({
+        parsed: { is_error: true, result: "Maximum turns reached." },
+        stdout: "",
+        stderr: "",
+      }).requiresLogin,
+    ).toBe(false);
+  });
+});
 
 describe("isClaudeTransientUpstreamError", () => {
   it("classifies the 'out of extra usage' subscription window failure as transient", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -6,7 +6,7 @@ import {
   parseJson,
 } from "@paperclipai/adapter-utils/server-utils";
 
-const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
+const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required|failed\s+to\s+authenticate|invalid\s+authentication|authentication_error)/i;
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =


### PR DESCRIPTION
## Summary

- Expanded \`CLAUDE_AUTH_REQUIRED_RE\` in \`packages/adapters/claude-local/src/server/parse.ts\` to match Anthropic API 401 error patterns: \`failed to authenticate\`, \`authentication_error\`, \`invalid authentication credentials\`
- Runs with an invalid/expired \`ANTHROPIC_API_KEY\` now produce \`errorCode: claude_auth_required\` instead of \`adapter_failed\`, fixing misclassification visible on the ALLAA dashboard
- Added \`detectClaudeLoginRequired\` test suite in \`parse.test.ts\` covering both subscription-auth and API-key-401 patterns

## Test Plan

- [ ] \`pnpm test\` in \`packages/adapters/claude-local\` — new \`detectClaudeLoginRequired\` tests pass
- [ ] CEO agent heartbeat on ALLAA shows \`claude_auth_required\` error code (not \`adapter_failed\`)
- [ ] Update \`ANTHROPIC_API_KEY\` in CEO agent adapter config to clear the 401 root cause