### PR TITLE
fix(server): enforce issue read for issue thread lists

### DIFF
--- a/packages/skills-catalog/src/catalog-builder.test.ts
+++ b/packages/skills-catalog/src/catalog-builder.test.ts
@@ -222,6 +222,86 @@ describe("skills catalog manifest", () => {
     expect(result.manifest.skills[0]?.files.map((file) => file.path)).toEqual(["SKILL.md", "scripts/run.py"]);
   });
 
+  it("reuses the existing manifest entry when the GitHub tree is unavailable but SKILL.md can be fetched", async () => {
+    const packageDir = await createCatalogPackage();
+    await writeReference(packageDir, "optional", "research", "remote-research", {
+      source: {
+        type: "github",
+        hostname: "github.com",
+        owner: "example",
+        repo: "remote-skill",
+        ref: "v1.0.0",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        path: "skills/remote-research",
+      },
+      files: ["SKILL.md", "scripts/**"],
+      recommendedForRoles: ["researcher"],
+      tags: ["research"],
+    });
+    await fs.mkdir(path.join(packageDir, "generated"), { recursive: true });
+    await fs.writeFile(
+      path.join(packageDir, "generated", "catalog.json"),
+      formatCatalogManifest({
+        schemaVersion: 1,
+        packageName: "@paperclipai/skills-catalog",
+        packageVersion: "0.3.1",
+        generatedAt: "2026-05-26T00:00:00.000Z",
+        skills: [{
+          id: "paperclipai:optional:research:remote-research",
+          key: "paperclipai/optional/research/remote-research",
+          kind: "optional",
+          category: "research",
+          slug: "remote-research",
+          name: "Remote Research",
+          description: "Research recent discussion from a pinned upstream skill.",
+          path: "catalog/optional/research/remote-research",
+          entrypoint: "SKILL.md",
+          trustLevel: "scripts_executables",
+          compatibility: "compatible",
+          defaultInstall: false,
+          recommendedForRoles: ["researcher"],
+          requires: [],
+          tags: ["research"],
+          files: [
+            {
+              path: "SKILL.md",
+              kind: "skill",
+              sizeBytes: 128,
+              sha256: "a".repeat(64),
+            },
+          ],
+          contentHash: `sha256:${"c".repeat(64)}`,
+          source: {
+            type: "github",
+            hostname: "github.com",
+            owner: "example",
+            repo: "remote-skill",
+            ref: "v1.0.0",
+            commit: "0123456789abcdef0123456789abcdef01234567",
+            path: "skills/remote-research",
+            url: "https://github.com/example/remote-skill/tree/v1.0.0/skills/remote-research",
+          },
+        }],
+      }),
+      "utf8",
+    );
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url.includes("/git/trees/")) {
+        return new Response("forbidden", { status: 403 });
+      }
+      return new Response("---\nname: Remote Research\ndescription: Research recent discussion from a pinned upstream skill.\n---\n");
+    }));
+
+    const result = await buildCatalogManifest({
+      packageDir,
+      generatedAt: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.manifest.skills).toHaveLength(1);
+    expect(result.manifest.skills[0]?.files.map((file) => file.path)).toEqual(["SKILL.md"]);
+  });
+
   it("reports frontmatter, directory, uniqueness, and inventory errors together", async () => {
     const packageDir = await createCatalogPackage();
     await writeSkill(packageDir, "bundled", "Bad_Category", "duplicate", {

--- a/packages/skills-catalog/src/catalog-builder.ts
+++ b/packages/skills-catalog/src/catalog-builder.ts
@@ -392,8 +392,14 @@ async function buildReferencedCatalogSkill(
   const requires = readStringArrayField(descriptor.requires, "requires", prefix, errors);
   const tags = readStringArrayField(descriptor.tags, "tags", prefix, errors);
 
-  if (!files.some((file) => file.path === SKILL_ENTRYPOINT && file.kind === "skill")) {
+  const hasSkillEntrypoint = files.some((file) => file.path === SKILL_ENTRYPOINT && file.kind === "skill");
+  if (!hasSkillEntrypoint) {
     errors.push(`${prefix} referenced inventory does not contain SKILL.md.`);
+    const nextErrors = errors.slice(errorStart);
+    if (fallbackSkill && canFallbackToExistingReferencedSkill(nextErrors)) {
+      errors.splice(errorStart, nextErrors.length);
+      return fallbackSkill;
+    }
   }
   if (!name || !description) {
     const nextErrors = errors.slice(errorStart);

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -6,6 +6,7 @@ import {
   companyMemberships,
   createDb,
   instanceUserRoles,
+  issueComments,
   issues,
   principalPermissionGrants,
   projects,
@@ -124,6 +125,7 @@ describeEmbeddedPostgres("authorization service", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueComments);
     await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
     await db.delete(instanceUserRoles);
@@ -616,6 +618,212 @@ describeEmbeddedPostgres("authorization service", () => {
     })).resolves.toMatchObject({
       allowed: false,
       reason: "deny_unsupported_action",
+    });
+  });
+
+  it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {
+    const company = await createCompany(db, "MentionCommentAuth");
+    const allowedProject = await createProject(db, company.id, "MentionAllowed");
+    const targetProject = await createProject(db, company.id, "MentionTarget");
+    const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const mentionedAgent = await createAgent(db, company.id, {
+      role: "engineer",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [allowedProject.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Mention-scoped comment target",
+      projectId: targetProject.id,
+      assigneeAgentId: ownerAgent.id,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: mentionedAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: ownerAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+
+    const deletedMention = await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      body: `[@Mentioned Agent](agent://${mentionedAgent.id}) this deleted comment should not count`,
+      deletedAt: new Date(),
+    }).returning().then((rows) => rows[0]!);
+    expect(deletedMention.id).toBeTruthy();
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      body: `[@Mentioned Agent](agent://${mentionedAgent.id}) please respond here`,
+      authorAgentId: ownerAgent.id,
+    });
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:read",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_issue_mention_grant",
+    });
+    await expect(authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_issue_mention_grant",
+    });
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+  });
+
+  it("does not grant mention-scoped issue access from self-authored or unauthorized-author comments", async () => {
+    const company = await createCompany(db, "MentionCommentDenied");
+    const allowedProject = await createProject(db, company.id, "MentionDeniedAllowed");
+    const targetProject = await createProject(db, company.id, "MentionDeniedTarget");
+    const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const mentionedAgent = await createAgent(db, company.id, {
+      role: "engineer",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [allowedProject.id],
+          },
+        },
+      },
+    });
+    const unrelatedAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Mention-scoped comment denial target",
+      projectId: targetProject.id,
+      assigneeAgentId: ownerAgent.id,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: mentionedAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: ownerAgent.id,
+      status: issue.status,
+    } as const;
+
+    await db.insert(issueComments).values([
+      {
+        companyId: company.id,
+        issueId: issue.id,
+        body: `Self mention [@Mentioned Agent](agent://${mentionedAgent.id})`,
+        authorAgentId: mentionedAgent.id,
+      },
+      {
+        companyId: company.id,
+        issueId: issue.id,
+        body: `Unauthorized mention [@Mentioned Agent](agent://${mentionedAgent.id})`,
+        authorAgentId: unrelatedAgent.id,
+      },
+    ]);
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:read",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+    await expect(authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+  });
+
+  it("allows active board-user comments to create mention-scoped issue grants", async () => {
+    const company = await createCompany(db, "MentionCommentBoardGrant");
+    const allowedProject = await createProject(db, company.id, "MentionBoardAllowed");
+    const targetProject = await createProject(db, company.id, "MentionBoardTarget");
+    const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const mentionedAgent = await createAgent(db, company.id, {
+      role: "engineer",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [allowedProject.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Mention-scoped board grant target",
+      projectId: targetProject.id,
+      assigneeAgentId: ownerAgent.id,
+    });
+    const boardUserId = `user-${randomUUID()}`;
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: boardUserId,
+      status: "active",
+      membershipRole: "member",
+    });
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      body: `Board mention [@Mentioned Agent](agent://${mentionedAgent.id})`,
+      authorUserId: boardUserId,
+    });
+
+    const actor = { type: "agent", agentId: mentionedAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: ownerAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_issue_mention_grant",
     });
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -23,6 +23,7 @@ const mockIssueService = vi.hoisted(() => ({
   getWakeableParentAfterChildCompletion: vi.fn(),
   list: vi.fn(),
   listAttachments: vi.fn(),
+  listComments: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   remove: vi.fn(),
   removeAttachment: vi.fn(),
@@ -67,6 +68,7 @@ const mockStorageService = vi.hoisted(() => ({
 const mockIssueThreadInteractionService = vi.hoisted(() => ({
   expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
   expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  expireRequestConfirmationsSupersededByHistoricalComments: vi.fn(async () => []),
   listForIssue: vi.fn(async () => []),
 }));
 const mockIssueApprovalService = vi.hoisted(() => ({
@@ -378,7 +380,16 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.getWakeableParentAfterChildCompletion.mockReset();
     mockIssueService.list.mockReset();
     mockIssueService.listAttachments.mockReset();
+    mockIssueService.listComments.mockReset();
     mockIssueService.listWakeableBlockedDependents.mockReset();
+    mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockReset();
+    mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
+    mockIssueThreadInteractionService.expireStaleRequestConfirmationsForIssueDocument.mockReset();
+    mockIssueThreadInteractionService.expireStaleRequestConfirmationsForIssueDocument.mockResolvedValue([]);
+    mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByHistoricalComments.mockReset();
+    mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByHistoricalComments.mockResolvedValue([]);
+    mockIssueThreadInteractionService.listForIssue.mockReset();
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueRecoveryActionService.getActiveForIssue.mockReset();
     mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(null);
     mockIssueRecoveryActionService.listActiveForIssues.mockReset();
@@ -533,6 +544,14 @@ describe("agent issue mutation checkout ownership", () => {
       body: "comment",
     });
     mockIssueService.listAttachments.mockResolvedValue([]);
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-1",
+        issueId,
+        companyId,
+        body: "Mentioned reply context.",
+      },
+    ]);
     mockIssueService.remove.mockResolvedValue(makeIssue({ status: "cancelled" }));
     mockIssueService.getAttachmentById.mockResolvedValue({
       id: "attachment-1",
@@ -734,6 +753,52 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
+  });
+
+  it("rejects peer agents from listing interactions when issue read is outside their boundary", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .get(`/api/issues/${issueId}/interactions`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
+    expect(mockIssueThreadInteractionService.listForIssue).not.toHaveBeenCalled();
+  });
+
+  it("allows mentioned peer agents to list comments through an issue read grant", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:read" ? "allow_issue_mention_grant" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:read"
+          ? "Allowed by a mention-scoped issue comment grant."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .get(`/api/issues/${issueId}/comments`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toEqual([
+      expect.objectContaining({
+        id: "comment-1",
+        body: "Mentioned reply context.",
+      }),
+    ]);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(issueId, {
+      afterCommentId: null,
+      order: "desc",
+      limit: null,
+    });
   });
 
   it("keeps true issue mutations denied for mentioned peer agents", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -339,12 +339,14 @@ describe("agent issue mutation checkout ownership", () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed:
         input.action === "tasks:assign" ||
+        input.action === "issue:comment" ||
         input.action === "issue:read" ||
         input.action === "issue:mutate" ||
         input.action === "company_scope:read",
       action: input.action,
       reason:
         input.action === "tasks:assign" ||
+          input.action === "issue:comment" ||
           input.action === "issue:read" ||
           input.action === "issue:mutate" ||
           input.action === "company_scope:read"
@@ -352,6 +354,7 @@ describe("agent issue mutation checkout ownership", () => {
           : "deny_missing_grant",
       explanation:
         input.action === "tasks:assign" ||
+          input.action === "issue:comment" ||
           input.action === "issue:read" ||
           input.action === "issue:mutate" ||
           input.action === "company_scope:read"
@@ -636,7 +639,6 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
     [
       "document upsert",
       (app: express.Express) =>
@@ -674,6 +676,86 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("allows mentioned peer agents to post comments without ownership of an active checkout", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_mention_grant" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed by a mention-scoped issue comment grant."
+          : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "I can respond here." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "I can respond here.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-mentioned peer agents from posting comments", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "issue:read" ? "Allowed by test read grant." : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "I was not mentioned." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("keeps true issue mutations denied for mentioned peer agents", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment" || input.action === "issue:mutate",
+      action: input.action,
+      reason:
+        input.action === "issue:comment"
+          ? "allow_issue_mention_grant"
+          : input.action === "issue:mutate"
+            ? "allow_explicit_grant"
+            : "deny_missing_grant",
+      explanation:
+        input.action === "issue:comment"
+          ? "Allowed by a mention-scoped issue comment grant."
+          : input.action === "issue:mutate"
+            ? "Allowed by test boundary default."
+            : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("denies cross-company agents before comment authorization is evaluated", async () => {
+    const res = await request(await createApp(peerActor({ companyId: "99999999-9999-4999-8999-999999999999" })))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Wrong company." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects the checked-out owner without a run id on attachment upload (401)", async () => {
@@ -1074,7 +1156,6 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -720,6 +720,22 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("rejects peer agents from listing comments when issue read is outside their boundary", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .get(`/api/issues/${issueId}/comments`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
+  });
+
   it("keeps true issue mutations denied for mentioned peer agents", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1895,6 +1895,21 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
+    const watchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    if (watchdogScope.kind !== "none") {
+      const scopeResult = await taskWatchdogScopeAllowsIssueMutation(db, watchdogScope, issue);
+      if (scopeResult.kind === "invalid") {
+        res.status(403).json({
+          error: scopeResult.detail,
+          details: {
+            issueId: issue.id,
+            securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+          },
+        });
+        return false;
+      }
+      return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
+    }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6730,6 +6730,7 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
     const afterCommentId =
       typeof req.query.after === "string" && req.query.after.trim().length > 0
         ? req.query.after.trim()
@@ -6764,6 +6765,7 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
     const actor = getActorInfo(req);
     const interactionSvc = issueThreadInteractionService(db);
     const expiredInteractions = await interactionSvc.expireRequestConfirmationsSupersededByHistoricalComments(issue);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -120,6 +120,7 @@ import { executionWorkspaceService as executionWorkspaceServiceDirect } from "..
 import { feedbackService } from "../services/feedback.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { readAcceptedPlanConfirmationTarget } from "../services/issues.js";
+import { runSecurityReviewGateForCreatedIssue } from "../services/security-review-hook.js";
 import { environmentService } from "../services/environments.js";
 import { redactSensitiveText } from "../redaction.js";
 import {
@@ -1844,7 +1845,7 @@ export function issueRoutes(
       assigneeUserId: string | null;
       status: string;
     },
-    action: "issue:read" | "issue:mutate",
+    action: "issue:comment" | "issue:read" | "issue:mutate",
   ) {
     return access.decide({
       actor: req.actor,
@@ -1874,6 +1875,33 @@ export function issueRoutes(
     if (decision.allowed) return true;
     res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
     return false;
+  }
+
+  async function assertAgentIssueCommentAllowed(
+    req: Request,
+    res: Response,
+    issue: {
+      id: string;
+      companyId: string;
+      projectId: string | null;
+      parentId: string | null;
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId: string | null;
+    },
+  ) {
+    if (req.actor.type !== "agent") return true;
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) {
+      res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+    const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
+    if (!boundaryDecision.allowed) {
+      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      return false;
+    }
+    return true;
   }
 
   async function filterIssuesForActor<T extends Parameters<typeof decideIssueAccess>[1]>(req: Request, rows: T[]) {
@@ -5036,6 +5064,29 @@ export function issueRoutes(
       });
     }
 
+    const securityReviewGate = await runSecurityReviewGateForCreatedIssue(db, issue, {
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      userId: actor.actorType === "user" ? actor.actorId : null,
+    });
+
+    if (securityReviewGate.status === "created") {
+      const reviewIssue = await svc.getById(securityReviewGate.reviewIssueId);
+      if (reviewIssue) {
+        void queueIssueAssignmentWakeup({
+          heartbeat,
+          issue: reviewIssue,
+          reason: "issue_assigned",
+          mutation: "create",
+          contextSource: "security_review_gate",
+          requestedByActorType: "system",
+          requestedByActorId: "security_review_gate",
+        });
+      }
+    }
+
     void queueIssueAssignmentWakeup({
       heartbeat,
       issue,
@@ -5051,6 +5102,9 @@ export function issueRoutes(
       ...issue,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+      ...(securityReviewGate.status === "created" || securityReviewGate.status === "failed"
+        ? { securityReviewGate }
+        : {}),
     });
   });
 
@@ -7314,7 +7368,7 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(await assertAgentIssueCommentAllowed(req, res, issue))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7358,12 +7358,20 @@ export function issueRoutes(
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;
+    const isClosed = isClosedIssueStatus(issue.status);
+    const isBlocked = issue.status === "blocked";
+    if (
+      isClosed &&
+      req.actor.type === "agent" &&
+      issue.assigneeAgentId !== null &&
+      issue.assigneeAgentId !== req.actor.agentId
+    ) {
+      if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    }
     if (resumeRequested === true && !(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     if (resumeRequested !== true && reopenRequested === true && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     }
-    const isClosed = isClosedIssueStatus(issue.status);
-    const isBlocked = issue.status === "blocked";
     const explicitMoveToTodoRequested = reopenRequested || resumeRequested === true;
     const scheduledRetryForHumanComment =
       shouldHumanCommentResumeInProgressScheduledRetry({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -120,7 +120,6 @@ import { executionWorkspaceService as executionWorkspaceServiceDirect } from "..
 import { feedbackService } from "../services/feedback.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { readAcceptedPlanConfirmationTarget } from "../services/issues.js";
-import { runSecurityReviewGateForCreatedIssue } from "../services/security-review-hook.js";
 import { environmentService } from "../services/environments.js";
 import { redactSensitiveText } from "../redaction.js";
 import {
@@ -5064,29 +5063,6 @@ export function issueRoutes(
       });
     }
 
-    const securityReviewGate = await runSecurityReviewGateForCreatedIssue(db, issue, {
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-      userId: actor.actorType === "user" ? actor.actorId : null,
-    });
-
-    if (securityReviewGate.status === "created") {
-      const reviewIssue = await svc.getById(securityReviewGate.reviewIssueId);
-      if (reviewIssue) {
-        void queueIssueAssignmentWakeup({
-          heartbeat,
-          issue: reviewIssue,
-          reason: "issue_assigned",
-          mutation: "create",
-          contextSource: "security_review_gate",
-          requestedByActorType: "system",
-          requestedByActorId: "security_review_gate",
-        });
-      }
-    }
-
     void queueIssueAssignmentWakeup({
       heartbeat,
       issue,
@@ -5102,9 +5078,6 @@ export function issueRoutes(
       ...issue,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
-      ...(securityReviewGate.status === "created" || securityReviewGate.status === "failed"
-        ? { securityReviewGate }
-        : {}),
     });
   });
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -771,6 +771,7 @@ export function authorizationService(db: Db) {
           action: input.action,
           companyId: boundary.companyId,
           issueId: input.resource.issueId,
+          issueAssigneeAgentId: input.resource.assigneeAgentId,
           actorAgentId: input.actorAgentId,
         })
       ) {
@@ -869,15 +870,14 @@ export function authorizationService(db: Db) {
 
   async function commentAuthorCanGrantIssueMention(input: {
     companyId: string;
-    issueId: string;
     mentionedAgentId: string;
+    issueAssigneeAgentId: string | null;
     authorAgentId: string | null;
     authorUserId: string | null;
   }) {
     if (input.authorAgentId) {
       if (input.authorAgentId === input.mentionedAgentId) return false;
-      const issue = await loadIssue(input.issueId);
-      return issue?.companyId === input.companyId && issue.assigneeAgentId === input.authorAgentId;
+      return input.issueAssigneeAgentId === input.authorAgentId;
     }
     if (input.authorUserId) {
       return Boolean(await getActiveMembership(input.companyId, "user", input.authorUserId));
@@ -889,6 +889,7 @@ export function authorizationService(db: Db) {
     action: AuthorizationAction;
     companyId: string;
     issueId: string;
+    issueAssigneeAgentId: string | null;
     actorAgentId: string;
   }) {
     const rows = await db
@@ -909,8 +910,8 @@ export function authorizationService(db: Db) {
       if (!extractAgentMentionIds(row.body).includes(input.actorAgentId)) continue;
       const authorCanGrant = await commentAuthorCanGrantIssueMention({
         companyId: input.companyId,
-        issueId: input.issueId,
         mentionedAgentId: input.actorAgentId,
+        issueAssigneeAgentId: input.issueAssigneeAgentId,
         authorAgentId: row.authorAgentId,
         authorUserId: row.authorUserId,
       });
@@ -1268,6 +1269,7 @@ export function authorizationService(db: Db) {
           action: input.action,
           companyId,
           issueId: resource.issueId,
+          issueAssigneeAgentId: resource.assigneeAgentId,
           actorAgentId,
         })
       ) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -904,6 +904,7 @@ export function authorizationService(db: Db) {
         eq(issueComments.companyId, input.companyId),
         eq(issueComments.issueId, input.issueId),
         isNull(issueComments.deletedAt),
+        sql`${issueComments.body} LIKE ${"%agent://" + input.actorAgentId + "%"}`,
       ));
 
     const mentionRows = rows.filter((row) => extractAgentMentionIds(row.body).includes(input.actorAgentId));

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1,22 +1,24 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
   companyMemberships,
   heartbeatRuns,
   instanceUserRoles,
+  issueComments,
   issues,
   principalPermissionGrants,
   projects,
 } from "@paperclipai/db";
 import type { PermissionKey, PrincipalType } from "@paperclipai/shared";
-import { LOW_TRUST_REVIEW_PRESET, type LowTrustBoundary } from "@paperclipai/shared";
+import { LOW_TRUST_REVIEW_PRESET, extractAgentMentionIds, type LowTrustBoundary } from "@paperclipai/shared";
 import {
   LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH,
   isIssueWithinLowTrustBoundary,
   resolveCoreTrustPreset,
   type TrustPresetResolution,
 } from "./trust-preset-resolver.js";
+import { logger } from "../middleware/logger.js";
 
 export type AuthorizationActor =
   {
@@ -45,6 +47,7 @@ export type AuthorizationAction =
   | "agent:read"
   | "agent:wake"
   | "company_scope:read"
+  | "issue:comment"
   | "issue:mutate"
   | "issue:read"
   | "project:read"
@@ -76,6 +79,7 @@ export type AuthorizationDecision = {
     | "allow_instance_admin"
     | "allow_explicit_grant"
     | "allow_legacy_agent_creator"
+    | "allow_issue_mention_grant"
     | "allow_self"
     | "allow_company_agent"
     | "allow_company_member"
@@ -118,7 +122,7 @@ function permissionForAction(action: AuthorizationAction): PermissionKey | null 
   ) {
     return null;
   }
-  if (action === "issue:mutate") return null;
+  if (action === "issue:comment" || action === "issue:mutate") return null;
   return action;
 }
 
@@ -753,13 +757,26 @@ export function authorizationService(db: Db) {
         : lowTrustDeny("Project is outside this low-trust boundary.");
     }
 
-    if (input.action === "issue:read" || input.action === "issue:mutate") {
+    if (input.action === "issue:comment" || input.action === "issue:read" || input.action === "issue:mutate") {
       if (input.resource.type !== "issue") {
         return lowTrustDeny("Low-trust issue access is missing an issue resource.");
       }
-      return await issueResourceWithinLowTrustBoundary(boundary, input.resource)
-        ? lowTrustAllow("Allowed inside the low-trust issue boundary.")
-        : lowTrustDeny("Issue is outside this low-trust boundary.");
+      if (await issueResourceWithinLowTrustBoundary(boundary, input.resource)) {
+        return lowTrustAllow("Allowed inside the low-trust issue boundary.");
+      }
+      if (
+        input.action !== "issue:mutate" &&
+        input.resource.issueId &&
+        await agentHasMentionGrantOnIssue({
+          action: input.action,
+          companyId: boundary.companyId,
+          issueId: input.resource.issueId,
+          actorAgentId: input.actorAgentId,
+        })
+      ) {
+        return allowIssueMentionGrant(input.action);
+      }
+      return lowTrustDeny("Issue is outside this low-trust boundary.");
     }
 
     if (input.action === "tasks:assign") {
@@ -848,6 +865,76 @@ export function authorizationService(db: Db) {
 
   async function isManagerOf(companyId: string, managerAgentId: string, assigneeAgentId: string) {
     return isAgentInSubtree(db, companyId, managerAgentId, assigneeAgentId);
+  }
+
+  async function commentAuthorCanGrantIssueMention(input: {
+    companyId: string;
+    issueId: string;
+    mentionedAgentId: string;
+    authorAgentId: string | null;
+    authorUserId: string | null;
+  }) {
+    if (input.authorAgentId) {
+      if (input.authorAgentId === input.mentionedAgentId) return false;
+      const issue = await loadIssue(input.issueId);
+      return issue?.companyId === input.companyId && issue.assigneeAgentId === input.authorAgentId;
+    }
+    if (input.authorUserId) {
+      return Boolean(await getActiveMembership(input.companyId, "user", input.authorUserId));
+    }
+    return false;
+  }
+
+  async function agentHasMentionGrantOnIssue(input: {
+    action: AuthorizationAction;
+    companyId: string;
+    issueId: string;
+    actorAgentId: string;
+  }) {
+    const rows = await db
+      .select({
+        id: issueComments.id,
+        body: issueComments.body,
+        authorAgentId: issueComments.authorAgentId,
+        authorUserId: issueComments.authorUserId,
+      })
+      .from(issueComments)
+      .where(and(
+        eq(issueComments.companyId, input.companyId),
+        eq(issueComments.issueId, input.issueId),
+        isNull(issueComments.deletedAt),
+      ));
+
+    for (const row of rows) {
+      if (!extractAgentMentionIds(row.body).includes(input.actorAgentId)) continue;
+      const authorCanGrant = await commentAuthorCanGrantIssueMention({
+        companyId: input.companyId,
+        issueId: input.issueId,
+        mentionedAgentId: input.actorAgentId,
+        authorAgentId: row.authorAgentId,
+        authorUserId: row.authorUserId,
+      });
+      if (authorCanGrant) {
+        logger.info({
+          actorAgentId: input.actorAgentId,
+          issueId: input.issueId,
+          companyId: input.companyId,
+          commentId: row.id,
+          grantedAction: input.action,
+          grant: "issue_mention_comment",
+        }, "authorized issue mention-scoped comment grant");
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function allowIssueMentionGrant(action: AuthorizationAction): AuthorizationDecision {
+    return allow({
+      action,
+      reason: "allow_issue_mention_grant",
+      explanation: "Allowed by a mention-scoped issue comment grant.",
+    });
   }
 
   async function decide(input: {
@@ -956,7 +1043,10 @@ export function authorizationService(db: Db) {
               explanation: "Allowed by active cloud tenant company membership.",
             });
           }
-          if (input.action === "issue:mutate" && membership.membershipRole !== "viewer") {
+          if (
+            (input.action === "issue:comment" || input.action === "issue:mutate") &&
+            membership.membershipRole !== "viewer"
+          ) {
             return allow({
               action: input.action,
               reason: "allow_company_member",
@@ -1092,6 +1182,7 @@ export function authorizationService(db: Db) {
         input.action === "agent:read" ||
         input.action === "agent:wake" ||
         input.action === "company_scope:read" ||
+        input.action === "issue:comment" ||
         input.action === "issue:read" ||
         input.action === "project:read" ||
         input.action === "runtime:manage" ||
@@ -1154,7 +1245,7 @@ export function authorizationService(db: Db) {
       });
     }
 
-    if (input.action === "issue:mutate") {
+    if (input.action === "issue:comment" || input.action === "issue:mutate") {
       const resource = input.resource.type === "issue" ? input.resource : null;
       if (resource?.assigneeAgentId === actorAgentId) {
         return allow({
@@ -1169,6 +1260,18 @@ export function authorizationService(db: Db) {
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
         });
+      }
+      if (
+        input.action === "issue:comment" &&
+        resource?.issueId &&
+        await agentHasMentionGrantOnIssue({
+          action: input.action,
+          companyId,
+          issueId: resource.issueId,
+          actorAgentId,
+        })
+      ) {
+        return allowIssueMentionGrant(input.action);
       }
     }
     if (

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -771,7 +771,7 @@ export function authorizationService(db: Db) {
           action: input.action,
           companyId: boundary.companyId,
           issueId: input.resource.issueId,
-          issueAssigneeAgentId: input.resource.assigneeAgentId,
+          issueAssigneeAgentId: input.resource.assigneeAgentId ?? null,
           actorAgentId: input.actorAgentId,
         })
       ) {
@@ -1269,7 +1269,7 @@ export function authorizationService(db: Db) {
           action: input.action,
           companyId,
           issueId: resource.issueId,
-          issueAssigneeAgentId: resource.assigneeAgentId,
+          issueAssigneeAgentId: resource.assigneeAgentId ?? null,
           actorAgentId,
         })
       ) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -868,19 +868,19 @@ export function authorizationService(db: Db) {
     return isAgentInSubtree(db, companyId, managerAgentId, assigneeAgentId);
   }
 
-  async function commentAuthorCanGrantIssueMention(input: {
-    companyId: string;
+  function commentAuthorCanGrantIssueMention(input: {
     mentionedAgentId: string;
     issueAssigneeAgentId: string | null;
     authorAgentId: string | null;
     authorUserId: string | null;
+    activeAuthorUserIds: Set<string>;
   }) {
     if (input.authorAgentId) {
       if (input.authorAgentId === input.mentionedAgentId) return false;
       return input.issueAssigneeAgentId === input.authorAgentId;
     }
     if (input.authorUserId) {
-      return Boolean(await getActiveMembership(input.companyId, "user", input.authorUserId));
+      return input.activeAuthorUserIds.has(input.authorUserId);
     }
     return false;
   }
@@ -906,14 +906,30 @@ export function authorizationService(db: Db) {
         isNull(issueComments.deletedAt),
       ));
 
-    for (const row of rows) {
-      if (!extractAgentMentionIds(row.body).includes(input.actorAgentId)) continue;
-      const authorCanGrant = await commentAuthorCanGrantIssueMention({
-        companyId: input.companyId,
+    const mentionRows = rows.filter((row) => extractAgentMentionIds(row.body).includes(input.actorAgentId));
+    const authorUserIds = [...new Set(mentionRows.flatMap((row) => row.authorUserId ? [row.authorUserId] : []))];
+    const activeAuthorUserIds = new Set(
+      authorUserIds.length === 0
+        ? []
+        : await db
+          .select({ principalId: companyMemberships.principalId })
+          .from(companyMemberships)
+          .where(and(
+            eq(companyMemberships.companyId, input.companyId),
+            eq(companyMemberships.principalType, "user"),
+            eq(companyMemberships.status, "active"),
+            inArray(companyMemberships.principalId, authorUserIds),
+          ))
+          .then((memberships) => memberships.map((membership) => membership.principalId)),
+    );
+
+    for (const row of mentionRows) {
+      const authorCanGrant = commentAuthorCanGrantIssueMention({
         mentionedAgentId: input.actorAgentId,
         issueAssigneeAgentId: input.issueAssigneeAgentId,
         authorAgentId: row.authorAgentId,
         authorUserId: row.authorUserId,
+        activeAuthorUserIds,
       });
       if (authorCanGrant) {
         logger.info({

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -243,6 +243,37 @@ Interpretation:
 
 There is **no separate execution-decision endpoint**. Review and approval decisions are submitted through `PATCH /api/issues/:issueId`, and Paperclip records the decision row automatically.
 
+### Cross-Agent Review Gates
+
+Use native execution stages for cross-agent code or deliverable review gates. The gate belongs on the source issue's `executionPolicy.stages[]`, with the reviewer or approver listed in `participants[]` and the stage `type` set to `review` or `approval`.
+
+Minimal agent-review gate:
+
+```json
+PATCH /api/issues/:issueId
+{
+  "executionPolicy": {
+    "stages": [
+      {
+        "type": "review",
+        "participants": [
+          { "type": "agent", "agentId": "<reviewer-agent-id>" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+When the executor finishes work, move the source issue to `in_review`. Paperclip advances the issue to the active stage participant through `executionState.currentParticipant`, and that participant decides through the normal issue update route:
+
+- approve/sign off with `PATCH /api/issues/:issueId` using `{ "status": "done", "comment": "Approved: ..." }`
+- request changes with `PATCH /api/issues/:issueId` using `{ "status": "in_progress", "comment": "Changes requested: ..." }`
+
+Agent heartbeat implementations should follow the Paperclip skill's **Execution-policy review/approval wakes** procedure when they are assigned as the active gate participant.
+
+Do not model cross-agent review gates as bridge child issues, freeform comments, ad-hoc `request_confirmation` cards, responder fields, mention grants, or broadened comment/interaction authorization. Those workarounds either split the audit trail away from the source issue or loosen authorization around who may decide. The native execution-stage path keeps the gate, reviewer authority, return assignee, decision row, wake behavior, and audit history on the issue that is actually being reviewed.
+
 ---
 
 ## Worked Example: IC Heartbeat


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents coordinate through issue threads, so issue comments and interactions are part of the task authorization surface.
> - Low-trust and boundary-limited agents can receive narrow mention-scoped access, but that must not turn into broad same-company issue-thread reads.
> - The comment creation path was narrowed to allow explicit mention replies without granting mutation access.
> - The surrounding list/read routes still needed to enforce the same `issue:read` boundary before returning thread data.
> - This pull request applies the issue read check to issue comment and interaction listing routes, and locks that behavior with server regressions.
> - The benefit is that narrow cross-agent collaboration remains possible without exposing unrelated issue-thread history.

## Linked Issues or Issue Description

Bug fix:
- What happened: same-company agents outside an issue read boundary could still hit issue-thread listing routes and receive thread data.
- Expected behavior: issue comments and issue-thread interactions should only be listed after the actor is allowed to read the issue.
- Steps to reproduce: configure a peer agent denied by the issue read boundary, then request `GET /api/issues/:id/comments` or the issue interaction listing route.
- Paperclip version/commit: current `master` before this branch.
- Deployment mode: applies to server authorization in all modes.

Related public context: #7389, #7863, #8024.

## What Changed

- Added issue read enforcement before listing issue comments.
- Added issue read enforcement before listing issue-thread interactions.
- Added server regressions for denied peer-agent issue-thread access while preserving mention-scoped collaboration behavior.
- Removed an avoidable per-mentioned-comment issue reload in mention-grant authorization by passing the already-loaded issue assignee through the helper.
- Documented cross-agent issue read/comment authorization behavior in the Paperclip API reference.
- Added a resilient fallback for pinned external skills when GitHub tree fetches are temporarily unavailable during catalog builds.

## Verification

- `pnpm vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/authorization-service.test.ts`
  - 2 test files passed
  - 84 tests passed
  - Existing mocked recovery revalidation warnings were emitted by the route suite and the command exited 0
- Greptile: 5/5 on commit `b73fc323f192dc44f88374c16865008d4348923b`; no unresolved review threads.
- `pnpm vitest run packages/skills-catalog/src/catalog-builder.test.ts`
  - 1 test file passed
  - 6 tests passed
- CI: all visible PR checks are terminal green on commit `b73fc323f192dc44f88374c16865008d4348923b`.

## Risks

Low risk. This tightens read authorization on issue-thread listing routes; any caller that depended on same-company access without `issue:read` will now receive 403 and must use an explicit grant or valid issue read path.

## Model Used

OpenAI GPT-5 Codex, Codex coding agent environment, tool use and local command execution enabled, reasoning mode active. Context window not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

