### PR TITLE
feat(eval): SAG-4341 — separate infra-error rows from quality regressions in alert detector

### DIFF
--- a/scripts/eval/digest_and_alert.py
+++ b/scripts/eval/digest_and_alert.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Nightly-eval regression detector: digest and alert.
+
+Reads per-task NDJSON eval rows, computes per-class quality metrics excluding
+infra-error rows, and classifies each class as REGRESSION, INCONCLUSIVE, or OK.
+
+Key invariant: rows with a non-null `error` field are infra-errors (timeouts,
+OOM, etc.) and must NOT count against quality. They are only counted against the
+`error_rate` gauge. A class with error_rate >= ERROR_RATE_INCONCLUSIVE_THRESHOLD
+is flagged INCONCLUSIVE — not a quality regression — because we lack a meaningful
+quality sample.
+
+Row schema (NDJSON):
+  {"gold_class": str, "task_id": str, "task_correct": 0|1,
+   "error": null | "timed out" | ..., "wall_s": float}
+"""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ERROR_RATE_INCONCLUSIVE_THRESHOLD = 0.25  # error_rate >= this → INCONCLUSIVE
+REGRESSION_DELTA_THRESHOLD = 0.10         # task_correct_rate drop >= 10 pp → alert
+MIN_CLEAN_ROWS_FOR_REGRESSION = 3         # need at least this many clean rows to call a regression
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ClassMetrics:
+    gold_class: str
+    total: int
+    errors: int
+    error_rate: float
+    clean: int
+    clean_rate: float          # fraction of non-errored rows (1 - error_rate)
+    task_correct_rate: float   # correct / clean (quality over non-errored rows only)
+    inconclusive: bool         # True when error_rate >= ERROR_RATE_INCONCLUSIVE_THRESHOLD
+
+
+@dataclass
+class Alert:
+    gold_class: str
+    kind: str        # "REGRESSION" | "INCONCLUSIVE"
+    delta: float     # task_correct_rate - baseline (negative for drops; 0.0 for INCONCLUSIVE)
+    error_rate: float
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+def compute_class_metrics(gold_class: str, rows: list[dict]) -> ClassMetrics:
+    """Aggregate per-task rows into per-class quality metrics.
+
+    Rows with a non-null `error` field are counted as infra-errors and excluded
+    from the quality denominator (task_correct_rate).
+    """
+    total = len(rows)
+    if total == 0:
+        return ClassMetrics(
+            gold_class=gold_class,
+            total=0,
+            errors=0,
+            error_rate=0.0,
+            clean=0,
+            clean_rate=0.0,
+            task_correct_rate=0.0,
+            inconclusive=False,
+        )
+
+    error_rows = [r for r in rows if r.get("error") is not None]
+    clean_rows = [r for r in rows if r.get("error") is None]
+
+    errors = len(error_rows)
+    clean = len(clean_rows)
+    error_rate = errors / total
+    clean_rate = clean / total
+
+    task_correct_rate = (
+        sum(int(r.get("task_correct", 0)) for r in clean_rows) / clean
+        if clean > 0
+        else 0.0
+    )
+
+    inconclusive = error_rate >= ERROR_RATE_INCONCLUSIVE_THRESHOLD
+
+    return ClassMetrics(
+        gold_class=gold_class,
+        total=total,
+        errors=errors,
+        error_rate=error_rate,
+        clean=clean,
+        clean_rate=clean_rate,
+        task_correct_rate=task_correct_rate,
+        inconclusive=inconclusive,
+    )
+
+
+def detect_regressions(
+    metrics: list[ClassMetrics],
+    baseline: dict[str, float],
+    regression_threshold: float = REGRESSION_DELTA_THRESHOLD,
+    min_clean_rows: int = MIN_CLEAN_ROWS_FOR_REGRESSION,
+) -> list[Alert]:
+    """Classify each class as REGRESSION, INCONCLUSIVE, or OK.
+
+    Rules applied in order:
+      1. INCONCLUSIVE: error_rate >= threshold → emit INCONCLUSIVE alert, skip regression check.
+      2. No baseline for class → skip (insufficient reference data).
+      3. Too few clean rows → skip (insufficient quality sample).
+      4. REGRESSION: task_correct_rate dropped >= regression_threshold vs baseline.
+      5. OK: no alert emitted.
+    """
+    alerts: list[Alert] = []
+
+    for m in metrics:
+        if m.inconclusive:
+            alerts.append(Alert(
+                gold_class=m.gold_class,
+                kind="INCONCLUSIVE",
+                delta=0.0,
+                error_rate=m.error_rate,
+            ))
+            continue
+
+        if m.gold_class not in baseline:
+            continue
+
+        if m.clean < min_clean_rows:
+            continue
+
+        delta = m.task_correct_rate - baseline[m.gold_class]
+        if delta < -regression_threshold:
+            alerts.append(Alert(
+                gold_class=m.gold_class,
+                kind="REGRESSION",
+                delta=delta,
+                error_rate=m.error_rate,
+            ))
+
+    return alerts
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def format_digest_table(metrics: list[ClassMetrics]) -> str:
+    """Render a fixed-width digest table with an errors column and INCONCLUSIVE markers."""
+    col_w = {
+        "gold_class": max(12, max((len(m.gold_class) for m in metrics), default=12)),
+        "total": 7,
+        "errors": 7,
+        "clean": 7,
+        "error_rate": 11,
+        "correct_rate": 13,
+        "status": 14,
+    }
+
+    def row_fmt(gc, total, errors, clean, err_rate, corr_rate, status):
+        return (
+            f"{gc:<{col_w['gold_class']}}  "
+            f"{total:>{col_w['total']}}  "
+            f"{errors:>{col_w['errors']}}  "
+            f"{clean:>{col_w['clean']}}  "
+            f"{err_rate:>{col_w['error_rate']}}  "
+            f"{corr_rate:>{col_w['correct_rate']}}  "
+            f"{status:<{col_w['status']}}"
+        )
+
+    header = row_fmt(
+        "gold_class", "total", "errors", "clean",
+        "error_rate", "correct_rate", "status"
+    )
+    sep = "-" * len(header)
+
+    lines = [header, sep]
+    for m in metrics:
+        status = "INCONCLUSIVE" if m.inconclusive else "ok"
+        lines.append(row_fmt(
+            m.gold_class,
+            m.total,
+            m.errors,
+            m.clean,
+            f"{m.error_rate:.1%}",
+            f"{m.task_correct_rate:.1%}" if m.clean > 0 else "n/a",
+            status,
+        ))
+
+    return "\n".join(lines)
+
+
+def format_alert_message(alerts: list[Alert]) -> str:
+    """Produce a human-readable alert body distinguishing infra-flake from quality drops."""
+    if not alerts:
+        return "No regressions or infra issues detected."
+
+    regressions = [a for a in alerts if a.kind == "REGRESSION"]
+    inconclusive = [a for a in alerts if a.kind == "INCONCLUSIVE"]
+
+    parts: list[str] = []
+    if regressions:
+        parts.append(
+            f"QUALITY REGRESSION ({len(regressions)} class(es)):\n"
+            + "\n".join(
+                f"  {a.gold_class}: delta={a.delta:+.1%} vs baseline"
+                for a in regressions
+            )
+        )
+    if inconclusive:
+        parts.append(
+            f"INCONCLUSIVE — re-run needed ({len(inconclusive)} class(es)):\n"
+            + "\n".join(
+                f"  {a.gold_class}: error_rate={a.error_rate:.1%} (infra flake, not a quality signal)"
+                for a in inconclusive
+            )
+        )
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# NDJSON loader
+# ---------------------------------------------------------------------------
+
+def load_rows(path: Path) -> list[dict]:
+    """Load all NDJSON rows from a file."""
+    rows: list[dict] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def group_by_class(rows: list[dict]) -> dict[str, list[dict]]:
+    """Partition rows into {gold_class: [row, ...]}."""
+    groups: dict[str, list[dict]] = {}
+    for row in rows:
+        gc = str(row.get("gold_class", "unknown"))
+        groups.setdefault(gc, []).append(row)
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Nightly-eval digest and alert")
+    parser.add_argument("ndjson", type=Path, help="NDJSON eval results file")
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="JSON file mapping gold_class → baseline task_correct_rate",
+    )
+    args = parser.parse_args()
+
+    rows = load_rows(args.ndjson)
+    groups = group_by_class(rows)
+
+    metrics_list = [
+        compute_class_metrics(gc, grp) for gc, grp in sorted(groups.items())
+    ]
+
+    print(format_digest_table(metrics_list))
+    print()
+
+    baseline: dict[str, float] = {}
+    if args.baseline:
+        baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+
+    alerts = detect_regressions(metrics_list, baseline)
+    print(format_alert_message(alerts))
+
+    regressions = [a for a in alerts if a.kind == "REGRESSION"]
+    sys.exit(1 if regressions else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval/tests/test_digest_and_alert.py
+++ b/scripts/eval/tests/test_digest_and_alert.py
@@ -1,0 +1,311 @@
+"""Tests for digest_and_alert.py — SAG-4341.
+
+Covers the three acceptance criteria:
+  (a) all-rows-timed-out class → INCONCLUSIVE, NOT a regression
+  (b) genuine quality drop with 0 errors → still emits a REGRESSION alert
+  (c) mixed (8/20 errored) → quality computed over 12 clean rows + INCONCLUSIVE
+
+Run with: python3 -m pytest scripts/eval/tests/test_digest_and_alert.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from digest_and_alert import (
+    ERROR_RATE_INCONCLUSIVE_THRESHOLD,
+    MIN_CLEAN_ROWS_FOR_REGRESSION,
+    ClassMetrics,
+    Alert,
+    compute_class_metrics,
+    detect_regressions,
+    format_digest_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _timed_out_row(gold_class: str) -> dict:
+    return {"gold_class": gold_class, "task_correct": 0, "error": "timed out", "wall_s": 0.0}
+
+
+def _clean_row(gold_class: str, task_correct: int = 1) -> dict:
+    return {"gold_class": gold_class, "task_correct": task_correct, "error": None, "wall_s": 45.0}
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+def test_inconclusive_threshold_is_25_percent():
+    assert ERROR_RATE_INCONCLUSIVE_THRESHOLD == 0.25
+
+
+# ---------------------------------------------------------------------------
+# compute_class_metrics
+# ---------------------------------------------------------------------------
+
+class TestComputeClassMetrics:
+    def test_all_clean_rows(self):
+        rows = [_clean_row("bookkeeping")] * 10
+        m = compute_class_metrics("bookkeeping", rows)
+        assert m.gold_class == "bookkeeping"
+        assert m.total == 10
+        assert m.errors == 0
+        assert m.clean == 10
+        assert m.error_rate == 0.0
+        assert m.task_correct_rate == 1.0
+        assert m.inconclusive is False
+
+    def test_all_timed_out(self):
+        rows = [_timed_out_row("code_review")] * 5
+        m = compute_class_metrics("code_review", rows)
+        assert m.total == 5
+        assert m.errors == 5
+        assert m.clean == 0
+        assert m.error_rate == 1.0
+        assert m.task_correct_rate == 0.0
+        assert m.inconclusive is True
+
+    def test_task_correct_rate_computed_over_clean_rows_only(self):
+        # 3 clean correct, 2 clean incorrect, 5 timed-out
+        clean_correct = [_clean_row("code_review", task_correct=1)] * 3
+        clean_wrong = [_clean_row("code_review", task_correct=0)] * 2
+        errored = [_timed_out_row("code_review")] * 5
+        rows = clean_correct + clean_wrong + errored
+
+        m = compute_class_metrics("code_review", rows)
+        assert m.total == 10
+        assert m.errors == 5
+        assert m.clean == 5
+        # 3 correct out of 5 clean = 0.6 (NOT 3/10 = 0.3)
+        assert abs(m.task_correct_rate - 0.6) < 1e-9
+
+    def test_clean_rate_is_fraction_of_non_errored_rows(self):
+        rows = [_clean_row("code_review")] * 7 + [_timed_out_row("code_review")] * 3
+        m = compute_class_metrics("code_review", rows)
+        assert abs(m.clean_rate - 0.7) < 1e-9
+
+    def test_exactly_at_inconclusive_threshold(self):
+        # 25% errored → exactly at threshold → INCONCLUSIVE
+        rows = [_clean_row("bookkeeping")] * 3 + [_timed_out_row("bookkeeping")] * 1
+        m = compute_class_metrics("bookkeeping", rows)
+        assert abs(m.error_rate - 0.25) < 1e-9
+        assert m.inconclusive is True
+
+    def test_just_below_inconclusive_threshold(self):
+        # 24% errored → below threshold → NOT inconclusive
+        rows = [_clean_row("bookkeeping")] * 19 + [_timed_out_row("bookkeeping")] * 6
+        # 6/25 = 24%
+        # let's do 24 clean + 6 errored = wait: 6/(24+6)=6/30=20%...
+        # Use exact: 24 rows total, error_rate = x. Want x < 0.25.
+        # 3 clean + 1 errored = 25% (at threshold, treated as INCONCLUSIVE above)
+        # 4 clean + 1 errored = 20% < 25% → NOT inconclusive
+        rows = [_clean_row("bookkeeping")] * 4 + [_timed_out_row("bookkeeping")] * 1
+        m = compute_class_metrics("bookkeeping", rows)
+        assert m.error_rate == 0.2
+        assert m.inconclusive is False
+
+    def test_non_null_error_string_other_than_timed_out(self):
+        rows = [
+            {"gold_class": "code_review", "task_correct": 0, "error": "OOM", "wall_s": 0.0},
+            _clean_row("code_review"),
+        ]
+        m = compute_class_metrics("code_review", rows)
+        assert m.errors == 1
+        assert m.clean == 1
+
+    def test_empty_rows(self):
+        m = compute_class_metrics("code_review", [])
+        assert m.total == 0
+        assert m.errors == 0
+        assert m.error_rate == 0.0
+        assert m.task_correct_rate == 0.0
+        assert m.inconclusive is False
+
+
+# ---------------------------------------------------------------------------
+# AC (a): all-rows-timed-out class → INCONCLUSIVE, NOT a regression
+# ---------------------------------------------------------------------------
+
+class TestAcceptanceCriteriaA:
+    """AC (a): all rows timed out → INCONCLUSIVE only, zero REGRESSION alerts."""
+
+    def test_all_timed_out_emits_inconclusive_not_regression(self):
+        rows = [_timed_out_row("code_review")] * 10
+        m = compute_class_metrics("code_review", rows)
+        assert m.inconclusive is True
+
+        baseline = {"code_review": 0.80}
+        alerts = detect_regressions([m], baseline)
+
+        inconclusive = [a for a in alerts if a.kind == "INCONCLUSIVE"]
+        regressions = [a for a in alerts if a.kind == "REGRESSION"]
+
+        assert len(inconclusive) == 1
+        assert inconclusive[0].gold_class == "code_review"
+        assert len(regressions) == 0
+
+    def test_inconclusive_alert_records_error_rate(self):
+        rows = [_timed_out_row("code_review")] * 5
+        m = compute_class_metrics("code_review", rows)
+        alerts = detect_regressions([m], {"code_review": 0.80})
+        assert len(alerts) == 1
+        assert alerts[0].error_rate == 1.0
+        assert alerts[0].kind == "INCONCLUSIVE"
+
+
+# ---------------------------------------------------------------------------
+# AC (b): genuine quality drop, zero errors → REGRESSION
+# ---------------------------------------------------------------------------
+
+class TestAcceptanceCriteriaB:
+    """AC (b): genuine quality drop with 0 errors → REGRESSION alert emitted."""
+
+    def test_clean_drop_below_baseline_emits_regression(self):
+        # baseline 80%, current 25% — clear drop
+        rows = (
+            [_clean_row("bookkeeping", task_correct=1)] * 1
+            + [_clean_row("bookkeeping", task_correct=0)] * 3
+        )
+        m = compute_class_metrics("bookkeeping", rows)
+        assert m.error_rate == 0.0
+        assert m.inconclusive is False
+        assert m.task_correct_rate == 0.25
+
+        baseline = {"bookkeeping": 0.80}
+        alerts = detect_regressions([m], baseline)
+        regressions = [a for a in alerts if a.kind == "REGRESSION"]
+
+        assert len(regressions) == 1
+        assert regressions[0].gold_class == "bookkeeping"
+        assert regressions[0].delta < 0  # delta is negative (drop)
+
+    def test_stable_quality_no_alert(self):
+        rows = [_clean_row("bookkeeping", task_correct=1)] * 8 + [_clean_row("bookkeeping", task_correct=0)] * 2
+        m = compute_class_metrics("bookkeeping", rows)
+        # task_correct_rate = 0.8, baseline = 0.8 → no drop
+        alerts = detect_regressions([m], {"bookkeeping": 0.80})
+        regressions = [a for a in alerts if a.kind == "REGRESSION"]
+        assert len(regressions) == 0
+
+
+# ---------------------------------------------------------------------------
+# AC (c): mixed errors (8/20) → quality over 12 clean + INCONCLUSIVE
+# ---------------------------------------------------------------------------
+
+class TestAcceptanceCriteriaC:
+    """AC (c): 8/20 errored → quality from 12 clean rows + INCONCLUSIVE flag."""
+
+    def test_mixed_errors_quality_from_clean_rows_flagged_inconclusive(self):
+        clean = [_clean_row("code_review", task_correct=1)] * 12
+        errored = [_timed_out_row("code_review")] * 8
+        rows = clean + errored
+
+        m = compute_class_metrics("code_review", rows)
+        assert m.total == 20
+        assert m.errors == 8
+        assert m.clean == 12
+        assert abs(m.error_rate - 0.40) < 1e-9
+        # Quality computed over 12 clean rows (all correct → 1.0)
+        assert m.task_correct_rate == 1.0
+        # 40% > 25% threshold → INCONCLUSIVE
+        assert m.inconclusive is True
+
+        baseline = {"code_review": 0.60}
+        alerts = detect_regressions([m], baseline)
+        inconclusive = [a for a in alerts if a.kind == "INCONCLUSIVE"]
+        regressions = [a for a in alerts if a.kind == "REGRESSION"]
+        assert len(inconclusive) == 1
+        assert len(regressions) == 0
+
+    def test_mixed_below_threshold_does_regress(self):
+        # 4/20 = 20% errored → NOT inconclusive; quality drop must still fire
+        clean_correct = [_clean_row("code_review", task_correct=1)] * 3
+        clean_wrong = [_clean_row("code_review", task_correct=0)] * 13
+        errored = [_timed_out_row("code_review")] * 4
+        rows = clean_correct + clean_wrong + errored
+
+        m = compute_class_metrics("code_review", rows)
+        assert m.total == 20
+        assert m.errors == 4
+        assert m.clean == 16
+        assert m.error_rate == 0.20
+        assert m.inconclusive is False
+        assert abs(m.task_correct_rate - 3 / 16) < 1e-9
+
+        baseline = {"code_review": 0.80}
+        alerts = detect_regressions([m], baseline)
+        regressions = [a for a in alerts if a.kind == "REGRESSION"]
+        assert len(regressions) == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_regressions — edge cases
+# ---------------------------------------------------------------------------
+
+class TestDetectRegressions:
+    def test_no_baseline_for_class_skips_regression(self):
+        rows = [_clean_row("new_class", task_correct=0)] * 5
+        m = compute_class_metrics("new_class", rows)
+        alerts = detect_regressions([m], baseline={})
+        assert alerts == []
+
+    def test_too_few_clean_rows_skips_regression(self):
+        # Only 2 clean rows — below MIN_CLEAN_ROWS_FOR_REGRESSION (3)
+        rows = [_clean_row("bookkeeping", task_correct=0)] * 2
+        m = compute_class_metrics("bookkeeping", rows)
+        assert m.clean == 2
+        assert m.clean < MIN_CLEAN_ROWS_FOR_REGRESSION
+
+        alerts = detect_regressions([m], {"bookkeeping": 1.0})
+        # No regression because too few clean rows for a meaningful signal
+        regressions = [a for a in alerts if a.kind == "REGRESSION"]
+        assert len(regressions) == 0
+
+    def test_multiple_classes_classified_independently(self):
+        m_inconclusive = compute_class_metrics("code_review", [_timed_out_row("code_review")] * 10)
+        m_regression = compute_class_metrics(
+            "bookkeeping",
+            [_clean_row("bookkeeping", task_correct=0)] * 10,
+        )
+        m_ok = compute_class_metrics(
+            "financial_reporting",
+            [_clean_row("financial_reporting", task_correct=1)] * 10,
+        )
+
+        baseline = {"code_review": 0.8, "bookkeeping": 0.9, "financial_reporting": 0.5}
+        alerts = detect_regressions([m_inconclusive, m_regression, m_ok], baseline)
+
+        kinds = {a.gold_class: a.kind for a in alerts}
+        assert kinds["code_review"] == "INCONCLUSIVE"
+        assert kinds["bookkeeping"] == "REGRESSION"
+        assert "financial_reporting" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# format_digest_table
+# ---------------------------------------------------------------------------
+
+class TestFormatDigestTable:
+    def test_table_includes_errors_column(self):
+        rows = [_clean_row("bookkeeping")] * 8 + [_timed_out_row("bookkeeping")] * 2
+        m = compute_class_metrics("bookkeeping", rows)
+        table = format_digest_table([m])
+        assert "errors" in table.lower()
+
+    def test_table_marks_inconclusive_class(self):
+        rows = [_timed_out_row("code_review")] * 10
+        m = compute_class_metrics("code_review", rows)
+        table = format_digest_table([m])
+        assert "INCONCLUSIVE" in table
+
+    def test_table_does_not_mark_clean_class_inconclusive(self):
+        rows = [_clean_row("bookkeeping")] * 10
+        m = compute_class_metrics("bookkeeping", rows)
+        table = format_digest_table([m])
+        assert "INCONCLUSIVE" not in table


### PR DESCRIPTION
## Summary

Fixes SAG-4341. Hardens `digest_and_alert.py` so infrastructure-error rows (timeout, GPU-contention, etc.) are excluded from the quality denominator and do not trigger false regression alerts.

**Key changes (3 files only — `scripts/eval/` only):**
- `digest_and_alert.py`: rows with non-null `error` are classified as infra-errors and excluded from `task_correct_rate`/`clean_rate` denominators. Classes with `error_rate >= ERROR_RATE_INCONCLUSIVE_THRESHOLD` (0.25) emit `INCONCLUSIVE` (exit 0, lower-severity) instead of a false `REGRESSION`. `MIN_CLEAN_ROWS_FOR_REGRESSION = 3` guards tiny-N. Genuine quality drops with low error-rate still fire `REGRESSION` (exit 1). Digest table adds `errors` column + `INCONCLUSIVE` marker per class.
- `tests/test_digest_and_alert.py`: 21 tests covering all 3 ACs (all-timed-out → INCONCLUSIVE, clean-drop → REGRESSION, mixed → INCONCLUSIVE + quality-from-clean-rows).
- `tests/__init__.py`: empty init for pytest discovery.

**Context:** SAG-4340 fired a P-high false positive (8 regressions) because an overnight GPU-contention cascade caused every row to time out (300s), scoring 0.0% with zero quality signal. A re-run on a free GPU returned exact baseline. This PR ensures that scenario emits INCONCLUSIVE, not REGRESSION.

**CTO gate (2026-06-19):** Code approved on merits (21/21 pass on PR-head blob, all 4 ACs verified). PR re-cut requested to de-stack from SAG-4314 commits and drop unrelated eval scripts.

## Changed files (exactly 3)
- `scripts/eval/digest_and_alert.py`
- `scripts/eval/tests/test_digest_and_alert.py`
- `scripts/eval/tests/__init__.py`

## Test plan
- [x] `pytest scripts/eval/tests/test_digest_and_alert.py` → 21/21 pass (verified locally)
- [x] `gh pr view <n> --json changedFiles` → changedFiles == 3
- [ ] CTO re-gate (code already approved; re-gate on clean PR only)
- [ ] One QA sign-off (AC audit requirement per issue)

Closes: SAG-4341
Parent: SAG-4340 / SAG-4193