### PR TITLE
Guard timer heartbeats against blocked assigned work

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -325,7 +325,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     });
     expect(wakeup?.payload).toMatchObject({
       heartbeatSkip: {
-        reason: expect.stringContaining("No assigned todo or in_progress issue"),
+        reason: expect.stringContaining("No assigned todo or in_progress issue is dependency-ready"),
       },
     });
     expect(runRows).toHaveLength(0);
@@ -451,10 +451,70 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     });
     expect(wakeup?.payload).toMatchObject({
       heartbeatSkip: {
-        reason: expect.stringContaining("No assigned todo or in_progress issue"),
+        reason: expect.stringContaining("No assigned todo or in_progress issue is dependency-ready"),
       },
     });
     expect(runRows).toHaveLength(0);
+  });
+
+  it("allows generic timer wakes when only newer assigned work is dependency-ready", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+        skipTimerWhenNoActionableWork: true,
+      },
+    });
+    const blockerId = randomUUID();
+    const blockedIssueIds = Array.from({ length: 50 }, () => randomUUID());
+    const readyIssueId = randomUUID();
+    const oldUpdatedAt = new Date("2026-01-01T00:00:00.000Z");
+    const readyUpdatedAt = new Date("2026-01-02T00:00:00.000Z");
+
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocking issue",
+        status: "todo",
+        priority: "high",
+      },
+      ...blockedIssueIds.map((issueId, index) => ({
+        id: issueId,
+        companyId,
+        title: `Blocked assigned work ${index + 1}`,
+        status: "todo" as const,
+        priority: "high" as const,
+        assigneeAgentId: agentId,
+        updatedAt: new Date(oldUpdatedAt.getTime() + index),
+      })),
+      {
+        id: readyIssueId,
+        companyId,
+        title: "Ready assigned work",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentId,
+        updatedAt: readyUpdatedAt,
+      },
+    ]);
+    await db.insert(issueRelations).values(
+      blockedIssueIds.map((blockedIssueId) => ({
+        companyId,
+        issueId: blockerId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      })),
+    );
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).not.toBeNull();
+    await waitForCondition(async () => countExecuteCallsForRun(run!.id) > 0);
+
+    expect(countExecuteCallsForRun(run!.id)).toBe(1);
   });
 
   it("runs generic timer wakes by default for proactive agents without assigned issue work", async () => {

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -12,6 +12,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueRelations,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
@@ -391,6 +392,69 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     await waitForCondition(async () => countExecuteCallsForRun(run!.id) > 0);
 
     expect(countExecuteCallsForRun(run!.id)).toBe(1);
+  });
+
+  it("skips generic timer wakes when assigned todo work is blocked by dependencies", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+        skipTimerWhenNoActionableWork: true,
+      },
+    });
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocking issue",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked assigned work",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const runRows = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "heartbeat.timer.no_actionable_work",
+    });
+    expect(wakeup?.payload).toMatchObject({
+      heartbeatSkip: {
+        reason: expect.stringContaining("No assigned todo or in_progress issue"),
+      },
+    });
+    expect(runRows).toHaveLength(0);
   });
 
   it("runs generic timer wakes by default for proactive agents without assigned issue work", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7024,8 +7024,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           inArray(issues.status, [...TIMER_ACTIONABLE_ISSUE_STATUSES]),
         ),
       )
-      .orderBy(asc(issues.updatedAt))
-      .limit(50);
+      .orderBy(asc(issues.updatedAt));
     if (candidateRows.length === 0) return false;
 
     const readinessByIssueId = await issuesSvc.listDependencyReadiness(
@@ -10740,7 +10739,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       !readNonEmptyString(enrichedContextSnapshot.taskKey);
     if (policy.skipTimerWhenNoActionableWork && genericTimerWake && !(await hasActionableTimerWork(agent))) {
       await writeSkippedHeartbeatRequest("heartbeat.timer.no_actionable_work", {
-        reason: "No assigned todo or in_progress issue requires this agent before timer adapter invocation.",
+        reason: "No assigned todo or in_progress issue is dependency-ready for this agent before timer adapter invocation.",
       });
       await markTimerHeartbeatChecked(agentId, source);
       return null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7012,7 +7012,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function hasActionableTimerWork(agent: typeof agents.$inferSelect) {
-    const row = await db
+    const candidateRows = await db
       .select({ id: issues.id })
       .from(issues)
       .where(
@@ -7024,9 +7024,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           inArray(issues.status, [...TIMER_ACTIONABLE_ISSUE_STATUSES]),
         ),
       )
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-    return Boolean(row);
+      .orderBy(asc(issues.updatedAt))
+      .limit(50);
+    if (candidateRows.length === 0) return false;
+
+    const readinessByIssueId = await issuesSvc.listDependencyReadiness(
+      agent.companyId,
+      candidateRows.map((row) => row.id),
+    );
+    return candidateRows.some((row) => readinessByIssueId.get(row.id)?.isDependencyReady ?? true);
   }
 
   async function markTimerHeartbeatChecked(agentId: string, source: WakeupOptions["source"]) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat subsystem controls when local adapter agents receive scheduled timer wakes and when those wakes are skipped before adapter execution.
> - The existing generic timer no-action gate only checked whether an agent had any assigned `todo` or `in_progress` issue.
> - That made dependency-blocked assigned work look actionable, allowing generic timer wakes to start full adapter runs even though the assigned work could not proceed.
> - This pull request makes the timer gate consult issue dependency readiness before deciding work is actionable.
> - The benefit is lower avoidable model usage for agents that opt into issue-only timer behavior, while preserving proactive timer behavior for agents without that opt-in.

## Linked Issues or Issue Description

No public GitHub issue exists for this internal operations incident.

### What happened

Generic scheduled timer wakes can start adapter runs even when the only assigned work is blocked by unresolved issue dependencies. This creates avoidable scheduled model runs and token usage for agents configured to stay idle when no issue work can proceed.

### Expected behavior

When `skipTimerWhenNoActionableWork` is enabled, blocked assigned work should not count as actionable timer work. Generic timer wakes should proceed only when at least one assigned `todo` or `in_progress` issue is dependency-ready.

### Steps to reproduce

1. Configure an agent with `heartbeat.skipTimerWhenNoActionableWork: true`.
2. Assign the agent a `todo` or `in_progress` issue that is blocked by an unresolved issue dependency.
3. Trigger a generic timer wake with no explicit issue or task context.
4. Observe that the timer wake reaches adapter execution instead of being skipped.

### Paperclip version or commit

Observed before this PR on `master`; regression coverage is included in this PR.

### Deployment mode

Local adapter heartbeat timer path.
## What Changed

- Updated the generic timer actionability gate to load assigned `todo`/`in_progress` candidates and require at least one dependency-ready issue.
- Added an embedded database regression test proving a blocked assigned issue produces a skipped wakeup and no heartbeat run.

## Verification

- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-stale-queue-invalidation.test.ts`
  - Passed: 1 file, 22 tests.
- `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps`
  - Passed.
- `./server/node_modules/.bin/tsc --noEmit -p server/tsconfig.json`
  - Passed.
- `git diff --check`
  - Passed.

Note: `COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm --filter @paperclipai/server typecheck` could not run as-is because the nested package script resolved this shell's pnpm v11 shim while the repo requires pnpm 9.15.4. The underlying plugin dependency build and server `tsc --noEmit` steps were run directly and passed.

## Risks

Low to moderate behavioral risk. This only changes agents that explicitly enable `skipTimerWhenNoActionableWork` or one of its aliases. For those agents, a generic timer wake will now stay idle when all assigned actionable-status issues are blocked by unresolved dependencies. Agents that intentionally need proactive timer sweeps without assigned work keep the existing default behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex coding agent based on GPT-5, with shell, git, and local test execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge