### PR TITLE
style: match Tasks view-mode toggle height to toolbar buttons

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -1354,16 +1354,16 @@ export function IssuesList({
 
         <div className="flex items-center gap-0.5 sm:gap-1 shrink-0">
           {/* View mode toggle */}
-          <div className="flex items-center border border-border rounded-md overflow-hidden mr-1">
+          <div className="flex h-8 items-center border border-border rounded-md overflow-hidden mr-1">
             <button
-              className={`p-1.5 transition-colors ${viewState.viewMode === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+              className={`flex h-full items-center justify-center px-2 transition-colors ${viewState.viewMode === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => updateView({ viewMode: "list" })}
               title="List view"
             >
               <List className="h-3.5 w-3.5" />
             </button>
             <button
-              className={`p-1.5 transition-colors ${viewState.viewMode === "board" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+              className={`flex h-full items-center justify-center px-2 transition-colors ${viewState.viewMode === "board" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => updateView({ viewMode: "board" })}
               title="Board view"
             >


### PR DESCRIPTION
## Thinking Path

The Tasks tab toolbar renders a row of action buttons that all use a fixed `h-8` (32px) height, but the list/board view-mode toggle was built with `p-1.5` and no fixed height, so it rendered at roughly 26px and sat visibly shorter than its neighbors. The cleanest fix is to give the toggle container the same `h-8` as the sibling buttons and let each inner button fill that height, rather than fiddling with padding to approximate the size. This keeps the toggle visually aligned with the rest of the row and stays robust if the shared button height changes later.

## What Changed

- `ui/src/components/IssuesList.tsx`: set the view-mode toggle container to `h-8` (matching sibling toolbar buttons).
- Each toggle button now uses `flex h-full items-center justify-center px-2` so it fills the full height and stays centered, replacing the previous `p-1.5`.

## Verification

- Confirmed all sibling toolbar buttons (nesting, compact, collapse, filter, sort, group) use `h-8`, so the toggle is now consistent at 32px.
- Ran a canary preview (Vite dev server on the branch) and the board reviewed the Tasks tab; the toggle now lines up with the rest of the toolbar and the confirmation was accepted.

## Risks

Very low — purely a CSS/Tailwind class change on two buttons and their container, no logic or behavior change. Icon sizes are unchanged; only the toggle's outer height and inner alignment were adjusted.

## Model Used

claude-opus-4-6
