### PR TITLE
fix(issues): Cancel stale wakeup requests when an issue is deleted

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5473,6 +5473,33 @@ export function issueService(db: Db) {
         }
 
         if (!removedIssue) return null;
+
+        // Cancel pending wakeup requests that reference this deleted issue
+        // (agentWakeupRequests and heartbeatRuns have no FK to issues — they store
+        // the issueId inside JSONB columns, so they survive the delete otherwise)
+        await tx
+          .update(agentWakeupRequests)
+          .set({ status: "cancelled" })
+          .where(
+            and(
+              inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+              or(
+                sql`${agentWakeupRequests.payload} ->> 'issueId' = ${id}`,
+                sql`${agentWakeupRequests.payload} -> '_paperclipWakeContext' ->> 'issueId' = ${id}`,
+              ),
+            ),
+          );
+
+        await tx
+          .update(heartbeatRuns)
+          .set({ status: "cancelled" })
+          .where(
+            and(
+              eq(heartbeatRuns.status, "queued"),
+              sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${id}`,
+            ),
+          );
+
         const [enriched] = await withIssueLabels(tx, [removedIssue]);
         return enriched;
       }),


### PR DESCRIPTION
## Problem

When an issue is hard-deleted via `issues.remove()`, pending `agentWakeupRequests` and queued `heartbeatRuns` referencing the issue via JSONB columns remain in the database. The periodic `reconcileStrandedAssignedIssues` scan re-fires recovery actions, creating a perpetual wake loop.

## Fix

After the issue row is deleted, also cancel pending `agentWakeupRequests` (status `queued`/`deferred_issue_execution`) and `heartbeatRuns` (status `queued`) whose JSONB payload/contextSnapshot reference the deleted issue ID. Runs inside the same transaction.

## Verification

TypeScript compiles cleanly (exit 0).