### PR TITLE
fix(codex): keep stable prompt before wake payload

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -684,10 +684,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const prompt = joinPromptSections([
       promptInstructionsPrefix,
       renderedBootstrapPrompt,
+      renderedPrompt,
       wakePrompt,
       codexFallbackHandoffNote,
       sessionHandoffNote,
-      renderedPrompt,
     ]);
     const promptMetrics = {
       promptChars: prompt.length,

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -478,6 +478,9 @@ describe("codex execute", () => {
         latestCommentId: "comment-2",
         commentIds: ["comment-1", "comment-2"],
       });
+      expect(capture.prompt.indexOf("You are agent agent-1 (Codex Coder).")).toBeLessThan(
+        capture.prompt.indexOf("## Paperclip Wake Payload"),
+      );
       expect(capture.prompt).toContain("## Paperclip Wake Payload");
       expect(capture.prompt).toContain("Treat this wake payload as the highest-priority change for the current heartbeat.");
       expect(capture.prompt).toContain("Do not switch to another issue until you have handled this wake.");


### PR DESCRIPTION
## Summary
- Reorders Codex fresh-session prompt assembly so the stable heartbeat template stays before issue-specific wake payload text.
- Keeps resumed-session wake-delta behavior unchanged.
- Adds a regression assertion that the static agent contract precedes `## Paperclip Wake Payload`.

## Why
LIB-636 showed live OpenAI/ChatGPT cache hit around 48% across fresh Codex runs while Anthropic was near 99%. A live CTO run had prompt metrics of 7.2k instruction chars, then 6.4k wake payload chars, then 2.6k static heartbeat template chars. The static tail after dynamic issue text cannot contribute to OpenAI prompt-prefix cache reuse.

This change preserves behavior but moves that static tail into the reusable prefix for fresh sessions. It is a scoped cache-efficiency mitigation, not a deployment or model-routing change.

## Verification
- `./node_modules/.bin/vitest run server/src/__tests__/codex-local-execute.test.ts packages/adapters/codex-local/src/server/codex-args.test.ts packages/adapters/codex-local/src/server/parse.test.ts`
- Result: 3 files passed, 28 tests passed

## Notes
- Initial `pnpm vitest ...` was blocked by a local pnpm version guard resolving pnpm 11.8.0 while the repo requires 9.15.4; Corepack fetch for 9.15.4 returned HTTP 403, so I used the checked-out local vitest binary for targeted verification.
- No deploy, no merge, no production configuration changes.