### PR TITLE
feat(activity-log): de-dupe writes within a 5-minute bucket

### DIFF
--- a/server/src/__tests__/activity-log-dedupe.test.ts
+++ b/server/src/__tests__/activity-log-dedupe.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock instance-settings before importing the module under test so the
+// async getGeneral() lookup in logActivity does not touch the database.
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    getGeneral: async () => ({ censorUsernameInLogs: false }),
+  }),
+}));
+
+// Mock live events: we only care that the DB insert side was skipped.
+vi.mock("../services/live-events.js", () => ({
+  publishLiveEvent: vi.fn(),
+}));
+
+import {
+  logActivity,
+  __resetActivityLogDedupeForTests,
+} from "../services/activity-log.js";
+
+describe("activity-log dedupe", () => {
+  let inserts: Array<Record<string, unknown>>;
+  let db: { insert: (table: unknown) => { values: (row: Record<string, unknown>) => Promise<void> } };
+
+  beforeEach(() => {
+    __resetActivityLogDedupeForTests();
+    inserts = [];
+    db = {
+      insert: () => ({
+        values: async (row) => {
+          inserts.push(row);
+        },
+      }),
+    };
+  });
+
+  afterEach(() => {
+    __resetActivityLogDedupeForTests();
+  });
+
+  it("writes the first occurrence and suppresses identical repeats within the window", async () => {
+    const input = {
+      companyId: "company-1",
+      actorType: "system" as const,
+      actorId: "local-board",
+      action: "agent.env.read",
+      entityType: "agent",
+      entityId: "agent-1",
+      details: { envKeys: ["OPENAI_API_KEY"], envKeyCount: 1 },
+    };
+
+    for (let i = 0; i < 50; i++) {
+      await logActivity(db as never, input);
+    }
+
+    expect(inserts).toHaveLength(1);
+  });
+
+  it("does not collapse writes with different payload hashes", async () => {
+    const base = {
+      companyId: "company-1",
+      actorType: "system" as const,
+      actorId: "local-board",
+      action: "agent.env.read",
+      entityType: "agent",
+      entityId: "agent-1",
+    };
+
+    await logActivity(db as never, { ...base, details: { envKeys: ["A"] } });
+    await logActivity(db as never, { ...base, details: { envKeys: ["B"] } });
+    await logActivity(db as never, { ...base, entityId: "agent-2", details: { envKeys: ["A"] } });
+    await logActivity(db as never, {
+      ...base,
+      actorId: "different-actor",
+      details: { envKeys: ["A"] },
+    });
+
+    expect(inserts).toHaveLength(4);
+  });
+
+  it("re-admits a write after the dedupe window expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const input = {
+        companyId: "company-1",
+        actorType: "system" as const,
+        actorId: "local-board",
+        action: "agent.env.read",
+        entityType: "agent",
+        entityId: "agent-1",
+        details: { envKeys: ["OPENAI_API_KEY"] },
+      };
+
+      await logActivity(db as never, input);
+      await logActivity(db as never, input);
+      expect(inserts).toHaveLength(1);
+
+      vi.setSystemTime(Date.now() + 6 * 60 * 1000);
+      await logActivity(db as never, input);
+      expect(inserts).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { Db } from "@paperclipai/db";
 import { activityLog } from "@paperclipai/db";
 import { PLUGIN_EVENT_TYPES, type PluginEventType } from "@paperclipai/shared";
@@ -62,6 +62,133 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
+const DEFAULT_DEDUPE_WINDOW_MS = 5 * 60 * 1000;
+const DEFAULT_DEDUPE_MAX_ENTRIES = 50_000;
+
+function readPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+const DEDUPE_WINDOW_MS = readPositiveInt(
+  "PAPERCLIP_ACTIVITY_LOG_DEDUPE_WINDOW_MS",
+  DEFAULT_DEDUPE_WINDOW_MS,
+);
+const DEDUPE_MAX_ENTRIES = readPositiveInt(
+  "PAPERCLIP_ACTIVITY_LOG_DEDUPE_MAX_ENTRIES",
+  DEFAULT_DEDUPE_MAX_ENTRIES,
+);
+const DEDUPE_DISABLED = process.env.PAPERCLIP_ACTIVITY_LOG_DEDUPE_DISABLED === "1";
+
+interface DedupeEntry {
+  expiresAt: number;
+  suppressed: number;
+  lastLoggedSuppressed: number;
+}
+
+const dedupeCache = new Map<string, DedupeEntry>();
+let dedupeSweepCursor = 0;
+
+function dedupeKey(
+  input: LogActivityInput,
+  redactedDetails: Record<string, unknown> | null,
+): string {
+  const detailsJson = redactedDetails ? JSON.stringify(redactedDetails) : "";
+  const hash = createHash("sha1");
+  hash.update(input.companyId);
+  hash.update("|");
+  hash.update(input.actorType);
+  hash.update("|");
+  hash.update(input.actorId);
+  hash.update("|");
+  hash.update(input.action);
+  hash.update("|");
+  hash.update(input.entityType);
+  hash.update("|");
+  hash.update(input.entityId);
+  hash.update("|");
+  hash.update(detailsJson);
+  return hash.digest("hex");
+}
+
+function shouldSuppressDuplicate(
+  input: LogActivityInput,
+  redactedDetails: Record<string, unknown> | null,
+  now: number,
+): { suppress: boolean; suppressedCount: number } {
+  if (DEDUPE_DISABLED || DEDUPE_WINDOW_MS === 0) {
+    return { suppress: false, suppressedCount: 0 };
+  }
+  const key = dedupeKey(input, redactedDetails);
+  const existing = dedupeCache.get(key);
+  if (existing && existing.expiresAt > now) {
+    existing.suppressed += 1;
+    // Avoid noisy logs: surface a warning when a single (actor, action, payload)
+    // tuple has been silenced an order of magnitude more times than the last
+    // notice. Catches runaway writers without flooding the log itself.
+    if (existing.suppressed >= existing.lastLoggedSuppressed * 10) {
+      logger.warn(
+        {
+          actorType: input.actorType,
+          actorId: input.actorId,
+          action: input.action,
+          entityType: input.entityType,
+          entityId: input.entityId,
+          suppressed: existing.suppressed,
+          windowMs: DEDUPE_WINDOW_MS,
+        },
+        "activity_log dedupe suppressed repeated write",
+      );
+      existing.lastLoggedSuppressed = existing.suppressed;
+    }
+    return { suppress: true, suppressedCount: existing.suppressed };
+  }
+  // Bound memory: evict expired entries first, then cap total size.
+  if (dedupeCache.size >= DEDUPE_MAX_ENTRIES) {
+    sweepExpired(now, /* aggressive */ true);
+  }
+  dedupeCache.set(key, {
+    expiresAt: now + DEDUPE_WINDOW_MS,
+    suppressed: 0,
+    lastLoggedSuppressed: 1,
+  });
+  return { suppress: false, suppressedCount: 0 };
+}
+
+function sweepExpired(now: number, aggressive: boolean): void {
+  // Incremental sweep: scan a slice of entries each call so we don't block on
+  // huge caches. Aggressive mode (cache at cap) walks the whole map.
+  const sliceSize = aggressive ? dedupeCache.size : 1024;
+  const keys = Array.from(dedupeCache.keys());
+  const start = dedupeSweepCursor % Math.max(keys.length, 1);
+  for (let i = 0; i < Math.min(sliceSize, keys.length); i++) {
+    const key = keys[(start + i) % keys.length];
+    const entry = dedupeCache.get(key);
+    if (entry && entry.expiresAt <= now) {
+      dedupeCache.delete(key);
+    }
+  }
+  dedupeSweepCursor = start + sliceSize;
+  // If still over cap after expiry sweep, drop the oldest entries by iteration
+  // order (Map preserves insertion order).
+  if (aggressive && dedupeCache.size >= DEDUPE_MAX_ENTRIES) {
+    const overflow = dedupeCache.size - Math.floor(DEDUPE_MAX_ENTRIES * 0.9);
+    let dropped = 0;
+    for (const key of dedupeCache.keys()) {
+      if (dropped >= overflow) break;
+      dedupeCache.delete(key);
+      dropped += 1;
+    }
+  }
+}
+
+export function __resetActivityLogDedupeForTests(): void {
+  dedupeCache.clear();
+  dedupeSweepCursor = 0;
+}
+
 export async function logActivity(db: Db, input: LogActivityInput) {
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
@@ -70,6 +197,12 @@ export async function logActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = sanitizedDetails
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;
+
+  const { suppress } = shouldSuppressDuplicate(input, redactedDetails, Date.now());
+  if (suppress) {
+    return;
+  }
+
   await db.insert(activityLog).values({
     companyId: input.companyId,
     actorType: input.actorType,


### PR DESCRIPTION
## Summary

On 2026-06-03 the `local-board` system actor wrote 19.4M identical `agent.env.read` rows in a single day, blowing up `activity_log` to 26.3M dead rows / ~9 GB after archive. Any high-cardinality writer hitting `logActivity()` can recreate this pattern.

This PR adds an in-memory dedupe layer in `server/src/services/activity-log.ts` keyed by `(companyId, actorType, actorId, action, entityType, entityId, payload-hash)`. Within a configurable window (default 5 minutes) identical writes are skipped entirely — no DB insert, no live event, no plugin event.

- 5-minute window, 50k entry cap, configurable via `PAPERCLIP_ACTIVITY_LOG_DEDUPE_WINDOW_MS` and `PAPERCLIP_ACTIVITY_LOG_DEDUPE_MAX_ENTRIES`
- Escape hatch: `PAPERCLIP_ACTIVITY_LOG_DEDUPE_DISABLED=1`
- Incremental expiry sweep + insertion-order eviction at cap so the dedupe map cannot become its own runaway
- Warns once per 10× suppressed for a given key, so runaway writers still surface in the log without flooding it

## Test plan

- [x] New `server/src/__tests__/activity-log-dedupe.test.ts` covers first-write-through, distinct payloads bypass, and re-admit after window expiry (3 tests pass)
- [x] `tsc --noEmit` clean on the changed file

## Context

Refs: BTCAAAAA-37844 (E in BTCAAAAA-37815 perf follow-up to BTCAAAAA-37812).