### PR TITLE
feat(opencode_local): host-global fan-out gate + model-enum hardening (XIP-4690)

### DIFF
--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,15 +1,43 @@
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  discoverOpenCodeModels,
+  discoverOpenCodeModelsCached,
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
   requireOpenCodeModelId,
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
 
+// Creates a fake `opencode` executable that records each invocation (one line
+// per spawn appended to `counterFile`), optionally sleeps `sleepSec`, then
+// prints a fixed two-model listing. Returns the script path.
+function makeFakeOpenCode(opts: { counterFile: string; sleepSec?: number }): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "fake-opencode-"));
+  const script = path.join(dir, "opencode");
+  const sleep = opts.sleepSec ? `sleep ${opts.sleepSec}` : "true";
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash\necho "$$" >> "${opts.counterFile}"\n${sleep}\n` +
+      `echo "anthropic/claude-x"\necho "openai/gpt-x"\n`,
+    "utf8",
+  );
+  chmodSync(script, 0o755);
+  return script;
+}
+
+function spawnCount(counterFile: string): number {
+  if (!existsSync(counterFile)) return 0;
+  return readFileSync(counterFile, "utf8").split("\n").filter((l) => l.trim()).length;
+}
+
 describe("openCode models", () => {
   afterEach(() => {
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
     delete process.env.OPENCODE_ALLOW_ALL_MODELS;
+    delete process.env.PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS;
     resetOpenCodeModelsCacheForTests();
   });
 
@@ -74,4 +102,45 @@ describe("openCode models", () => {
       }),
     ).rejects.toThrow("OpenCode requires `adapterConfig.model`");
   });
+
+  // XIP-4690 Fix 2a: single-flight collapses concurrent cold-cache lookups to one spawn.
+  it("single-flights concurrent discovery into a single `opencode models` spawn", async () => {
+    const counterFile = path.join(mkdtempSync(path.join(os.tmpdir(), "oc-count-")), "count");
+    const cmd = makeFakeOpenCode({ counterFile, sleepSec: 1 });
+
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => discoverOpenCodeModelsCached({ command: cmd })),
+    );
+
+    expect(spawnCount(counterFile)).toBe(1);
+    for (const r of results) {
+      expect(r).toEqual([
+        { id: "anthropic/claude-x", label: "anthropic/claude-x" },
+        { id: "openai/gpt-x", label: "openai/gpt-x" },
+      ]);
+    }
+  }, 20_000);
+
+  // XIP-4690 Fix 2b: cache key ignores cwd, so different researcher cwds share a cached result.
+  it("reuses the cached model list across different cwds (cwd not part of cache key)", async () => {
+    const counterFile = path.join(mkdtempSync(path.join(os.tmpdir(), "oc-count-")), "count");
+    const cmd = makeFakeOpenCode({ counterFile });
+
+    const a = await discoverOpenCodeModelsCached({ command: cmd, cwd: os.tmpdir() });
+    const b = await discoverOpenCodeModelsCached({ command: cmd, cwd: process.cwd() });
+
+    expect(spawnCount(counterFile)).toBe(1);
+    expect(a).toEqual(b);
+  }, 20_000);
+
+  // XIP-4690 Fix 2c: the enumeration timeout is configurable via env.
+  it("honours PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS for the enumeration timeout", async () => {
+    const counterFile = path.join(mkdtempSync(path.join(os.tmpdir(), "oc-count-")), "count");
+    const cmd = makeFakeOpenCode({ counterFile, sleepSec: 5 });
+    process.env.PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS = "1000";
+
+    await expect(discoverOpenCodeModels({ command: cmd })).rejects.toThrow(
+      "`opencode models` timed out after 1s.",
+    );
+  }, 20_000);
 });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -9,7 +9,20 @@ import {
 import { isValidOpenCodeModelId } from "../index.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
-const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const MODELS_DISCOVERY_TIMEOUT_DEFAULT_MS = 20_000;
+
+// XIP-4690: the 20s enumeration timeout was hardcoded, so when the shared local
+// host is saturated (the daily research fan-out spawns several `opencode`
+// processes at once) the wrapper trips even though `opencode models` is healthy.
+// Make it configurable so operators can relax it under known-heavy load.
+function resolveModelsDiscoveryTimeoutMs(): number {
+  const raw = process.env.PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS;
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    const parsed = Math.floor(Number(raw));
+    if (Number.isFinite(parsed) && parsed >= 1_000) return parsed;
+  }
+  return MODELS_DISCOVERY_TIMEOUT_DEFAULT_MS;
+}
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =
@@ -21,6 +34,10 @@ function resolveOpenCodeCommand(input: unknown): string {
 }
 
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+// XIP-4690: single-flight de-duplication. On a cold cache a simultaneous
+// fan-out (N agents) would each spawn `opencode models`; sharing one in-flight
+// promise per cache key collapses that to a single spawn.
+const inFlightDiscoveries = new Map<string, Promise<AdapterModel[]>>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
 
@@ -94,13 +111,17 @@ function hashValue(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function discoveryCacheKey(command: string, cwd: string, env: Record<string, string>) {
+// XIP-4690: the cache key intentionally omits `cwd`. The model list is a
+// function of the opencode binary and its provider auth (env), not the working
+// directory, so keying on cwd meant distinct researcher cwds never shared a
+// cached result and each re-enumerated under load.
+function discoveryCacheKey(command: string, env: Record<string, string>) {
   const envKey = Object.entries(env)
     .filter(([key]) => !isVolatileEnvKey(key))
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `${key}=${hashValue(value)}`)
     .join("\n");
-  return `${command}\n${cwd}\n${envKey}`;
+  return `${command}\n${envKey}`;
 }
 
 function pruneExpiredDiscoveryCache(now: number) {
@@ -132,6 +153,7 @@ export async function discoverOpenCodeModels(input: {
   // Prevent OpenCode from writing an opencode.json into the working directory.
   const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env, ...(resolvedHome ? { HOME: resolvedHome } : {}), OPENCODE_DISABLE_PROJECT_CONFIG: "true" }));
 
+  const timeoutMs = resolveModelsDiscoveryTimeoutMs();
   const result = await runChildProcess(
     `opencode-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,
     command,
@@ -139,14 +161,14 @@ export async function discoverOpenCodeModels(input: {
     {
       cwd,
       env: runtimeEnv,
-      timeoutSec: MODELS_DISCOVERY_TIMEOUT_MS / 1000,
-      graceSec: 3,
+      timeoutSec: timeoutMs / 1000,
+      graceSec: 5,
       onLog: async () => {},
     },
   );
 
   if (result.timedOut) {
-    throw new Error(`\`opencode models\` timed out after ${MODELS_DISCOVERY_TIMEOUT_MS / 1000}s.`);
+    throw new Error(`\`opencode models\` timed out after ${timeoutMs / 1000}s.`);
   }
   if ((result.exitCode ?? 1) !== 0) {
     const detail = firstNonEmptyLine(result.stderr) || firstNonEmptyLine(result.stdout);
@@ -164,15 +186,28 @@ export async function discoverOpenCodeModelsCached(input: {
   const command = resolveOpenCodeCommand(input.command);
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
-  const key = discoveryCacheKey(command, cwd, env);
+  const key = discoveryCacheKey(command, env);
   const now = Date.now();
   pruneExpiredDiscoveryCache(now);
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
 
-  const models = await discoverOpenCodeModels({ command, cwd, env });
-  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
-  return models;
+  // Single-flight: if a discovery for this key is already running, await it
+  // instead of spawning a second `opencode models`.
+  const inFlight = inFlightDiscoveries.get(key);
+  if (inFlight) return inFlight;
+
+  const discovery = (async () => {
+    const models = await discoverOpenCodeModels({ command, cwd, env });
+    discoveryCache.set(key, { expiresAt: Date.now() + MODELS_CACHE_TTL_MS, models });
+    return models;
+  })();
+  inFlightDiscoveries.set(key, discovery);
+  try {
+    return await discovery;
+  } finally {
+    inFlightDiscoveries.delete(key);
+  }
 }
 
 export function isTruthyEnvFlag(value: string | undefined): boolean {
@@ -229,4 +264,5 @@ export async function listOpenCodeModels(): Promise<AdapterModel[]> {
 
 export function resetOpenCodeModelsCacheForTests() {
   discoveryCache.clear();
+  inFlightDiscoveries.clear();
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -220,6 +220,24 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+
+// XIP-4690: host-global concurrency gate for local opencode runs. The per-agent
+// maxConcurrentRuns cap does not constrain cross-agent fan-out — the daily
+// research fire wakes several distinct opencode_local researcher agents at once,
+// each spawning `opencode run`/`opencode models`, saturating the shared local
+// host and tripping opencode's spawn timeout. This caps the TOTAL number of
+// concurrently running opencode_local runs across all agents on the host.
+const OPENCODE_LOCAL_ADAPTER_TYPE = "opencode_local";
+const OPENCODE_LOCAL_GLOBAL_MAX_CONCURRENT_DEFAULT = 2;
+
+function resolveOpenCodeLocalGlobalMaxConcurrent(): number {
+  const raw = process.env.PAPERCLIP_OPENCODE_LOCAL_MAX_CONCURRENT;
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    const parsed = Math.floor(Number(raw));
+    if (Number.isFinite(parsed) && parsed >= 1) return parsed;
+  }
+  return OPENCODE_LOCAL_GLOBAL_MAX_CONCURRENT_DEFAULT;
+}
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -7244,6 +7262,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
+  // XIP-4690: count running runs across ALL agents of a given adapter type, for
+  // the host-global concurrency gate. Joins runs -> agents on adapterType.
+  async function countRunningRunsForAdapterType(adapterType: string) {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(and(eq(heartbeatRuns.status, "running"), eq(agents.adapterType, adapterType)));
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -8207,6 +8236,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const runningCount = await countRunningRunsForAgent(agentId);
       const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
       if (availableSlots <= 0) return [];
+
+      // XIP-4690: host-global concurrency gate for opencode_local runs. Held
+      // runs stay queued; resumeQueuedRuns() (periodic tick) re-polls every
+      // agent with queued work and drains them as global slots free, so this
+      // gate cannot starve a queued run.
+      if (agent.adapterType === OPENCODE_LOCAL_ADAPTER_TYPE) {
+        const globalMax = resolveOpenCodeLocalGlobalMaxConcurrent();
+        const globalRunning = await countRunningRunsForAdapterType(OPENCODE_LOCAL_ADAPTER_TYPE);
+        if (globalRunning >= globalMax) return [];
+      }
 
       const queuedRuns = await db
         .select()


### PR DESCRIPTION
## What & why

Durable fix for the `opencode_local` thundering-herd incident (Paperclip XIP-4675 / XIP-4690). The daily research fan-out wakes ~6 distinct `opencode_local` researcher agents simultaneously; each spawns `opencode run` + `opencode models`, saturating the shared local host until the enumeration wrapper trips `opencode models timed out after 20s`. Root cause: **the dispatcher only caps runs per-agent — there is no host-global gate across agents.** An interim routine-stagger already mitigated the incident; this is the durable, defense-in-depth fix.

## Changes

### Fix 1 — host-global concurrency gate for `opencode_local` (`server/src/services/heartbeat.ts`)
- New `countRunningRunsForAdapterType(adapterType)` helper (joins `heartbeatRuns` → `agents`).
- In `startNextQueuedRunForAgent`, after the per-agent slot check, gate `opencode_local` agents on a host-global cap: `PAPERCLIP_OPENCODE_LOCAL_MAX_CONCURRENT` (default **2**). Over the cap, the run stays queued; the existing periodic `resumeQueuedRuns()` re-poll drains it as slots free — no starvation.

### Fix 2 — model-enum hardening (`packages/adapters/opencode-local/src/server/models.ts`)
- **(a) single-flight:** concurrent cold-cache lookups now share one in-flight `opencode models` spawn.
- **(b) cache key:** dropped `cwd` from the cache key — the model list is a function of the binary + provider auth, not the working directory, so distinct researcher cwds now share a cached result.
- **(c) env timeout:** `PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS` makes the previously-hardcoded 20s enumeration timeout configurable (min 1000ms); grace bumped to 5s.

### Fix 3 — orphan reaper
Out of scope for this PR (kept reviewable). `runChildProcess` already group-kills the opencode run's process group; residual orphans are re-parented helper grandchildren (agent-browser / Chrome-for-Testing / railway-mcp). Tracked separately; if a host reaper is added it must be age+orphan-gated and must not touch docker/postgres/es.

## Tests
`packages/adapters/opencode-local/src/server/models.test.ts` — added three tests using a controllable fake `opencode`:
- single-flight collapses 6 concurrent lookups to 1 spawn;
- cache reused across different cwds (1 spawn);
- `PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS` honored (times out at the configured 1s).

## New env knobs
| Var | Default | Effect |
|---|---|---|
| `PAPERCLIP_OPENCODE_LOCAL_MAX_CONCURRENT` | `2` | Max concurrent running `opencode_local` runs host-wide |
| `PAPERCLIP_OPENCODE_MODELS_TIMEOUT_MS` | `20000` | `opencode models` enumeration timeout (ms) |

Backward-compatible: both default to prior behavior aside from the new global cap (2), which is the intended primary fix.
