### PR TITLE
feat(billing): add estimated_market_value_cents to cost events

### DIFF
--- a/packages/adapter-utils/src/billing.test.ts
+++ b/packages/adapter-utils/src/billing.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { inferOpenAiCompatibleBiller } from "./billing.js";
+import {
+  estimateTokenMarketValueCents,
+  estimateTokenMarketValueUsd,
+  inferOpenAiCompatibleBiller,
+} from "./billing.js";
 
 describe("inferOpenAiCompatibleBiller", () => {
   it("returns openrouter when OPENROUTER_API_KEY is present", () => {
@@ -24,5 +28,43 @@ describe("inferOpenAiCompatibleBiller", () => {
         "openai",
       ),
     ).toBe("openai");
+  });
+});
+
+describe("token market value estimates", () => {
+  it("estimates OpenAI token usage with cached input tokens", () => {
+    expect(
+      estimateTokenMarketValueUsd({
+        provider: "openai",
+        model: "gpt-5.5",
+        inputTokens: 100000,
+        cachedInputTokens: 50000,
+        outputTokens: 1000,
+      }),
+    ).toBe(0.555);
+  });
+
+  it("estimates Claude token usage with cache-read tokens", () => {
+    expect(
+      estimateTokenMarketValueCents({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6-20260601",
+        inputTokens: 100000,
+        cachedInputTokens: 50000,
+        outputTokens: 1000,
+      }),
+    ).toBe(33);
+  });
+
+  it("returns null for unknown provider or model pricing", () => {
+    expect(
+      estimateTokenMarketValueCents({
+        provider: "unknown",
+        model: "unknown-model",
+        inputTokens: 100000,
+        cachedInputTokens: 0,
+        outputTokens: 1000,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/adapter-utils/src/billing.ts
+++ b/packages/adapter-utils/src/billing.ts
@@ -3,6 +3,29 @@ function readEnv(env: NodeJS.ProcessEnv, key: string): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+const TOKENS_PER_MILLION = 1_000_000;
+
+type TokenPricing = {
+  inputUsdPerMillion: number;
+  cachedInputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+};
+
+const OPENAI_MODEL_PRICING: Record<string, TokenPricing> = {
+  "gpt-5.5": { inputUsdPerMillion: 5, cachedInputUsdPerMillion: 0.5, outputUsdPerMillion: 30 },
+  "gpt-5.4": { inputUsdPerMillion: 2.5, cachedInputUsdPerMillion: 0.25, outputUsdPerMillion: 15 },
+  "gpt-5.4-mini": { inputUsdPerMillion: 0.75, cachedInputUsdPerMillion: 0.075, outputUsdPerMillion: 4.5 },
+  "gpt-5.4-nano": { inputUsdPerMillion: 0.2, cachedInputUsdPerMillion: 0.02, outputUsdPerMillion: 1.25 },
+  "gpt-5.3-codex": { inputUsdPerMillion: 1.75, cachedInputUsdPerMillion: 0.175, outputUsdPerMillion: 14 },
+  "gpt-5.3-codex-spark": { inputUsdPerMillion: 1.75, cachedInputUsdPerMillion: 0.175, outputUsdPerMillion: 14 },
+  "gpt-5": { inputUsdPerMillion: 1.25, cachedInputUsdPerMillion: 0.125, outputUsdPerMillion: 10 },
+  "gpt-5-mini": { inputUsdPerMillion: 0.25, cachedInputUsdPerMillion: 0.025, outputUsdPerMillion: 2 },
+  "gpt-5-nano": { inputUsdPerMillion: 0.05, cachedInputUsdPerMillion: 0.005, outputUsdPerMillion: 0.4 },
+  o3: { inputUsdPerMillion: 2, cachedInputUsdPerMillion: 0.5, outputUsdPerMillion: 8 },
+  "o4-mini": { inputUsdPerMillion: 1.1, cachedInputUsdPerMillion: 0.275, outputUsdPerMillion: 4.4 },
+  "codex-mini-latest": { inputUsdPerMillion: 1.5, cachedInputUsdPerMillion: 0.375, outputUsdPerMillion: 6 },
+};
+
 export function inferOpenAiCompatibleBiller(
   env: NodeJS.ProcessEnv,
   fallback: string | null = "openai",
@@ -17,4 +40,81 @@ export function inferOpenAiCompatibleBiller(
   if (baseUrl && /openrouter\.ai/i.test(baseUrl)) return "openrouter";
 
   return fallback;
+}
+
+function normalizeProvider(provider: string | null | undefined): string {
+  return typeof provider === "string" ? provider.trim().toLowerCase() : "";
+}
+
+function normalizeModel(model: string | null | undefined): string {
+  return typeof model === "string" ? model.trim().toLowerCase() : "";
+}
+
+function resolveAnthropicPricing(model: string): TokenPricing | null {
+  if (model.includes("fable-5") || model.includes("mythos-5")) {
+    return { inputUsdPerMillion: 10, cachedInputUsdPerMillion: 1, outputUsdPerMillion: 50 };
+  }
+  if (/opus[-_\s.]*4[-_\s.]*1/.test(model)) {
+    return { inputUsdPerMillion: 15, cachedInputUsdPerMillion: 1.5, outputUsdPerMillion: 75 };
+  }
+  if (/opus[-_\s.]*4[-_\s.]*[5678]/.test(model) || /opus[-_\s.]*4(?:[-_\s.]|$)/.test(model)) {
+    return { inputUsdPerMillion: 5, cachedInputUsdPerMillion: 0.5, outputUsdPerMillion: 25 };
+  }
+  if (/sonnet[-_\s.]*4/.test(model)) {
+    return { inputUsdPerMillion: 3, cachedInputUsdPerMillion: 0.3, outputUsdPerMillion: 15 };
+  }
+  if (/haiku[-_\s.]*4[-_\s.]*5/.test(model)) {
+    return { inputUsdPerMillion: 1, cachedInputUsdPerMillion: 0.1, outputUsdPerMillion: 5 };
+  }
+  return null;
+}
+
+function resolveTokenPricing(provider: string | null | undefined, model: string | null | undefined): TokenPricing | null {
+  const normalizedProvider = normalizeProvider(provider);
+  const normalizedModel = normalizeModel(model);
+  if (!normalizedProvider || !normalizedModel) return null;
+
+  if (normalizedProvider === "openai") {
+    return OPENAI_MODEL_PRICING[normalizedModel] ?? null;
+  }
+
+  if (normalizedProvider === "anthropic") {
+    return resolveAnthropicPricing(normalizedModel);
+  }
+
+  return null;
+}
+
+function normalizeTokenCount(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+export function estimateTokenMarketValueUsd(input: {
+  provider: string | null | undefined;
+  model: string | null | undefined;
+  inputTokens: number;
+  cachedInputTokens?: number | null;
+  outputTokens: number;
+}): number | null {
+  const pricing = resolveTokenPricing(input.provider, input.model);
+  if (!pricing) return null;
+
+  const total =
+    (normalizeTokenCount(input.inputTokens) * pricing.inputUsdPerMillion +
+      normalizeTokenCount(input.cachedInputTokens) * pricing.cachedInputUsdPerMillion +
+      normalizeTokenCount(input.outputTokens) * pricing.outputUsdPerMillion) /
+    TOKENS_PER_MILLION;
+
+  return Number(total.toFixed(8));
+}
+
+export function estimateTokenMarketValueCents(input: {
+  provider: string | null | undefined;
+  model: string | null | undefined;
+  inputTokens: number;
+  cachedInputTokens?: number | null;
+  outputTokens: number;
+}): number | null {
+  const usd = estimateTokenMarketValueUsd(input);
+  return usd === null ? null : Math.max(0, Math.round(usd * 100));
 }

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { estimateTokenMarketValueUsd } from "@paperclipai/adapter-utils/billing";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -67,6 +68,7 @@ import {
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
   /^\d{4}-\d{2}-\d{2}T[^\s]+\s+ERROR\s+codex_core::rollout::list:\s+state db missing rollout path for thread\s+[a-z0-9-]+$/i;
+const DEFAULT_MAX_CONTEXT_TOKENS = 200_000;
 
 function stripCodexRolloutNoise(text: string): string {
   const parts = text.split(/\r?\n/);
@@ -115,6 +117,11 @@ function signalCodexChild(
   return false;
 }
 
+function formatCount(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "0";
+  return value.toLocaleString("en-US");
+}
+
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
@@ -129,6 +136,49 @@ function resolveCodexBiller(env: Record<string, string>, billingType: "api" | "s
   const openAiCompatibleBiller = inferOpenAiCompatibleBiller(env, "openai");
   if (openAiCompatibleBiller === "openrouter") return "openrouter";
   return billingType === "subscription" ? "chatgpt" : openAiCompatibleBiller ?? "openai";
+}
+
+function normalizeCodexModelForPricing(model: string | null | undefined): string {
+  const normalized = typeof model === "string" ? model.trim().toLowerCase() : "";
+  return normalized || "gpt-5.5";
+}
+
+export function estimateCodexCostUsd(input: {
+  model: string | null | undefined;
+  inputTokens: number;
+  cachedInputTokens?: number;
+  outputTokens: number;
+}): number | null {
+  return estimateTokenMarketValueUsd({
+    provider: "openai",
+    model: normalizeCodexModelForPricing(input.model),
+    inputTokens: input.inputTokens,
+    cachedInputTokens: input.cachedInputTokens,
+    outputTokens: input.outputTokens,
+  });
+}
+
+function resolveMaxContextTokens(config: Record<string, unknown>): number {
+  const configured = Math.floor(asNumber(config.maxContextTokens, DEFAULT_MAX_CONTEXT_TOKENS));
+  return configured > 0 ? configured : 0;
+}
+
+function buildContextTokenWarning(input: {
+  usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number };
+  maxContextTokens: number;
+}) {
+  if (input.maxContextTokens <= 0) return null;
+  const inputContextTokens = Math.max(0, input.usage.inputTokens + input.usage.cachedInputTokens);
+  const totalTokens = inputContextTokens + Math.max(0, input.usage.outputTokens);
+  if (inputContextTokens < input.maxContextTokens && totalTokens < input.maxContextTokens) return null;
+
+  return {
+    type: "codex_context_tokens_exceeded",
+    maxContextTokens: input.maxContextTokens,
+    inputContextTokens,
+    totalTokens,
+    message: `Codex context usage reached ${formatCount(inputContextTokens)} input/context tokens (${formatCount(totalTokens)} total), meeting or exceeding the configured ${formatCount(input.maxContextTokens)} token warning threshold.`,
+  };
 }
 
 async function isLikelyPaperclipRepoRoot(candidate: string): Promise<boolean> {
@@ -329,6 +379,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   );
   const command = asString(config.command, "codex");
   const model = asString(config.model, "");
+  const maxContextTokens = resolveMaxContextTokens(config);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -910,7 +961,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
     };
 
-    const toResult = (
+    const toResult = async (
       attempt: {
         proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
         rawStderr: string;
@@ -921,7 +972,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       },
       clearSessionOnMissingSession = false,
       isRetry = false,
-    ): AdapterExecutionResult => {
+    ): Promise<AdapterExecutionResult> => {
       if (attempt.monitor?.fired) {
         const errorMessage = formatOutputInactivityMonitorErrorMessage(attempt.monitor.elapsedMsSinceLastEvent);
         return {
@@ -1003,6 +1054,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stderr: attempt.proc.stderr,
           errorMessage: fallbackErrorMessage,
         });
+      const contextTokenWarning = buildContextTokenWarning({
+        usage: attempt.parsed.usage,
+        maxContextTokens,
+      });
+      if (contextTokenWarning) {
+        await onLog("stdout", `[paperclip] Warning: ${contextTokenWarning.message}\n`);
+      }
+      const effectiveModel = normalizeCodexModelForPricing(model);
+      const costUsd = estimateCodexCostUsd({
+        model: effectiveModel,
+        inputTokens: attempt.parsed.usage.inputTokens,
+        cachedInputTokens: attempt.parsed.usage.cachedInputTokens,
+        outputTokens: attempt.parsed.usage.outputTokens,
+      });
 
       return {
         exitCode: attempt.proc.exitCode,
@@ -1024,12 +1089,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         sessionDisplayId: resolvedSessionId,
         provider: "openai",
         biller: resolveCodexBiller(effectiveEnv, billingType),
-        model,
+        model: effectiveModel,
         billingType,
-        costUsd: null,
+        costUsd,
         resultJson: {
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
+          ...(costUsd !== null ? { total_cost_usd: costUsd, cost_usd: costUsd } : {}),
+          ...(contextTokenWarning ? { contextTokenWarning } : {}),
           ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
           ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
           ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
@@ -1052,10 +1119,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
         );
         const retry = await runAttempt(null);
-        return toResult(retry, true, true);
+        return await toResult(retry, true, true);
       }
 
-      return toResult(initial, false, false);
+      return await toResult(initial, false, false);
     } finally {
       if (paperclipBridge) {
         await paperclipBridge.stop();

--- a/packages/db/src/migrations/0111_cost_event_estimated_market_value.sql
+++ b/packages/db/src/migrations/0111_cost_event_estimated_market_value.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cost_events" ADD COLUMN "estimated_market_value_cents" integer;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1781902400000,
       "tag": "0110_document_company_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0111_cost_event_estimated_market_value",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/cost_events.ts
+++ b/packages/db/src/schema/cost_events.ts
@@ -24,7 +24,10 @@ export const costEvents = pgTable(
     inputTokens: integer("input_tokens").notNull().default(0),
     cachedInputTokens: integer("cached_input_tokens").notNull().default(0),
     outputTokens: integer("output_tokens").notNull().default(0),
+    // actual billed spend; zero for subscription-included usage
     costCents: integer("cost_cents").notNull(),
+    // market-value estimate for subscription-billed runs; null for API-metered events
+    estimatedMarketValueCents: integer("estimated_market_value_cents"),
     occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -16,7 +16,10 @@ export interface CostEvent {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
+  /** actual billed spend; zero for subscription-included usage */
   costCents: number;
+  /** market-value estimate for subscription-billed runs; null for API-metered events */
+  estimatedMarketValueCents: number | null;
   occurredAt: Date;
   createdAt: Date;
 }

--- a/packages/shared/src/validators/cost.ts
+++ b/packages/shared/src/validators/cost.ts
@@ -16,6 +16,7 @@ export const createCostEventSchema = z.object({
   cachedInputTokens: z.number().int().nonnegative().optional().default(0),
   outputTokens: z.number().int().nonnegative().optional().default(0),
   costCents: z.number().int().nonnegative(),
+  estimatedMarketValueCents: z.number().int().nonnegative().optional().nullable(),
   occurredAt: z.string().datetime(),
 }).transform((value) => ({
   ...value,

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -270,6 +270,62 @@ describe("cost routes", () => {
     });
   });
 
+  it("accepts estimated market value separately from actual billed spend", async () => {
+    const event = {
+      id: "cost-event-1",
+      companyId: "company-1",
+      agentId: "11111111-1111-4111-8111-111111111111",
+      issueId: null,
+      projectId: null,
+      goalId: null,
+      heartbeatRunId: null,
+      billingCode: null,
+      provider: "anthropic",
+      biller: "anthropic",
+      billingType: "subscription_included",
+      model: "claude-sonnet-4-6-20260601",
+      inputTokens: 100000,
+      cachedInputTokens: 50000,
+      outputTokens: 1000,
+      costCents: 0,
+      estimatedMarketValueCents: 33,
+      occurredAt: new Date("2026-06-23T00:00:00.000Z"),
+      createdAt: new Date("2026-06-23T00:00:00.000Z"),
+    };
+    mockCostService.createEvent.mockResolvedValueOnce(event);
+
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/cost-events")
+      .send({
+        agentId: event.agentId,
+        provider: event.provider,
+        biller: event.biller,
+        billingType: event.billingType,
+        model: event.model,
+        inputTokens: event.inputTokens,
+        cachedInputTokens: event.cachedInputTokens,
+        outputTokens: event.outputTokens,
+        costCents: event.costCents,
+        estimatedMarketValueCents: event.estimatedMarketValueCents,
+        occurredAt: event.occurredAt.toISOString(),
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockCostService.createEvent).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        costCents: 0,
+        estimatedMarketValueCents: 33,
+        billingType: "subscription_included",
+      }),
+    );
+    expect(res.body).toMatchObject({
+      costCents: 0,
+      estimatedMarketValueCents: 33,
+    });
+  });
+
   it("returns 400 for invalid finance event list limits", async () => {
     const { parseCostLimit } = await loadCostParsers();
     expect(() => parseCostLimit({ limit: "0" })).toThrow(/invalid 'limit'/i);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -183,6 +183,7 @@ import {
   resolveSessionCompactionPolicy,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
+import { estimateTokenMarketValueCents } from "@paperclipai/adapter-utils/billing";
 import {
   readPaperclipSkillSyncPreference,
   writePaperclipSkillSyncPreference,
@@ -8154,6 +8155,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const hasTokenUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const provider = result.provider ?? "unknown";
     const biller = resolveLedgerBiller(result);
+    const model = result.model ?? "unknown";
+    const estimatedMarketValueCents = hasTokenUsage
+      ? estimateTokenMarketValueCents({
+          provider,
+          model,
+          inputTokens,
+          cachedInputTokens,
+          outputTokens,
+        })
+      : null;
     const ledgerScope = await resolveLedgerScopeForRun(db, agent.companyId, run);
 
     await db
@@ -8182,11 +8193,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         provider,
         biller,
         billingType,
-        model: result.model ?? "unknown",
+        model,
         inputTokens,
         cachedInputTokens,
         outputTokens,
         costCents: additionalCostCents,
+        estimatedMarketValueCents,
         occurredAt: new Date(),
       });
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Cost event records are the durable accounting surface for agent execution cost telemetry.
> - Subscription-backed local adapters can correctly record actual billed spend as zero while still needing market-value visibility for execution-health analysis.
> - The existing `cost_cents` field should remain actual billed spend so budget enforcement and spend summaries do not change semantics.
> - This pull request adds a separate nullable market-value estimate field and wires it through the shared contract and runtime persistence path.
> - The benefit is better observability for subscription-included usage without changing actual billing behavior.

## Linked Issues or Issue Description

No public GitHub issue exists for this change, so the underlying feature request is described inline.

## Problem or motivation

`cost_events.cost_cents` correctly represents actual billed spend. For subscription-backed local agent runs, actual billed spend can be zero even when the run consumed a meaningful number of model tokens. That leaves execution-health and cost-quality reporting without a durable market-value signal unless each report recomputes estimates from raw usage.

## Proposed solution

Add a separate nullable `estimated_market_value_cents` field on cost events and expose it through the shared cost event contract. Populate it from local Codex token usage while keeping budget enforcement and actual-spend summaries on `cost_cents`.

## Alternatives considered

- Continue computing estimates only in reporting scripts. This keeps schema unchanged but repeats pricing logic and prevents other analytics consumers from querying the estimate.
- Reuse `cost_cents` for estimated value. This was rejected because `cost_cents` represents actual billed spend and is used by budget/spend semantics.

## Roadmap alignment

This is a small observability and accounting-contract improvement. It does not overlap with roadmap feature work and does not request deployment or runtime activation.

## What Changed

- Add nullable `cost_events.estimated_market_value_cents` with migration `0111_cost_event_estimated_market_value`.
- Add `estimatedMarketValueCents` to shared cost event types and creation validator handling.
- Move token market-value estimation into adapter-utils billing helpers with focused tests.
- Persist estimated market value for local Codex heartbeat/cost event paths while preserving `costCents` as actual spend.
- Add server cost service coverage for reading/persisting the new nullable field.

## Verification

Pre-publication validation reported PASS for:

- `pnpm --filter @paperclipai/db typecheck`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run packages/adapter-utils/src/billing.test.ts server/src/__tests__/costs-service.test.ts`

Publication/update evidence:

- Base: `paperclipai/paperclip:master`
- `git diff --check origin/master...HEAD` passed after rebase.
- Changed files are limited to the DB/schema/shared/runtime/test files required for the feature.

## Risks

- Low migration risk: additive nullable column, no default, historical rows remain valid.
- Billing semantics risk is constrained by keeping `cost_cents` as actual billed spend and storing market-value estimates separately.
- Pricing table drift remains possible and should be handled by follow-up pricing maintenance if needed.
- No production deployment is requested by this PR.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

GPT-5 via Codex CLI, with repository inspection, shell execution, git/GitHub CLI operations, and Paperclip board coordination.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [x] For merge, deploy, or runtime activation approval, I have included current machine-verifiable evidence tied to the exact commit/config being approved
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge