### PR TITLE
fix(cli): harden $meta.source writer + auto-heal doctor for invalid enum

### DIFF
--- a/cli/src/__tests__/config-store.test.ts
+++ b/cli/src/__tests__/config-store.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { writeConfig } from "../config/store.js";
+import type { PaperclipConfig } from "../config/schema.js";
+
+function buildValidConfig(runtimeRoot: string): PaperclipConfig {
+  return {
+    $meta: {
+      version: 1,
+      updatedAt: "2026-06-20T00:00:00.000Z",
+      source: "configure",
+    },
+    database: {
+      mode: "embedded-postgres",
+      embeddedPostgresDataDir: path.join(runtimeRoot, "db"),
+      embeddedPostgresPort: 55432,
+      backup: {
+        enabled: true,
+        intervalMinutes: 60,
+        retentionDays: 30,
+        dir: path.join(runtimeRoot, "backups"),
+      },
+    },
+    logging: { mode: "file", logDir: path.join(runtimeRoot, "logs") },
+    server: {
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+      port: 3199,
+      allowedHostnames: [],
+      serveUi: true,
+    },
+    auth: { baseUrlMode: "auto", disableSignUp: false },
+    telemetry: { enabled: true },
+    storage: {
+      provider: "local_disk",
+      localDisk: { baseDir: path.join(runtimeRoot, "storage") },
+      s3: { bucket: "paperclip", region: "us-east-1", prefix: "", forcePathStyle: false },
+    },
+    secrets: {
+      provider: "local_encrypted",
+      strictMode: false,
+      localEncrypted: { keyFilePath: path.join(runtimeRoot, "secrets", "master.key") },
+    },
+  };
+}
+
+describe("writeConfig", () => {
+  it("refuses to persist a config whose $meta.source is outside the enum (BASA-29492)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-store-"));
+    const configPath = path.join(root, ".paperclip", "config.json");
+    const valid = buildValidConfig(path.join(root, "runtime"));
+
+    const tampered = {
+      ...valid,
+      $meta: { ...valid.$meta, source: "basa29364-r3-config-drift-fix" },
+    } as unknown as PaperclipConfig;
+
+    expect(() => writeConfig(tampered, configPath)).toThrow(/Refusing to write invalid config/);
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it("writes successfully when $meta.source is a valid enum value", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-store-"));
+    const configPath = path.join(root, ".paperclip", "config.json");
+    const valid = buildValidConfig(path.join(root, "runtime"));
+
+    expect(() => writeConfig(valid, configPath)).not.toThrow();
+    const onDisk = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(onDisk.$meta.source).toBe("configure");
+  });
+});

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -99,4 +99,41 @@ describe("doctor", () => {
     expect(summary.warned).toBe(0);
     expect(process.env.PAPERCLIP_AGENT_JWT_SECRET).toBeTruthy();
   });
+
+  it("auto-heals an invalid $meta.source enum value when --repair is set (BASA-29492)", async () => {
+    const configPath = createTempConfig();
+    // Reproduce the BASA-29492 incident: $meta.source was set to a branch/label
+    // string outside the enum by an ad-hoc heartbeat script.
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    raw.$meta.source = "basa29364-r3-config-drift-fix";
+    fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n");
+
+    const summary = await doctor({
+      config: configPath,
+      repair: true,
+      yes: true,
+    });
+
+    expect(summary.failed).toBe(0);
+    const healed = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(healed.$meta.source).toBe("doctor");
+  });
+
+  it("does not auto-heal when invalid $meta.source is accompanied by other schema violations", async () => {
+    const configPath = createTempConfig();
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    raw.$meta.source = "not-a-valid-source";
+    raw.database.embeddedPostgresPort = "not-a-number"; // second unrelated issue
+    fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n");
+
+    const summary = await doctor({
+      config: configPath,
+      repair: true,
+      yes: true,
+    });
+
+    expect(summary.failed).toBeGreaterThan(0);
+    const stillBroken = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(stillBroken.$meta.source).toBe("not-a-valid-source");
+  });
 });

--- a/cli/src/checks/config-check.ts
+++ b/cli/src/checks/config-check.ts
@@ -1,5 +1,9 @@
-import { readConfig, configExists, resolveConfigPath } from "../config/store.js";
+import fs from "node:fs";
+import { paperclipConfigSchema } from "../config/schema.js";
+import { readConfig, configExists, resolveConfigPath, writeConfig } from "../config/store.js";
 import type { CheckResult } from "./index.js";
+
+const AUTO_HEAL_SOURCE = "doctor" as const;
 
 export function configCheck(configPath?: string): CheckResult {
   const filePath = resolveConfigPath(configPath);
@@ -22,6 +26,19 @@ export function configCheck(configPath?: string): CheckResult {
       message: `Valid config at ${filePath}`,
     };
   } catch (err) {
+    const heal = detectSourceOnlyHeal(filePath);
+    if (heal) {
+      return {
+        name: "Config file",
+        status: "fail",
+        message: `Invalid config: ${err instanceof Error ? err.message : String(err)}`,
+        canRepair: true,
+        repairHint: `Reset $meta.source to "${AUTO_HEAL_SOURCE}" (was ${JSON.stringify(heal.invalidValue)})`,
+        repair: () => {
+          writeConfig(heal.repaired, configPath);
+        },
+      };
+    }
     return {
       name: "Config file",
       status: "fail",
@@ -30,4 +47,42 @@ export function configCheck(configPath?: string): CheckResult {
       repairHint: "Run `paperclipai configure --section database` (or `paperclipai onboard` to recreate)",
     };
   }
+}
+
+function detectSourceOnlyHeal(
+  filePath: string,
+): { repaired: ReturnType<typeof paperclipConfigSchema.parse>; invalidValue: unknown } | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return null;
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+
+  const meta = (raw as { $meta?: unknown }).$meta;
+  if (typeof meta !== "object" || meta === null || Array.isArray(meta)) return null;
+  const invalidValue = (meta as { source?: unknown }).source;
+
+  const patched = {
+    ...(raw as Record<string, unknown>),
+    $meta: { ...(meta as Record<string, unknown>), source: AUTO_HEAL_SOURCE },
+  };
+  const reparsed = paperclipConfigSchema.safeParse(patched);
+  if (!reparsed.success) return null;
+
+  // Only auto-heal if the original failure was driven solely by the source enum.
+  const original = paperclipConfigSchema.safeParse(raw);
+  if (original.success) return null;
+  const issues = original.error.issues;
+  const onlySourceIssue =
+    issues.length === 1 &&
+    issues[0]?.code === "invalid_enum_value" &&
+    Array.isArray(issues[0]?.path) &&
+    issues[0].path.length === 2 &&
+    issues[0].path[0] === "$meta" &&
+    issues[0].path[1] === "source";
+  if (!onlySourceIssue) return null;
+
+  return { repaired: reparsed.data, invalidValue };
 }

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -35,10 +35,15 @@ export async function doctor(opts: {
   loadPaperclipEnvFile(configPath);
   const results: CheckResult[] = [];
 
-  // 1. Config check (must pass before others)
-  const cfgResult = configCheck(opts.config);
+  // 1. Config check (must pass before others). Routed through runRepairableCheck
+  // so an auto-healable $meta.source enum violation can be fixed in place when
+  // --repair is set (BASA-29492).
+  const cfgResult = await runRepairableCheck({
+    run: () => configCheck(opts.config),
+    configPath,
+    opts,
+  });
   results.push(cfgResult);
-  printResult(cfgResult);
 
   if (cfgResult.status === "fail") {
     return printSummary(results);

--- a/cli/src/config/store.ts
+++ b/cli/src/config/store.ts
@@ -100,6 +100,17 @@ export function writeConfig(
   configPath?: string,
 ): void {
   const filePath = resolveConfigPath(configPath);
+
+  // Validate at the write boundary so a runtime-mutated config (e.g. an ad-hoc
+  // script that set $meta.source to a label string) cannot be persisted. The TS
+  // type narrows the literal at compile time but objects are mutable; without
+  // this gate, an invalid value round-trips to disk and only blows up the next
+  // time doctor or the server reads it back. BASA-29492.
+  const validated = paperclipConfigSchema.safeParse(config);
+  if (!validated.success) {
+    throw new Error(`Refusing to write invalid config to ${filePath}: ${formatValidationError(validated.error)}`);
+  }
+
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
 
@@ -110,7 +121,7 @@ export function writeConfig(
     fs.chmodSync(backupPath, 0o600);
   }
 
-  fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", {
+  fs.writeFileSync(filePath, JSON.stringify(validated.data, null, 2) + "\n", {
     mode: 0o600,
   });
 }


### PR DESCRIPTION
## Thinking Path

A Paperclip operator's `~/.paperclip/instances/default/config.json` ended up with `$meta.source = "basa29364-r3-config-drift-fix"` — a value outside the `configMetaSchema` enum (`"onboard" | "configure" | "doctor"`). `paperclip doctor` blocked server startup with a generic _Invalid enum value_ error and pointed the operator at a full re-onboarding; the operator had to hand-patch the JSON to recover.

This PR adds two defenses so the next occurrence is either prevented or auto-healed:

1. **Writer-side guard** — `writeConfig` Zod-validates the entire config at the write boundary. The TS type narrows the literal at compile time but the object is mutable; without this gate, an ad-hoc script that mutates `$meta.source` after typing the object round-trips an invalid value to disk and only blows up on the next read.
2. **Doctor auto-heal** — `configCheck` detects the specific “`$meta.source` is the sole schema violation” case and offers a repair that rewrites it to `"doctor"`. The repair is gated on the existing `--repair` flag and routed through `runRepairableCheck` so the standard prompt/re-run loop fires. When other schema issues are present the heal is skipped, so we don't paper over unrelated corruption.

## Linked Issues

- Source incident: BASA-29492
- Fix tracker: BASA-29493

## What Changed

- `cli/src/config/store.ts` — `writeConfig` now runs `paperclipConfigSchema.safeParse` before writing and throws a clear `Refusing to write invalid config to <path>` error on failure.
- `cli/src/checks/config-check.ts` — added `detectSourceOnlyHeal` which returns a repair closure when the original error is exactly one `invalid_enum_value` at `['$meta', 'source']`.
- `cli/src/commands/doctor.ts` — routes `configCheck` through `runRepairableCheck` so `--repair` (and `--yes`) fire the heal.
- `cli/src/__tests__/doctor.test.ts` — new tests for the positive and negative auto-heal paths.
- `cli/src/__tests__/config-store.test.ts` — new tests for `writeConfig` rejection and acceptance.

## Verification

- `npx vitest run cli/src/__tests__/doctor.test.ts cli/src/__tests__/config-store.test.ts` — the 4 new tests pass on Windows (the only doctor.test.ts failure is the pre-existing `666` perms warning, unrelated to this PR).
- `npx vitest run packages/shared/src/config-schema.test.ts` — passes.
- `npx tsc --noEmit` against `cli/src/**` — clean (server `@paperclipai/plugin-sdk` errors are unrelated and pre-existing).

## Risks

- Writer-side validation could surface latent bugs in other code paths that built a config object incrementally (e.g., `as PaperclipConfig` casts that omit fields). All in-tree writers were already passing typed objects, but if a downstream tool relied on writing a malformed config, it will now throw with a clear message — which is the intended behavior.
- The auto-heal is intentionally narrow (sole-issue + enum-only). Configs with multiple schema violations still fall through to the existing `paperclipai configure` / `paperclipai onboard` hint.

## Model Used

claude-opus-4-7