### PR TITLE
fix(heartbeat): close stale-run evaluation loop and add agent run-overlap guard

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -1010,4 +1010,67 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  // Patch A.3 — when the underlying heartbeat_run reaches a terminal status, open
+  // `stale_active_run_evaluation` issues for that run must be auto-cancelled so the
+  // assignee is not woken with an alert about a run that no longer exists.
+  it("auto-cancels open stale-run evaluation issues when the underlying run is cancelled", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const scanResult = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(scanResult.created).toBe(1);
+    const evaluationIssueId = scanResult.evaluationIssueIds[0]!;
+
+    const [openEvaluation] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, evaluationIssueId));
+    expect(openEvaluation?.status).toBe("todo");
+
+    await heartbeat.cancelRun(runId, "test: simulate run terminal status");
+
+    const [closedEvaluation] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, evaluationIssueId));
+    expect(closedEvaluation?.status).toBe("cancelled");
+
+    const closeComments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, evaluationIssueId));
+    const closeNoteBody = closeComments.map((row) => row.body).join("\n");
+    expect(closeNoteBody).toContain("System-cancelled");
+    expect(closeNoteBody).toContain("terminal status");
+  });
+
+  it("auto-cancel on terminal run is idempotent and only acts on the matching run", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const scanResult = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(scanResult.created).toBe(1);
+    const evaluationIssueId = scanResult.evaluationIssueIds[0]!;
+
+    await heartbeat.cancelRun(runId, "first terminal transition");
+
+    // Second cancel attempt is a no-op on the already-cancelled run but must not
+    // crash the close hook or append duplicate close comments.
+    await heartbeat.cancelRun(runId, "second terminal transition (idempotent)");
+
+    const closeComments = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, evaluationIssueId));
+    expect(closeComments).toHaveLength(1);
+  });
 });

--- a/server/src/__tests__/heartbeat-agent-active-run-overlap.test.ts
+++ b/server/src/__tests__/heartbeat-agent-active-run-overlap.test.ts
@@ -1,0 +1,270 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping agent active-run overlap tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// Agent-level run-overlap guard — timer-source wakes must not pile up against an agent
+// that already has a queued/running/scheduled_retry heartbeat_run. These tests cover the
+// two layers:
+//   B.1 — tickTimers pre-skips agents with active runs so enqueueWakeup is not invoked.
+//   B.2 — enqueueWakeup defends against the same condition for any timer-source caller.
+describeEmbeddedPostgres("agent active-run overlap guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-agent-active-run-overlap-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    // Use TRUNCATE CASCADE to wipe all referencing tables (agent_runtime_state,
+    // execution_workspaces, etc.) — listing tables explicitly with db.delete() runs
+    // into FK violations from rows that orchestration writes through the run path.
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgentWithRun(opts: {
+    runStatus: "queued" | "running" | "scheduled_retry";
+    runInvocationSource?: string;
+    runIssueId?: string | null;
+    lastHeartbeatMinutesAgo?: number;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = opts.runIssueId === undefined ? randomUUID() : opts.runIssueId;
+    const now = new Date();
+    const lastHeartbeatAt = new Date(
+      now.getTime() - (opts.lastHeartbeatMinutesAgo ?? 10) * 60_000,
+    );
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Overlap Co",
+      status: "active",
+      issuePrefix: `O${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Overlap Worker",
+      role: "engineer",
+      status: opts.runStatus === "running" ? "running" : "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 60,
+          wakeOnDemand: true,
+        },
+      },
+      permissions: {},
+      lastHeartbeatAt,
+    });
+
+    if (issueId) {
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Active work",
+        status: "in_progress",
+        assigneeAgentId: agentId,
+      });
+    }
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: opts.runStatus,
+      invocationSource: opts.runInvocationSource ?? "assignment",
+      triggerDetail: "system",
+      startedAt: opts.runStatus === "running" ? lastHeartbeatAt : null,
+      processStartedAt: opts.runStatus === "running" ? lastHeartbeatAt : null,
+      lastOutputAt: opts.runStatus === "running" ? lastHeartbeatAt : null,
+      contextSnapshot: issueId ? { issueId } : {},
+      logBytes: 0,
+    });
+
+    return { companyId, agentId, runId, issueId };
+  }
+
+  it("B.1: tickTimers skips agents that already have a running run", async () => {
+    const { agentId, runId } = await seedAgentWithRun({ runStatus: "running" });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.tickTimers(new Date());
+
+    // The agent was checked (passed invokability + heartbeat policy gates) but the
+    // active-run pre-filter prevented enqueueWakeup from being invoked, so no new run
+    // was queued behind the active one.
+    expect(result.checked).toBe(1);
+    expect(result.enqueued).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const runsForAgent = await db
+      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .then((rows) => rows.filter((row) => row.id === runId || row.status === "queued"));
+    // Only the original active run exists; no new queued run was created.
+    expect(runsForAgent).toHaveLength(1);
+    expect(runsForAgent[0]?.id).toBe(runId);
+  });
+
+  it("B.1: tickTimers skips agents that already have a queued run", async () => {
+    await seedAgentWithRun({ runStatus: "queued" });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.tickTimers(new Date());
+
+    expect(result.checked).toBe(1);
+    expect(result.enqueued).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const allRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns);
+    // No additional rows beyond the seeded queued run should exist.
+    expect(allRuns.length).toBe(1);
+  });
+
+  it("B.1: tickTimers still enqueues for agents with no active run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const now = new Date();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Idle Co",
+      status: "active",
+      issuePrefix: `I${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Idle Worker",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: { enabled: true, intervalSec: 60, wakeOnDemand: true },
+      },
+      permissions: {},
+      lastHeartbeatAt: new Date(now.getTime() - 5 * 60_000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.tickTimers(now);
+
+    expect(result.checked).toBe(1);
+    expect(result.enqueued).toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("B.2: wakeup with source=timer is skipped when the agent has an active issue_assigned run", async () => {
+    const { agentId, runId } = await seedAgentWithRun({
+      runStatus: "running",
+      runInvocationSource: "assignment",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat_scheduler",
+      contextSnapshot: {
+        source: "scheduler",
+        reason: "interval_elapsed",
+        now: new Date().toISOString(),
+      },
+    });
+
+    // Skipped — no new run is queued behind the active issue_assigned run.
+    expect(result).toBeNull();
+
+    const allRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns);
+    expect(allRuns).toHaveLength(1);
+    expect(allRuns[0]?.id).toBe(runId);
+
+    const skippedWakeups = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        source: agentWakeupRequests.source,
+      })
+      .from(agentWakeupRequests)
+      .then((rows) => rows.filter((row) => row.source === "timer"));
+    expect(skippedWakeups).toHaveLength(1);
+    expect(skippedWakeups[0]).toMatchObject({
+      status: "skipped",
+      reason: "agent.has_active_run",
+    });
+  });
+
+  it("B.2: wakeup with non-timer source is NOT skipped by the active-run guard", async () => {
+    // Cross-task non-timer wakes (e.g. user-driven cross-issue wakes) must keep their
+    // existing semantics — only same-scope coalescing applies, and the active-run guard
+    // is intentionally scoped to source=timer.
+    const { agentId } = await seedAgentWithRun({
+      runStatus: "running",
+      runInvocationSource: "assignment",
+      runIssueId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "user",
+      reason: "user_wake",
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+      contextSnapshot: {},
+    });
+
+    // Either a new run is queued (different scope) or the wake coalesces into the
+    // active run via same-scope semantics — both are valid; the assertion is that the
+    // active-run guard does NOT silently skip this non-timer wake.
+    const skippedActiveRunGuard = await db
+      .select({
+        reason: agentWakeupRequests.reason,
+      })
+      .from(agentWakeupRequests)
+      .then((rows) => rows.find((row) => row.reason === "agent.has_active_run"));
+    expect(skippedActiveRunGuard).toBeUndefined();
+    expect(result).not.toBeNull();
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4776,9 +4776,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       });
       publishRunLifecyclePluginEvent(updated);
+      await autoCancelStaleRunEvaluationsOnTerminal(updated);
     }
 
     return updated;
+  }
+
+  // Auto-cancel-on-terminal-run:
+  // Once a heartbeat_run reaches a terminal status, any still-open
+  // `stale_active_run_evaluation` issue bound to that run is operating on a non-event.
+  // Auto-cancel them so the assignee is not woken by an alert about a run that no longer
+  // exists. Centralised here so all run-status transitions (finalization + cancellation)
+  // benefit uniformly.
+  async function autoCancelStaleRunEvaluationsOnTerminal(
+    updated: typeof heartbeatRuns.$inferSelect,
+  ) {
+    if (!(HEARTBEAT_RUN_TERMINAL_STATUSES as readonly string[]).includes(updated.status)) {
+      return;
+    }
+    try {
+      await recovery.closeOpenStaleEvaluationIssuesForRun({
+        companyId: updated.companyId,
+        runId: updated.id,
+        runStatus: updated.status,
+      });
+    } catch (err) {
+      logger.warn(
+        { err, runId: updated.id, runStatus: updated.status },
+        "failed to auto-cancel stale-run evaluation issues on run terminal",
+      );
+    }
   }
 
   async function setRunStatusIfRunning(
@@ -4810,6 +4837,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       });
       publishRunLifecyclePluginEvent(updated);
+      await autoCancelStaleRunEvaluationsOnTerminal(updated);
       return { run: updated, updated: true as const };
     }
 
@@ -11339,6 +11367,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       !sameScopeQueuedRun &&
       shouldQueueFollowupForRunningIssueWake({ contextSnapshot: enrichedContextSnapshot, wakeCommentId });
 
+    // Agent-level run-overlap guard (timer source):
+    // For timer-source wakes, skip entirely when the agent already has ANY active run
+    // — not just one in the same task scope. A `heartbeat_timer` wake fired while the
+    // agent has an `issue_assigned` run going has nothing new to do; queuing it up
+    // behind the active run creates a back-to-back overlap (the new run starts the
+    // moment the active one ends). We deliberately do NOT coalesce into the active
+    // run because the timer's context (`source: scheduler`, `reason: interval_elapsed`)
+    // would clobber the active run's issue context via mergeCoalescedContextSnapshot.
+    // Non-timer sources still fall through to the existing same-scope coalescing logic
+    // to preserve user/system wake semantics.
+    if (source === "timer" && activeRuns.length > 0) {
+      await writeSkippedRequest("agent.has_active_run");
+      return null;
+    }
+
     const rawCoalescedTarget =
       sameScopeQueuedRun ??
       sameScopeScheduledRetryRun ??
@@ -12054,6 +12097,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .innerJoin(companies, eq(companies.id, agents.companyId))
         .where(eq(companies.status, "active"));
       const agentsByCompany = groupAgentOrgRowsByCompany(allAgents.map(toAgentOrgRow));
+
+      // Agent-level run-overlap guard (scheduler side):
+      // Pre-fetch the set of agents that already have an active run
+      // (queued/running/scheduled_retry) so the scheduler skips them before issuing a
+      // new timer wake. Without this, a stuck issue_assigned run on agent X causes
+      // every tickTimers pass to enqueue another timer wake against X, which queues
+      // behind the active run and starts the moment it finishes — observable as a high
+      // count of back-to-back run-start pairs per agent in production telemetry.
+      const activeAgentRows = await db
+        .select({ agentId: heartbeatRuns.agentId })
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]));
+      const agentsWithActiveRun = new Set(activeAgentRows.map((row) => row.agentId));
+
       let checked = 0;
       let enqueued = 0;
       let skipped = 0;
@@ -12068,6 +12125,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const baseline = new Date(agent.lastHeartbeatAt ?? agent.createdAt).getTime();
         const elapsedMs = now.getTime() - baseline;
         if (elapsedMs < policy.intervalSec * 1000) continue;
+
+        if (agentsWithActiveRun.has(agent.id)) {
+          skipped += 1;
+          continue;
+        }
 
         const run = await enqueueWakeup(agent.id, {
           source: "timer",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -921,6 +921,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  // Lists open stale-run evaluation issues bound to a specific run. Used to auto-close
+  // alerts when the underlying run reaches a terminal status before a reviewer responds —
+  // the alert is moot once the run is no longer running, so leaving it open generates
+  // assignment wakes against a non-event.
+  async function listOpenStaleRunEvaluations(companyId: string, runId: string) {
+    return db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      );
+  }
+
   // Returns a `done` stale-run evaluation issue for this run if one exists.
   // Used to detect when a reviewer closed an alert directly on the board without going through
   // the watchdog decision API — which would not leave a dismissed_false_positive decision record.
@@ -1811,6 +1835,72 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
     return { kind: "created" as const, evaluationIssueId: evaluation.id };
+  }
+
+  // Auto-cancels any open `stale_active_run_evaluation` issues bound to a run that has
+  // reached a terminal status (completed/failed/cancelled/timeout). The alert was raised
+  // because the run was silent while still alive — once the run is gone, the alert is
+  // moot and would otherwise keep firing assignment wakes against the manager.
+  //
+  // We use `cancelled` (not `done`) because the closure is system-driven cleanup, not
+  // a reviewer's "false positive" verdict. `done` is reserved for explicit board acks
+  // and is what triggers the auto-`dismissed_false_positive` path in
+  // `createOrUpdateStaleRunEvaluation`.
+  async function closeOpenStaleEvaluationIssuesForRun(input: {
+    companyId: string;
+    runId: string;
+    runStatus: string;
+  }) {
+    const open = await listOpenStaleRunEvaluations(input.companyId, input.runId);
+    if (open.length === 0) return { closed: 0, issueIds: [] as string[] };
+
+    const closedIds: string[] = [];
+    for (const evaluation of open) {
+      try {
+        await issuesSvc.update(evaluation.id, { status: "cancelled" });
+        await issuesSvc.addComment(
+          evaluation.id,
+          [
+            "System-cancelled: underlying heartbeat run reached terminal status.",
+            "",
+            `- Run: \`${input.runId}\``,
+            `- Run terminal status: \`${input.runStatus}\``,
+            "- Outcome: alert is moot; the run can no longer be silent.",
+          ].join("\n"),
+          { runId: input.runId },
+        );
+        closedIds.push(evaluation.id);
+      } catch (err) {
+        logger.warn(
+          {
+            err,
+            evaluationIssueId: evaluation.id,
+            runId: input.runId,
+          },
+          "failed to auto-cancel stale-run evaluation issue on terminal run",
+        );
+      }
+    }
+
+    if (closedIds.length > 0) {
+      await logActivity(db, {
+        companyId: input.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: input.runId,
+        action: "heartbeat.stale_run_evaluation_auto_cancelled_on_terminal",
+        entityType: "heartbeat_run",
+        entityId: input.runId,
+        details: {
+          source: "recovery.close_open_stale_evaluation_issues_for_run",
+          runStatus: input.runStatus,
+          closedEvaluationIssueIds: closedIds,
+        },
+      });
+    }
+
+    return { closed: closedIds.length, issueIds: closedIds };
   }
 
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string }) {
@@ -4004,6 +4094,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,
     scanSilentActiveRuns,
+    closeOpenStaleEvaluationIssuesForRun,
     reconcileStrandedAssignedIssues,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,


### PR DESCRIPTION
Thinking Path
Paperclip is the open source app people use to manage AI agents for work.
The recovery watchdog raises a stale_active_run_evaluation issue when a heartbeat run goes silent past the suspicion threshold so the assignee's manager can triage.
In production we observed a feedback loop: a single stuck run (~40h) amplified into thousands of "Review silent active run" issues over a few days. Each closure on the board did not stop the next 30s scan from recreating the alert.
The dominant cause (sequential re-creation after board-close without a watchdog decision) was already addressed in 01e59c074a0481efa72700fd0b706315b81db06c.
Two gaps remain: (1) when the underlying run reaches a terminal status, any still-open evaluation issue is operating on a non-event and should be auto-cancelled; (2) the heartbeat scheduler does not pre-filter agents with active runs, and timer-source wakes only coalesce against same-task-scope runs, so a timer fired while an issue_assigned run is going queues a new run that starts the moment the active one ends — a measurable back-to-back overlap.
This pull request closes those two gaps with three small, scoped changes plus tests.
The benefit is that one stuck run can produce at most one open evaluation alert (auto-cancelled when the run terminates), and timer wakes can no longer pile up behind an active run on the same agent.
Linked Issues or Issue Description
No public GitHub issue exists for this; the problem is described in-PR following the Bug template.

Bug summary. When a heartbeat run becomes silent past ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS, the recovery watchdog raises a stale_active_run_evaluation issue. Today, if the underlying run reaches a terminal status (succeeded/failed/cancelled/timed_out) before a reviewer triages, the issue stays open and the assignee continues to be woken with an alert about a run that no longer exists.

Separately, tickTimers() and enqueueWakeup() only coalesce timer wakes by task scope. A heartbeat_timer wake fired while the agent already has an issue_assigned run going queues a new run that starts the moment the active one finishes — producing back-to-back run-start pairs visible in production telemetry.

What Changed
server/src/services/recovery/service.ts:
Added listOpenStaleRunEvaluations(companyId, runId) — lists open stale_active_run_evaluation issues bound to a run.
Added closeOpenStaleEvaluationIssuesForRun({ companyId, runId, runStatus }) — auto-cancels those open evaluations with a System-cancelled: underlying heartbeat run reached terminal status comment and records a heartbeat.stale_run_evaluation_auto_cancelled_on_terminal activity row. Uses cancelled (not done) because this is system-driven cleanup, not a reviewer's "false positive" verdict — done is reserved for explicit board acks and is what triggers the auto dismissed_false_positive path in createOrUpdateStaleRunEvaluation.
Exported closeOpenStaleEvaluationIssuesForRun.
server/src/services/heartbeat.ts:
Added autoCancelStaleRunEvaluationsOnTerminal(updated) and call it from setRunStatus and setRunStatusIfRunning whenever the run reaches a status in HEARTBEAT_RUN_TERMINAL_STATUSES. Centralised so all cancellation + finalization paths benefit uniformly.
tickTimers(): pre-fetch the set of agent ids with a queued/running/scheduled_retry run and skip them before issuing a timer wake. Counts toward skipped in the return summary.
enqueueWakeup() no-issue branch: for source === "timer", when the agent has ANY active run, write a skipped wakeup with reason agent.has_active_run and return null. Deliberately not coalesced into the active run because the timer's context (source: scheduler, reason: interval_elapsed) would clobber the active run's issue context via mergeCoalescedContextSnapshot. Non-timer sources keep the existing same-scope semantics.
server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts:
Added: "auto-cancels open stale-run evaluation issues when the underlying run is cancelled".
Added: "auto-cancel on terminal run is idempotent and only acts on the matching run".
server/src/__tests__/heartbeat-agent-active-run-overlap.test.ts (new):
tickTimers skips agents with a running run.
tickTimers skips agents with a queued run.
tickTimers still enqueues for agents with no active run.
wakeup with source=timer is skipped when the agent has an active issue_assigned run (different task scope).
wakeup with non-timer source is NOT skipped by the active-run guard (semantics preserved).
Verification
pnpm --filter @paperclipai/server typecheck
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/heartbeat-active-run-output-watchdog.test.ts \
  src/__tests__/heartbeat-agent-active-run-overlap.test.ts

Copy
Typecheck clean.
20/20 watchdog tests pass (including 2 new auto-cancel cases).
5/5 overlap tests pass.
Risks
Low to medium. The auto-cancel only acts on issues with originKind === stale_active_run_evaluation and matching originId === runId, so it cannot accidentally cancel unrelated work. The close is wrapped in try/catch so a failure to cancel does not break the run finalization path; a warn-level log is emitted on failure.
The scheduler-side guard adds one extra SELECT per tickTimers pass, bounded by the active-run table size and gated by EXECUTION_PATH_HEARTBEAT_RUN_STATUSES.
The enqueueWakeup change shifts timer-source semantics: previously a cross-task timer would queue a new run behind the active one (visible as overlap); now it is dropped with reason agent.has_active_run in agent_wakeup_requests. Non-timer sources are unchanged. The skipped wakeup is recorded with a clear reason so the behaviour is observable.
Model Used
Provider: Anthropic
Model: Claude Opus 4.7 (claude-opus-4-7), full agentic tool use, extended thinking enabled.
Mode: agentic code analysis + targeted edit, running in Claude Code.
Checklist
 I have included a thinking path that traces from project context to this change
 I have specified the model used (with version and capability details)
 I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
 I have searched GitHub for duplicate or related PRs and linked them above
 I have either (a) linked existing issues with Fixes: # / Closes # / Refs # OR (b) described the issue in-PR following the relevant issue template
 I have not referenced internal/instance-local Paperclip issues or links (only public GitHub #NNN / github.com/paperclipai/paperclip URLs)
 My branch name describes the change (e.g. docs/..., fix/...) and contains no internal Paperclip ticket id or instance-derived details
 I have run tests locally and they pass
 I have added or updated tests where applicable
 I have updated relevant documentation to reflect my changes (no user-facing docs changed)
 I have considered and documented any risks above
 All Paperclip CI gates are green (will verify after PR opens)
 Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address)
 I will address all Greptile and reviewer comments before requesting merge