### PR TITLE
fix(recovery): guard escalateStrandedAssignedIssue against terminal-status race

### DIFF
--- a/server/src/__tests__/recovery-terminal-status-race-guard.test.ts
+++ b/server/src/__tests__/recovery-terminal-status-race-guard.test.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+  activityLog,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../telemetry.ts", () => ({ getTelemetryClient: () => mockTelemetryClient }));
+
+import { recoveryService } from "../services/recovery/service.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres terminal-status race-guard tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+// Regression coverage for the race condition where reconcileStrandedAssignedIssues
+// reads an issue (status="in_progress"), the assignee patches it to "done" before
+// escalateStrandedAssignedIssue can finish, and the recovery sweep then overwrites
+// the completion with "blocked" — causing a reopen / ping-pong loop.
+//
+// The guard re-reads the issue's status immediately before mutating it. If the
+// fresh status is terminal ("done" / "cancelled"), escalation is skipped.
+describeEmbeddedPostgres("recovery escalateStrandedAssignedIssue terminal-status race guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-terminal-race-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "failed",
+      invocationSource: "manual",
+      finishedAt: new Date(),
+    });
+
+    return { companyId, agentId, runId };
+  }
+
+  it("skips escalation and leaves status untouched when the issue is `done` between scan and update", async () => {
+    const { companyId, agentId, runId } = await seed();
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Race: assignee completes between reconcile scan and recovery update",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    // Snapshot the issue as the reconcile sweep would have seen it (in_progress).
+    const [staleSnapshot] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(staleSnapshot.status).toBe("in_progress");
+
+    // Simulate the assignee winning the race: patch the row to `done` AFTER the
+    // sweep took its snapshot but BEFORE escalateStrandedAssignedIssue runs.
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, issueId));
+
+    const enqueueWakeup = vi.fn();
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: staleSnapshot,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: runId,
+        agentId,
+        status: "failed",
+        error: null,
+        errorCode: null,
+        contextSnapshot: null,
+        livenessState: null,
+      } as any,
+    });
+
+    // The guard short-circuits — no return value, no wake, no flip to blocked.
+    expect(result).toBeNull();
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+
+    const [final] = await db
+      .select({ status: issues.status, assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(final).toEqual({ status: "done", assigneeAgentId: agentId });
+  });
+
+  it("also skips when the assignee won the race with `cancelled` rather than `done`", async () => {
+    const { companyId, agentId, runId } = await seed();
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Race: issue cancelled between reconcile scan and recovery update",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const [staleSnapshot] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId));
+
+    await db.update(issues).set({ status: "cancelled" }).where(eq(issues.id, issueId));
+
+    const enqueueWakeup = vi.fn();
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.escalateStrandedAssignedIssue({
+      issue: staleSnapshot,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: runId,
+        agentId,
+        status: "failed",
+        error: null,
+        errorCode: null,
+        contextSnapshot: null,
+        livenessState: null,
+      } as any,
+    });
+
+    expect(result).toBeNull();
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+
+    const [final] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(final.status).toBe("cancelled");
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2350,6 +2350,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }) {
     if (input.recoveryCause === "workspace_validation_failed") return;
     if (input.recoveryCause === "configuration_incomplete") return;
+    // Defence-in-depth: if the source issue already reached a terminal status,
+    // do not emit a recovery wake. The primary guard lives in
+    // escalateStrandedAssignedIssue, but this is a cheap second check that
+    // prevents stale callers from waking owners against a `done`/`cancelled`
+    // issue.
+    if (isTerminalIssueStatus(input.issue.status)) return;
     if (!input.action.ownerAgentId) return;
     await deps.enqueueWakeup(input.action.ownerAgentId, {
       source: "assignment",
@@ -2553,6 +2559,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         previousStatus: input.previousStatus,
         latestRun: input.latestRun,
       });
+    }
+
+    // Race guard: between the reconcile scan that produced `input.issue` and this
+    // call, the assignee may have patched the issue to a terminal status. Re-read
+    // the latest status; if terminal, skip escalation entirely so we do not
+    // overwrite the assignee's completion with `blocked` and trigger a reopen loop.
+    const freshStatusRow = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, input.issue.id))
+      .limit(1)
+      .then((rows) => rows[0]);
+    if (freshStatusRow && isTerminalIssueStatus(freshStatusRow.status)) {
+      return null;
     }
 
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";


### PR DESCRIPTION
## Summary

`reconcileStrandedAssignedIssues` snapshots an issue, then later calls `escalateStrandedAssignedIssue` to flip it to `blocked`. If the assignee patches the issue to `done` (or `cancelled`) between the snapshot and the update, the recovery sweep overwrites the completion with `blocked`. The dependent graph then re-wakes the original owner, who re-marks `done`, and the cycle repeats — a reopen / ping-pong loop.

## Changes

Two guards in `server/src/services/recovery/service.ts`:

1. **Primary guard** — `escalateStrandedAssignedIssue` re-reads the issue's status from the database immediately after the early-return checks. If the fresh status is terminal (`done` / `cancelled`), the function returns `null` and skips the rest of the escalation pipeline. No `blocked` flip, no recovery action, no wake. Placed at function entry (after the existing `isStrandedIssueRecoveryIssue` early return) rather than immediately before `issuesSvc.update` so we don't leave a phantom recovery action behind in the racing path.

2. **Defence-in-depth** — `enqueueSourceScopedStrandedRecoveryWake` also checks `isTerminalIssueStatus(input.issue.status)` at entry. The primary guard already prevents the racing path from reaching this function, but a future caller passing a stale `input.issue` should still not be able to wake owners against a terminal issue.

Both guards reuse the existing `isTerminalIssueStatus` predicate.

## Tests

New: `server/src/__tests__/recovery-terminal-status-race-guard.test.ts` — uses the existing embedded-Postgres harness (same pattern as `recovery-stale-issue-lock-sweep.test.ts`). Two cases:

- The assignee patches `done` between the reconcile snapshot and the recovery update → `escalateStrandedAssignedIssue` returns `null`, status stays `done`, no wake is enqueued.
- Same scenario with `cancelled` instead of `done`.

## Background

Discovered in production via a local TeamE deployment (internal ticket `TEAAAA-229`): an issue was being repeatedly reopened from `done` → `blocked` by the recovery sweep, only to be re-completed by the assignee on the next heartbeat. The patch has been validated in that environment by patching the compiled `dist/services/recovery/service.js` directly. This PR ports the validated fix to the TypeScript source and adds the regression test.

## Test plan

- [ ] CI green on the new test file and existing recovery tests
- [ ] No regression in `recovery-stale-issue-lock-sweep.test.ts` or `service.pause-durability.test.ts`
- [ ] Verify in a release that the TEAAAA-229 ping-pong shape does not recur on rollout

---

🤖 Submitted on behalf of @teamesys via Claude Code (Team-E internal escalation TEAAAA-233).