### PR TITLE
fix: block agent checkout and mutation of user-assigned issues

### DIFF
--- a/server/src/__tests__/issue-agent-user-assignee-checkout-routes.test.ts
+++ b/server/src/__tests__/issue-agent-user-assignee-checkout-routes.test.ts
@@ -1,0 +1,158 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = {
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  update: vi.fn(),
+  checkout: vi.fn(),
+  release: vi.fn(),
+  remove: vi.fn(),
+  listAttachments: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+};
+
+const mockHeartbeatService = {
+  wakeup: vi.fn(async () => null),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+  reportRunActivity: vi.fn(async () => null),
+};
+
+vi.mock("../services/index.js", () => ({
+  accessService: vi.fn(() => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+    decide: vi.fn(async () => ({ allowed: true })),
+  })),
+  agentService: vi.fn(() => ({ getById: vi.fn() })),
+  clampIssueListLimit: vi.fn((value: number) => value),
+  companySearchService: vi.fn(() => ({ search: vi.fn() })),
+  companyService: vi.fn(() => ({ getById: vi.fn() })),
+  documentAnnotationService: vi.fn(() => ({})),
+  documentService: vi.fn(() => ({})),
+  executionWorkspaceService: vi.fn(() => ({})),
+  goalService: vi.fn(() => ({ getById: vi.fn() })),
+  heartbeatService: vi.fn(() => mockHeartbeatService),
+  issueApprovalService: vi.fn(() => ({ listApprovalsForIssue: vi.fn(), link: vi.fn(), unlink: vi.fn() })),
+  issueRecoveryActionService: vi.fn(() => ({ getActiveForIssue: vi.fn(async () => null) })),
+  issueReferenceService: vi.fn(() => ({})),
+  issueService: vi.fn(() => mockIssueService),
+  issueThreadInteractionService: vi.fn(() => ({
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  })),
+  ISSUE_LIST_DEFAULT_LIMIT: 50,
+  ISSUE_LIST_MAX_LIMIT: 100,
+  logActivity: vi.fn(async () => undefined),
+  projectService: vi.fn(() => ({ getById: vi.fn(async () => null) })),
+  routineService: vi.fn(() => ({ syncRunStatusForIssue: vi.fn(async () => undefined) })),
+  workProductService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/execution-workspaces.js", () => ({
+  executionWorkspaceService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/environments.js", () => ({
+  environmentService: vi.fn(() => ({})),
+}));
+
+import { issueRoutes } from "../routes/issues.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = {
+      type: "agent",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      runId: "22222222-2222-4222-8222-222222222222",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as never, { deleteObject: vi.fn() } as never));
+  return app;
+}
+
+const userAssignedIssue = {
+  id: "issue-1",
+  companyId: "company-1",
+  projectId: null,
+  parentId: null,
+  assigneeAgentId: null,
+  assigneeUserId: "board-user-1",
+  status: "todo",
+  identifier: "PAP-1",
+  title: "User-owned issue",
+  createdByUserId: "board-user-1",
+};
+
+const unassignedIssue = {
+  ...userAssignedIssue,
+  assigneeUserId: null,
+};
+
+describe("issueRoutes user-assignee checkout boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.listAttachments.mockResolvedValue([]);
+  });
+
+  it("rejects agent patches against user-assigned issues", async () => {
+    mockIssueService.getById.mockResolvedValue(userAssignedIssue);
+
+    const res = await request(createApp())
+      .patch("/api/issues/issue-1")
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agents cannot mutate or checkout user-assigned issues" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent checkout against user-assigned issues", async () => {
+    mockIssueService.getById.mockResolvedValue(userAssignedIssue);
+
+    const res = await request(createApp())
+      .post("/api/issues/issue-1/checkout")
+      .send({ agentId: "11111111-1111-4111-8111-111111111111", expectedStatuses: ["todo"] });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agents cannot mutate or checkout user-assigned issues" });
+    expect(mockIssueService.checkout).not.toHaveBeenCalled();
+  });
+
+  it("still allows agent checkout for truly unassigned issues", async () => {
+    mockIssueService.getById.mockResolvedValue(unassignedIssue);
+    mockIssueService.checkout.mockResolvedValue({
+      ...unassignedIssue,
+      assigneeAgentId: "11111111-1111-4111-8111-111111111111",
+      status: "in_progress",
+    });
+
+    const res = await request(createApp())
+      .post("/api/issues/issue-1/checkout")
+      .send({ agentId: "11111111-1111-4111-8111-111111111111", expectedStatuses: ["todo"] });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      "issue-1",
+      "11111111-1111-4111-8111-111111111111",
+      ["todo"],
+      "22222222-2222-4222-8222-222222222222",
+    );
+  });
+});

--- a/server/src/routes/issue-agent-mutation-guard.ts
+++ b/server/src/routes/issue-agent-mutation-guard.ts
@@ -1,0 +1,14 @@
+type IssueAssignmentBoundary = {
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+};
+
+export function isIssueUnassigned(issue: IssueAssignmentBoundary) {
+  return issue.assigneeAgentId === null && issue.assigneeUserId === null;
+}
+
+export function canAgentMutateOrCheckoutIssue(issue: IssueAssignmentBoundary) {
+  if (isIssueUnassigned(issue)) return true;
+  if (issue.assigneeUserId !== null && issue.assigneeAgentId === null) return false;
+  return true;
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -97,6 +97,7 @@ import {
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { canAgentMutateOrCheckoutIssue, isIssueUnassigned } from "./issue-agent-mutation-guard.js";
 import {
   isInlineAttachmentContentType,
   isAllowedContentType,
@@ -4799,6 +4800,17 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+    const isAgentBlockedByUserAssignment =
+      req.actor.type === "agent" &&
+      !isIssueUnassigned(existing) &&
+      !canAgentMutateOrCheckoutIssue(existing);
+    const userAssignedRecoveryAction = isAgentBlockedByUserAssignment
+      ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
+      : null;
+    if (isAgentBlockedByUserAssignment && !userAssignedRecoveryAction) {
+      res.status(403).json({ error: "Agents cannot mutate or checkout user-assigned issues" });
+      return;
+    }
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
@@ -4854,7 +4866,7 @@ export function issueRoutes(
       req.body.executionPolicy !== undefined ||
       explicitMoveToTodoRequested;
     const activeRecoveryActionBeforeUpdate = recoveryRelevantSourceMutationRequested
-      ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
+      ? (userAssignedRecoveryAction ?? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id))
       : null;
     if (
       recoveryRelevantSourceMutationRequested &&
@@ -5850,6 +5862,11 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    if (req.actor.type === "agent" && !canAgentMutateOrCheckoutIssue(issue)) {
+      res.status(403).json({ error: "Agents cannot mutate or checkout user-assigned issues" });
+      return;
+    }
+    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
 
     if (issue.projectId) {
       const project = await projectsSvc.getById(issue.projectId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source system for managing agent work, so issue assignment and mutation boundaries are part of its core safety model.
> - The server issue routes are the subsystem that decides which actor can checkout or mutate a task.
> - GitHub issue `#8242` exposed a gap where agent flows could treat human-assigned issues as if they were unassigned.
> - That gap matters because it weakens the separation between human-owned work and autonomous agent execution.
> - This pull request tightens those route-level guards by sharing the user-assignment check between checkout and mutation paths.
> - The benefit is that normal agents now get a deterministic rejection for human-assigned issues, while truly unassigned issues continue to work as before.

## Linked Issues or Issue Description

- Fixes #8242

## What Changed

- Added a shared route guard helper for deciding whether an agent may mutate or checkout an issue when assignment state is involved.
- Reused that guard in the plain agent `PATCH /api/issues/:id` path so agents cannot mutate user-assigned issues without an active recovery delegation.
- Added the corresponding checkout rejection for issues that are assigned to a user but not to an agent.
- Added regression coverage for rejected user-assigned checkout, rejected user-assigned mutation, and still-allowed checkout of truly unassigned issues.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-user-assignee-checkout-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`

## Risks

- Low-to-moderate risk. The change is narrow and covered by route tests, but it does tighten assignment-boundary behavior in the checkout path.
- The main follow-up risk is recovery-flow parity: checkout now rejects user-assigned issues outright, while plain mutation still has an active-recovery delegation bypass. If recovery workflows need checkout parity too, that should be handled in a follow-up code change rather than assumed here.

> I checked `ROADMAP.md`; this is bug-fix work on existing issue-assignment boundaries, not overlapping planned core feature work.

## Model Used

- OpenAI Codex local adapter using `gpt-5.4` with tool use, shell execution, and repository inspection.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

