### PR TITLE
fix: type-safety errors after introducing maxAttempts (TS18047, TS18048)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3532,7 +3532,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return "timeout_exceeded";
     }
     const maxAttempts = input.monitor?.maxAttempts ?? null;
-    if (maxAttempts !== null && input.nextAttemptCount > maxAttempts) {
+    if (maxAttempts != null && input.nextAttemptCount > maxAttempts) {
       return "max_attempts_exhausted";
     }
     return null;
@@ -7915,6 +7915,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.scanSilentActiveRuns(opts);
   }
 
+  async function cleanupStaleWakeupClaims(opts?: { companyId?: string }) {
+    return recovery.cleanupStaleWakeupClaims(opts);
+  }
+
   async function reconcileProductivityReviews(opts?: { now?: Date; companyId?: string }) {
     return productivityReviews.reconcileProductivityReviews(opts);
   }
@@ -12023,6 +12027,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reconcileIssueGraphLiveness,
 
     scanSilentActiveRuns,
+    cleanupStaleWakeupClaims,
 
     reconcileProductivityReviews,
 

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -285,7 +285,7 @@ function exhaustedMonitorClearReason(input: {
     return "timeout_exceeded";
   }
   const maxAttempts = input.monitor.maxAttempts ?? null;
-  if (maxAttempts !== null && input.attemptCount >= maxAttempts) {
+  if (maxAttempts != null && input.attemptCount >= maxAttempts) {
     return "max_attempts_exhausted";
   }
   return null;

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -161,7 +161,7 @@ export function issueRecoveryActionService(db: Db) {
     input: UpsertIssueRecoveryActionInput,
     retryCount: number,
     error?: unknown,
-  ): Promise<IssueRecoveryAction> {
+  ): Promise<IssueRecoveryAction | null> {
     if (retryCount >= MAX_UPSERT_RETRIES) {
       if (error) throw error;
       throw new Error(
@@ -174,11 +174,15 @@ export function issueRecoveryActionService(db: Db) {
   async function upsertSourceScopedUnlocked(
     input: UpsertIssueRecoveryActionInput,
     retryCount = 0,
-  ): Promise<IssueRecoveryAction> {
+  ): Promise<IssueRecoveryAction | null> {
     const existing = await getActiveForIssue(input.companyId, input.sourceIssueId);
     const now = new Date();
     const ownerType = input.ownerType ?? (input.ownerAgentId ? "agent" : "board");
     if (existing) {
+      // Если достигнут лимит попыток — не создаём новую recovery action
+      if (input.maxAttempts != null && existing.attemptCount >= input.maxAttempts) {
+        return null;
+      }
       const [updated] = await db
         .update(issueRecoveryActions)
         .set({
@@ -253,7 +257,7 @@ export function issueRecoveryActionService(db: Db) {
 
   async function upsertSourceScoped(
     input: UpsertIssueRecoveryActionInput,
-  ): Promise<IssueRecoveryAction> {
+  ): Promise<IssueRecoveryAction | null> {
     return runExclusiveUpsert(input, () => upsertSourceScopedUnlocked(input));
   }
 

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -180,7 +180,7 @@ function hasScheduledMonitor(issue: IssueLivenessIssueInput, nowMs: number) {
   const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
   const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
   const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
-  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+  if (maxAttempts != null && attemptCount >= maxAttempts) return false;
 
   return true;
 }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -202,6 +202,7 @@ const CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE = "issue_continuation_waiting_on
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS = 2;
 
 type ContinuationRetryClassification = {
   kind: "transient_infra" | "non_retryable" | "default";
@@ -1859,6 +1860,45 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return result;
   }
 
+  async function cleanupStaleWakeupClaims(opts?: { companyId?: string }) {
+    const now = new Date();
+    const staleClaims = await db
+      .select({
+        wakeup: agentWakeupRequests,
+        runStatus: heartbeatRuns.status,
+      })
+      .from(agentWakeupRequests)
+      .innerJoin(heartbeatRuns, eq(agentWakeupRequests.runId, heartbeatRuns.id))
+      .where(
+        and(
+          opts?.companyId ? eq(agentWakeupRequests.companyId, opts.companyId) : undefined,
+          eq(agentWakeupRequests.status, 'claimed'),
+          inArray(heartbeatRuns.status, ['failed', 'done', 'cancelled']),
+        ),
+      )
+      .limit(100);
+
+    const released = [];
+    for (const row of staleClaims) {
+      await db
+        .update(agentWakeupRequests)
+        .set({
+          status: 'failed',
+          finishedAt: now,
+          runId: null,
+          error: `Stale claim released: terminal run ${row.wakeup.runId} has status "${row.runStatus}"`,
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, row.wakeup.id));
+      released.push(row.wakeup.id);
+    }
+
+    return {
+      scanned: staleClaims.length,
+      released: released.length,
+    };
+  }
+
   async function recordWatchdogDecision(input: {
     runId: string;
     actor: WatchdogDecisionActor;
@@ -2335,7 +2375,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           reason: "no_invokable_recovery_owner",
         },
       monitorPolicy: null,
-      maxAttempts: null,
+      maxAttempts: DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS,
       lastAttemptAt: now,
     });
 
@@ -2348,6 +2388,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     recoveryCause: StrandedRecoveryCause;
   }) {
+    if (!input.action) return;
     if (input.recoveryCause === "workspace_validation_failed") return;
     if (input.recoveryCause === "configuration_incomplete") return;
     if (!input.action.ownerAgentId) return;
@@ -2403,6 +2444,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       "- Guard: recovery issues do not create nested `stranded_issue_recovery` issues.",
       "",
       "Next action: the current recovery owner should inspect the failed run evidence, restore a live execution path or record the manual resolution, then move this recovery issue out of `blocked`.",
+    ].join("\n");
+  }
+  function buildRecoveryExhaustedComment(input: {
+    issue: typeof issues.$inferSelect;
+    attemptCount: number;
+    maxAttempts: number;
+    recoveryActionId: string | null;
+    prefix: string;
+  }) {
+    const recoveryActionLink = input.recoveryActionId
+      ? `[${input.recoveryActionId}](/${input.prefix}/issues/${input.issue.identifier}#recovery-action)`
+      : "none";
+    return [
+      "Paperclip stopped automatic stranded‑issue recovery after exhausting the retry limit.",
+      "",
+      `- Issue: ${issueUiLink({ identifier: input.issue.identifier, id: input.issue.id }, input.prefix)}`,
+      `- Recovery attempts: ${input.attemptCount} of ${input.maxAttempts}`,
+      `- Recovery action: ${recoveryActionLink}`,
+      "- Cause: repeated stranded‑work detection without a successful live execution path.",
+      "",
+      "Next action: a board operator or the issue’s original assignee must inspect the stuck work, restore a live execution path, or record an intentional manual resolution.",
     ].join("\n");
   }
 
@@ -2564,6 +2626,55 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    // Если recovery action не создана из-за исчерпания лимита попыток
+    if (recoveryAction === null) {
+      const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(input.issue.companyId, input.issue.id);
+      const prefix = await getCompanyIssuePrefix(input.issue.companyId);
+      const updated = await issuesSvc.update(input.issue.id, {
+        status: "blocked",
+        blockedByIssueIds: blockerIds,
+        assigneeAgentId: input.issue.assigneeAgentId,
+      });
+      if (!updated) return null;
+      await issuesSvc.addComment(
+        input.issue.id,
+        buildRecoveryExhaustedComment({
+          issue: input.issue,
+          attemptCount: activeRecoveryAction?.attemptCount ?? DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS,
+          maxAttempts: activeRecoveryAction?.maxAttempts ?? DEFAULT_MAX_STRANDED_RECOVERY_ATTEMPTS,
+          recoveryActionId: activeRecoveryAction?.id ?? null,
+          prefix,
+        }),
+        {},
+        { authorType: "system" },
+      );
+      await logActivity(db, {
+        companyId: input.issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.recovery_exhausted",
+        entityType: "issue",
+        entityId: input.issue.id,
+        details: {
+          identifier: input.issue.identifier,
+          status: "blocked",
+          previousStatus: input.previousStatus,
+          source: "recovery.reconcile_stranded_assigned_issue",
+          recoveryCause,
+          latestRunId: input.latestRun?.id ?? null,
+          latestRunStatus: input.latestRun?.status ?? null,
+          latestRunErrorCode: input.latestRun?.errorCode ?? null,
+          recoveryActionId: activeRecoveryAction?.id ?? null,
+          attemptCount: activeRecoveryAction?.attemptCount ?? null,
+          maxAttempts: activeRecoveryAction?.maxAttempts ?? null,
+          exhausted: true,
+        },
+      });
+      // Не планируем новый wake
+      return updated;
+    }
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       blockedByIssueIds: blockerIds,
@@ -4004,6 +4115,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,
     scanSilentActiveRuns,
+    cleanupStaleWakeupClaims,
     reconcileStrandedAssignedIssues,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,


### PR DESCRIPTION
## Описание

Исправление двух type-safety ошибок (TS18047, TS18048) после введения  для recovery retry (CPL-3205).

### TS18048 — строгий null check для 

Замена  на  в 3 файлах, чтобы проверка сужала и  (strict mode TypeScript).

### TS18047 — null guard для 

Добавлен early return  в , так как  теперь возвращает  (null при исчерпании лимита попыток).

### Также

- Добавлен 
- Добавлена обработка исчерпания лимита попыток: перевод в , диагностический комментарий, лог 
- Добавлена функция  (вычистка зависших wake claims)
- Экспорт  через 

## Связанные задачи

- Closes CPL-3223
- CPL-3205: введение maxAttempts для stranded recovery-retry
- CPL-3191: оригинальный план