### PR TITLE
Inject Docker build metadata into health build info

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,12 +43,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
+      - name: Build metadata
+        id: build-metadata
+        run: echo "timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
+            BUILD_BRANCH=${{ github.ref_name }}
+            BUILD_TIMESTAMP=${{ steps.build-metadata.outputs.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN pnpm install --frozen-lockfile
 
 FROM base AS build
 ARG BUILD_SHA=unknown
-ARG BUILD_BRANCH=
+ARG BUILD_BRANCH=unknown
 ARG BUILD_TIMESTAMP=
 ENV BUILD_SHA=${BUILD_SHA} \
   BUILD_BRANCH=${BUILD_BRANCH} \
@@ -62,6 +62,9 @@ RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" &
 FROM base AS production
 ARG USER_UID=1000
 ARG USER_GID=1000
+ARG BUILD_SHA=unknown
+ARG BUILD_BRANCH=unknown
+ARG BUILD_TIMESTAMP=
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
 RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai @google/gemini-cli@latest \
@@ -83,6 +86,9 @@ ENV NODE_ENV=production \
   PAPERCLIP_INSTANCE_ID=default \
   USER_UID=${USER_UID} \
   USER_GID=${USER_GID} \
+  BUILD_SHA=${BUILD_SHA} \
+  BUILD_BRANCH=${BUILD_BRANCH} \
+  BUILD_TIMESTAMP=${BUILD_TIMESTAMP} \
   PAPERCLIP_CONFIG=/paperclip/instances/default/config.json \
   PAPERCLIP_DEPLOYMENT_MODE=authenticated \
   PAPERCLIP_DEPLOYMENT_EXPOSURE=private \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,18 @@ COPY scripts/link-plugin-dev-sdk.mjs scripts/
 RUN pnpm install --frozen-lockfile
 
 FROM base AS build
+ARG BUILD_SHA=unknown
+ARG BUILD_BRANCH=
+ARG BUILD_TIMESTAMP=
+ENV BUILD_SHA=${BUILD_SHA} \
+  BUILD_BRANCH=${BUILD_BRANCH} \
+  BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build
 RUN pnpm --filter @paperclipai/plugin-sdk build
-RUN pnpm --filter @paperclipai/server build
+RUN printf '%s\n' "$BUILD_TIMESTAMP" > /tmp/paperclip-build-timestamp && pnpm --filter @paperclipai/server build
 RUN test -f server/dist/index.js || (echo "ERROR: server build output missing" && exit 1)
 
 FROM base AS production

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -19,8 +19,8 @@ Build arguments:
 | `USER_UID` | `1000` | UID for the container `node` user (match your host UID to avoid permission issues on bind mounts) |
 | `USER_GID` | `1000` | GID for the container `node` group |
 | `BUILD_SHA` | `unknown` | Commit SHA embedded into `GET /api/health` build metadata |
-| `BUILD_BRANCH` | empty | Branch or tag embedded into `GET /api/health` build metadata |
-| `BUILD_TIMESTAMP` | empty | Deploy-build timestamp cache buster so `build.buildTimestamp` is regenerated during the server build |
+| `BUILD_BRANCH` | `unknown` | Branch or tag embedded into `GET /api/health` build metadata |
+| `BUILD_TIMESTAMP` | empty | Build timestamp embedded into `GET /api/health` build metadata |
 
 ```sh
 docker build -t paperclip-local \

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -18,10 +18,24 @@ Build arguments:
 |-----|---------|---------|
 | `USER_UID` | `1000` | UID for the container `node` user (match your host UID to avoid permission issues on bind mounts) |
 | `USER_GID` | `1000` | GID for the container `node` group |
+| `BUILD_SHA` | `unknown` | Commit SHA embedded into `GET /api/health` build metadata |
+| `BUILD_BRANCH` | empty | Branch or tag embedded into `GET /api/health` build metadata |
+| `BUILD_TIMESTAMP` | empty | Deploy-build timestamp cache buster so `build.buildTimestamp` is regenerated during the server build |
 
 ```sh
 docker build -t paperclip-local \
   --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) .
+```
+
+For release or deployment builds, pass the git metadata explicitly because the
+production build stage does not rely on `.git` being present:
+
+```sh
+docker build -t paperclip-local \
+  --build-arg BUILD_SHA="$(git rev-parse HEAD)" \
+  --build-arg BUILD_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
+  --build-arg BUILD_TIMESTAMP="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  .
 ```
 
 ## One-liner (build + run)

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -23,6 +23,9 @@ describe("GET /health", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockReadPersistedDevServerStatus.mockReturnValue(undefined);
+    delete process.env.BUILD_SHA;
+    delete process.env.BUILD_BRANCH;
+    delete process.env.BUILD_TIMESTAMP;
   });
 
   afterEach(() => {
@@ -32,8 +35,38 @@ describe("GET /health", () => {
     const app = createApp();
     const res = await request(app).get("/health");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok", version: serverVersion });
+    expect(res.body).toEqual({
+      status: "ok",
+      version: serverVersion,
+      build: {
+        commitSha: "unknown",
+        shortSha: "unknown",
+        branch: "unknown",
+        buildTimestamp: null,
+      },
+    });
   }, 15_000);
+
+  it("returns Docker build metadata when present", async () => {
+    process.env.BUILD_SHA = "0123456789abcdef0123456789abcdef01234567";
+    process.env.BUILD_BRANCH = "test-build-metadata";
+    process.env.BUILD_TIMESTAMP = "2026-06-20T00:00:00Z";
+    const app = createApp();
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      status: "ok",
+      version: serverVersion,
+      build: {
+        commitSha: "0123456789abcdef0123456789abcdef01234567",
+        shortSha: "0123456789ab",
+        branch: "test-build-metadata",
+        buildTimestamp: "2026-06-20T00:00:00Z",
+      },
+    });
+  });
 
   it("returns 200 when the database probe succeeds", async () => {
     const db = {
@@ -60,6 +93,12 @@ describe("GET /health", () => {
     expect(res.body).toEqual({
       status: "unhealthy",
       version: serverVersion,
+      build: {
+        commitSha: "unknown",
+        shortSha: "unknown",
+        branch: "unknown",
+        buildTimestamp: null,
+      },
       error: "database_unreachable"
     });
   });
@@ -171,6 +210,12 @@ describe("GET /health", () => {
     expect(res.body).toMatchObject({
       status: "ok",
       version: serverVersion,
+      build: {
+        commitSha: "unknown",
+        shortSha: "unknown",
+        branch: "unknown",
+        buildTimestamp: null,
+      },
       deploymentMode: "authenticated",
       deploymentExposure: "public",
       authReady: true,

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -103,6 +103,38 @@ describe("GET /health", () => {
     });
   });
 
+  it("redacts build metadata on authenticated anonymous database failures", async () => {
+    process.env.BUILD_SHA = "0123456789abcdef0123456789abcdef01234567";
+    process.env.BUILD_BRANCH = "test-build-metadata";
+    process.env.BUILD_TIMESTAMP = "2026-06-20T00:00:00Z";
+    const db = {
+      execute: vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+    } as unknown as Db;
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).actor = { type: "none", source: "none" };
+      next();
+    });
+    app.use(
+      "/health",
+      healthRoutes(db, {
+        deploymentMode: "authenticated",
+        deploymentExposure: "public",
+        authReady: true,
+        companyDeletionEnabled: false,
+      }),
+    );
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      status: "unhealthy",
+      version: serverVersion,
+      error: "database_unreachable",
+    });
+  });
+
   it("redacts detailed metadata for anonymous requests in authenticated mode", async () => {
     const devServerStatus = await import("../dev-server-status.js");
     vi.spyOn(devServerStatus, "readPersistedDevServerStatus").mockReturnValue(undefined);

--- a/server/src/build-info.ts
+++ b/server/src/build-info.ts
@@ -1,0 +1,22 @@
+export interface BuildInfo {
+  commitSha: string;
+  shortSha: string;
+  branch: string;
+  buildTimestamp: string | null;
+}
+
+function readBuildValue(name: string, fallback: string) {
+  const value = process.env[name]?.trim();
+  return value || fallback;
+}
+
+export function getBuildInfo(): BuildInfo {
+  const commitSha = readBuildValue("BUILD_SHA", "unknown");
+
+  return {
+    commitSha,
+    shortSha: commitSha === "unknown" ? "unknown" : commitSha.slice(0, 12),
+    branch: readBuildValue("BUILD_BRANCH", "unknown"),
+    buildTimestamp: process.env.BUILD_TIMESTAMP?.trim() || null,
+  };
+}

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,6 +7,7 @@ import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import { readPersistedDevServerStatus, toDevServerHealthStatus, writeDevServerRestartRequest } from "../dev-server-status.js";
 import { logger } from "../middleware/logger.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
+import { getBuildInfo } from "../build-info.js";
 import { serverVersion } from "../version.js";
 
 function shouldExposeFullHealthDetails(
@@ -90,7 +91,7 @@ export function healthRoutes(
     if (!db) {
       res.json(
         exposeFullDetails
-          ? { status: "ok", version: serverVersion }
+          ? { status: "ok", version: serverVersion, build: getBuildInfo() }
           : { status: "ok", deploymentMode: opts.deploymentMode },
       );
       return;
@@ -103,6 +104,7 @@ export function healthRoutes(
       res.status(503).json({
         status: "unhealthy",
         version: serverVersion,
+        build: getBuildInfo(),
         error: "database_unreachable"
       });
       return;
@@ -168,6 +170,7 @@ export function healthRoutes(
     res.json({
       status: "ok",
       version: serverVersion,
+      build: getBuildInfo(),
       deploymentMode: opts.deploymentMode,
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -104,7 +104,7 @@ export function healthRoutes(
       res.status(503).json({
         status: "unhealthy",
         version: serverVersion,
-        build: getBuildInfo(),
+        ...(exposeFullDetails ? { build: getBuildInfo() } : {}),
         error: "database_unreachable"
       });
       return;

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -753,6 +753,12 @@ registry.registerPath({
     200: r.ok(z.object({
       status: z.enum(["ok", "unhealthy"]),
       version: z.string().optional(),
+      build: z.object({
+        commitSha: z.string(),
+        shortSha: z.string(),
+        branch: z.string(),
+        buildTimestamp: z.string().nullable(),
+      }).optional(),
       deploymentMode: z.string().optional(),
       bootstrapStatus: z.enum(["ready", "bootstrap_pending"]).optional(),
       bootstrapInviteActive: z.boolean().optional(),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators need `/api/health` to identify the build actually serving traffic
> - Detailed health responses already expose server/runtime metadata for operator diagnosis
> - Production Docker builds should not rely on `.git` being available in the build stage to identify the deployed artifact
> - The Docker publish workflow already has the GitHub commit and ref available at build time
> - This pull request passes that metadata into the Docker image and exposes it through detailed health build metadata
> - The benefit is that deployed health responses can be tied back to the actual image commit instead of a placeholder

## Linked Issues or Issue Description

No public GitHub issue found for this deployment-health bug. Public duplicate search for `docker build metadata health build-info` returned no matching issues or PRs.

### Bug report

**What happened?**
Docker-built Paperclip images did not have a reliable way to expose the image commit, branch, or build time through `GET /api/health` when `.git` metadata was unavailable in the Docker build context/stages.

**Expected behavior**
Docker-published artifacts should embed the GitHub SHA/ref/build timestamp supplied by the Docker publish workflow, and detailed `GET /api/health` responses should include that build metadata for operators.

**Steps to reproduce**
1. Build Paperclip through the production Dockerfile path where `.git` metadata is unavailable or not used for the server runtime.
2. Run the image.
3. Call `GET /api/health` as an operator/full-detail caller.
4. Observe that the response cannot identify the deployed image commit/branch/build time.

**Paperclip version or commit**
Reproduced on `master` before this PR.

**Deployment mode**
Docker.

**Installation method**
Docker.

**Agent adapter(s) involved**
Not adapter-specific (core health/deploy metadata).

**Database mode**
Not database-related.

**Access context**
Board/operator health check.

**Additional context**
The Docker publish workflow already has `github.sha` and `github.ref_name`; this PR threads those values into the image and exposes them through health metadata.

## What Changed

- Added `BUILD_SHA`, `BUILD_BRANCH`, and `BUILD_TIMESTAMP` build args to the Docker build and production stages.
- Passed GitHub Actions `github.sha`, `github.ref_name`, and a UTC build timestamp into the GHCR Docker build.
- Added server build metadata parsing and included it in detailed `/api/health` responses.
- Updated the health OpenAPI schema and health route tests for build metadata.
- Documented the build args and release/deployment Docker build command in `doc/DOCKER.md`.

## Verification

- `BUILD_SHA=0123456789abcdef0123456789abcdef01234567 BUILD_BRANCH=test-build-metadata BUILD_TIMESTAMP=2026-06-20T00:00:00Z pnpm --filter @paperclipai/server build`
- `pnpm exec vitest run server/src/__tests__/health.test.ts`
- `git diff --check`
- `git diff --cached --check`
- Searched public GitHub issues and PRs for `docker build metadata health build-info`; no duplicates found.

## Risks

Low risk. The Docker args default to safe `unknown`/empty values for local builds. Rollback path: revert the Dockerfile, workflow, health-route, and docs changes; Docker builds return to the previous health metadata behavior. The operational risk is incorrect build-arg wiring in GitHub Actions, which CI/docker publish logs should expose.

## Model Used

OpenAI Codex, GPT-5 coding agent with repository/tool access and command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge