### PR TITLE
fix(openclaw-gateway): support gateway protocol v4 (OpenClaw 2026.6.x)

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -50,3 +50,14 @@ describe("resolveSessionKey", () => {
     ).toBe("agent:meridian:paperclip");
   });
 });
+
+import { PROTOCOL_VERSION } from "./execute.js";
+
+describe("PROTOCOL_VERSION (gateway protocol negotiation)", () => {
+  // OpenClaw 2026.6.x gateways require protocol v4 (`expected=4 probeMin=4`).
+  // The adapter must negotiate >=4 or the WebSocket connect is rejected with
+  // `[ws] protocol mismatch` (code 1002). See issue #8440.
+  it("negotiates gateway protocol v4 or higher (OpenClaw 2026.6.x compatibility)", () => {
+    expect(PROTOCOL_VERSION).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,7 +86,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 4;
+export const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,7 +86,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
@@ -1144,7 +1144,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
 
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
     agentParams.agentId = configuredAgentId;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `openclaw-gateway` adapter connects Paperclip agents to an OpenClaw gateway over WebSocket
> - OpenClaw's gateway protocol moved to **v4** (2026.6.x), but the bundled adapter still negotiates **v3** (`minProtocol=3, maxProtocol=3`) → `[ws] protocol mismatch … expected=4 probeMin=4`, WS close 1002
> - After a version bump, v4's strict agent-params schema also rejects the adapter's top-level `paperclip` property → `invalid agent params: at root: unexpected property 'paperclip'`
> - This blocks every `openclaw_gateway` agent heartbeat against a current OpenClaw gateway
> - This PR negotiates v4 and stops sending the rejected `paperclip` agent-param (Paperclip context still reaches the agent via the wake text + the claimed API key file)
> - The benefit: `openclaw_gateway` agents connect and run against OpenClaw 2026.6.x

## Linked Issues or Issue Description

- Fixes: #8440

## What Changed

- `packages/adapters/openclaw-gateway/src/server/execute.ts`: `const PROTOCOL_VERSION = 3;` → `export const PROTOCOL_VERSION = 4;` (negotiate v4).
- Same file: removed `agentParams.paperclip = paperclipPayload;` (v4 rejects the top-level `paperclip` agent-param).
- `packages/adapters/openclaw-gateway/src/server/execute.test.ts`: added a test asserting `PROTOCOL_VERSION >= 4`.

## Verification

- New unit test: `expect(PROTOCOL_VERSION).toBeGreaterThanOrEqual(4)` in `execute.test.ts` (run via `pnpm test:run:general`; CI will run it).
- Integration (against OpenClaw 2026.6.8, `ws://127.0.0.1:18789`, token + device auth): onboarded an `openclaw_gateway` agent (invite → accept → approve → claim); heartbeat `succeeded`; gateway log `[ws] ⇄ res ✓ agent`; run log shows the agent streaming + making Paperclip `/api/` calls (issues). Before the fix: `[ws] protocol mismatch` (code 1002), then `invalid agent params: unexpected property 'paperclip'`.

## Risks

- **Dropped structured context.** Removing `paperclip` from agent-params loses the structured Paperclip context (runId/agentId/apiUrl/workspace/…). This is a **stop-gap**: maintainers should carry that context in whatever field v4 expects rather than dropping it. Treat the v4 protocol contract as source of truth.
- **v3 gateways.** Gateways still on v3 will reject v4 negotiation. If dual support is wanted, negotiate `min=3 max=4` instead (not done here, to keep the fix minimal).
- Low risk otherwise; the change is two lines + a test.

## Model Used

- The bug was surfaced and the fix derived during a self-hosted Paperclip deployment operated by an AI coding assistant (Codex, `gpt-5.4`, via the `codex_local` adapter). The diff itself was hand-derived from the observed `[ws] protocol mismatch` gateway logs and the v4 `unexpected property 'paperclip'` rejection — no model authored the patch wholesale.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] Dedup-search: searched GitHub for `openclaw-gateway protocol v4` / `openclaw protocol mismatch` — no existing PRs found
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR — `Fixes: #8440`
- [x] I have run tests locally and they pass (new `PROTOCOL_VERSION` test; full suite via `pnpm test:run:general`)
- [x] I have added or updated tests where applicable
- N/A — no UI changes
- N/A — no docs changes required
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI on this push)
- [ ] Greptile is 5/5 (pending)
- [x] I will address all Greptile and reviewer comments before requesting merge
