### PR TITLE
fix(finops): suppress idle timer heartbeats

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -324,10 +324,39 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     });
     expect(wakeup?.payload).toMatchObject({
       heartbeatSkip: {
-        reason: expect.stringContaining("No assigned todo or in_progress issue"),
+        reason: expect.stringContaining("No assigned todo, in_progress, or in_review issue"),
       },
     });
     expect(runRows).toHaveLength(0);
+  });
+
+  it("skips generic timer wakes by default when no assigned work is actionable", async () => {
+    const { agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+      },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [wakeup] = await db
+      .select({
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+
+    expect(wakeup).toMatchObject({
+      status: "skipped",
+      reason: "heartbeat.timer.no_actionable_work",
+    });
   });
 
   it("rate-limits skipped generic timer wakes by advancing the timer baseline", async () => {
@@ -393,11 +422,38 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(run!.id)).toBe(1);
   });
 
-  it("runs generic timer wakes by default for proactive agents without assigned issue work", async () => {
+  it("allows generic timer wakes for explicitly configured proactive agents without assigned issue work", async () => {
     const { agentId } = await seedCompanyAndAgent({
       heartbeatConfig: {
         enabled: true,
+        allowIdleTimerWakes: true,
       },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).not.toBeNull();
+    await waitForCondition(async () => countExecuteCallsForRun(run!.id) > 0);
+
+    expect(countExecuteCallsForRun(run!.id)).toBe(1);
+  });
+
+  it("allows generic timer wakes when the agent has assigned review work", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+      },
+    });
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Assigned review",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: agentId,
     });
 
     const run = await heartbeat.wakeup(agentId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -239,7 +239,7 @@ const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_r
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
-const TIMER_ACTIONABLE_ISSUE_STATUSES = ["todo", "in_progress"] as const;
+const TIMER_ACTIONABLE_ISSUE_STATUSES = ["todo", "in_progress", "in_review"] as const;
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
@@ -6871,6 +6871,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   function parseHeartbeatPolicy(agent: typeof agents.$inferSelect) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
+    const allowIdleTimerWakes = asBoolean(
+      heartbeat.allowIdleTimerWakes ??
+        heartbeat.allowGenericTimerWakes ??
+        heartbeat.allowIdleHeartbeat,
+      false,
+    );
 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
@@ -6881,7 +6887,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         heartbeat.skipTimerWhenNoActionableWork ??
           heartbeat.requireActionableTimerWork ??
           heartbeat.issueOnlyTimer,
-        false,
+        !allowIdleTimerWakes,
       ),
       maxDailyRuns: normalizeOptionalNonNegativeInteger(
         heartbeat.maxDailyRuns ?? heartbeat.dailyRunLimit ?? heartbeat.dailyRunCap ?? heartbeat.maxRunsPerDay,
@@ -10734,7 +10740,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       !readNonEmptyString(enrichedContextSnapshot.taskKey);
     if (policy.skipTimerWhenNoActionableWork && genericTimerWake && !(await hasActionableTimerWork(agent))) {
       await writeSkippedHeartbeatRequest("heartbeat.timer.no_actionable_work", {
-        reason: "No assigned todo or in_progress issue requires this agent before timer adapter invocation.",
+        reason: "No assigned todo, in_progress, or in_review issue requires this agent before timer adapter invocation.",
       });
       await markTimerHeartbeatChecked(agentId, source);
       return null;


### PR DESCRIPTION
## Summary

- flips generic timer heartbeat preflight on by default so no-issue timer wakes skip before adapter/model invocation when an agent has no assigned actionable work
- treats assigned `todo`, `in_progress`, and `in_review` issues as actionable timer work
- keeps an explicit opt-in for intentionally proactive idle polling via `runtimeConfig.heartbeat.allowIdleTimerWakes` (aliases: `allowGenericTimerWakes`, `allowIdleHeartbeat`)

## Context

Addresses LIB-740: FinOps observed material no-issue timer burn even after cache-ratio improvements. The existing guard existed behind `skipTimerWhenNoActionableWork: true`; this makes that guard the default while preserving an explicit escape hatch.

Supersedes #8442, which had the same diff but missed the required Paperclip co-author trailer. This branch uses a compliant commit without force-pushing.

## Verification

- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-stale-queue-invalidation.test.ts --reporter=default` passed: 23 tests
- `PATH="/tmp/paperclip-corepack-shims:$PATH" pnpm --filter @paperclipai/server typecheck` passed

Note: dependency linking in the isolated worktree emitted existing plugin-sdk bin warnings during `pnpm install --frozen-lockfile`; no package files changed.
