### PR TITLE
fix: align linked-issue PR guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,8 +19,10 @@
 <!--
   Required. Pick ONE of the following two paths:
 
-  (A) Issue exists — tag each linked issue with `Fixes: #123`, `Closes #123`,
-      or `Refs #123`. Include duplicates and closely related issues too.
+  (A) Issue exists — tag each linked issue with `Fixes #123`, `Closes #123`,
+      `Resolves #123`, or `Refs #123`. A bare `#123` also counts, but use an
+      explicit keyword when it describes the relationship. Include duplicates
+      and closely related issues too.
 
   Only reference PUBLIC GitHub issues/PRs here. Do NOT paste internal,
   instance-local Paperclip references — ticket ids like PAPA-123 / PAP-224,
@@ -28,8 +30,9 @@
   contributors cannot open them. See CONTRIBUTING.md → "No Internal Issue
   References".
 
-  (B) No issue exists — describe the underlying problem here, following the
-      relevant issue template so reviewers get the same fields:
+  (B) No issue exists — describe the underlying problem here with at least
+      three headings or labels from the relevant issue template so reviewers
+      get the same fields:
         • Bug:     .github/ISSUE_TEMPLATE/bug_report.yml
         • Feature: .github/ISSUE_TEMPLATE/feature_request.yml
         • Adapter: .github/ISSUE_TEMPLATE/adapter_request.yml
@@ -86,7 +89,7 @@
 - [ ] I have specified the model used (with version and capability details)
 - [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
 - [ ] I have searched GitHub for duplicate or related PRs and linked them above
-- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
+- [ ] I have either (a) linked existing issues with `Fixes #` / `Closes #` / `Resolves #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
 - [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
 - [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
 - [ ] I have run tests locally and they pass

--- a/.github/scripts/check-pr-linked-issue.mjs
+++ b/.github/scripts/check-pr-linked-issue.mjs
@@ -106,7 +106,7 @@ export function checkLinkedIssue(body, prTitle = '') {
     passed,
     failures: passed ? [] : [
       'No linked issue or inline issue description found — either tag an existing issue ' +
-      'with `Fixes #NNN` / `Closes #NNN` / `Refs #NNN`, or describe the underlying issue ' +
+      'with `Fixes #NNN` / `Closes #NNN` / `Resolves #NNN` / `Refs #NNN`, or describe the underlying issue ' +
       'inline in the PR body following one of our issue templates ' +
       '(https://github.com/paperclipai/paperclip/tree/master/.github/ISSUE_TEMPLATE). ' +
       'See CONTRIBUTING.md → "Link Issues or Describe Them In-PR".',

--- a/.github/scripts/tests/check-pr-linked-issue.test.mjs
+++ b/.github/scripts/tests/check-pr-linked-issue.test.mjs
@@ -52,6 +52,7 @@ test('fails with no issue reference when no skip prefix', () => {
   const result = checkLinkedIssue('Added a cool feature, no issue linked', 'feat: something');
   assert.equal(result.passed, false);
   assert.ok(result.failures[0].includes('Fixes #NNN'));
+  assert.ok(result.failures[0].includes('Resolves #NNN'));
 });
 
 test('fails with cross-repo issue reference', () => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ Every pull request **must** follow the PR template at [`.github/PULL_REQUEST_TEM
 
 We do not gate PRs on a pre-existing issue. Two acceptable paths:
 
-1. **Issue exists** — search the [Issues database](https://github.com/paperclipai/paperclip/issues) for anything this PR addresses and tag each one with `Fixes: #123` / `Closes #123` / `Refs #123` so GitHub auto-links them. If there are **duplicate or closely related issues**, link all of them, not just the one you picked. If there are **related PRs** (prior attempts, dependent work, follow-ups, abandoned predecessors), link those too.
-2. **No issue exists** — describe the problem directly in your PR body, following one of our [issue templates](.github/ISSUE_TEMPLATE/) so a reviewer has the same fields they'd get from a filed issue:
+1. **Issue exists** — search the [Issues database](https://github.com/paperclipai/paperclip/issues) for anything this PR addresses and tag each one with `Fixes #123` / `Closes #123` / `Resolves #123` / `Refs #123` so GitHub auto-links them. A bare `#123` also counts, but use an explicit keyword when it describes the relationship. If there are **duplicate or closely related issues**, link all of them, not just the one you picked. If there are **related PRs** (prior attempts, dependent work, follow-ups, abandoned predecessors), link those too.
+2. **No issue exists** — describe the problem directly in your PR body, using at least three headings or labels from one of our [issue templates](.github/ISSUE_TEMPLATE/) so a reviewer has the same fields they'd get from a filed issue:
    - **Bug fix:** what happened, expected behavior, steps to reproduce, Paperclip version/commit, deployment mode. See [`bug_report.yml`](.github/ISSUE_TEMPLATE/bug_report.yml).
    - **Feature:** problem/motivation, proposed solution, alternatives considered, roadmap alignment. See [`feature_request.yml`](.github/ISSUE_TEMPLATE/feature_request.yml).
    - **New adapter:** agent or provider, why it's useful, how it's invoked. See [`adapter_request.yml`](.github/ISSUE_TEMPLATE/adapter_request.yml).
@@ -66,7 +66,7 @@ Either way, a reviewer should be able to understand the underlying issue without
 
 Many contributors run their own Paperclip instance to manage their work. Issue ids and links from *your* instance are private — reviewers and other contributors cannot open them, so they show up as clutter or broken links.
 
-In your PR title, description, commits, and comments, **only reference public GitHub issues and PRs** — `#123`, `Fixes #123` / `Closes #123` / `Refs #123`, or full `https://github.com/paperclipai/paperclip/...` URLs.
+In your PR title, description, commits, and comments, **only reference public GitHub issues and PRs** — `#123`, `Fixes #123` / `Closes #123` / `Resolves #123` / `Refs #123`, or full `https://github.com/paperclipai/paperclip/...` URLs.
 
 Do **not** include references to internal/instance-local Paperclip work, such as:
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Contributors and Paperclip-managed agents open GitHub pull requests against the Paperclip repository.
> - Those PRs are checked by commitperclip, which expects either a public issue reference or an inline issue-template-shaped description.
> - The current contributor guidance has the right section, but its examples are slightly incomplete and inconsistent with the checker: it omits `Resolves #123`, still shows `Fixes: #123` in places, and does not state the three-field inline-description threshold clearly.
> - A previous AGENTS-based docs attempt, Refs #8503, was closed because root agent instructions may be the wrong surface for Paperclip-specific contributor policy.
> - This pull request keeps the guidance in contributor-facing PR surfaces and commitperclip's own failure text instead of root `AGENTS.md` or bundled product skills.
> - The benefit is that people and agents opening Paperclip repository PRs see accurate commitperclip instructions without leaking those rules into Paperclip product defaults.

## Linked Issues or Issue Description

Refs #8430 as a public example of a PR that hit the linked-issue check after opening.

Refs #8503 as the closed prior docs attempt that used the wrong instruction surface.

No public issue exists specifically for this documentation mismatch, so the underlying issue is described inline using the feature-request shape.

**Problem or motivation**

Contributors and agents need the PR template and contributing guide to match commitperclip's actual linked-issue behavior. Inconsistent examples cause avoidable failed checks and reviewer cleanup.

**Proposed solution**

Update the PR template, contributing guide, and commitperclip failure text so they all list the same accepted explicit keywords, mention that bare `#123` counts, and state the inline issue-description fallback as at least three headings or labels from a matching issue template.

**Alternatives considered**

Root `AGENTS.md` and bundled `github-pr-workflow` skill changes were considered, but they are broader instruction surfaces than this policy needs. Keeping the change in contributor-facing PR docs and commitperclip's own message scopes it to Paperclip repository contribution workflow.

**Roadmap alignment**

This is a docs and contributor-workflow cleanup. It does not alter product roadmap behavior.

Related GitHub search:

- Searched public PRs and issues for `commitperclip linked issue docs PR template`; the only matching PR was the closed prior attempt, #8503.
- No matching public issue was found.

## What Changed

- Updated `.github/PULL_REQUEST_TEMPLATE.md` to list `Fixes #123`, `Closes #123`, `Resolves #123`, `Refs #123`, and the bare-issue fallback consistently.
- Clarified in the PR template and `CONTRIBUTING.md` that the no-issue fallback needs at least three issue-template headings or labels.
- Updated the commitperclip linked-issue failure message to include `Resolves #NNN`.
- Added a regression assertion that the failure message advertises `Resolves #NNN`.

## Verification

- `node --test .github/scripts/tests/check-pr-linked-issue.test.mjs` passed 31/31.
- `git diff --check` passed.
- PR body passed `check-pr-template.mjs`, `check-pr-linked-issue.mjs`, and `check-pr-dedup-search.mjs` locally.
- Watched PR #8505 checks on head `ca0e60e00`; all CI, security, commitperclip, and Greptile checks passed.
- Greptile reported Confidence Score: 5/5 with no unresolved review threads.

## Risks

Low risk. This changes contributor documentation and one check failure message; it does not alter commitperclip pass/fail logic or product runtime behavior.

## Model Used

OpenAI GPT-5 via Codex local. The runtime did not expose an exact context-window value. The model used shell, Git, GitHub CLI, and Paperclip API tools to inspect the repo, prepare the branch, run targeted verification, and open this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes #` / `Closes #` / `Resolves #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

