### PR TITLE
fix(db): watchdog the pg_dump pipeline in runDatabaseBackup

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import postgres from "postgres";
-import { createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
+import { BackupTimeoutError, createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
 import { ensurePostgresDatabase } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -408,6 +408,73 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
       }
     },
     60_000,
+  );
+
+  it(
+    "throws BackupTimeoutError when pg_dump never exits, instead of hanging",
+    async () => {
+      const sourceConnectionString = await createTempDatabase();
+      const backupDir = createTempDir("paperclip-db-backup-timeout-");
+      const stubDir = createTempDir("paperclip-db-backup-timeout-stub-");
+      const stubPath = path.join(stubDir, "pg_dump_hang.sh");
+      // Emit a small amount on stdout so bytesWritten is observably non-zero,
+      // then sleep far past the test timeout. SIGTERM ends `sleep` immediately
+      // on POSIX shells, so the watchdog can reap the child cleanly.
+      await fs.promises.writeFile(
+        stubPath,
+        "#!/bin/sh\nprintf 'fake pg_dump output\\n'\nsleep 300\n",
+        { mode: 0o755 },
+      );
+
+      const previousPgDumpPath = process.env.PAPERCLIP_PG_DUMP_PATH;
+      process.env.PAPERCLIP_PG_DUMP_PATH = stubPath;
+      cleanups.push(() => {
+        if (previousPgDumpPath === undefined) {
+          delete process.env.PAPERCLIP_PG_DUMP_PATH;
+        } else {
+          process.env.PAPERCLIP_PG_DUMP_PATH = previousPgDumpPath;
+        }
+      });
+
+      try {
+        const startedAt = Date.now();
+        await expect(
+          runDatabaseBackup({
+            connectionString: sourceConnectionString,
+            backupDir,
+            retention: { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+            filenamePrefix: "paperclip-timeout-test",
+            backupEngine: "pg_dump",
+            backupTimeoutSeconds: 0.5,
+          }),
+        ).rejects.toBeInstanceOf(BackupTimeoutError);
+        const elapsedMs = Date.now() - startedAt;
+
+        // Fire-on-timeout (500ms) plus SIGTERM + child-exit settle should be
+        // well under 10s — orders of magnitude faster than the pre-fix hang.
+        expect(elapsedMs).toBeLessThan(10_000);
+
+        // The watchdog must NOT leave a partial .sql.gz behind: runDatabaseBackup
+        // cleans up the backup file on any throw, including BackupTimeoutError.
+        const leftovers = fs
+          .readdirSync(backupDir)
+          .filter((name) => name.startsWith("paperclip-timeout-test-"));
+        expect(leftovers).toEqual([]);
+      } finally {
+        // Defensive: make sure no stray stub pg_dump child outlives the test.
+        // The watchdog already SIGTERMs the child, but a failed assertion above
+        // could short-circuit before that path runs.
+        try {
+          // shellcheck-style guard: only kill processes that match our stub path.
+          const { execSync } = await import("node:child_process");
+          execSync(`pkill -f ${JSON.stringify(stubPath)} 2>/dev/null || true`);
+        } catch {
+          // Best-effort: pkill may not exist on the host; in that case the
+          // BackupTimeoutError path already killed the child.
+        }
+      }
+    },
+    20_000,
   );
 
   it(

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -411,7 +411,7 @@ async function runPgDumpBackup(opts: {
       waitForChildExit(child, pgDumpBin),
     ]);
 
-    if (timedOut) {
+    if (timedOut && pipelineResult.status === "rejected") {
       const elapsedMs = Date.now() - startedAt;
       const bytesWritten = fileWriter.bytesWritten;
       throw new BackupTimeoutError(

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -20,6 +20,13 @@ export type RunDatabaseBackupOptions = {
   filenamePrefix?: string;
   connectTimeoutSeconds?: number;
   /**
+   * Upper bound on how long the pg_dump pipeline may run before it is aborted
+   * and treated as a hang. Defaults to 30 minutes. Set to a small value in
+   * tests; set to a larger value for very large databases. A non-positive
+   * value disables the watchdog (not recommended outside of tests).
+   */
+  backupTimeoutSeconds?: number;
+  /**
    * @deprecated Migration-journal schemas are included with the normal backup
    * scope. This option is kept for compatibility and no longer changes backup
    * engine selection.
@@ -29,6 +36,25 @@ export type RunDatabaseBackupOptions = {
   nullifyColumns?: Record<string, string[]>;
   backupEngine?: "auto" | "pg_dump" | "javascript";
 };
+
+/**
+ * Raised when the pg_dump pipeline inside {@link runDatabaseBackup} does not
+ * settle within the configured backup timeout. Callers (notably the in-process
+ * backup scheduler) rely on this being thrown — rather than the pipeline
+ * hanging — so their `try/finally` mutex can clear and the next scheduled
+ * backup can run.
+ */
+export class BackupTimeoutError extends Error {
+  readonly code = "BACKUP_TIMEOUT" as const;
+  constructor(
+    message: string,
+    readonly elapsedMs: number,
+    readonly bytesWritten: number,
+  ) {
+    super(message);
+    this.name = "BackupTimeoutError";
+  }
+}
 
 export type RunDatabaseBackupResult = {
   backupFile: string;
@@ -70,6 +96,9 @@ const DEFAULT_BACKUP_WRITE_BUFFER_BYTES = 1024 * 1024;
 const BACKUP_DATA_CURSOR_ROWS = 100;
 const BACKUP_CLI_STDERR_BYTES = 64 * 1024;
 const BACKUP_BREAKPOINT_DETECT_BYTES = 64 * 1024;
+const DEFAULT_BACKUP_TIMEOUT_MS = 30 * 60 * 1000;
+// Grace window between SIGTERM and SIGKILL when forcibly stopping a hung pg_dump child.
+const PG_DUMP_KILL_GRACE_MS = 5_000;
 
 const STATEMENT_BREAKPOINT = "-- paperclip statement breakpoint 69f6f3f1-42fd-46a6-bf17-d1d85f8f3900";
 
@@ -315,6 +344,7 @@ async function runPgDumpBackup(opts: {
   connectionString: string;
   backupFile: string;
   connectTimeout: number;
+  timeoutMs: number;
 }): Promise<void> {
   const pgDumpBin = process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump";
   const child = spawn(
@@ -340,10 +370,68 @@ async function runPgDumpBackup(opts: {
     throw new Error("pg_dump did not expose stdout");
   }
 
-  await Promise.all([
-    pipeline(child.stdout, createGzip(), createWriteStream(opts.backupFile)),
-    waitForChildExit(child, pgDumpBin),
-  ]);
+  const startedAt = Date.now();
+  const fileWriter = createWriteStream(opts.backupFile);
+  const controller = new AbortController();
+  let timedOut = false;
+  let watchdog: NodeJS.Timeout | undefined;
+  let killGraceTimer: NodeJS.Timeout | undefined;
+
+  if (opts.timeoutMs > 0) {
+    watchdog = setTimeout(() => {
+      // Order matters: abort the pipeline first so the gzip/file writers tear
+      // down cleanly, then SIGTERM the child so waitForChildExit settles.
+      timedOut = true;
+      controller.abort();
+      try {
+        if (!child.killed) child.kill("SIGTERM");
+      } catch {
+        // Best-effort: the child may have already exited between checks.
+      }
+      killGraceTimer = setTimeout(() => {
+        try {
+          if (!child.killed) child.kill("SIGKILL");
+        } catch {
+          // Best-effort: ignore — there is nothing useful to do here.
+        }
+      }, PG_DUMP_KILL_GRACE_MS);
+      // Don't keep the event loop alive just for the kill grace timer.
+      killGraceTimer.unref?.();
+    }, opts.timeoutMs);
+    watchdog.unref?.();
+  }
+
+  try {
+    // allSettled (rather than Promise.all) so we wait for BOTH the pipeline
+    // and the child to settle before throwing. On a timeout, the pipeline
+    // aborts and the child is killed; we want both to be torn down before
+    // runDatabaseBackup proceeds with cleanup so there is no dangling work.
+    const [pipelineResult, childResult] = await Promise.allSettled([
+      pipeline(child.stdout, createGzip(), fileWriter, { signal: controller.signal }),
+      waitForChildExit(child, pgDumpBin),
+    ]);
+
+    if (timedOut) {
+      const elapsedMs = Date.now() - startedAt;
+      const bytesWritten = fileWriter.bytesWritten;
+      throw new BackupTimeoutError(
+        `${pgDumpBin} backup timed out after ${opts.timeoutMs}ms ` +
+          `(elapsed ${elapsedMs}ms, wrote ${bytesWritten} bytes before timeout)`,
+        elapsedMs,
+        bytesWritten,
+      );
+    }
+
+    if (pipelineResult.status === "rejected") {
+      throw pipelineResult.reason;
+    }
+    if (childResult.status === "rejected") {
+      throw childResult.reason;
+    }
+  } finally {
+    if (watchdog) clearTimeout(watchdog);
+    if (killGraceTimer) clearTimeout(killGraceTimer);
+  }
 }
 
 async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: number): Promise<void> {
@@ -522,6 +610,14 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
   const filenamePrefix = opts.filenamePrefix ?? "paperclip";
   const retention = opts.retention;
   const connectTimeout = Math.max(1, Math.trunc(opts.connectTimeoutSeconds ?? 5));
+  // 0 (or negative) disables the watchdog; otherwise apply a hard ceiling so a
+  // stalled pg_dump child or gzip pipeline can never hang runDatabaseBackup
+  // indefinitely. The in-process backup scheduler relies on this function
+  // settling so its mutex `try/finally` can reset databaseBackupInFlight.
+  const backupTimeoutSeconds = opts.backupTimeoutSeconds ?? DEFAULT_BACKUP_TIMEOUT_MS / 1000;
+  const pgDumpTimeoutMs = backupTimeoutSeconds > 0
+    ? Math.max(1, Math.trunc(backupTimeoutSeconds * 1000))
+    : 0;
   const backupEngine = opts.backupEngine ?? "auto";
   const canUsePgDump = !hasBackupTransforms(opts);
   const excludedTableNames = normalizeTableNameSet(opts.excludeTables);
@@ -547,6 +643,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           connectionString: opts.connectionString,
           backupFile,
           connectTimeout,
+          timeoutMs: pgDumpTimeoutMs,
         });
         await writer.abort();
         const sizeBytes = statSync(backupFile).size;
@@ -561,6 +658,12 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           try { unlinkSync(backupFile); } catch { /* ignore */ }
         }
         if (backupEngine === "pg_dump") {
+          throw error;
+        }
+        // The watchdog ceiling is the operator's hard guarantee that this
+        // function settles; do not silently re-attempt with the JS engine
+        // after already burning the full timeout budget.
+        if (error instanceof BackupTimeoutError) {
           throw error;
         }
         sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,7 @@ export {
   runDatabaseBackup,
   runDatabaseRestore,
   formatDatabaseBackupResult,
+  BackupTimeoutError,
   type BackupRetentionPolicy,
   type RunDatabaseBackupOptions,
   type RunDatabaseBackupResult,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - One of the operator-facing capabilities is a scheduled database backup that runs every hour inside the running server process
> - Scheduling is gated by a single in-flight mutex in `runServerDatabaseBackup` (`databaseBackupInFlight = true` / cleared in `finally`) so two backups never overlap
> - The mutex relies on `runDatabaseBackup` actually settling — but when its `pg_dump` child or the gzip pipeline stalls, the `await Promise.all([pipeline(...), waitForChildExit(...)])` never returns
> - With the mutex held forever, every subsequent scheduled tick logs `WARN: Skipping scheduled database backup because a previous backup is still running` and the operator silently loses their backups until the process is restarted
> - This pull request wraps the `pg_dump` pipeline in an `AbortController` with a configurable, default-30-min timeout, throws a typed `BackupTimeoutError` on expiry, and SIGTERM/SIGKILLs the child so the mutex can clear and the next scheduled tick can run
> - The benefit is that a stalled `pg_dump` is now a recoverable error, not a silent permanent outage of the scheduled-backup path

## Linked Issues or Issue Description

This is a bug fix — no upstream GitHub issue exists yet, so describing in-PR per the bug-report template.

**What happened**

The in-process scheduled database backup wedged indefinitely after a single hung `pg_dump` invocation. From the affected operator's server logs:

```
04:01:00.000Z INFO  Automatic database backup starting
… nothing for hours …
05:01:00.001Z WARN  Skipping scheduled database backup because a previous backup is still running
06:01:00.000Z WARN  Skipping scheduled database backup because a previous backup is still running
07:01:00.000Z WARN  Skipping scheduled database backup because a previous backup is still running
…
```

Every subsequent hourly tick logged the WARN and produced no backup until the server was restarted.

**Expected behavior**

A hung `pg_dump` should fail the current backup attempt within a bounded time, surface an error in the logs, release the in-flight mutex, and let the next scheduled tick run normally.

**Root cause**

`runPgDumpBackup` in `packages/db/src/backup-lib.ts`:

```js
await Promise.all([
  pipeline(child.stdout, createGzip(), createWriteStream(opts.backupFile)),
  waitForChildExit(child, pgDumpBin),
]);
```

If `pg_dump` blocks (network stall mid-`COPY`, lost db connection that doesn't time out, OS pipe stall, etc.) neither side of the `Promise.all` settles. `runDatabaseBackup` never returns, and so the upstream `try/finally` mutex in `runServerDatabaseBackup` never fires.

**Steps to reproduce**

The added unit test (`packages/db/src/backup-lib.test.ts`) reproduces deterministically: it stubs `pg_dump` via `PAPERCLIP_PG_DUMP_PATH` with a shell script that emits a small amount of output and then `sleep 300`, then calls `runDatabaseBackup({ backupTimeoutSeconds: 0.5, backupEngine: "pg_dump" })`. Before the fix the call hangs until the vitest test timeout; with the fix it rejects with `BackupTimeoutError` in ~500ms.

**Paperclip version / deployment mode**

Observed on a `local_trusted` deployment running paperclipai 2026.609.0 with embedded postgres, but the bug is in shared library code and applies to all deployment modes.

## What Changed

- `packages/db/src/backup-lib.ts`:
  - Add `BackupTimeoutError` (exported, includes `elapsedMs` and `bytesWritten` for diagnostics).
  - Add `backupTimeoutSeconds?: number` to `RunDatabaseBackupOptions` (default 30 min; `0` disables the watchdog for tests).
  - `runPgDumpBackup` now takes a `timeoutMs` argument, sets up an `AbortController`, and uses `Promise.allSettled` (not `Promise.all`) so both the pipeline and child-exit can be torn down before throwing.
  - On timeout: abort the pipeline (clean tear-down of gzip + writer), send `SIGTERM`, then `SIGKILL` after a 5s grace window, and throw `BackupTimeoutError` so callers can distinguish a hang from a `pg_dump` exit-code failure or stream error.
  - In `auto` backup-engine mode, `BackupTimeoutError` now propagates instead of silently falling back to the JS engine — the timeout is the operator's hard ceiling, not a transient hint to try a different engine.
- `packages/db/src/index.ts`: re-export `BackupTimeoutError` so server-side callers can `instanceof`-check the typed error.
- `packages/db/src/backup-lib.test.ts`: new unit test exercising the timeout path end-to-end against embedded postgres with a stubbed `pg_dump`.

## Verification

- **Targeted tests:** `pnpm exec vitest run packages/db/src/backup-lib.test.ts` — 6/6 pass in ~12s (the new test fires the watchdog at 500ms and the assertion lands well under the 10s sanity ceiling).
- **Workspace-wide typecheck:** `pnpm -r typecheck` — all packages green, including `server` which imports the affected module.
- **Behavior diff (manual):** with `PAPERCLIP_PG_DUMP_PATH` pointing at a `sleep 300` shell stub:
  - **Before:** `runDatabaseBackup` never resolves. `runServerDatabaseBackup`'s `databaseBackupInFlight` stays `true`. Every scheduled tick logs the WARN and produces no backup.
  - **After:** `runDatabaseBackup` throws `BackupTimeoutError` within the configured window. `runServerDatabaseBackup`'s `try/finally` fires, the mutex resets, and the next scheduled tick proceeds normally.

## Risks

- **Low risk for the common case.** The default 30-minute ceiling is well above the observed runtime of healthy backups on real-world Paperclip databases; healthy backups are unaffected.
- **Behavioral shift for genuinely-long backups.** Operators with very large databases that legitimately take more than 30 minutes to dump will now see `BackupTimeoutError` instead of waiting indefinitely. The fix is to raise `backupTimeoutSeconds` on the call from `runServerDatabaseBackup` — wiring that through as an operator-tunable setting is a small follow-up that this PR intentionally leaves for a separate change. Until then operators can override by setting `backupTimeoutSeconds` to a larger value through any code path that constructs `RunDatabaseBackupOptions`.
- **`auto` engine mode no longer falls back on timeout.** This is intentional: a 30-min hang followed by another 30-min JS-engine attempt is worse UX than failing fast. Other failure modes (binary missing, version mismatch, dataset incompatibility) still fall back as before.
- **No public API removed; one new optional field and one new exported class.** Existing call sites compile and run unchanged.

## Model Used

- Provider: Anthropic Claude (via Claude Code / Paperclip)
- Model: `claude-opus-4-7` (1M context)
- Mode: standard tool-use (no extended thinking turned on for this PR)
- Capabilities: code edit + bash + repo navigation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
