### PR TITLE
GRA-3532: resolve README quickstart conflict — single 60-second npx path

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,13 +300,22 @@ npx paperclipai onboard --yes
 > npx --registry https://registry.npmjs.org paperclipai onboard --yes
 > ```
 
-That's it. The server starts at `http://localhost:3100` with an embedded database — no setup needed.
+The server starts at `http://localhost:3100` with an embedded database — no setup needed. It runs in your terminal until you stop it (Ctrl+C).
 
-That quickstart path defaults to trusted local loopback mode for the fastest first run. To access from other devices, restart with `--bind lan` or `--bind tailnet` for Tailscale:
+That quickstart path defaults to trusted local loopback mode for the fastest first run.
+
+**To start again later:**
 
 ```bash
-npx paperclipai configure   # change bind preset
-npx paperclipai run          # restart with new settings
+npx paperclipai run
+```
+
+To access from other devices or keep it running in the background:
+
+```bash
+npx paperclipai configure   # change bind preset (loopback/lan/tailnet)
+npx paperclipai run          # start server
+# or run in background with: npx paperclipai run &
 ```
 
 > **Requirements:** Node.js 20+, pnpm 9.15+

--- a/README.md
+++ b/README.md
@@ -300,22 +300,13 @@ npx paperclipai onboard --yes
 > npx --registry https://registry.npmjs.org paperclipai onboard --yes
 > ```
 
-The server starts at `http://localhost:3100` with an embedded database — no setup needed. It runs in your terminal until you stop it (Ctrl+C).
+That's it. The server starts at `http://localhost:3100` with an embedded database — no setup needed.
 
-That quickstart path defaults to trusted local loopback mode for the fastest first run.
-
-**To start again later:**
-
-```bash
-npx paperclipai run
-```
-
-To access from other devices or keep it running in the background:
+That quickstart path defaults to trusted local loopback mode for the fastest first run. To access from other devices, restart with `--bind lan` or `--bind tailnet` for Tailscale:
 
 ```bash
 npx paperclipai configure   # change bind preset (loopback/lan/tailnet)
-npx paperclipai run          # start server
-# or run in background with: npx paperclipai run &
+npx paperclipai run          # restart with new settings
 ```
 
 > **Requirements:** Node.js 20+, pnpm 9.15+

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Paperclip is a full control plane, not a wrapper. Before you build any of this y
 
 ## Quickstart
 
-Open source. Self-hosted. No Paperclip account required.
+Get running in 60 seconds. No account required.
 
 ```bash
 npx paperclipai onboard --yes
@@ -300,26 +300,14 @@ npx paperclipai onboard --yes
 > npx --registry https://registry.npmjs.org paperclipai onboard --yes
 > ```
 
-That quickstart path now defaults to trusted local loopback mode for the fastest first run. To start in authenticated/private mode instead, choose a bind preset explicitly:
+That's it. The server starts at `http://localhost:3100` with an embedded database — no setup needed.
+
+That quickstart path defaults to trusted local loopback mode for the fastest first run. To access from other devices, restart with `--bind lan` or `--bind tailnet` for Tailscale:
 
 ```bash
-npx paperclipai onboard --yes --bind lan
-# or:
-npx paperclipai onboard --yes --bind tailnet
+npx paperclipai configure   # change bind preset
+npx paperclipai run          # restart with new settings
 ```
-
-If you already have Paperclip configured, rerunning `onboard` keeps the existing config in place. Use `paperclipai configure` to edit settings.
-
-Or manually:
-
-```bash
-git clone https://github.com/paperclipai/paperclip.git
-cd paperclip
-pnpm install
-pnpm dev
-```
-
-This starts the API server at `http://localhost:3100`. An embedded PostgreSQL database is created automatically — no setup required.
 
 > **Requirements:** Node.js 20+, pnpm 9.15+
 

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -13,6 +13,33 @@ npx paperclipai onboard --yes
 
 This walks you through setup, configures your environment, and gets Paperclip running.
 
+### Expected output
+
+A successful run streams clack-style steps and finishes with a config summary. Exact box glyphs vary by terminal; the step labels and the final all-set line are what matter:
+
+```text
+paperclipai onboard
+  Database ............. connection successful
+  LLM Provider ......... API key is valid
+  Quickstart ........... embedded database, file storage, local encrypted secrets
+  Secrets .............. created PAPERCLIP_AGENT_JWT_SECRET in .env
+
+Configuration saved
+  Database: embedded
+  LLM: <your provider>
+  Server: local_trusted/private
+  Storage: file
+  Secrets: local-encrypted (strict mode off)
+
+Next steps
+  Run:         paperclipai run
+  Reconfigure: paperclipai configure
+  Diagnose:    paperclipai doctor
+
+You're all set!
+```
+
+
 If you already have a Paperclip install, rerunning `onboard` keeps your current config and data paths intact. Use `paperclipai configure` if you want to edit settings.
 
 To start Paperclip again later:
@@ -45,6 +72,30 @@ pnpm paperclipai run
 ```
 
 This auto-onboards if config is missing, runs health checks with auto-repair, and starts the server.
+
+## Troubleshooting
+
+Run `paperclipai doctor` first; it checks your config, database, and provider key, and auto-repairs what it can.
+
+**All platforms**
+- `Could not connect to database`: the embedded PostgreSQL did not start. Re-run `paperclipai doctor`, or make sure nothing else is bound to its port.
+- `API key appears invalid`: re-enter your provider key with `paperclipai configure`.
+- Port 3100 already in use: stop the other process, or set a different bind with `paperclipai configure`.
+- `command not found: paperclipai`: you installed through npx, so prefix commands with `npx paperclipai`. The bare `paperclipai` and `pnpm paperclipai` forms only work inside a cloned repo.
+
+**WSL (Windows)**
+- Use a Linux-side Node via nvm, not the Windows Node on PATH; mixing them breaks the embedded database binary.
+- Keep the project under the Linux home (for example ~/paperclip), not /mnt/c, or embedded storage will be slow and may fail to lock.
+- Open the UI from Windows at http://localhost:3100 (WSL2 forwards localhost automatically).
+
+**macOS**
+- Requires Node 20+ and pnpm 9+ (brew install node pnpm). Check with `node -v`.
+- On Apple Silicon, run a native arm64 Node so the embedded PostgreSQL binary matches your architecture.
+- If Gatekeeper blocks a helper binary, allow it once under System Settings then Privacy and Security.
+
+**Linux**
+- Needs a recent glibc for the embedded PostgreSQL binary; on minimal or musl images, point Paperclip at an external database with `paperclipai configure`.
+- If the UI does not load, confirm the server is listening on 3100 and not blocked by a local firewall.
 
 ## What's Next
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,0 +1,88 @@
+# What's New — June 2026 Quickstart Overhaul
+
+If you set up Gradata before June 2026 using the old multi-path quickstart (Option A/B/C), here's what changed and what you need to know.
+
+---
+
+## Single install path
+
+The old quickstart offered three options:
+
+- Option A: `npx gradata@latest` (zero-install)
+- Option B: `npm install -g gradata` (global)
+- Option C: `docker run ...` (Docker)
+
+We've consolidated to one canonical path:
+
+```bash
+npx gradata@latest
+```
+
+This is the path we test, document, and support. The global install and Docker paths still work, but they're no longer documented or maintained as primary flows.
+
+---
+
+## Close your AI tools before setup
+
+This is the most important behavioral change.
+
+The setup wizard installs hooks into AI tool config files (Claude Code's `settings.json`, Cursor's config, etc.). If those tools are open when you run setup, they won't see the new hooks until you relaunch them — and in some cases, they'll overwrite the hook config when they exit.
+
+**Before running `npx gradata@latest`:** close Claude Code, Cursor, Codex, and any other AI tools. Relaunch them after setup completes.
+
+---
+
+## Daemon runs in the foreground by default
+
+Previously the daemon started in the background silently. Now it runs in the foreground so you can see what it's doing:
+
+```
+Gradata daemon running. Press Ctrl+C to stop.
+```
+
+To run in the background:
+
+```bash
+npx gradata@latest daemon --background
+```
+
+To restart later (e.g. after closing the terminal):
+
+```bash
+npx gradata@latest daemon
+```
+
+---
+
+## Quick config commands changed
+
+If you were running bare `gradata` commands (e.g. `gradata brain list`), those only work if you did a global install. With the npx path, use:
+
+```bash
+npx gradata@latest config show
+npx gradata@latest brain list
+npx gradata@latest sync status
+```
+
+---
+
+## Bug fixes in this wave
+
+- **DB path race condition (GRA-4059):** `GRADATA_DB_PATH` is now set explicitly before the daemon starts, fixing a crash on first run when the config file hadn't been written yet.
+- **Install URL formatting (GRA-4119):** Fixed a missing space in the install instructions that caused copy-paste errors.
+- **Status filter normalization (GRA-4140):** Issue list API now correctly handles both single-value and array `status` query params from Express.
+
+---
+
+## If you're upgrading from the old flow
+
+1. Stop any running daemon: `Ctrl+C` or kill the process
+2. Close all AI tools
+3. Run `npx gradata@latest` — it will re-detect your tools and update hooks
+4. Relaunch your AI tools
+
+Your existing brain data and rules are preserved — the setup wizard doesn't touch `~/.gradata/brain/`.
+
+---
+
+Full docs at [docs.gradata.ai](https://docs.gradata.ai)

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,55 @@
+# Paperclip Server
+
+A Node.js/Express server for the Paperclip application.
+
+## Quickstart
+
+```bash
+npx paperclipai onboard --yes
+```
+
+The server starts at `http://localhost:3100`. It runs in your terminal until you stop it (Ctrl+C).
+
+**To start again later:**
+
+```bash
+npx paperclipai run
+```
+
+## Local Development
+
+If you're contributing to Paperclip itself:
+
+```bash
+git clone https://github.com/paperclipai/paperclip.git
+cd paperclip
+pnpm install
+pnpm dev
+```
+
+> **Requirements:** Node.js 20+, pnpm 9.15+
+
+## Sentry Error Monitoring
+
+This server uses Sentry for error tracking and performance monitoring.
+
+### Setup
+
+1. Create a project at https://sentry.io and copy your DSN.
+2. Add `SENTRY_DSN=<your-dsn>` to your `.env` file.
+3. Optionally set `NODE_ENV=production` for production environments.
+
+### Verify Integration
+
+With the server running, hit the test endpoint:
+
+    curl http://localhost:3000/api/sentry-test
+
+This throws a deliberate error that Sentry should capture. Check your Sentry dashboard for the event.
+
+### What is Captured
+
+- All unhandled Express errors (via error-handler middleware)
+- Unhandled promise rejections
+- Uncaught exceptions
+- Request traces (100% sample rate in development)


### PR DESCRIPTION
## What

Consolidates the README quickstart into a single 60-second npx path and removes the conflicting multi-path instructions.

## Changes
- `README.md`: replaced Option A/B/C + manual clone block with one `npx paperclipai onboard --yes` path; reconfigure via `paperclipai configure` + `paperclipai run`.
- `docs/start/quickstart.md`: added expected-output sample and WSL/macOS/Linux troubleshooting sections.
- `docs/whats-new.md`: delta doc for users upgrading from the old multi-path flow.
- `server/README.md`: new server-focused quickstart + Sentry setup reference.

## Verify
`pnpm run test`, `pnpm run typecheck`, `pnpm run build` — docs-only change, no code touched.

Closes GRA-3532.