### PR TITLE
Plugin file/url based load fix

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1211,7 +1211,10 @@ export function pluginLoader(
               );
             });
             
-            if (matchedKey) {
+            // Valid npm package names: unscoped [a-z0-9._-] or scoped @scope/name
+            const NPM_PKG_RE = /^(?:@[a-z0-9._-]+\/[a-z0-9._-]+|[a-z0-9._-]+)$/;
+
+            if (matchedKey && NPM_PKG_RE.test(matchedKey)) {
               log.info(
                 { packageName: targetPackageName, matchedKey },
                 "plugin-loader: resolved alias for installed package",
@@ -1223,6 +1226,11 @@ export function pluginLoader(
               } else {
                 resolvedPackagePath = path.join(nodeModulesPath, resolvedPackageName);
               }
+            } else if (matchedKey) {
+              log.warn(
+                { matchedKey },
+                "plugin-loader: dependency key failed validation, skipping",
+              );
             }
           } catch (e) {
             log.warn({ err: e }, "plugin-loader: failed to read package.json dependencies for resolution");

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1211,10 +1211,12 @@ export function pluginLoader(
               );
             });
             
-            // Valid npm package names: unscoped [a-z0-9._-] or scoped @scope/name
-            const NPM_PKG_RE = /^(?:@[a-z0-9._-]+\/[a-z0-9._-]+|[a-z0-9._-]+)$/;
+            // Valid npm package names: unscoped [a-z0-9][a-z0-9._-]* or scoped @scope/name
+            // Must start with alphanumeric (not . or _) to reject `.`, `..`, `.dotfiles`, etc.
+            const NPM_PKG_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/;
+            const isDirectoryTraversal = !!matchedKey && (matchedKey === "." || matchedKey === ".." || matchedKey.startsWith("."));
 
-            if (matchedKey && NPM_PKG_RE.test(matchedKey)) {
+            if (matchedKey && !isDirectoryTraversal && NPM_PKG_RE.test(matchedKey)) {
               log.info(
                 { packageName: targetPackageName, matchedKey },
                 "plugin-loader: resolved alias for installed package",

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1191,6 +1191,45 @@ export function pluginLoader(
         resolvedPackagePath = path.join(nodeModulesPath, resolvedPackageName);
       }
 
+      // If the path does not exist, try to resolve it from targetInstallDir's package.json dependencies
+      if (!existsSync(resolvedPackagePath)) {
+        const packageJsonPath = path.join(targetInstallDir, "package.json");
+        if (existsSync(packageJsonPath)) {
+          try {
+            const pkgJsonRaw = await readFile(packageJsonPath, "utf8");
+            const pkgJson = JSON.parse(pkgJsonRaw);
+            const deps = pkgJson.dependencies || {};
+            
+            const targetPackageName = packageName!;
+            // Find a dependency key where the value contains or ends with our packageName specifier
+            // or where the key itself matches
+            const matchedKey = Object.keys(deps).find((key) => {
+              const val = deps[key];
+              return (
+                key === targetPackageName ||
+                (typeof val === "string" && (val === targetPackageName || val.endsWith(targetPackageName) || val.includes(targetPackageName)))
+              );
+            });
+            
+            if (matchedKey) {
+              log.info(
+                { packageName: targetPackageName, matchedKey },
+                "plugin-loader: resolved alias for installed package",
+              );
+              resolvedPackageName = matchedKey;
+              if (resolvedPackageName.startsWith("@")) {
+                const [scope, name] = resolvedPackageName.split("/");
+                resolvedPackagePath = path.join(nodeModulesPath, scope!, name!);
+              } else {
+                resolvedPackagePath = path.join(nodeModulesPath, resolvedPackageName);
+              }
+            }
+          } catch (e) {
+            log.warn({ err: e }, "plugin-loader: failed to read package.json dependencies for resolution");
+          }
+        }
+      }
+
       if (!existsSync(resolvedPackagePath)) {
         throw new Error(
           `Package directory not found after installation: ${resolvedPackagePath}`,

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1207,7 +1207,7 @@ export function pluginLoader(
               const val = deps[key];
               return (
                 key === targetPackageName ||
-                (typeof val === "string" && (val === targetPackageName || val.endsWith(targetPackageName) || val.includes(targetPackageName)))
+                (typeof val === "string" && val === targetPackageName)
               );
             });
             


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The plugin loader subsystem manages discovering, installing, and dynamically loading external plugins and adapters.
> - When installing plugins from non-standard NPM specifiers (e.g., local directory paths like `file:../plugin` or remote Git URLs), the initial directory lookup under `node_modules` fails because NPM resolves and creates directories using the actual package name declared in the plugin's own `package.json` rather than the raw specifier string.
> - This causes the plugin loader to throw a "Package directory not found after installation" error, preventing the plugin/adapter from being loaded or initialized.
> - This pull request adds a fallback resolution mechanism to inspect the target installation's `package.json` dependencies and map the specifier to the correct package directory name under `node_modules`.
> - The benefit is that developers and users can successfully load locally developed or git-hosted plugins and adapters.

## Linked Issues or Issue Description

### Bug Report

**What happened**
When attempting to install and load a plugin or adapter via a local path specifier (e.g., `file:../some-plugin`) or a Git URL specifier, NPM installs it successfully under its declared package name in `node_modules/`, but the plugin loader looks for a folder named exactly after the specifier (e.g., `node_modules/file:../some-plugin`). This leads to a `Package directory not found after installation` error and dynamic load failure.

**Expected behavior**
The plugin loader should successfully locate and load the plugin package directory under `node_modules` regardless of whether the installer used a registry package name, a local path, or a Git URL.

**Steps to reproduce**
1. Trigger plugin installation with a local path (e.g., `file:../my-plugin`).
2. Observe that NPM successfully installs the package, but the loader fails with:
   `Error: Package directory not found after installation: <path>/node_modules/file:../my-plugin`

**Deployment mode**
Local development / self-hosted environments.

## What Changed

- **Fallback Resolution in `plugin-loader.ts`**: Added a fallback block inside the `fetchAndValidate` function. If the package directory is not found under the default `resolvedPackagePath`:
  - It reads the `package.json` file in the installation directory.
  - It scans the `dependencies` keys and values to locate the entry matching or containing the requested `packageName` (specifier).
  - If a match is found, it resolves the package name to the actual dependency key (the folder name inside `node_modules`) and updates the path.
- **Improved Logging**: Added a debug log entry using `log.info` when an alias or specifier is successfully resolved for an installed package.

## Verification

### Manual Verification
1. Run the Paperclip server locally.
2. Install a plugin using a local file path specifier (e.g., via Board UI or CLI plugin install flow pointing to a local directory or using a `file:` path).
3. Confirm that the plugin resolves, loads, and initializes without throwing directory not found errors.

### Automated Tests
1. Run the Vitest unit tests:
   ```sh
   pnpm test
   ```

## Risks

- **Low risk**: The fallback resolution block only executes if the initial package directory lookup fails. Standard NPM registry installations are completely unaffected.

## Model Used

Gemini 3.5 Flash

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
