### PR TITLE
fix(recovery): reap process_detached zombie runs in stale-lock sweep

### DIFF
--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -223,4 +223,90 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     expect(first.cleared).toBe(1);
     expect(second.cleared).toBe(0);
   });
+
+  it("reaps a process_detached run silent past the critical threshold, then clears its stranded lock", async () => {
+    const { companyId, agentId } = await seed();
+    const detachedRunId = randomUUID();
+    const silentSince = new Date(Date.now() - 5 * 60 * 60 * 1000); // 5h > 4h critical threshold
+    await db.insert(heartbeatRuns).values({
+      id: detachedRunId,
+      companyId,
+      agentId,
+      status: "running",
+      errorCode: "process_detached",
+      invocationSource: "manual",
+      startedAt: silentSince,
+      lastOutputAt: silentSince,
+    });
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stranded lock — detached zombie run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: detachedRunId,
+      executionRunId: detachedRunId,
+      executionLockedAt: silentSince,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    expect(result.cleared).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issueRow = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(issueRow).toEqual({ checkoutRunId: null, executionRunId: null });
+
+    // The dead zombie is reaped to a terminal status so the silence-detector stops re-flagging it.
+    const runRow = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, detachedRunId))
+      .then((rows) => rows[0]);
+    expect(runRow?.status).toBe("timed_out");
+  });
+
+  it("does not reap a process_detached run still within the critical threshold", async () => {
+    const { companyId, agentId } = await seed();
+    const detachedRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: detachedRunId,
+      companyId,
+      agentId,
+      status: "running",
+      errorCode: "process_detached",
+      invocationSource: "manual",
+      startedAt: new Date(),
+      lastOutputAt: new Date(Date.now() - 10 * 60 * 1000), // 10 min < 4h — may still be alive
+    });
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Recently-detached run — preserve",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: detachedRunId,
+      executionRunId: null,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    expect(result.cleared).toBe(0);
+    const runRow = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, detachedRunId))
+      .then((rows) => rows[0]);
+    expect(runRow?.status).toBe("running");
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -67,6 +67,10 @@ const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_r
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
+
+// Mirrors heartbeat.ts DETACHED_PROCESS_ERROR_CODE. Kept local to avoid a
+// heartbeat<->recovery import cycle (heartbeat imports this module).
+const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
@@ -3923,12 +3927,75 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runRows =
       referencedRunIds.length > 0
         ? await db
-            .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+            .select({
+              id: heartbeatRuns.id,
+              companyId: heartbeatRuns.companyId,
+              agentId: heartbeatRuns.agentId,
+              status: heartbeatRuns.status,
+              errorCode: heartbeatRuns.errorCode,
+              lastOutputAt: heartbeatRuns.lastOutputAt,
+              createdAt: heartbeatRuns.createdAt,
+            })
             .from(heartbeatRuns)
             .where(inArray(heartbeatRuns.id, referencedRunIds))
         : [];
+    const now = new Date();
     const runStatusById = new Map<string, string>();
-    for (const row of runRows) runStatusById.set(row.id, row.status);
+    for (const row of runRows) {
+      let status = row.status;
+      // A `process_detached` run lost its in-memory process handle but its pid still
+      // looked alive, so the reaper keeps it `running` (a live detached child clears this
+      // warning on its next output via clearDetachedRunWarning). One that is ALSO silent
+      // past the critical threshold is a dead zombie nothing reaps — the reaper skips it
+      // (pid "alive") and the silence-detector is observability-only — so it strands the
+      // issue checkout lock forever (every /checkout, /release, PATCH and /comments 409 for
+      // all actors, including the legitimate assignee). Reap it to a terminal status so the
+      // clearing below frees the lock.
+      const silenceRef = row.lastOutputAt ?? row.createdAt;
+      const silenceMs = silenceRef ? now.getTime() - new Date(silenceRef).getTime() : Number.POSITIVE_INFINITY;
+      if (
+        status === "running" &&
+        row.errorCode === DETACHED_PROCESS_ERROR_CODE &&
+        silenceMs >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS
+      ) {
+        const reaped = await db
+          .update(heartbeatRuns)
+          .set({
+            status: "timed_out",
+            error: "Reaped by stale-lock sweep: process_detached run silent past the critical output threshold",
+            finishedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(heartbeatRuns.id, row.id),
+              eq(heartbeatRuns.status, "running"),
+              eq(heartbeatRuns.errorCode, DETACHED_PROCESS_ERROR_CODE),
+            ),
+          )
+          .returning({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+          .then((rows) => rows[0] ?? null);
+        if (reaped) {
+          status = reaped.status;
+          await logActivity(db, {
+            companyId: row.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: row.agentId,
+            runId: row.id,
+            action: "heartbeat.detached_run_reaped",
+            entityType: "heartbeat_run",
+            entityId: row.id,
+            details: {
+              source: "recovery.sweep_stale_issue_locks",
+              silenceAgeMs: Number.isFinite(silenceMs) ? silenceMs : null,
+              lastOutputAt: row.lastOutputAt ? new Date(row.lastOutputAt).toISOString() : null,
+            },
+          });
+        }
+      }
+      runStatusById.set(row.id, status);
+    }
 
     const isCleanable = (runId: string | null) => {
       if (!runId) return true;


### PR DESCRIPTION
## Problem

A heartbeat run flagged `process_detached` (the supervisor lost its in-memory process handle but the child pid still looked alive) is intentionally kept `running` by the reaper — a live detached child clears the warning on its next output via `clearDetachedRunWarning`. But if such a run then goes **silent past the critical output threshold**, nothing terminates it:

- the reaper keeps skipping it (`processPidAlive` → `continue`), and
- the silence-detector is observability-only — it creates an evaluation issue and wakes the agent, but explicitly leaves the run *"not been cancelled."*

The dead zombie therefore strands the issue's checkout lock **forever**: the owner-run guard only releases a lock when the owner run is in `TERMINAL_HEARTBEAT_RUN_STATUSES`, so `/checkout`, `/release`, `PATCH` and `POST /comments` all return `409 Issue run ownership conflict` for every actor — including the legitimate assignee on a fresh run. The issue becomes permanently ungrabbable.

## Fix

`sweepStaleIssueLocks()` already clears locks whose run is terminal but skips `running` runs. Extend it with a small reap pass: a `process_detached` run silent ≥ `ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS` is a confirmed dead zombie (a live detached child would have cleared its warning), so transition it to `timed_out`. The existing terminal-based clearing then frees the lock, and the silence-detector stops re-flagging the now-terminal run.

Scope is deliberately narrow: only `process_detached` runs past the 4h critical threshold are touched — healthy runs and recently-detached (possibly-alive) runs are left exactly as before.

## Tests

Adds two cases to `recovery-stale-issue-lock-sweep.test.ts`:
- a `process_detached` run silent past the threshold is reaped to `timed_out` and its stranded lock cleared;
- a `process_detached` run still within the threshold is preserved (not reaped, lock retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
