### PR TITLE
fix(recovery): log handoff_resolved for escalated state on issue done transition

### DIFF
--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -399,6 +399,57 @@ describe("issue activity event routes", () => {
     });
   });
 
+  it("logs successful_run_handoff_resolved when an in_progress issue transitions to done with an escalated handoff", async () => {
+    const issue = { ...makeIssue(), status: "in_progress" };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const handoffActivityRow = {
+      entityId: issue.id,
+      action: "issue.successful_run_handoff_escalated",
+      agentId: issue.assigneeAgentId,
+      runId: "run-2",
+      details: {
+        sourceRunId: "run-1",
+        correctiveRunId: "run-2",
+      },
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    };
+    const dbMock = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: async () => [handoffActivityRow],
+          }),
+        }),
+      }),
+    };
+
+    const res = await request(await createApp(dbMock))
+      .patch(`/api/issues/${issue.id}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "issue.successful_run_handoff_resolved",
+          entityId: issue.id,
+          details: expect.objectContaining({
+            identifier: "PAP-580",
+            sourceRunId: "run-1",
+            resolvedByStatus: "done",
+          }),
+        }),
+      );
+    });
+  });
+
   it("does not log successful_run_handoff_resolved when status stays in_progress", async () => {
     const issue = { ...makeIssue(), status: "in_progress" };
     mockIssueService.getById.mockResolvedValue(issue);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5226,7 +5226,7 @@ export function issueRoutes(
       await listSuccessfulRunHandoffStates(db, issue.companyId, [issue.id])
         .then(async (handoffStates) => {
           const handoff = handoffStates.get(issue.id);
-          if (handoff?.state !== "required") return;
+          if (handoff?.state !== "required" && handoff?.state !== "escalated") return;
           await logActivity(db, {
             companyId: issue.companyId,
             actorType: actor.actorType,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent heartbeats and tracks whether each run leaves a clean disposition
> - When a run ends without a clear next step, the recovery system creates a `successfulRunHandoff` requirement tracked via activity log events (`_required`, `_escalated`, `_resolved`)
> - After escalation (`issue.successful_run_handoff_escalated`), if the issue is subsequently closed/done, the PATCH handler checks the current handoff state and should log `_resolved` to clear it
> - The guard at `server/src/routes/issues.ts:5252` was `if (handoff?.state !== "required") return` — this correctly lets `"required"` through but early-exits for `"escalated"`, so the resolved event is never written
> - The derived `successfulRunHandoff` state (computed from the latest activity event) therefore stays `"escalated"` permanently even after the issue is `done`
> - This caused repeated `source_scoped_recovery_action` wakes on already-done issues (observed: 10 wakes/1h, 14 wakes/6h on MIN-241)
> - Fix: extend the guard to pass through both `"required"` and `"escalated"` states so the resolved event is always logged on `in_progress` → done/cancelled transitions when a handoff is outstanding
> - The benefit is that done issues with a previously-escalated handoff stop generating recovery wakes

## Linked Issues or Issue Description

No upstream GitHub issue. The problem was reported internally as MIN-594.

**Bug description:**
- **What happened:** Issues that were `done` + `completedAt` but had a previously-escalated `successfulRunHandoff` kept receiving `source_scoped_recovery_action` wakes — 10+/hour in the worst case.
- **Expected behavior:** Marking an issue `done` while `successfulRunHandoff.state === "escalated"` should log `issue.successful_run_handoff_resolved` and stop recovery wakes.
- **Steps to reproduce:**
  1. Issue is `in_progress`, runs fail → recovery escalates handoff → `issue.successful_run_handoff_escalated` logged
  2. Issue is PATCH'd to `done` by the board or an agent
  3. Observe: `issue.successful_run_handoff_resolved` is NOT logged; derived state stays `"escalated"`
  4. `source_scoped_recovery_action` wakes continue firing against a done issue
- **Paperclip version:** master as of this PR

## What Changed

- `server/src/routes/issues.ts`: Changed the guard from `if (handoff?.state !== "required") return` to `if (handoff?.state !== "required" && handoff?.state !== "escalated") return` — both active handoff states now trigger the resolved event when an issue exits `in_progress`
- `server/src/__tests__/issue-activity-events-routes.test.ts`: Added regression test "logs successful_run_handoff_resolved when an in_progress issue transitions to done with an escalated handoff"

## Verification

```bash
# Run the targeted test suite
npx vitest run server/src/__tests__/issue-activity-events-routes.test.ts
# Expected: 6 tests pass (was 5 before this PR)

# Server typecheck
pnpm typecheck 2>&1 | grep "server typecheck"
# Expected: "server typecheck: Done"
```

The new test mocks an activity log returning `issue.successful_run_handoff_escalated` as the latest handoff event, then PATCHes the issue to `done` and asserts that `mockLogActivity` was called with `action: "issue.successful_run_handoff_resolved"`.

## Risks

Low risk. The change is a single-line condition extension that only fires when:
1. An issue transitions from `in_progress` to a non-`in_progress` status, AND
2. The current `successfulRunHandoff.state` is `"escalated"`

Previously this path was a no-op (early return). The new behavior writes an activity event and is idempotent — logging resolved twice is harmless since `listSuccessfulRunHandoffStates` returns the latest event.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Context: 200K token context window
- Mode: Tool use / agentic (Paperclip CTO agent heartbeat)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI run)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending CI run)
- [ ] I will address all Greptile and reviewer comments before requesting merge