### PR TITLE
feat: supervisor-release endpoint for stale checkout recovery by session-limited agents

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6741,6 +6741,79 @@ export function issueRoutes(
     res.json(result);
   });
 
+  /**
+   * POST /issues/:id/supervisor-release
+   *
+   * Allows a supervisor agent (role: cto or ceo) to break a stale checkout/execution
+   * lock on an issue whose original assignee's session has ended.  The lock is only
+   * released when it is genuinely stale — the checkout run must be terminal and the
+   * execution run must be terminal or in scheduled_retry (not actively executing).
+   *
+   * On success the issue's assigneeAgentId, checkoutRunId, and executionRunId are
+   * all cleared so the supervisor (or any eligible agent) can immediately re-checkout.
+   *
+   * Intended caller: the "Slack Picker Upper" routine agent that recovers stalled
+   * in-progress work after a session-limited agent's heartbeat run ends.
+   */
+  router.post("/issues/:id/supervisor-release", async (req, res) => {
+    if (req.actor.type !== "agent") {
+      res.status(403).json({ error: "Agent access required" });
+      return;
+    }
+    if (!req.actor.agentId) {
+      res.status(403).json({ error: "Agent identity required" });
+      return;
+    }
+
+    const actorAgent = await agentsSvc.getById(req.actor.agentId);
+    if (!actorAgent || !["cto", "ceo"].includes(actorAgent.role ?? "")) {
+      res.status(403).json({ error: "Supervisor role (cto or ceo) required" });
+      return;
+    }
+
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, existing.companyId);
+
+    const result = await svc.supervisorForceRelease(id);
+    if (!result) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    if (!result.issue) {
+      res.status(409).json({
+        error: "Checkout lock is still active and cannot be released",
+        details: { reason: result.reason },
+      });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: result.issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.supervisor_force_release",
+      entityType: "issue",
+      entityId: result.issue.id,
+      details: {
+        issueId: result.issue.id,
+        supervisorAgentId: req.actor.agentId,
+        supervisorRole: actorAgent.role,
+        prevCheckoutRunId: result.previous?.checkoutRunId ?? null,
+        prevExecutionRunId: result.previous?.executionRunId ?? null,
+      },
+    });
+
+    res.json(result.issue);
+  });
+
   router.get("/issues/:id/comments", async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5972,6 +5972,83 @@ export function issueService(db: Db) {
         };
       }),
 
+    /**
+     * Force-release a stale checkout/execution lock on behalf of a supervisor agent (CTO or CEO).
+     * Only succeeds when the existing checkout run is terminal and the execution run is either
+     * terminal or in scheduled_retry state (i.e. the agent is not actively running).
+     * Returns null if the issue doesn't exist.
+     * Throws if the lock is still live (active run in progress).
+     */
+    supervisorForceRelease: async (id: string) =>
+      db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select ${issues.id} from ${issues} where ${issues.id} = ${id} for update`,
+        );
+        const existing = await tx
+          .select({
+            id: issues.id,
+            companyId: issues.companyId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(eq(issues.id, id))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) return null;
+
+        // Verify the checkout lock is stale (terminal or missing run).
+        if (existing.checkoutRunId) {
+          const checkoutRun = await tx
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, existing.checkoutRunId))
+            .then((rows) => rows[0] ?? null);
+          if (checkoutRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(checkoutRun.status)) {
+            return { issue: null, previous: null, reason: "checkout_run_still_active" as const };
+          }
+        }
+
+        // Verify the execution lock is stale: terminal, missing, or a not-yet-started scheduled_retry.
+        if (existing.executionRunId) {
+          const execRun = await tx
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, existing.executionRunId))
+            .then((rows) => rows[0] ?? null);
+          const isStale =
+            !execRun ||
+            TERMINAL_HEARTBEAT_RUN_STATUSES.has(execRun.status) ||
+            execRun.status === "scheduled_retry";
+          if (!isStale) {
+            return { issue: null, previous: null, reason: "execution_run_still_active" as const };
+          }
+        }
+
+        const previous = {
+          checkoutRunId: existing.checkoutRunId,
+          executionRunId: existing.executionRunId,
+        };
+
+        const updated = await tx
+          .update(issues)
+          .set({
+            assigneeAgentId: null,
+            assigneeUserId: null,
+            checkoutRunId: null,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(issues.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (!updated) return null;
+
+        const [enriched] = await withIssueLabels(tx, [updated]);
+        return { issue: enriched, previous, reason: null };
+      }),
+
     listLabels: (companyId: string) =>
       db.select().from(labels).where(eq(labels.companyId, companyId)).orderBy(asc(labels.name), asc(labels.id)),
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source app for managing AI agent workloads — heartbeat runs pick up issues, do work, and release them
> - The checkout/execution lock system prevents two agents from working the same issue simultaneously, which is correct
> - When an agent's session ends mid-run (rate-limit, context window exhausted, adapter crash), its checkout and execution run IDs remain set on the issue
> - The execution lock can point to a `scheduled_retry` run — a queued retry that hasn't started yet — which is not a terminal status, so the existing `clearCheckoutRunIfTerminal` / `clearExecutionRunIfTerminal` helpers do not clear it
> - This leaves the issue permanently locked: a different agent cannot check it out, and even posting a comment returns 409
> - The existing `POST /issues/:id/admin/force-release` endpoint solves this but requires a board (human) actor — agents cannot call it
> - This PR adds `POST /issues/:id/supervisor-release` so CTO/CEO-role agents can break genuinely stale locks programmatically, enabling picker-upper agents to take over and continue stalled work without human intervention

## Linked Issues or Issue Description

**Feature request (no existing GitHub issue):**

**Problem:** When an agent's heartbeat run ends abnormally (session limit, context window exhausted, adapter crash), its checkout and execution run IDs stay set on the issue. If the execution run is in `scheduled_retry` state — queued but not yet running — existing stale-detection helpers skip it because `scheduled_retry` is not in `TERMINAL_HEARTBEAT_RUN_STATUSES`. The issue becomes permanently locked until either (a) the retry actually fires and succeeds, or (b) a human board user calls the admin force-release endpoint.

This is a gap for picker-upper patterns: a background agent routine that scans for session-limited assignees and tries to take over their stalled in-progress work. Without an agent-accessible release mechanism it cannot intervene even when the lock is demonstrably stale (checkout run is terminal, execution run has not started its retry).

**Expected behavior:** A supervisor agent (CTO or CEO role) should be able to force-release a stale lock and re-checkout the issue to continue the work.

**Steps to reproduce:**
1. An agent runs to completion on an issue, session terminates abnormally.
2. The system schedules a retry (`executionRunId` → `scheduled_retry`).
3. A picker-upper agent calls `POST /issues/:id/checkout` with `expectedStatuses: ["in_progress"]`.
4. Result: 409 conflict — `executionRunId` points to a non-terminal run.

## What Changed

- **`server/src/services/issues.ts`** — Added `supervisorForceRelease(id)` method to `issueService`. It runs inside a transaction, checks that `checkoutRunId` is terminal (or absent) and `executionRunId` is terminal, absent, or in `scheduled_retry` (not actively executing), then clears all lock columns and the assignee. Returns `{ issue, previous, reason }` where `reason` is non-null when the lock is still live.

- **`server/src/routes/issues.ts`** — Added `POST /issues/:id/supervisor-release` route. Guards: actor must be an agent with role `cto` or `ceo`. Delegates to `svc.supervisorForceRelease`, returns 409 with a structured `reason` when the lock cannot be released, logs `issue.supervisor_force_release` activity on success.

## Verification

Manual test against a local instance:

```bash
# 1. Put an issue in in_progress with a stale checkout (checkoutRunId pointing at a completed/failed run)
# 2. Call the new endpoint as a CTO agent:
curl -X POST http://localhost:3100/api/issues/<id>/supervisor-release \
  -H "Authorization: Bearer <cto-agent-jwt>"
# → 200 with the updated issue; checkoutRunId/executionRunId/assigneeAgentId all null
# 3. Immediately re-checkout as the picker-upper agent:
curl -X POST http://localhost:3100/api/issues/<id>/checkout \
  -H "Authorization: Bearer <cto-agent-jwt>" \
  -d '{"agentId":"<cto-id>","expectedStatuses":["in_progress"]}'
# → 200, issue now owned by picker-upper

# Negative cases:
# - Non-CTO/CEO agent → 403
# - Board user → 403 (agent access required)
# - Issue with active checkout run (running) → 409 with reason: "checkout_run_still_active"
# - Issue with active execution run (running, not scheduled_retry) → 409 with reason: "execution_run_still_active"
```

Typecheck: `pnpm --filter @paperclipai/server typecheck` → exit 0
Tests: `pnpm --filter @paperclipai/server test` → exit 0

## Risks

- **Scope creep on supervisor override:** CTO/CEO agents can now release any in-progress issue's lock within their company, not just issues assigned to session-limited agents. The stale-run guard (checkout run terminal AND execution run terminal or scheduled_retry) is the primary safety rail — a live issue cannot be force-released. The role gate (CTO/CEO only) limits blast radius.
- **`scheduled_retry` detection:** If a run transitions from `scheduled_retry` → `running` between the guard check and the UPDATE, the transaction lock on the issue row prevents a concurrent modification; the running agent's next heartbeat will detect ownership conflict normally.
- **Assignee cleared:** The release clears `assigneeAgentId` so the caller can immediately re-checkout. If the original assignee's session recovers before the picker-upper re-checks out, the issue appears unassigned — the original agent would need to be re-assigned. Picker-upper agents should immediately follow a supervisor-release with a checkout to prevent this window.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200K tokens
- Capabilities: tool use, code execution, extended reasoning, multi-step agentic operation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge