### PR TITLE
rename: agent-runtime-* images to runtime-*

### DIFF
--- a/.github/workflows/runtime-images.yml
+++ b/.github/workflows/runtime-images.yml
@@ -1,4 +1,4 @@
-name: Agent runtime images
+name: Runtime images
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
     paths:
       - "docker/agent-runtime/**"
       - "tools/agent-shim/**"
-      - ".github/workflows/agent-runtime-images.yml"
+      - ".github/workflows/runtime-images.yml"
   workflow_dispatch:
     inputs:
       version:
@@ -75,24 +75,24 @@ jobs:
 
       - name: Cosign sign base
         run: |
-          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-base@${{ steps.bake.outputs.base_digest }}"
+          cosign sign --yes "${{ env.REGISTRY }}/runtime-base@${{ steps.bake.outputs.base_digest }}"
 
       - name: Cosign sign opencode
         run: |
-          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-opencode@${{ steps.bake.outputs.opencode_digest }}"
+          cosign sign --yes "${{ env.REGISTRY }}/runtime-opencode@${{ steps.bake.outputs.opencode_digest }}"
 
       - name: Cosign sign pi
         run: |
-          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-pi@${{ steps.bake.outputs.pi_digest }}"
+          cosign sign --yes "${{ env.REGISTRY }}/runtime-pi@${{ steps.bake.outputs.pi_digest }}"
 
       - name: Cosign sign codex
         run: |
-          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-codex@${{ steps.bake.outputs.codex_digest }}"
+          cosign sign --yes "${{ env.REGISTRY }}/runtime-codex@${{ steps.bake.outputs.codex_digest }}"
 
       - name: Cosign sign gemini
         run: |
-          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-gemini@${{ steps.bake.outputs.gemini_digest }}"
+          cosign sign --yes "${{ env.REGISTRY }}/runtime-gemini@${{ steps.bake.outputs.gemini_digest }}"
 
       - name: Cosign sign claude
         run: |
-          cosign sign --yes "${{ env.REGISTRY }}/agent-runtime-claude@${{ steps.bake.outputs.claude_digest }}"
+          cosign sign --yes "${{ env.REGISTRY }}/runtime-claude@${{ steps.bake.outputs.claude_digest }}"

--- a/docker/agent-runtime/Dockerfile.acpx
+++ b/docker/agent-runtime/Dockerfile.acpx
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 USER root
 # acpx is the ACPX wrapper that bridges to claude / codex backends.

--- a/docker/agent-runtime/Dockerfile.claude
+++ b/docker/agent-runtime/Dockerfile.claude
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 USER root
 RUN npm install -g @anthropic-ai/claude-code@latest \

--- a/docker/agent-runtime/Dockerfile.codex
+++ b/docker/agent-runtime/Dockerfile.codex
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 USER root
 RUN npm install -g @openai/codex@latest \

--- a/docker/agent-runtime/Dockerfile.gemini
+++ b/docker/agent-runtime/Dockerfile.gemini
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 USER root
 RUN npm install -g @google/gemini-cli@latest \

--- a/docker/agent-runtime/Dockerfile.hermes
+++ b/docker/agent-runtime/Dockerfile.hermes
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 # hermes_local is in the legacy sessioned-adapter set but has no upstream
 # npm package wired into Paperclip locally yet (see

--- a/docker/agent-runtime/Dockerfile.opencode
+++ b/docker/agent-runtime/Dockerfile.opencode
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 USER root
 # opencode-ai npm package; binary on PATH is `opencode`.

--- a/docker/agent-runtime/Dockerfile.pi
+++ b/docker/agent-runtime/Dockerfile.pi
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 ARG BASE_TAG=dev
-FROM paperclipai/agent-runtime-base:${BASE_TAG}
+FROM paperclipai/runtime-base:${BASE_TAG}
 
 USER root
 # pi is the multi-provider Pi coding-agent router. Verified npm package:

--- a/docker/agent-runtime/README.md
+++ b/docker/agent-runtime/README.md
@@ -1,16 +1,16 @@
 # Agent Runtime Image Family
 
-Container images for running coding-agent harnesses in sandboxed environments (for example the kubernetes sandbox provider, stage 1 of the k8s contribution). Images are named `agent-runtime-{harness}:{version}` and published to `ghcr.io/paperclipai/` by the `agent-runtime-images` workflow. The registry is overridable: every reference flows through the `REGISTRY` bake variable.
+Container images for running coding-agent harnesses in sandboxed environments (for example the kubernetes sandbox provider, stage 1 of the k8s contribution). Images are named `runtime-{harness}:{version}` and published to `ghcr.io/paperclipai/` by the `runtime-images` workflow. The registry is overridable: every reference flows through the `REGISTRY` bake variable.
 
 ## Image Lineup
 
-- **`agent-runtime-base`**: Foundation. Ubuntu 22.04 + Node 22 + git + tini + non-root user (uid 1000) + the agent shim.
-- **`agent-runtime-opencode`**: Extends base with `opencode-ai` globally installed.
-- **`agent-runtime-pi`**: Extends base with `@mariozechner/pi-coding-agent`.
-- **`agent-runtime-codex`**: Extends base with `@openai/codex`.
-- **`agent-runtime-gemini`**: Extends base with `@google/gemini-cli` plus headless auth-mode settings.
-- **`agent-runtime-claude`**: Extends base with `@anthropic-ai/claude-code` (symlinked as `claude-code`).
-- **`agent-runtime-acpx`** / **`agent-runtime-hermes`**: Dockerfiles included in the bake group, not in the default publish scope (hermes is a stub until a CLI package exists).
+- **`runtime-base`**: Foundation. Ubuntu 22.04 + Node 22 + git + tini + non-root user (uid 1000) + the agent shim.
+- **`runtime-opencode`**: Extends base with `opencode-ai` globally installed.
+- **`runtime-pi`**: Extends base with `@mariozechner/pi-coding-agent`.
+- **`runtime-codex`**: Extends base with `@openai/codex`.
+- **`runtime-gemini`**: Extends base with `@google/gemini-cli` plus headless auth-mode settings.
+- **`runtime-claude`**: Extends base with `@anthropic-ai/claude-code` (symlinked as `claude-code`).
+- **`runtime-acpx`** / **`runtime-hermes`**: Dockerfiles included in the bake group, not in the default publish scope (hermes is a stub until a CLI package exists).
 
 ## Base Image Contents
 
@@ -47,11 +47,11 @@ REGISTRY=myregistry VERSION=mytag \
 
 ## Quickstart Smoke Test
 
-Build and verify the `agent-runtime-claude` image runs locally:
+Build and verify the `runtime-claude` image runs locally:
 
 ```bash
 docker buildx bake -f docker/agent-runtime/buildx-bake.hcl base claude --load
-docker run --rm ghcr.io/paperclipai/agent-runtime-claude:dev claude-code --version
+docker run --rm ghcr.io/paperclipai/runtime-claude:dev claude-code --version
 ```
 
 ## Agent Container (paperclip-agent-shim)
@@ -82,4 +82,4 @@ The shim makes no assumptions about command structure; it is harness-agnostic. N
 
 ## Publishing
 
-`.github/workflows/agent-runtime-images.yml` builds and pushes the default scope (base, opencode, pi, codex, gemini, claude) on `workflow_dispatch` (with an explicit version tag) or on pushes to `master` touching these paths, then signs each digest with cosign keyless OIDC.
+`.github/workflows/runtime-images.yml` builds and pushes the default scope (base, opencode, pi, codex, gemini, claude) on `workflow_dispatch` (with an explicit version tag) or on pushes to `master` touching these paths, then signs each digest with cosign keyless OIDC.

--- a/docker/agent-runtime/buildx-bake.hcl
+++ b/docker/agent-runtime/buildx-bake.hcl
@@ -9,19 +9,19 @@ target "base" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.base"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-base:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-base:${VERSION}"]
 }
 
 target "claude" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.claude"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-claude:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-claude:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }
 
@@ -29,12 +29,12 @@ target "codex" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.codex"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-codex:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-codex:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }
 
@@ -42,12 +42,12 @@ target "gemini" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.gemini"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-gemini:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-gemini:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }
 
@@ -55,12 +55,12 @@ target "acpx" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.acpx"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-acpx:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-acpx:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }
 
@@ -68,12 +68,12 @@ target "opencode" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.opencode"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-opencode:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-opencode:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }
 
@@ -81,12 +81,12 @@ target "pi" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.pi"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-pi:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-pi:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }
 
@@ -94,11 +94,11 @@ target "hermes" {
   context = "."
   dockerfile = "docker/agent-runtime/Dockerfile.hermes"
   platforms = ["linux/amd64"]
-  tags = ["${REGISTRY}/agent-runtime-hermes:${VERSION}"]
+  tags = ["${REGISTRY}/runtime-hermes:${VERSION}"]
   args = {
     BASE_TAG = "${VERSION}"
   }
   contexts = {
-    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+    "paperclipai/runtime-base:${VERSION}" = "target:base"
   }
 }

--- a/packages/plugins/sandbox-providers/kubernetes/SMOKE.md
+++ b/packages/plugins/sandbox-providers/kubernetes/SMOKE.md
@@ -66,7 +66,7 @@ curl -s -X POST -H "Content-Type: application/json" \
       \"kubeconfig\": $KUBECONFIG_CONTENT,
       \"companySlug\": \"smoke\",
       \"adapterType\": \"claude_local\",
-      \"imageAllowList\": [\"ghcr.io/paperclipai/agent-runtime-claude:v1\"]
+      \"imageAllowList\": [\"ghcr.io/paperclipai/runtime-claude:v1\"]
     }
   }" \
   http://127.0.0.1:3100/api/companies/$CO_ID/environments | jq

--- a/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
@@ -11,43 +11,43 @@ export interface AdapterDefaults {
 
 const REGISTRY: Record<string, AdapterDefaults> = {
   claude_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-claude:v1",
     envKeys: ["ANTHROPIC_API_KEY"],
     allowFqdns: ["api.anthropic.com"],
     probeCommand: ["claude", "--version"],
   },
   codex_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-codex:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-codex:v1",
     envKeys: ["OPENAI_API_KEY"],
     allowFqdns: ["api.openai.com"],
     probeCommand: ["codex", "--version"],
   },
   gemini_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-gemini:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-gemini:v1",
     envKeys: ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
     allowFqdns: ["generativelanguage.googleapis.com"],
     probeCommand: ["gemini", "--version"],
   },
   cursor_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-cursor:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-cursor:v1",
     envKeys: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
     allowFqdns: ["api.anthropic.com", "api.openai.com"],
     probeCommand: ["cursor-agent", "--version"],
   },
   opencode_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-opencode:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-opencode:v1",
     envKeys: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"],
     allowFqdns: ["api.anthropic.com", "api.openai.com", "openrouter.ai"],
     probeCommand: ["opencode", "--version"],
   },
   acpx_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-acpx:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-acpx:v1",
     envKeys: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
     allowFqdns: ["api.anthropic.com", "api.openai.com"],
     probeCommand: ["acpx", "--version"],
   },
   pi_local: {
-    runtimeImage: "ghcr.io/paperclipai/agent-runtime-pi:v1",
+    runtimeImage: "ghcr.io/paperclipai/runtime-pi:v1",
     envKeys: ["ANTHROPIC_API_KEY"],
     allowFqdns: ["api.anthropic.com"],
     probeCommand: ["pi", "--version"],

--- a/packages/plugins/sandbox-providers/kubernetes/src/image-allowlist.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/image-allowlist.ts
@@ -46,7 +46,7 @@ export function resolveImage(
 }
 
 function rewriteRegistry(image: string, registry: string): string {
-  // image is like "ghcr.io/paperclipai/agent-runtime-claude:v1"
+  // image is like "ghcr.io/paperclipai/runtime-claude:v1"
   // we want to replace the first two path segments (host + org) with `registry`
   const cleanRegistry = registry.replace(/\/+$/, "");
   const colonIdx = image.lastIndexOf(":");

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
@@ -11,7 +11,7 @@ import type { AdapterRegistryEntry } from "../../src/adapter-registry.js";
 describe("adapter-defaults (built-in)", () => {
   it("returns defaults for claude_local", () => {
     const d = getAdapterDefaults("claude_local");
-    expect(d.runtimeImage).toBe("ghcr.io/paperclipai/agent-runtime-claude:v1");
+    expect(d.runtimeImage).toBe("ghcr.io/paperclipai/runtime-claude:v1");
     expect(d.envKeys).toContain("ANTHROPIC_API_KEY");
     expect(d.allowFqdns).toContain("api.anthropic.com");
     expect(d.probeCommand).toEqual(["claude", "--version"]);
@@ -19,7 +19,7 @@ describe("adapter-defaults (built-in)", () => {
 
   it("returns defaults for codex_local", () => {
     const d = getAdapterDefaults("codex_local");
-    expect(d.runtimeImage).toBe("ghcr.io/paperclipai/agent-runtime-codex:v1");
+    expect(d.runtimeImage).toBe("ghcr.io/paperclipai/runtime-codex:v1");
     expect(d.envKeys).toContain("OPENAI_API_KEY");
     expect(d.probeCommand).toEqual(["codex", "--version"]);
   });
@@ -46,7 +46,7 @@ describe("adapter-defaults (built-in)", () => {
 describe("getAdapterDefaults", () => {
   it("returns built-in defaults when no registry is supplied", () => {
     const d = getAdapterDefaults("claude_local");
-    expect(d.runtimeImage).toContain("agent-runtime-claude");
+    expect(d.runtimeImage).toContain("runtime-claude");
     expect(d.envKeys).toEqual(["ANTHROPIC_API_KEY"]);
     expect(d.defaultEnv).toBeUndefined();
   });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/image-allowlist.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/image-allowlist.test.ts
@@ -3,7 +3,7 @@ import { globMatch, resolveImage } from "../../src/image-allowlist.js";
 
 describe("globMatch", () => {
   it("matches exact image", () => {
-    expect(globMatch("ghcr.io/paperclipai/agent-runtime-claude:v1", "ghcr.io/paperclipai/agent-runtime-claude:v1")).toBe(true);
+    expect(globMatch("ghcr.io/paperclipai/runtime-claude:v1", "ghcr.io/paperclipai/runtime-claude:v1")).toBe(true);
   });
 
   it("matches single-character wildcard", () => {
@@ -12,21 +12,21 @@ describe("globMatch", () => {
   });
 
   it("matches multi-character wildcard", () => {
-    expect(globMatch("ghcr.io/paperclipai/*:v1", "ghcr.io/paperclipai/agent-runtime-claude:v1")).toBe(true);
+    expect(globMatch("ghcr.io/paperclipai/*:v1", "ghcr.io/paperclipai/runtime-claude:v1")).toBe(true);
     expect(globMatch("ghcr.io/paperclipai/*:v1", "docker.io/other/img:v1")).toBe(false);
   });
 
   it("does not allow wildcard to span slashes by default", () => {
-    expect(globMatch("ghcr.io/*:v1", "ghcr.io/paperclipai/agent-runtime-claude:v1")).toBe(false);
+    expect(globMatch("ghcr.io/*:v1", "ghcr.io/paperclipai/runtime-claude:v1")).toBe(false);
   });
 });
 
 describe("resolveImage", () => {
-  const defaults = { runtimeImage: "ghcr.io/paperclipai/agent-runtime-claude:v1" };
+  const defaults = { runtimeImage: "ghcr.io/paperclipai/runtime-claude:v1" };
 
   it("uses adapter default when no override", () => {
     expect(resolveImage({ imageOverride: null }, defaults, { imageAllowList: [], imageRegistry: undefined })).toBe(
-      "ghcr.io/paperclipai/agent-runtime-claude:v1",
+      "ghcr.io/paperclipai/runtime-claude:v1",
     );
   });
 
@@ -37,7 +37,7 @@ describe("resolveImage", () => {
         defaults,
         { imageAllowList: [], imageRegistry: "registry.example.com/paperclip" },
       ),
-    ).toBe("registry.example.com/paperclip/agent-runtime-claude:v1");
+    ).toBe("registry.example.com/paperclip/runtime-claude:v1");
   });
 
   it("accepts imageOverride when in allowlist", () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-spec-builder.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-spec-builder.test.ts
@@ -5,7 +5,7 @@ const baseInput = {
   namespace: "paperclip-acme",
   jobName: "r-01h00000000000000000000000",
   adapterType: "claude_local",
-  image: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+  image: "ghcr.io/paperclipai/runtime-claude:v1",
   envSecretName: "r-01h00000000000000000000000-env",
   serviceAccountName: "paperclip-tenant-sa",
   labels: { "paperclip.io/run-id": "r1" },

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
@@ -5,7 +5,7 @@ const baseInput = {
   namespace: "paperclip-acme",
   sandboxName: "pc-01h00000000000000000000000",
   adapterType: "claude_local",
-  image: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+  image: "ghcr.io/paperclipai/runtime-claude:v1",
   envSecretName: "pc-01h00000000000000000000000-env",
   serviceAccountName: "paperclip-tenant-sa",
   labels: { "paperclip.io/run-id": "r1" },

--- a/packages/shared/src/validators/adapter-registry.test.ts
+++ b/packages/shared/src/validators/adapter-registry.test.ts
@@ -6,7 +6,7 @@ describe("adapterRegistrySchema", () => {
     const parsed = adapterRegistrySchema.parse([
       {
         adapterType: "opencode_local",
-        runtimeImage: "ghcr.io/paperclipai/agent-runtime-opencode:v1",
+        runtimeImage: "ghcr.io/paperclipai/runtime-opencode:v1",
         envKeys: ["ANTHROPIC_API_KEY"],
         allowFqdns: [],
         probeCommand: ["opencode", "--version"],


### PR DESCRIPTION
## Summary

Rename all `agent-runtime-{harness}` Docker images to `runtime-{harness}` (image names, tags, FROM lines, CI workflow, adapter defaults, tests, docs).

## Motivation

The `agent-` prefix is redundant since all images are published under `ghcr.io/paperclipai/`. Dropping it shortens image names while preserving clarity.

## What changed

- **buildx-bake.hcl**: All 8 image tags renamed, context names updated
- **Dockerfiles (7)**: FROM lines updated from `paperclipai/agent-runtime-base` to `paperclipai/runtime-base`
- **CI workflow**: Renamed from `agent-runtime-images.yml` to `runtime-images.yml`, cosign sign commands updated, workflow name updated
- **adapter-defaults.ts**: All 7 runtimeImage values renamed
- **Tests (5)**: All image references in K8s sandbox tests and shared validator test updated
- **README**: All image names and workflow references updated
- **SMOKE.md**: Image reference updated
- **image-allowlist.ts**: Comment updated

## What did NOT change

- `docker/agent-runtime/` directory path (filesystem path, not an image name)
- `buildNewAgentRuntimeConfig` etc. in UI (unrelated function names)

## Files changed

18 files changed, 62 insertions(+), 62 deletions(-)

## Testing

- All image name references are consistent across Dockerfiles, bake config, CI workflow, K8s sandbox provider defaults, and test fixtures
- Dockerfile `FROM` lines and bake `contexts` are synchronized
- No remaining `agent-runtime-` image name references in source (verified with `rg` excluding node_modules, .git, dist, releases, storybook)