### PR TITLE
[security-gated] fix: seed codex probe auth from host login

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -302,6 +302,25 @@ describe("seedManagedCodexHome", () => {
     }
   });
 
+  it("copies shared config files as regular files (COPYFILE_EXCL happy path)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-config-"));
+    try {
+      const sharedCodexHome = path.join(root, "shared-codex-home");
+      const agentHome = path.join(root, "agent-home");
+      await fs.mkdir(sharedCodexHome, { recursive: true });
+      await fs.writeFile(path.join(sharedCodexHome, "config.toml"), 'model = "gpt-5"', "utf8");
+
+      await seedManagedCodexHome(agentHome, { CODEX_HOME: sharedCodexHome }, async () => {});
+
+      const copied = path.join(agentHome, "config.toml");
+      // Real file, not a symlink that a racing attacker could have redirected.
+      expect((await fs.lstat(copied)).isSymbolicLink()).toBe(false);
+      expect(await fs.readFile(copied, "utf8")).toBe('model = "gpt-5"');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("writes an API-key auth.json into the home when an apiKey is supplied", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-apikey-"));
     try {

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
@@ -176,7 +177,12 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (existing) return;
   await ensureParentDir(target);
-  await fs.copyFile(source, target);
+  // COPYFILE_EXCL closes the TOCTOU window between the lstat above and this
+  // copy: if anything (e.g. a symlink an attacker raced into place) now exists
+  // at `target`, the copy fails with EEXIST instead of following the link and
+  // writing the shared file through it. Under normal operation the target was
+  // just confirmed absent, so this never changes behaviour.
+  await fs.copyFile(source, target, fsConstants.COPYFILE_EXCL);
 }
 
 /**

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -6,6 +6,7 @@ import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-uti
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
+const COPIED_PROBE_LOGIN_FILES = ["auth.json", "config.toml"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const AUTH_CREDENTIAL_KEYS = /(?:openai[_-]?key|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|session|auth)/i;
 
@@ -177,6 +178,55 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   if (existing) return;
   await ensureParentDir(target);
   await fs.copyFile(source, target);
+}
+
+export interface SeedCodexProbeHomeResult {
+  sourceHome: string;
+  copiedAuth: boolean;
+}
+
+/**
+ * Seeds a managed CODEX_HOME used by the environment probe from the host login
+ * without symlinking auth. The probe may refresh tokens while proving auth
+ * works, so it gets an isolated copy and leaves the host login file untouched.
+ */
+export async function seedCodexProbeHomeFromHostLogin(
+  targetHome: string,
+  env: NodeJS.ProcessEnv,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<SeedCodexProbeHomeResult> {
+  const sourceHome = resolveSharedCodexHomeDir(env);
+  const seedFromShared = path.resolve(sourceHome) !== path.resolve(targetHome);
+  let copiedAuth = false;
+
+  await fs.mkdir(targetHome, { recursive: true });
+
+  if (seedFromShared) {
+    for (const name of COPIED_PROBE_LOGIN_FILES) {
+      const target = path.join(targetHome, name);
+      const existing = await fs.lstat(target).catch(() => null);
+      if (existing) continue;
+
+      const source = path.join(sourceHome, name);
+      if (!(await pathExists(source))) continue;
+
+      await ensureParentDir(target);
+      await fs.copyFile(source, target);
+      if (name === "auth.json") {
+        await fs.chmod(target, 0o600).catch(() => undefined);
+        copiedAuth = true;
+      }
+    }
+
+    if (copiedAuth) {
+      await onLog(
+        "stdout",
+        `[paperclip] Seeded Codex probe home "${targetHome}" from host login "${sourceHome}" (copied auth.json).\n`,
+      );
+    }
+  }
+
+  return { sourceHome, copiedAuth };
 }
 
 /**

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -6,7 +6,6 @@ import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-uti
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
-const COPIED_PROBE_LOGIN_FILES = ["auth.json", "config.toml"] as const;
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const AUTH_CREDENTIAL_KEYS = /(?:openai[_-]?key|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|session|auth)/i;
 
@@ -178,55 +177,6 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   if (existing) return;
   await ensureParentDir(target);
   await fs.copyFile(source, target);
-}
-
-export interface SeedCodexProbeHomeResult {
-  sourceHome: string;
-  copiedAuth: boolean;
-}
-
-/**
- * Seeds a managed CODEX_HOME used by the environment probe from the host login
- * without symlinking auth. The probe may refresh tokens while proving auth
- * works, so it gets an isolated copy and leaves the host login file untouched.
- */
-export async function seedCodexProbeHomeFromHostLogin(
-  targetHome: string,
-  env: NodeJS.ProcessEnv,
-  onLog: AdapterExecutionContext["onLog"],
-): Promise<SeedCodexProbeHomeResult> {
-  const sourceHome = resolveSharedCodexHomeDir(env);
-  const seedFromShared = path.resolve(sourceHome) !== path.resolve(targetHome);
-  let copiedAuth = false;
-
-  await fs.mkdir(targetHome, { recursive: true });
-
-  if (seedFromShared) {
-    for (const name of COPIED_PROBE_LOGIN_FILES) {
-      const target = path.join(targetHome, name);
-      const existing = await fs.lstat(target).catch(() => null);
-      if (existing) continue;
-
-      const source = path.join(sourceHome, name);
-      if (!(await pathExists(source))) continue;
-
-      await ensureParentDir(target);
-      await fs.copyFile(source, target);
-      if (name === "auth.json") {
-        await fs.chmod(target, 0o600).catch(() => undefined);
-        copiedAuth = true;
-      }
-    }
-
-    if (copiedAuth) {
-      await onLog(
-        "stdout",
-        `[paperclip] Seeded Codex probe home "${targetHome}" from host login "${sourceHome}" (copied auth.json).\n`,
-      );
-    }
-  }
-
-  return { sourceHome, copiedAuth };
 }
 
 /**

--- a/packages/adapters/codex-local/src/server/test.auth.test.ts
+++ b/packages/adapters/codex-local/src/server/test.auth.test.ts
@@ -102,7 +102,7 @@ describe("codex local environment probe auth", () => {
     return { root, paperclipHome, sharedCodexHome, workspaceDir, managedAgentHome };
   }
 
-  it("copies host Codex login into an empty managed CODEX_HOME before the local probe", async () => {
+  it("symlinks host Codex login into an empty managed CODEX_HOME before the local probe", async () => {
     const fx = await makeFixture();
 
     const result = await testEnvironment({
@@ -123,7 +123,7 @@ describe("codex local environment probe auth", () => {
     expect(result.checks.some((check) => check.code === "codex_native_auth_present")).toBe(true);
 
     const agentAuth = path.join(fx.managedAgentHome, "auth.json");
-    expect((await fs.lstat(agentAuth)).isSymbolicLink()).toBe(false);
+    expect((await fs.lstat(agentAuth)).isSymbolicLink()).toBe(true);
     expect(JSON.parse(await fs.readFile(agentAuth, "utf8"))).toEqual({
       accessToken: "host-access-token",
       accountId: "acct-1",
@@ -136,6 +136,52 @@ describe("codex local environment probe auth", () => {
       | [string, unknown, string, string[], { env: Record<string, string> }]
       | undefined;
     expect(probeCall?.[4].env.CODEX_HOME).toBe(fx.managedAgentHome);
+  });
+
+  it("keeps probe token refreshes on the host login through the auth symlink", async () => {
+    const fx = await makeFixture();
+    const hostAuth = path.join(fx.sharedCodexHome, "auth.json");
+    runAdapterExecutionTargetProcess.mockImplementationOnce(async (_runId, _target, _command, _args, options) => {
+      await fs.writeFile(
+        path.join(options.env.CODEX_HOME, "auth.json"),
+        JSON.stringify({ accessToken: "rotated-by-probe", accountId: "acct-1" }),
+        "utf8",
+      );
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          "{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}",
+          "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"hello\"}}",
+          "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"cached_input_tokens\":0,\"output_tokens\":1}}",
+        ].join("\n"),
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      };
+    });
+
+    await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        command: "codex",
+        cwd: fx.workspaceDir,
+        env: {
+          CODEX_HOME: fx.managedAgentHome,
+          OPENAI_API_KEY: "",
+        },
+      },
+    });
+
+    const agentAuth = path.join(fx.managedAgentHome, "auth.json");
+    expect((await fs.lstat(agentAuth)).isSymbolicLink()).toBe(true);
+    expect(await fs.realpath(agentAuth)).toBe(await fs.realpath(hostAuth));
+    expect(JSON.parse(await fs.readFile(hostAuth, "utf8"))).toEqual({
+      accessToken: "rotated-by-probe",
+      accountId: "acct-1",
+    });
   });
 
   it("keeps the API-key probe path isolated from the managed CODEX_HOME", async () => {

--- a/packages/adapters/codex-local/src/server/test.auth.test.ts
+++ b/packages/adapters/codex-local/src/server/test.auth.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureAdapterExecutionTargetDirectory,
+  ensureAdapterExecutionTargetCommandResolvable,
+  maybeRunSandboxInstallCommand,
+  runAdapterExecutionTargetProcess,
+  resolveAdapterExecutionTargetCwd,
+} = vi.hoisted(() => ({
+  ensureAdapterExecutionTargetDirectory: vi.fn(async () => {}),
+  ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => {}),
+  maybeRunSandboxInstallCommand: vi.fn(async () => null),
+  runAdapterExecutionTargetProcess: vi.fn(),
+  resolveAdapterExecutionTargetCwd: vi.fn((_target, configuredCwd, fallbackCwd) => {
+    if (typeof configuredCwd === "string" && configuredCwd.trim().length > 0) return configuredCwd;
+    return fallbackCwd;
+  }),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetDirectory,
+    ensureAdapterExecutionTargetCommandResolvable,
+    maybeRunSandboxInstallCommand,
+    runAdapterExecutionTargetProcess,
+    resolveAdapterExecutionTargetCwd,
+  };
+});
+
+import { testEnvironment } from "./test.js";
+
+describe("codex local environment probe auth", () => {
+  const cleanupDirs: string[] = [];
+
+  beforeEach(() => {
+    runAdapterExecutionTargetProcess.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        "{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}",
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"hello\"}}",
+        "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"cached_input_tokens\":0,\"output_tokens\":1}}",
+      ].join("\n"),
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function makeFixture(options: { hostAuth?: boolean } = {}) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-probe-auth-"));
+    cleanupDirs.push(root);
+
+    const paperclipHome = path.join(root, "paperclip-home");
+    const sharedCodexHome = path.join(root, "host-codex-home");
+    const workspaceDir = path.join(root, "workspace");
+    const managedAgentHome = path.join(
+      paperclipHome,
+      "instances",
+      "default",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "codex-home",
+    );
+
+    await fs.mkdir(sharedCodexHome, { recursive: true });
+    await fs.mkdir(workspaceDir, { recursive: true });
+    if (options.hostAuth !== false) {
+      await fs.writeFile(
+        path.join(sharedCodexHome, "auth.json"),
+        JSON.stringify({ accessToken: "host-access-token", accountId: "acct-1" }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(sharedCodexHome, "config.toml"), "model = \"gpt-5.5\"\n", "utf8");
+    }
+
+    vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+    vi.stubEnv("CODEX_HOME", sharedCodexHome);
+    vi.stubEnv("OPENAI_API_KEY", "");
+
+    return { root, paperclipHome, sharedCodexHome, workspaceDir, managedAgentHome };
+  }
+
+  it("copies host Codex login into an empty managed CODEX_HOME before the local probe", async () => {
+    const fx = await makeFixture();
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        command: "codex",
+        cwd: fx.workspaceDir,
+        env: {
+          CODEX_HOME: fx.managedAgentHome,
+          OPENAI_API_KEY: "",
+        },
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.checks.some((check) => check.code === "codex_probe_auth_seeded_from_host_login")).toBe(true);
+    expect(result.checks.some((check) => check.code === "codex_native_auth_present")).toBe(true);
+
+    const agentAuth = path.join(fx.managedAgentHome, "auth.json");
+    expect((await fs.lstat(agentAuth)).isSymbolicLink()).toBe(false);
+    expect(JSON.parse(await fs.readFile(agentAuth, "utf8"))).toEqual({
+      accessToken: "host-access-token",
+      accountId: "acct-1",
+    });
+    await expect(fs.readFile(path.join(fx.managedAgentHome, "config.toml"), "utf8")).resolves.toBe(
+      "model = \"gpt-5.5\"\n",
+    );
+
+    const probeCall = runAdapterExecutionTargetProcess.mock.calls[0] as unknown as
+      | [string, unknown, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(probeCall?.[4].env.CODEX_HOME).toBe(fx.managedAgentHome);
+  });
+
+  it("keeps the API-key probe path isolated from the managed CODEX_HOME", async () => {
+    const fx = await makeFixture();
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        command: "codex",
+        cwd: fx.workspaceDir,
+        env: {
+          CODEX_HOME: fx.managedAgentHome,
+          OPENAI_API_KEY: "sk-test",
+        },
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.checks.some((check) => check.code === "codex_probe_auth_seeded_from_host_login")).toBe(false);
+    await expect(fs.access(path.join(fx.managedAgentHome, "auth.json"))).rejects.toBeTruthy();
+
+    const probeCall = runAdapterExecutionTargetProcess.mock.calls[0] as unknown as
+      | [string, unknown, string, string[], { env: Record<string, string> }]
+      | undefined;
+    expect(probeCall?.[2]).toBe("sh");
+    expect(probeCall?.[4].env.CODEX_HOME).toContain("paperclip-codex-probe-codex-envtest-");
+    expect(JSON.parse(probeCall?.[4].env._PAPERCLIP_CODEX_AUTH_JSON ?? "{}")).toEqual({
+      OPENAI_API_KEY: "sk-test",
+    });
+  });
+
+  it("keeps the auth-required hint when no API key or host login exists", async () => {
+    const fx = await makeFixture({ hostAuth: false });
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "401 Unauthorized: Missing bearer",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        command: "codex",
+        cwd: fx.workspaceDir,
+        env: {
+          CODEX_HOME: fx.managedAgentHome,
+          OPENAI_API_KEY: "",
+        },
+      },
+    });
+
+    const authCheck = result.checks.find((check) => check.code === "codex_hello_probe_auth_required");
+    expect(result.status).toBe("warn");
+    expect(authCheck?.hint).toContain("run `codex login` on the host first");
+    await expect(fs.access(path.join(fx.managedAgentHome, "auth.json"))).rejects.toBeTruthy();
+  });
+});

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -27,7 +27,8 @@ import { buildCodexExecArgs } from "./codex-args.js";
 import {
   isManagedCodexHomePath,
   prepareManagedCodexHome,
-  seedCodexProbeHomeFromHostLogin,
+  resolveSharedCodexHomeDir,
+  seedManagedCodexHome,
 } from "./codex-home.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
@@ -247,17 +248,14 @@ export async function testEnvironment(
     const configuredHomeIsManaged =
       configuredCodexHome != null && isManagedCodexHomePath(process.env, ctx.companyId, configuredCodexHome);
     if (configuredHomeIsManaged) {
-      const seedResult = await seedCodexProbeHomeFromHostLogin(
-        configuredCodexHome,
-        process.env,
-        async () => {},
-      );
-      if (seedResult.copiedAuth) {
+      await seedManagedCodexHome(configuredCodexHome, process.env, async () => {});
+      const sourceHome = resolveSharedCodexHomeDir(process.env);
+      if (await fs.access(path.join(configuredCodexHome, "auth.json")).then(() => true).catch(() => false)) {
         checks.push({
           code: "codex_probe_auth_seeded_from_host_login",
           level: "info",
           message: "Seeded Codex probe authentication from the host login.",
-          detail: `Copied auth.json from ${path.join(seedResult.sourceHome, "auth.json")} into ${path.join(configuredCodexHome, "auth.json")}.`,
+          detail: `Symlinked auth.json from ${path.join(sourceHome, "auth.json")} into ${path.join(configuredCodexHome, "auth.json")}.`,
         });
       }
     }

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -24,7 +24,11 @@ import { parseCodexJsonl } from "./parse.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 import { codexHomeDir, readCodexAuthInfo } from "./quota.js";
 import { buildCodexExecArgs } from "./codex-args.js";
-import { prepareManagedCodexHome } from "./codex-home.js";
+import {
+  isManagedCodexHomePath,
+  prepareManagedCodexHome,
+  seedCodexProbeHomeFromHostLogin,
+} from "./codex-home.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -239,6 +243,25 @@ export async function testEnvironment(
       detail: `Detected in ${source}.`,
     });
   } else if (!targetIsRemote) {
+    const configuredCodexHome = isNonEmpty(env.CODEX_HOME) ? path.resolve(env.CODEX_HOME) : null;
+    const configuredHomeIsManaged =
+      configuredCodexHome != null && isManagedCodexHomePath(process.env, ctx.companyId, configuredCodexHome);
+    if (configuredHomeIsManaged) {
+      const seedResult = await seedCodexProbeHomeFromHostLogin(
+        configuredCodexHome,
+        process.env,
+        async () => {},
+      );
+      if (seedResult.copiedAuth) {
+        checks.push({
+          code: "codex_probe_auth_seeded_from_host_login",
+          level: "info",
+          message: "Seeded Codex probe authentication from the host login.",
+          detail: `Copied auth.json from ${path.join(seedResult.sourceHome, "auth.json")} into ${path.join(configuredCodexHome, "auth.json")}.`,
+        });
+      }
+    }
+
     // Local-only auth file check. On remote targets, the probe will surface
     // any missing-auth errors directly from the remote `codex` invocation.
     const codexHome = isNonEmpty(env.CODEX_HOME) ? env.CODEX_HOME : undefined;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The codex_local adapter probes the local Codex CLI before agent runs
> - Codex reads credentials from `CODEX_HOME/auth.json`, while Paperclip uses managed per-agent Codex homes for local agents
> - Hosts can already be authenticated through the shared Codex/ChatGPT login while the managed probe home is still empty
> - That makes the probe fail with missing bearer auth even though the host login is usable
> - Earlier copy-based seeding was hardened after security review so OAuth credentials are not copied into stale per-agent files
> - This pull request symlinks managed probe auth to the host login and only copies non-secret config with an exclusive create guard
> - The benefit is an accurate codex_local probe on ChatGPT-login hosts without weakening credential rotation or revocation behavior

## Linked Issues or Issue Description

Refs #5939
Refs #8492

This reopens the original codex_local auth-seeding PR at the hardened head from #8492. It addresses a managed `CODEX_HOME` probe failure mode where the host has a valid Codex/ChatGPT login but no `OPENAI_API_KEY`, while the per-agent managed probe home has no `auth.json` yet.

## What Changed

- Reused the existing managed Codex home seeding path for local probe homes when no API key is configured.
- Symlinked `auth.json` instead of copying OAuth credentials, preserving shared-login refresh and revocation behavior.
- Kept non-secret `config.toml` copying, hardened with `COPYFILE_EXCL` to avoid target-race overwrites.
- Added targeted coverage for host-login seeding, unchanged API-key probe behavior, no-login/no-key auth-required hints, symlink handling, and the exclusive-copy guard.

## Verification

- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm exec tsx -` smoke confirmed `testEnvironment` passes, emits the host-login seeded event, preserves native auth, and prepares managed probe home auth.
- PR #8492 CI passed at the same head `23dda6dbf6ebb710245d217cd695e4ae04ffa7ac`, including Typecheck, Build, general tests, serialized suites, e2e, Canary Dry Run, Greptile, Socket, Snyk, and Superagent Security Scan.
- Local targeted Vitest still cannot start in this Windows/pnpm checkout because Vite/Vitest package-private imports fail before test execution; CI coverage is the reliable verification lane for this branch.

## Risks

- Auth-handling surface: this PR intentionally touches Codex login material. The hardened version symlinks `auth.json` instead of copying OAuth credentials, avoids logging token contents, and only operates on managed local probe homes.
- Non-secret config copy race: mitigated with `fs.constants.COPYFILE_EXCL` so a target appearing after the pre-check fails closed.
- Upstream merge coordination: #8492 carries the same hardened head and full security-review history; this reopened PR keeps the original issue-named branch available as the public artifact.

## Model Used

- OpenAI GPT-5 Codex via Paperclip codex_local agent, tool-assisted code editing, GitHub CLI, and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge