### PR TITLE
fix(ui): replace selection on paste instead of linkifying it (#2930)

### DIFF
--- a/ui/src/components/MarkdownEditor.test.tsx
+++ b/ui/src/components/MarkdownEditor.test.tsx
@@ -8,8 +8,10 @@ import {
   computeMentionMenuPosition,
   findClosestAutocompleteAnchor,
   findMentionMatch,
+  isPasteableLinkUrl,
   isSameAutocompleteSession,
   issueMentionTitle,
+  looksLikeUrl,
   MarkdownEditor,
   type MentionOption,
   placeCaretAfterMentionAnchor,
@@ -991,5 +993,48 @@ describe("MarkdownEditor", () => {
     await act(async () => {
       root.unmount();
     });
+  });
+});
+
+describe("looksLikeUrl / isPasteableLinkUrl (paste-over-selection gate, issue #2930)", () => {
+  // These strings must NOT be treated as link targets, otherwise pasting them
+  // over highlighted text wraps the selection in a link instead of replacing it.
+  const notUrls = [
+    "hello",
+    "hello world",
+    "replace this text",
+    "Some sentence with a period.",
+    "v1.2.3",
+    "",
+    "   ",
+    "name@example", // missing a real domain/scheme; not a paste-to-link target
+    "C:\\Users\\foo",
+  ];
+  it.each(notUrls)("treats %p as plain text, not a URL", (value) => {
+    expect(looksLikeUrl(value)).toBe(false);
+    expect(isPasteableLinkUrl(value)).toBe(false);
+  });
+
+  const urls = [
+    "https://example.com",
+    "http://example.com/path?q=1#frag",
+    "https://sub.example.co.uk/a/b",
+    "ftp://files.example.com/x",
+    "mailto:foo@bar.com",
+    "tel:+15551234567",
+    "//cdn.example.com/app.js",
+    "www.example.com",
+    "www.example.com/path",
+  ];
+  it.each(urls)("treats %p as a URL", (value) => {
+    expect(looksLikeUrl(value)).toBe(true);
+    expect(isPasteableLinkUrl(value)).toBe(true);
+  });
+
+  it("rejects dangerous schemes even when URL-shaped", () => {
+    // looksLikeUrl may match the shape, but the safety gate must veto it so the
+    // selection is never wrapped in a javascript:/data: link.
+    expect(isPasteableLinkUrl("javascript://alert(1)")).toBe(false);
+    expect(isPasteableLinkUrl("vbscript://x")).toBe(false);
   });
 });

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -175,6 +175,42 @@ function isSafeMarkdownLinkUrl(url: string): boolean {
   return !/^(javascript|data|vbscript):/i.test(trimmed);
 }
 
+/**
+ * Whether a pasted string is unambiguously a URL.
+ *
+ * Lexical's `LinkPlugin` registers a paste handler that, when text is selected,
+ * wraps the selection in a link if `validateUrl(clipboardText)` is true instead
+ * of replacing it. `isSafeMarkdownLinkUrl` alone is far too permissive for that
+ * gate — it returns true for any non-dangerous string — so pasting *any* plain
+ * text over highlighted text silently turned it into a link (rendered as an
+ * underline) rather than replacing it (issue #2930). Keep the implicit
+ * paste-to-link behavior only for things that clearly are URLs; everything else
+ * falls through to the normal "replace the selection" paste.
+ */
+export function looksLikeUrl(value: string): boolean {
+  const trimmed = value.trim();
+  // URLs never contain whitespace; sentences/most prose are excluded here.
+  if (!trimmed || /\s/.test(trimmed)) return false;
+  // Explicit scheme with an authority, e.g. https://example.com, ftp://host.
+  if (/^[a-z][a-z0-9+.-]*:\/\/\S/i.test(trimmed)) return true;
+  // Schemes without an authority, e.g. mailto:foo@bar.com, tel:+1234.
+  if (/^(mailto|tel):\S/i.test(trimmed)) return true;
+  // Protocol-relative URL, e.g. //cdn.example.com/app.js.
+  if (/^\/\/\S+/.test(trimmed)) return true;
+  // www-prefixed bare domain, e.g. www.example.com/path?q=1.
+  if (/^www\.[a-z0-9-]+(\.[a-z0-9-]+)*\.[a-z]{2,}([/?#:].*)?$/i.test(trimmed)) return true;
+  return false;
+}
+
+/**
+ * Validator handed to the link plugin. Used both to gate paste-to-link and to
+ * validate programmatic link toggles, so it must reject unsafe schemes *and*
+ * anything that isn't actually a URL.
+ */
+export function isPasteableLinkUrl(url: string): boolean {
+  return isSafeMarkdownLinkUrl(url) && looksLikeUrl(url);
+}
+
 /* ---- Mention detection helpers ---- */
 
 interface MentionState {
@@ -781,7 +817,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
       listsPlugin(),
       quotePlugin(),
       tablePlugin(),
-      linkPlugin({ validateUrl: isSafeMarkdownLinkUrl }),
+      linkPlugin({ validateUrl: isPasteableLinkUrl }),
       linkDialogPlugin(),
       mentionDeletionPlugin(),
       pasteNormalizationPlugin(),


### PR DESCRIPTION
﻿## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issue comments, descriptions, and plan docs are authored in a rich markdown editor (`ui/src/components/MarkdownEditor.tsx`) built on Lexical
> - When a user selects text and pastes (Ctrl/Cmd+V), the expected behavior is the standard OS one: the pasted text replaces the selection
> - Instead, the selected text was being wrapped into a link (rendered underlined), keeping the old text as the link label and the pasted text as the URL
> - Root cause: Lexical's `LinkPlugin` auto-links a non-collapsed selection on paste whenever `validateUrl(clipboardText)` returns true, and the editor passed `isSafeMarkdownLinkUrl`, which returns true for *any* non-dangerous string — so every paste-over-selection got linkified
> - This pull request gates paste-to-link on a strict "looks like a URL" check so only genuine URLs auto-link and everything else replaces the selection
> - The benefit is the editor now matches the universal paste-over-selection behavior users expect on Windows and macOS

## Linked Issues or Issue Description

Fixes #2930

## What Changed

- Added `looksLikeUrl()` in `ui/src/components/MarkdownEditor.tsx` — a strict check that only treats genuine URLs (`https://…`, `http://…`, `mailto:…`, `tel:…`, protocol-relative `//…`, `www.…`) as link candidates.
- Composed it with the existing safety check as `isPasteableLinkUrl()` and passed that to `linkPlugin({ validateUrl })`, replacing the permissive `isSafeMarkdownLinkUrl`.
- Result: pasting over a selection now replaces the selection for ordinary text (words, sentences, paths, versions); only real URLs still auto-link a selection; unsafe schemes (`javascript:`/`data:`/`vbscript:`) remain rejected.
- Added unit tests in `ui/src/components/MarkdownEditor.test.tsx` covering non-URL strings (must replace), real URLs (must link), and unsafe URL-shaped schemes (must be vetoed).

## Verification

```
ui: vitest run src/components/MarkdownEditor.test.tsx  →  54 passed
ui: tsc --noEmit                                       →  clean
```

Manual: in the markdown editor, select existing text, copy a plain word, and paste — the selection is replaced (previously it became an underlined link). Copy a real URL (e.g. `https://example.com`), select text, and paste — the selection auto-links as before.

## Risks

Low risk. The change only narrows when a paste auto-links a selection; it does not affect the link dialog (which dispatches `TOGGLE_LINK_COMMAND` with an object payload and bypasses `validateUrl`), and unsafe-scheme rejection is preserved via `isSafeMarkdownLinkUrl`. Worst case for an edge URL form not matched by `looksLikeUrl()` is that the user selects-and-uses the explicit link button instead of relying on paste-to-link.

## Model Used

Claude (Anthropic) — claude-opus-4-8, extended thinking, via Claude Code with tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


