### PR TITLE
feat(issues): production health gate before closing incidents

### DIFF
--- a/server/src/__tests__/production-health-gate.test.ts
+++ b/server/src/__tests__/production-health-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertProductionHealthyForClosure,
   getProductionHealthTargets,
@@ -124,5 +124,37 @@ describe("assertProductionHealthyForClosure", () => {
         probeFn: oneDown,
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("probe (real fetch path)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("follows redirects and treats a settled 200 as healthy", async () => {
+    const inits: RequestInit[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init: RequestInit) => {
+        inits.push(init);
+        return Promise.resolve(new Response("ok", { status: 200 }));
+      }),
+    );
+
+    // No probeFn -> the real probe() runs, exercising the fetch call.
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: incidentIssue,
+        existingStatus: "in_progress",
+        requestedStatus: "done",
+        env: envWith(),
+      }),
+    ).resolves.toBeUndefined();
+
+    // One probe per configured target, each following redirects (not "manual",
+    // which would yield an opaque status 0 and falsely fail a healthy endpoint).
+    expect(inits).toHaveLength(2);
+    expect(inits.every((init) => init.redirect === "follow")).toBe(true);
   });
 });

--- a/server/src/__tests__/production-health-gate.test.ts
+++ b/server/src/__tests__/production-health-gate.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertProductionHealthyForClosure,
+  getProductionHealthTargets,
+  isProductionIncidentIssue,
+  ProductionHealthGateError,
+  type ProductionHealthResult,
+  type ProductionHealthTarget,
+} from "../services/production-health-gate.js";
+
+const TARGETS_JSON = JSON.stringify({
+  targets: [
+    { name: "pulse-web", url: "https://pulse-web-prod.example.app", expect: { status: 200 } },
+    { name: "pulse", url: "https://getpulse-app.example.app", expect: { status: 200 } },
+  ],
+});
+
+const envWith = (extra: Record<string, string> = {}): NodeJS.ProcessEnv => ({
+  PRODUCTION_HEALTH_TARGETS: TARGETS_JSON,
+  ...extra,
+});
+
+const incidentIssue = { title: "P0: Production Down — all routes 401", labels: [] };
+const ordinaryIssue = { title: "Tweak button padding on settings page", labels: ["ui"] };
+
+const allHealthy = (t: ProductionHealthTarget): Promise<ProductionHealthResult> =>
+  Promise.resolve({ name: t.name, url: t.url, healthy: true, status: 200 });
+const oneDown = (t: ProductionHealthTarget): Promise<ProductionHealthResult> =>
+  Promise.resolve(
+    t.name === "pulse"
+      ? { name: t.name, url: t.url, healthy: false, status: 401, reason: "got 401, expected 200" }
+      : { name: t.name, url: t.url, healthy: true, status: 200 },
+  );
+
+describe("getProductionHealthTargets", () => {
+  it("returns [] when unconfigured", () => {
+    expect(getProductionHealthTargets({})).toEqual([]);
+  });
+  it("parses the {targets:[...]} shape", () => {
+    expect(getProductionHealthTargets(envWith()).map((t) => t.name)).toEqual(["pulse-web", "pulse"]);
+  });
+});
+
+describe("isProductionIncidentIssue", () => {
+  it("matches a production-incident title", () => {
+    expect(isProductionIncidentIssue(incidentIssue, envWith())).toBe(true);
+  });
+  it("matches a configured label", () => {
+    expect(isProductionIncidentIssue({ title: "x", labels: ["outage"] }, envWith())).toBe(true);
+  });
+  it("ignores ordinary issues", () => {
+    expect(isProductionIncidentIssue(ordinaryIssue, envWith())).toBe(false);
+  });
+});
+
+describe("assertProductionHealthyForClosure", () => {
+  it("blocks closing a production incident when a target is down", async () => {
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: incidentIssue,
+        existingStatus: "in_progress",
+        requestedStatus: "done",
+        env: envWith(),
+        probeFn: oneDown,
+      }),
+    ).rejects.toBeInstanceOf(ProductionHealthGateError);
+  });
+
+  it("allows closing when all targets are healthy", async () => {
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: incidentIssue,
+        existingStatus: "in_progress",
+        requestedStatus: "done",
+        env: envWith(),
+        probeFn: allHealthy,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no-ops when the issue is not a production incident", async () => {
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: ordinaryIssue,
+        existingStatus: "in_progress",
+        requestedStatus: "done",
+        env: envWith(),
+        probeFn: oneDown, // would throw if it ran
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no-ops when not transitioning into a closed status", async () => {
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: incidentIssue,
+        existingStatus: "todo",
+        requestedStatus: "in_progress",
+        env: envWith(),
+        probeFn: oneDown,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no-ops when the issue is already closed (no re-gate)", async () => {
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: incidentIssue,
+        existingStatus: "done",
+        requestedStatus: "done",
+        env: envWith(),
+        probeFn: oneDown,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no-ops (fail-open) when the gate is unconfigured", async () => {
+    await expect(
+      assertProductionHealthyForClosure({
+        issue: incidentIssue,
+        existingStatus: "in_progress",
+        requestedStatus: "done",
+        env: {},
+        probeFn: oneDown,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/server/src/__tests__/production-health-gate.test.ts
+++ b/server/src/__tests__/production-health-gate.test.ts
@@ -4,6 +4,7 @@ import {
   getProductionHealthTargets,
   isProductionIncidentIssue,
   ProductionHealthGateError,
+  toPublicUnhealthy,
   type ProductionHealthResult,
   type ProductionHealthTarget,
 } from "../services/production-health-gate.js";
@@ -156,5 +157,38 @@ describe("probe (real fetch path)", () => {
     // which would yield an opaque status 0 and falsely fail a healthy endpoint).
     expect(inits).toHaveLength(2);
     expect(inits.every((init) => init.redirect === "follow")).toBe(true);
+  });
+});
+
+describe("toPublicUnhealthy (409 response projection)", () => {
+  const results: ProductionHealthResult[] = [
+    { name: "pulse-web", url: "https://pulse-web-prod.internal.example", healthy: true, status: 200 },
+    {
+      name: "pulse",
+      url: "https://getpulse-app.internal.example",
+      healthy: false,
+      status: 401,
+      reason: "got 401, expected 200",
+    },
+  ];
+
+  it("never leaks the internal target url (regression: superagent-security #8358)", () => {
+    const projected = toPublicUnhealthy(results);
+    for (const entry of projected) {
+      expect(entry).not.toHaveProperty("url");
+    }
+    // Defensive: no value in the payload contains the internal host either.
+    expect(JSON.stringify(projected)).not.toContain("internal.example");
+  });
+
+  it("returns only the unhealthy targets with name/status/reason", () => {
+    expect(toPublicUnhealthy(results)).toEqual([
+      { name: "pulse", status: 401, reason: "got 401, expected 200" },
+    ]);
+  });
+
+  it("returns an empty array when every target is healthy", () => {
+    const healthy = results.map((r) => ({ ...r, healthy: true }));
+    expect(toPublicUnhealthy(healthy)).toEqual([]);
   });
 });

--- a/server/src/__tests__/production-health-gate.test.ts
+++ b/server/src/__tests__/production-health-gate.test.ts
@@ -52,6 +52,20 @@ describe("isProductionIncidentIssue", () => {
   it("ignores ordinary issues", () => {
     expect(isProductionIncidentIssue(ordinaryIssue, envWith())).toBe(false);
   });
+
+  it("does not match a marker embedded inside another word (regression: greptile #8358)", () => {
+    // "reproduction" contains "production"; "p0lish" contains "p0" — substring
+    // matching would wrongly trip the gate and block these during an outage.
+    expect(isProductionIncidentIssue({ title: "Update reproduction steps for QA", labels: [] }, envWith())).toBe(
+      false,
+    );
+    expect(isProductionIncidentIssue({ title: "p0lish the settings UI", labels: [] }, envWith())).toBe(false);
+  });
+
+  it("still matches a whole-word marker next to punctuation", () => {
+    expect(isProductionIncidentIssue({ title: "P0: production is down", labels: [] }, envWith())).toBe(true);
+    expect(isProductionIncidentIssue({ title: "x", labels: ["p0"] }, envWith())).toBe(true);
+  });
 });
 
 describe("assertProductionHealthyForClosure", () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -125,6 +125,7 @@ import { redactSensitiveText } from "../redaction.js";
 import {
   assertProductionHealthyForClosure,
   ProductionHealthGateError,
+  toPublicUnhealthy,
 } from "../services/production-health-gate.js";
 import {
   createCompanySearchRateLimiter,
@@ -5846,15 +5847,12 @@ export function issueRoutes(
       });
     } catch (gateErr) {
       if (gateErr instanceof ProductionHealthGateError) {
-        // Omit each target's `url` — it points at internal production
-        // infrastructure and must not be disclosed to issue-closers. Return
-        // only the non-identifying name/status/reason.
+        // toPublicUnhealthy() strips each target's `url` (internal production
+        // infrastructure) so it is never disclosed to issue-closers.
         res.status(409).json({
           error: gateErr.message,
           code: "production_health_gate_failed",
-          unhealthy: gateErr.results
-            .filter((r) => !r.healthy)
-            .map((r) => ({ name: r.name, status: r.status, reason: r.reason })),
+          unhealthy: toPublicUnhealthy(gateErr.results),
         });
         return;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5846,10 +5846,15 @@ export function issueRoutes(
       });
     } catch (gateErr) {
       if (gateErr instanceof ProductionHealthGateError) {
+        // Omit each target's `url` — it points at internal production
+        // infrastructure and must not be disclosed to issue-closers. Return
+        // only the non-identifying name/status/reason.
         res.status(409).json({
           error: gateErr.message,
           code: "production_health_gate_failed",
-          unhealthy: gateErr.results.filter((r) => !r.healthy),
+          unhealthy: gateErr.results
+            .filter((r) => !r.healthy)
+            .map((r) => ({ name: r.name, status: r.status, reason: r.reason })),
         });
         return;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -123,6 +123,10 @@ import { readAcceptedPlanConfirmationTarget } from "../services/issues.js";
 import { environmentService } from "../services/environments.js";
 import { redactSensitiveText } from "../redaction.js";
 import {
+  assertProductionHealthyForClosure,
+  ProductionHealthGateError,
+} from "../services/production-health-gate.js";
+import {
   createCompanySearchRateLimiter,
   type CompanySearchRateLimiter,
 } from "../services/company-search-rate-limit.js";
@@ -5829,6 +5833,27 @@ export function issueRoutes(
           assigneeUserId: nextAssigneeUserId,
         });
       }
+    }
+
+    // Production health gate: a production incident may not be closed while the
+    // live production URLs are unhealthy (no-op unless PRODUCTION_HEALTH_TARGETS
+    // is configured and the issue looks like a production incident).
+    try {
+      await assertProductionHealthyForClosure({
+        issue: { title: existing.title, labels: (existing as { labels?: unknown }).labels },
+        existingStatus: existing.status,
+        requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
+      });
+    } catch (gateErr) {
+      if (gateErr instanceof ProductionHealthGateError) {
+        res.status(409).json({
+          error: gateErr.message,
+          code: "production_health_gate_failed",
+          unhealthy: gateErr.results.filter((r) => !r.healthy),
+        });
+        return;
+      }
+      throw gateErr;
     }
 
     let issue;

--- a/server/src/services/production-health-gate.ts
+++ b/server/src/services/production-health-gate.ts
@@ -1,0 +1,154 @@
+/**
+ * Production health gate for incident closure.
+ *
+ * Blocks a production-incident issue from transitioning into a closed status
+ * ("done") unless the configured production URLs actually return HTTP 200. This
+ * replaces "the board approved it" with an automated check against live
+ * production — a P0 was approved-closed three times while production was still
+ * down (every deploy BLOCKED / behind a 401 protection wall).
+ *
+ * Fail-open by design when UNCONFIGURED: if no targets are set, the gate is a
+ * no-op so it can never block unrelated issue closures. It only enforces once
+ * PRODUCTION_HEALTH_TARGETS is provided.
+ */
+
+export type ProductionHealthTarget = {
+  name: string;
+  url: string;
+  expectStatus?: number;
+  bodyIncludes?: string;
+};
+
+export type ProductionHealthResult = {
+  name: string;
+  url: string;
+  healthy: boolean;
+  status: number;
+  reason?: string;
+};
+
+export class ProductionHealthGateError extends Error {
+  readonly results: ProductionHealthResult[];
+  constructor(results: ProductionHealthResult[]) {
+    const failed = results.filter((r) => !r.healthy);
+    super(
+      `Production health gate failed: ${failed.length}/${results.length} target(s) not healthy ` +
+        `(${failed.map((r) => `${r.name}=${r.status}`).join(", ")}). ` +
+        `Resolve production before closing this incident.`,
+    );
+    this.name = "ProductionHealthGateError";
+    this.results = results;
+  }
+}
+
+const DEFAULT_EXPECT_STATUS = 200;
+const DEFAULT_RETRIES = 3;
+const DEFAULT_DELAY_MS = 4000;
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+/** Parse PRODUCTION_HEALTH_TARGETS (JSON: array or {targets:[...]}). Empty = gate disabled. */
+export function getProductionHealthTargets(env: NodeJS.ProcessEnv = process.env): ProductionHealthTarget[] {
+  const raw = env.PRODUCTION_HEALTH_TARGETS?.trim();
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  const list = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { targets?: unknown }).targets)
+      ? (parsed as { targets: unknown[] }).targets
+      : [];
+  return list
+    .map((item): ProductionHealthTarget | null => {
+      const t = item as Record<string, unknown>;
+      const expect = (t.expect as Record<string, unknown> | undefined) ?? {};
+      if (typeof t.url !== "string" || !t.url) return null;
+      return {
+        name: typeof t.name === "string" ? t.name : t.url,
+        url: t.url,
+        expectStatus: typeof expect.status === "number" ? expect.status : undefined,
+        bodyIncludes: typeof expect.bodyIncludes === "string" ? expect.bodyIncludes : undefined,
+      };
+    })
+    .filter((t): t is ProductionHealthTarget => t !== null);
+}
+
+/** Issue is a production incident when a configured marker appears in its labels or title. */
+export function isProductionIncidentIssue(
+  issue: { title?: string | null; labels?: unknown },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const markers = (env.PRODUCTION_INCIDENT_MARKERS ?? "production,p0,incident,outage")
+    .split(",")
+    .map((m) => m.trim().toLowerCase())
+    .filter(Boolean);
+  if (markers.length === 0) return false;
+  const labels = Array.isArray(issue.labels) ? issue.labels : [];
+  const haystack = [
+    issue.title ?? "",
+    ...labels.map((l) => (typeof l === "string" ? l : ((l as { name?: string })?.name ?? ""))),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return markers.some((m) => haystack.includes(m));
+}
+
+async function probe(target: ProductionHealthTarget): Promise<ProductionHealthResult> {
+  const expectStatus = target.expectStatus ?? DEFAULT_EXPECT_STATUS;
+  let lastStatus = 0;
+  let lastReason: string | undefined;
+  for (let attempt = 1; attempt <= DEFAULT_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+    try {
+      const res = await fetch(target.url, { redirect: "manual", signal: controller.signal });
+      const body = target.bodyIncludes ? await res.text().catch(() => "") : "";
+      const statusOk = res.status === expectStatus;
+      const bodyOk =
+        !target.bodyIncludes || body.toLowerCase().includes(target.bodyIncludes.toLowerCase());
+      lastStatus = res.status;
+      if (statusOk && bodyOk) {
+        return { name: target.name, url: target.url, healthy: true, status: res.status };
+      }
+      lastReason = !statusOk
+        ? `got ${res.status}, expected ${expectStatus}`
+        : `body missing "${target.bodyIncludes}"`;
+    } catch (err) {
+      lastStatus = 0;
+      lastReason = err instanceof Error && err.name === "AbortError" ? "timeout" : String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (attempt < DEFAULT_RETRIES) await new Promise((r) => setTimeout(r, DEFAULT_DELAY_MS));
+  }
+  return { name: target.name, url: target.url, healthy: false, status: lastStatus, reason: lastReason };
+}
+
+/**
+ * Throw {@link ProductionHealthGateError} if a production incident is being closed
+ * while production is unhealthy. No-op when the gate is unconfigured, the issue is
+ * not a production incident, or the transition is not into a closed status.
+ */
+export async function assertProductionHealthyForClosure(input: {
+  issue: { title?: string | null; labels?: unknown };
+  existingStatus: string | null | undefined;
+  requestedStatus: string | null | undefined;
+  env?: NodeJS.ProcessEnv;
+  probeFn?: (t: ProductionHealthTarget) => Promise<ProductionHealthResult>;
+}): Promise<void> {
+  const env = input.env ?? process.env;
+  const closing = input.requestedStatus === "done" && input.existingStatus !== "done";
+  if (!closing) return;
+  if (!isProductionIncidentIssue(input.issue, env)) return;
+  const targets = getProductionHealthTargets(env);
+  if (targets.length === 0) return; // gate disabled / unconfigured
+
+  const probeFn = input.probeFn ?? probe;
+  const results = await Promise.all(targets.map((t) => probeFn(t)));
+  if (results.some((r) => !r.healthy)) {
+    throw new ProductionHealthGateError(results);
+  }
+}

--- a/server/src/services/production-health-gate.ts
+++ b/server/src/services/production-health-gate.ts
@@ -27,6 +27,24 @@ export type ProductionHealthResult = {
   reason?: string;
 };
 
+/**
+ * Public, API-safe projection of an unhealthy target. Deliberately omits `url`,
+ * which points at internal production infrastructure and must not be disclosed
+ * to issue-closers in an error response.
+ */
+export type PublicUnhealthyTarget = {
+  name: string;
+  status: number;
+  reason?: string;
+};
+
+/** Project gate results down to the unhealthy targets, stripping internal URLs. */
+export function toPublicUnhealthy(results: ProductionHealthResult[]): PublicUnhealthyTarget[] {
+  return results
+    .filter((r) => !r.healthy)
+    .map((r) => ({ name: r.name, status: r.status, reason: r.reason }));
+}
+
 export class ProductionHealthGateError extends Error {
   readonly results: ProductionHealthResult[];
   constructor(results: ProductionHealthResult[]) {

--- a/server/src/services/production-health-gate.ts
+++ b/server/src/services/production-health-gate.ts
@@ -98,6 +98,8 @@ export function getProductionHealthTargets(env: NodeJS.ProcessEnv = process.env)
     .filter((t): t is ProductionHealthTarget => t !== null);
 }
 
+const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 /** Issue is a production incident when a configured marker appears in its labels or title. */
 export function isProductionIncidentIssue(
   issue: { title?: string | null; labels?: unknown },
@@ -115,7 +117,10 @@ export function isProductionIncidentIssue(
   ]
     .join(" ")
     .toLowerCase();
-  return markers.some((m) => haystack.includes(m));
+  // Word-boundary match, not substring: a substring `includes` would classify
+  // "Update reproduction steps" or "p0lish the UI" as production incidents and,
+  // during a real outage, block closing those unrelated issues with a 409.
+  return markers.some((m) => new RegExp(`\\b${escapeRegExp(m)}\\b`).test(haystack));
 }
 
 async function probe(target: ProductionHealthTarget): Promise<ProductionHealthResult> {

--- a/server/src/services/production-health-gate.ts
+++ b/server/src/services/production-health-gate.ts
@@ -42,9 +42,13 @@ export class ProductionHealthGateError extends Error {
 }
 
 const DEFAULT_EXPECT_STATUS = 200;
-const DEFAULT_RETRIES = 3;
-const DEFAULT_DELAY_MS = 4000;
-const DEFAULT_TIMEOUT_MS = 12_000;
+// Keep the total retry budget well under the ~30s where most HTTP clients,
+// ALBs, and nginx proxies cut the connection — otherwise an activated gate
+// holds the PATCH handler long enough that the caller sees a network timeout
+// instead of the intended 409. Worst case here: 2 * 5s timeout + 1 * 1s delay = 11s.
+const DEFAULT_RETRIES = 2;
+const DEFAULT_DELAY_MS = 1000;
+const DEFAULT_TIMEOUT_MS = 5000;
 
 /** Parse PRODUCTION_HEALTH_TARGETS (JSON: array or {targets:[...]}). Empty = gate disabled. */
 export function getProductionHealthTargets(env: NodeJS.ProcessEnv = process.env): ProductionHealthTarget[] {
@@ -104,7 +108,11 @@ async function probe(target: ProductionHealthTarget): Promise<ProductionHealthRe
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
     try {
-      const res = await fetch(target.url, { redirect: "manual", signal: controller.signal });
+      // Follow redirects and judge the final settled status. With redirect:"manual",
+      // undici returns an opaque response whose status is always 0, so a target that
+      // does any redirect (http->https, trailing-slash, etc.) would never match the
+      // expected 200 and the gate would block every closure on a healthy endpoint.
+      const res = await fetch(target.url, { redirect: "follow", signal: controller.signal });
       const body = target.bodyIncludes ? await res.text().catch(() => "") : "";
       const statusOk = res.status === expectStatus;
       const bodyOk =


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues are how teams track production incidents; closing one (`status → done`) is the signal that the incident is resolved
> - Closure today is approval-based — a human marks it done — with nothing checking that production actually recovered
> - This gap bit us directly: a P0 was approved-closed **three times** while production was still down (deploys `BLOCKED` by a git-author gate, then sitting behind a 401 protection wall)
> - This PR adds an automated health gate in the `PATCH /issues/:id` path: a production-incident issue cannot transition into `done` while its configured live URLs are unhealthy
> - The benefit is that "resolved" means production returns HTTP 200, not just that someone clicked close — and the gate is fail-open (a pure no-op unless explicitly configured) so it can never block unrelated work

## Linked Issues or Issue Description

No existing public issue — describing inline (bug-report shape):

- **What happens:** A production-incident issue can be moved to `done` purely on approval, with no check against live production. We closed a real P0 three times while production was still fully down.
- **Expected:** Closing a production incident should require that the configured production URLs are actually healthy (HTTP 200, optional body marker) at close time.
- **Impact:** Incidents get marked resolved while customers are still down, eroding the meaning of "done" and delaying real remediation.
- **Scope:** Backend only — the issue-update route and a new service. No schema or API-contract changes.

## What Changed

- **New service `server/src/services/production-health-gate.ts`** — `assertProductionHealthyForClosure()` classifies an issue as a production incident (title/label markers), probes each configured target with retry + timeout, and throws `ProductionHealthGateError` if any target isn't healthy.
- **`PATCH /issues/:id` (`server/src/routes/issues.ts`)** — runs the gate before the DB write; on failure returns **409** `{ code: "production_health_gate_failed", unhealthy: [...] }` instead of closing.
- **Probe latency bounded (review fix)** — retry budget cut from a 44s worst case to **11s** (`RETRIES 3→2`, `TIMEOUT 12s→5s`, `DELAY 4s→1s`) so an activated gate returns its 409 well inside the ~30s client/proxy timeout instead of surfacing as a network timeout.
- **Redirect handling fixed (review fix)** — `fetch` now uses `redirect: "follow"` instead of `"manual"`. With `"manual"`, undici returns an opaque response whose status is always `0`, which would falsely fail any production URL that redirects (http→https, trailing-slash, etc.) and permanently block closure on a healthy endpoint.
- **Tests** — 11 existing vitest cases plus a new case that runs the real probe with `fetch` stubbed, asserting it follows redirects and treats a settled 200 as healthy (covers the previously untested `fetch` path).

## Verification

```bash
pnpm --filter @paperclipai/server vitest run production-health-gate
# -> Test Files 1 passed | Tests 12 passed (11 existing + 1 new probe/redirect case)
```

- Gate **off** (no `PRODUCTION_HEALTH_TARGETS`): ordinary and incident issues close normally — verified by the unconfigured/fail-open cases.
- Gate **on**, all targets 200: incident closes.
- Gate **on**, a target down (e.g. 401): close is blocked with 409 and the unhealthy targets are listed.
- Non-incident issues and non-closing transitions skip the gate entirely.

## Risks

- **Low / opt-in.** The gate is a complete no-op unless `PRODUCTION_HEALTH_TARGETS` is set, the issue matches incident markers, and the transition is into `done`, so unrelated closures are unaffected.
- **In-band latency:** the probe runs inside the PATCH handler. Worst case is now 11s (was 44s), comfortably under typical 30s proxy timeouts.
- **Fail-closed only for genuine incidents:** if production is actually unhealthy, a configured incident cannot be closed — which is the intended behavior.
- No migrations, no breaking API changes; the only new response is the additive 409 on a blocked incident closure.

## Model Used

Claude (Anthropic) — **Opus 4.8**, 1M context window, extended thinking + tool use. Used to assist the implementation and to produce this review-response revision (probe-latency and redirect fixes, added test).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none — closest is #5447, unrelated incident-cooldown logic)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — backend only)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will confirm after push)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (re-running after push)
- [x] I will address all Greptile and reviewer comments before requesting merge
