### PR TITLE
docs: clarify commitperclip linked-issue requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,11 +163,28 @@ When adding endpoints:
 When creating a pull request (via `gh pr create` or any other method), you **must** read and fill in every section of [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Do not craft ad-hoc PR bodies — use the template as the structure for your PR description. Required sections:
 
 - **Thinking Path** — trace reasoning from project context to this change (see `CONTRIBUTING.md` for examples)
+- **Linked Issues or Issue Description** — see below; this is the most common reason `commitperclip` fails a PR
 - **What Changed** — bullet list of concrete changes
 - **Verification** — how a reviewer can confirm it works
 - **Risks** — what could go wrong
 - **Model Used** — the AI model that produced or assisted with the change (provider, exact model ID, context window, capabilities). Write "None — human-authored" if no AI was used.
 - **Checklist** — all items checked
+
+### Linked issue (avoid the most common `commitperclip` failure)
+
+`commitperclip` runs on every PR and **fails it** unless the body satisfies one of the two paths below. Do this when you write the PR body, not after the bot complains:
+
+1. **A public GitHub issue exists** — tag it in the body with `Fixes #123`, `Closes #123`, `Resolves #123`, or `Refs #123` (a bare `#123` also counts). Link **all** related/duplicate issues and prior PRs, not just one.
+2. **No public issue exists** — describe the problem inline so a reviewer gets the same fields a filed issue would give them. Include **at least 3** headings/labels from the matching issue template:
+   - **Bug:** `What happened`, `Expected behavior`, `Steps to reproduce`, `Paperclip version or commit`, `Deployment mode`
+   - **Feature:** `Problem or motivation`, `Proposed solution`, `Alternatives considered`, `Roadmap alignment`
+   - **Adapter:** `Agent or provider`, `Why this adapter is useful`, `How the agent is invoked`
+
+   Write each as its own `## Heading`, `**Bold label**`, or `Label:` line — that is what the check scans for.
+
+The check is **skipped** only for PRs whose title uses a `docs:`, `chore:`, `build:`, `ci:`, `style:`, `test:`, or `revert:` conventional-commit prefix. Everything else (`feat:`, `fix:`, `refactor:`, `perf:`, or no prefix) requires path 1 or path 2.
+
+> **Only reference public GitHub issues.** Never put internal/instance-local Paperclip references in the PR title, body, commits, or branch name — no `PAPA-123` / `PAP-224` ticket ids, no `/PAP/issues/...` or `agent://...` links, no `localhost`/tailnet URLs. The working branch is usually named after an internal ticket (e.g. `PAPA-945-...`); rename it to describe the change (e.g. `docs/...`, `fix/...`) before pushing. If an internal issue had useful context, restate it in plain English. See `CONTRIBUTING.md` → "No Internal Issue References".
 
 ## 11. Definition of Done
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Contributors and Paperclip-managed agents open GitHub pull requests as part of the Paperclip repository engineering workflow.
> - The Paperclip repository's commitperclip checks require PR descriptions to either link a public issue or describe the issue inline using template-shaped fields.
> - The repo-local agent instructions listed the PR template sections, but did not call out the linked-issue requirement clearly enough for agents working on Paperclip itself.
> - A recent public PR, Refs #8430, showed the failure mode: the change itself was real, but the PR body did not satisfy the linked-issue gate on first try.
> - This pull request updates only the Paperclip repository's `AGENTS.md` instructions so agents working in this repo get the linked-issue rule right before opening a PR.
> - The benefit is fewer failed commitperclip runs and less maintainer cleanup on Paperclip-repo PRs, without shipping Paperclip-specific rules in bundled product guidance for other users.

## Linked Issues or Issue Description

Refs #8430 as a public example of the commitperclip linked-issue failure mode this documentation is meant to prevent.

No public GitHub issue exists specifically for this docs gap, so the underlying issue is described inline using the feature-request shape.

**Problem or motivation**

Agents were opening otherwise valid Paperclip PRs without satisfying commitperclip's linked-issue requirement. The root cause was repo-local documentation drift: `AGENTS.md` emphasized using the PR template, but did not clearly explain the `Linked Issues or Issue Description` section, the acceptable fallback when no public issue exists, or the rule against leaking internal Paperclip task references.

**Proposed solution**

Update the Paperclip repository's root `AGENTS.md` to explain the two valid paths: link public GitHub issues or PRs when they exist, or describe the issue inline with enough fields from the matching issue template. Also document the conventional-commit prefixes that skip the linked-issue gate and the requirement to keep internal task ids, instance links, and local URLs out of public PR titles, bodies, branches, and commits.

**Alternatives considered**

Changing the bundled `github-pr-workflow` skill would teach every Paperclip user Paperclip-repository-specific commitperclip rules, which is the wrong scope. This PR keeps that bundled product guidance generic and puts the stricter rules only in the Paperclip repo's contributor instructions.

**Roadmap alignment**

This is a docs and contributor-workflow cleanup. It does not add or redirect roadmap-level product work, and ROADMAP.md says docs, polish, and tightly scoped improvements remain the easiest contributions to merge.

Related GitHub search:

- Searched public issues and PRs for `commitperclip linked issue docs PR template` and `linked-issue gate`; no duplicate docs PR or issue was found.
- Related public context: #8430.

## What Changed

- Added `Linked Issues or Issue Description` to the required PR-template section list in root `AGENTS.md`.
- Documented commitperclip's linked-issue paths (`Fixes`, `Closes`, `Resolves`, `Refs`, and bare `#NNN`), inline issue-description fallback, skip prefixes, and no-internal-reference rule in root `AGENTS.md`.
- Kept bundled skills unchanged so Paperclip-specific PR rules are not baked into product-wide agent guidance.

## Verification

- `node --test .github/scripts/tests/check-pr-linked-issue.test.mjs` passed 31/31.
- `git diff --check origin/master...HEAD` passed.
- Validated the PR body locally with `check-pr-template.mjs`, `check-pr-linked-issue.mjs`, and `check-pr-dedup-search.mjs` before updating the PR.
- Confirmed the branch is based on current `origin/master` with one docs commit and only `AGENTS.md` changed.
- Watched PR #8503 checks on head `467250203`; all CI, security, commitperclip, and Greptile checks passed.
- Greptile reported Confidence Score: 5/5 after the final docs wording update.

## Risks

Low risk. This is repo-local documentation only. The main risk is stale wording if commitperclip changes again later; this PR ties the Paperclip repo instructions to the current helper script behavior and existing PR template without changing product-shipped bundled skills.

## Model Used

OpenAI GPT-5 via Codex local. The runtime did not expose an exact context-window value. The model used shell, Git, GitHub CLI, and Paperclip API tools to inspect the repo, prepare the clean branch, verify the docs change, and update this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

