### PR TITLE
Classify codex rmcp invalid_grant stderr as benign noise

### DIFF
--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -79,3 +79,15 @@ The environment test checks:
 - Working directory is absolute and available (auto-created if missing and permitted)
 - Authentication signal (`OPENAI_API_KEY` presence)
 - A live hello probe (`codex exec --json -` with prompt `Respond with hello.`) to verify the CLI can actually run
+
+## Known stderr Noise
+
+Successful `codex_local` runs may emit this exact rmcp transport line on stderr:
+
+```text
+ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when Auth(TokenRefreshFailed("Server returned error response: invalid_grant: Invalid refresh token"))
+```
+
+This is known-benign ambient MCP transport noise when the run otherwise continues and reaches a normal terminal state. Paperclip keeps the raw stderr in run logs, but operator-facing liveness and transcript summaries treat only this exact line as noise so it is not misattributed as a venture credential, Railway, or platform auth outage.
+
+Do not generalize this rule to other auth, token, `invalid_grant`, or refresh-token failures. Any nearby but non-identical auth/token failure remains actionable and should still be escalated through normal diagnostics.

--- a/server/src/__tests__/run-liveness.test.ts
+++ b/server/src/__tests__/run-liveness.test.ts
@@ -38,6 +38,27 @@ describe("run liveness classifier", () => {
     expect(classification.actionability).toBe("unknown");
   });
 
+  it("ignores chronic codex rmcp invalid_grant stderr as ambient noise", () => {
+    const classification = classifyRunLiveness({
+      ...baseInput,
+      stderrExcerpt:
+        'ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when Auth(TokenRefreshFailed("Server returned error response: invalid_grant: Invalid refresh token"))',
+    });
+
+    expect(classification.livenessState).toBe("empty_response");
+    expect(classification.actionability).toBe("unknown");
+  });
+
+  it("still escalates unrelated token/auth stderr", () => {
+    const classification = classifyRunLiveness({
+      ...baseInput,
+      stderrExcerpt: "Fatal: cannot proceed because primary agent auth needs a valid access token.",
+    });
+
+    expect(classification.livenessState).toBe("blocked");
+    expect(classification.actionability).toBe("blocked_external");
+  });
+
   it("treats issue comments, documents, products, and actions as progress", () => {
     const latestEvidenceAt = new Date("2026-04-18T12:00:00Z");
     const classification = classifyRunLiveness({

--- a/server/src/services/run-liveness.ts
+++ b/server/src/services/run-liveness.ts
@@ -75,6 +75,8 @@ const RUNNABLE_RE =
 const PLAN_TASK_TITLE_RE = /\b(?:plan|planning|analysis|investigation|research|report|proposal|design doc|write-?up)\b/i;
 const PLAN_TASK_DESCRIPTION_RE =
   /\b(?:create|write|produce|draft|update|revise|prepare)\s+(?:a\s+|the\s+)?(?:plan|analysis|investigation|research report|report|proposal|design doc|write-?up)\b/i;
+const CODEX_RMCP_INVALID_GRANT_NOISE_RE =
+  /^ERROR\s+rmcp::transport::worker:\s+worker quit with fatal:\s+Transport channel closed,\s+when Auth\(TokenRefreshFailed\("Server returned error response:\s+invalid_grant:\s+Invalid refresh token"\)\)$/i;
 
 function compactReason(reason: string) {
   return reason.length <= 500 ? reason : `${reason.slice(0, 497)}...`;
@@ -216,6 +218,7 @@ function isNoisyTranscriptLine(line: string) {
   const trimmed = line.trim();
   if (!trimmed) return true;
   return (
+    CODEX_RMCP_INVALID_GRANT_NOISE_RE.test(trimmed) ||
     /^(?:command|status|exit_code|tool|tool_call|tool_result|stdout|stderr|event|payload|session|cwd|ref_id)\s*:/i.test(trimmed) ||
     /^(?:\{|\[).{0,80}(?:tool|event|stdout|stderr|cmd|command|payload)/i.test(trimmed) ||
     /^\$?\s*(?:rg|sed|cat|ls|git|pnpm|npm|yarn|curl|node|python)\b/i.test(trimmed)

--- a/ui/src/components/transcript/RunTranscriptView.test.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.test.tsx
@@ -82,6 +82,50 @@ describe("RunTranscriptView", () => {
     });
   });
 
+  it("hides chronic codex rmcp invalid_grant stderr from nice mode normalization", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: 'ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when Auth(TokenRefreshFailed("Server returned error response: invalid_grant: Invalid refresh token"))',
+      },
+      {
+        kind: "assistant",
+        ts: "2026-03-12T00:00:01.000Z",
+        text: "Working on the task.",
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "Working on the task.",
+    });
+  });
+
+  it("keeps mixed stderr chunks visible when rmcp invalid_grant appears with real signal", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        kind: "stderr",
+        ts: "2026-03-12T00:00:00.000Z",
+        text: [
+          'ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when Auth(TokenRefreshFailed("Server returned error response: invalid_grant: Invalid refresh token"))',
+          "Fatal: primary token refresh failed for the Codex CLI.",
+        ].join("\n"),
+      },
+    ];
+
+    const blocks = normalizeTranscript(entries, false);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "stderr_group",
+    });
+  });
+
   it("renders successful result summaries as markdown in nice mode", () => {
     const html = renderToStaticMarkup(
       <ThemeProvider>

--- a/ui/src/components/transcript/RunTranscriptView.tsx
+++ b/ui/src/components/transcript/RunTranscriptView.tsx
@@ -20,6 +20,8 @@ const RAW_VIRTUALIZATION_THRESHOLD = 300;
 const RAW_OVERSCAN_ROWS = 40;
 const RAW_ESTIMATED_ROW_HEIGHT = 36;
 const RAW_INITIAL_ROWS = 180;
+const CODEX_RMCP_INVALID_GRANT_NOISE_RE =
+  /^ERROR\s+rmcp::transport::worker:\s+worker quit with fatal:\s+Transport channel closed,\s+when Auth\(TokenRefreshFailed\("Server returned error response:\s+invalid_grant:\s+Invalid refresh token"\)\)$/i;
 
 interface RunTranscriptViewProps {
   entries: TranscriptEntry[];
@@ -319,8 +321,18 @@ function parseSystemActivity(text: string): { activityId?: string; name: string;
 }
 
 function shouldHideNiceModeStderr(text: string): boolean {
-  const normalized = compactWhitespace(text).toLowerCase();
-  return normalized.startsWith("[paperclip] skipping saved session resume");
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return true;
+  return lines.every((line) => {
+    const normalized = compactWhitespace(line).toLowerCase();
+    return (
+      normalized.startsWith("[paperclip] skipping saved session resume") ||
+      CODEX_RMCP_INVALID_GRANT_NOISE_RE.test(line)
+    );
+  });
 }
 
 function groupCommandBlocks(blocks: TranscriptBlock[]): TranscriptBlock[] {


### PR DESCRIPTION
## Summary
- Treat only the exact chronic codex_local rmcp invalid_grant stderr line as noise in server liveness raw-output classification.
- Hide that same exact line in transcript nice mode when it appears alone, while keeping mixed stderr chunks visible.
- Document the known-benign signature in docs/adapters/codex-local.md with the boundary that other auth/token failures still escalate.

## Docs used
- docs/adapters/codex-local.md
- doc/spec/agent-runs.md

## Verification
- pnpm exec vitest run server/src/__tests__/run-liveness.test.ts ui/src/components/transcript/RunTranscriptView.test.tsx

## Risk frame
Successful codex_local stderr remains stored in raw logs and mixed/non-identical auth failures remain visible. The classifier only matches the exact rmcp TokenRefreshFailed invalid_grant line captured in VEN-1067.