### PR TITLE
docs: add PR publication and workspace hygiene guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,23 @@ diagnostics/
 # Doc maintenance cursor
 .doc-review-cursor
 
+# Agent scratch files belong under .paperclip-local/scratch/<issue-id>/.
+# Keep root-level helper/output files out of future status and PR scopes.
+/.ful*.cjs
+/.ful*.json
+/.ful*.txt
+/.ful*.md
+/.health*.cjs
+/.health*.json
+/.health*.txt
+/.health*.md
+/.health*.sh
+/.post-health*.cjs
+/.help2day*.cjs
+/.comment-response.json
+/.create-disk*
+/.disk-ticket*
+
 # Playwright
 tests/e2e/test-results/
 tests/e2e/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,12 @@ When you are creating a plan file in the repository itself, new plan documents b
 6. Attach inspectable generated artifacts.
 When your task produces a user-inspectable deliverable file, follow the Paperclip skill's "Generated Artifacts and Work Products" workflow before final disposition. In this repo, prefer the self-contained skill helper at `skills/paperclip/scripts/paperclip-upload-artifact.sh` so the file is available through the Paperclip API, create/update an artifact work product when the file is the deliverable, link the uploaded artifact in the final issue comment, and then set status. Do not rely on local filesystem paths as the only access path. If an important file intentionally remains workspace-only, create/update a work product with `metadata.resourceRef.kind: "workspace_file"` and a workspace-relative path, then name that work product and path in the final comment. Treat browse/search as a fallback for recovering workspace files, not the preferred deliverable path. See `doc/AGENT-ARTIFACTS.md` for details and `.mp4`/`.webm` examples.
 
+7. Publish PRs only from clean, scoped branches.
+When a task asks you to publish reviewed local changes, do not push from a shared project-primary checkout or a branch that contains unrelated ahead-of-base commits. Follow `doc/PR-PUBLICATION-HANDOFF.md`: identify the exact source workspace, intended base, dependency commits, and file list; create a clean branch/worktree; apply only the reviewed diff; run `scripts/check-pr-publication-readiness.sh` before pushing.
+
+8. Keep workspace scratch files out of repo roots.
+Do not write issue helper scripts, command outputs, API responses, or temporary evidence as root-level `.ful*`, `.health*`, `.tmp*`, or ad hoc JSON/TXT files. Put transient files under `.paperclip-local/scratch/<issue-id>/` and durable evidence under the Paperclip issue as an attachment/work product. If a workspace-local file must stay, document it in `doc/WORKSPACE-HYGIENE.md` or the issue work product.
+
 ## 6. Database Change Workflow
 
 When changing data model:

--- a/doc/PR-PUBLICATION-HANDOFF.md
+++ b/doc/PR-PUBLICATION-HANDOFF.md
@@ -1,0 +1,54 @@
+# PR Publication Handoff
+
+Use this process whenever one agent reviews or prepares changes and another agent is asked to publish the branch or open the PR.
+
+## Required Handoff Fields
+
+The handoff comment or task description must include:
+
+- Source workspace path or branch name.
+- Intended PR base branch and base commit.
+- Intended head branch name.
+- Exact files expected in the PR.
+- Whether the change depends on unmerged commits or another PR.
+- Verification commands already run, with pass/fail status.
+- Any files that are intentionally workspace-only and why.
+
+If any field is missing, the publisher must ask for it or reconstruct it before pushing.
+
+## Publisher Procedure
+
+1. Start from a clean branch or clean git worktree based on the intended base.
+2. Apply only the reviewed diff and any explicitly named prerequisite commits.
+3. Run:
+
+```sh
+scripts/check-pr-publication-readiness.sh --base <base-ref>
+```
+
+4. Confirm the output shows only intended commits and files.
+5. Read `.github/PULL_REQUEST_TEMPLATE.md`, `CONTRIBUTING.md`, and `.github/workflows/pr.yml`.
+6. Create the PR using the repository PR template.
+
+## Dependency Rules
+
+- If the reviewed change depends on an unmerged commit, create a stacked PR or publish the prerequisite first.
+- Do not silently include unrelated local commits to make the diff apply.
+- If the dependency is unclear, stop and post the exact missing base/dependency information to the issue.
+
+## Never Do This
+
+- Do not push directly from a shared dirty checkout.
+- Do not include root-level agent scratch files in a PR.
+- Do not mix production deployment work into a non-production publication handoff.
+- Do not create a deployment issue unless the source task explicitly asks for deployment.
+
+## Evidence to Post Back
+
+Before marking the publication task done, post:
+
+- PR URL.
+- Base branch and head branch.
+- `git log --oneline <base>..HEAD` summary.
+- `git diff --name-only <base>...HEAD` summary.
+- Verification commands run after creating the clean branch.

--- a/doc/WORKSPACE-HYGIENE.md
+++ b/doc/WORKSPACE-HYGIENE.md
@@ -1,0 +1,58 @@
+# Workspace Hygiene
+
+Repo roots should contain source code, tracked documentation, and intentionally ignored tool state only. Agent scratch files in the repo root make PR publication slower and increase the chance of unrelated files leaking into commits.
+
+## Where Files Belong
+
+| File type | Location |
+| --- | --- |
+| Temporary issue scripts | `.paperclip-local/scratch/<issue-id>/` |
+| Command output used during investigation | `.paperclip-local/scratch/<issue-id>/` |
+| Durable deliverables for board/reviewer inspection | Paperclip issue attachment or work product |
+| Repo documentation | `doc/` or `docs/` |
+| Repo automation scripts | `scripts/` |
+| Test fixtures committed with code | nearest package test fixture directory |
+
+## What May Stay in the Repo Root
+
+- Standard tracked project files such as `package.json`, `pnpm-workspace.yaml`, `README.md`, `AGENTS.md`, and config files.
+- Intentional ignored local runtime directories listed in `.gitignore`, such as `node_modules/`, `.paperclip/`, `.paperclip-local/`, and `.runtime-backups/`.
+
+Anything else in the root should have a clear owner and reason, or it should be moved to a scratch/archive directory.
+
+## Scratch Archive Convention
+
+When cleaning old root-level agent output, move it to:
+
+```text
+.paperclip-local/scratch-archive/YYYY-MM-DD/<issue-or-category>/
+```
+
+Add a `MANIFEST.md` in that archive directory with:
+
+- Cleanup date.
+- Who moved the files.
+- Why the files were moved.
+- Whether they are safe to delete later.
+
+Do not move files that belong to an active run or an active uncommitted change.
+
+## Before Starting Work
+
+Run:
+
+```sh
+git status --short
+```
+
+If unrelated untracked files are present, ignore them unless they block your task. For PR publication work, use a clean worktree instead of trying to reason around a cluttered shared checkout.
+
+## Before Publishing a PR
+
+Run:
+
+```sh
+scripts/check-pr-publication-readiness.sh --base <base-ref>
+```
+
+The script reports branch, status, commits ahead of base, tracked diff files, and untracked files. Do not push until the output matches the intended scope.

--- a/scripts/check-pr-publication-readiness.sh
+++ b/scripts/check-pr-publication-readiness.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="origin/master"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE_REF="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: scripts/check-pr-publication-readiness.sh [--base <base-ref>]
+
+Print a PR publication preflight summary. Use this before pushing a branch or
+opening a PR from reviewed local changes.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$BASE_REF" ]]; then
+  echo "--base requires a non-empty ref" >&2
+  exit 2
+fi
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Not inside a git repository" >&2
+  exit 2
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if ! git rev-parse --verify "$BASE_REF^{commit}" >/dev/null 2>&1; then
+  echo "Base ref not found: $BASE_REF" >&2
+  echo "Fetch the base ref first, then rerun this check." >&2
+  exit 2
+fi
+
+CURRENT_BRANCH="$(git branch --show-current || true)"
+HEAD_SHA="$(git rev-parse --short HEAD)"
+AHEAD_COUNT="$(git rev-list --count "$BASE_REF"..HEAD)"
+
+echo "PR publication readiness"
+echo "repo: $ROOT"
+echo "branch: ${CURRENT_BRANCH:-detached}"
+echo "head: $HEAD_SHA"
+echo "base: $BASE_REF"
+echo "commits_ahead_of_base: $AHEAD_COUNT"
+echo
+
+echo "status:"
+git status --short
+echo
+
+echo "commits:"
+git log --oneline "$BASE_REF"..HEAD || true
+echo
+
+echo "tracked_diff_files:"
+git diff --name-only "$BASE_REF"...HEAD
+echo
+
+echo "working_tree_diff_files:"
+git diff --name-only
+echo
+
+echo "untracked_files:"
+git ls-files --others --exclude-standard
+echo
+
+if git status --porcelain | grep -q .; then
+  echo "RESULT: review_required"
+  echo "Reason: working tree is not clean. Verify every listed file is intended before pushing."
+else
+  echo "RESULT: clean"
+fi


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent-run work often moves from implementation to a separate PR publication handoff
> - Shared local checkouts and root-level scratch files can make publication scope hard to inspect
> - That creates risk that unrelated commits or temporary agent files get pushed with an otherwise focused PR
> - This pull request adds a documented clean-publication protocol and a small preflight script
> - The benefit is that agents and humans have a simple, repeatable way to publish reviewed changes from clean branches

## Linked Issues or Issue Description

No public GitHub issue exists. This is a documentation and workflow hardening change for PR publication hygiene.

Problem:
- Publishing reviewed local changes from a shared dirty checkout can accidentally include unrelated commits or scratch files.
- Agents need one short checklist and one command to inspect PR scope before pushing.

Expected behavior:
- PR publication handoffs name source, base, intended files, and dependencies.
- Publishers use clean branches/worktrees and run a preflight before opening a PR.

## What Changed

- Added `doc/PR-PUBLICATION-HANDOFF.md` with required handoff fields, publisher steps, dependency rules, and evidence to post back.
- Added `doc/WORKSPACE-HYGIENE.md` with scratch-file locations, archive convention, and cleanup expectations.
- Added `scripts/check-pr-publication-readiness.sh` to summarize branch/base, status, commits, tracked diff files, working-tree diffs, and untracked files.
- Updated `AGENTS.md` to make clean PR publication and scratch-file placement explicit contributor rules.
- Updated `.gitignore` to keep root-level agent scratch files out of future status and PR scopes.

## Verification

- `bash -n scripts/check-pr-publication-readiness.sh`
- `scripts/check-pr-publication-readiness.sh --base origin/master`

The preflight reported this branch as one commit ahead of `origin/master`, no uncommitted or untracked files after commit, and only the intended files in scope.

## Risks

Low risk. This is documentation plus a read-only shell preflight. The `.gitignore` additions only affect root-level agent scratch patterns and do not ignore source, package, migration, test, or docs paths.

## Model Used

OpenAI Codex, GPT-5 coding agent, CLI tool use with local shell execution and file edits.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] For merge, deploy, or runtime activation approval, I have included current machine-verifiable evidence tied to the exact commit/config being approved
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
