### PR TITLE
[codex] Avoid stale local execution workspace reuse

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -11,7 +11,6 @@ import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
   assertPushCapabilityCheckoutValid,
-  buildRealizedExecutionWorkspaceFromPersisted,
   buildExplicitResumeSessionOverride,
   deriveTaskKeyWithHeartbeatFallback,
   extractWakeCommentIds,
@@ -809,51 +808,6 @@ describe("mergeExecutionWorkspaceMetadataForPersistence", () => {
         resolvedSha: "abc1234567890",
       },
     });
-  });
-});
-
-describe("buildRealizedExecutionWorkspaceFromPersisted", () => {
-  it("reuses the persisted execution workspace path instead of deriving a new worktree", () => {
-    const result = buildRealizedExecutionWorkspaceFromPersisted({
-      base: buildResolvedWorkspace({
-        cwd: "/tmp/project-primary",
-        repoRef: "main",
-      }),
-      workspace: {
-        id: "execution-workspace-1",
-        companyId: "company-1",
-        projectId: "project-1",
-        projectWorkspaceId: "workspace-1",
-        sourceIssueId: "issue-1",
-        mode: "isolated_workspace",
-        strategyType: "git_worktree",
-        name: "PAP-880-thumbs-capture-for-evals-feature",
-        status: "active",
-        cwd: "/tmp/reused-worktree",
-        repoUrl: "https://example.com/paperclip.git",
-        baseRef: "main",
-        branchName: "PAP-880-thumbs-capture-for-evals-feature",
-        providerType: "git_worktree",
-        providerRef: "/tmp/reused-worktree",
-        derivedFromExecutionWorkspaceId: null,
-        lastUsedAt: new Date(),
-        openedAt: new Date(),
-        closedAt: null,
-        cleanupEligibleAt: null,
-        cleanupReason: null,
-        config: null,
-        metadata: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    expect(result.created).toBe(false);
-    expect(result.strategy).toBe("git_worktree");
-    expect(result.cwd).toBe("/tmp/reused-worktree");
-    expect(result.worktreePath).toBe("/tmp/reused-worktree");
-    expect(result.branchName).toBe("PAP-880-thumbs-capture-for-evals-feature");
-    expect(result.source).toBe("task_session");
   });
 });
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1965,6 +1965,45 @@ describe("realizeExecutionWorkspace", () => {
     expect(actualHead).toBe(expectedHead);
   }, 15_000);
 
+  it("does not reuse a missing persisted local filesystem workspace", async () => {
+    const baseCwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-workspace-base-"));
+    const missingCwd = path.join(baseCwd, "missing-workspace");
+
+    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+      },
+      workspace: {
+        mode: "shared_workspace",
+        strategyType: "project_primary",
+        cwd: missingCwd,
+        providerRef: null,
+        projectId: "project-1",
+        projectWorkspaceId: null,
+        repoUrl: null,
+        baseRef: null,
+        branchName: null,
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-453",
+        title: "Missing local workspace",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(restored).toBeNull();
+  });
+
   it("reprovisions an existing persisted git worktree before manual control starts it", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -920,35 +920,6 @@ export function stripWorkspaceRuntimeFromExecutionRunConfig(config: Record<strin
   return nextConfig;
 }
 
-export function buildRealizedExecutionWorkspaceFromPersisted(input: {
-  base: ExecutionWorkspaceInput;
-  workspace: ExecutionWorkspace;
-}): RealizedExecutionWorkspace | null {
-  const cwd = readNonEmptyString(input.workspace.cwd) ?? readNonEmptyString(input.workspace.providerRef);
-  if (!cwd) {
-    return null;
-  }
-
-  const strategy = input.workspace.strategyType === "git_worktree" ? "git_worktree" : "project_primary";
-  const baseRefSnapshot = parseObject(input.workspace.metadata?.baseRefSnapshot);
-  const baseRefSha = typeof baseRefSnapshot.resolvedSha === "string" ? baseRefSnapshot.resolvedSha : null;
-  return {
-    baseCwd: input.base.baseCwd,
-    source: input.workspace.mode === "shared_workspace" ? "project_primary" : "task_session",
-    projectId: input.workspace.projectId ?? input.base.projectId,
-    workspaceId: input.workspace.projectWorkspaceId ?? input.base.workspaceId,
-    repoUrl: input.workspace.repoUrl ?? input.base.repoUrl,
-    repoRef: input.workspace.baseRef ?? input.base.repoRef,
-    strategy,
-    cwd,
-    branchName: input.workspace.branchName ?? null,
-    worktreePath: strategy === "git_worktree" ? (readNonEmptyString(input.workspace.providerRef) ?? cwd) : null,
-    warnings: [],
-    created: false,
-    baseRefSha,
-  };
-}
-
 function buildExecutionWorkspaceConfigSnapshot(
   config: Record<string, unknown>,
   environmentId?: string | null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8867,9 +8867,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             companyId: agent.companyId,
           },
           recorder: workspaceOperationRecorder,
-        }) ?? buildRealizedExecutionWorkspaceFromPersisted({
-          base: executionWorkspaceBase,
-          workspace: existingExecutionWorkspace,
         })
       : null;
     const executionWorkspace = reusedExecutionWorkspace ?? await realizeExecutionWorkspace({

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1471,6 +1471,9 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
   const provisionCommand = asString(input.workspace.config?.provisionCommand, "").trim();
 
   if (strategy !== "git_worktree") {
+    if (!await directoryExists(cwd)) {
+      return null;
+    }
     return realized;
   }
   const repoRoot = await runGit(["rev-parse", "--show-toplevel"], input.base.baseCwd);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent execution uses persisted execution workspace rows so follow-up runs can reuse the same local or worktree checkout.
> - Local filesystem execution workspaces can outlive the host path that created them, especially when an instance is moved between homes or restored from another environment.
> - The availability check rejected missing git worktrees but still accepted missing non-git local filesystem paths.
> - Heartbeat then had an additional fallback that could rebuild a realized workspace directly from the stale persisted row after the availability check returned `null`.
> - This pull request makes missing persisted local filesystem workspaces unavailable and forces heartbeat to realize a fresh workspace instead of launching from a stale absolute path.
> - The benefit is safer local agent startup after instance relocation or stale workspace cleanup, without changing valid persisted workspace reuse.

## Linked Issues or Issue Description

No public issue found. I searched GitHub for related stale execution workspace / stale cwd reports and did not find a duplicate.

### Bug Report

#### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest released version of Paperclip (or can reproduce on `master`).
- [x] I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration.

#### What happened?

When an agent issue reused a persisted non-git local filesystem execution workspace whose `cwd` no longer existed on the current host, Paperclip could still launch the run from the stale absolute path. This caused local runtime files, such as the Codex auth wrapper, to be resolved under a deleted or moved instance path.

#### Expected behavior

When a persisted local filesystem execution workspace points to a missing directory, Paperclip should treat that workspace as unavailable and realize a fresh workspace from the current project/agent context.

#### Steps to reproduce

1. Create or persist a shared local filesystem execution workspace for an issue.
2. Move the Paperclip instance home or delete the persisted workspace directory so the row's `cwd` points to a missing path.
3. Trigger a follow-up heartbeat run for the issue with `executionWorkspacePreference` set to reuse the existing workspace.
4. Observe that the run can be reconstructed from the stale persisted row instead of realizing a fresh workspace.

#### Paperclip version or commit

Reproduced from source on `master` before this PR.

#### Deployment mode

Local dev (`pnpm dev`).

#### Installation method

Built from source (`pnpm dev`).

#### Agent adapter(s) involved

- [x] Codex
- [x] Not adapter-specific (core bug)

#### Database mode

External Postgres in the local reproduction, but the bug is in persisted execution workspace reuse logic and is not database-mode specific.

#### Access context

Board-triggered and scheduler-triggered issue runs.

#### Node.js version

`v22.12.0` in the local reproduction.

#### Operating system

macOS, Apple Silicon.

#### Relevant logs or output

```shell
Command is not executable: "<old-paperclip-home>/instances/default/projects/<company-id>/<project-id>/_default/.paperclip-codex-auth-wrapper.sh"
```

The concrete local path and company identifiers are redacted because they came from a local Paperclip instance.

#### Relevant config (if applicable)

Not applicable.

#### Additional context

The failure mode is generic: any persisted non-git local filesystem workspace can become stale if its backing directory is removed or if a Paperclip instance is moved to a different home directory.

#### Privacy checklist

- [x] I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.

## What Changed

- Treat missing persisted non-git local filesystem execution workspace directories as unavailable.
- Remove heartbeat's fallback that rebuilt a realized workspace from an unavailable persisted row.
- Add regression coverage for missing persisted local filesystem workspace reuse.
- Remove the now-unused persisted-workspace reconstruction helper and its obsolete unit test.

## Verification

- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t "missing persisted local filesystem workspace"`
- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts`

## Risks

Low risk. The change only affects persisted non-git local filesystem execution workspaces whose directory is missing. Existing valid local paths and git worktree restore behavior are unchanged.

## Model Used

OpenAI Codex CLI coding agent. Exact underlying model/version was not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
