### PR TITLE
fix(issues): strip NUL bytes from comment bodies before insert (FUS-594)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3942,6 +3942,37 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
       },
     });
   });
+
+  it("strips NUL bytes from a comment body instead of failing the insert (FUS-594)", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue closed with a NUL-bearing comment",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    // A stray NUL (U+0000) in agent-authored comment text previously made the
+    // issue_comments insert fail with Postgres "invalid byte sequence for
+    // encoding UTF8: 0x00", surfacing as an HTTP 500 on PATCH/POST.
+    const nul = String.fromCharCode(0);
+    const body = `Active routine: ${nul}57b3010 done`;
+
+    const comment = await svc.addComment(issueId, body, {});
+
+    expect(comment.body).toBe("Active routine: 57b3010 done");
+    expect(comment.body.includes(nul)).toBe(false);
+  });
 });
 
 describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -131,6 +131,16 @@ function applyStatusSideEffects(
   return patch;
 }
 
+// PostgreSQL text/jsonb columns cannot store NUL (U+0000) bytes and reject them
+// with "invalid byte sequence for encoding UTF8: 0x00". Agent-authored comment
+// bodies occasionally carry a stray NUL (e.g. from a mangled UUID interpolation),
+// which previously surfaced as an HTTP 500 on PATCH/POST when closing an issue with
+// a comment. Strip NULs so the comment persists instead of failing the request.
+function stripNullBytes(input: string): string {
+  if (input.indexOf("\u0000") === -1) return input;
+  return input.split("\u0000").join("");
+}
+
 function readStringFromRecord(record: unknown, key: string) {
   if (!record || typeof record !== "object") return null;
   const value = (record as Record<string, unknown>)[key];
@@ -6087,7 +6097,7 @@ export function issueService(db: Db) {
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
       };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+      const redactedBody = redactCurrentUserText(stripNullBytes(body), currentUserRedactionOptions);
       const authorType = issueCommentAuthorTypeSchema.parse(
         options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
       );


### PR DESCRIPTION
## Problem

`PATCH`/`POST /api/issues/{id}` returns **HTTP 500** when an agent closes an issue with a comment whose body contains a stray **NUL (U+0000)** byte (e.g. a mangled UUID interpolation).

PostgreSQL rejects NUL in text columns:

```
invalid byte sequence for encoding "UTF8": 0x00
```

This fails the `issue_comments` INSERT inside `issueService.addComment` and rolls back the transaction, so the status change is never persisted and the completed work is left stuck `in_progress`, which then triggers a retry wake. Diagnosed from the live server log — 38 occurrences, all the same `issue_comments` insert failing on `0x00`:

```
ERROR: PATCH /api/issues/{id} 500 — Failed query: insert into "issue_comments" ...
  at async Object.addComment (.../services/issues.js)
  at async .../routes/issues.js  (PATCH handler, comment branch)
DrizzleQueryError: ... invalid byte sequence for encoding "UTF8": 0x00
```

## Fix

Strip NUL (U+0000) bytes from the comment body before it is persisted, in `addComment` (the single choke point for all comment inserts). Other characters are left untouched.

## Test

Adds an embedded-postgres regression test that closes an issue with a NUL-bearing comment and asserts the comment is stored with the NUL removed (previously this threw the Postgres `0x00` error and surfaced as a 500).

> Note: the full vitest suite could not be run in the authoring environment — the working checkout path exceeds Windows `MAX_PATH`, which breaks vitest's ESM bootstrap (`ERR_PACKAGE_IMPORT_NOT_DEFINED` resolving vite's `#module-sync-enabled` from the deep `.pnpm` path). The new test relies on CI for execution; the fix logic was verified in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
