### PR TITLE
Prevent gpt-5.5 fallback for codex_local

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -27,11 +27,7 @@ export function isCodexLocalManualModel(model: string | null | undefined): boole
 export function isCodexLocalFastModeSupported(model: string | null | undefined): boolean {
   if (isCodexLocalManualModel(model)) return true;
   const normalizedModel = typeof model === "string" ? model.trim() : "";
-  // Empty means we're omitting --model so the Codex CLI picks its own default.
-  // On subscription auth that's gpt-5.5 (fast-mode capable); manual model IDs
-  // are also treated as supported. Match that policy: pass the fast-mode
-  // overrides through and let the CLI reject them if the chosen model can't use them.
-  if (!normalizedModel) return true;
+  if (!normalizedModel) return false;
   return CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS.includes(
     normalizedModel as (typeof CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS)[number],
   );

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -70,21 +70,21 @@ describe("buildCodexExecArgs", () => {
     ]);
   });
 
-  it("enables Codex fast mode overrides when model is omitted (CLI default)", () => {
+  it("defaults omitted model to gpt-5.3-codex and ignores fast mode", () => {
     const result = buildCodexExecArgs({
       fastMode: true,
     });
 
     expect(result.fastModeRequested).toBe(true);
-    expect(result.fastModeApplied).toBe(true);
-    expect(result.fastModeIgnoredReason).toBeNull();
+    expect(result.fastModeApplied).toBe(false);
+    expect(result.fastModeIgnoredReason).toBe(
+      "Configured fast mode is currently only supported on gpt-5.5, gpt-5.4 or manually configured model IDs; Paperclip will ignore it for model gpt-5.3-codex.",
+    );
     expect(result.args).toEqual([
       "exec",
       "--json",
-      "-c",
-      'service_tier="fast"',
-      "-c",
-      "features.fast_mode=true",
+      "--model",
+      "gpt-5.3-codex",
       "-",
     ]);
   });

--- a/packages/adapters/codex-local/src/server/codex-args.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.ts
@@ -1,5 +1,6 @@
 import { asBoolean, asString, asStringArray } from "@paperclipai/adapter-utils/server-utils";
 import {
+  DEFAULT_CODEX_LOCAL_MODEL,
   CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS,
   isCodexLocalFastModeSupported,
 } from "../index.js";
@@ -36,7 +37,7 @@ export function buildCodexExecArgs(
   } = {},
 ): BuildCodexExecArgsResult {
   const record = asRecord(config);
-  const model = asString(record.model, "").trim();
+  const model = asString(record.model, "").trim() || DEFAULT_CODEX_LOCAL_MODEL;
   const modelReasoningEffort = asString(
     record.modelReasoningEffort,
     asString(record.reasoningEffort, ""),

--- a/report/2026-06-20-gpt-5-5-fleet-cost-exposure.md
+++ b/report/2026-06-20-gpt-5-5-fleet-cost-exposure.md
@@ -2,13 +2,13 @@
 
 Date: 2026-06-20
 
-Issue: LIB-638
+Issues: LIB-638, LIB-641
 
 ## Summary
 
-The FinOps alert is valid. GPT-5.5 usage is present in the current Codex local fleet, with high token volume over a short window and no dollar-cost accounting recorded in Paperclip.
+The FinOps alert is valid. GPT-5.5 usage is present in the current Codex local fleet, with high token volume over a short window, weak OpenAI prompt-cache reuse in newer telemetry, and no dollar-cost accounting recorded in Paperclip.
 
-The immediate risk is not just model choice. Paperclip is currently reporting token volume with `costCents: 0`, `budgetMonthlyCents: 0`, and `spentMonthlyCents: 0`, so budget enforcement cannot catch this exposure.
+The immediate risk is not just model choice. Paperclip is currently reporting token volume with `costCents: 0`, `budgetMonthlyCents: 0`, and `spentMonthlyCents: 0`, so budget enforcement cannot catch this exposure. The cache-prefix implementation path is already represented by PR #8392 from LIB-636; this report remains the audit and review artifact for Alex.
 
 ## Evidence
 
@@ -24,6 +24,20 @@ The LIB-638 issue payload reported this 5-hour GPT-5.5 window on 2026-06-20:
 | Memory & Context Engineer | 30M | 27M | 89% |
 
 Total: about 288M input tokens in 5 hours, with about 263M cached input tokens.
+
+LIB-641 later reported a broader same-day `openai/gpt-5.5` exposure row:
+
+| Metric | Value |
+| --- | ---: |
+| Fresh input tokens | 356,254,571 |
+| Cached input tokens | 321,604,864 |
+| Output tokens | 2,624,059 |
+| Total tokens | 680,483,494 |
+| Cache hit | 47.44% |
+| Cold share | 52.56% |
+| Recorded spend | $0.00 |
+
+The same LIB-641 snapshot reported Anthropic at 20,752,239 fresh input tokens, 1,468,662,306 cached input tokens, and 10,427,038 output tokens, for a 98.61% cache hit rate. If GPT-5.5 matched that 98.61% cache hit on the same 677,859,435 prompt-token base, fresh input would drop to about 9,422,246 tokens, avoiding about 346,832,325 fresh input tokens in the observed window.
 
 Paperclip API checks during this review showed:
 
@@ -46,7 +60,7 @@ OpenAI's API pricing page lists GPT-5.5 standard short-context prices per 1M tok
 | Cached input | $0.50 |
 | Output | $30.00 |
 
-The GPT-5.5 model page also notes that prompts above 272K input tokens are priced at 2x input and 1.5x output for the full session. This review uses the lower short-context standard price unless noted, so the estimate is conservative for long-context runs.
+The GPT-5.5 pricing table also lists long-context standard prices at 2x input, 2x cached input, and 1.5x output for the full session. This review uses the lower short-context standard price unless noted, so the estimate is conservative for long-context runs.
 
 Sources:
 
@@ -79,6 +93,16 @@ This excludes output tokens, long-context multipliers, priority/fast processing,
 
 Using the currently stored by-agent token ledger for the six named agents, and pricing those stored uncached input, cached input, and output tokens at GPT-5.5 standard rates, the implied exposure is about $2,829.36 for the stored ledger rows. Paperclip records that as $0 today.
 
+LIB-641 same-day exposure estimate:
+
+| Basis | Estimate |
+| --- | ---: |
+| Standard short-context GPT-5.5 rate | $2,020.80 |
+| Standard long-context GPT-5.5 rate | $4,002.23 |
+| Fresh-input exposure avoidable at Anthropic-equivalent cache hit | $1,734.16 |
+
+These figures remain estimates because Paperclip currently records the events as subscription-included and does not apply price mapping to the ledger rows.
+
 ## Root Cause Assessment
 
 1. The CTO is explicitly configured to use GPT-5.5.
@@ -87,17 +111,19 @@ Using the currently stored by-agent token ledger for the six named agents, and p
 4. Adapter source comments state that an empty model lets the Codex CLI pick its subscription default, which is GPT-5.5 on subscription auth.
 5. Paperclip's cost ledger is not converting subscription token telemetry into cost events.
 6. Company and agent monthly budgets are zero, so the 80% and 100% budget gates cannot protect spend.
+7. The cache-prefix code mitigation for fresh Codex sessions is already proposed in PR #8392 from LIB-636. That change reorders fresh-session prompt assembly so the stable heartbeat template precedes issue-specific wake payload text, which should improve OpenAI prefix-cache reuse without disabling any work.
 
 ## Proposed Mitigation
 
 Do not make live config changes without Alex approval. The approval-gated implementation should:
 
-1. Pin bulk worker agents to an explicit cheaper model profile, starting with `gpt-5.3-codex-spark` for routine worker/reviewer lanes.
-2. Keep GPT-5.5 available only for roles or tasks where frontier reasoning is explicitly required.
-3. Add a FinOps guardrail that treats empty `codex_local.adapterConfig.model` as a cost-risk state when Codex CLI would default to GPT-5.5.
-4. Fix Paperclip cost accounting so subscription token telemetry produces nonzero `costCents`.
-5. Set monthly budgets on company and high-volume agents so the documented budget thresholds can fire.
-6. Add a regression check that prevents new Codex local agents from silently inheriting GPT-5.5 as the runtime default.
+1. Review and merge PR #8392 if Alex accepts the scoped cache-prefix mitigation.
+2. Pin bulk worker agents to an explicit cheaper model profile, starting with `gpt-5.3-codex-spark` for routine worker/reviewer lanes.
+3. Keep GPT-5.5 available only for roles or tasks where frontier reasoning is explicitly required.
+4. Add a FinOps guardrail that treats empty `codex_local.adapterConfig.model` as a cost-risk state when Codex CLI would default to GPT-5.5.
+5. Fix Paperclip cost accounting so subscription token telemetry produces nonzero `costCents`.
+6. Set monthly budgets on company and high-volume agents so the documented budget thresholds can fire.
+7. Add a regression check that prevents new Codex local agents from silently inheriting GPT-5.5 as the runtime default.
 
 ## Acceptance Criteria For Follow-Up
 
@@ -117,5 +143,6 @@ Commands run:
 - `GET /api/companies/{companyId}/costs/by-project`
 - `GET /api/agents/{agentId}` for the six named agents
 - `GET /api/companies/{companyId}/adapters/codex_local/models`
+- Official OpenAI API pricing page checked on 2026-06-20
 
 No live agent configuration, budget, deployment, database, or infrastructure changes were made.

--- a/report/2026-06-20-gpt-5-5-fleet-cost-exposure.md
+++ b/report/2026-06-20-gpt-5-5-fleet-cost-exposure.md
@@ -1,0 +1,121 @@
+# GPT-5.5 Fleet Cost Exposure Review
+
+Date: 2026-06-20
+
+Issue: LIB-638
+
+## Summary
+
+The FinOps alert is valid. GPT-5.5 usage is present in the current Codex local fleet, with high token volume over a short window and no dollar-cost accounting recorded in Paperclip.
+
+The immediate risk is not just model choice. Paperclip is currently reporting token volume with `costCents: 0`, `budgetMonthlyCents: 0`, and `spentMonthlyCents: 0`, so budget enforcement cannot catch this exposure.
+
+## Evidence
+
+The LIB-638 issue payload reported this 5-hour GPT-5.5 window on 2026-06-20:
+
+| Agent | Input | Cached input | Cache ratio |
+| --- | ---: | ---: | ---: |
+| Software Engineer | 80M | 72M | 90% |
+| Site Reliability Engineer | 49M | 44M | 90% |
+| Code Reviewer | 44M | 41M | 92% |
+| CTO | 44M | 42M | 95% |
+| Security Engineer | 41M | 37M | 91% |
+| Memory & Context Engineer | 30M | 27M | 89% |
+
+Total: about 288M input tokens in 5 hours, with about 263M cached input tokens.
+
+Paperclip API checks during this review showed:
+
+| Check | Result |
+| --- | --- |
+| Company cost summary | `spendCents: 0`, `budgetCents: 0`, `utilizationPercent: 0` |
+| By-agent cost rows | Large token counts present, all `costCents: 0` |
+| CTO detailed config | `adapterType: codex_local`, `adapterConfig.model: gpt-5.5` |
+| Other five named agents | `adapterType: codex_local`, no explicit `adapterConfig.model` |
+| Codex local adapter default | Code default is `gpt-5.3-codex`; empty model omits `--model`, allowing the Codex CLI subscription default to select GPT-5.5 |
+| Available cheap profile | `gpt-5.3-codex-spark` with `modelReasoningEffort: high` |
+
+## Pricing Basis
+
+OpenAI's API pricing page lists GPT-5.5 standard short-context prices per 1M tokens as:
+
+| Token class | Price |
+| --- | ---: |
+| Input | $5.00 |
+| Cached input | $0.50 |
+| Output | $30.00 |
+
+The GPT-5.5 model page also notes that prompts above 272K input tokens are priced at 2x input and 1.5x output for the full session. This review uses the lower short-context standard price unless noted, so the estimate is conservative for long-context runs.
+
+Sources:
+
+- https://developers.openai.com/api/docs/pricing
+- https://developers.openai.com/api/docs/models/gpt-5.5
+
+## Exposure Estimate
+
+Input-side cost for the 5-hour LIB-638 window:
+
+| Agent | Uncached input | Cached input | Estimated input-side cost |
+| --- | ---: | ---: | ---: |
+| Software Engineer | 8M | 72M | $76.00 |
+| Site Reliability Engineer | 5M | 44M | $47.00 |
+| Code Reviewer | 3M | 41M | $35.50 |
+| CTO | 2M | 42M | $31.00 |
+| Security Engineer | 4M | 37M | $38.50 |
+| Memory & Context Engineer | 3M | 27M | $28.50 |
+
+Total input-side estimate for the 5-hour window: $256.50.
+
+Linearized run rate from that 5-hour window:
+
+| Period | Input-side estimate |
+| --- | ---: |
+| 24 hours | $1,231.20 |
+| 30 days | $36,936.00 |
+
+This excludes output tokens, long-context multipliers, priority/fast processing, tool charges, and any non-listed agents. It is therefore a lower-bound exposure estimate.
+
+Using the currently stored by-agent token ledger for the six named agents, and pricing those stored uncached input, cached input, and output tokens at GPT-5.5 standard rates, the implied exposure is about $2,829.36 for the stored ledger rows. Paperclip records that as $0 today.
+
+## Root Cause Assessment
+
+1. The CTO is explicitly configured to use GPT-5.5.
+2. The other named agents do not show explicit model overrides in the agent API.
+3. The Codex local adapter omits `--model` when `adapterConfig.model` is empty.
+4. Adapter source comments state that an empty model lets the Codex CLI pick its subscription default, which is GPT-5.5 on subscription auth.
+5. Paperclip's cost ledger is not converting subscription token telemetry into cost events.
+6. Company and agent monthly budgets are zero, so the 80% and 100% budget gates cannot protect spend.
+
+## Proposed Mitigation
+
+Do not make live config changes without Alex approval. The approval-gated implementation should:
+
+1. Pin bulk worker agents to an explicit cheaper model profile, starting with `gpt-5.3-codex-spark` for routine worker/reviewer lanes.
+2. Keep GPT-5.5 available only for roles or tasks where frontier reasoning is explicitly required.
+3. Add a FinOps guardrail that treats empty `codex_local.adapterConfig.model` as a cost-risk state when Codex CLI would default to GPT-5.5.
+4. Fix Paperclip cost accounting so subscription token telemetry produces nonzero `costCents`.
+5. Set monthly budgets on company and high-volume agents so the documented budget thresholds can fire.
+6. Add a regression check that prevents new Codex local agents from silently inheriting GPT-5.5 as the runtime default.
+
+## Acceptance Criteria For Follow-Up
+
+- Every active Codex local agent has an explicit model policy: frontier, standard, or cheap.
+- At least the Software Engineer, SRE, Code Reviewer, Security Engineer, and Memory & Context Engineer no longer inherit GPT-5.5 through an empty model config unless Alex approves that role.
+- Company and by-agent cost endpoints report nonzero `costCents` when token telemetry is present.
+- A test or documented verification demonstrates that an empty Codex local model config is detected as a FinOps risk.
+- Alex receives a before/after table showing expected monthly run-rate reduction.
+
+## Verification
+
+Commands run:
+
+- `GET /api/issues/{issueId}/heartbeat-context`
+- `GET /api/companies/{companyId}/costs/summary`
+- `GET /api/companies/{companyId}/costs/by-agent`
+- `GET /api/companies/{companyId}/costs/by-project`
+- `GET /api/agents/{agentId}` for the six named agents
+- `GET /api/companies/{companyId}/adapters/codex_local/models`
+
+No live agent configuration, budget, deployment, database, or infrastructure changes were made.

--- a/report/2026-06-20-gpt-5-5-fleet-cost-exposure.md
+++ b/report/2026-06-20-gpt-5-5-fleet-cost-exposure.md
@@ -2,30 +2,42 @@
 
 Date: 2026-06-20
 
-Issues: LIB-638, LIB-641
+Issue: LIB-617
+
+Corroborating issues: LIB-638, LIB-641
 
 ## Summary
 
-The FinOps alert is valid. GPT-5.5 usage is present in the current Codex local fleet, with high token volume over a short window, weak OpenAI prompt-cache reuse in newer telemetry, and no dollar-cost accounting recorded in Paperclip.
+The FinOps alert is valid. LIB-617 reported fleet-wide GPT-5.5 usage with roughly 47-49% prompt-cache reuse, far below the 92-99% Anthropic cache-hit range reported for comparable same-day agent work. Current Paperclip API checks also show high subscription-token volume with no nonzero dollar-cost accounting recorded in Paperclip.
 
-The immediate risk is not just model choice. Paperclip is currently reporting token volume with `costCents: 0`, `budgetMonthlyCents: 0`, and `spentMonthlyCents: 0`, so budget enforcement cannot catch this exposure. The cache-prefix implementation path is already represented by PR #8392 from LIB-636; this report remains the audit and review artifact for Alex.
+The immediate risk is not just model choice. Paperclip is currently reporting token volume with `costCents: 0`, `budgetMonthlyCents: 0`, and `spentMonthlyCents: 0`, so budget enforcement cannot catch this exposure. The cache-prefix implementation path is already represented by PR #8392 from LIB-636; this report remains the LIB-617 audit and approval artifact for Alex.
 
 ## Evidence
 
-The LIB-638 issue payload reported this 5-hour GPT-5.5 window on 2026-06-20:
+LIB-617 reported this 5-hour GPT-5.5 window on 2026-06-20:
 
 | Agent | Input | Cached input | Cache ratio |
 | --- | ---: | ---: | ---: |
-| Software Engineer | 80M | 72M | 90% |
-| Site Reliability Engineer | 49M | 44M | 90% |
-| Code Reviewer | 44M | 41M | 92% |
-| CTO | 44M | 42M | 95% |
-| Security Engineer | 41M | 37M | 91% |
-| Memory & Context Engineer | 30M | 27M | 89% |
+| Software Engineer | 79.9M | 37.6M | 47% |
+| Site Reliability Engineer | 46.0M | 22.1M | 48% |
+| CTO | 44.2M | 21.6M | 49% |
+| Code Reviewer | 40.1M | 19.2M | 48% |
+| Security Engineer | 39.0M | 18.7M | 48% |
+| Software Engineer, model empty | 28.8M | 13.8M | 48% |
+| Memory & Context Engineer | 28.6M | 13.4M | 47% |
+| FinOps Analyst | 19.1M | 9.2M | 48% |
 
-Total: about 288M input tokens in 5 hours, with about 263M cached input tokens.
+The rows listed in LIB-617 total about 325.6M input tokens in 5 hours, with about 155.7M cached input tokens and about 170.0M fresh input tokens. The issue summary reports about 370M total GPT-5.5 input tokens for the broader 5-hour window.
 
-LIB-641 later reported a broader same-day `openai/gpt-5.5` exposure row:
+For comparison, the same LIB-617 payload reported Anthropic agents in the 95-99% cache-hit range over the same day:
+
+| Agent | Model | Input | Cache ratio |
+| --- | --- | ---: | ---: |
+| FinOps Analyst | claude-opus-4-8 | 5.1M | 95% |
+| Memory & Context Engineer | claude-opus-4-8 | 2.7M | 99% |
+| CTO | claude-opus-4-8 | 1.8M | 99% |
+
+LIB-641 later reported a broader same-day `openai/gpt-5.5` aggregate exposure row:
 
 | Metric | Value |
 | --- | ---: |
@@ -46,7 +58,7 @@ Paperclip API checks during this review showed:
 | Company cost summary | `spendCents: 0`, `budgetCents: 0`, `utilizationPercent: 0` |
 | By-agent cost rows | Large token counts present, all `costCents: 0` |
 | CTO detailed config | `adapterType: codex_local`, `adapterConfig.model: gpt-5.5` |
-| Other five named agents | `adapterType: codex_local`, no explicit `adapterConfig.model` |
+| Other five named agents | `adapterType: codex_local`, no explicit `adapterConfig.model` in the reviewed agent payloads |
 | Codex local adapter default | Code default is `gpt-5.3-codex`; empty model omits `--model`, allowing the Codex CLI subscription default to select GPT-5.5 |
 | Available cheap profile | `gpt-5.3-codex-spark` with `modelReasoningEffort: high` |
 
@@ -69,25 +81,27 @@ Sources:
 
 ## Exposure Estimate
 
-Input-side cost for the 5-hour LIB-638 window:
+Input-side cost for the listed LIB-617 rows:
 
 | Agent | Uncached input | Cached input | Estimated input-side cost |
 | --- | ---: | ---: | ---: |
-| Software Engineer | 8M | 72M | $76.00 |
-| Site Reliability Engineer | 5M | 44M | $47.00 |
-| Code Reviewer | 3M | 41M | $35.50 |
-| CTO | 2M | 42M | $31.00 |
-| Security Engineer | 4M | 37M | $38.50 |
-| Memory & Context Engineer | 3M | 27M | $28.50 |
+| Software Engineer | 42.3M | 37.6M | $230.52 |
+| Site Reliability Engineer | 23.9M | 22.1M | $130.76 |
+| CTO | 22.5M | 21.6M | $123.44 |
+| Code Reviewer | 20.8M | 19.2M | $113.85 |
+| Security Engineer | 20.3M | 18.7M | $110.62 |
+| Software Engineer, model empty | 15.0M | 13.8M | $81.83 |
+| Memory & Context Engineer | 15.1M | 13.4M | $82.44 |
+| FinOps Analyst | 9.9M | 9.2M | $54.17 |
 
-Total input-side estimate for the 5-hour window: $256.50.
+Total input-side estimate for the listed LIB-617 rows: about $927.63 for 5 hours at standard short-context GPT-5.5 rates, excluding output tokens.
 
 Linearized run rate from that 5-hour window:
 
 | Period | Input-side estimate |
 | --- | ---: |
-| 24 hours | $1,231.20 |
-| 30 days | $36,936.00 |
+| 24 hours | $4,452.63 |
+| 30 days | $133,578.86 |
 
 This excludes output tokens, long-context multipliers, priority/fast processing, tool charges, and any non-listed agents. It is therefore a lower-bound exposure estimate.
 

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -315,6 +315,7 @@ describe("agent routes adapter validation", () => {
     expect(agentId).toMatch(/^[0-9a-f-]{36}$/i);
     const adapterConfig = createInput.adapterConfig as Record<string, unknown>;
     const env = adapterConfig.env as Record<string, unknown>;
+    expect(adapterConfig.model).toBe("gpt-5.3-codex");
     expect(env.OPENAI_API_KEY).toBe("");
     expect(env.CODEX_HOME).toContain(`/companies/company-1/agents/${agentId}/codex-home`);
     expect(String(env.CODEX_HOME)).not.toContain("/companies/company-1/codex-home");

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
@@ -625,6 +625,82 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
         }),
       ]),
     );
+  });
+
+  it("deduplicates explicit idempotency-keyed assignment wakes", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        maxConcurrentRuns: 1,
+      },
+    });
+    const issueId = randomUUID();
+    const idempotencyKey = `issue-assignment:${issueId}:status_change:issue.update`;
+
+    const wakeupRequestId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "status_change" },
+      status: "queued",
+      idempotencyKey,
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId,
+      contextSnapshot: {
+        issueId,
+        source: "issue-status-webhook",
+      },
+    });
+    await db
+      .update(agentWakeupRequests)
+      .set({ runId })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+
+    const firstRun = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "status_change" },
+      idempotencyKey,
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: { issueId },
+    });
+    const secondRun = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "status_change" },
+      idempotencyKey,
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: { issueId },
+    });
+
+    expect(firstRun?.id).toBe(runId);
+    expect(secondRun?.id).toBe(runId);
+
+    const wakeups = await db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.idempotencyKey, idempotencyKey), eq(agentWakeupRequests.agentId, agentId)));
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+
+    expect(wakeups).toHaveLength(1);
+    expect(runs).toHaveLength(1);
   });
 
   it("skips wakes before queueing when per-agent daily cost cap is reached", async () => {

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+describe("issue assignment wakeup", () => {
+  it("passes a stable assignment idempotency key to heartbeat wakeup", async () => {
+    const wakeup = vi.fn().mockResolvedValue("ok");
+    const heartbeat = { wakeup };
+
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: {
+        id: "issue-123",
+        assigneeAgentId: "agent-1",
+        status: "todo",
+      },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "routine.dispatch",
+      requestedByActorType: "system",
+      requestedByActorId: "agent-1",
+    });
+
+    expect(wakeup).toHaveBeenCalledOnce();
+    expect(wakeup).toHaveBeenCalledWith("agent-1", {
+      source: "assignment",
+      triggerDetail: "system",
+      idempotencyKey: "issue-assignment:issue-123:create:routine.dispatch",
+      reason: "issue_assigned",
+      payload: { issueId: "issue-123", mutation: "create" },
+      requestedByActorType: "system",
+      requestedByActorId: "agent-1",
+      contextSnapshot: { issueId: "issue-123", source: "routine.dispatch" },
+    });
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -89,7 +89,10 @@ import {
   DEFAULT_ACPX_LOCAL_NON_INTERACTIVE_PERMISSIONS,
   DEFAULT_ACPX_LOCAL_PERMISSION_MODE,
 } from "@paperclipai/adapter-acpx-local";
-import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
@@ -1222,6 +1225,9 @@ export function agentRoutes(
       return ensureGatewayDeviceKey(adapterType, next);
     }
     if (adapterType === "codex_local") {
+      if (!asNonEmptyString(next.model)) {
+        next.model = DEFAULT_CODEX_LOCAL_MODEL;
+      }
       const hasBypassFlag =
         typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean" ||
         typeof next.dangerouslyBypassSandbox === "boolean";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -224,6 +224,13 @@ const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
 ];
+const IDEMPOTENT_QUEUED_WAKE_STATUSES = [
+  "queued",
+  "coalesced",
+  "deferred_issue_execution",
+  "claimed",
+  "completed",
+] as const;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
@@ -10585,6 +10592,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
+
+    if (opts.idempotencyKey) {
+      const existingWakeup = await db
+        .select({ id: agentWakeupRequests.id, runId: agentWakeupRequests.runId, status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, agent.companyId),
+            eq(agentWakeupRequests.agentId, agent.id),
+            eq(agentWakeupRequests.idempotencyKey, opts.idempotencyKey),
+            inArray(agentWakeupRequests.status, IDEMPOTENT_QUEUED_WAKE_STATUSES),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      if (existingWakeup?.runId) {
+        const existingRun = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, existingWakeup.runId))
+          .then((rows) => rows[0] ?? null);
+        if (existingRun) return existingRun;
+      }
+
+      if (existingWakeup) {
+        return null;
+      }
+    }
 
     const writeSkippedRequest = async (
       skipReason: string,

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -9,6 +9,7 @@ export interface IssueAssignmentWakeupDeps {
     opts: {
       source?: WakeupSource;
       triggerDetail?: WakeupTriggerDetail;
+      idempotencyKey?: string | null;
       reason?: string | null;
       payload?: Record<string, unknown> | null;
       requestedByActorType?: "user" | "agent" | "system";
@@ -34,6 +35,7 @@ export function queueIssueAssignmentWakeup(input: {
     .wakeup(input.issue.assigneeAgentId, {
       source: "assignment",
       triggerDetail: "system",
+      idempotencyKey: `issue-assignment:${input.issue.id}:${input.mutation}:${input.contextSource}`,
       reason: input.reason,
       payload: { issueId: input.issue.id, mutation: input.mutation },
       requestedByActorType: input.requestedByActorType,


### PR DESCRIPTION
## Why
- Codex local agents were able to run with omitted/empty `model`, which allows the CLI default (`gpt-5.5`) to be selected and bypass cache-efficient defaults.
- This reintroduced elevated new-token churn in FinOps windows.

## What changed
- Set explicit `gpt-5.3-codex` as the default model for `codex_local` at request validation when model is absent (`server/src/routes/agents.ts`).
- Default model in execution arg builder so legacy/empty records also land on `gpt-5.3-codex` (`packages/adapters/codex-local/src/server/codex-args.ts`).
- Prevent fast-mode override when model is omitted by removing empty-model fast-mode passthrough (`packages/adapters/codex-local/src/index.ts`, `packages/adapters/codex-local/src/server/codex-args.test.ts`).
- Add deterministic idempotency keys for issue-assignment wakeups and dedupe wakeup/run creation for matching queued/coalesced/deferred/claimed/completed states (`server/src/services/issue-assignment-wakeup.ts`, `server/src/services/heartbeat.ts`).
- Add regression coverage in adapter tests and server wakeup/stale-queue tests.

## Verification
- Ran: `node_modules/.bin/vitest run packages/adapters/codex-local/src/server/codex-args.test.ts server/src/__tests__/agent-adapter-validation-routes.test.ts server/src/__tests__/issue-assignment-wakeup.test.ts server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`
- Result: 35 passed.
