### PR TITLE
feat(server): dashboard agentsStatus four-field split (CMP-379)

### DIFF
--- a/server/src/__tests__/dashboard-agents-status.test.ts
+++ b/server/src/__tests__/dashboard-agents-status.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { computeAgentsStatus, type AgentStatusEntry } from "../services/dashboard.js";
+
+// ---------------------------------------------------------------------------
+// Minimal drizzle-compatible db stub.
+// computeAgentsStatus issues 3–4 sequential .select() calls; we return
+// each batch from a queue.
+// ---------------------------------------------------------------------------
+
+function makeDrizzleStub(batches: unknown[][]) {
+  const queue = [...batches];
+  const makeQuery = () => {
+    const terminal = { then: (res: (v: unknown[]) => unknown) => Promise.resolve(res(queue.shift() ?? [])) };
+    const query: Record<string, () => typeof query & typeof terminal> = {} as never;
+    const wrap = () => Object.assign({ ...query, ...terminal });
+    query.from = wrap;
+    query.where = wrap;
+    query.orderBy = wrap;
+    query.innerJoin = wrap;
+    return wrap();
+  };
+  return { select: () => makeQuery() } as never;
+}
+
+const NOW = new Date("2026-06-22T12:00:00.000Z");
+
+// Convenience factory for an agent row
+function ag(id: string, overrides: Partial<{
+  name: string; status: string; lastHeartbeatAt: Date | null
+}> = {}) {
+  return {
+    id,
+    name: overrides.name ?? `Agent-${id}`,
+    status: overrides.status ?? "idle",
+    lastHeartbeatAt: overrides.lastHeartbeatAt ?? null,
+  };
+}
+
+// Convenience factory for a run row
+function run(agentId: string, status: string, finishedAt: Date) {
+  return { agentId, status, finishedAt };
+}
+
+describe("computeAgentsStatus", () => {
+  it("returns empty array when company has no agents", async () => {
+    const db = makeDrizzleStub([[/* agents */]]);
+    const result = await computeAgentsStatus(db, "company-1", NOW);
+    expect(result).toEqual([]);
+  });
+
+  it("returns lastRunOutcome=none when agent has no finished runs", async () => {
+    const db = makeDrizzleStub([
+      [ag("a1")],              // agents
+      [],                      // heartbeat_runs (empty)
+      [],                      // issue_relations blocked side (empty)
+      // blockerStatus lookup skipped when no relation rows
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.lastRunOutcome).toBe("none");
+    expect(entry.quietSince).toBeNull();
+    expect(entry.quietForMs).toBeNull();
+    expect(entry.blockersOpen).toBe(0);
+    expect(entry.quiescenceMode).toBe("unknown");
+  });
+
+  it("maps succeeded run to lastRunOutcome=succeeded", async () => {
+    const finishedAt = new Date("2026-06-22T10:00:00.000Z");
+    const db = makeDrizzleStub([
+      [ag("a1")],
+      [run("a1", "succeeded", finishedAt)],
+      [],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.lastRunOutcome).toBe("succeeded");
+  });
+
+  it("maps failed run to lastRunOutcome=failed", async () => {
+    const finishedAt = new Date("2026-06-22T10:00:00.000Z");
+    const db = makeDrizzleStub([
+      [ag("a1")],
+      [run("a1", "failed", finishedAt)],
+      [],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.lastRunOutcome).toBe("failed");
+  });
+
+  it("maps crashed/timeout runs to lastRunOutcome=error", async () => {
+    for (const status of ["crashed", "timeout", "error"]) {
+      const finishedAt = new Date("2026-06-22T10:00:00.000Z");
+      const db = makeDrizzleStub([
+        [ag("a1")],
+        [run("a1", status, finishedAt)],
+        [],
+      ]);
+      const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+      expect(entry.lastRunOutcome).toBe("error");
+    }
+  });
+
+  it("queued/running runs yield lastRunOutcome=none (no completed outcome)", async () => {
+    for (const status of ["queued", "running", "cancelled"]) {
+      const finishedAt = new Date("2026-06-22T10:00:00.000Z");
+      const db = makeDrizzleStub([
+        [ag("a1")],
+        [run("a1", status, finishedAt)],
+        [],
+      ]);
+      const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+      expect(entry.lastRunOutcome).toBe("none");
+    }
+  });
+
+  it("prefers agents.lastHeartbeatAt as quietSince anchor when set", async () => {
+    const lastHeartbeatAt = new Date("2026-06-22T08:00:00.000Z");
+    const finishedAt = new Date("2026-06-22T06:00:00.000Z"); // older
+    const db = makeDrizzleStub([
+      [ag("a1", { lastHeartbeatAt })],
+      [run("a1", "succeeded", finishedAt)],
+      [],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.quietSince).toBe(lastHeartbeatAt.toISOString());
+    expect(entry.quietForMs).toBe(NOW.getTime() - lastHeartbeatAt.getTime());
+  });
+
+  it("falls back to finishedAt when lastHeartbeatAt is null", async () => {
+    const finishedAt = new Date("2026-06-22T06:00:00.000Z");
+    const db = makeDrizzleStub([
+      [ag("a1", { lastHeartbeatAt: null })],
+      [run("a1", "succeeded", finishedAt)],
+      [],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.quietSince).toBe(finishedAt.toISOString());
+    expect(entry.quietForMs).toBe(NOW.getTime() - finishedAt.getTime());
+  });
+
+  it("counts only non-terminal blockers in blockersOpen", async () => {
+    const db = makeDrizzleStub([
+      [ag("a1")],
+      [],
+      // blocked side: two blocker issues for agent a1's issues
+      [
+        { blockerIssueId: "b1", blockedAgentId: "a1" },
+        { blockerIssueId: "b2", blockedAgentId: "a1" },
+        { blockerIssueId: "b3", blockedAgentId: "a1" },
+      ],
+      // blocker statuses: b1=blocked (open), b2=done (terminal), b3=cancelled (terminal)
+      [
+        { id: "b1", status: "blocked" },
+        { id: "b2", status: "done" },
+        { id: "b3", status: "cancelled" },
+      ],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.blockersOpen).toBe(1); // only b1
+  });
+
+  it("deduplicates blocker IDs when the same blocker appears via multiple blocked issues", async () => {
+    const db = makeDrizzleStub([
+      [ag("a1")],
+      [],
+      // same blocker b1 appears twice (blocks two different assigned issues of a1)
+      [
+        { blockerIssueId: "b1", blockedAgentId: "a1" },
+        { blockerIssueId: "b1", blockedAgentId: "a1" },
+      ],
+      [{ id: "b1", status: "in_progress" }],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.blockersOpen).toBe(1);
+  });
+
+  it("includes deprecated status alias matching agents.status", async () => {
+    const db = makeDrizzleStub([
+      [ag("a1", { status: "paused" })],
+      [],
+      [],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.status).toBe("paused");
+  });
+
+  it("always returns quiescenceMode=unknown pending CMP-365 Children B+C", async () => {
+    const db = makeDrizzleStub([
+      [ag("a1")],
+      [],
+      [],
+    ]);
+    const [entry] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entry.quiescenceMode).toBe("unknown");
+  });
+
+  it("handles multiple agents independently", async () => {
+    const heartbeatAt1 = new Date("2026-06-22T09:00:00.000Z");
+    const finishedAt2 = new Date("2026-06-22T07:00:00.000Z");
+    const db = makeDrizzleStub([
+      [ag("a1", { lastHeartbeatAt: heartbeatAt1 }), ag("a2", { lastHeartbeatAt: null })],
+      [
+        run("a1", "succeeded", new Date("2026-06-22T08:00:00.000Z")),
+        run("a2", "error", finishedAt2),
+      ],
+      [],
+    ]);
+    const entries: AgentStatusEntry[] = await computeAgentsStatus(db, "company-1", NOW);
+    expect(entries).toHaveLength(2);
+    const e1 = entries.find((e) => e.agentId === "a1")!;
+    const e2 = entries.find((e) => e.agentId === "a2")!;
+    expect(e1.lastRunOutcome).toBe("succeeded");
+    expect(e1.quietSince).toBe(heartbeatAt1.toISOString());
+    expect(e2.lastRunOutcome).toBe("error");
+    expect(e2.quietSince).toBe(finishedAt2.toISOString());
+  });
+});

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,6 +1,14 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
+import {
+  agents,
+  approvals,
+  companies,
+  costEvents,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
 import { notFound } from "../errors.js";
 import { budgetService } from "./budgets.js";
 
@@ -20,6 +28,30 @@ function getRecentUtcDateKeys(now: Date, days: number): string[] {
     const dayOffset = index - (days - 1);
     return formatUtcDateKey(new Date(todayUtc + dayOffset * 24 * 60 * 60 * 1000));
   });
+}
+
+export type LastRunOutcome = "succeeded" | "failed" | "error" | "none";
+export type QuiescenceMode = "A" | "A_prime" | "B1" | "B2" | "unknown";
+
+export interface AgentStatusEntry {
+  agentId: string;
+  name: string;
+  status: string;
+  lastRunOutcome: LastRunOutcome;
+  quietSince: string | null;
+  quietForMs: number | null;
+  quiescenceMode: QuiescenceMode;
+  blockersOpen: number;
+}
+
+const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
+
+function mapRunStatusToOutcome(status: string | null | undefined): LastRunOutcome {
+  if (!status) return "none";
+  if (status === "succeeded") return "succeeded";
+  if (status === "failed") return "failed";
+  if (status === "error" || status === "crashed" || status === "timeout") return "error";
+  return "none";
 }
 
 export function dashboardService(db: Db) {
@@ -134,6 +166,8 @@ export function dashboardService(db: Db) {
           : 0;
       const budgetOverview = await budgets.overview(companyId);
 
+      const agentsStatus = await computeAgentsStatus(db, companyId, now);
+
       return {
         companyId,
         agents: {
@@ -142,6 +176,7 @@ export function dashboardService(db: Db) {
           paused: agentCounts.paused,
           error: agentCounts.error,
         },
+        agentsStatus,
         tasks: taskCounts,
         costs: {
           monthSpendCents,
@@ -159,4 +194,134 @@ export function dashboardService(db: Db) {
       };
     },
   };
+}
+
+// Per-agent status computation for the CMP-379 watch-list field split.
+// Surfaces lastRunOutcome, quietSince/quietForMs, quiescenceMode, blockersOpen
+// per agent so audits can distinguish "harness errored last run" from
+// "agent has been intentionally idle for N hours".
+//
+// quiescenceMode is currently returned as "unknown" pending the CMP-365
+// sibling deliverables:
+//   - Child B (adapter retry queue) — needed to detect A_prime (close-out-stuck)
+//   - Child C (staleness scanner) — needed to distinguish A vs B1 vs B2 from
+//     the agent's blocker chain plus quiet duration
+// Once those land, the inference function below should be updated to consume
+// their outputs. B2 ("blocked with live chain") is already inferrable from
+// blockersOpen > 0 but we keep the field "unknown" until the full taxonomy is
+// computable end-to-end to avoid mixed-fidelity reporting.
+export async function computeAgentsStatus(
+  db: Db,
+  companyId: string,
+  now: Date = new Date(),
+): Promise<AgentStatusEntry[]> {
+  const agentRows = await db
+    .select({
+      id: agents.id,
+      name: agents.name,
+      status: agents.status,
+      lastHeartbeatAt: agents.lastHeartbeatAt,
+    })
+    .from(agents)
+    .where(eq(agents.companyId, companyId));
+
+  if (agentRows.length === 0) return [];
+
+  const agentIds = agentRows.map((row) => row.id);
+
+  // Latest completed heartbeat run per agent. We pull both the status and the
+  // finishedAt so quietSince anchors to the last actual run completion when
+  // agents.lastHeartbeatAt is unset.
+  const latestRunRows = await db
+    .select({
+      agentId: heartbeatRuns.agentId,
+      status: heartbeatRuns.status,
+      finishedAt: heartbeatRuns.finishedAt,
+    })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, companyId),
+        inArray(heartbeatRuns.agentId, agentIds),
+        isNotNull(heartbeatRuns.finishedAt),
+      ),
+    )
+    .orderBy(sql`${heartbeatRuns.agentId}, ${heartbeatRuns.finishedAt} desc`);
+
+  const latestByAgent = new Map<
+    string,
+    { status: string | null; finishedAt: Date | null }
+  >();
+  for (const row of latestRunRows) {
+    if (!latestByAgent.has(row.agentId)) {
+      latestByAgent.set(row.agentId, { status: row.status, finishedAt: row.finishedAt });
+    }
+  }
+
+  // blockersOpen per agent: count distinct blocker issues (issue_relations
+  // type='blocks', where the blocked issue is assigned to the agent and the
+  // blocker is itself non-terminal).
+  //
+  // We join issue_relations -> issues (the blocked side, to filter by
+  // assignee), then look up blocker statuses in a second pass to avoid
+  // joining `issues` twice in the same query.
+  const blockedSideRows = await db
+    .select({
+      blockerIssueId: issueRelations.issueId,
+      blockedAgentId: issues.assigneeAgentId,
+    })
+    .from(issueRelations)
+    .innerJoin(issues, eq(issueRelations.relatedIssueId, issues.id))
+    .where(
+      and(
+        eq(issueRelations.companyId, companyId),
+        eq(issueRelations.type, "blocks"),
+        inArray(issues.assigneeAgentId, agentIds),
+      ),
+    );
+
+  const blockerIssueIds = [
+    ...new Set(blockedSideRows.map((row) => row.blockerIssueId)),
+  ];
+  const blockerStatusById = new Map<string, string>();
+  if (blockerIssueIds.length > 0) {
+    const blockerStatusRows = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(inArray(issues.id, blockerIssueIds));
+    for (const row of blockerStatusRows) {
+      blockerStatusById.set(row.id, row.status);
+    }
+  }
+
+  const blockersOpenByAgent = new Map<string, Set<string>>();
+  for (const row of blockedSideRows) {
+    if (!row.blockedAgentId) continue;
+    const blockerStatus = blockerStatusById.get(row.blockerIssueId);
+    if (!blockerStatus || TERMINAL_ISSUE_STATUSES.has(blockerStatus)) continue;
+    if (!blockersOpenByAgent.has(row.blockedAgentId)) {
+      blockersOpenByAgent.set(row.blockedAgentId, new Set());
+    }
+    blockersOpenByAgent.get(row.blockedAgentId)!.add(row.blockerIssueId);
+  }
+
+  return agentRows.map((agent): AgentStatusEntry => {
+    const latest = latestByAgent.get(agent.id);
+    const quietAnchor = agent.lastHeartbeatAt ?? latest?.finishedAt ?? null;
+    return {
+      agentId: agent.id,
+      name: agent.name,
+      // Deprecated single status field — derives from agents.status. Kept for
+      // one minor version while consumers migrate to the four orthogonal
+      // signals below (CMP-379, sub-finding 1 of CMP-365).
+      status: agent.status,
+      lastRunOutcome: mapRunStatusToOutcome(latest?.status),
+      quietSince: quietAnchor ? quietAnchor.toISOString() : null,
+      quietForMs: quietAnchor ? Math.max(0, now.getTime() - quietAnchor.getTime()) : null,
+      // See note on quiescenceMode above. Returns "unknown" until CMP-365
+      // Children B and C land.
+      quiescenceMode: "unknown",
+      blockersOpen: blockersOpenByAgent.get(agent.id)?.size ?? 0,
+    };
+  });
 }


### PR DESCRIPTION
## Summary

Implements **Sub-finding 1** of the harness-improvement umbrella (watch-list status disambiguation): the dashboard's single per-agent `status` field conflated _no-heartbeat-in-N-hours_ with _harness-errored-on-last-run_, so every audit mis-tallied which agents were stuck. This PR splits the watch-list signal into four orthogonal, machine-readable fields on the dashboard summary response.

`GET /api/companies/:companyId/dashboard` now includes an additive `agentsStatus[]` block:

| Field | Type / enum | Source |
|-------|-------------|--------|
| `agentId` / `name` / `status` | identity + legacy single-value status (deprecated alias, kept for one minor version) | `agents` |
| `lastRunOutcome` | `succeeded` \| `failed` \| `error` \| `none` | most recent `heartbeat_runs.status` per agent; `error` collapses crashed/timeout; queued/running/cancelled/unknown collapse to `none` |
| `quietSince` / `quietForMs` | ISO timestamp + derived ms gap | `agents.lastHeartbeatAt`, falling back to `heartbeat_runs.finishedAt`; `null` when neither exists |
| `quiescenceMode` | `A` \| `A_prime` \| `B1` \| `B2` \| `unknown` | currently always `"unknown"` — full inference gated on the retry-queue and staleness-scanner sibling tickets so the audit pipeline doesn't ship mixed-fidelity reporting |
| `blockersOpen` | integer | distinct `issue_relations type='blocks'` count over the agent's assigned issues, excluding `done` / `cancelled` blockers |

Legacy per-agent `status` is retained as a deprecated alias per the acceptance criterion (one-minor-version deprecation window). `runActivity`, `getUtcMonthStart`, and the `monthSpend` `::double precision` cast added by recent master commits are preserved unchanged — `agentsStatus[]` is purely additive on the summary response.

OTel metrics (`paperclip_harness_quiescence_mode` gauge and the four retry/staleness counters) and the agent-status memo template four-field render are split into child tickets and do not gate this PR.

## Test plan

- [x] `vitest run server/src/__tests__/dashboard-agents-status.test.ts` — 13 unit tests covering every `lastRunOutcome` enum value, the `quietSince` fallback chain, `blockersOpen` dedup + terminal-status exclusion, multi-agent independence, and the `quiescenceMode=unknown` contract.
- [x] `vitest run server/src/__tests__/dashboard-service.test.ts` — 2 existing dashboard-service tests still pass (no regressions to `runActivity` / `monthSpend`).
- [x] `tsc --noEmit` on `server/src/services/dashboard.ts` — zero typecheck errors in changed files. Pre-existing errors in unrelated `plugin-*.ts` files (missing `@paperclipai/plugin-sdk` workspace link) are not introduced by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
