### PR TITLE
perf(heartbeat): narrow hot dispatcher SELECT to skip TOAST columns

### DIFF
--- a/server/src/__tests__/heartbeat-dispatcher-projection.test.ts
+++ b/server/src/__tests__/heartbeat-dispatcher-projection.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  HEARTBEAT_RUN_DISPATCHER_OMITTED_COLUMNS,
+  heartbeatRunDispatcherColumns,
+} from "../services/heartbeat.ts";
+
+// Regression for BTCAAAAA-37843: the hot dispatcher / claim-loop SELECT on
+// `heartbeat_runs` must not project TOAST-stored columns. Detoasting them on
+// every heartbeat across many concurrent backends produced the 16-17 active-
+// backend thundering herd flagged in BTCAAAAA-37812.
+describe("heartbeat dispatcher projection (BTCAAAAA-37843)", () => {
+  it("omits TOAST-stored columns from the dispatcher projection", () => {
+    const projectedKeys = new Set(Object.keys(heartbeatRunDispatcherColumns));
+    const omittedCamelCase = [
+      "usageJson",
+      "logStore",
+      "logRef",
+      "logBytes",
+      "logSha256",
+      "logCompressed",
+    ];
+    for (const key of omittedCamelCase) {
+      expect(projectedKeys.has(key)).toBe(false);
+    }
+  });
+
+  it("documents the omitted physical column names so reviewers can audit query logs", () => {
+    expect([...HEARTBEAT_RUN_DISPATCHER_OMITTED_COLUMNS].sort()).toEqual([
+      "log_bytes",
+      "log_compressed",
+      "log_ref",
+      "log_sha256",
+      "log_store",
+      "usage_json",
+    ]);
+  });
+
+  it("keeps the columns the dispatcher and claim loop actually consume", () => {
+    const projectedKeys = new Set(Object.keys(heartbeatRunDispatcherColumns));
+    const required = [
+      "id",
+      "companyId",
+      "agentId",
+      "status",
+      "startedAt",
+      "createdAt",
+      "wakeupRequestId",
+      "contextSnapshot",
+      "scheduledRetryReason",
+      // resultJson is preserved because cancel paths merge it into the
+      // cancelled run's stop-reason payload; only the 6 TOAST columns above
+      // are dropped.
+      "resultJson",
+    ];
+    for (const key of required) {
+      expect(projectedKeys.has(key)).toBe(true);
+    }
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1532,6 +1532,68 @@ const heartbeatRunIssueSummaryColumns = {
   issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
 } as const;
 
+// Hot dispatcher / claim-loop projection. Skips TOAST-stored columns
+// (`usage_json`, `log_store`, `log_ref`, `log_bytes`, `log_sha256`,
+// `log_compressed`) so Postgres does not detoast them on every heartbeat
+// across concurrent backends (BTCAAAAA-37843).
+export const HEARTBEAT_RUN_DISPATCHER_OMITTED_COLUMNS = [
+  "usage_json",
+  "log_store",
+  "log_ref",
+  "log_bytes",
+  "log_sha256",
+  "log_compressed",
+] as const;
+export const heartbeatRunDispatcherColumns = {
+  id: heartbeatRuns.id,
+  companyId: heartbeatRuns.companyId,
+  agentId: heartbeatRuns.agentId,
+  invocationSource: heartbeatRuns.invocationSource,
+  triggerDetail: heartbeatRuns.triggerDetail,
+  status: heartbeatRuns.status,
+  startedAt: heartbeatRuns.startedAt,
+  finishedAt: heartbeatRuns.finishedAt,
+  error: heartbeatRuns.error,
+  wakeupRequestId: heartbeatRuns.wakeupRequestId,
+  exitCode: heartbeatRuns.exitCode,
+  signal: heartbeatRuns.signal,
+  resultJson: heartbeatRuns.resultJson,
+  sessionIdBefore: heartbeatRuns.sessionIdBefore,
+  sessionIdAfter: heartbeatRuns.sessionIdAfter,
+  stdoutExcerpt: heartbeatRuns.stdoutExcerpt,
+  stderrExcerpt: heartbeatRuns.stderrExcerpt,
+  errorCode: heartbeatRuns.errorCode,
+  externalRunId: heartbeatRuns.externalRunId,
+  processPid: heartbeatRuns.processPid,
+  processGroupId: heartbeatRuns.processGroupId,
+  processStartedAt: heartbeatRuns.processStartedAt,
+  lastOutputAt: heartbeatRuns.lastOutputAt,
+  lastOutputSeq: heartbeatRuns.lastOutputSeq,
+  lastOutputStream: heartbeatRuns.lastOutputStream,
+  lastOutputBytes: heartbeatRuns.lastOutputBytes,
+  retryOfRunId: heartbeatRuns.retryOfRunId,
+  processLossRetryCount: heartbeatRuns.processLossRetryCount,
+  scheduledRetryAt: heartbeatRuns.scheduledRetryAt,
+  scheduledRetryAttempt: heartbeatRuns.scheduledRetryAttempt,
+  scheduledRetryReason: heartbeatRuns.scheduledRetryReason,
+  issueCommentStatus: heartbeatRuns.issueCommentStatus,
+  issueCommentSatisfiedByCommentId: heartbeatRuns.issueCommentSatisfiedByCommentId,
+  issueCommentRetryQueuedAt: heartbeatRuns.issueCommentRetryQueuedAt,
+  livenessState: heartbeatRuns.livenessState,
+  livenessReason: heartbeatRuns.livenessReason,
+  continuationAttempt: heartbeatRuns.continuationAttempt,
+  lastUsefulActionAt: heartbeatRuns.lastUsefulActionAt,
+  nextAction: heartbeatRuns.nextAction,
+  contextSnapshot: heartbeatRuns.contextSnapshot,
+  createdAt: heartbeatRuns.createdAt,
+  updatedAt: heartbeatRuns.updatedAt,
+} as const;
+
+type HeartbeatRunDispatcherRow = Omit<
+  typeof heartbeatRuns.$inferSelect,
+  "usageJson" | "logStore" | "logRef" | "logBytes" | "logSha256" | "logCompressed"
+>;
+
 function appendExcerpt(prev: string, chunk: string) {
   return appendWithByteCap(prev, chunk, MAX_EXCERPT_BYTES);
 }
@@ -7104,7 +7166,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function cancelQueuedRunForHeartbeatDailyCap(
-    run: typeof heartbeatRuns.$inferSelect,
+    run: HeartbeatRunDispatcherRow,
     dailyCapBlock: NonNullable<Awaited<ReturnType<typeof getHeartbeatDailyCapBlock>>>,
   ) {
     const now = new Date();
@@ -7208,7 +7270,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function listQueuedRunDependencyReadiness(
     companyId: string,
-    queuedRuns: Array<typeof heartbeatRuns.$inferSelect>,
+    queuedRuns: Array<HeartbeatRunDispatcherRow>,
   ) {
     const issueIds = [...new Set(
       queuedRuns
@@ -7229,7 +7291,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
-  async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
+  async function claimQueuedRun(run: HeartbeatRunDispatcherRow, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
     if (!agent) {
@@ -7380,7 +7442,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function cancelQueuedRunForBlockedDependencies(
-    run: typeof heartbeatRuns.$inferSelect,
+    run: HeartbeatRunDispatcherRow,
     issueId: string,
     unresolvedBlockerIssueIds: string[],
   ) {
@@ -7454,7 +7516,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
 
   async function evaluateQueuedRunStaleness(
-    run: typeof heartbeatRuns.$inferSelect,
+    run: HeartbeatRunDispatcherRow,
     issueId: string,
     context: Record<string, unknown>,
   ): Promise<QueuedRunStaleness> {
@@ -7588,7 +7650,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function cancelQueuedRunForStaleIssue(
-    run: typeof heartbeatRuns.$inferSelect,
+    run: HeartbeatRunDispatcherRow,
     issueId: string,
     staleness: Extract<QueuedRunStaleness, { stale: true }>,
   ) {
@@ -8193,8 +8255,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
       if (availableSlots <= 0) return [];
 
+      // BTCAAAAA-37843: project only the columns the dispatcher consumes so
+      // Postgres does not detoast `usage_json`, `log_store`, `log_ref`,
+      // `log_bytes`, `log_sha256`, `log_compressed` on every heartbeat across
+      // concurrent backends.
       const queuedRuns = await db
-        .select()
+        .select(heartbeatRunDispatcherColumns)
         .from(heartbeatRuns)
         .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.status, "queued")))
         .orderBy(asc(heartbeatRuns.createdAt));
@@ -8238,7 +8304,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return left.createdAt.getTime() - right.createdAt.getTime();
       });
 
-      const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
+      const claimedRuns: Array<HeartbeatRunDispatcherRow> = [];
       for (const queuedRun of prioritizedRuns) {
         if (claimedRuns.length >= availableSlots) break;
         const claimed = await claimQueuedRun(queuedRun, companyAgents);
@@ -8266,7 +8332,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // claimQueuedRun can also leave the run queued when dependencies are unresolved.
         return;
       }
-      run = claimed;
+      // Re-fetch the full row so `run` keeps its original (wider) projection
+      // shape that downstream executeRun logic expects.
+      const refreshed = await getRun(runId);
+      if (!refreshed) return;
+      run = refreshed;
     }
 
     activeRunExecutions.add(run.id);


### PR DESCRIPTION
## Summary

- `startNextQueuedRunForAgent` (the per-heartbeat claim loop in `server/src/services/heartbeat.ts`) ran `select()` against `heartbeat_runs`, which projects every column including the TOAST-stored `usage_json`, `log_store`, `log_ref`, `log_bytes`, `log_sha256`, and `log_compressed`. With many concurrent backends polling, Postgres detoasted those values on every heartbeat, contributing to the persistent 16-17 active-backend thundering herd flagged in `BTCAAAAA-37812`.
- Introduces `heartbeatRunDispatcherColumns` — an explicit projection of exactly the columns the dispatcher and claim path consume (id, agentId, contextSnapshot, status, scheduledRetryReason, resultJson, etc.) — and uses it in the dispatcher SELECT.
- Narrows the input type on `claimQueuedRun` and the queued-run cancel helpers to `HeartbeatRunDispatcherRow` (= `Omit<HeartbeatRun, 6 TOAST cols>`) so the type system enforces the dispatcher hot path never depends on the omitted columns.
- `executeRun` still keeps its original behavior — after a successful claim it re-fetches via `getRun` so downstream code that needs the full row gets it explicitly.

### Before / after column list

Before — `select()` expanded to every column on `heartbeat_runs` (47 columns including the 6 TOAST ones).

After — projection is:
`id, company_id, agent_id, invocation_source, trigger_detail, status, started_at, finished_at, error, wakeup_request_id, exit_code, signal, result_json, session_id_before, session_id_after, stdout_excerpt, stderr_excerpt, error_code, external_run_id, process_pid, process_group_id, process_started_at, last_output_at, last_output_seq, last_output_stream, last_output_bytes, retry_of_run_id, process_loss_retry_count, scheduled_retry_at, scheduled_retry_attempt, scheduled_retry_reason, issue_comment_status, issue_comment_satisfied_by_comment_id, issue_comment_retry_queued_at, liveness_state, liveness_reason, continuation_attempt, last_useful_action_at, next_action, context_snapshot, created_at, updated_at`.

Omitted: `usage_json, log_store, log_ref, log_bytes, log_sha256, log_compressed`.

`result_json` is intentionally kept because the queued-run cancel paths (`cancelQueuedRunForBlockedDependencies`, `cancelQueuedRunForStaleIssue`, `cancelQueuedRunForHeartbeatDailyCap`) merge it into the cancelled run's stop-reason payload. Only the six TOAST columns named in `BTCAAAAA-37843` are dropped.

## Test plan

- [ ] `pnpm --filter @paperclipai/server test src/__tests__/heartbeat-dispatcher-projection.test.ts` (new test asserts the projected key set excludes the six TOAST columns and retains the fields the dispatcher consumes).
- [ ] CI `pnpm --filter @paperclipai/server test` — existing heartbeat suites continue to pass; type-narrowing on the cancel helpers is enforced at compile time.
- [ ] In a staging Postgres, run `EXPLAIN (VERBOSE)` on the dispatcher SELECT and confirm `usage_json` / `log_*` no longer appear in the output column list.

Refs: `BTCAAAAA-37843` (parent `BTCAAAAA-37815`, related `BTCAAAAA-37812`).