### PR TITLE
style: match Tasks filter button stroke to sibling toolbar buttons

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -1481,6 +1481,7 @@ export function IssuesList({
             currentUserId={currentUserId}
             enableRoutineVisibilityFilter={enableRoutineVisibilityFilter}
             iconOnly
+            buttonVariant="outline"
             workspaces={isolatedWorkspacesEnabled ? workspaceOptions : undefined}
           />
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The web UI's issue/task views render a toolbar of icon buttons (view toggle, column picker, sort, filter) above the list.
> - On the Tasks tab the filter (funnel) button rendered without the border/stroke its sibling icon buttons have, so it looked visually inconsistent.
> - The funnel is rendered by `IssueFiltersPopover`, whose trigger `variant` defaults to `ghost` (no border), and the Tasks call site never opted into `outline`.
> - This pull request opts the Tasks call site into the `outline` variant, the same convention already used by the Inbox call sites and the neighboring `IssueColumnPicker`.
> - The benefit is a consistent toolbar where every icon button shares the same stroke, size, and hover treatment.

## Linked Issues or Issue Description

No public GitHub issue exists; describing the bug inline:

**What happened?**
In the Tasks tab toolbar, the filter (funnel) icon button renders without a border/stroke, unlike the sibling icon buttons (view toggle, column picker, sort), making it look visually inconsistent.

**Expected behavior**
The filter button should match its sibling toolbar icon buttons: same border/stroke, size, and hover behavior, in both light and dark themes.

**Steps to reproduce**
1. Open the web UI and go to the Tasks tab.
2. Look at the toolbar above the task list.
3. Observe that the funnel/filter button has no border while the neighboring icon buttons do.

## What Changed

- Added `buttonVariant="outline"` to the `IssueFiltersPopover` usage in the Tasks toolbar (`ui/src/components/IssuesList.tsx`), matching the Inbox call sites and the neighboring `IssueColumnPicker`. The `IssueFiltersPopover` default stays `ghost`, so no other call site is affected.

## Verification

- Ran the web UI locally on this branch and confirmed the Tasks toolbar filter button now shows the same border/stroke, size (`h-8 w-8`), and hover behavior as its neighbors, in both light and dark themes.
- Confirmed the active-filter state (blue tint + count badge) still renders correctly.
- Confirmed no visual change to the Inbox or other toolbar buttons (shared default unchanged).
- Before/after preview (Cutter): https://artifacts.cutter.sh/8526/run-e3367bb-2026-06-23T06-45-13/preview/change-01.png

## Risks

Low risk. Single-line, opt-in prop at one call site; no logic change and no change to the shared component default, so no other call site or behavior is affected.

## Model Used

Claude Opus 4.6 (Anthropic), model ID `claude-opus-4-6`, extended thinking enabled, with tool use / code execution via the Paperclip agent harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list (open + recently closed) for similar/duplicate PRs and confirmed this is not a duplicate
- [x] I have described the issue in-PR following the bug issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [x] I have run the app locally and verified the change
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
