### PR TITLE
fix(server): block checkout from reopening terminal issues (SUP-13)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4407,6 +4407,124 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
+  // Regression for SUP-13: checkout must never resurrect terminal (done/
+  // cancelled) work, even when the caller passes that status in
+  // expectedStatuses. This is the loop class that caused SUP-9 (12 runs / 11
+  // re-verify→re-close comments in 1h). Resuming finished work must go through
+  // the explicit `resume: true` path.
+  async function seedTerminalIssue(status: "done" | "cancelled") {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: `Terminal ${status} issue`,
+      status,
+      priority: "medium",
+      assigneeAgentId: agentId,
+      completedAt: status === "done" ? new Date("2026-06-10T10:01:00.000Z") : null,
+      cancelledAt: status === "cancelled" ? new Date("2026-06-10T10:01:00.000Z") : null,
+    });
+
+    return { companyId, agentId, issueId, checkoutRunId };
+  }
+
+  it("checkout does not reopen a 'done' issue even when 'done' is in expectedStatuses", async () => {
+    const { agentId, issueId, checkoutRunId } = await seedTerminalIssue("done");
+
+    await expect(svc.checkout(issueId, agentId, ["todo", "in_progress", "done"], checkoutRunId))
+      .rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        startedAt: issues.startedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "done",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      startedAt: null,
+    });
+  });
+
+  it("checkout does not reopen a 'cancelled' issue even when 'cancelled' is in expectedStatuses", async () => {
+    const { agentId, issueId, checkoutRunId } = await seedTerminalIssue("cancelled");
+
+    await expect(svc.checkout(issueId, agentId, ["todo", "cancelled"], checkoutRunId))
+      .rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        startedAt: issues.startedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "cancelled",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      startedAt: null,
+    });
+  });
+
+  it("repeated checkout of a 'done' issue is idempotent and produces no status churn (SUP-9 loop)", async () => {
+    const { agentId, issueId } = await seedTerminalIssue("done");
+
+    for (let i = 0; i < 12; i++) {
+      await expect(svc.checkout(issueId, agentId, ["todo", "in_progress", "done"], randomUUID()))
+        .rejects.toMatchObject({ status: 409 });
+    }
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        startedAt: issues.startedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "done",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      startedAt: null,
+    });
+  });
+
   it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
     // Regression for PR #2482 checkout-adoption review finding: any adoption
     // helper that re-locks an existing in_progress issue (e.g. when the prior

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -94,6 +94,9 @@ import {
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+// Terminal statuses must never be silently reopened by a checkout. Resuming
+// finished work has to go through the explicit `resume: true` path instead.
+const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
@@ -5536,11 +5539,26 @@ export function issueService(db: Db) {
 
     checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
       const issueCompany = await db
-        .select({ companyId: issues.companyId })
+        .select({ companyId: issues.companyId, status: issues.status })
         .from(issues)
         .where(eq(issues.id, id))
         .then((rows) => rows[0] ?? null);
       if (!issueCompany) throw notFound("Issue not found");
+
+      // A checkout must never resurrect completed work. Reject terminal
+      // (done/cancelled) issues outright — even when the caller passes that
+      // status in expectedStatuses — so no wake path can flip a finished issue
+      // back to in_progress. Resuming finished work must go through the
+      // explicit `resume: true` path. Mirrors the early-return style used for
+      // the subtree pause-hold gate below.
+      if (TERMINAL_ISSUE_STATUSES.has(issueCompany.status)) {
+        throw conflict("Cannot checkout a completed issue", {
+          issueId: id,
+          status: issueCompany.status,
+          securityPrinciples: ["Fail Securely", "Secure Defaults"],
+        });
+      }
+
       await assertAssignableAgent(db, issueCompany.companyId, agentId, { kind: "work" });
 
       const now = new Date();


### PR DESCRIPTION
## Summary
Fixes **SUP-13**: `checkout()` could silently resurrect completed work, causing the SUP-9 reopen→re-verify→re-close loop (12 runs / 11 comments in 1h).

`checkout` in `server/src/services/issues.ts` set `status: "in_progress"` whenever the current status was in the caller's `expectedStatuses` (`inArray(issues.status, expectedStatuses)`), with no guard against terminal states. Any wake path reaching checkout with `done`/`cancelled` reachable (e.g. the caller passing that status in `expectedStatuses`) would flip a finished issue back to `in_progress`.

## Change
- Add an early terminal-status gate at the top of `checkout()`: reject `done`/`cancelled` issues with a **409** (`"Cannot checkout a completed issue"`) before any status mutation, mirroring the subtree pause-hold early-return style. The initial company lookup now also selects `status`, so no extra round-trip.
- Resuming finished work must go through the explicit `resume: true` path. Legitimate checkouts (`todo`/`backlog`/`blocked`/`in_review`) are unaffected.

## Tests
Added regression tests in `server/src/__tests__/issues-service.test.ts`:
- checkout of a `done` issue does **not** reopen it, even with `done` in `expectedStatuses`
- checkout of a `cancelled` issue does **not** reopen it, even with `cancelled` in `expectedStatuses`
- SUP-9 loop: 12 repeated checkouts of a `done` issue are idempotent — no status / lock churn

```
npx vitest run src/__tests__/issues-service.test.ts -t "checkout"
# 14 passed (incl. 3 new), existing adoption tests still green
```

## Acceptance criteria
- [x] `checkout(...)` rejects when current status is `done`/`cancelled`, even if passed in `expectedStatuses` (clear 409 over silent flip)
- [x] Existing legitimate checkouts unaffected
- [x] Regression tests for done / cancelled / SUP-9 idempotency
- [x] Scoped checkout/issues service tests pass

Resolves SUP-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)