### PR TITLE
docs(create-agent): add pre-hire governance gate to Preconditions

### DIFF
--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -19,6 +19,12 @@ You need either:
 
 If you do not have this permission, escalate to your CEO or board.
 
+> **Pre-hire governance gate.** `can_create_agents=true` is a capability, not implicit
+> board approval. Unless the hire is trivially in-scope of an already-approved plan, post a
+> `request_board_approval` (or equivalent) with the draft prompt/config/role and **wait for
+> acceptance before submitting**. This natural gate prevents the COD-873 / COD-1264 pattern,
+> where a privileged agent submitted the hire first and the board had to ratify after the fact.
+
 ## Workflow
 
 ### 1. Confirm identity and company context


### PR DESCRIPTION
## What

Adds a short governance-gate blockquote to the **Preconditions** section of `skills/paperclip-create-agent/SKILL.md`.

It clarifies that `can_create_agents=true` is a capability, **not** implicit board approval: unless a hire is trivially in-scope of an already-approved plan, the agent should post a `request_board_approval` with the draft prompt/config/role and **wait for acceptance before submitting**.

## Why

Two recurrences of the same bypass pattern, 4 weeks apart:

- **COD-873** — SecurityEngineer hire (2026-05-23). CTO had `canCreateAgents=true` and submitted directly; board ratified post-hoc.
- **COD-1264** — Dreamer hire (2026-06-19). CEO had `canCreateAgents=true` and submitted directly; board ratified confirmation 3e92cc04 after the fact.

The natural gate prevents the "hire lands first, board ratifies after" pattern.

## Scope

- Edits only the Preconditions section (a 5-line blockquote). Workflow steps 8 (Submit hire request) and 9 (Handle governance state) are untouched — they already cover the post-submit path.
- Board-authorized platform edit via COD-1271 (overrides the usual "no platform internals from company workstreams" default).

Refs COD-1306.