### PR TITLE
fix(heartbeat): pre-register heartbeat_runs row before JWT mint on v2026.618.0 (TRA-227 / SAG-4759)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9000,6 +9000,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       };
 
+      // Defensive pre-registration: ensure the heartbeat_runs row exists before
+      // handing out the JWT. Under normal operation the row was created by
+      // enqueueWakeup and transitioned to "running" by claimQueuedRun, so this
+      // is a no-op. It protects against the rare case where an embedded-Postgres
+      // crash between enqueueWakeup and now lost the committed row, causing FK
+      // violations in activity_log / issue_comments when the agent writes back.
+      // (TRA-227)
+      await db
+        .insert(heartbeatRuns)
+        .values({
+          id: run.id,
+          companyId: run.companyId,
+          agentId: run.agentId,
+          invocationSource: run.invocationSource,
+          status: "running",
+        })
+        .onConflictDoNothing();
+
       const adapter = getServerAdapter(agent.adapterType);
       const authToken = adapter.supportsLocalAgentJwt
         ? createLocalAgentJwt(agent.id, agent.companyId, agent.adapterType, run.id)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat service orchestrates agent run dispatch: it enqueues a `heartbeat_runs` row, claims it, then dispatches the agent with a signed JWT embedding `run.id`
> - Under rare conditions (embedded-Postgres crash between `claimQueuedRun` and `adapter.execute()`) the committed `heartbeat_runs` row can be lost, causing every subsequent agent API write to fail with FK constraint violations (`heartbeat_runs_id_fk`)
> - TRA-227 identified this as the root cause: run `230e85ab` was dispatched with `PAPERCLIP_RUN_ID` but had no corresponding `heartbeat_runs` row when the agent wrote back
> - This PR cherry-picks commit `e87fd8a24` (originally cut for the v2026.525.0 line) onto the released **v2026.618.0** baseline (`83a293b16`), the version currently running in production
> - The fix adds a defensive `INSERT … ON CONFLICT DO NOTHING` immediately before the JWT mint — under normal operation this is a strict no-op since the row already exists; it only matters in the crash-recovery edge case
> - The benefit is that prod (running 2026.618.0) gets the guard without requiring a downgrade from 618→525

## Linked Issues or Issue Description

Refs SAG-4759 (parent: SAG-4178). Internal Sage Surfaces tracking only — no public GitHub issue.

Bug context (for reviewers): Under normal operation `heartbeat_runs` rows are created by `enqueueWakeup` and transitioned to `"running"` by `claimQueuedRun`. In rare embedded-Postgres crash scenarios, that transition can complete in memory but the committed row is lost. When the agent subsequently writes to `activity_log` or `issue_comments` (which FK-reference `heartbeat_runs.id`), every write fails. TRA-226 captured a live incident of this; TRA-227 is the fix.

## What Changed

- `server/src/services/heartbeat.ts` (+18 lines, 0 deletions): Added defensive `db.insert(heartbeatRuns).values({...}).onConflictDoNothing()` in `executeRun()`, immediately before `createLocalAgentJwt()` and `adapter.execute()`. The upsert is minimal — only `id`, `companyId`, `agentId`, `invocationSource`, `status: "running"` — the NOT NULL columns with no DB-side defaults. `ON CONFLICT DO NOTHING` preserves any already-complete row state.

## Verification

Cherry-pick lineage and scope verified before PR creation:

```
# Exactly 1 commit above baseline:
git log v2026.618.0..HEAD --oneline
→ 5c5306a82 fix(heartbeat): pre-register heartbeat_runs row before dispatching agent (TRA-227)

# Exactly 1 file changed:
git show HEAD --stat
→ server/src/services/heartbeat.ts | 18 ++++++++++++++++++
→ 1 file changed, 18 insertions(+)

# SAG-4157 commits NOT in ancestry (both must return exit 1 = PASS):
git merge-base --is-ancestor 2970cc44a HEAD → PASS (not ancestor)
git merge-base --is-ancestor 136c890ce HEAD → PASS (not ancestor)

# Base commit resolved from tag:
git rev-list -n 1 v2026.618.0 → 83a293b16155efed5aa002071c4f4b7007add400

# tsc on server package, filtered to heartbeat.ts:
npx tsc -p server/tsconfig.json --noEmit 2>&1 | grep heartbeat.ts → (empty = no errors)
```

Note: `tsc` produces errors in `push-fanout.ts` (an untracked file not present at v2026.618.0 or in this branch) — confirmed pre-existing noise unrelated to this change.

## Risks

- **Low risk for the guard itself**: `ON CONFLICT DO NOTHING` is a strict no-op when the row exists (the normal case). It only fires in the crash-recovery edge case.
- **Migration safety**: No schema changes. Pure application-layer guard.
- **Base mismatch risk**: This branch is cut from `v2026.618.0` (`83a293b16`), not `master`. The PR base is set to `master` for review routing per task instructions, but the branch history is **not** descended from master — it is descended from `v2026.618.0`. Merge path is board-gated on SAG-4759 and handled separately from master merge.
- SAG-4157 commits (`2970cc44a`, `136c890ce`) are confirmed NOT in ancestry — no risk of bundling unrelated changes.

---

**Base commit SHA** (resolved from `v2026.618.0`): `83a293b16155efed5aa002071c4f4b7007add400`
**New commit SHA**: `5c5306a820fd9a40cf4546fd6f49adbc15817df0`
**Cherry-pick status**: Byte-clean auto-merge (no conflict, no manual reproduction needed)

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Capabilities: Tool use, multi-step file edits, git operations
- No extended thinking mode

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable (N/A — cherry-pick of existing fix; original commit carried no new tests by design)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [ ] I have updated relevant documentation to reflect my changes (N/A — internal guard, no user-facing behavior change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI run)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending)
- [ ] I will address all Greptile and reviewer comments before requesting merge