### PR TITLE
Remove adapter support matrix table from Company Environments

### DIFF
--- a/ui/src/pages/CompanyEnvironments.tsx
+++ b/ui/src/pages/CompanyEnvironments.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  AGENT_ADAPTER_TYPES,
-  getAdapterEnvironmentSupport,
   type EnvBinding,
   type Environment,
   type EnvironmentProbeResult,
   type JsonSchema,
 } from "@paperclipai/shared";
-import { Check, Settings } from "lucide-react";
+import { Settings } from "lucide-react";
 import { environmentsApi } from "@/api/environments";
 import { instanceSettingsApi } from "@/api/instanceSettings";
 import { secretsApi } from "@/api/secrets";
@@ -30,7 +28,6 @@ import { queryKeys } from "@/lib/queryKeys";
 import {
   Field,
   ToggleField,
-  adapterLabels,
 } from "../components/agent-config-primitives";
 
 type EnvironmentFormState = {
@@ -49,11 +46,6 @@ type EnvironmentFormState = {
   sandboxConfig: Record<string, unknown>;
   envVars: Record<string, EnvBinding>;
 };
-
-const ENVIRONMENT_SUPPORT_ROWS = AGENT_ADAPTER_TYPES.map((adapterType) => ({
-  adapterType,
-  support: getAdapterEnvironmentSupport(adapterType),
-}));
 
 function buildEnvironmentPayload(form: EnvironmentFormState) {
   return {
@@ -171,17 +163,6 @@ function summarizeSandboxConfig(config: Record<string, unknown>): string | null 
     }
   }
   return null;
-}
-
-function SupportMark({ supported }: { supported: boolean }) {
-  return supported ? (
-    <span className="inline-flex items-center gap-1 text-green-700 dark:text-green-400">
-      <Check className="h-3 w-3" />
-      Yes
-    </span>
-  ) : (
-    <span className="text-muted-foreground">No</span>
-  );
 }
 
 export function CompanyEnvironments() {
@@ -440,7 +421,6 @@ export function CompanyEnvironments() {
     }))
     .sort((left, right) => left.displayName.localeCompare(right.displayName));
   const sandboxCreationEnabled = discoveredPluginSandboxProviders.length > 0;
-  const sandboxSupportVisible = sandboxCreationEnabled;
   const pluginSandboxProviders =
     environmentForm.sandboxProvider.trim().length > 0 &&
     environmentForm.sandboxProvider !== "fake" &&
@@ -560,62 +540,6 @@ export function CompanyEnvironments() {
               </div>
             </div>
           </div>
-        </div>
-        <div className="rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-          Environment choices use the same adapter support matrix as agent defaults. SSH is always available for
-          remote-managed adapters, and sandbox environments appear only when a run-capable sandbox provider plugin is
-          installed.
-        </div>
-        {sandboxCreationEnabled ? (
-          <div className="rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-            Installed sandbox providers:{" "}
-            <span className="font-medium text-foreground">
-              {discoveredPluginSandboxProviders.map((provider) => provider.displayName).join(", ")}
-            </span>
-            . These are not adapter types. They back the Sandbox driver for adapters that support sandbox execution.
-          </div>
-        ) : null}
-
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[34rem] text-left text-xs">
-            <caption className="sr-only">Environment support by adapter</caption>
-            <thead className="border-b border-border text-muted-foreground">
-              <tr>
-                <th className="py-2 pr-3 font-medium">Adapter</th>
-                <th className="px-3 py-2 font-medium">Local</th>
-                <th className="px-3 py-2 font-medium">SSH</th>
-                {sandboxSupportVisible ? (
-                  <th className="px-3 py-2 font-medium">Sandbox via plugin</th>
-                ) : null}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/60">
-              {(environmentCapabilities?.adapters.map((support) => ({
-                adapterType: support.adapterType,
-                support,
-              })) ?? ENVIRONMENT_SUPPORT_ROWS).map(({ adapterType, support }) => (
-                <tr key={adapterType}>
-                  <td className="py-2 pr-3 font-medium">
-                    {adapterLabels[adapterType] ?? adapterType}
-                  </td>
-                  <td className="px-3 py-2">
-                    <SupportMark supported={support.drivers.local === "supported"} />
-                  </td>
-                  <td className="px-3 py-2">
-                    <SupportMark supported={support.drivers.ssh === "supported"} />
-                  </td>
-                  {sandboxSupportVisible ? (
-                    <td className="px-3 py-2">
-                      <SupportMark
-                        supported={discoveredPluginSandboxProviders.some((provider) =>
-                          support.sandboxProviders[provider.provider] === "supported")}
-                      />
-                    </td>
-                  ) : null}
-                </tr>
-              ))}
-            </tbody>
-          </table>
         </div>
 
         <div className="space-y-3">

--- a/ui/src/pages/CompanySettings.test.tsx
+++ b/ui/src/pages/CompanySettings.test.tsx
@@ -351,9 +351,7 @@ describe("CompanyEnvironments", () => {
     await flushReact();
     await flushReact();
 
-    expect(container.textContent).toContain("Installed sandbox providers:");
     expect(container.textContent).toContain("Secure Sandbox");
-    expect(container.textContent).toContain("These are not adapter types.");
 
     const editButton = Array.from(container.querySelectorAll("button"))
       .find((button) => button.textContent?.trim() === "Edit");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run in execution environments, and the Company Environments settings page lets operators configure them
> - That page rendered an "environment support by adapter" matrix table plus two descriptive text boxes explaining the adapter/driver/sandbox support model
> - That matrix duplicated information already surfaced where operators actually pick a driver/provider, and added a wide, dense table that provided no actionable value on this screen
> - This pull request removes the support-matrix table and the two explanatory text boxes above it, along with the now-orphaned helper component, derived constant, and unused imports
> - The benefit is a simpler, less cluttered environments settings page that only shows the controls an operator acts on

## Linked Issues or Issue Description

No public GitHub issue exists for this. Describing the change following the feature-request template:

### Problem or motivation

The Company Environments settings page showed an adapter support matrix table (Adapter × Local/SSH/Sandbox) and two paragraphs of descriptive text above it. The table restated the static adapter/driver support model and the sandbox-provider plugin caveat, neither of which is actionable on this page — operators don't change adapter capabilities here, they create and edit environments. The table was wide enough to require horizontal scroll and added visual noise without helping the operator complete any task.

### Proposed solution

Remove the support-matrix table and the two descriptive text boxes above it from `CompanyEnvironments.tsx`, along with the now-unused helper component, derived constant, locals, and imports. Leave all environment create/edit controls, provider selection, and sandbox-provider logic untouched.

### Alternatives considered

Collapsing the table behind a disclosure/"Learn more" toggle instead of removing it — rejected because the information is static, non-actionable on this screen, and already available where operators pick a driver/provider; hiding it would keep the maintenance cost without adding value.

### Roadmap alignment

Not a roadmap feature — this is a small, focused UI cleanup that removes non-actionable content from an existing settings page.

Related (already merged) work that last touched this copy: paperclipai/paperclip#4902 (clarified sandbox-provider messaging in company environments). No open duplicate PR was found.

## What Changed

- Removed the adapter support matrix `<table>` from `ui/src/pages/CompanyEnvironments.tsx`
- Removed the two descriptive text boxes rendered above that table (adapter support model + installed sandbox providers blurbs)
- Deleted the now-unused `SupportMark` helper component and the `ENVIRONMENT_SUPPORT_ROWS` derived constant
- Removed the now-unused `sandboxSupportVisible` local and four now-unused imports (`AGENT_ADAPTER_TYPES`, `getAdapterEnvironmentSupport`, `Check`, `adapterLabels`)
- Updated `ui/src/pages/CompanySettings.test.tsx` to drop the two assertions tied to the removed copy

## Verification

- `vitest run src/pages/CompanySettings.test.tsx` → 4/4 pass
- `tsc --noEmit` on the UI project → no errors in the changed files
- The remaining environment create/edit controls, provider selection, and sandbox-provider logic are untouched (the `environmentCapabilities`, `discoveredPluginSandboxProviders`, and `sandboxCreationEnabled` values are still used by the form)

## Risks

Low risk — pure presentational removal of a read-only informational table and static copy. No API, data model, or behavioral changes; no state that other components depend on was removed.

## Model Used

Claude (Anthropic), model id `claude-opus-4-8` (Claude Opus 4.x family), with extended thinking and tool use, run via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
