### PR TITLE
Fix gate-confirmation mirror security review blockers

### DIFF
--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -405,6 +405,66 @@ describe("issue activity event routes", () => {
     });
   });
 
+  it("mirrors gate confirmations before dependency wakeups when an approval comment completes the issue", async () => {
+    const stageId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const issue = {
+      ...makeIssue(),
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      executionPolicy: normalizeIssueExecutionPolicy({
+        stages: [{
+          id: stageId,
+          type: "review",
+          participants: [{ type: "user", userId: "local-board" }],
+        }],
+      }),
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "user", userId: "local-board" },
+        returnAssignee: { type: "user", userId: "local-board" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    const approvalBody = "kind: review\ndecision: approved";
+    mockIssueService.addComment.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      body: approvalBody,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const tx = {
+      insert: () => ({
+        values: async () => [],
+      }),
+    };
+    const dbMock = {
+      transaction: async (callback: (tx: unknown) => unknown) => callback(tx),
+    };
+
+    const res = await request(await createApp(dbMock))
+      .post(`/api/issues/${issue.id}/comments`)
+      .send({ body: approvalBody });
+
+    expect(res.status).toBe(201);
+    await vi.waitFor(() => {
+      expect(mockIssueService.mirrorGateConfirmationToParent).toHaveBeenCalledWith(issue.id);
+      expect(mockIssueService.mirrorGateConfirmationToParent.mock.invocationCallOrder[0]).toBeLessThan(
+        mockIssueService.listWakeableBlockedDependents.mock.invocationCallOrder[0],
+      );
+    });
+  });
+
   it("does not log successful_run_handoff_resolved when status stays in_progress", async () => {
     const issue = { ...makeIssue(), status: "in_progress" };
     mockIssueService.getById.mockResolvedValue(issue);

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
+  mirrorGateConfirmationToParent: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
 }));
@@ -176,6 +177,7 @@ describe("issue activity event routes", () => {
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
     mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.mirrorGateConfirmationToParent.mockResolvedValue(null);
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
     mockAccessService.canUser.mockResolvedValue(false);
@@ -383,6 +385,10 @@ describe("issue activity event routes", () => {
 
     expect(res.status).toBe(200);
     await vi.waitFor(() => {
+      expect(mockIssueService.mirrorGateConfirmationToParent).toHaveBeenCalledWith(issue.id);
+      expect(mockIssueService.mirrorGateConfirmationToParent.mock.invocationCallOrder[0]).toBeLessThan(
+        mockIssueService.listWakeableBlockedDependents.mock.invocationCallOrder[0],
+      );
       expect(mockLogActivity).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2957,7 +2957,13 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
       body: `A user pasted the mirror marker: <!-- gate-confirmation-mirror:${child.id} -->`,
     });
 
-    const mirrored = await svc.mirrorGateConfirmationToParent(child.id);
+    const mirrorResults = await Promise.all([
+      svc.mirrorGateConfirmationToParent(child.id),
+      svc.mirrorGateConfirmationToParent(child.id),
+    ]);
+    expect(mirrorResults.filter(Boolean)).toHaveLength(1);
+    expect(mirrorResults.filter((result) => result === null)).toHaveLength(1);
+    const mirrored = mirrorResults.find(Boolean);
     expect(mirrored).toMatchObject({
       issueId: parentIssueId,
       authorType: "system",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2898,6 +2898,106 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
 
     expect(child.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
   });
+
+  it("persists server-owned gate-confirmation mirror state and mirrors a done child once", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const goalId = randomUUID();
+    const parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Ship gate confirmations",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      goalId,
+      name: "Gate project",
+      status: "in_progress",
+    });
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const { issue: child } = await svc.createChild(parentIssueId, {
+      title: "Security gate",
+      status: "todo",
+      gateConfirmationMirror: true,
+    });
+
+    expect(child.executionState).toMatchObject({
+      gateConfirmationMirror: {
+        version: 1,
+        parentIssueId,
+      },
+    });
+
+    await svc.addComment(child.id, "Approved. The implementation keeps the system write bounded.", {});
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, child.id));
+
+    const mirrored = await svc.mirrorGateConfirmationToParent(child.id);
+    expect(mirrored).toMatchObject({
+      issueId: parentIssueId,
+      authorType: "system",
+    });
+    expect(mirrored?.body).toContain("## Gate Confirmation");
+    expect(mirrored?.body).toContain(child.identifier);
+    expect(mirrored?.body).toContain("Approved. The implementation keeps the system write bounded.");
+
+    await expect(svc.mirrorGateConfirmationToParent(child.id)).resolves.toBeNull();
+    const parentComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, parentIssueId));
+    expect(parentComments).toHaveLength(1);
+  });
+
+  it("does not mirror unflagged done children", async () => {
+    const companyId = randomUUID();
+    const parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const { issue: child } = await svc.createChild(parentIssueId, {
+      title: "Normal child",
+      status: "done",
+    });
+
+    await expect(svc.mirrorGateConfirmationToParent(child.id)).resolves.toBeNull();
+    const parentComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, parentIssueId));
+    expect(parentComments).toHaveLength(0);
+  });
 });
 
 describeEmbeddedPostgres("issueService blockers and dependency wake readiness", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2936,7 +2936,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
 
     const { issue: child } = await svc.createChild(parentIssueId, {
-      title: "Security gate",
+      title: "Security <gate> **bold** [x](y) `code` # heading | table!",
       status: "todo",
       gateConfirmationMirror: true,
     });
@@ -2950,6 +2950,12 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
 
     await svc.addComment(child.id, "Approved. The implementation keeps the system write bounded.", {});
     await db.update(issues).set({ status: "done" }).where(eq(issues.id, child.id));
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: parentIssueId,
+      authorType: "user",
+      body: `A user pasted the mirror marker: <!-- gate-confirmation-mirror:${child.id} -->`,
+    });
 
     const mirrored = await svc.mirrorGateConfirmationToParent(child.id);
     expect(mirrored).toMatchObject({
@@ -2958,6 +2964,10 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
     expect(mirrored?.body).toContain("## Gate Confirmation");
     expect(mirrored?.body).toContain(child.identifier);
+    expect(mirrored?.body).toContain(
+      String.raw`Security &lt;gate&gt; \*\*bold\*\* \[x\]\(y\) \`code\` \# heading \| table\!`,
+    );
+    expect(mirrored?.body).not.toContain("Security <gate> **bold** [x](y) `code` # heading | table!");
     expect(mirrored?.body).toContain("Approved. The implementation keeps the system write bounded.");
 
     await expect(svc.mirrorGateConfirmationToParent(child.id)).resolves.toBeNull();
@@ -2965,7 +2975,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
       .select()
       .from(issueComments)
       .where(eq(issueComments.issueId, parentIssueId));
-    expect(parentComments).toHaveLength(1);
+    expect(parentComments).toHaveLength(2);
   });
 
   it("does not mirror unflagged done children", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6465,6 +6465,11 @@ export function issueRoutes(
 
       const becameDone = existing.status !== "done" && issue.status === "done";
       if (becameDone) {
+        try {
+          await svc.mirrorGateConfirmationToParent(issue.id);
+        } catch (err) {
+          logger.warn({ err, issueId: issue.id }, "failed to mirror gate confirmation to parent");
+        }
         const dependents = await svc.listWakeableBlockedDependents(issue.id);
         for (const dependent of dependents) {
           addWakeup(dependent.assigneeAgentId, {
@@ -7855,6 +7860,11 @@ export function issueRoutes(
 
       const becameDone = issueBeforeCommentDecision.status !== "done" && currentIssue.status === "done";
       if (becameDone) {
+        try {
+          await svc.mirrorGateConfirmationToParent(currentIssue.id);
+        } catch (err) {
+          logger.warn({ err, issueId: currentIssue.id }, "failed to mirror gate confirmation to parent");
+        }
         const dependents = await svc.listWakeableBlockedDependents(currentIssue.id);
         for (const dependent of dependents) {
           addWakeup(dependent.assigneeAgentId, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -483,6 +483,17 @@ function buildGateConfirmationMirrorMarker(childIssueId: string) {
   return `<!-- gate-confirmation-mirror:${childIssueId} -->`;
 }
 
+function escapeMarkdownText(value: string) {
+  return value.replace(/[\\[\]()]/g, "\\$&").replace(/\s+/g, " ").trim();
+}
+
+function indentMarkdownCodeBlock(value: string) {
+  return value
+    .split(/\r?\n/)
+    .map((line) => `    ${line}`)
+    .join("\n");
+}
+
 function buildGateConfirmationMirrorComment(input: {
   childIssueId: string;
   childIdentifier: string | null;
@@ -493,11 +504,11 @@ function buildGateConfirmationMirrorComment(input: {
   const childLabel = input.childIdentifier
     ? `[${input.childIdentifier}](${prefix ? `/${prefix}/issues/${input.childIdentifier}` : "#"})`
     : `child issue ${input.childIssueId}`;
-  const summary = input.childSummary ? `\n\nLatest child update:\n\n${input.childSummary}` : "";
+  const summary = input.childSummary ? `\n\nLatest child update:\n\n${indentMarkdownCodeBlock(input.childSummary)}` : "";
   return [
     "## Gate Confirmation",
     "",
-    `${childLabel} completed the delegated gate-confirmation task: ${input.childTitle}.`,
+    `${childLabel} completed the delegated gate-confirmation task: ${escapeMarkdownText(input.childTitle)}.`,
     summary,
     "",
     buildGateConfirmationMirrorMarker(input.childIssueId),
@@ -4655,7 +4666,6 @@ export function issueService(db: Db) {
           eq(issueComments.companyId, child.companyId),
           eq(issueComments.issueId, child.parentId),
           like(issueComments.body, `%${marker}%`),
-          isNull(issueComments.deletedAt),
         ))
         .limit(1)
         .then((rows) => rows[0] ?? null);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4645,8 +4645,8 @@ export function issueService(db: Db) {
       };
     },
 
-    mirrorGateConfirmationToParent: async (childIssueId: string) => {
-      const child = await db
+    mirrorGateConfirmationToParent: async (childIssueId: string) => db.transaction(async (tx) => {
+      const child = await tx
         .select({
           id: issues.id,
           companyId: issues.companyId,
@@ -4658,6 +4658,7 @@ export function issueService(db: Db) {
         })
         .from(issues)
         .where(eq(issues.id, childIssueId))
+        .for("update")
         .then((rows) => rows[0] ?? null);
       if (!child || child.status !== "done" || !child.parentId) return null;
 
@@ -4665,7 +4666,7 @@ export function issueService(db: Db) {
       if (!mirror || mirror.parentIssueId !== child.parentId) return null;
 
       const marker = buildGateConfirmationMirrorMarker(child.id);
-      const existingMirror = await db
+      const existingMirror = await tx
         .select({ id: issueComments.id })
         .from(issueComments)
         .where(and(
@@ -4678,7 +4679,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (existingMirror) return null;
 
-      const latestChildComment = await db
+      const latestChildComment = await tx
         .select({ body: issueComments.body })
         .from(issueComments)
         .where(and(
@@ -4700,8 +4701,9 @@ export function issueService(db: Db) {
         }),
         {},
         { authorType: "system" },
+        tx,
       );
-    },
+    }),
 
     createChild: async (
       parentIssueId: string,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -484,7 +484,13 @@ function buildGateConfirmationMirrorMarker(childIssueId: string) {
 }
 
 function escapeMarkdownText(value: string) {
-  return value.replace(/[\\[\]()]/g, "\\$&").replace(/\s+/g, " ").trim();
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/[\\`*_{}[\]()#+\-.!|]/g, "\\$&");
 }
 
 function indentMarkdownCodeBlock(value: string) {
@@ -4665,6 +4671,7 @@ export function issueService(db: Db) {
         .where(and(
           eq(issueComments.companyId, child.companyId),
           eq(issueComments.issueId, child.parentId),
+          eq(issueComments.authorType, "system"),
           like(issueComments.body, `%${marker}%`),
         ))
         .limit(1)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -101,6 +101,7 @@ const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
 export const MAX_CHILD_ISSUES_CREATED_BY_HELPER = 25;
 const MAX_CHILD_COMPLETION_SUMMARIES = 20;
 const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
+const GATE_CONFIRMATION_MIRROR_SUMMARY_MAX_CHARS = 1200;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_MAX_LOG_BYTES = 2_000_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_CHUNK_BYTES = 256_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS = 60_000;
@@ -370,6 +371,7 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
 type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
   blockParentUntilDone?: boolean;
+  gateConfirmationMirror?: boolean;
   actorAgentId?: string | null;
   actorUserId?: string | null;
 };
@@ -409,6 +411,12 @@ export type ChildIssueCompletionSummary = {
   summary: string | null;
 };
 
+type GateConfirmationMirrorState = {
+  version: 1;
+  parentIssueId: string;
+  createdAt: string;
+};
+
 function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
   if (actorRunId) return checkoutRunId === actorRunId;
   return checkoutRunId == null;
@@ -438,6 +446,62 @@ function truncateInlineSummary(value: string | null | undefined, maxChars = CHIL
   const normalized = value?.trim();
   if (!normalized) return null;
   return normalized.length > maxChars ? `${normalized.slice(0, Math.max(0, maxChars - 15)).trimEnd()} [truncated]` : normalized;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function buildGateConfirmationMirrorState(
+  executionState: unknown,
+  parentIssueId: string,
+): Record<string, unknown> {
+  return {
+    ...(readRecord(executionState) ?? {}),
+    gateConfirmationMirror: {
+      version: 1,
+      parentIssueId,
+      createdAt: new Date().toISOString(),
+    } satisfies GateConfirmationMirrorState,
+  };
+}
+
+function readGateConfirmationMirrorState(executionState: unknown): GateConfirmationMirrorState | null {
+  const mirror = readRecord(readRecord(executionState)?.gateConfirmationMirror);
+  if (!mirror) return null;
+  if (mirror.version !== 1) return null;
+  if (typeof mirror.parentIssueId !== "string" || !isUuidLike(mirror.parentIssueId)) return null;
+  if (typeof mirror.createdAt !== "string") return null;
+  return {
+    version: 1,
+    parentIssueId: mirror.parentIssueId,
+    createdAt: mirror.createdAt,
+  };
+}
+
+function buildGateConfirmationMirrorMarker(childIssueId: string) {
+  return `<!-- gate-confirmation-mirror:${childIssueId} -->`;
+}
+
+function buildGateConfirmationMirrorComment(input: {
+  childIssueId: string;
+  childIdentifier: string | null;
+  childTitle: string;
+  childSummary: string | null;
+}) {
+  const prefix = input.childIdentifier?.match(/^([A-Z][A-Z0-9]*)-\d+$/)?.[1] ?? null;
+  const childLabel = input.childIdentifier
+    ? `[${input.childIdentifier}](${prefix ? `/${prefix}/issues/${input.childIdentifier}` : "#"})`
+    : `child issue ${input.childIssueId}`;
+  const summary = input.childSummary ? `\n\nLatest child update:\n\n${input.childSummary}` : "";
+  return [
+    "## Gate Confirmation",
+    "",
+    `${childLabel} completed the delegated gate-confirmation task: ${input.childTitle}.`,
+    summary,
+    "",
+    buildGateConfirmationMirrorMarker(input.childIssueId),
+  ].join("\n");
 }
 
 function truncateByCodePoint(value: string, maxChars: number): string {
@@ -4564,6 +4628,64 @@ export function issueService(db: Db) {
       };
     },
 
+    mirrorGateConfirmationToParent: async (childIssueId: string) => {
+      const child = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          parentId: issues.parentId,
+          identifier: issues.identifier,
+          title: issues.title,
+          status: issues.status,
+          executionState: issues.executionState,
+        })
+        .from(issues)
+        .where(eq(issues.id, childIssueId))
+        .then((rows) => rows[0] ?? null);
+      if (!child || child.status !== "done" || !child.parentId) return null;
+
+      const mirror = readGateConfirmationMirrorState(child.executionState);
+      if (!mirror || mirror.parentIssueId !== child.parentId) return null;
+
+      const marker = buildGateConfirmationMirrorMarker(child.id);
+      const existingMirror = await db
+        .select({ id: issueComments.id })
+        .from(issueComments)
+        .where(and(
+          eq(issueComments.companyId, child.companyId),
+          eq(issueComments.issueId, child.parentId),
+          like(issueComments.body, `%${marker}%`),
+          isNull(issueComments.deletedAt),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (existingMirror) return null;
+
+      const latestChildComment = await db
+        .select({ body: issueComments.body })
+        .from(issueComments)
+        .where(and(
+          eq(issueComments.companyId, child.companyId),
+          eq(issueComments.issueId, child.id),
+          isNull(issueComments.deletedAt),
+        ))
+        .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      return issueService(db).addComment(
+        child.parentId,
+        buildGateConfirmationMirrorComment({
+          childIssueId: child.id,
+          childIdentifier: child.identifier,
+          childTitle: child.title,
+          childSummary: truncateInlineSummary(latestChildComment?.body, GATE_CONFIRMATION_MIRROR_SUMMARY_MAX_CHARS),
+        }),
+        {},
+        { authorType: "system" },
+      );
+    },
+
     createChild: async (
       parentIssueId: string,
       data: IssueChildCreateInput,
@@ -4586,6 +4708,7 @@ export function issueService(db: Db) {
       const {
         acceptanceCriteria,
         blockParentUntilDone,
+        gateConfirmationMirror,
         actorAgentId,
         actorUserId,
         ...issueData
@@ -4599,6 +4722,9 @@ export function issueService(db: Db) {
           Math.max(clampIssueRequestDepth(parent.requestDepth) + 1, issueData.requestDepth ?? 0),
         ),
         description: appendAcceptanceCriteriaToDescription(issueData.description, acceptanceCriteria),
+        ...(gateConfirmationMirror
+          ? { executionState: buildGateConfirmationMirrorState(issueData.executionState, parent.id) }
+          : {}),
         inheritExecutionWorkspaceFromIssueId: parent.id,
       });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent workflows can delegate gate-confirmation work to child issues before a parent task proceeds.
> - The parent issue needs a reliable, bounded signal when one of those delegated gate-confirmation children completes.
> - That signal must be server-owned so public child creation and accepted-plan request schemas do not become a covert write channel.
> - Completion also needs to happen before blocker and parent wakeups so downstream agents see the mirrored evidence in the right order.
> - This pull request persists an internal mirror opt-in on child issues and posts one idempotent system comment back to the parent when the child reaches done.
> - The benefit is a self-contained gate-confirmation mirror path without relying on a non-core security-review hook.

## Linked Issues or Issue Description

No public GitHub issue exists for this fix.

Bug report:
- What happened: delegated gate-confirmation child issues could complete without mirroring bounded completion evidence back to the parent issue through a self-contained server path.
- Expected behavior: internally created gate-confirmation children carry a server-owned mirror marker, and when they become `done`, the server mirrors a bounded system-authored parent comment exactly once before dependency wakeups.
- Steps to reproduce: create a child issue through the internal helper with a gate-confirmation mirror opt-in, mark it done after a child comment, and inspect the parent issue comments and wakeup ordering.
- Paperclip version/commit: reproduced on current `master` before this branch.
- Deployment mode: local development / server route tests.

Related public PR search:
- Searched GitHub PRs and issues for `gate confirmation mirror`; no related public issue was found. One unrelated PR result was `#7461`.

## What Changed

- Added a server-owned `gateConfirmationMirror` child helper option that persists mirror state inside `executionState`.
- Added `issueService(db).mirrorGateConfirmationToParent(...)` to post a bounded, idempotent system comment to the parent issue when a flagged child is done.
- Wired both issue completion paths to run the mirror before dependency and parent wakeups.
- Added regression coverage for service persistence/idempotency/concurrency/no-op behavior, markdown escaping, and route-side ordering.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-activity-events-routes.test.ts` passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts -t "gate-confirmation"` passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- PR checks are green on head `45bccb700d9250efead64cf68dc10399ff35ed74`, including Greptile, Superagent, Snyk, typecheck, build, general tests, serialized server suites, e2e, canary dry run, policy, review, and aggregate `verify`.

## Risks

Low to medium risk. The change is server-side and scoped to internally created child issues with an explicit helper opt-in. Main risk is parent-comment noise or missed mirroring; this is limited by a system-authored idempotency marker, row-level serialization for concurrent mirror attempts, and service/route coverage.

## Model Used

OpenAI GPT-5 Codex, tool-enabled coding agent with repository file access, shell command execution, Git/GitHub CLI usage, and iterative reasoning for implementation and verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
