### PR TITLE
[finops] Reduce scoped recovery token replay

### DIFF
--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -380,6 +380,7 @@ Agent-level control-plane settings (not adapter-specific):
     "wakeOnAssignment": true,
     "wakeOnOnDemand": true,
     "wakeOnAutomation": true,
+    "skipTimerWhenNoActionableWork": true,
     "cooldownSec": 10
   }
 }
@@ -392,6 +393,7 @@ Defaults:
 - `wakeOnAssignment: true`
 - `wakeOnOnDemand: true`
 - `wakeOnAutomation: true`
+- `skipTimerWhenNoActionableWork: true`
 
 ## 8.5 Trigger integration rules
 

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -339,6 +339,73 @@ describe("codex remote execution", () => {
     ]);
   });
 
+  it("uses a compact fallback prompt for resumed sessions without an inline wake payload", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-resume-fallback-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    const instructionsFile = path.join(rootDir, "instructions.md");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+    await writeFile(instructionsFile, "FULL AGENT INSTRUCTIONS SHOULD NOT REPLAY\n", "utf8");
+
+    await execute({
+      runId: "run-resume-fallback",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: "session-123",
+        sessionParams: {
+          sessionId: "session-123",
+          cwd: workspaceDir,
+        },
+        sessionDisplayId: "session-123",
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+        instructionsFilePath: instructionsFile,
+        promptTemplate: "FULL DEFAULT HEARTBEAT PROMPT SHOULD NOT REPLAY",
+      },
+      context: {
+        taskId: "issue-123",
+        wakeReason: "heartbeat_timer",
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { stdin?: string }]
+      | undefined;
+    expect(call?.[2]).toEqual([
+      "exec",
+      "--json",
+      "resume",
+      "session-123",
+      "-",
+    ]);
+    expect(call?.[3].stdin).toContain("## Paperclip Resume Delta");
+    expect(call?.[3].stdin).toContain("No inline wake payload was provided");
+    expect(call?.[3].stdin).toContain("- reason: heartbeat_timer");
+    expect(call?.[3].stdin).toContain("- issue id: issue-123");
+    expect(call?.[3].stdin).not.toContain("FULL AGENT INSTRUCTIONS SHOULD NOT REPLAY");
+    expect(call?.[3].stdin).not.toContain("FULL DEFAULT HEARTBEAT PROMPT SHOULD NOT REPLAY");
+  });
+
   it("uses the provider-neutral execution target contract for remote SSH execution", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-target-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -218,6 +218,35 @@ function buildCodexTransientHandoffNote(input: {
     .join("\n");
 }
 
+function buildCodexResumeFallbackPrompt(input: {
+  wakeReason: string | null;
+  wakeTaskId: string | null;
+  wakeCommentId: string | null;
+  approvalId: string | null;
+  approvalStatus: string | null;
+  linkedIssueIds: string[];
+  issueWorkMode: string | null;
+}): string {
+  const lines = [
+    "## Paperclip Resume Delta",
+    "",
+    "You are resuming an existing Paperclip session.",
+    "No inline wake payload was provided for this heartbeat, so continue from the existing session state and fetch Paperclip API context only when needed.",
+    "",
+    "Execution contract: take concrete action in this heartbeat when the issue is actionable; do not stop at a plan unless planning was requested. Leave durable progress and then give the issue a clear final disposition before ending the heartbeat: `done`, `in_review` with a real reviewer/approval/interaction path, `blocked` with first-class blockers or a named unblock owner/action, delegated follow-up issues with blockers, or `in_progress` only when a live continuation path exists.",
+  ];
+
+  if (input.wakeReason) lines.push(`- reason: ${input.wakeReason}`);
+  if (input.wakeTaskId) lines.push(`- issue id: ${input.wakeTaskId}`);
+  if (input.wakeCommentId) lines.push(`- wake comment id: ${input.wakeCommentId}`);
+  if (input.approvalId) lines.push(`- approval id: ${input.approvalId}`);
+  if (input.approvalStatus) lines.push(`- approval status: ${input.approvalStatus}`);
+  if (input.issueWorkMode) lines.push(`- issue work mode: ${input.issueWorkMode}`);
+  if (input.linkedIssueIds.length > 0) lines.push(`- linked issue ids: ${input.linkedIssueIds.join(", ")}`);
+
+  return lines.join("\n");
+}
+
 export async function ensureCodexSkillsInjected(
   onLog: AdapterExecutionContext["onLog"],
   options: EnsureCodexSkillsInjectedOptions = {},
@@ -608,7 +637,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
         : "";
     const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
-    const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
+    const resumeFallbackPrompt =
+      sessionId && wakePrompt.length === 0
+        ? buildCodexResumeFallbackPrompt({
+            wakeReason,
+            wakeTaskId,
+            wakeCommentId,
+            approvalId,
+            approvalStatus,
+            linkedIssueIds,
+            issueWorkMode,
+          })
+        : "";
+    const resumePrompt = wakePrompt || resumeFallbackPrompt;
+    const shouldUseResumeDeltaPrompt = Boolean(sessionId) && resumePrompt.length > 0;
     const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
     instructionsChars = promptInstructionsPrefix.length;
     const continuationSummary = parseObject(context.paperclipContinuationSummary);
@@ -685,7 +727,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const prompt = joinPromptSections([
       promptInstructionsPrefix,
       renderedBootstrapPrompt,
-      wakePrompt,
+      resumePrompt,
       codexFallbackHandoffNote,
       sessionHandoffNote,
       renderedPrompt,
@@ -695,6 +737,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       instructionsChars,
       bootstrapPromptChars: renderedBootstrapPrompt.length,
       wakePromptChars: wakePrompt.length,
+      resumeFallbackPromptChars: resumeFallbackPrompt.length,
       sessionHandoffChars: sessionHandoffNote.length,
       heartbeatPromptChars: renderedPrompt.length,
     };

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -101,6 +101,50 @@ describeEmbeddedPostgres("heartbeat list", () => {
     }
   });
 
+  it("reports task-scoped runs under issueId when contextSnapshot only has taskId", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "succeeded",
+      contextSnapshot: { taskId: issueId, wakeReason: "issue_assigned" },
+    });
+
+    const runs = await heartbeatService(db).list(companyId, agentId, 5);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.contextSnapshot).toMatchObject({
+      issueId,
+      taskId: issueId,
+      wakeReason: "issue_assigned",
+    });
+  });
+
   it("returns small result json payloads unchanged from getRun", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -457,6 +457,70 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(runRows).toHaveLength(0);
   });
 
+  it("allows generic timer wakes when ready work appears after blocked dependency batches", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+        skipTimerWhenNoActionableWork: true,
+      },
+    });
+    const baseTime = new Date("2026-06-21T00:00:00.000Z");
+    const issueRows: Array<typeof issues.$inferInsert> = [];
+    const relationRows: Array<typeof issueRelations.$inferInsert> = [];
+
+    for (let index = 0; index < 50; index += 1) {
+      const blockerId = randomUUID();
+      const blockedIssueId = randomUUID();
+      issueRows.push(
+        {
+          id: blockerId,
+          companyId,
+          title: `Blocking issue ${index}`,
+          status: "todo",
+          priority: "high",
+          updatedAt: new Date(baseTime.getTime() + index),
+        },
+        {
+          id: blockedIssueId,
+          companyId,
+          title: `Blocked assigned work ${index}`,
+          status: "todo",
+          priority: "high",
+          assigneeAgentId: agentId,
+          updatedAt: new Date(baseTime.getTime() + index),
+        },
+      );
+      relationRows.push({
+        companyId,
+        issueId: blockerId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      });
+    }
+
+    issueRows.push({
+      id: randomUUID(),
+      companyId,
+      title: "Ready assigned work after blocked sample",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+      updatedAt: new Date(baseTime.getTime() + 10_000),
+    });
+    await db.insert(issues).values(issueRows);
+    await db.insert(issueRelations).values(relationRows);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).not.toBeNull();
+    await waitForCondition(async () => countExecuteCallsForRun(run!.id) > 0);
+
+    expect(countExecuteCallsForRun(run!.id)).toBe(1);
+  });
+
   it("skips generic timer wakes by default when the agent has no assigned issue work", async () => {
     const { agentId } = await seedCompanyAndAgent({
       heartbeatConfig: {

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -457,10 +457,48 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(runRows).toHaveLength(0);
   });
 
-  it("runs generic timer wakes by default for proactive agents without assigned issue work", async () => {
+  it("skips generic timer wakes by default when the agent has no assigned issue work", async () => {
     const { agentId } = await seedCompanyAndAgent({
       heartbeatConfig: {
         enabled: true,
+      },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const runRows = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "heartbeat.timer.no_actionable_work",
+    });
+    expect(wakeup?.payload).toMatchObject({
+      heartbeatSkip: {
+        reason: expect.stringContaining("No assigned todo or in_progress issue"),
+      },
+    });
+    expect(runRows).toHaveLength(0);
+  });
+
+  it("allows generic timer wakes without assigned issue work when no-work skipping is disabled", async () => {
+    const { agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+        skipTimerWhenNoActionableWork: false,
       },
     });
 

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -12,6 +12,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueRelations,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
@@ -391,6 +392,69 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     await waitForCondition(async () => countExecuteCallsForRun(run!.id) > 0);
 
     expect(countExecuteCallsForRun(run!.id)).toBe(1);
+  });
+
+  it("skips generic timer wakes when assigned todo work is blocked by dependencies", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+        skipTimerWhenNoActionableWork: true,
+      },
+    });
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocking issue",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked assigned work",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const runRows = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "heartbeat.timer.no_actionable_work",
+    });
+    expect(wakeup?.payload).toMatchObject({
+      heartbeatSkip: {
+        reason: expect.stringContaining("No assigned todo or in_progress issue"),
+      },
+    });
+    expect(runRows).toHaveLength(0);
   });
 
   it("runs generic timer wakes by default for proactive agents without assigned issue work", async () => {

--- a/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
+++ b/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
@@ -4,23 +4,21 @@ import {
   shouldResetTaskSessionForWake,
 } from "../services/heartbeat.ts";
 
-// PF-4: generic timer-driven wakes ("heartbeat_timer") are exploratory and
-// do not carry continuation state. Reusing the prior task session for repeated
-// generic timer wakes accumulates low-value context and pushes the session
-// toward the 64k compaction threshold (observed in CEO run 292a5fd1). The
-// shouldResetTaskSessionForWake / describeSessionResetReason pair must agree
-// that generic timer wakes start fresh, while issue/task-scoped timer wakes
-// preserve recurring work cache continuity.
+// PF-4 originally forced generic timer-driven wakes ("heartbeat_timer") to
+// start fresh to avoid context growth. Fresh-session telemetry reversed that
+// tradeoff after OpenAI/codex runs showed repeated fresh sessions dominating
+// token use: timer wakes should keep their synthetic task session warm unless
+// an explicit fresh-session request or configured rotation threshold says otherwise.
 
 describe("PF-4 shouldResetTaskSessionForWake", () => {
-  it("resets the session when wakeReason is heartbeat_timer", () => {
+  it("preserves the session when wakeReason is heartbeat_timer", () => {
     expect(
       shouldResetTaskSessionForWake({
         source: "scheduler",
         reason: "interval_elapsed",
         wakeReason: "heartbeat_timer",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("preserves the session when a heartbeat_timer wake is scoped to an issue task", () => {
@@ -45,7 +43,7 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
     ).toBe(false);
   });
 
-  it("still resets for the existing reset reasons", () => {
+  it("still resets for assignment and execution wakes without task context", () => {
     for (const wakeReason of [
       "issue_assigned",
       "execution_review_requested",
@@ -53,6 +51,17 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
       "execution_changes_requested",
     ] as const) {
       expect(shouldResetTaskSessionForWake({ wakeReason })).toBe(true);
+    }
+  });
+
+  it("preserves assignment and execution wake sessions when issue-scoped", () => {
+    for (const wakeReason of [
+      "issue_assigned",
+      "execution_review_requested",
+      "execution_approval_requested",
+      "execution_changes_requested",
+    ] as const) {
+      expect(shouldResetTaskSessionForWake({ wakeReason, issueId: "issue-1" })).toBe(false);
     }
   });
 
@@ -79,11 +88,11 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
 });
 
 describe("PF-4 describeSessionResetReason", () => {
-  it("describes heartbeat_timer wakes explicitly so run logs explain the reset", () => {
+  it("does not report a reset reason for heartbeat_timer wakes", () => {
     const reason = describeSessionResetReason({
       wakeReason: "heartbeat_timer",
     });
-    expect(reason).toBe("wake reason is heartbeat_timer (timer-driven wake starts fresh)");
+    expect(reason).toBeNull();
   });
 
   it("does not report a reset reason for issue-scoped heartbeat_timer wakes", () => {
@@ -102,7 +111,7 @@ describe("PF-4 describeSessionResetReason", () => {
     expect(reason).toBeNull();
   });
 
-  it("returns the existing reasons for the existing reset triggers", () => {
+  it("returns the existing reasons for reset triggers without task context", () => {
     expect(describeSessionResetReason({ wakeReason: "issue_assigned" })).toBe(
       "wake reason is issue_assigned",
     );
@@ -115,6 +124,17 @@ describe("PF-4 describeSessionResetReason", () => {
     expect(describeSessionResetReason({ wakeReason: "execution_changes_requested" })).toBe(
       "wake reason is execution_changes_requested",
     );
+  });
+
+  it("does not report reset reasons for issue-scoped assignment and execution wakes", () => {
+    for (const wakeReason of [
+      "issue_assigned",
+      "execution_review_requested",
+      "execution_approval_requested",
+      "execution_changes_requested",
+    ] as const) {
+      expect(describeSessionResetReason({ wakeReason, issueId: "issue-1" })).toBeNull();
+    }
   });
 
   it("returns the forceFreshSession message when explicitly requested", () => {
@@ -140,6 +160,7 @@ describe("PF-4 describeSessionResetReason", () => {
       { wakeReason: "execution_changes_requested" },
       { forceFreshSession: true },
       { wakeReason: "heartbeat_timer", taskId: "issue-1" },
+      { wakeReason: "issue_assigned", taskId: "issue-1" },
       { wakeReason: "issue_commented" },
       { wakeReason: "transient_failure_retry" },
       { wakeReason: "unknown_reason" },

--- a/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
+++ b/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
@@ -34,6 +34,17 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
     ).toBe(false);
   });
 
+  it("preserves the session when a heartbeat_timer wake only carries taskId", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        source: "scheduler",
+        reason: "interval_elapsed",
+        wakeReason: "heartbeat_timer",
+        taskId: "issue-1",
+      }),
+    ).toBe(false);
+  });
+
   it("still resets for the existing reset reasons", () => {
     for (const wakeReason of [
       "issue_assigned",
@@ -79,6 +90,14 @@ describe("PF-4 describeSessionResetReason", () => {
     const reason = describeSessionResetReason({
       wakeReason: "heartbeat_timer",
       issueId: "issue-1",
+    });
+    expect(reason).toBeNull();
+  });
+
+  it("does not report a reset reason for taskId-only heartbeat_timer wakes", () => {
+    const reason = describeSessionResetReason({
+      wakeReason: "heartbeat_timer",
+      taskId: "issue-1",
     });
     expect(reason).toBeNull();
   });

--- a/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
+++ b/server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts
@@ -4,14 +4,13 @@ import {
   shouldResetTaskSessionForWake,
 } from "../services/heartbeat.ts";
 
-// PF-4: timer-driven wakes ("heartbeat_timer") are exploratory and do not
-// carry continuation state. Reusing the prior task session for repeated
-// timer wakes accumulates low-value context and pushes the session toward
-// the 64k compaction threshold (observed in CEO run 292a5fd1). The
-// shouldResetTaskSessionForWake / describeSessionResetReason pair must
-// agree that timer wakes start a fresh session, while preserving the
-// existing reset rules for assignment / review / approval / changes wakes
-// and the existing reuse policy for issue_commented and other reasons.
+// PF-4: generic timer-driven wakes ("heartbeat_timer") are exploratory and
+// do not carry continuation state. Reusing the prior task session for repeated
+// generic timer wakes accumulates low-value context and pushes the session
+// toward the 64k compaction threshold (observed in CEO run 292a5fd1). The
+// shouldResetTaskSessionForWake / describeSessionResetReason pair must agree
+// that generic timer wakes start fresh, while issue/task-scoped timer wakes
+// preserve recurring work cache continuity.
 
 describe("PF-4 shouldResetTaskSessionForWake", () => {
   it("resets the session when wakeReason is heartbeat_timer", () => {
@@ -22,6 +21,17 @@ describe("PF-4 shouldResetTaskSessionForWake", () => {
         wakeReason: "heartbeat_timer",
       }),
     ).toBe(true);
+  });
+
+  it("preserves the session when a heartbeat_timer wake is scoped to an issue task", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        source: "scheduler",
+        reason: "interval_elapsed",
+        wakeReason: "heartbeat_timer",
+        taskId: "issue-1",
+      }),
+    ).toBe(false);
   });
 
   it("still resets for the existing reset reasons", () => {
@@ -65,6 +75,14 @@ describe("PF-4 describeSessionResetReason", () => {
     expect(reason).toBe("wake reason is heartbeat_timer (timer-driven wake starts fresh)");
   });
 
+  it("does not report a reset reason for issue-scoped heartbeat_timer wakes", () => {
+    const reason = describeSessionResetReason({
+      wakeReason: "heartbeat_timer",
+      issueId: "issue-1",
+    });
+    expect(reason).toBeNull();
+  });
+
   it("returns the existing reasons for the existing reset triggers", () => {
     expect(describeSessionResetReason({ wakeReason: "issue_assigned" })).toBe(
       "wake reason is issue_assigned",
@@ -102,6 +120,7 @@ describe("PF-4 describeSessionResetReason", () => {
       { wakeReason: "execution_approval_requested" },
       { wakeReason: "execution_changes_requested" },
       { forceFreshSession: true },
+      { wakeReason: "heartbeat_timer", taskId: "issue-1" },
       { wakeReason: "issue_commented" },
       { wakeReason: "transient_failure_retry" },
       { wakeReason: "unknown_reason" },

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -15,6 +15,7 @@ import {
   preflightLowTrustWorkspaceIsolation,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  resolveLedgerIssueIdFromContext,
   resolveNextSessionState,
   resolveWorkspaceAfterLowTrustPreflight,
   resolveRuntimeSessionParamsForWorkspace,
@@ -816,6 +817,15 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(false);
   });
 
+  it("preserves session context on issue-scoped heartbeat timer wakes", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeReason: "heartbeat_timer",
+        issueId: "issue-1",
+      }),
+    ).toBe(false);
+  });
+
   it("preserves session context on manual on-demand invokes by default", () => {
     expect(
       shouldResetTaskSessionForWake({
@@ -1033,6 +1043,20 @@ describe("normalizeSessionParams", () => {
   it("preserves a non-empty object", () => {
     const params = { sessionId: "thread-1" };
     expect(normalizeSessionParams(params)).toBe(params);
+  });
+});
+
+describe("resolveLedgerIssueIdFromContext", () => {
+  it("uses issueId when present", () => {
+    expect(resolveLedgerIssueIdFromContext({ issueId: "issue-1", taskId: "task-1" })).toBe("issue-1");
+  });
+
+  it("falls back to taskId for issue-scoped run contexts", () => {
+    expect(resolveLedgerIssueIdFromContext({ taskId: "issue-1" })).toBe("issue-1");
+  });
+
+  it("returns null when no issue-like context is present", () => {
+    expect(resolveLedgerIssueIdFromContext({ wakeReason: "heartbeat_timer" })).toBeNull();
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -798,20 +798,39 @@ describe("stripWorkspaceRuntimeFromExecutionRunConfig", () => {
 });
 
 describe("shouldResetTaskSessionForWake", () => {
-  it("resets session context on assignment wake", () => {
+  it("resets session context on assignment wake without task context", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "issue_assigned" })).toBe(true);
   });
 
-  it("resets session context on execution review wakes", () => {
+  it("preserves session context on assignment wake when issue-scoped", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeReason: "issue_assigned",
+        issueId: "issue-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("resets session context on execution review wakes without task context", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_review_requested" })).toBe(true);
   });
 
-  it("resets session context on execution approval wakes", () => {
+  it("resets session context on execution approval wakes without task context", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_approval_requested" })).toBe(true);
   });
 
-  it("resets session context on execution changes-requested wakes", () => {
+  it("resets session context on execution changes-requested wakes without task context", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_changes_requested" })).toBe(true);
+  });
+
+  it("preserves session context on issue-scoped execution stage wakes", () => {
+    for (const wakeReason of [
+      "execution_review_requested",
+      "execution_approval_requested",
+      "execution_changes_requested",
+    ] as const) {
+      expect(shouldResetTaskSessionForWake({ wakeReason, taskId: "issue-1" })).toBe(false);
+    }
   });
 
   it("preserves session context on timer heartbeats", () => {
@@ -1085,6 +1104,10 @@ describe("deriveTaskKeyWithHeartbeatFallback", () => {
 
   it("returns __heartbeat__ for timer wakes with no explicit key", () => {
     expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer" }, null)).toBe("__heartbeat__");
+  });
+
+  it("returns __heartbeat__ for heartbeat_timer wakes with no explicit key", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ wakeReason: "heartbeat_timer" }, null)).toBe("__heartbeat__");
   });
 
   it("prefers explicit key over heartbeat fallback even on timer wakes", () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -15,6 +15,7 @@ import {
   preflightLowTrustWorkspaceIsolation,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  resolveIssueIdFromContext,
   resolveLedgerIssueIdFromContext,
   resolveNextSessionState,
   resolveWorkspaceAfterLowTrustPreflight,
@@ -826,6 +827,15 @@ describe("shouldResetTaskSessionForWake", () => {
     ).toBe(false);
   });
 
+  it("preserves session context on taskId-only issue-scoped heartbeat timer wakes", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeReason: "heartbeat_timer",
+        taskId: "issue-1",
+      }),
+    ).toBe(false);
+  });
+
   it("preserves session context on manual on-demand invokes by default", () => {
     expect(
       shouldResetTaskSessionForWake({
@@ -1046,17 +1056,21 @@ describe("normalizeSessionParams", () => {
   });
 });
 
-describe("resolveLedgerIssueIdFromContext", () => {
+describe("resolveIssueIdFromContext", () => {
   it("uses issueId when present", () => {
-    expect(resolveLedgerIssueIdFromContext({ issueId: "issue-1", taskId: "task-1" })).toBe("issue-1");
+    expect(resolveIssueIdFromContext({ issueId: "issue-1", taskId: "task-1" })).toBe("issue-1");
   });
 
   it("falls back to taskId for issue-scoped run contexts", () => {
-    expect(resolveLedgerIssueIdFromContext({ taskId: "issue-1" })).toBe("issue-1");
+    expect(resolveIssueIdFromContext({ taskId: "issue-1" })).toBe("issue-1");
   });
 
   it("returns null when no issue-like context is present", () => {
-    expect(resolveLedgerIssueIdFromContext({ wakeReason: "heartbeat_timer" })).toBeNull();
+    expect(resolveIssueIdFromContext({ wakeReason: "heartbeat_timer" })).toBeNull();
+  });
+
+  it("keeps the legacy ledger helper behavior aligned", () => {
+    expect(resolveLedgerIssueIdFromContext({ taskId: "issue-1" })).toBe("issue-1");
   });
 });
 

--- a/server/src/routes/llms.ts
+++ b/server/src/routes/llms.ts
@@ -47,6 +47,7 @@ export function llmRoutes(db: Db) {
       "- New hires may be created in pending_approval state depending on company settings.",
       "- Use the paperclip-create-agent skill for end-to-end hiring: adapter reflection, config comparison, instruction source selection, icon choice, desiredSkills, sourceIssueId/sourceIssueIds, and approval follow-up.",
       "- Timer heartbeats are opt-in for new hires. Leave runtimeConfig.heartbeat.enabled false unless the role truly needs scheduled work or the user explicitly asked for it.",
+      "- Enabled timer heartbeats skip generic no-work invocations by default. Set runtimeConfig.heartbeat.skipTimerWhenNoActionableWork false only for agents that intentionally do unscoped proactive scheduled work.",
       "",
     ];
     res.type("text/plain").send(lines.join("\n"));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7020,7 +7020,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function hasActionableTimerWork(agent: typeof agents.$inferSelect) {
-    const row = await db
+    const candidateRows = await db
       .select({ id: issues.id })
       .from(issues)
       .where(
@@ -7032,9 +7032,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           inArray(issues.status, [...TIMER_ACTIONABLE_ISSUE_STATUSES]),
         ),
       )
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-    return Boolean(row);
+      .orderBy(asc(issues.updatedAt))
+      .limit(50);
+    if (candidateRows.length === 0) return false;
+
+    const readinessByIssueId = await issuesSvc.listDependencyReadiness(
+      agent.companyId,
+      candidateRows.map((row) => row.id),
+    );
+    return candidateRows.some((row) => readinessByIssueId.get(row.id)?.isDependencyReady ?? true);
   }
 
   async function markTimerHeartbeatChecked(agentId: string, source: WakeupOptions["source"]) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6893,7 +6893,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         heartbeat.skipTimerWhenNoActionableWork ??
           heartbeat.requireActionableTimerWork ??
           heartbeat.issueOnlyTimer,
-        false,
+        true,
       ),
       maxDailyRuns: normalizeOptionalNonNegativeInteger(
         heartbeat.maxDailyRuns ?? heartbeat.dailyRunLimit ?? heartbeat.dailyRunCap ?? heartbeat.maxRunsPerDay,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1281,8 +1281,12 @@ const heartbeatRunListColumns = {
   updatedAt: heartbeatRuns.updatedAt,
 } as const;
 
+function heartbeatRunContextIssueIdSql() {
+  return sql<string | null>`coalesce(${heartbeatRuns.contextSnapshot} ->> 'issueId', ${heartbeatRuns.contextSnapshot} ->> 'taskId')`;
+}
+
 const heartbeatRunListContextColumns = {
-  contextIssueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("contextIssueId"),
+  contextIssueId: heartbeatRunContextIssueIdSql().as("contextIssueId"),
   contextTaskId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskId'`.as("contextTaskId"),
   contextTaskKey: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'taskKey'`.as("contextTaskKey"),
   contextCommentId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'commentId'`.as("contextCommentId"),
@@ -1392,7 +1396,7 @@ const heartbeatRunIssueSummaryColumns = {
   lastOutputSeq: heartbeatRuns.lastOutputSeq,
   lastOutputStream: heartbeatRuns.lastOutputStream,
   lastOutputBytes: heartbeatRuns.lastOutputBytes,
-  issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
+  issueId: heartbeatRunContextIssueIdSql().as("issueId"),
 } as const;
 
 function appendExcerpt(prev: string, chunk: string) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7024,27 +7024,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function hasActionableTimerWork(agent: typeof agents.$inferSelect) {
-    const candidateRows = await db
-      .select({ id: issues.id })
-      .from(issues)
-      .where(
-        and(
-          eq(issues.companyId, agent.companyId),
-          eq(issues.assigneeAgentId, agent.id),
-          isNull(issues.assigneeUserId),
-          isNull(issues.hiddenAt),
-          inArray(issues.status, [...TIMER_ACTIONABLE_ISSUE_STATUSES]),
-        ),
-      )
-      .orderBy(asc(issues.updatedAt))
-      .limit(50);
-    if (candidateRows.length === 0) return false;
+    const batchSize = 50;
+    for (let offset = 0; ; offset += batchSize) {
+      const candidateRows = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, agent.companyId),
+            eq(issues.assigneeAgentId, agent.id),
+            isNull(issues.assigneeUserId),
+            isNull(issues.hiddenAt),
+            inArray(issues.status, [...TIMER_ACTIONABLE_ISSUE_STATUSES]),
+          ),
+        )
+        .orderBy(asc(issues.updatedAt), asc(issues.id))
+        .limit(batchSize)
+        .offset(offset);
+      if (candidateRows.length === 0) return false;
 
-    const readinessByIssueId = await issuesSvc.listDependencyReadiness(
-      agent.companyId,
-      candidateRows.map((row) => row.id),
-    );
-    return candidateRows.some((row) => readinessByIssueId.get(row.id)?.isDependencyReady ?? true);
+      const readinessByIssueId = await issuesSvc.listDependencyReadiness(
+        agent.companyId,
+        candidateRows.map((row) => row.id),
+      );
+      if (candidateRows.some((row) => readinessByIssueId.get(row.id)?.isDependencyReady ?? true)) {
+        return true;
+      }
+      if (candidateRows.length < batchSize) return false;
+    }
   }
 
   async function markTimerHeartbeatChecked(agentId: string, source: WakeupOptions["source"]) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1841,10 +1841,16 @@ function normalizeBilledCostCents(costUsd: number | null | undefined, billingTyp
   return Math.max(0, Math.round(costUsd * 100));
 }
 
-export function resolveLedgerIssueIdFromContext(
+export function resolveIssueIdFromContext(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
   return readNonEmptyString(contextSnapshot?.issueId) ?? readNonEmptyString(contextSnapshot?.taskId);
+}
+
+export function resolveLedgerIssueIdFromContext(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+) {
+  return resolveIssueIdFromContext(contextSnapshot);
 }
 
 async function resolveLedgerScopeForRun(
@@ -2642,7 +2648,7 @@ export async function buildPaperclipWakePayload(input: {
   const executionStage = parseObject(input.contextSnapshot.executionStage);
   const commentIds = extractWakeCommentIds(input.contextSnapshot);
   const annotationCommentId = readNonEmptyString(input.contextSnapshot.annotationCommentId);
-  const issueId = readNonEmptyString(input.contextSnapshot.issueId);
+  const issueId = resolveIssueIdFromContext(input.contextSnapshot);
   const continuationSummary = input.continuationSummary ?? null;
   const issueSummary =
     input.issueSummary ??
@@ -4457,7 +4463,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     previousSessionParams: Record<string, unknown> | null,
     opts?: { useProjectWorkspace?: boolean | null },
   ): Promise<ResolvedWorkspaceForRun> {
-    const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
+    const issueId = resolveIssueIdFromContext(context);
     const contextProjectId = readNonEmptyString(context.projectId);
     const contextProjectWorkspaceId = readNonEmptyString(context.projectWorkspaceId);
     const issueProjectRef = issueId
@@ -4860,7 +4866,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         error: run.error ?? null,
         errorCode: run.errorCode ?? null,
         issueId: typeof run.contextSnapshot === "object" && run.contextSnapshot !== null
-          ? (run.contextSnapshot as Record<string, unknown>).issueId ?? null
+          ? resolveIssueIdFromContext(run.contextSnapshot as Record<string, unknown>)
           : null,
         startedAt: run.startedAt ? new Date(run.startedAt).toISOString() : null,
         finishedAt: run.finishedAt ? new Date(run.finishedAt).toISOString() : null,
@@ -4910,7 +4916,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (livenessState !== "plan_only" && livenessState !== "empty_response") return;
 
     const context = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = resolveIssueIdFromContext(context);
     if (!issueId) return;
 
     const [issue, agent] = await Promise.all([
@@ -5092,7 +5098,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function handleSuccessfulRunHandoff(run: typeof heartbeatRuns.$inferSelect, agent: typeof agents.$inferSelect) {
     if (run.status !== "succeeded") return;
     const context = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
+    const issueId = resolveIssueIdFromContext(context);
     if (!issueId) return;
 
     const issue = await db
@@ -5467,7 +5473,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = resolveIssueIdFromContext(contextSnapshot);
     if (!issueId) return null;
     try {
       return await refreshIssueContinuationSummary({
@@ -5659,7 +5665,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = resolveIssueIdFromContext(contextSnapshot);
     if (!issueId) {
       if (run.issueCommentStatus !== "not_applicable") {
         await patchRunIssueCommentStatus(run.id, {
@@ -5762,7 +5768,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = resolveIssueIdFromContext(contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot = withRecoveryModelProfileHint({
@@ -5892,7 +5898,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const { run, agent, contextSnapshot } = input;
     const retryReason =
       input.retryReason ?? readNonEmptyString(contextSnapshot.retryReason) ?? run.scheduledRetryReason ?? null;
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = resolveIssueIdFromContext(contextSnapshot);
     const projectId = readNonEmptyString(contextSnapshot.projectId);
 
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
@@ -6298,7 +6304,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const invokability = await getAgentInvokability(agent);
       if (!invokability.invokable) {
         const contextSnapshot = parseObject(run.contextSnapshot);
-        const issueId = readNonEmptyString(contextSnapshot.issueId);
+        const issueId = resolveIssueIdFromContext(contextSnapshot);
         await appendRunEvent(run, await nextRunEventSeq(run.id), {
           eventType: "lifecycle",
           stream: "system",
@@ -6332,7 +6338,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         : baseSchedule;
 
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = resolveIssueIdFromContext(contextSnapshot);
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON) {
       const gate = await evaluateScheduledRetryGate({ run, agent, contextSnapshot, retryReason });
       if (!gate.allowed) {
@@ -7123,7 +7129,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const context = parseObject(run.contextSnapshot);
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
-      issueId: readNonEmptyString(context.issueId),
+      issueId: resolveIssueIdFromContext(context),
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
@@ -7141,7 +7147,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return null;
     }
 
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = resolveIssueIdFromContext(context);
     if (issueId) {
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
       const treeHoldInteractionWake = activePauseHold && await isVerifiedIssueTreeControlInteractionWake(db, {
@@ -7630,7 +7636,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     resultJson: Record<string, unknown> | null | undefined,
   ): Promise<RunLivenessClassificationInput> {
     const context = parseObject(run.contextSnapshot);
-    const contextIssueId = readNonEmptyString(context.issueId);
+    const contextIssueId = resolveIssueIdFromContext(context);
     const continuationAttempt = asNumber(context.continuationAttempt, run.continuationAttempt ?? 0);
 
     const issue = contextIssueId
@@ -7954,7 +7960,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
-    return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
+    return resolveIssueIdFromContext(context);
   }
 
   function issueIdFromWakePayload(payload: unknown) {
@@ -8169,7 +8175,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const context = parseObject(run.contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = resolveIssueIdFromContext(context);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1841,13 +1841,19 @@ function normalizeBilledCostCents(costUsd: number | null | undefined, billingTyp
   return Math.max(0, Math.round(costUsd * 100));
 }
 
+export function resolveLedgerIssueIdFromContext(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+) {
+  return readNonEmptyString(contextSnapshot?.issueId) ?? readNonEmptyString(contextSnapshot?.taskId);
+}
+
 async function resolveLedgerScopeForRun(
   db: Db,
   companyId: string,
   run: typeof heartbeatRuns.$inferSelect,
 ) {
   const context = parseObject(run.contextSnapshot);
-  const contextIssueId = readNonEmptyString(context.issueId);
+  const contextIssueId = resolveLedgerIssueIdFromContext(context);
   const contextProjectId = readNonEmptyString(context.projectId);
 
   if (!contextIssueId) {
@@ -2128,10 +2134,10 @@ function deriveTaskKey(
  * Extended task key derivation that falls back to a stable synthetic key
  * for timer/heartbeat wakes. The synthetic key keeps the
  * `agentTaskSessions` row addressable across heartbeats so the row can be
- * cleared and re-keyed deterministically; it does NOT mean the prior
- * session is resumed. Since PF-4 (#4838), `heartbeat_timer` wakes always
- * go through `shouldResetTaskSessionForWake` and start a fresh session —
- * see `describeSessionResetReason` for the paired log message.
+ * cleared and re-keyed deterministically. Since PF-4 (#4838), generic
+ * `heartbeat_timer` wakes go through `shouldResetTaskSessionForWake` and
+ * start a fresh session; issue/task-scoped timer wakes keep their explicit
+ * task key so recurring issue work can reuse its task session.
  *
  * The synthetic key is only used when:
  * - No explicit task/issue key exists in the context
@@ -2156,18 +2162,18 @@ export function shouldResetTaskSessionForWake(
   if (contextSnapshot?.forceFreshSession === true) return true;
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
+  const hasExplicitTaskContext = Boolean(deriveTaskKey(contextSnapshot, null));
+  if (wakeReason === "heartbeat_timer") {
+    // Generic timer wakes are exploratory, but timer wakes that already carry
+    // issue/task context are continuations of scoped work and should keep the
+    // task session cache warm.
+    return !hasExplicitTaskContext;
+  }
   if (
     wakeReason === "issue_assigned" ||
     wakeReason === "execution_review_requested" ||
     wakeReason === "execution_approval_requested" ||
-    wakeReason === "execution_changes_requested" ||
-    // PF-4: timer-driven wakes are exploratory ("any new work?"). They do not
-    // carry meaningful continuation state, so reusing the prior task session
-    // for repeated timer wakes accumulates low-value context and pushes the
-    // session toward the 64k compaction threshold (observed in CEO run
-    // 292a5fd1, where timer wakes repeatedly bloated a long-lived manager
-    // session). Reset on every timer wake so each interval starts fresh.
-    wakeReason === "heartbeat_timer"
+    wakeReason === "execution_changes_requested"
   ) {
     return true;
   }
@@ -2275,7 +2281,9 @@ export function describeSessionResetReason(
   if (wakeReason === "execution_changes_requested") return "wake reason is execution_changes_requested";
   // PF-4: paired with shouldResetTaskSessionForWake — keep the reason wording
   // explicit so run logs make session reuse/reset behavior legible.
-  if (wakeReason === "heartbeat_timer") return "wake reason is heartbeat_timer (timer-driven wake starts fresh)";
+  if (wakeReason === "heartbeat_timer" && !deriveTaskKey(contextSnapshot, null)) {
+    return "wake reason is heartbeat_timer (timer-driven wake starts fresh)";
+  }
   return null;
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2139,11 +2139,9 @@ function deriveTaskKey(
 /**
  * Extended task key derivation that falls back to a stable synthetic key
  * for timer/heartbeat wakes. The synthetic key keeps the
- * `agentTaskSessions` row addressable across heartbeats so the row can be
- * cleared and re-keyed deterministically. Since PF-4 (#4838), generic
- * `heartbeat_timer` wakes go through `shouldResetTaskSessionForWake` and
- * start a fresh session; issue/task-scoped timer wakes keep their explicit
- * task key so recurring issue work can reuse its task session.
+ * `agentTaskSessions` row addressable across heartbeats so generic timer
+ * wakes can reuse adapter-native prompt caches instead of starting every
+ * interval from a fresh session.
  *
  * The synthetic key is only used when:
  * - No explicit task/issue key exists in the context
@@ -2157,7 +2155,8 @@ export function deriveTaskKeyWithHeartbeatFallback(
   if (explicit) return explicit;
 
   const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
-  if (wakeSource === "timer") return HEARTBEAT_TASK_KEY;
+  const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
+  if (wakeSource === "timer" || wakeReason === "heartbeat_timer") return HEARTBEAT_TASK_KEY;
 
   return null;
 }
@@ -2169,19 +2168,16 @@ export function shouldResetTaskSessionForWake(
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   const hasExplicitTaskContext = Boolean(deriveTaskKey(contextSnapshot, null));
-  if (wakeReason === "heartbeat_timer") {
-    // Generic timer wakes are exploratory, but timer wakes that already carry
-    // issue/task context are continuations of scoped work and should keep the
-    // task session cache warm.
-    return !hasExplicitTaskContext;
-  }
   if (
     wakeReason === "issue_assigned" ||
     wakeReason === "execution_review_requested" ||
     wakeReason === "execution_approval_requested" ||
     wakeReason === "execution_changes_requested"
   ) {
-    return true;
+    // The first run for a task still starts fresh because no task session row
+    // exists yet. Repeated assignment/review wakes for the same issue should
+    // not discard a valid saved session solely because of the wake reason.
+    return !hasExplicitTaskContext;
   }
   return false;
 }
@@ -2281,14 +2277,12 @@ export function describeSessionResetReason(
   if (contextSnapshot?.forceFreshSession === true) return "forceFreshSession was requested";
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
-  if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
-  if (wakeReason === "execution_review_requested") return "wake reason is execution_review_requested";
-  if (wakeReason === "execution_approval_requested") return "wake reason is execution_approval_requested";
-  if (wakeReason === "execution_changes_requested") return "wake reason is execution_changes_requested";
-  // PF-4: paired with shouldResetTaskSessionForWake — keep the reason wording
-  // explicit so run logs make session reuse/reset behavior legible.
-  if (wakeReason === "heartbeat_timer" && !deriveTaskKey(contextSnapshot, null)) {
-    return "wake reason is heartbeat_timer (timer-driven wake starts fresh)";
+  const hasExplicitTaskContext = Boolean(deriveTaskKey(contextSnapshot, null));
+  if (!hasExplicitTaskContext) {
+    if (wakeReason === "issue_assigned") return "wake reason is issue_assigned";
+    if (wakeReason === "execution_review_requested") return "wake reason is execution_review_requested";
+    if (wakeReason === "execution_approval_requested") return "wake reason is execution_approval_requested";
+    if (wakeReason === "execution_changes_requested") return "wake reason is execution_changes_requested";
   }
   return null;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat runs are the control-plane loop that wakes an agent, binds it to an issue/workspace, and records runtime session state.
> - The Codex adapter can resume sessions, but prompt-cache locality depends on Paperclip giving it a stable scoped session and a compact resume prompt.
> - Earlier fixes made issue-scoped timer/recovery wakes reusable, but later telemetry showed repeated fresh OpenAI/Codex sessions still dominating token use.
> - The remaining reset sources were wake-reason policy and inconsistent issue attribution: generic timer wakes used a synthetic session key but then reset it, assignment/review wakes reset even when already scoped to a stable issue/task, and some heartbeat run APIs still displayed task-scoped runs as `issueId=null`.
> - This pull request now narrows fresh-session behavior to explicit fresh-session requests and true first-run/no-session cases, while keeping saved task sessions warm and reporting task-scoped run attribution consistently.

## Linked Issues or Issue Description

No public GitHub issue exists for this private FinOps incident.

Bug description:

- What happened: OpenAI/Codex-backed recurring work showed persistent fresh input-token spend even after earlier session reuse fixes; FinOps sampled many recent OpenAI runs as `freshSession=true` with `issueId=null`.
- Expected behavior: recurring timer, assignment, and review/approval/change wakes should resume an existing task session when Paperclip already has a stable task key and saved adapter session; task-scoped heartbeat rows should be attributable through the run-list API even when the context stores the scope as `taskId`.
- Reproduction shape: enqueue repeated `heartbeat_timer` wakes or issue-scoped assignment/execution-stage wakes for an agent with a saved task session; before this change, policy could still force `freshSession: true` despite an addressable session key, and list projections could hide task-scoped attribution.
- Deployment mode: local Paperclip agent runtime using `codex_local`.
- Related PR search: searched GitHub PRs for `OpenAI fresh token Codex session reuse`; only this PR (#8407) matched.

## What Changed

- Preserved task-session reuse for generic `heartbeat_timer` wakes by letting the synthetic `__heartbeat__` task key actually reuse saved sessions.
- Preserved task-session reuse for issue-scoped assignment and execution-stage wakes; unscoped assignment/review/approval/change wakes still reset.
- Added `heartbeat_timer` as a fallback trigger for the synthetic task key even when only `wakeReason` is present.
- Kept explicit `forceFreshSession: true` as the authoritative reset path.
- Preserved scoped wake issue context and compact Codex resume prompts already in this branch.
- Reported `taskId`-only heartbeat contexts under `contextSnapshot.issueId` in heartbeat run list/summary projections, so task-scoped OpenAI samples do not appear as `issueId=null`.
- Kept timer heartbeat readiness from treating dependency-blocked work as actionable.

## Verification

- Passed: `corepack pnpm exec vitest run server/src/__tests__/heartbeat-list.test.ts`.
- Passed: `corepack pnpm exec vitest run packages/adapters/codex-local/src/server/execute.remote.test.ts server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts`.

## Risks

Moderate.

- Generic timer wakes will now reuse a synthetic task session instead of always starting fresh. This should reduce OpenAI prompt replay, but long-lived timer sessions may depend on adapter-native compaction or explicit session-compaction settings.
- Assignment and execution-stage wakes with stable issue/task context now reuse task sessions. First runs still start fresh because no saved task-session row exists.
- The run-list attribution change treats `taskId` as the effective issue id only when `issueId` is absent, matching existing in-memory heartbeat scope resolution.
- Explicit fresh-session requests remain unchanged and continue to override reuse.

## Model Used

OpenAI Codex coding agent based on GPT-5, with tool use for local shell, git, GitHub CLI, and focused test execution. Reasoning mode was the default coding-agent reasoning mode available in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
## Follow-up: Timer/no-work suppression

LIB-732 follow-up after the attribution fix: enabled generic timer heartbeats now skip adapter invocation by default when the agent has no assigned `todo` or `in_progress` work with ready dependencies. Agents that intentionally perform unscoped proactive scheduled work can still opt out with `runtimeConfig.heartbeat.skipTimerWhenNoActionableWork: false`.

Additional verification:

- Passed: `corepack pnpm exec vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`.
- Passed: `corepack pnpm exec vitest run server/src/__tests__/llms-routes.test.ts server/src/__tests__/heartbeat-timer-wake-session-reset-pf4.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts`.