### PR TITLE
test(issues): cover cancelled child not sampled with blocked explicit blockers

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -298,6 +298,51 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe("PBD-4");
   });
 
+  it("does not sample a cancelled child when explicit blockers need attention", async () => {
+    const { companyId, agentId } = await createCompany("PBE");
+    const parentId = await insertIssue({ companyId, identifier: "PBE-1", title: "Parent", status: "blocked" });
+    const blockedBlockerOneId = await insertIssue({
+      companyId,
+      identifier: "PBE-2",
+      title: "Blocked dependency one",
+      status: "blocked",
+      assigneeAgentId: agentId,
+    });
+    const blockedBlockerTwoId = await insertIssue({
+      companyId,
+      identifier: "PBE-3",
+      title: "Blocked dependency two",
+      status: "blocked",
+      assigneeAgentId: agentId,
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBE-4",
+      title: "Cancelled child",
+      status: "cancelled",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: blockedBlockerOneId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: blockedBlockerTwoId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 2,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 2,
+    });
+    expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe("PBE-4");
+    expect([
+      "PBE-2",
+      "PBE-3",
+    ]).toContain(parent?.blockerAttention?.sampleBlockerIdentifier);
+  });
+
   it("covers recursive blocker chains when the downstream leaf has active work", async () => {
     const { companyId, agentId } = await createCompany("PBR");
     const parentId = await insertIssue({ companyId, identifier: "PBR-1", title: "Parent", status: "blocked" });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue blocker attention (`blockerAttention`) derives a blocked issue's health from the live issue graph, mixing explicit `blockedBy` edges with implicit direct-child edges.
> - A cancelled direct child used to inflate a blocked parent's `unresolvedBlockerCount` and could become the `sampleBlockerIdentifier`, which made a blocked issue look like it still needed attention on a superseded child even after the explicit blocker graph was refreshed.
> - PR #7577 narrowed child-edge traversal to non-terminal children so cancelled children are ignored with done children, fixing that regression.
> - This pull request adds a regression test that mirrors the exact stale-attention scenario: a blocked parent with blocked (non-active) explicit blockers plus a cancelled direct child, asserting the cancelled child is excluded and the sample is one of the live explicit blockers.
> - The benefit is a locked-in guard against the cancelled-child regression returning in the `needs_attention` path, not only the previously covered `covered` path.

## Linked Issues or Issue Description

- Refs #7578 (cancelled child blocker attention regression, already fixed by #7577)

## What Changed

- Added `does not sample a cancelled child when explicit blockers need attention` to `server/src/__tests__/issue-blocker-attention.test.ts`. It builds a blocked parent with two `blocked` explicit blockers (no active run) and a `cancelled` direct child, then asserts `unresolvedBlockerCount: 2`, `attentionBlockerCount: 2`, `state: needs_attention`, `sampleBlockerIdentifier` is not the cancelled child, and the sample is one of the two live explicit blockers.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-blocker-attention.test.ts` -> 23 tests passed (was 22 before this change).
- `pnpm --filter @paperclipai/server typecheck` -> clean.

## Risks

- Low risk: test-only change; no production behavior or schema touched.

## Model Used

- OpenAI GPT via local opencode adapter (`github-copilot/claude-sonnet-4.6` was unavailable; work done with GLM-5.2 through `opencode_local`). Reasoning over the issue graph traversal code and existing test patterns; no code execution beyond the local Vitest run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable; test-only)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

Fixes #7578