### PR TITLE
fix(server): pass createPostgresUser to embedded-postgres when running as root

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -85,6 +85,7 @@ type EmbeddedPostgresCtor = new (opts: {
   password: string;
   port: number;
   persistent: boolean;
+  createPostgresUser?: boolean;
   initdbFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
@@ -428,6 +429,7 @@ export async function startServer(): Promise<StartedServer> {
           password: "paperclip",
           port,
           persistent: true,
+          createPostgresUser: true,
           initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
           onLog: appendEmbeddedPostgresLog,
           onError: appendEmbeddedPostgresLog,


### PR DESCRIPTION
## Problem

When running Paperclip as root (common in Docker containers), the server fails to start with:

```
Paperclip server failed to start.
You are running this script as root. Postgres does not support running as root.
If you wish to continue, configure embedded-postgres to create a Postgres user
by setting the `createPostgresUser` option to true.
```

## Root Cause

The `embedded-postgres` library provides a `createPostgresUser` option that creates a dedicated OS user to run PostgreSQL under, working around the restriction that PostgreSQL cannot run as root. The Paperclip config schema already exposes `createPostgresUser` in the database section, but the value was never forwarded to the `EmbeddedPostgres` constructor in `server/src/index.ts`.

## Fix

- Add `createPostgresUser` to the `EmbeddedPostgresCtor` options type
- Always pass `createPostgresUser: true` when constructing the `EmbeddedPostgres` instance

This is consistent with the existing config default (`createPostgresUser: true` is already written by `onboard`) and is a no-op on non-root systems.

## Test

Reproduced by running `npx paperclipai run` as root. With this fix applied, the server initialises and starts successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)