### PR TITLE
Move toast viewport to bottom-right

### DIFF
--- a/ui/src/components/ToastViewport.tsx
+++ b/ui/src/components/ToastViewport.tsx
@@ -89,7 +89,7 @@ export function ToastViewport() {
     <aside
       aria-live="polite"
       aria-atomic="false"
-      className="pointer-events-none fixed bottom-3 left-3 z-[120] w-full max-w-sm px-1"
+      className="pointer-events-none fixed bottom-3 right-3 z-[120] w-full max-w-sm px-1"
     >
       <ol className="flex w-full flex-col-reverse gap-2">
         {toasts.map((toast) => (


### PR DESCRIPTION
Move the toast notification viewport from bottom-left to bottom-right to match expected notification placement.

One-line change in `ui/src/components/ToastViewport.tsx`: `bottom-3 left-3` → `bottom-3 right-3`.

Verified live in a dev instance (HMR) — fresh toasts land bottom-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)