### PR TITLE
feat(server): add /api/healthz minimal liveness probe

### DIFF
--- a/server/src/__tests__/healthz.test.ts
+++ b/server/src/__tests__/healthz.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { Db } from "@paperclipai/db";
+import { healthzRoutes } from "../routes/healthz.js";
+import { serverVersion } from "../version.js";
+
+function createApp(db?: Db, opts: { port?: number } = {}) {
+  const app = express();
+  app.use("/healthz", healthzRoutes(db, opts));
+  return app;
+}
+
+describe("GET /healthz", () => {
+  const originalEnvPort = process.env.PAPERCLIP_LISTEN_PORT;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PAPERCLIP_LISTEN_PORT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalEnvPort === undefined) {
+      delete process.env.PAPERCLIP_LISTEN_PORT;
+    } else {
+      process.env.PAPERCLIP_LISTEN_PORT = originalEnvPort;
+    }
+  });
+
+  it("returns 200 with the minimal liveness shape when no db is wired", async () => {
+    const app = createApp(undefined, { port: 4711 });
+
+    const res = await request(app).get("/healthz");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      version: serverVersion,
+      port: 4711,
+      dbReachable: true,
+    });
+    expect(typeof res.body.uptimeSec).toBe("number");
+    expect(res.body.uptimeSec).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns 200 when the database probe succeeds", async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue([{ "?column?": 1 }]),
+    } as unknown as Db;
+    const app = createApp(db, { port: 4711 });
+
+    const res = await request(app).get("/healthz");
+
+    expect(res.status).toBe(200);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+    expect(res.body).toMatchObject({
+      ok: true,
+      version: serverVersion,
+      port: 4711,
+      dbReachable: true,
+    });
+  });
+
+  it("returns 503 with ok=false when the database probe fails", async () => {
+    const db = {
+      execute: vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+    } as unknown as Db;
+    const app = createApp(db, { port: 4711 });
+
+    const res = await request(app).get("/healthz");
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      ok: false,
+      version: serverVersion,
+      port: 4711,
+      dbReachable: false,
+    });
+    expect(typeof res.body.uptimeSec).toBe("number");
+  });
+
+  it("falls back to PAPERCLIP_LISTEN_PORT env when no port opt is passed", async () => {
+    process.env.PAPERCLIP_LISTEN_PORT = "5123";
+    const app = createApp();
+
+    const res = await request(app).get("/healthz");
+
+    expect(res.status).toBe(200);
+    expect(res.body.port).toBe(5123);
+  });
+
+  it("returns port=undefined when neither opt nor env are set", async () => {
+    const app = createApp();
+
+    const res = await request(app).get("/healthz");
+
+    expect(res.status).toBe(200);
+    // JSON drops `undefined` keys — assert by absence rather than value.
+    expect(res.body.port).toBeUndefined();
+    expect(res.body).toMatchObject({
+      ok: true,
+      version: serverVersion,
+      dbReachable: true,
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { applyTrustProxy, parseTrustProxyEnv } from "./middleware/trust-proxy.js";
 import { healthRoutes } from "./routes/health.js";
+import { healthzRoutes } from "./routes/healthz.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
 import { teamsCatalogRoutes } from "./routes/teams-catalog.js";
@@ -217,6 +218,7 @@ export async function createApp(
       companyDeletionEnabled: opts.companyDeletionEnabled,
     }),
   );
+  api.use("/healthz", healthzRoutes(db));
   api.use(openApiRoutes());
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(llmRoutes(db));

--- a/server/src/routes/healthz.ts
+++ b/server/src/routes/healthz.ts
@@ -1,0 +1,55 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { sql } from "drizzle-orm";
+import { logger } from "../middleware/logger.js";
+import { serverVersion } from "../version.js";
+
+/**
+ * Minimal liveness probe at `/api/healthz` — separate from the richer
+ * `/api/health` route. Designed for unauthenticated loopback callers (systemd
+ * timers, container orchestrators) that just need a stable shape and a
+ * 200/503 verdict after a restart.
+ *
+ * Shape: `{ ok, version, port, uptimeSec, dbReachable }`
+ *
+ * - `ok` is the only field a caller is expected to assert on.
+ * - 200 when reachable and (if a db is wired) the `SELECT 1` probe succeeds.
+ * - 503 when the db probe fails. `ok` is `false` in that case.
+ */
+export function healthzRoutes(
+  db?: Db,
+  opts: { port?: number } = {},
+) {
+  const router = Router();
+
+  router.get("/", async (_req, res) => {
+    const port =
+      opts.port ??
+      (process.env.PAPERCLIP_LISTEN_PORT
+        ? Number(process.env.PAPERCLIP_LISTEN_PORT)
+        : undefined);
+    const uptimeSec = Math.round(process.uptime());
+
+    let dbReachable = true;
+    if (db) {
+      try {
+        await db.execute(sql`SELECT 1`);
+      } catch (error) {
+        logger.warn({ err: error }, "healthz database probe failed");
+        dbReachable = false;
+      }
+    }
+
+    const body = {
+      ok: dbReachable,
+      version: serverVersion,
+      port,
+      uptimeSec,
+      dbReachable,
+    };
+
+    res.status(dbReachable ? 200 : 503).json(body);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## What

Adds a minimal liveness probe at `/api/healthz`, a sibling to the existing richer `/api/health` route.

It is intended for **unauthenticated loopback callers** — systemd timers, container orchestrators, deploy verifiers — that need a small, stable shape and a simple `200`/`503` verdict after a restart, without parsing the larger `/api/health` payload.

### Shape

```json
{ "ok": true, "version": "x.y.z", "port": 4711, "uptimeSec": 42, "dbReachable": true }
```

- `ok` is the only field a caller is expected to assert on.
- **200** when reachable and (if a db is wired) the `SELECT 1` probe succeeds.
- **503** with `ok: false` when the db probe fails.
- `port` resolves from an explicit opt, then `PAPERCLIP_LISTEN_PORT`, else omitted.

## Why

A pull-based deployer needs a cheap, dependency-light endpoint to confirm the server came back up and its DB connection is live after an automated restart. `/api/health` already exposes richer status but isn't shaped as a minimal liveness verdict.

## Notes

- `/api/health` is **left completely unchanged** (backwards compatible).
- No auth on `/api/healthz` by liveness/loopback convention — it leaks no sensitive data (version + port + uptime + a boolean).
- The `db.execute(sql\`SELECT 1\`)` probe mirrors the existing pattern in `server/src/routes/health.ts`.
- Tests mirror `health.test.ts`: 5 cases (no-db, db-ok, db-fail→503, env-port fallback, port-absent). All green locally on `server` (`vitest run src/__tests__/healthz.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
