### PR TITLE
fix(server): reap hung no-progress running runs so their issue can be adopted

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -620,6 +620,27 @@ DB backups are not full instance filesystem backups. For full local disaster
 recovery, also back up local storage files and the local encrypted secrets key if
 those providers are enabled.
 
+## Run Recovery (Orphan & Hung-Run Reaping)
+
+The server periodically reaps heartbeat runs that are stuck in the `running` state so a
+hung run cannot pin its issue in `in_progress` forever:
+
+- **Lost-process runs** — a `running` run whose worker process is gone is failed with
+  `errorCode = process_lost` (and retried once for local adapters), releasing the issue.
+- **Hung (no-progress) runs** — a `running` run whose worker is still alive as a PID but has
+  produced no new output for longer than the hung-run threshold is failed with
+  `errorCode = process_hung`. Hung runs are **not** auto-retried; their issue's execution and
+  checkout locks are released so a healthy run can adopt the work (no more 409 on checkout).
+
+Environment overrides:
+
+- `PAPERCLIP_HUNG_RUN_REAP_THRESHOLD_MS=<ms>` — no-progress window after which an alive-but-idle
+  `running` run is treated as hung and reaped. Default `21600000` (6h). Positive values are
+  floored at `60000` (1m). Set to `0` (or any value `<= 0`) to disable the hung-run watchdog and
+  reap only runs whose process is provably gone. Output progress is measured from the run's last
+  streamed output (falling back to process/run start time), so healthy long runs that stream
+  output regularly are never affected.
+
 ## Secrets in Dev
 
 Agent env vars now support secret references. By default, secret values are stored with local encryption and only secret refs are persisted in agent config.

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -976,6 +976,95 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("reaps a hung local run whose pid is alive but has made no progress past the threshold", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+
+    // Simulate a worker that is alive as a PID but has emitted no output for an hour
+    // (the DEV-680 "zombie" scenario: blocked in epoll_wait, doing no work).
+    const staleOutputAt = new Date(Date.now() - 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ lastOutputAt: staleOutputAt, processStartedAt: staleOutputAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+
+    // Watchdog enabled with a 1-minute no-progress threshold; staleness gate disabled so the
+    // only thing under test is the hung detection.
+    const result = await heartbeat.reapOrphanedRuns({
+      staleThresholdMs: 0,
+      hungRunThresholdMs: 60_000,
+    });
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const failedRun = await heartbeat.getRun(runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_hung");
+    expect(failedRun?.error).toContain("hung");
+    expect(failedRun?.livenessState).toBe("failed");
+
+    // Hung runs are not auto-retried (unlike process_lost): only the original run exists.
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+
+    // The issue's execution + checkout locks are released so another agent can adopt it
+    // without hitting a 409.
+    const releasedIssue = await waitForValue(async () =>
+      db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => {
+          const row = rows[0] ?? null;
+          return row && row.checkoutRunId === null && row.executionRunId === null ? row : null;
+        }),
+    );
+    expect(releasedIssue?.checkoutRunId).toBeNull();
+    expect(releasedIssue?.executionRunId).toBeNull();
+
+    // The stuck worker process is terminated as part of reaping the hung run.
+    expect(await waitForPidExit(child.pid as number)).toBe(true);
+  });
+
+  it("does not reap an alive local run that is still making progress within the threshold", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      includeIssue: false,
+    });
+
+    // Fresh output: the run is actively producing progress, so the watchdog must leave it
+    // alone even though the no-progress threshold is configured.
+    await db
+      .update(heartbeatRuns)
+      .set({ lastOutputAt: new Date() })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({
+      staleThresholdMs: 0,
+      hungRunThresholdMs: 60_000,
+    });
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,6 +85,7 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  hungRunReapThresholdMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -106,6 +107,22 @@ function detectTailnetBindHost(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+// Default no-progress window after which a non-terminal ("running") heartbeat run with no
+// observable output is treated as hung and reaped so its issue can be adopted. Kept large so
+// that healthy long runs (which stream output regularly) are never affected; operators can
+// lower it for faster recovery or set it to 0 to disable the watchdog entirely.
+const DEFAULT_HUNG_RUN_REAP_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6h
+const MIN_HUNG_RUN_REAP_THRESHOLD_MS = 60 * 1000; // floor positive overrides to 1m
+
+function resolveHungRunReapThresholdMs(): number {
+  const raw = process.env.PAPERCLIP_HUNG_RUN_REAP_THRESHOLD_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_HUNG_RUN_REAP_THRESHOLD_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_HUNG_RUN_REAP_THRESHOLD_MS;
+  if (parsed <= 0) return 0; // explicit opt-out disables the hung-run watchdog
+  return Math.max(MIN_HUNG_RUN_REAP_THRESHOLD_MS, parsed);
 }
 
 export function loadConfig(): Config {
@@ -331,6 +348,7 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    hungRunReapThresholdMs: resolveHungRunReapThresholdMs(),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -782,7 +782,9 @@ export async function startServer(): Promise<StartedServer> {
     await (async () => {
       for (let attempt = 1; attempt <= 2; attempt++) {
         try {
-          const result = await heartbeat.reapOrphanedRuns();
+          const result = await heartbeat.reapOrphanedRuns({
+            hungRunThresholdMs: config.hungRunReapThresholdMs,
+          });
           logger.info(
             { reaped: result.reaped, runIds: result.runIds },
             "startup reap of orphaned heartbeat runs complete",
@@ -877,7 +879,7 @@ export async function startServer(): Promise<StartedServer> {
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
       void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000, hungRunThresholdMs: config.hungRunReapThresholdMs })
         .then(() => heartbeat.promoteDueScheduledRetries())
         .then(async (promotion) => {
           await heartbeat.resumeQueuedRuns();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -229,6 +229,7 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const HUNG_RUN_ERROR_CODE = "process_hung";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -3161,6 +3162,24 @@ function buildProcessLossMessage(run: {
     return `Process lost -- process group ${run.processGroupId} is no longer running`;
   }
   return "Process lost -- server may have restarted";
+}
+
+function buildHungRunMessage(
+  run: {
+    processPid: number | null;
+    processGroupId: number | null;
+  },
+  noProgressMs: number,
+) {
+  const where = run.processPid
+    ? `child pid ${run.processPid}`
+    : run.processGroupId
+      ? `process group ${run.processGroupId}`
+      : "worker";
+  const duration = Number.isFinite(noProgressMs)
+    ? `${Math.floor(noProgressMs / 60_000)}m`
+    : "an extended period";
+  return `Run hung -- ${where} made no observable progress (no new output) for ${duration} and was reaped so the issue can be adopted`;
 }
 
 function truncateDisplayId(value: string | null | undefined, max = 128) {
@@ -7922,8 +7941,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; hungRunThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const hungRunThresholdMs = opts?.hungRunThresholdMs ?? 0;
     const now = new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
@@ -7951,7 +7971,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
-      if (processPidAlive) {
+
+      // No-progress ("hung") watchdog for non-terminal runs. A worker can stay alive as a PID
+      // while doing no work (e.g. blocked in epoll_wait) and emitting no output. Such a run
+      // would otherwise pin its issue in `in_progress` forever: the pid-alive branch below
+      // never reaps it, and lock-sweep / checkout adoption only release terminal runs. When a
+      // run whose process is still alive has shown no observable progress (no new streamed
+      // output) for longer than the configured threshold, reap it anyway so the issue becomes
+      // adoptable. This is deliberately gated on a *live* local process: a run whose pid is
+      // already gone is handled by the process-loss path below (which retries once), and a
+      // run with no observable progress but a dead/unknown process is not "hung" — it is lost.
+      // The threshold defaults large enough that healthy long runs — which stream output
+      // regularly — are never affected. Disabled when the threshold is <= 0.
+      const lastProgressAt =
+        run.lastOutputAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt;
+      const noProgressMs = lastProgressAt
+        ? now.getTime() - new Date(lastProgressAt).getTime()
+        : Number.POSITIVE_INFINITY;
+      const hung =
+        hungRunThresholdMs > 0 &&
+        (processPidAlive || processGroupAlive) &&
+        noProgressMs >= hungRunThresholdMs;
+
+      if (processPidAlive && !hung) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
           const detachedRun = await setRunStatus(run.id, "running", {
@@ -7974,7 +8016,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      if (hung) {
+        // `hung` implies a live local process; terminate it before finalizing so it cannot keep
+        // holding resources or later mutate the shared working tree.
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+      } else if (processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,
@@ -7982,19 +8031,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const reapErrorCode = hung ? HUNG_RUN_ERROR_CODE : "process_lost";
+      // Hung runs are never auto-retried: the same degraded worker would likely hang again,
+      // and re-driving a stuck assignee can corrupt the shared working tree. Releasing the
+      // issue lets the orphan/adoption path hand the work to a healthy run instead.
+      const shouldRetry =
+        !hung && tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
+      const baseMessage = hung
+        ? buildHungRunMessage(run, noProgressMs)
+        : buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
-        errorCode: "process_lost",
+        errorCode: reapErrorCode,
         finishedAt: now,
         resultJson: mergeRunStopMetadataForAgent(
           { adapterType, adapterConfig },
           "failed",
           {
             resultJson: parseObject(run.resultJson),
-            errorCode: "process_lost",
+            errorCode: reapErrorCode,
             errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
           },
         ),
@@ -8036,6 +8092,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          ...(hung
+            ? {
+                hung: true,
+                errorCode: HUNG_RUN_ERROR_CODE,
+                noProgressMs: Number.isFinite(noProgressMs) ? noProgressMs : null,
+              }
+            : {}),
         },
       });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; each agent assignment runs as a supervised heartbeat run, frequently a local child process.
> - The heartbeat reaper `reapOrphanedRuns()` reconciles in-memory run state against the DB and is responsible for freeing an issue whose run has died or wedged.
> - For local runs the reaper makes a binary keep-or-kill decision purely on "is the recorded pid still alive?" — if the pid is alive it `continue`s and never reaps.
> - That misses the "hung worker" failure mode: a child can stay alive as a PID while doing no work (e.g. blocked in `epoll_wait`) and emitting no output, so the run sits in `running` indefinitely.
> - Because `sweepStaleIssueLocks` and checkout adoption only release **terminal** runs, the hung run pins its issue — another agent trying to check the issue out gets `409` forever.
> - This pull request adds a no-progress watchdog: a run whose local process is still alive but has streamed no output past a configurable threshold is terminated and finalized as `failed` / `process_hung`, releasing the issue's locks so a healthy run can adopt it.
> - The benefit is that a single wedged worker can no longer strand an issue for hours; recovery becomes automatic and bounded by an operator-tunable threshold, with a clean opt-out.

## Linked Issues or Issue Description

No existing public GitHub issue — describing in-PR (bug report):

**What happens:** A heartbeat run can remain `running` with liveness `unknown` indefinitely. Observed: a worker process stayed alive as a PID (blocked in `epoll_wait`, a few seconds of CPU over ~12h) while emitting no comments/artifacts/log progress. The tracked run never terminated, so its issue stayed pinned and no other agent could adopt it — checkout returned `409`.

**Root cause:**
- `reapOrphanedRuns()` early-returns (`continue`) for any local run whose recorded pid is still alive, so a hung-but-alive run is never reaped.
- `sweepStaleIssueLocks` and checkout adoption (`isTerminalOrMissingHeartbeatRun`) only release **terminal** runs, so the issue's checkout/execution locks are never cleared while the run is non-terminal.
- Net effect: a hung non-terminal run pins its issue in `in_progress` indefinitely.

**Related in-flight PRs** (same area; this PR is a single self-contained alternative that covers both the detection half and the lock-release/adoption half):
- Refs #5109 — detect stream-stalled runs in `reapOrphanedRuns` (detection half)
- Refs #6407 — auto-terminate `process_detached` runs silent > 6h
- Refs #6273 — kill detached child after 5-min grace
- Refs #5660 — clear issue checkout/execution locks on terminal heartbeat run (adoption half)

## What Changed

- `server/src/services/heartbeat.ts`: add a no-progress ("hung") watchdog to `reapOrphanedRuns`. A run whose **live** local process (pid or process group) has streamed no output for longer than `hungRunThresholdMs` is treated as hung — the worker is terminated, the run is finalized `failed` with `errorCode = process_hung`, and the issue's execution/checkout locks are released via the existing terminal-run release + promote path so a healthy run can adopt it. Hung runs are **not** auto-retried (the same degraded worker would likely hang again and could corrupt the shared working tree). Gating on a *live* process preserves the existing `process_lost` retry-once path for genuinely lost processes and leaves non-local-child adapters unchanged.
- `server/src/config.ts`: add `hungRunReapThresholdMs` config and `PAPERCLIP_HUNG_RUN_REAP_THRESHOLD_MS` env override — default `21600000` (6h); positive values floored at `60000` (1m); `<= 0` disables the watchdog and restores prior behavior.
- `server/src/index.ts`: pass the configured threshold into the startup and periodic `reapOrphanedRuns` calls.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: add regression tests — a hung live run is reaped and its issue released; a progressing live run is left alone.
- `doc/DEVELOPING.md`: document the new env var and run-recovery behavior.

## Verification

- `pnpm --filter @paperclipai/server typecheck` → green.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` → the two new tests pass, and the existing dead-pid `process_lost` retry test is unchanged and passes.
  - Two unrelated tests in this file are pre-existing flakes under full-file serial load (`environments_local_driver_idx` duplicate-key from cross-test environment leakage, and a 5s per-test timeout). They were reproduced identically on `master` with this change stashed, so they are not introduced by this PR.
- Case reasoning: live-pid + no-progress → reaped as `process_hung`, issue released; live-pid + recent output → left alone; dead-pid → unchanged `process_lost` + retry; non-local-child adapter → unchanged; threshold `<= 0` → exact prior behavior.

## Risks

- Low. The default threshold (6h) is well above healthy long-run output cadence, so healthy runs that stream output regularly are never affected. The watchdog only acts on runs with a *live* local process and no streamed output past the threshold, and can be fully disabled with `PAPERCLIP_HUNG_RUN_REAP_THRESHOLD_MS=0`. No schema or migration changes. Behavioral change is scoped to `reapOrphanedRuns`.

## Model Used

- Claude (Anthropic), model id `claude-opus-4.8`, accessed via GitHub Copilot. Agentic/extended-thinking mode with tool use and code execution (ran typecheck and targeted vitest during development).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending — CI runs on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [ ] I will address all Greptile and reviewer comments before requesting merge
