### PR TITLE
[codex] LIB-577: suppress timer recovery on blocked routine issues (fast-follow of #8245)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -580,6 +580,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
     runErrorCode?: string | null;
     runError?: string | null;
+    originKind?: string;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -678,6 +679,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         assigneeUserId: input.assignToUser ? "user-1" : null,
         checkoutRunId: input.status === "in_progress" ? runId : null,
         executionRunId: null,
+        ...(input.originKind ? { originKind: input.originKind } : {}),
         issueNumber: input.activePauseHold ? 2 : 1,
         identifier: `${issuePrefix}-${input.activePauseHold ? 2 : 1}`,
         startedAt: input.status === "in_progress" ? now : null,
@@ -2569,6 +2571,62 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(retryRun?.id).toBeTruthy();
     expect((retryRun?.contextSnapshot as Record<string, unknown>)?.retryReason).toBe("issue_continuation_needed");
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  // LIB-577 (LIB-576 Finding B): a blocked routine_execution issue must not get
+  // a timer/interval-driven `productive_terminal_continuation_recovery` run —
+  // its only valid continuation is the blocker resolving. PR #8245 suppressed
+  // the max-turn continuation path only; this covers the continuationAttempt=0
+  // reconcile path that re-posted an identical blocked status on LIB-554.
+  it("suppresses timer recovery for a blocked routine_execution issue", async () => {
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "blocked",
+      originKind: "routine_execution",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.blockedRoutineContinuationSuppressed).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    // No recovery run scheduled: only the original seeded run exists.
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(runId);
+  });
+
+  // Scope guard: the LIB-577 suppression is keyed on originKind. A non-routine
+  // blocked issue still follows the existing productive-continuation path, so a
+  // regression here would mean the suppression leaked beyond routine_execution.
+  it("still requeues continuation for a blocked non-routine issue", async () => {
+    const { agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "blocked",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.blockedRoutineContinuationSuppressed).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.livenessState !== "blocked");
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -139,6 +139,8 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     scheduledRetryAttempt?: number;
     runtimeConfig?: Record<string, unknown>;
     issueStatus?: string;
+    issueOriginKind?: string;
+    contextSnapshot?: Record<string, unknown>;
   }) {
     const companyId = input?.companyId ?? randomUUID();
     const agentId = input?.agentId ?? randomUUID();
@@ -194,6 +196,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       contextSnapshot: {
         issueId,
         wakeReason: "issue_assigned",
+        ...(input?.contextSnapshot ?? {}),
       },
       updatedAt: now,
       createdAt: now,
@@ -209,6 +212,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       executionRunId: runId,
       executionAgentNameKey: "claudecoder",
       executionLockedAt: now,
+      originKind: input?.issueOriginKind ?? "manual",
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
     });
@@ -421,6 +425,80 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRuns[0]?.id);
+  });
+
+  it("suppresses max-turn continuations for routine execution issues by default", async () => {
+    const { issueId, runId, now } = await seedMaxTurnFixture({
+      issueOriginKind: "routine_execution",
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+          maxTurnContinuation: {
+            enabled: true,
+            maxAttempts: 10,
+            delayMs: 1_000,
+          },
+        },
+      },
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      maxAttempts: 10,
+      delayMs: 1_000,
+    });
+
+    expect(scheduled).toMatchObject({
+      outcome: "not_scheduled",
+      errorCode: "routine_execution_auto_continuation_disabled",
+      issueId,
+    });
+
+    const retryRuns = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(retryRuns).toBe(0);
+
+    const event = await db
+      .select({
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(sql`${heartbeatRunEvents.seq} desc`)
+      .then((rows) => rows[0] ?? null);
+    expect(event?.message).toContain("routine execution issue");
+    expect(event?.payload).toMatchObject({
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      maxAttempts: 10,
+      originKind: "routine_execution",
+      optInContextKey: "allowMaxTurnContinuation",
+    });
+  });
+
+  it("allows routine max-turn continuation when the run explicitly opts in", async () => {
+    const { runId, now } = await seedMaxTurnFixture({
+      issueOriginKind: "routine_execution",
+      contextSnapshot: { allowMaxTurnContinuation: true },
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+      wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
+      maxAttempts: 2,
+      delayMs: 1_000,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+    expect(scheduled.attempt).toBe(1);
   });
 
   it("does not promote a duplicate max-turn continuation that does not own the issue lock", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6189,7 +6189,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             | "issue_cancelled"
             | "issue_terminal_status"
             | "issue_not_in_progress"
-            | "issue_execution_lock_changed";
+            | "issue_execution_lock_changed"
+            | "routine_execution_auto_continuation_disabled";
           issueId: string | null;
           details: Record<string, unknown>;
         };
@@ -6256,6 +6257,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               status: issues.status,
               assigneeAgentId: issues.assigneeAgentId,
               executionRunId: issues.executionRunId,
+              originKind: issues.originKind,
             })
             .from(issues)
             .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -6316,6 +6318,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 issueId,
                 expectedExecutionRunId: run.id,
                 currentExecutionRunId: lockedIssue.executionRunId,
+              },
+            };
+          }
+
+          if (
+            lockedIssue.originKind === "routine_execution" &&
+            contextSnapshot.allowMaxTurnContinuation !== true
+          ) {
+            return {
+              outcome: "not_scheduled",
+              reason:
+                "Scheduled max-turn continuation suppressed for routine execution issue without explicit allowMaxTurnContinuation opt-in",
+              errorCode: "routine_execution_auto_continuation_disabled",
+              issueId,
+              details: {
+                issueId,
+                originKind: lockedIssue.originKind,
+                optInContextKey: "allowMaxTurnContinuation",
               },
             };
           }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2661,6 +2661,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       continuationRequeued: 0,
       productiveContinuationObserved: 0,
       successfulContinuationObserved: 0,
+      blockedRoutineContinuationSuppressed: 0,
       orphanBlockersAssigned: 0,
       successfulRunHandoffEscalated: 0,
       escalated: 0,
@@ -2810,6 +2811,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
       if (isSuccessfulInProgressContinuationRun(latestRun)) {
         const successfulRun = latestRun;
+
+        // LIB-577 (LIB-576 Finding B): a `routine_execution` issue whose latest
+        // run is liveness-`blocked` ("Issue status is blocked") has no valid
+        // timer/interval-driven continuation — `isProductiveContinuationRun`
+        // counts `blocked` as productive, so without this guard the reconcile
+        // sweep keeps enqueuing `productive_terminal_continuation_recovery` and
+        // replays full context (e.g. LIB-554: ~889K input re-posting an
+        // identical blocked status). A blocked routine issue's only valid
+        // continuation is the blocker resolving, not a recovery rehydration.
+        // Mirrors PR #8245's `routine_execution` suppression, which only covered
+        // the max-turn continuation path and never reached continuationAttempt=0.
+        if (
+          issue.originKind === "routine_execution" &&
+          successfulRun.livenessState === "blocked"
+        ) {
+          result.blockedRoutineContinuationSuppressed += 1;
+          result.skipped += 1;
+          continue;
+        }
 
         if (!isProductiveContinuationRun(successfulRun)) {
           result.successfulContinuationObserved += 1;


### PR DESCRIPTION
## Summary
Fast-follow of #8245. Closes the gap from **LIB-576 Finding B** (audit of LIB-573): `productive_terminal_continuation_recovery` re-runs a `routine_execution` issue on a timer even after it is blocked.

`reconcileStrandedAssignedIssues` enqueues `productive_terminal_continuation_recovery` for any successful in-progress continuation run, and `isProductiveContinuationRun` classifies `livenessState === "blocked"` as *productive*. So a routine issue that declared a blocker gets replayed on the interval, rehydrating full context to re-post an identical blocked status (LIB-554: ~889K input / 7.2K output, 43 min after the issue was already blocked). This is `continuationAttempt=0`, so #8245's max-turn suppression never reached it.

## Change (minimal, same fix family as #8245)
- `server/src/services/recovery/service.ts`: in the productive-continuation branch, skip recovery when `issue.originKind === "routine_execution"` **and** the latest successful run's `livenessState === "blocked"`. Surfaced via a new `blockedRoutineContinuationSuppressed` counter. Mirrors #8245's `routine_execution` suppression.
- Scoped to `routine_execution`: blocked **non-routine** issues keep the existing productive-continuation path (and its downstream escalate-to-`blocked` behavior).

## Tests — `server/src/__tests__/heartbeat-process-recovery.test.ts`
- blocked routine issue → **no recovery run scheduled** (the LIB-577 regression).
- blocked non-routine issue → **still requeues** (scope guard).
- Full file: 57 passed (1 pre-existing, unrelated flake: `queues exactly one retry when the recorded local pid is dead` — fails identically on clean master in this sandbox; real-process pid tracking).

## Gates
- Code review: **APPROVE**. Security scan: **PASS** (1 MEDIUM tracked as follow-up).
- Follow-up (already anticipated in LIB-577): routine-level `maxTurns`/recovery-budget so a routine issue stuck `in_progress` + `blocked`-liveness with no registered blocker escalates rather than waiting indefinitely. Filed separately.

## Notes for reviewer
This branch stacks on #8245 (`2a0a5c3`, still in review). Merge after/with #8245. Do not squash away the #8245 commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)