### PR TITLE
fix(approvals): deduplicate pending board approvals per issueId+type

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -12,6 +12,7 @@ const mockApprovalService = vi.hoisted(() => ({
   resubmit: vi.fn(),
   listComments: vi.fn(),
   addComment: vi.fn(),
+  findPendingForIssueIds: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -127,6 +128,7 @@ describe("approval routes idempotent retries", () => {
     mockApprovalService.resubmit.mockReset();
     mockApprovalService.listComments.mockReset();
     mockApprovalService.addComment.mockReset();
+    mockApprovalService.findPendingForIssueIds.mockReset();
     mockHeartbeatService.wakeup.mockReset();
     mockIssueApprovalService.listIssuesForApproval.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
@@ -443,5 +445,69 @@ describe("approval routes idempotent retries", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toContain("Cheap status-only recovery runs cannot create or modify approvals");
     expect(mockApprovalService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("returns existing pending approval instead of creating a duplicate for same issueId+type", async () => {
+    const existingApproval = {
+      id: "approval-existing",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve hosting spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    };
+    mockApprovalService.findPendingForIssueIds.mockResolvedValue(existingApproval);
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend" },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe("approval-existing");
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+    expect(mockIssueApprovalService.linkManyForApproval).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("creates a new approval after previous one is resolved", async () => {
+    mockApprovalService.findPendingForIssueIds.mockResolvedValue(null);
+    mockApprovalService.create.mockResolvedValue({
+      id: "approval-new",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve hosting spend v2" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend v2" },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("approval-new");
+    expect(mockApprovalService.create).toHaveBeenCalled();
+    expect(mockIssueApprovalService.linkManyForApproval).toHaveBeenCalled();
+    expect(mockLogActivity).toHaveBeenCalled();
   });
 });

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -145,6 +145,14 @@ export function approvalRoutes(
           )
         : approvalInput.payload;
 
+    if (uniqueIssueIds.length > 0) {
+      const existingPending = await svc.findPendingForIssueIds(companyId, uniqueIssueIds, approvalInput.type);
+      if (existingPending) {
+        res.status(200).json(redactApprovalPayload(existingPending));
+        return;
+      }
+    }
+
     const actor = getActorInfo(req);
     const approval = await svc.create(companyId, {
       ...approvalInput,

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { approvalComments, approvals } from "@paperclipai/db";
+import { approvalComments, approvals, issueApprovals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { agentService } from "./agents.js";
@@ -282,6 +282,25 @@ export function approvalService(db: Db) {
         })
         .returning()
         .then((rows) => redactApprovalComment(rows[0], currentUserRedactionOptions.enabled));
+    },
+
+    findPendingForIssueIds: async (companyId: string, issueIds: string[], type: string) => {
+      if (issueIds.length === 0) return null;
+      const row = await db
+        .select({ approval: approvals })
+        .from(issueApprovals)
+        .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+        .where(
+          and(
+            inArray(issueApprovals.issueId, issueIds),
+            eq(approvals.companyId, companyId),
+            eq(approvals.type, type),
+            eq(approvals.status, "pending"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0]?.approval ?? null);
+      return row;
     },
   };
 }


### PR DESCRIPTION
## Thinking Path

PAP-372 reports that `POST /companies/:companyId/approvals` creates duplicate pending board approvals for the same issue+type pair. Two failure modes: agent double-fire (same run calls `request_board_approval` twice) and watcher auto-file (independent file alongside agent-filed approval).

**Root cause**: The POST handler always inserts a new approval row regardless of existing pending approvals linked to the same issueIds with the same type.

**Fix**: Add a `findPendingForIssueIds` service method that JOINs `issue_approvals` → `approvals` and checks for any `pending` approval already linked to the submitted issueIds with the matching type. In the POST handler, check before creating — if found, return the existing approval with HTTP 200.

**Files changed**:
1. `server/src/services/approvals.ts` — added `findPendingForIssueIds` method
2. `server/src/routes/approvals.ts` — added deduplication check before `svc.create()`
3. `server/src/__tests__/approval-routes-idempotency.test.ts` — added 2 new tests

## What Changed

- Added `findPendingForIssueIds(companyId, issueIds, type)` to approval service: JOINs `issue_approvals` → `approvals`, returns first pending match or null.
- Added deduplication guard in `POST /companies/:companyId/approvals`: checks for existing pending approval before creating; returns existing with 200 if found.
- Added test: "returns existing pending approval instead of creating a duplicate for same issueId+type" — verifies 200, no create/link/log calls.
- Added test: "creates a new approval after previous one is resolved" — verifies 201, create/link/log all called when no pending exists.

## Verification

```
pnpm --filter @paperclipai/server typecheck  # passed
npx vitest run server/src/__tests__/approval-routes-idempotency.test.ts  # 13/13 passed
npx vitest run server/src/__tests__/approvals-service.test.ts  # 6/6 passed
```

## Risks

- The deduplication check only applies when `issueIds` is non-empty. Approvals without issueIds will still create new rows (per spec, dedup is per issueId+type).
- Returns HTTP 200 instead of 201 for duplicates — clients should handle both status codes for approval creation.
- Only checks `pending` status — resolved/rejected approvals do not block new ones (correct behavior per spec).

## Model Used

None — human-authored

## Checklist

- [x] Behavior matches `doc/SPEC-implementation.md` requirements
- [x] Typecheck passes (server package)
- [x] All tests pass (13/13 in approval-routes-idempotency.test.ts, 6/6 in approvals-service.test.ts)
- [x] Contracts synced across db/schema, service, route, and tests
- [x] Only changed files committed (no `git add -A`)
- [x] PR description follows template with all sections filled
