### PR TITLE
Default-skip empty timer heartbeats

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -393,10 +393,27 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(run!.id)).toBe(1);
   });
 
-  it("runs generic timer wakes by default for proactive agents without assigned issue work", async () => {
+  it("skips generic timer wakes by default when there is no actionable assigned issue work", async () => {
     const { agentId } = await seedCompanyAndAgent({
       heartbeatConfig: {
         enabled: true,
+      },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "schedule",
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit proactive generic timer wakes without assigned issue work", async () => {
+    const { agentId } = await seedCompanyAndAgent({
+      heartbeatConfig: {
+        enabled: true,
+        skipTimerWhenNoActionableWork: false,
       },
     });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6881,7 +6881,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         heartbeat.skipTimerWhenNoActionableWork ??
           heartbeat.requireActionableTimerWork ??
           heartbeat.issueOnlyTimer,
-        false,
+        true,
       ),
       maxDailyRuns: normalizeOptionalNonNegativeInteger(
         heartbeat.maxDailyRuns ?? heartbeat.dailyRunLimit ?? heartbeat.dailyRunCap ?? heartbeat.maxRunsPerDay,


### PR DESCRIPTION
## Summary
- Default generic timer heartbeats to skip before adapter/model invocation when the agent has no actionable assigned issue.
- Preserve intentional proactive no-issue timer behavior via `runtimeConfig.heartbeat.skipTimerWhenNoActionableWork: false`.
- Update heartbeat stale-queue coverage for both default suppression and explicit opt-out.

## Root Cause
Generic timer wakes only used the pre-model no-actionable-work guard when `skipTimerWhenNoActionableWork` was explicitly enabled. Agents without that opt-in could continue launching no-issue GPT timer runs, matching the LIB-744 FinOps evidence.

## Validation
- `corepack pnpm@9.15.4 vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`

## Notes
- Local `pnpm vitest ...` initially failed before test execution because the shell resolved pnpm v11.8.0 while the repo pins pnpm 9.15.4; reran with `corepack pnpm@9.15.4`.
- Existing untracked `opensrc/` directory was not staged or committed.