### PR TITLE
fix(approvals): deduplicate pending board approvals per issueId+type

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -12,6 +12,7 @@ const mockApprovalService = vi.hoisted(() => ({
   resubmit: vi.fn(),
   listComments: vi.fn(),
   addComment: vi.fn(),
+  findPendingForIssueIds: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -127,6 +128,7 @@ describe("approval routes idempotent retries", () => {
     mockApprovalService.resubmit.mockReset();
     mockApprovalService.listComments.mockReset();
     mockApprovalService.addComment.mockReset();
+    mockApprovalService.findPendingForIssueIds.mockReset();
     mockHeartbeatService.wakeup.mockReset();
     mockIssueApprovalService.listIssuesForApproval.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
@@ -443,5 +445,141 @@ describe("approval routes idempotent retries", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toContain("Cheap status-only recovery runs cannot create or modify approvals");
     expect(mockApprovalService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("returns existing pending approval instead of creating a duplicate for same issueId+type", async () => {
+    const existingApproval = {
+      id: "approval-existing",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve hosting spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-06-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    };
+
+    // First call: no existing pending approval, so it creates one
+    mockApprovalService.findPendingForIssueIds.mockResolvedValueOnce(null);
+    mockApprovalService.create.mockResolvedValueOnce(existingApproval);
+
+    // Second call: existing pending approval found, should return it without calling create
+    mockApprovalService.findPendingForIssueIds.mockResolvedValueOnce(existingApproval);
+
+    const agentApp = await createAgentApp();
+
+    // First POST — should create
+    const res1 = await request(agentApp)
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend" },
+      });
+    expect(res1.status).toBe(201);
+    expect(res1.body.id).toBe("approval-existing");
+    expect(mockApprovalService.create).toHaveBeenCalledTimes(1);
+    expect(mockIssueApprovalService.linkManyForApproval).toHaveBeenCalledTimes(1);
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+
+    // Reset mocks for second call
+    vi.clearAllMocks();
+    mockApprovalService.findPendingForIssueIds.mockResolvedValueOnce(existingApproval);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      action: "company_scope:read",
+      reason: "allow_test",
+      explanation: "Allowed by test mock.",
+    });
+
+    // Second POST — should return existing, not create
+    const res2 = await request(agentApp)
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend" },
+      });
+    expect(res2.status).toBe(200);
+    expect(res2.body.id).toBe("approval-existing");
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+    expect(mockIssueApprovalService.linkManyForApproval).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("creates a new approval after previous one is resolved", async () => {
+    const firstApproval = {
+      id: "approval-first",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "approved",
+      payload: { title: "Approve hosting spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-06-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    };
+
+    const secondApproval = {
+      id: "approval-second",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve hosting spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-06-02T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-02T00:00:00.000Z"),
+    };
+
+    // First POST: no pending approval found, creates first one
+    mockApprovalService.findPendingForIssueIds.mockResolvedValueOnce(null);
+    mockApprovalService.create.mockResolvedValueOnce(firstApproval);
+
+    const agentApp = await createAgentApp();
+
+    const res1 = await request(agentApp)
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend" },
+      });
+    expect(res1.status).toBe(201);
+    expect(res1.body.id).toBe("approval-first");
+    expect(mockApprovalService.create).toHaveBeenCalledTimes(1);
+
+    // Reset mocks
+    vi.clearAllMocks();
+    mockApprovalService.findPendingForIssueIds.mockResolvedValueOnce(null);
+    mockApprovalService.create.mockResolvedValueOnce(secondApproval);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      action: "company_scope:read",
+      reason: "allow_test",
+      explanation: "Allowed by test mock.",
+    });
+
+    // Second POST: first approval is resolved (approved), so no pending match, creates new one
+    const res2 = await request(agentApp)
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend" },
+      });
+    expect(res2.status).toBe(201);
+    expect(res2.body.id).toBe("approval-second");
+    expect(mockApprovalService.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -145,6 +145,15 @@ export function approvalRoutes(
           )
         : approvalInput.payload;
 
+    // Deduplicate: if a pending approval already exists for any of the issueIds+type, return it.
+    if (uniqueIssueIds.length > 0) {
+      const existingPending = await svc.findPendingForIssueIds(companyId, uniqueIssueIds, approvalInput.type);
+      if (existingPending) {
+        res.status(200).json(redactApprovalPayload(existingPending));
+        return;
+      }
+    }
+
     const actor = getActorInfo(req);
     const approval = await svc.create(companyId, {
       ...approvalInput,

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { approvalComments, approvals } from "@paperclipai/db";
+import { approvalComments, approvals, issueApprovals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { agentService } from "./agents.js";
@@ -282,6 +282,25 @@ export function approvalService(db: Db) {
         })
         .returning()
         .then((rows) => redactApprovalComment(rows[0], currentUserRedactionOptions.enabled));
+    },
+
+    findPendingForIssueIds: async (companyId: string, issueIds: string[], type: string) => {
+      if (issueIds.length === 0) return null;
+      const row = await db
+        .select({ approval: approvals })
+        .from(issueApprovals)
+        .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+        .where(
+          and(
+            inArray(issueApprovals.issueId, issueIds),
+            eq(approvals.companyId, companyId),
+            eq(approvals.type, type),
+            eq(approvals.status, "pending"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0]?.approval ?? null);
+      return row;
     },
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The approvals subsystem (`POST /companies/:companyId/approvals`) manages board-level approval requests from agents
> - A bug allows duplicate pending approvals to be created for the same issue+type pair — this happens when an agent double-fires or a watcher files an approval alongside one the agent already created
> - Duplicate approvals force operators to open both and compare, with no safe way to dismiss one
> - This pull request adds an idempotency guard: before inserting a new approval, it checks for an existing pending approval linked to the same `issueIds` + `type`, and returns the existing record (HTTP 200) if one is found
> - The benefit is that downstream agents and operators get a stable, deduplicated approval object regardless of how many times the POST is called

## Linked Issues or Issue Description

Fixes: #8179

## What Changed

- **server/src/services/approvals.ts**: Added `findPendingForIssueIds(companyId, issueIds, type)` method that JOINs `issue_approvals` → `approvals` and returns any pending approval already linked to those issueIds with that type. Added `issueApprovals` to imports.
- **server/src/routes/approvals.ts**: In `POST /companies/:companyId/approvals`, added dedup check after `uniqueIssueIds` is computed and before `svc.create()`. If a match is found, return 200 with existing approval (skip insert, skip linkMany, skip logActivity).
- **server/src/__tests__/approval-routes-idempotency.test.ts**: Added `findPendingForIssueIds` mock. Added two tests: (1) second POST with same issueId+type returns existing pending approval without calling svc.create; (2) POST after first approval is resolved (null return) creates a new one normally with 201.

## Verification

```bash
cd /home/isak/projects/paperclip-dev/server && npx vitest run src/__tests__/approval-routes-idempotency.test.ts
```
Result: 10 tests passed (8 existing + 2 new), 792ms.

```bash
cd /home/isak/projects/paperclip-dev && pnpm --filter @paperclipai/server typecheck
```
Result: passed (0 errors).

## Risks

- The dedup check only applies when `uniqueIssueIds.length > 0`. Approvals without issue IDs will still create new rows (no dedup possible). This is correct behavior per the spec.
- If the same agent double-fires with different issueIds, only issueId overlap matters — non-overlapping issueIds will create separate approvals. This is correct.
- No DB migration needed; only reads from existing tables.
- Concurrent double-fire edge case: two simultaneous requests can both pass the check-before-insert window. Accepted trade-off for now — this is an application-level guard targeting the common sequential double-fire case.

## Model Used

Devstral-Small-2-24B via hermes_local on the GX10.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #8179` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/deduplicate-pending-approvals`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
