### PR TITLE
fix(auth): traverse full ancestry in issue:mutate authorization

### DIFF
--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -77,6 +77,7 @@ export type AuthorizationDecision = {
     | "allow_explicit_grant"
     | "allow_legacy_agent_creator"
     | "allow_self"
+    | "allow_ancestor_owner"
     | "allow_company_agent"
     | "allow_company_member"
     | "allow_simple_company_member"
@@ -642,6 +643,36 @@ export function authorizationService(db: Db) {
     );
   }
 
+  async function actorIsAncestorAssignee(
+    companyId: string,
+    parentIssueId: string,
+    actorAgentId: string,
+  ): Promise<boolean> {
+    const rows = await db.execute(sql`
+      WITH RECURSIVE ancestors(id, parent_id, assignee_agent_id, depth) AS (
+        SELECT id, parent_id, assignee_agent_id, 0
+        FROM issues
+        WHERE company_id = ${companyId}
+          AND id = ${parentIssueId}
+        UNION ALL
+        SELECT parent.id, parent.parent_id, parent.assignee_agent_id, ancestors.depth + 1
+        FROM issues parent
+        JOIN ancestors ON parent.id = ancestors.parent_id
+        WHERE parent.company_id = ${companyId}
+          AND ancestors.depth < ${LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH - 1}
+      )
+      SELECT EXISTS(
+        SELECT 1 FROM ancestors WHERE assignee_agent_id = ${actorAgentId}
+      ) AS is_ancestor_owner
+    `);
+    const first = Array.isArray(rows) ? rows[0] : null;
+    return Boolean(
+      first &&
+        typeof first === "object" &&
+        (first as Record<string, unknown>).is_ancestor_owner === true,
+    );
+  }
+
   async function issueResourceWithinLowTrustBoundary(
     boundary: LowTrustBoundaryWithCompany,
     resource: Extract<AuthorizationResource, { type: "issue" }>,
@@ -1169,6 +1200,18 @@ export function authorizationService(db: Db) {
           reason: "allow_company_agent",
           explanation: "Allowed because the issue has no agent assignee.",
         });
+      }
+      // An agent assigned to an ancestor issue is the subtree owner and may
+      // mutate any descendant, even if that descendant has a different assignee.
+      if (resource?.parentIssueId) {
+        const isSubtreeOwner = await actorIsAncestorAssignee(resource.companyId, resource.parentIssueId, actorAgentId);
+        if (isSubtreeOwner) {
+          return allow({
+            action: input.action,
+            reason: "allow_ancestor_owner",
+            explanation: "Allowed because the actor is assigned to an ancestor issue and is the subtree owner.",
+          });
+        }
       }
     }
     if (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The authorization subsystem (`authorization.ts`) controls who can mutate issues via `issue:mutate`
> - When an agent owns a parent issue (is the assignee), it should be the subtree owner and able to patch any descendant
> - Currently `allowIssueResourceWithinLowTrustBoundary` only checks if the actor is the direct assignee of the target issue, not of any ancestor
> - This PR adds `actorIsAncestorAssignee` — a recursive CTE query that walks the parent chain up to `LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH` levels
> - If any ancestor has the actor as its assignee, the request is allowed with reason `allow_ancestor_owner`
> - The benefit is that parent-issue owners can properly delegate to child tasks without hitting spurious 403s

## Linked Issues or Issue Description

No public GitHub issue exists. The problem:

**Bug:** An agent assigned to a parent issue cannot PATCH its own descendant issues when those descendants have a different assignee. The `issue:mutate` authorization check only verifies direct assignee, missing the subtree ownership concept.

- **Expected behavior:** Agent assigned to ancestor issue can mutate any descendant.
- **Actual behavior:** Returns 403 unless the agent is the direct assignee of the target issue.
- **Steps to reproduce:** Assign agent A to issue P; create child C under P with agent B as assignee; agent A attempts to PATCH C → 403.
- **Deployment mode:** All modes affected.

## What Changed

- Added `actorIsAncestorAssignee(companyId, parentIssueId, actorAgentId)` — recursive CTE walks the ancestry chain up to `LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH` levels and returns true if any ancestor has `actorAgentId` as assignee
- Added `allow_ancestor_owner` to the `AuthorizationDecision` reason union type
- In `allowIssueResourceWithinLowTrustBoundary` → `issue:mutate` path: after the direct-assignee check, if `resource.parentIssueId` exists, call `actorIsAncestorAssignee`; allow with `allow_ancestor_owner` reason if true

## Verification

1. Create parent issue P, assign agent A.
2. Create child issue C under P, assign agent B.
3. Agent A attempts `PATCH /api/issues/{C.id}` → should return 200 (was 403 before this fix).
4. Agent B (direct assignee) still works → 200.
5. Agent C (unrelated) still blocked → 403.
6. Run `pnpm test` in `server/` — no regressions in authorization tests.

## Risks

Low risk. The new check only adds an allow path — it never denies something previously allowed. The recursive CTE is bounded by `LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH` (same constant already used elsewhere) to prevent unbounded traversal.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context: 200k token context window
- Capabilities: Tool use, code execution, extended reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/poe-8812-auth-boundary-full-ancestry`)
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] I have considered and documented any risks above