### PR TITLE
[agent] Coalesce blocked scheduled routine runs

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -803,6 +803,85 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
+  it.each(["blocked", "in_review"] as const)(
+    "coalesces scheduled routine runs into an existing %s issue without a live heartbeat",
+    async (status) => {
+      const { companyId, issueSvc, routine, svc, wakeups } = await seedFixture();
+      const previousRunId = randomUUID();
+      const previousIssue = await issueSvc.create(companyId, {
+        projectId: routine.projectId,
+        title: routine.title,
+        description: routine.description,
+        status,
+        priority: routine.priority,
+        assigneeAgentId: routine.assigneeAgentId,
+        originKind: "routine_execution",
+        originId: routine.id,
+        originRunId: previousRunId,
+      });
+
+      await db.insert(routineRuns).values({
+        id: previousRunId,
+        companyId,
+        routineId: routine.id,
+        triggerId: null,
+        source: "schedule",
+        status: "issue_created",
+        triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+        linkedIssueId: previousIssue.id,
+        completedAt: new Date("2026-03-20T12:00:00.000Z"),
+      });
+
+      const { trigger } = await svc.createTrigger(
+        routine.id,
+        {
+          kind: "schedule",
+          label: "every two hours",
+          cronExpression: "0 */2 * * *",
+          timezone: "UTC",
+        },
+        {},
+      );
+      await db
+        .update(routineTriggers)
+        .set({ nextRunAt: new Date("2026-03-20T14:00:00.000Z") })
+        .where(eq(routineTriggers.id, trigger.id));
+
+      const result = await svc.tickScheduledTriggers(new Date("2026-03-20T14:00:00.000Z"));
+
+      expect(result.triggered).toBe(1);
+      expect(wakeups).toHaveLength(0);
+
+      const routineIssues = await db
+        .select({ id: issues.id, status: issues.status })
+        .from(issues)
+        .where(eq(issues.originId, routine.id));
+      expect(routineIssues).toEqual([{ id: previousIssue.id, status }]);
+
+      const runs = await db
+        .select()
+        .from(routineRuns)
+        .where(eq(routineRuns.routineId, routine.id));
+      expect(runs).toHaveLength(2);
+      const coalescedRun = runs.find((run) => run.id !== previousRunId);
+      expect(coalescedRun).toMatchObject({
+        source: "schedule",
+        status: "coalesced",
+        linkedIssueId: previousIssue.id,
+        coalescedIntoRunId: previousRunId,
+      });
+
+      const [updatedTrigger] = await db
+        .select({ lastResult: routineTriggers.lastResult, nextRunAt: routineTriggers.nextRunAt })
+        .from(routineTriggers)
+        .where(eq(routineTriggers.id, trigger.id));
+      expect(updatedTrigger?.lastResult).toMatch(/coalesced/i);
+      expect(updatedTrigger?.nextRunAt?.getTime()).toBeGreaterThan(
+        new Date("2026-03-20T14:00:00.000Z").getTime(),
+      );
+    },
+  );
+
   it("touches a coalesced routine issue for the manual runner's inbox", async () => {
     const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
     const userId = randomUUID();

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -62,6 +62,7 @@ import { logActivity } from "./activity-log.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
 const OPEN_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked"];
+const UNRESOLVED_SCHEDULE_COALESCE_STATUSES = ["in_review", "blocked"];
 const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"];
 const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
 const MAX_CATCH_UP_RUNS = 25;
@@ -1012,6 +1013,33 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function findUnresolvedScheduleExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+    origin?: { kind: string; id: string | null },
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    const originKind = origin?.kind ?? "routine_execution";
+    const originId = origin?.id ?? routine.id;
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, originKind),
+          eq(issues.originId, originId),
+          inArray(issues.status, UNRESOLVED_SCHEDULE_COALESCE_STATUSES),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -1271,10 +1299,14 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+        const origin = {
           kind: issueOriginKind,
           id: issueOriginId,
-        });
+        };
+        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, origin) ??
+          (input.source === "schedule"
+            ? await findUnresolvedScheduleExecutionIssue(input.routine, txDb, dispatchFingerprint, origin)
+            : null);
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           if (manualRunnerUserId) {


### PR DESCRIPTION
## Summary
- Coalesce scheduled routine dispatch into existing same-fingerprint `blocked` or `in_review` routine execution issues even when no heartbeat run is live.
- Keep manual/API/webhook behavior unchanged so fresh external input can still create new work when appropriate.
- Add regression coverage for scheduled ticks against `blocked` and `in_review` routine issues with no live heartbeat.

## Root Cause
`findLiveExecutionIssue` only matched routine issues tied to queued/running/scheduled heartbeat runs. Once an agent marked a routine execution issue `blocked`, the heartbeat was no longer live, so the next scheduled tick could create another issue and wake the agent back into the same blocked/no-followup context.

## Verification
- `node ~/.cache/node/corepack/v1/pnpm/9.15.4/bin/pnpm.cjs vitest run server/src/__tests__/routines-service.test.ts`
- `git diff --check`

## Notes
- `pnpm exec eslint ...` was unavailable because this checkout does not expose an `eslint` command.