### PR TITLE
[codex] Harden asset and plugin entrypoint handling

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -388,6 +388,7 @@ Rules:
   backwards compatibility
 - `capabilities` must be static and install-time visible
 - config schema must be JSON Schema compatible
+- `entrypoints.worker` and `entrypoints.ui` are relative package paths; absolute paths, URL-like paths, and `..` traversal segments are invalid
 - `entrypoints.ui` points to the directory containing the built UI bundle
 - `ui.slots` declares which extension slots the plugin fills, so the host knows what to mount without loading the bundle eagerly; each slot references an `exportName` from the UI bundle
 - declare managed declarations with the matching `*.managed` capability:

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1322,6 +1322,7 @@ export {
   pluginLauncherDeclarationSchema,
   pluginDatabaseDeclarationSchema,
   pluginApiRouteDeclarationSchema,
+  isSafePackageRelativeEntrypoint,
   pluginManifestV1Schema,
   installPluginSchema,
   upsertPluginConfigSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -543,6 +543,7 @@ export {
   pluginManagedSkillFileDeclarationSchema,
   pluginManagedSkillDeclarationSchema,
   pluginApiRouteDeclarationSchema,
+  isSafePackageRelativeEntrypoint,
   pluginManifestV1Schema,
   installPluginSchema,
   upsertPluginConfigSchema,

--- a/packages/shared/src/validators/plugin.test.ts
+++ b/packages/shared/src/validators/plugin.test.ts
@@ -37,6 +37,53 @@ describe("plugin manifest validators", () => {
 
     expect(parsed.capabilities).toEqual(["ui.dashboardWidget.register"]);
   });
+
+  it.each([
+    "../dist/worker.js",
+    "dist/../../worker.js",
+    "/tmp/worker.js",
+    "C:\\tmp\\worker.js",
+    "https://example.com/worker.js",
+  ])("rejects unsafe worker entrypoint %s", (worker) => {
+    const parsed = pluginManifestV1Schema.safeParse({
+      id: "paperclip.unsafe-worker",
+      apiVersion: 1,
+      version: "0.1.0",
+      displayName: "Unsafe Worker",
+      description: "Plugin with an unsafe worker entrypoint.",
+      author: "Paperclip",
+      categories: ["automation"],
+      capabilities: ["jobs.schedule"],
+      entrypoints: { worker },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it.each([
+    "../dist/ui",
+    "dist/../../ui",
+    "/tmp/ui",
+    "C:\\tmp\\ui",
+    "https://example.com/ui",
+  ])("rejects unsafe UI entrypoint %s", (ui) => {
+    const parsed = pluginManifestV1Schema.safeParse({
+      id: "paperclip.unsafe-ui",
+      apiVersion: 1,
+      version: "0.1.0",
+      displayName: "Unsafe UI",
+      description: "Plugin with an unsafe UI entrypoint.",
+      author: "Paperclip",
+      categories: ["ui"],
+      capabilities: ["ui.dashboardWidget.register"],
+      entrypoints: {
+        worker: "./dist/worker.js",
+        ui,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
 });
 
 describe("plugin managed routine validators", () => {

--- a/packages/shared/src/validators/plugin.ts
+++ b/packages/shared/src/validators/plugin.ts
@@ -567,6 +567,34 @@ export const pluginApiRouteDeclarationSchema = z.object({
 
 export type PluginApiRouteDeclarationInput = z.infer<typeof pluginApiRouteDeclarationSchema>;
 
+const entrypointWindowsDrivePathPattern = /^[a-zA-Z]:/;
+const entrypointUrlSchemePattern = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+export function isSafePackageRelativeEntrypoint(entrypoint: string): boolean {
+  const candidate = entrypoint.trim();
+  if (!candidate || candidate.includes("\0")) return false;
+  if (
+    candidate.startsWith("/")
+    || candidate.startsWith("\\")
+    || candidate.startsWith("//")
+    || candidate.startsWith("\\\\")
+    || entrypointWindowsDrivePathPattern.test(candidate)
+    || entrypointUrlSchemePattern.test(candidate)
+  ) {
+    return false;
+  }
+
+  return candidate
+    .replace(/\\/g, "/")
+    .split("/")
+    .every(segment => segment !== "..");
+}
+
+const pluginEntrypointPathSchema = z.string().min(1).refine(
+  isSafePackageRelativeEntrypoint,
+  "Entrypoint paths must be relative to the plugin package and cannot contain '..' segments",
+);
+
 // ---------------------------------------------------------------------------
 // Plugin Manifest V1 schema
 // ---------------------------------------------------------------------------
@@ -589,8 +617,8 @@ export type PluginApiRouteDeclarationInput = z.infer<typeof pluginApiRouteDeclar
  * | `minimumHostVersion`     | string?    | semver lower bound if present, no leading `v`|
  * | `minimumPaperclipVersion`| string?    | legacy alias of `minimumHostVersion`         |
  * | `capabilities`           | enum[]     | at least one; values from PLUGIN_CAPABILITIES|
- * | `entrypoints.worker`     | string     | min 1 char                                   |
- * | `entrypoints.ui`         | string?    | required when `ui.slots` is declared         |
+ * | `entrypoints.worker`     | string     | relative package path; no `..` segments      |
+ * | `entrypoints.ui`         | string?    | relative package path; required for UI       |
  *
  * Cross-field rules enforced via `superRefine`:
  * - `entrypoints.ui` required when `ui.slots` declared
@@ -631,8 +659,8 @@ export const pluginManifestV1Schema = z.object({
   ).optional(),
   capabilities: z.array(z.enum(PLUGIN_CAPABILITIES)).min(1),
   entrypoints: z.object({
-    worker: z.string().min(1),
-    ui: z.string().min(1).optional(),
+    worker: pluginEntrypointPathSchema,
+    ui: pluginEntrypointPathSchema.optional(),
   }),
   instanceConfigSchema: jsonSchemaSchema.optional(),
   jobs: z.array(pluginJobDeclarationSchema).optional(),

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import express from "express";
 import request from "supertest";
+import { Readable } from "node:stream";
 import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import type { StorageService } from "../storage/types.js";
 
@@ -174,26 +175,65 @@ describe("POST /api/companies/:companyId/assets/images", () => {
     });
   });
 
-  it("allows supported non-image attachments outside the company logo flow", async () => {
-    const text = createStorageService("text/plain");
-    const app = await createApp(text);
-
-    createAssetMock.mockResolvedValue({
-      ...createAsset(),
-      contentType: "text/plain",
-      originalFilename: "note.txt",
-    });
+  it("rejects HTML uploads to the image asset endpoint", async () => {
+    const html = createStorageService("text/html");
+    const app = await createApp(html);
 
     const res = await requestApp(app, (baseUrl) =>
       request(baseUrl)
         .post("/api/companies/company-1/assets/images")
         .field("namespace", "issues/drafts")
-        .attach("file", Buffer.from("hello"), { filename: "note.txt", contentType: "text/plain" }),
+        .attach("file", Buffer.from("<script>alert(1)</script>"), { filename: "payload.html", contentType: "text/html" }),
     );
 
-    expect([200, 201]).toContain(res.status);
-    expect(res.body.contentPath).toBe("/api/assets/asset-1/content");
-    expect(res.body.contentType).toBe("text/plain");
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("Unsupported image type: text/html");
+    expect(createAssetMock).not.toHaveBeenCalled();
+    expect(html.__calls.putFileInputs).toHaveLength(0);
+  });
+});
+
+describe("GET /api/assets/:assetId/content", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/assets.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/assets.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    createAssetMock.mockReset();
+    getAssetByIdMock.mockReset();
+    logActivityMock.mockReset();
+  });
+
+  it("forces stored HTML assets to download under a sandbox CSP", async () => {
+    const storage = createStorageService("text/html");
+    const app = await createApp(storage);
+    const body = Buffer.from("<script>alert(1)</script>");
+    getAssetByIdMock.mockResolvedValue({
+      ...createAsset(),
+      contentType: "text/html",
+      byteSize: body.length,
+      originalFilename: "payload.html",
+    });
+    vi.mocked(storage.getObject).mockResolvedValue({
+      stream: Readable.from([body]),
+      contentType: "text/html",
+      contentLength: body.length,
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get("/api/assets/asset-1/content"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.headers["content-disposition"]).toContain("attachment;");
+    expect(res.headers["content-security-policy"]).toContain("sandbox");
+    expect(storage.getObject).toHaveBeenCalledWith("company-1", "assets/abc");
   });
 });
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1017,24 +1017,20 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(retryRun?.processLossRetryCount).toBe(1);
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
 
-    const issue = await waitForValue(async () =>
-      db
-        .select()
-        .from(issues)
-        .where(eq(issues.id, issueId))
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          return row?.checkoutRunId === null ? row : null;
-        })
-    );
-    expect([retryRun?.id ?? null, null]).toContain(issue?.executionRunId ?? null);
+    const checkoutReleasedIssue = await waitForValue(async () => {
+      const row = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+      if (row?.checkoutRunId !== null) return null;
 
-    const checkoutReleasedIssue = await waitForValue(async () =>
-      db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
-        const row = rows[0] ?? null;
-        return row?.checkoutRunId === null ? row : null;
-      })
-    );
+      const latestRetryRun = retryRun?.id ? await heartbeat.getRun(retryRun.id) : null;
+      const retryIsActive = latestRetryRun?.status === "queued" || latestRetryRun?.status === "running";
+      if (retryIsActive && row.executionRunId !== retryRun?.id) return null;
+      if (!retryIsActive && row.executionRunId !== null) return null;
+
+      return row;
+    });
+    const latestRetryRun = retryRun?.id ? await heartbeat.getRun(retryRun.id) : null;
+    const retryIsActive = latestRetryRun?.status === "queued" || latestRetryRun?.status === "running";
+    expect(checkoutReleasedIssue?.executionRunId).toBe(retryIsActive ? retryRun?.id : null);
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
   });

--- a/server/src/__tests__/plugin-entrypoint-paths.test.ts
+++ b/server/src/__tests__/plugin-entrypoint-paths.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  isSafePackageRelativeEntrypoint,
+  resolveExistingPackageEntrypoint,
+} from "../services/plugin-entrypoint-paths.js";
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-plugin-entrypoints-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("plugin entrypoint path helpers", () => {
+  it("accepts package-relative entrypoints", () => {
+    expect(isSafePackageRelativeEntrypoint("./dist/worker.js")).toBe(true);
+    expect(isSafePackageRelativeEntrypoint("dist/ui")).toBe(true);
+  });
+
+  it.each([
+    "../dist/worker.js",
+    "dist/../../worker.js",
+    "/tmp/worker.js",
+    "C:\\tmp\\worker.js",
+    "https://example.com/worker.js",
+  ])("rejects unsafe entrypoint path %s", (entrypoint) => {
+    expect(isSafePackageRelativeEntrypoint(entrypoint)).toBe(false);
+  });
+
+  it("resolves existing files inside the package root", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "plugin");
+    const worker = path.join(packageRoot, "dist", "worker.js");
+    fs.mkdirSync(path.dirname(worker), { recursive: true });
+    fs.writeFileSync(worker, "export {};\n", "utf8");
+
+    expect(resolveExistingPackageEntrypoint(packageRoot, "./dist/worker.js", "file")).toBe(worker);
+  });
+
+  it("rejects sibling-prefix traversal outside the package root", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "plugin");
+    const outsideWorker = path.join(root, "plugin-evil", "worker.js");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.mkdirSync(path.dirname(outsideWorker), { recursive: true });
+    fs.writeFileSync(outsideWorker, "export {};\n", "utf8");
+
+    expect(resolveExistingPackageEntrypoint(packageRoot, "../plugin-evil/worker.js", "file")).toBeNull();
+  });
+
+  it("rejects symlinks that resolve outside the package root", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "plugin");
+    const outsideWorker = path.join(root, "outside", "worker.js");
+    const linkPath = path.join(packageRoot, "dist", "worker.js");
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.mkdirSync(path.dirname(outsideWorker), { recursive: true });
+    fs.writeFileSync(outsideWorker, "export {};\n", "utf8");
+    fs.symlinkSync(outsideWorker, linkPath);
+
+    expect(resolveExistingPackageEntrypoint(packageRoot, "./dist/worker.js", "file")).toBeNull();
+  });
+});

--- a/server/src/__tests__/plugin-ui-static.test.ts
+++ b/server/src/__tests__/plugin-ui-static.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolvePluginUiDir } from "../routes/plugin-ui-static.js";
+
+const tempRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-plugin-ui-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("resolvePluginUiDir", () => {
+  it("resolves UI directories inside a persisted package path", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "plugin");
+    const uiDir = path.join(packageRoot, "dist", "ui");
+    fs.mkdirSync(uiDir, { recursive: true });
+
+    expect(resolvePluginUiDir(root, "paperclip-plugin-test", "./dist/ui", packageRoot)).toBe(uiDir);
+  });
+
+  it("rejects sibling-prefix traversal from a persisted package path", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "plugin");
+    const outsideUiDir = path.join(root, "plugin-evil", "ui");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.mkdirSync(outsideUiDir, { recursive: true });
+
+    expect(resolvePluginUiDir(root, "paperclip-plugin-test", "../plugin-evil/ui", packageRoot)).toBeNull();
+  });
+
+  it("rejects traversal from a node_modules package root", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "node_modules", "paperclip-plugin-test");
+    const outsideUiDir = path.join(root, "secret", "ui");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.mkdirSync(outsideUiDir, { recursive: true });
+
+    expect(resolvePluginUiDir(root, "paperclip-plugin-test", "../../secret/ui")).toBeNull();
+  });
+
+  it("rejects UI directory symlinks that resolve outside the package root", () => {
+    const root = createTempRoot();
+    const packageRoot = path.join(root, "plugin");
+    const outsideUiDir = path.join(root, "outside-ui");
+    const linkPath = path.join(packageRoot, "dist", "ui");
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.mkdirSync(outsideUiDir, { recursive: true });
+    fs.symlinkSync(outsideUiDir, linkPath, "dir");
+
+    expect(resolvePluginUiDir(root, "paperclip-plugin-test", "./dist/ui", packageRoot)).toBeNull();
+  });
+});

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -2107,6 +2107,8 @@ describe("realizeExecutionWorkspace", () => {
     const bareRemote = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-bare-symref-"));
     await runGit(bareRemote, ["init", "--bare"]);
     await runGit(repoRoot, ["remote", "add", "origin", bareRemote]);
+    // Hosts with git init.defaultBranch=main do not create a local master branch.
+    await runGit(repoRoot, ["branch", "-f", "master", "main"]);
     await runGit(repoRoot, ["push", "-u", "origin", "main", "master"]);
     await runGit(repoRoot, ["fetch", "origin"]);
     // Explicitly set refs/remotes/origin/HEAD to exercise the symbolic-ref path

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -6,10 +6,11 @@ import type { Db } from "@paperclipai/db";
 import { createAssetImageMetadataSchema } from "@paperclipai/shared";
 import type { StorageService } from "../storage/types.js";
 import { assetService, logActivity } from "../services/index.js";
-import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
+import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 const SVG_CONTENT_TYPE = "image/svg+xml";
-const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
+const HTML_CONTENT_TYPES = new Set(["text/html", "application/xhtml+xml"]);
+const ALLOWED_IMAGE_CONTENT_TYPES = new Set([
   "image/png",
   "image/jpeg",
   "image/jpg",
@@ -139,8 +140,8 @@ export function assetRoutes(db: Db, storage: StorageService) {
 
     const namespaceSuffix = parsedMeta.data.namespace ?? "general";
     const contentType = (file.mimetype || "").toLowerCase();
-    if (contentType !== SVG_CONTENT_TYPE && !isAllowedContentType(contentType)) {
-      res.status(422).json({ error: `Unsupported file type: ${contentType || "unknown"}` });
+    if (!ALLOWED_IMAGE_CONTENT_TYPES.has(contentType)) {
+      res.status(422).json({ error: `Unsupported image type: ${contentType || "unknown"}` });
       return;
     }
     let fileBody = file.buffer;
@@ -235,7 +236,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
     }
 
     const contentType = (file.mimetype || "").toLowerCase();
-    if (!ALLOWED_COMPANY_LOGO_CONTENT_TYPES.has(contentType)) {
+    if (!ALLOWED_IMAGE_CONTENT_TYPES.has(contentType)) {
       res.status(422).json({ error: `Unsupported image type: ${contentType || "unknown"}` });
       return;
     }
@@ -320,15 +321,17 @@ export function assetRoutes(db: Db, storage: StorageService) {
 
     const object = await storage.getObject(asset.companyId, asset.objectKey);
     const responseContentType = asset.contentType || object.contentType || "application/octet-stream";
+    const responseMediaType = responseContentType.split(";")[0]?.trim().toLowerCase() ?? "";
     res.setHeader("Content-Type", responseContentType);
     res.setHeader("Content-Length", String(asset.byteSize || object.contentLength || 0));
     res.setHeader("Cache-Control", "private, max-age=60");
     res.setHeader("X-Content-Type-Options", "nosniff");
-    if (responseContentType === SVG_CONTENT_TYPE) {
+    if (responseMediaType === SVG_CONTENT_TYPE || HTML_CONTENT_TYPES.has(responseMediaType)) {
       res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'");
     }
     const filename = asset.originalFilename ?? "asset";
-    res.setHeader("Content-Disposition", `inline; filename=\"${filename.replaceAll("\"", "")}\"`);
+    const disposition = HTML_CONTENT_TYPES.has(responseMediaType) ? "attachment" : "inline";
+    res.setHeader("Content-Disposition", `${disposition}; filename=\"${filename.replaceAll("\"", "")}\"`);
 
     object.stream.on("error", (err) => {
       next(err);

--- a/server/src/routes/plugin-ui-static.ts
+++ b/server/src/routes/plugin-ui-static.ts
@@ -33,6 +33,7 @@ import fs from "node:fs";
 import crypto from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { pluginRegistryService } from "../services/plugin-registry.js";
+import { resolveExistingPackageEntrypoint } from "../services/plugin-entrypoint-paths.js";
 import { logger } from "../middleware/logger.js";
 
 // ---------------------------------------------------------------------------
@@ -114,16 +115,8 @@ export function resolvePluginUiDir(
 ): string | null {
   // For local-path installs, prefer the persisted package path.
   if (packagePath) {
-    const resolvedPackagePath = path.resolve(packagePath);
-    if (fs.existsSync(resolvedPackagePath)) {
-      const uiDirFromPackagePath = path.resolve(resolvedPackagePath, entrypointsUi);
-      if (
-        uiDirFromPackagePath.startsWith(resolvedPackagePath)
-        && fs.existsSync(uiDirFromPackagePath)
-      ) {
-        return uiDirFromPackagePath;
-      }
-    }
+    const uiDirFromPackagePath = resolveExistingPackageEntrypoint(packagePath, entrypointsUi, "directory");
+    if (uiDirFromPackagePath) return uiDirFromPackagePath;
   }
 
   // Resolve the package root within the local plugin directory's node_modules.
@@ -151,15 +144,7 @@ export function resolvePluginUiDir(
     }
   }
 
-  // Resolve the UI directory relative to the package root
-  const uiDir = path.resolve(packageRoot, entrypointsUi);
-
-  // Verify the resolved UI directory exists and is actually inside the package
-  if (!fs.existsSync(uiDir)) {
-    return null;
-  }
-
-  return uiDir;
+  return resolveExistingPackageEntrypoint(packageRoot, entrypointsUi, "directory");
 }
 
 /**

--- a/server/src/services/plugin-entrypoint-paths.ts
+++ b/server/src/services/plugin-entrypoint-paths.ts
@@ -1,0 +1,48 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import { isSafePackageRelativeEntrypoint } from "@paperclipai/shared";
+
+export type PluginEntrypointKind = "file" | "directory" | "any";
+
+export { isSafePackageRelativeEntrypoint };
+
+export function isPathWithinDirectory(root: string, target: string): boolean {
+  const relativePath = path.relative(root, target);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+export function resolvePackageRelativeEntrypoint(packageRoot: string, entrypoint: string): string | null {
+  if (!isSafePackageRelativeEntrypoint(entrypoint)) return null;
+
+  const resolvedPackageRoot = path.resolve(packageRoot);
+  const resolvedEntrypoint = path.resolve(resolvedPackageRoot, entrypoint);
+  if (!isPathWithinDirectory(resolvedPackageRoot, resolvedEntrypoint)) return null;
+
+  return resolvedEntrypoint;
+}
+
+export function resolveExistingPackageEntrypoint(
+  packageRoot: string,
+  entrypoint: string,
+  expectedKind: PluginEntrypointKind = "any",
+): string | null {
+  const resolvedEntrypoint = resolvePackageRelativeEntrypoint(packageRoot, entrypoint);
+  if (!resolvedEntrypoint || !existsSync(resolvedEntrypoint)) return null;
+
+  let entrypointStat;
+  let realPackageRoot: string;
+  let realEntrypoint: string;
+  try {
+    entrypointStat = statSync(resolvedEntrypoint);
+    realPackageRoot = realpathSync(path.resolve(packageRoot));
+    realEntrypoint = realpathSync(resolvedEntrypoint);
+  } catch {
+    return null;
+  }
+
+  if (expectedKind === "file" && !entrypointStat.isFile()) return null;
+  if (expectedKind === "directory" && !entrypointStat.isDirectory()) return null;
+  if (!isPathWithinDirectory(realPackageRoot, realEntrypoint)) return null;
+
+  return resolvedEntrypoint;
+}

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -49,6 +49,7 @@ import type { PluginJobStore } from "./plugin-job-store.js";
 import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
+import { resolveExistingPackageEntrypoint } from "./plugin-entrypoint-paths.js";
 
 const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -2316,9 +2317,9 @@ function resolveWorkerEntrypoint(
   const workerRelPath = manifest.entrypoints.worker;
 
   // For local-path installs we persist the resolved package path; use it first
-  if (plugin.packagePath && existsSync(plugin.packagePath)) {
-    const entrypoint = path.resolve(plugin.packagePath, workerRelPath);
-    if (entrypoint.startsWith(path.resolve(plugin.packagePath)) && existsSync(entrypoint)) {
+  if (plugin.packagePath) {
+    const entrypoint = resolveExistingPackageEntrypoint(plugin.packagePath, workerRelPath, "file");
+    if (entrypoint) {
       return entrypoint;
     }
   }
@@ -2341,22 +2342,10 @@ function resolveWorkerEntrypoint(
 
   // Try in order: node_modules path, direct path
   for (const dir of [packageDir, directDir]) {
-    const entrypoint = path.resolve(dir, workerRelPath);
-
-    // Security: ensure entrypoint is actually inside the directory (prevent path traversal)
-    if (!entrypoint.startsWith(path.resolve(dir))) {
-      continue;
-    }
-
-    if (existsSync(entrypoint)) {
+    const entrypoint = resolveExistingPackageEntrypoint(dir, workerRelPath, "file");
+    if (entrypoint) {
       return entrypoint;
     }
-  }
-
-  // Fallback: try the worker path as-is (absolute or relative to cwd)
-  // ONLY if it's already an absolute path and we trust the manifest (which we've already validated)
-  if (path.isAbsolute(workerRelPath) && existsSync(workerRelPath)) {
-    return workerRelPath;
   }
 
   throw new Error(

--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -1025,6 +1025,16 @@ describe("NewIssueDialog", () => {
       enableIsolatedWorkspaces: false,
       enableTaskWatchdogs: true,
     });
+    mockAgentsApi.list.mockResolvedValue([
+      {
+        id: "agent-9",
+        name: "Watchdog",
+        role: "executor",
+        title: null,
+        icon: "scan-eye",
+        status: "idle",
+      },
+    ]);
     localStorage.setItem(
       "paperclip:issue-draft",
       JSON.stringify({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source control plane for AI agent companies, their tasks, files, and plugin extensions.
> - The asset system stores uploaded files and serves them back through authenticated routes.
> - The plugin system loads worker and UI entrypoints from package manifests and local package paths.
> - Those boundaries should treat user-provided MIME types and plugin manifest paths as untrusted input.
> - The previous implementation allowed image upload routes to accept broader attachment types, served stored HTML inline, and used prefix-style path containment for plugin entrypoints.
> - This PR narrows those trust boundaries with image-only upload gates, download-only sandboxed HTML delivery, and package-relative plugin entrypoint resolution with realpath containment.
> - The benefit is a smaller upload and plugin-package attack surface while preserving valid image, SVG, and package-relative plugin behavior.

## Linked Issues or Issue Description

No public GitHub issue exists for this audit finding, so the issue is described inline.

Duplicate PR search found only this PR and the old closed plugin-support PR [#432](https://github.com/paperclipai/paperclip/pull/432), which is related to plugin infrastructure but is not a duplicate of this security hardening.

### What happened

Asset and plugin entrypoint handling accepted more input surface than necessary. Image upload routes could accept non-image attachment content, stored HTML assets could be served inline, and plugin worker/UI entrypoints relied on string-prefix containment checks that are easy to get wrong around sibling-prefix paths and symlinks.

### Expected behavior

Image upload endpoints should accept only image content types. Stored HTML/XHTML assets should download under a sandbox CSP instead of rendering inline. Plugin entrypoints should be package-relative, reject traversal/absolute/URL-like paths, and stay inside the package after realpath resolution.

### Steps to reproduce

1. Upload HTML content through the image asset endpoint.
2. Request stored HTML asset content and inspect Content-Disposition/CSP headers.
3. Install or resolve a plugin whose worker/UI entrypoint points outside the package root via traversal or symlink.

### Paperclip version or commit

Observed during local audit of `master` before this PR.

## What Changed

- Restricted company image and logo upload flows to explicit image MIME types.
- Forced stored HTML/XHTML asset responses to use `Content-Disposition: attachment` with a sandbox CSP.
- Added a shared package-relative plugin entrypoint validator and reused it from server-side entrypoint resolution.
- Replaced plugin UI and worker entrypoint path resolution with realpath-backed package containment checks.
- Removed the worker-loader absolute path fallback for manifest entrypoints.
- Added focused tests for asset handling, plugin entrypoint resolution, symlink escapes, validator rejection, heartbeat retry cleanup, git default branches, and watchdog draft restoration.
- Documented plugin entrypoint path constraints in the plugin spec.

## Verification

- `npx --yes pnpm@9.15.4 exec vitest run server/src/__tests__/plugin-entrypoint-paths.test.ts packages/shared/src/validators/plugin.test.ts`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/shared typecheck`
- `npx --yes pnpm@9.15.4 --filter @paperclipai/server typecheck`
- `npx --yes pnpm@9.15.4 test`
- `git diff --check`

## Risks

- Existing callers that used the image asset endpoint for non-image attachments will now receive `422`; this is intentional because the endpoint is image-specific.
- Plugins with absolute worker/UI entrypoints or traversal-style manifest paths will no longer load; plugin entrypoints are now required to be package-relative.
- Stored HTML/XHTML assets can still be downloaded, but they will no longer render inline through the asset content route.

## Model Used

OpenAI GPT-5 via Codex desktop, with tool-assisted repository inspection, local test execution, GitHub CLI usage, and code editing. Reasoning was used internally by the coding agent; no hidden chain-of-thought is included in this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green or addressed by this PR-body update
- [x] Greptile feedback has been addressed in code and PR metadata
- [x] I will address all Greptile and reviewer comments before requesting merge
