### PR TITLE
fix(recovery): guard escalateStrandedAssignedIssue against terminal-status race condition

### DIFF
--- a/server/src/services/recovery/service.terminal-race-guard.test.ts
+++ b/server/src/services/recovery/service.terminal-race-guard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { recoveryService } from "./service.js";
+
+// Minimal DB mock for the terminal-status race-guard tests.
+// We only need to stub the `select` chain used by escalateStrandedAssignedIssue
+// to re-read the issue status before overwriting it.
+function makeDb(freshStatus: string | null) {
+  const selectResult = freshStatus !== null ? [{ status: freshStatus }] : [];
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(selectResult),
+      }),
+    }),
+  } as any;
+}
+
+function makeIssue(status: string) {
+  return {
+    id: "issue-1",
+    companyId: "company-1",
+    identifier: "TST-1",
+    title: "Test issue",
+    status,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    executionState: null,
+    parentId: null,
+    metadata: null,
+  } as any;
+}
+
+const latestRun = {
+  id: "run-1",
+  agentId: "agent-1",
+  status: "failed",
+  errorCode: "process_lost",
+  contextSnapshot: null,
+  outputCount: 0,
+  lastOutputAt: null,
+} as any;
+
+describe("escalateStrandedAssignedIssue — terminal-status race guard (TEAAAA-229)", () => {
+  it("returns null without calling issuesSvc.update when DB re-read shows done", async () => {
+    const db = makeDb("done");
+    const issueUpdateSpy = vi.fn();
+    const svc = recoveryService(db, { enqueueWakeup: vi.fn() } as any);
+
+    // Patch internal issuesSvc — we reach it through recoveryService's closure,
+    // but here we verify the guard fires before any update by checking the spy.
+    // Since the real issuesSvc is not injected (it comes from the module),
+    // the test verifies that escalation returns null for a terminal issue.
+    const result = await (svc as any).escalateStrandedAssignedIssue({
+      issue: makeIssue("in_progress"),
+      previousStatus: "in_progress",
+      latestRun,
+    }).catch(() => null); // The real issuesSvc will fail without a real DB; null is the expected guard return.
+
+    // If the guard fires correctly, result is null and issueUpdateSpy was never called.
+    expect(result).toBeNull();
+    expect(issueUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null without calling issuesSvc.update when DB re-read shows cancelled", async () => {
+    const db = makeDb("cancelled");
+    const issueUpdateSpy = vi.fn();
+    const svc = recoveryService(db, { enqueueWakeup: vi.fn() } as any);
+
+    const result = await (svc as any).escalateStrandedAssignedIssue({
+      issue: makeIssue("in_progress"),
+      previousStatus: "in_progress",
+      latestRun,
+    }).catch(() => null);
+
+    expect(result).toBeNull();
+    expect(issueUpdateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("enqueueSourceScopedStrandedRecoveryWake — terminal-status skip guard (TEAAAA-229)", () => {
+  it("does not call enqueueWakeup when source issue status is done", async () => {
+    const db = makeDb("done");
+    const enqueueWakeup = vi.fn();
+    const svc = recoveryService(db, { enqueueWakeup } as any);
+
+    // Calling through reconcileStrandedAssignedIssues would require a full DB;
+    // instead verify the guard logic by inspecting that no wake is sent when
+    // the issue is already terminal by the time enqueueSourceScopedStrandedRecoveryWake runs.
+    // This is a documentation-level integration reminder — the full integration test
+    // lives in the reconcile integration suite.
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/recovery/service.terminal-race-guard.test.ts
+++ b/server/src/services/recovery/service.terminal-race-guard.test.ts
@@ -1,9 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
+
+// Module-level mocks for the issue service and recovery-action service so we
+// can spy on issuesSvc.update and observe whether the terminal-status guards
+// short-circuit before any write happens.
+const { issueUpdateSpy, ensureRecoveryActionSpy, enqueueWakeupSpy } = vi.hoisted(() => ({
+  issueUpdateSpy: vi.fn(),
+  ensureRecoveryActionSpy: vi.fn(),
+  enqueueWakeupSpy: vi.fn(),
+}));
+
+vi.mock("../issues.js", async () => {
+  const actual = await vi.importActual<typeof import("../issues.js")>("../issues.js");
+  return {
+    ...actual,
+    issueService: () => ({
+      update: issueUpdateSpy,
+      existingUnresolvedBlockerIssueIds: async () => [],
+    }),
+  };
+});
+
+vi.mock("../issue-recovery-actions.js", async () => {
+  const actual = await vi.importActual<typeof import("../issue-recovery-actions.js")>(
+    "../issue-recovery-actions.js",
+  );
+  return {
+    ...actual,
+    issueRecoveryActionService: () => ({
+      upsertSourceScoped: ensureRecoveryActionSpy,
+    }),
+  };
+});
+
 import { recoveryService } from "./service.js";
 
-// Minimal DB mock for the terminal-status race-guard tests.
-// We only need to stub the `select` chain used by escalateStrandedAssignedIssue
-// to re-read the issue status before overwriting it.
 function makeDb(freshStatus: string | null) {
   const selectResult = freshStatus !== null ? [{ status: freshStatus }] : [];
   return {
@@ -27,6 +57,7 @@ function makeIssue(status: string) {
     executionState: null,
     parentId: null,
     metadata: null,
+    originKind: null,
   } as any;
 }
 
@@ -40,54 +71,48 @@ const latestRun = {
   lastOutputAt: null,
 } as any;
 
-describe("escalateStrandedAssignedIssue — terminal-status race guard (TEAAAA-229)", () => {
-  it("returns null without calling issuesSvc.update when DB re-read shows done", async () => {
+describe("escalateStrandedAssignedIssue — terminal-status race guard", () => {
+  it("returns null and skips issuesSvc.update + recovery-action upsert when fresh DB status is done", async () => {
+    issueUpdateSpy.mockReset();
+    ensureRecoveryActionSpy.mockReset();
     const db = makeDb("done");
-    const issueUpdateSpy = vi.fn();
-    const svc = recoveryService(db, { enqueueWakeup: vi.fn() } as any);
+    const svc = recoveryService(db, { enqueueWakeup: enqueueWakeupSpy } as any);
 
-    // Patch internal issuesSvc — we reach it through recoveryService's closure,
-    // but here we verify the guard fires before any update by checking the spy.
-    // Since the real issuesSvc is not injected (it comes from the module),
-    // the test verifies that escalation returns null for a terminal issue.
-    const result = await (svc as any).escalateStrandedAssignedIssue({
+    const result = await svc.escalateStrandedAssignedIssue({
       issue: makeIssue("in_progress"),
       previousStatus: "in_progress",
       latestRun,
-    }).catch(() => null); // The real issuesSvc will fail without a real DB; null is the expected guard return.
+    });
 
-    // If the guard fires correctly, result is null and issueUpdateSpy was never called.
     expect(result).toBeNull();
     expect(issueUpdateSpy).not.toHaveBeenCalled();
+    // The recovery-action upsert lives after the guard, so it must not run either —
+    // this catches a regression where the guard is deleted but issuesSvc.update is
+    // also removed: ensureRecoveryActionSpy would still get called.
+    expect(ensureRecoveryActionSpy).not.toHaveBeenCalled();
   });
 
-  it("returns null without calling issuesSvc.update when DB re-read shows cancelled", async () => {
+  it("returns null and skips issuesSvc.update + recovery-action upsert when fresh DB status is cancelled", async () => {
+    issueUpdateSpy.mockReset();
+    ensureRecoveryActionSpy.mockReset();
     const db = makeDb("cancelled");
-    const issueUpdateSpy = vi.fn();
-    const svc = recoveryService(db, { enqueueWakeup: vi.fn() } as any);
+    const svc = recoveryService(db, { enqueueWakeup: enqueueWakeupSpy } as any);
 
-    const result = await (svc as any).escalateStrandedAssignedIssue({
+    const result = await svc.escalateStrandedAssignedIssue({
       issue: makeIssue("in_progress"),
       previousStatus: "in_progress",
       latestRun,
-    }).catch(() => null);
+    });
 
     expect(result).toBeNull();
     expect(issueUpdateSpy).not.toHaveBeenCalled();
+    expect(ensureRecoveryActionSpy).not.toHaveBeenCalled();
   });
-});
 
-describe("enqueueSourceScopedStrandedRecoveryWake — terminal-status skip guard (TEAAAA-229)", () => {
-  it("does not call enqueueWakeup when source issue status is done", async () => {
-    const db = makeDb("done");
-    const enqueueWakeup = vi.fn();
-    const svc = recoveryService(db, { enqueueWakeup } as any);
-
-    // Calling through reconcileStrandedAssignedIssues would require a full DB;
-    // instead verify the guard logic by inspecting that no wake is sent when
-    // the issue is already terminal by the time enqueueSourceScopedStrandedRecoveryWake runs.
-    // This is a documentation-level integration reminder — the full integration test
-    // lives in the reconcile integration suite.
-    expect(enqueueWakeup).not.toHaveBeenCalled();
-  });
+  // Regression-detection note: the two tests above NO LONGER use a
+  // `.catch(() => null)` swallow. If the guard at service.ts:2562 is removed,
+  // the next line (`ensureSourceScopedStrandedRecoveryAction`) reaches into
+  // the real DB through `resolveStrandedIssueRecoveryOwnerAgentId`, which
+  // fails against the stub `db` here — the resulting unhandled rejection
+  // surfaces as a failed test rather than a silently-green one.
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2351,6 +2351,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (input.recoveryCause === "workspace_validation_failed") return;
     if (input.recoveryCause === "configuration_incomplete") return;
     if (!input.action.ownerAgentId) return;
+    // TEAAAA-229 fix: Don't send recovery wakes when source issue already reached terminal state.
+    if (isTerminalIssueStatus(input.issue.status)) return;
     await deps.enqueueWakeup(input.action.ownerAgentId, {
       source: "assignment",
       triggerDetail: "system",
@@ -2553,6 +2555,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         previousStatus: input.previousStatus,
         latestRun: input.latestRun,
       });
+    }
+
+    // TEAAAA-229 fix: Re-read status before overwriting — guards against race condition where
+    // the assignee patched done/cancelled between the reconcile scan and this update.
+    const freshStatus = await db.select({ status: issues.status }).from(issues)
+      .where(eq(issues.id, input.issue.id)).then(rows => rows[0]?.status ?? null);
+    if (freshStatus !== null && isTerminalIssueStatus(freshStatus)) {
+      logger.info({ issueId: input.issue.id, freshStatus }, "escalateStrandedAssignedIssue: skipping — issue already terminal");
+      return null;
     }
 
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2351,7 +2351,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (input.recoveryCause === "workspace_validation_failed") return;
     if (input.recoveryCause === "configuration_incomplete") return;
     if (!input.action.ownerAgentId) return;
-    // TEAAAA-229 fix: Don't send recovery wakes when source issue already reached terminal state.
+    // Don't enqueue recovery wakes when the source issue already reached a
+    // terminal state — otherwise the recovery action would keep firing and
+    // re-flipping a completed issue back to in_progress.
     if (isTerminalIssueStatus(input.issue.status)) return;
     await deps.enqueueWakeup(input.action.ownerAgentId, {
       source: "assignment",
@@ -2557,8 +2559,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
 
-    // TEAAAA-229 fix: Re-read status before overwriting — guards against race condition where
-    // the assignee patched done/cancelled between the reconcile scan and this update.
+    // Re-read status before overwriting — guards against the race where the
+    // assignee patched the issue to done/cancelled between the reconcile scan
+    // and this update, which would otherwise trigger an infinite reopen loop
+    // via the source_scoped_recovery_action wake.
     const freshStatus = await db.select({ status: issues.status }).from(issues)
       .where(eq(issues.id, input.issue.id)).then(rows => rows[0]?.status ?? null);
     if (freshStatus !== null && isTerminalIssueStatus(freshStatus)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery service `reconcileStrandedAssignedIssues` is responsible for moving stranded in-progress issues to `blocked` so a human can intervene
> - It reads the issue snapshot, then later calls `issuesSvc.update(id, { status: 'blocked' })` to escalate — a TOCTOU window between the two operations
> - When an assignee patches the issue to `done` (or `cancelled`) inside that window, the recovery write overwrites the terminal status with `blocked`, and the next sweep flips it back to `in_progress` via `source_scoped_recovery_action`, causing an infinite ping-pong reopen loop
> - This pull request closes the race by re-reading status from the DB immediately before the write, and skipping recovery wakes when the source issue is already terminal
> - The benefit is that legitimately-completed issues stay `done` and stranded recovery does not silently overwrite agent decisions

## Linked Issues or Issue Description

No public GitHub issue — describing the bug inline below.

### Bug

**Summary:** `reconcileStrandedAssignedIssues` overwrites terminal issue status (`done` / `cancelled`) with `blocked` when the assignee completes the issue between the recovery scan and the recovery write, causing an infinite reopen loop driven by `source_scoped_recovery_action`.

**Steps to reproduce:**
1. Have an in-progress issue assigned to an agent that has no live run (so it is eligible for stranded recovery).
2. Inside the reconcile sweep, between `escalateStrandedAssignedIssue` reading the issue snapshot and calling `issuesSvc.update(..., { status: 'blocked' })`, have the assignee PATCH the issue to `done`.
3. Observe that recovery overwrites `done` → `blocked`. The next sweep then triggers another reopen via the recovery action wake, and the loop never converges.

**Expected:** Recovery should detect the terminal status and skip the write.

**Actual:** Recovery overwrites the terminal status, triggers more recovery wakes, and ping-pongs.

## What Changed

- `server/src/services/recovery/service.ts` — `escalateStrandedAssignedIssue` now re-reads `issues.status` from the DB right before the `issuesSvc.update(..., { status: 'blocked' })` call; if the fresh status is terminal (`done` / `cancelled`), it logs and returns `null` instead of overwriting.
- `server/src/services/recovery/service.ts` — `enqueueSourceScopedStrandedRecoveryWake` now early-returns when `input.issue.status` is already terminal, preventing follow-on recovery wakes for issues that have already resolved.
- `server/src/services/recovery/service.terminal-race-guard.test.ts` — new test covering the race-guard behaviour for both `done` and `cancelled` terminal statuses.

## Verification

- New test: `pnpm --filter server test src/services/recovery/service.terminal-race-guard.test.ts` — verifies that `escalateStrandedAssignedIssue` returns `null` and does NOT call `issuesSvc.update` when the fresh DB status is `done` or `cancelled`.
- Full server suite green in this PR's CI run (`General tests (server (1/3..3/3))`, `Verify serialized server suites (1/4..4/4)`, `e2e`, `Canary Dry Run`).
- Manual: the same patch (compiled JS) has been running on the reporter's local instance since 2026-06-21; the previously-recurring done→in_progress ping-pong on the affected issue has stopped.

## Risks

- Low risk. Both guards are read-only filters that strictly narrow the set of issues recovery will touch. If `freshStatus` is `null` (issue missing) or non-terminal, behaviour is unchanged. If the DB read fails, the existing surrounding error handling applies — no new failure mode is introduced.
- No migration, no schema change, no breaking change to public APIs.
- One extra single-column status read per `escalateStrandedAssignedIssue` invocation; negligible cost relative to the work the recovery path already does.

## Model Used

- Provider: Anthropic
- Model: Claude
- Model ID: `claude-opus-4-7`
- Mode: standard Claude Code session (no extended thinking flag)
- Tool use: Read / Edit / Bash via Claude Code CLI; no autonomous code execution beyond Claude Code's normal tool surface

## Dedup search

- [x] I have searched the [GitHub PR list](https://github.com/paperclipai/paperclip/pulls?q=is%3Apr+recovery+stranded+terminal) for similar PRs touching `recovery/service.ts` / `escalateStrandedAssignedIssue` / stranded recovery and confirmed this is the canonical PR. PR #8418 was a prior draft from the same author and has been closed as superseded by this PR.

