### PR TITLE
feat(claude-local): --fallback-model so transient 529/overload bumps model instead of failing the run

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -38,6 +38,7 @@ Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file injected at runtime
 - model (string, optional): Claude model id
+- fallbackModel (string, optional): Claude model id passed via --fallback-model; the CLI auto-switches to it when the primary model is overloaded or returns 529 in headless/print-mode runs, so a transient capacity blip bumps to the fallback instead of failing the run. Defaults to a lower-load model when a primary model is set; pass "none" to disable. Note the fallback shares the same Anthropic capacity pool, so it mitigates model-specific load, not a platform-wide incident.
 - effort (string, optional): reasoning effort passed via --effort (low|medium|high)
 - chrome (boolean, optional): pass --chrome when running Claude
 - promptTemplate (string, optional): run prompt template

--- a/packages/adapters/claude-local/src/server/execute.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.test.ts
@@ -1,0 +1,139 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runChildProcess, ensureCommandResolvable, resolveCommandForLogs } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "session-1", model: "claude-opus-4-8" }),
+      JSON.stringify({
+        type: "result",
+        session_id: "session-1",
+        result: "ok",
+        usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "claude"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+import { resolveClaudeFallbackModel, DEFAULT_CLAUDE_FALLBACK_MODEL } from "./execute.js";
+
+const cleanupDirs: string[] = [];
+
+async function runLocalExecute(config: Record<string, unknown>): Promise<string[]> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-fallback-"));
+  cleanupDirs.push(rootDir);
+  const workspaceDir = path.join(rootDir, "workspace");
+  await mkdir(workspaceDir, { recursive: true });
+
+  await execute({
+    runId: "run-fallback",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: { command: "claude", cwd: workspaceDir, ...config },
+    context: {
+      paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" },
+    },
+    onLog: async () => {},
+  });
+
+  expect(runChildProcess).toHaveBeenCalledTimes(1);
+  const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
+  return call?.[2] ?? [];
+}
+
+describe("resolveClaudeFallbackModel", () => {
+  it("honors an explicit fallback model", () => {
+    expect(resolveClaudeFallbackModel("claude-haiku-4-6", "claude-opus-4-8")).toBe("claude-haiku-4-6");
+  });
+
+  it("disables the fallback for none/off-style values", () => {
+    for (const value of ["none", "off", "false", "disabled", "0", "NONE"]) {
+      expect(resolveClaudeFallbackModel(value, "claude-opus-4-8")).toBe("");
+    }
+  });
+
+  it("drops a fallback identical to the primary model", () => {
+    expect(resolveClaudeFallbackModel("claude-opus-4-8", "claude-opus-4-8")).toBe("");
+  });
+
+  it("defaults to a lower-load model when a primary model is pinned", () => {
+    expect(resolveClaudeFallbackModel("", "claude-opus-4-8")).toBe(DEFAULT_CLAUDE_FALLBACK_MODEL);
+  });
+
+  it("does not default when the primary already is the default fallback", () => {
+    expect(resolveClaudeFallbackModel("", DEFAULT_CLAUDE_FALLBACK_MODEL)).toBe("");
+  });
+
+  it("does not default when no primary model is pinned", () => {
+    expect(resolveClaudeFallbackModel("", "")).toBe("");
+  });
+});
+
+describe("claude execution --fallback-model wiring", () => {
+  afterEach(async () => {
+    vi.clearAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("passes an explicitly configured --fallback-model", async () => {
+    const args = await runLocalExecute({ model: "claude-opus-4-8", fallbackModel: "claude-haiku-4-6" });
+    const idx = args.indexOf("--fallback-model");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe("claude-haiku-4-6");
+  });
+
+  it("defaults --fallback-model when a primary model is set but no fallback is configured", async () => {
+    const args = await runLocalExecute({ model: "claude-opus-4-8" });
+    const idx = args.indexOf("--fallback-model");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe(DEFAULT_CLAUDE_FALLBACK_MODEL);
+  });
+
+  it("omits --fallback-model when explicitly disabled with none", async () => {
+    const args = await runLocalExecute({ model: "claude-opus-4-8", fallbackModel: "none" });
+    expect(args).not.toContain("--fallback-model");
+  });
+
+  it("omits --fallback-model when no primary model is pinned", async () => {
+    const args = await runLocalExecute({});
+    expect(args).not.toContain("--fallback-model");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -66,6 +66,36 @@ import { prepareClaudePromptBundle } from "./prompt-cache.js";
 import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
+// Lower-load default fallback for the Claude CLI's --fallback-model flag. When a
+// primary model is pinned but no explicit fallback is configured, long runs still
+// get an overload escape hatch without per-agent configuration. See FUS-596.
+export const DEFAULT_CLAUDE_FALLBACK_MODEL = "claude-sonnet-4-6";
+
+const FALLBACK_MODEL_DISABLED_VALUES = new Set(["none", "off", "false", "disabled", "0"]);
+
+/**
+ * Resolve the model to pass via Claude Code's `--fallback-model` flag, which
+ * auto-switches when the primary model is overloaded / returns 529 in
+ * headless/print-mode runs (FUS-596).
+ *
+ * - An explicit `fallbackModel` config wins; "none"/"off"/etc. disables it.
+ * - Falling back to the same model is a no-op and is dropped.
+ * - With no explicit config but a pinned primary model, default to a lower-load
+ *   model so overloads bump to the fallback instead of failing the run.
+ */
+export function resolveClaudeFallbackModel(configuredFallbackModel: string, primaryModel: string): string {
+  const configured = configuredFallbackModel.trim();
+  const primary = primaryModel.trim();
+  if (configured.length > 0) {
+    if (FALLBACK_MODEL_DISABLED_VALUES.has(configured.toLowerCase())) return "";
+    return configured === primary ? "" : configured;
+  }
+  if (primary.length > 0 && primary !== DEFAULT_CLAUDE_FALLBACK_MODEL) {
+    return DEFAULT_CLAUDE_FALLBACK_MODEL;
+  }
+  return "";
+}
+
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 interface ClaudeExecutionInput {
@@ -377,6 +407,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   );
   const model = asString(config.model, "");
+  // Pair the primary model with a fallback so a transient 529/overload on the
+  // primary auto-switches via Claude Code's --fallback-model instead of failing
+  // the whole run. The flag is honored in headless/print-mode (how Paperclip runs
+  // Claude) and ignored interactively, so it is always safe to pass. See FUS-596.
+  const fallbackModel = resolveClaudeFallbackModel(asString(config.fallbackModel, ""), model);
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
@@ -722,6 +757,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // on Bedrock, so skip them and let the CLI use its own configured model.
     if (model && (!isBedrockAuth(effectiveEnv) || isBedrockModelId(model))) {
       args.push("--model", model);
+    }
+    // Same Bedrock guard as --model: Anthropic-style fallback IDs are invalid on
+    // Bedrock, so only pass --fallback-model when it is a usable identifier.
+    if (fallbackModel && (!isBedrockAuth(effectiveEnv) || isBedrockModelId(fallbackModel))) {
+      args.push("--fallback-model", fallbackModel);
     }
     if (effectiveEffort) args.push("--effort", effectiveEffort);
     if (maxTurns > 0) args.push("--max-turns", String(maxTurns));


### PR DESCRIPTION
## What & why

Worker agents with long tool-call chains (e.g. Long-Form Writer) frequently lose an entire run to a single mid-session `API Error: 529 Overloaded`. Claude Code's `--fallback-model` flag auto-switches to a secondary model when the primary is overloaded / returns 529. It is honored in headless/print-mode runs (exactly how Paperclip invokes Claude) and ignored only in interactive sessions, so it is a safe, always-on escape hatch.

This adds the missing fallback-model half of FUS-596. The transient-retry half (529/503/429 → `errorFamily: "transient_upstream"` + `retryNotBefore` → heartbeat exponential backoff) already exists on `master` via `parse.ts` (`isClaudeTransientUpstreamError`) and `execute.ts`, so no changes were needed there.

## Changes

- **New `fallbackModel` config field** on the `claude_local` adapter, wired into `buildClaudeArgs` as `--fallback-model` with the **same Bedrock guard** used for `--model`.
- **Sensible default:** when a primary `model` is pinned but no fallback is configured, default to a lower-load model (`claude-sonnet-4-6`). A fallback identical to the primary is dropped as a no-op; `none`/`off`/`disabled`/`false`/`0` disables it.
- Adapter config doc updated.

## Behavior notes

- The fallback shares the same Anthropic capacity pool, so it mitigates *model-specific* load, not a full platform-wide incident.
- Agents with no primary `model` pinned get no fallback. The `cheap` profile (primary already sonnet-4-6) correctly emits no fallback.

## Verification

- `pnpm --filter @paperclipai/adapter-claude-local typecheck` → clean
- New `execute.test.ts`: 10 tests (unit + execution wiring) → pass
- Existing `execute.remote.test.ts` + `parse.test.ts` → 33 tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)