### PR TITLE
feat(server): add /api/admin/quiet-window probe for safe-restart gating

### DIFF
--- a/server/src/__tests__/admin-quiet-window.test.ts
+++ b/server/src/__tests__/admin-quiet-window.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { Db } from "@paperclipai/db";
+import { adminQuietWindowRoutes } from "../routes/admin-quiet-window.js";
+
+/**
+ * Build a stub db whose `select().from().where()` resolves to `rows`.
+ *
+ * Drizzle's query builder is a thenable, so `await select(...).from(...).where(...)`
+ * calls `.then` on the final node. The stub matches that shape.
+ */
+function stubDbWithRows(rows: unknown[]): Db {
+  const thenable = {
+    from() {
+      return this;
+    },
+    where() {
+      return Promise.resolve(rows);
+    },
+  };
+  return {
+    select: vi.fn(() => thenable),
+  } as unknown as Db;
+}
+
+function stubDbThatThrows(error: Error): Db {
+  const thenable = {
+    from() {
+      return this;
+    },
+    where() {
+      return Promise.reject(error);
+    },
+  };
+  return {
+    select: vi.fn(() => thenable),
+  } as unknown as Db;
+}
+
+function createApp(db?: Db) {
+  const app = express();
+  app.use("/admin/quiet-window", adminQuietWindowRoutes(db));
+  return app;
+}
+
+describe("GET /admin/quiet-window", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns safeToRestart=true when no runs are queued or running", async () => {
+    const db = stubDbWithRows([{ checkedOutCount: 0, oldestStartedAt: null }]);
+    const app = createApp(db);
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      checkedOutCount: 0,
+      oldestRunStartedAt: null,
+      safeToRestart: true,
+    });
+  });
+
+  it("returns safeToRestart=false with the oldest run timestamp when work is in flight", async () => {
+    const oldest = new Date("2026-05-18T22:30:00.000Z");
+    const db = stubDbWithRows([{ checkedOutCount: 3, oldestStartedAt: oldest }]);
+    const app = createApp(db);
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      checkedOutCount: 3,
+      oldestRunStartedAt: oldest.toISOString(),
+      safeToRestart: false,
+    });
+  });
+
+  it("normalises a string oldestStartedAt into an ISO timestamp", async () => {
+    // Some drivers return MIN(timestamp) as a string rather than a Date.
+    const db = stubDbWithRows([
+      { checkedOutCount: 1, oldestStartedAt: "2026-05-18T22:30:00.000Z" },
+    ]);
+    const app = createApp(db);
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(200);
+    expect(res.body.oldestRunStartedAt).toBe("2026-05-18T22:30:00.000Z");
+    expect(res.body.safeToRestart).toBe(false);
+  });
+
+  it("returns safe=true and skips the db when no db is wired", async () => {
+    const app = createApp();
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      checkedOutCount: 0,
+      oldestRunStartedAt: null,
+      safeToRestart: true,
+    });
+  });
+
+  it("returns 503 with database_unreachable when the probe query throws", async () => {
+    const db = stubDbThatThrows(new Error("connect ECONNREFUSED"));
+    const app = createApp(db);
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: "database_unreachable" });
+  });
+
+  it("rejects non-loopback callers with no admin actor", async () => {
+    const db = stubDbWithRows([{ checkedOutCount: 0, oldestStartedAt: null }]);
+    const app = express();
+    app.use((req, _res, next) => {
+      // Forge an off-host source to exercise the loopback gate.
+      Object.defineProperty(req, "ip", { value: "10.0.0.5" });
+      Object.defineProperty(req.socket, "remoteAddress", {
+        value: "10.0.0.5",
+        configurable: true,
+      });
+      next();
+    });
+    app.use("/admin/quiet-window", adminQuietWindowRoutes(db));
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "loopback_only" });
+    expect((db.select as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("allows an off-host caller that is an authenticated board admin", async () => {
+    const db = stubDbWithRows([{ checkedOutCount: 0, oldestStartedAt: null }]);
+    const app = express();
+    app.use((req, _res, next) => {
+      Object.defineProperty(req, "ip", { value: "10.0.0.5" });
+      Object.defineProperty(req.socket, "remoteAddress", {
+        value: "10.0.0.5",
+        configurable: true,
+      });
+      (req as unknown as { actor: unknown }).actor = {
+        type: "board",
+        source: "session",
+        userId: "user-1",
+        userName: "Admin",
+        userEmail: null,
+        isInstanceAdmin: true,
+      };
+      next();
+    });
+    app.use("/admin/quiet-window", adminQuietWindowRoutes(db));
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(200);
+    expect(res.body.safeToRestart).toBe(true);
+  });
+
+  it("rejects an off-host caller whose board grant came from local_trusted implicit-board", async () => {
+    const db = stubDbWithRows([{ checkedOutCount: 0, oldestStartedAt: null }]);
+    const app = express();
+    app.use((req, _res, next) => {
+      Object.defineProperty(req, "ip", { value: "10.0.0.5" });
+      Object.defineProperty(req.socket, "remoteAddress", {
+        value: "10.0.0.5",
+        configurable: true,
+      });
+      (req as unknown as { actor: unknown }).actor = {
+        type: "board",
+        source: "local_implicit",
+        userId: "local-board",
+        userName: "Local Board",
+        userEmail: null,
+        isInstanceAdmin: true,
+      };
+      next();
+    });
+    app.use("/admin/quiet-window", adminQuietWindowRoutes(db));
+
+    const res = await request(app).get("/admin/quiet-window");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "loopback_only" });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
 import { applyTrustProxy, parseTrustProxyEnv } from "./middleware/trust-proxy.js";
 import { healthRoutes } from "./routes/health.js";
+import { adminQuietWindowRoutes } from "./routes/admin-quiet-window.js";
 import { companyRoutes } from "./routes/companies.js";
 import { companySkillRoutes } from "./routes/company-skills.js";
 import { teamsCatalogRoutes } from "./routes/teams-catalog.js";
@@ -218,6 +219,7 @@ export async function createApp(
     }),
   );
   api.use(openApiRoutes());
+  api.use("/admin/quiet-window", adminQuietWindowRoutes(db));
   api.use("/companies", companyRoutes(db, opts.storageService));
   api.use(llmRoutes(db));
   api.use(companySkillRoutes(db));

--- a/server/src/routes/admin-quiet-window.ts
+++ b/server/src/routes/admin-quiet-window.ts
@@ -1,0 +1,118 @@
+import { Router, type Request as ExpressRequest } from "express";
+import type { Db } from "@paperclipai/db";
+import { count, inArray, sql } from "drizzle-orm";
+import { heartbeatRuns } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+/**
+ * Loopback-first administrative probe at `/api/admin/quiet-window`.
+ *
+ * Designed for the roclaw `paperclip-gce-deployer` pull-based deploy unit:
+ * the timer hits this endpoint every ~1 minute and only issues
+ * `systemctl --user restart paperclip.service` when `safeToRestart === true`.
+ *
+ * Shape:
+ * ```
+ * {
+ *   checkedOutCount: number,
+ *   oldestRunStartedAt: string | null, // ISO timestamp
+ *   safeToRestart: boolean             // checkedOutCount === 0
+ * }
+ * ```
+ *
+ * Access rules:
+ * - Loopback callers (127.0.0.1, ::1, ::ffff:127.0.0.1, or unix socket) are
+ *   always allowed.
+ * - Non-loopback callers must be an authenticated board actor whose grant
+ *   did not come from the `local_trusted` implicit-board path. This prevents
+ *   the Tailscale-exposed `local_trusted` deployment from silently letting
+ *   any LAN/Tailscale caller hit the probe.
+ *
+ * Source: `heartbeatRuns` where `status in ('queued', 'running')`. This
+ * mirrors `activeRunCount` already computed in `health.ts`, but in a
+ * dedicated, stable-shape endpoint the deployer can scrape cheaply.
+ */
+
+const LOOPBACK_ADDRESSES = new Set([
+  "127.0.0.1",
+  "::1",
+  "::ffff:127.0.0.1",
+]);
+
+function isLoopbackRequest(req: ExpressRequest): boolean {
+  const ip = req.ip;
+  if (typeof ip === "string" && LOOPBACK_ADDRESSES.has(ip)) return true;
+
+  const socketAddress = req.socket.remoteAddress;
+  if (typeof socketAddress === "string" && LOOPBACK_ADDRESSES.has(socketAddress)) {
+    return true;
+  }
+
+  // Unix-domain sockets and tests using `request(app)` won't have a remote
+  // address. Treat absent remote-address as loopback — it cannot have come
+  // from off-host.
+  if (!socketAddress && (!ip || ip === "")) return true;
+
+  return false;
+}
+
+function isAuthenticatedAdmin(req: ExpressRequest): boolean {
+  const actor = "actor" in req ? req.actor : null;
+  if (!actor || actor.type !== "board") return false;
+  // The `local_trusted` deployment mode auto-grants every request as
+  // `board` via `local_implicit`. That's fine for loopback, but we don't
+  // want it counting as an authenticated admin for off-host calls.
+  if ((actor as { source?: string }).source === "local_implicit") return false;
+  return true;
+}
+
+export function adminQuietWindowRoutes(db?: Db) {
+  const router = Router();
+
+  router.get("/", async (req, res) => {
+    if (!isLoopbackRequest(req) && !isAuthenticatedAdmin(req)) {
+      res.status(403).json({ error: "loopback_only" });
+      return;
+    }
+
+    if (!db) {
+      // No DB wired (test/bootstrap): nothing is checked out, by definition.
+      res.json({
+        checkedOutCount: 0,
+        oldestRunStartedAt: null,
+        safeToRestart: true,
+      });
+      return;
+    }
+
+    try {
+      const rows = await db
+        .select({
+          checkedOutCount: count(),
+          oldestStartedAt: sql<Date | string | null>`MIN(${heartbeatRuns.startedAt})`,
+        })
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.status, ["queued", "running"]));
+
+      const checkedOutCount = Number(rows[0]?.checkedOutCount ?? 0);
+      const oldestRaw = rows[0]?.oldestStartedAt ?? null;
+      const oldestRunStartedAt =
+        oldestRaw instanceof Date
+          ? oldestRaw.toISOString()
+          : typeof oldestRaw === "string" && oldestRaw.length > 0
+            ? new Date(oldestRaw).toISOString()
+            : null;
+
+      res.json({
+        checkedOutCount,
+        oldestRunStartedAt,
+        safeToRestart: checkedOutCount === 0,
+      });
+    } catch (error) {
+      logger.warn({ err: error }, "quiet-window probe database query failed");
+      res.status(503).json({ error: "database_unreachable" });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/quiet-window` — a lightweight probe endpoint for the `paperclip-gce-deployer` systemd pull-based deploy unit
- Deployer polls every ~1 minute and only restarts `paperclip.service` when `safeToRestart === true`, preventing mid-flight heartbeat interruptions
- Root cause fix for the **2026-05-18 03:36 UTC silent-drift incident** on roclaw (mid-flight restart corrupted in-progress heartbeat runs)

## Shape

```json
{
  "checkedOutCount": 0,
  "oldestRunStartedAt": null,
  "safeToRestart": true
}
```

Source: `heartbeatRuns` where `status IN ('queued', 'running')` — mirrors the `activeRunCount` already computed in `health.ts`.

## Access control

- **Loopback callers** (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`, unix socket, or supertest with no remote address) are always allowed
- **Non-loopback callers** must be an authenticated board actor whose grant did not come from the `local_trusted` implicit-board path — prevents Tailscale-exposed `local_trusted` deployments from allowing arbitrary LAN callers

## Files changed

| File | Change |
|------|--------|
| `server/src/routes/admin-quiet-window.ts` | New route handler (118 lines) |
| `server/src/__tests__/admin-quiet-window.test.ts` | Tests (196 lines) |
| `server/src/app.ts` | Import + mount (2 lines) |

## Test coverage

- Happy path: no queued/running runs → `safeToRestart: true`
- In-flight: runs active → `safeToRestart: false` with `oldestRunStartedAt`
- String/Date `oldestStartedAt` normalisation (some drivers return string from `MIN()`)
- No-db fallback: returns safe=true when db not wired
- DB failure: returns 503 `database_unreachable`
- Loopback gate: non-loopback + no actor → 403 `loopback_only`
- Auth admin off-host: board actor with non-local_implicit source → 200
- local_implicit off-host: blocked → 403 `loopback_only`

## Context

This PR is the upstream dependency for `paperclip-gce` branch changes (ROC-37 GCE deployer systemd unit). Once merged to master, the `paperclip-gce` branch will be rebased to include this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)