### PR TITLE
fix: add scheduled retry cancel controls

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -561,6 +561,8 @@ export type {
   SuccessfulRunHandoffStateKind,
   IssueScheduledRetry,
   IssueScheduledRetryStatus,
+  IssueCancelScheduledRetryOutcome,
+  IssueCancelScheduledRetryResponse,
   IssueRetryNowOutcome,
   IssueRetryNowResponse,
   IssueReferenceSource,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -296,6 +296,8 @@ export type {
   SuccessfulRunHandoffStateKind,
   IssueScheduledRetry,
   IssueScheduledRetryStatus,
+  IssueCancelScheduledRetryOutcome,
+  IssueCancelScheduledRetryResponse,
   IssueRetryNowOutcome,
   IssueRetryNowResponse,
   IssueReferenceSource,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -386,6 +386,18 @@ export interface IssueRetryNowResponse {
   scheduledRetry: IssueScheduledRetry | null;
 }
 
+export type IssueCancelScheduledRetryOutcome =
+  | "cancelled"
+  | "already_cancelled"
+  | "already_promoted"
+  | "no_scheduled_retry";
+
+export interface IssueCancelScheduledRetryResponse {
+  outcome: IssueCancelScheduledRetryOutcome;
+  message: string;
+  scheduledRetry: IssueScheduledRetry | null;
+}
+
 export interface IssueRelation {
   id: string;
   companyId: string;

--- a/server/src/__tests__/issue-scheduled-retry-routes.test.ts
+++ b/server/src/__tests__/issue-scheduled-retry-routes.test.ts
@@ -392,6 +392,40 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
     });
   });
 
+  it("does not report historical non-board cancellations as duplicate cancel", async () => {
+    const { companyId, issueId, retryRunId } = await seedIssueWithRetry();
+    const now = new Date("2026-05-06T18:30:00.000Z");
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "cancelled",
+        finishedAt: now,
+        error: "Agent is paused",
+        errorCode: "agent_not_invokable",
+        updatedAt: now,
+      })
+      .where(eq(heartbeatRuns.id, retryRunId));
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: now,
+      })
+      .where(eq(issues.id, issueId));
+
+    const res = await request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/scheduled-retry/cancel`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      outcome: "no_scheduled_retry",
+      scheduledRetry: null,
+    });
+  });
+
   it("reports already-promoted retries without creating another run", async () => {
     const { companyId, issueId, retryRunId } = await seedIssueWithRetry({ retryStatus: "queued" });
 

--- a/server/src/__tests__/issue-scheduled-retry-routes.test.ts
+++ b/server/src/__tests__/issue-scheduled-retry-routes.test.ts
@@ -287,6 +287,111 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
     });
   });
 
+  it("cancels the existing scheduled retry and treats duplicate cancels as idempotent", async () => {
+    const { companyId, issueId, retryRunId } = await seedIssueWithRetry();
+    const app = createApp(boardActor(companyId));
+
+    const first = await request(app).post(`/api/issues/${issueId}/scheduled-retry/cancel`).send({});
+
+    expect(first.status, JSON.stringify(first.body)).toBe(200);
+    expect(first.body).toMatchObject({
+      outcome: "cancelled",
+      scheduledRetry: {
+        runId: retryRunId,
+        status: "cancelled",
+        errorCode: "scheduled_retry_cancelled",
+      },
+    });
+
+    const [run] = await db
+      .select({
+        status: heartbeatRuns.status,
+        error: heartbeatRuns.error,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId));
+    expect(run).toEqual({
+      status: "cancelled",
+      error: "Scheduled retry cancelled by board request",
+      errorCode: "scheduled_retry_cancelled",
+    });
+
+    const [wakeup] = await db
+      .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.runId, retryRunId));
+    expect(wakeup).toEqual({
+      status: "cancelled",
+      error: "Scheduled retry cancelled by board request",
+    });
+
+    const [issue] = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(issue).toEqual({
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const [activity] = await db
+      .select({ action: activityLog.action, entityId: activityLog.entityId, runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity).toEqual({
+      action: "issue.scheduled_retry_cancel",
+      entityId: issueId,
+      runId: retryRunId,
+    });
+
+    const second = await request(app).post(`/api/issues/${issueId}/scheduled-retry/cancel`).send({});
+
+    expect(second.status, JSON.stringify(second.body)).toBe(200);
+    expect(second.body).toMatchObject({
+      outcome: "already_cancelled",
+      scheduledRetry: {
+        runId: retryRunId,
+        status: "cancelled",
+      },
+    });
+  });
+
+  it("returns a clear no-op response when cancelling without a scheduled retry", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "NOCANCEL",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "No retry",
+      status: "todo",
+      priority: "medium",
+      issueNumber: 1,
+      identifier: "NOCANCEL-1",
+    });
+
+    const res = await request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/scheduled-retry/cancel`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      outcome: "no_scheduled_retry",
+      scheduledRetry: null,
+    });
+  });
+
   it("reports already-promoted retries without creating another run", async () => {
     const { companyId, issueId, retryRunId } = await seedIssueWithRetry({ retryStatus: "queued" });
 
@@ -302,6 +407,29 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
         status: "queued",
       },
     });
+  });
+
+  it("reports already-promoted retries on cancel without cancelling the active retry", async () => {
+    const { companyId, issueId, retryRunId } = await seedIssueWithRetry({ retryStatus: "queued" });
+
+    const res = await request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/scheduled-retry/cancel`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      outcome: "already_promoted",
+      scheduledRetry: {
+        runId: retryRunId,
+        status: "queued",
+      },
+    });
+
+    const [run] = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, retryRunId));
+    expect(run).toEqual({ status: "queued", errorCode: null });
   });
 
   it("uses normal promotion gates and records gate-suppressed retries", async () => {
@@ -348,11 +476,31 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
     expect(res.status).toBe(403);
   });
 
+  it("requires board access for scheduled retry cancel", async () => {
+    const { companyId, agentId, issueId } = await seedIssueWithRetry();
+
+    const res = await request(createApp(agentActor(companyId, agentId)))
+      .post(`/api/issues/${issueId}/scheduled-retry/cancel`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
   it("enforces company scoping for retry-now", async () => {
     const { issueId } = await seedIssueWithRetry();
 
     const res = await request(createApp(boardActor(randomUUID())))
       .post(`/api/issues/${issueId}/scheduled-retry/retry-now`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it("enforces company scoping for scheduled retry cancel", async () => {
+    const { issueId } = await seedIssueWithRetry();
+
+    const res = await request(createApp(boardActor(randomUUID())))
+      .post(`/api/issues/${issueId}/scheduled-retry/cancel`)
       .send({});
 
     expect(res.status).toBe(403);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5628,6 +5628,44 @@ export function issueRoutes(
     res.json(result);
   });
 
+  router.post("/issues/:id/scheduled-retry/cancel", async (req, res) => {
+    assertBoard(req);
+    const id = req.params.id as string;
+    const issue = await svc.getById(id);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+
+    const actor = getActorInfo(req);
+    const result = await heartbeat.cancelScheduledRetry({
+      issueId: issue.id,
+      actor: {
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+      },
+    });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      action: "issue.scheduled_retry_cancel",
+      entityType: "issue",
+      entityId: issue.id,
+      agentId: result.scheduledRetry?.agentId ?? issue.assigneeAgentId ?? null,
+      runId: result.scheduledRetry?.runId ?? null,
+      details: {
+        outcome: result.outcome,
+        message: result.message,
+        scheduledRetry: result.scheduledRetry,
+      },
+    });
+
+    res.json(result);
+  });
+
   router.patch("/issues/:id", validate(updateIssueRouteSchema), async (req, res) => {
     const id = req.params.id as string;
     const existing = await svc.getById(id);

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -4528,6 +4528,13 @@ registerCurrentRoute({
 
 registerCurrentRoute({
   method: "post",
+  path: "/api/issues/{id}/scheduled-retry/cancel",
+  tags: ["issues"],
+  summary: "Cancel a scheduled issue retry",
+});
+
+registerCurrentRoute({
+  method: "post",
   path: "/api/issues/{id}/monitor/check-now",
   tags: ["issues"],
   summary: "Run an issue monitor check now",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6887,6 +6887,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
   }
 
+  function isBoardCancelledScheduledRetry(row: { run: typeof heartbeatRuns.$inferSelect }) {
+    return row.run.errorCode === "scheduled_retry_cancelled";
+  }
+
   async function retryScheduledRetryNow(input: {
     issueId: string;
     actor?: { actorType?: "user" | "agent" | "system"; actorId?: string | null };
@@ -7042,7 +7046,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         };
       }
       const alreadyCancelled = await getIssueRetryRun(issue.companyId, issue.id, ["cancelled"]);
-      if (alreadyCancelled) {
+      if (alreadyCancelled && isBoardCancelledScheduledRetry(alreadyCancelled)) {
         return {
           outcome: "already_cancelled" as const,
           message: "Scheduled retry was already cancelled",
@@ -7141,7 +7145,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
     const alreadyCancelled = await getIssueRetryRun(issue.companyId, issue.id, ["cancelled"]);
-    if (alreadyCancelled) {
+    if (alreadyCancelled && isBoardCancelledScheduledRetry(alreadyCancelled)) {
       return {
         outcome: "already_cancelled" as const,
         message: "Scheduled retry was already cancelled",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7104,7 +7104,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return row;
     });
 
-    if (cancelled?.status === "cancelled") {
+    if (cancelled) {
       await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
         eventType: "lifecycle",
         stream: "system",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7020,6 +7020,141 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
   }
 
+  async function cancelScheduledRetry(input: {
+    issueId: string;
+    actor?: { actorType?: "user" | "agent" | "system"; actorId?: string | null };
+  }) {
+    const issue = await db
+      .select({ id: issues.id, companyId: issues.companyId })
+      .from(issues)
+      .where(eq(issues.id, input.issueId))
+      .then((rows) => rows[0] ?? null);
+    if (!issue) throw notFound("Issue not found");
+
+    const scheduled = await getIssueRetryRun(issue.companyId, issue.id, ["scheduled_retry"]);
+    if (!scheduled) {
+      const alreadyPromoted = await getIssueRetryRun(issue.companyId, issue.id, ["queued", "running"]);
+      if (alreadyPromoted) {
+        return {
+          outcome: "already_promoted" as const,
+          message: "Scheduled retry was already promoted",
+          scheduledRetry: summarizeIssueScheduledRetryRun(alreadyPromoted),
+        };
+      }
+      const alreadyCancelled = await getIssueRetryRun(issue.companyId, issue.id, ["cancelled"]);
+      if (alreadyCancelled) {
+        return {
+          outcome: "already_cancelled" as const,
+          message: "Scheduled retry was already cancelled",
+          scheduledRetry: summarizeIssueScheduledRetryRun(alreadyCancelled),
+        };
+      }
+      return {
+        outcome: "no_scheduled_retry" as const,
+        message: "No live scheduled retry exists for this issue",
+        scheduledRetry: null,
+      };
+    }
+
+    const now = new Date();
+    const reason = "Scheduled retry cancelled by board request";
+    const cancelled = await db.transaction(async (tx) => {
+      const row = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: reason,
+          errorCode: "scheduled_retry_cancelled",
+          updatedAt: now,
+        })
+        .where(and(eq(heartbeatRuns.id, scheduled.run.id), eq(heartbeatRuns.status, "scheduled_retry")))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+
+      if (row.wakeupRequestId) {
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            status: "cancelled",
+            finishedAt: now,
+            error: reason,
+            updatedAt: now,
+          })
+          .where(eq(agentWakeupRequests.id, row.wakeupRequestId));
+      }
+
+      await tx
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.companyId, issue.companyId),
+            eq(issues.id, issue.id),
+            eq(issues.executionRunId, row.id),
+          ),
+        );
+
+      return row;
+    });
+
+    if (cancelled?.status === "cancelled") {
+      await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: "scheduled retry cancelled",
+        payload: {
+          issueId: issue.id,
+          scheduledRetryAttempt: cancelled.scheduledRetryAttempt,
+          scheduledRetryAt: cancelled.scheduledRetryAt
+            ? new Date(cancelled.scheduledRetryAt).toISOString()
+            : null,
+          scheduledRetryReason: cancelled.scheduledRetryReason,
+          requestedByActorType: input.actor?.actorType ?? null,
+          requestedByActorId: input.actor?.actorId ?? null,
+        },
+      });
+
+      return {
+        outcome: "cancelled" as const,
+        message: "Scheduled retry was cancelled",
+        scheduledRetry: summarizeIssueScheduledRetryRun({
+          run: cancelled,
+          agentName: scheduled.agentName,
+        }),
+      };
+    }
+
+    const alreadyPromoted = await getIssueRetryRun(issue.companyId, issue.id, ["queued", "running"]);
+    if (alreadyPromoted) {
+      return {
+        outcome: "already_promoted" as const,
+        message: "Scheduled retry was already promoted",
+        scheduledRetry: summarizeIssueScheduledRetryRun(alreadyPromoted),
+      };
+    }
+    const alreadyCancelled = await getIssueRetryRun(issue.companyId, issue.id, ["cancelled"]);
+    if (alreadyCancelled) {
+      return {
+        outcome: "already_cancelled" as const,
+        message: "Scheduled retry was already cancelled",
+        scheduledRetry: summarizeIssueScheduledRetryRun(alreadyCancelled),
+      };
+    }
+    return {
+      outcome: "no_scheduled_retry" as const,
+      message: "No live scheduled retry exists for this issue",
+      scheduledRetry: null,
+    };
+  }
+
   function parseHeartbeatPolicy(agent: typeof agents.$inferSelect) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
@@ -12197,6 +12332,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reapOrphanedRuns,
 
     promoteDueScheduledRetries,
+    cancelScheduledRetry,
     retryScheduledRetryNow,
 
     resumeQueuedRuns,

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -9,6 +9,7 @@ import type {
   FeedbackVote,
   Issue,
   IssueAttachment,
+  IssueCancelScheduledRetryResponse,
   IssueCostSummary,
   IssueComment,
   IssueDocument,
@@ -188,6 +189,8 @@ export const issuesApi = {
   checkMonitorNow: (id: string) => api.post<{ ok: true }>(`/issues/${id}/monitor/check-now`, {}),
   retryScheduledRetryNow: (id: string) =>
     api.post<IssueRetryNowResponse>(`/issues/${id}/scheduled-retry/retry-now`, {}),
+  cancelScheduledRetry: (id: string) =>
+    api.post<IssueCancelScheduledRetryResponse>(`/issues/${id}/scheduled-retry/cancel`, {}),
   remove: (id: string) => api.delete<Issue>(`/issues/${id}`),
   checkout: (id: string, agentId: string) =>
     api.post<Issue>(`/issues/${id}/checkout`, {

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -36,6 +36,8 @@ const mockIssuesApi = vi.hoisted(() => ({
   createLabel: vi.fn(),
   upsertWatchdog: vi.fn(),
   deleteWatchdog: vi.fn(),
+  retryScheduledRetryNow: vi.fn(),
+  cancelScheduledRetry: vi.fn(),
 }));
 
 const mockAuthApi = vi.hoisted(() => ({
@@ -407,6 +409,8 @@ describe("IssueProperties", () => {
     }));
     mockIssuesApi.upsertWatchdog.mockResolvedValue({});
     mockIssuesApi.deleteWatchdog.mockResolvedValue({ ok: true });
+    mockIssuesApi.retryScheduledRetryNow.mockReset();
+    mockIssuesApi.cancelScheduledRetry.mockReset();
     mockAuthApi.getSession.mockResolvedValue({ user: { id: "user-1" } });
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableTaskWatchdogs: false,
@@ -480,6 +484,72 @@ describe("IssueProperties", () => {
     });
     await flush();
     expect(onUpdate).toHaveBeenCalledWith({ assigneeAgentId: "agent-2", assigneeUserId: null });
+
+    act(() => root.unmount());
+  });
+
+  it("shows scheduled retry actions in issue properties and cancels the retry", async () => {
+    mockIssuesApi.cancelScheduledRetry.mockResolvedValue({
+      outcome: "cancelled",
+      message: "Scheduled retry was cancelled",
+      scheduledRetry: {
+        runId: "run-retry-1",
+        status: "cancelled",
+        agentId: "agent-1",
+        agentName: "ClaudeCoder",
+        retryOfRunId: "run-prev-1",
+        scheduledRetryAt: "2026-04-18T20:15:00.000Z",
+        scheduledRetryAttempt: 4,
+        scheduledRetryReason: "transient_failure",
+        retryExhaustedReason: null,
+        error: "Upstream provider rate limited",
+        errorCode: "rate_limited",
+      },
+    });
+
+    const root = renderProperties(container, {
+      issue: createIssue({
+        scheduledRetry: {
+          runId: "run-retry-1",
+          status: "scheduled_retry",
+          agentId: "agent-1",
+          agentName: "ClaudeCoder",
+          retryOfRunId: "run-prev-1",
+          scheduledRetryAt: "2026-04-18T20:15:00.000Z",
+          scheduledRetryAttempt: 4,
+          scheduledRetryReason: "transient_failure",
+          retryExhaustedReason: null,
+          error: "Upstream provider rate limited",
+          errorCode: "rate_limited",
+        },
+      }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+    });
+    await flush();
+
+    expect(container.textContent).toContain("Scheduled retry");
+    expect(container.textContent).toContain("Attempt 4");
+    expect(container.textContent).toContain("Retry now");
+    expect(container.textContent).toContain("Cancel retry");
+
+    const cancelButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="issue-scheduled-retry-properties-cancel"]',
+    );
+    expect(cancelButton).not.toBeNull();
+    await act(async () => {
+      cancelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(mockIssuesApi.cancelScheduledRetry).toHaveBeenCalledWith("issue-1");
+      expect(cancelButton!.textContent).toContain("Cancelled");
+      expect(cancelButton!.disabled).toBe(true);
+      const retryButton = container.querySelector<HTMLButtonElement>(
+        '[data-testid="issue-scheduled-retry-properties-retry-now"]',
+      );
+      expect(retryButton?.disabled).toBe(true);
+    });
 
     act(() => root.unmount());
   });

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -28,6 +28,7 @@ import { formatAssigneeUserLabel } from "../lib/assignees";
 import { buildExecutionPolicy, stageParticipantValues } from "../lib/issue-execution-policy";
 import { formatMonitorOffset } from "../lib/issue-monitor";
 import { formatRetryReason } from "../lib/runRetryState";
+import { useCancelScheduledRetryMutation } from "../hooks/useCancelScheduledRetryMutation";
 import { useRetryNowMutation } from "../hooks/useRetryNowMutation";
 import { RetryErrorBand } from "./IssueScheduledRetryCard";
 import { extractProviderIdWithFallback } from "../lib/model-utils";
@@ -64,7 +65,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { User, Hexagon, ArrowUpRight, Tag, Plus, GitBranch, FolderOpen, Check, ExternalLink, X, Clock, RotateCcw, Loader2, CheckCircle2, ScanEye } from "lucide-react";
+import { User, Hexagon, ArrowUpRight, Tag, Plus, GitBranch, FolderOpen, Check, ExternalLink, X, Clock, RotateCcw, Loader2, CheckCircle2, ScanEye, Ban } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
 import {
@@ -1428,6 +1429,7 @@ export function IssueProperties({
 
   const scheduledRetry = issue.scheduledRetry ?? null;
   const retryNow = useRetryNowMutation(issue.id);
+  const cancelRetry = useCancelScheduledRetryMutation(issue.id);
   const showScheduledRetryRow = scheduledRetry && scheduledRetry.status === "scheduled_retry";
   const scheduledRetryDueAtIso = scheduledRetry?.scheduledRetryAt
     ? new Date(scheduledRetry.scheduledRetryAt).toISOString()
@@ -1458,6 +1460,9 @@ export function IssueProperties({
   })();
   const scheduledRetryRetryNowSuccess = retryNow.isSuccess
     && (retryNow.data?.outcome === "promoted" || retryNow.data?.outcome === "already_promoted");
+  const scheduledRetryCancelSuccess = cancelRetry.isSuccess
+    && (cancelRetry.data?.outcome === "cancelled" || cancelRetry.data?.outcome === "already_cancelled");
+  const scheduledRetryControlsSettled = scheduledRetryRetryNowSuccess || scheduledRetryCancelSuccess;
   const scheduledRetryAttemptBadge = scheduledRetryAttempt !== null ? (
     <span className="text-xs text-muted-foreground">Attempt {scheduledRetryAttempt}</span>
   ) : null;
@@ -1547,40 +1552,83 @@ export function IssueProperties({
           retryNow.mutate();
         }}
       />
+      <RetryErrorBand
+        error={cancelRetry.lastError}
+        title="Couldn't cancel retry"
+        testId="issue-scheduled-retry-properties-cancel-error-band"
+        onRetry={() => {
+          cancelRetry.reset();
+          cancelRetry.mutate();
+        }}
+      />
       <Separator className="my-1" />
       <div className="flex items-center justify-between gap-2">
-        <Button
-          type="button"
-          size="sm"
-          variant="default"
-          onClick={() => retryNow.mutate()}
-          disabled={retryNow.isPending || scheduledRetryRetryNowSuccess}
-          data-testid="issue-scheduled-retry-properties-retry-now"
-        >
-          {retryNow.isPending ? (
-            <span className="inline-flex items-center gap-1.5">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-              Retrying…
-            </span>
-          ) : scheduledRetryRetryNowSuccess ? (
-            <span className="inline-flex items-center gap-1.5">
-              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
-              {retryNow.data?.outcome === "already_promoted" ? "Already promoted" : "Promoted"}
-            </span>
-          ) : (
-            <span className="inline-flex items-center gap-1.5">
-              <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
-              Retry now
-            </span>
-          )}
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="default"
+            onClick={() => retryNow.mutate()}
+            disabled={retryNow.isPending || cancelRetry.isPending || scheduledRetryControlsSettled}
+            data-testid="issue-scheduled-retry-properties-retry-now"
+          >
+            {retryNow.isPending ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                Retrying…
+              </span>
+            ) : scheduledRetryRetryNowSuccess ? (
+              <span className="inline-flex items-center gap-1.5">
+                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                {retryNow.data?.outcome === "already_promoted" ? "Already promoted" : "Promoted"}
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5">
+                <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+                Retry now
+              </span>
+            )}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="border-rose-500/30 text-rose-700 shadow-none hover:bg-rose-500/10 dark:text-rose-300"
+            onClick={() => cancelRetry.mutate()}
+            disabled={retryNow.isPending || cancelRetry.isPending || scheduledRetryControlsSettled}
+            data-testid="issue-scheduled-retry-properties-cancel"
+          >
+            {cancelRetry.isPending ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                Cancelling…
+              </span>
+            ) : scheduledRetryCancelSuccess ? (
+              <span className="inline-flex items-center gap-1.5">
+                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                {cancelRetry.data?.outcome === "already_cancelled" ? "Already cancelled" : "Cancelled"}
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5">
+                <Ban className="h-3.5 w-3.5" aria-hidden="true" />
+                Cancel retry
+              </span>
+            )}
+          </Button>
+        </div>
         <span className="text-right text-xs text-muted-foreground">
           {retryNow.isPending
             ? "Promoting scheduled retry"
+            : cancelRetry.isPending
+              ? "Cancelling scheduled retry"
             : scheduledRetryRetryNowSuccess
               ? retryNow.data?.outcome === "already_promoted"
                 ? "Already promoted — run starting"
                 : "Promoted — run starting"
+              : scheduledRetryCancelSuccess
+                ? cancelRetry.data?.outcome === "already_cancelled"
+                  ? "Already cancelled — retry will not start"
+                  : "Cancelled — retry will not start"
               : scheduledRetryIsContinuation
                 ? "Pulls continuation forward immediately"
                 : "Pulls retry forward immediately"}

--- a/ui/src/components/IssueScheduledRetryCard.test.tsx
+++ b/ui/src/components/IssueScheduledRetryCard.test.tsx
@@ -5,11 +5,16 @@ import type { ComponentProps, ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { IssueRetryNowOutcome, IssueScheduledRetry } from "@paperclipai/shared";
+import type {
+  IssueCancelScheduledRetryOutcome,
+  IssueRetryNowOutcome,
+  IssueScheduledRetry,
+} from "@paperclipai/shared";
 import { IssueScheduledRetryCard } from "./IssueScheduledRetryCard";
 import { ToastProvider } from "../context/ToastContext";
 
 const retryNowMock = vi.hoisted(() => vi.fn());
+const cancelRetryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/router", () => ({
   Link: ({ children, to, ...props }: { children: ReactNode; to: string } & ComponentProps<"a">) => (
@@ -20,7 +25,13 @@ vi.mock("@/lib/router", () => ({
 vi.mock("../api/issues", () => ({
   issuesApi: {
     retryScheduledRetryNow: retryNowMock,
+    cancelScheduledRetry: cancelRetryMock,
   },
+}));
+
+vi.mock("../context/ToastContext", () => ({
+  ToastProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useToastActions: () => ({ pushToast: vi.fn() }),
 }));
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -63,12 +74,39 @@ function buildRetryResponse(outcome: IssueRetryNowOutcome) {
   };
 }
 
+function buildCancelResponse(outcome: IssueCancelScheduledRetryOutcome) {
+  return {
+    outcome,
+    message:
+      outcome === "cancelled"
+        ? "Scheduled retry was cancelled"
+        : outcome === "already_cancelled"
+          ? "Scheduled retry was already cancelled"
+          : outcome === "already_promoted"
+            ? "Scheduled retry was already promoted"
+            : "No scheduled retry",
+    scheduledRetry:
+      outcome === "cancelled" || outcome === "already_cancelled"
+        ? { ...baseRetry, status: "cancelled" as const }
+        : outcome === "already_promoted"
+          ? { ...baseRetry, status: "queued" as const }
+          : null,
+  };
+}
+
 async function waitForUi(assertion: () => void) {
   await vi.waitFor(async () => {
     await act(async () => {
       await Promise.resolve();
     });
     assertion();
+  });
+}
+
+async function clickAndFlush(button: HTMLButtonElement) {
+  await act(async () => {
+    button.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 
@@ -99,6 +137,7 @@ function renderWithProviders(ui: ReactNode) {
 beforeEach(() => {
   dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(SYSTEM_NOW);
   retryNowMock.mockReset();
+  cancelRetryMock.mockReset();
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -117,6 +156,12 @@ function getCard() {
 function getRetryNowButton() {
   return container.querySelector<HTMLButtonElement>(
     '[data-testid="issue-scheduled-retry-card-retry-now"]',
+  );
+}
+
+function getCancelButton() {
+  return container.querySelector<HTMLButtonElement>(
+    '[data-testid="issue-scheduled-retry-card-cancel"]',
   );
 }
 
@@ -148,6 +193,7 @@ describe("IssueScheduledRetryCard", () => {
     expect(text).toContain("Transient failure");
     expect(text).toContain("Automatic retry in 15m");
     expect(text).toContain("run-prev");
+    expect(text).toContain("Cancel retry");
   });
 
   it("uses continuation copy for max-turn continuations", () => {
@@ -182,14 +228,13 @@ describe("IssueScheduledRetryCard", () => {
     const button = getRetryNowButton();
     expect(button).not.toBeNull();
 
-    act(() => {
-      button!.click();
-    });
+    await clickAndFlush(button!);
     await waitForRetryButtonText("Promoted");
     expect(retryNowMock).toHaveBeenCalledWith("issue-1");
     const finalButton = getRetryNowButton();
     expect(finalButton!.textContent ?? "").toContain("Promoted");
     expect(finalButton!.disabled).toBe(true);
+    expect(getCancelButton()!.disabled).toBe(true);
   });
 
   it("shows already promoted state when backend reports duplicate click", async () => {
@@ -197,9 +242,7 @@ describe("IssueScheduledRetryCard", () => {
     renderWithProviders(
       <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
     );
-    act(() => {
-      getRetryNowButton()!.click();
-    });
+    await clickAndFlush(getRetryNowButton()!);
     await waitForRetryButtonText("Already promoted");
     expect(getRetryNowButton()!.textContent ?? "").toContain("Already promoted");
     expect(container.querySelector('[data-testid="issue-scheduled-retry-error-band"]')).toBeNull();
@@ -210,9 +253,7 @@ describe("IssueScheduledRetryCard", () => {
     renderWithProviders(
       <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
     );
-    act(() => {
-      getRetryNowButton()!.click();
-    });
+    await clickAndFlush(getRetryNowButton()!);
     await waitForUi(() => {
       const band = container.querySelector('[data-testid="issue-scheduled-retry-error-band"]');
       expect(band).not.toBeNull();
@@ -226,14 +267,72 @@ describe("IssueScheduledRetryCard", () => {
     renderWithProviders(
       <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
     );
-    act(() => {
-      getRetryNowButton()!.click();
-    });
+    await clickAndFlush(getRetryNowButton()!);
     await waitForUi(() => {
       const band = container.querySelector('[data-testid="issue-scheduled-retry-error-band"]');
       expect(band).not.toBeNull();
       expect((band?.textContent ?? "")).toContain("Promotion suppressed");
       expect(getRetryNowButton()!.disabled).toBe(false);
+    });
+  });
+
+  it("invokes cancel retry and shows cancelled state on success", async () => {
+    cancelRetryMock.mockResolvedValue(buildCancelResponse("cancelled"));
+    renderWithProviders(
+      <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
+    );
+    const button = getCancelButton();
+    expect(button).not.toBeNull();
+
+    await clickAndFlush(button!);
+    await waitForUi(() => {
+      expect(getCancelButton()!.textContent ?? "").toContain("Cancelled");
+      expect(getCancelButton()!.disabled).toBe(true);
+      expect(getRetryNowButton()!.disabled).toBe(true);
+      expect(getCard()!.textContent ?? "").toContain("retry will not start");
+    });
+    expect(cancelRetryMock).toHaveBeenCalledWith("issue-1");
+  });
+
+  it("shows already cancelled state when backend reports a duplicate cancel", async () => {
+    cancelRetryMock.mockResolvedValue(buildCancelResponse("already_cancelled"));
+    renderWithProviders(
+      <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
+    );
+    await clickAndFlush(getCancelButton()!);
+    await waitForUi(() => {
+      expect(getCancelButton()!.textContent ?? "").toContain("Already cancelled");
+      expect(getCancelButton()!.disabled).toBe(true);
+      expect(container.querySelector('[data-testid="issue-scheduled-retry-cancel-error-band"]')).toBeNull();
+    });
+  });
+
+  it("renders an inline cancel error band on backend failure", async () => {
+    cancelRetryMock.mockRejectedValue(new Error("Server error"));
+    renderWithProviders(
+      <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
+    );
+    await clickAndFlush(getCancelButton()!);
+    await waitForUi(() => {
+      const band = container.querySelector('[data-testid="issue-scheduled-retry-cancel-error-band"]');
+      expect(band).not.toBeNull();
+      expect((band?.textContent ?? "")).toContain("Couldn't cancel retry");
+      expect((band?.textContent ?? "")).toContain("Server error");
+      expect(getCancelButton()!.disabled).toBe(false);
+    });
+  });
+
+  it("surfaces already-promoted cancel outcomes via the inline error band", async () => {
+    cancelRetryMock.mockResolvedValue(buildCancelResponse("already_promoted"));
+    renderWithProviders(
+      <IssueScheduledRetryCard issueId="issue-1" scheduledRetry={baseRetry} />,
+    );
+    await clickAndFlush(getCancelButton()!);
+    await waitForUi(() => {
+      const band = container.querySelector('[data-testid="issue-scheduled-retry-cancel-error-band"]');
+      expect(band).not.toBeNull();
+      expect((band?.textContent ?? "")).toContain("Scheduled retry was already promoted");
+      expect(getCancelButton()!.disabled).toBe(false);
     });
   });
 });

--- a/ui/src/components/IssueScheduledRetryCard.tsx
+++ b/ui/src/components/IssueScheduledRetryCard.tsx
@@ -1,11 +1,12 @@
-import { Clock, RotateCcw, AlertCircle, Loader2, CheckCircle2 } from "lucide-react";
+import { Clock, RotateCcw, AlertCircle, Loader2, CheckCircle2, Ban } from "lucide-react";
 import { Link } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { cn, formatDateTime } from "@/lib/utils";
 import { formatMonitorOffset } from "@/lib/issue-monitor";
 import { formatRetryReason } from "@/lib/runRetryState";
 import type { IssueScheduledRetry } from "@paperclipai/shared";
-import { useRetryNowMutation, type RetryNowError } from "../hooks/useRetryNowMutation";
+import { useCancelScheduledRetryMutation } from "../hooks/useCancelScheduledRetryMutation";
+import { useRetryNowMutation } from "../hooks/useRetryNowMutation";
 
 const MAX_TURN_CONTINUATION = "max_turns_continuation";
 
@@ -27,6 +28,7 @@ export function IssueScheduledRetryCard({
   scheduledRetry,
 }: IssueScheduledRetryCardProps) {
   const retryNow = useRetryNowMutation(issueId);
+  const cancelRetry = useCancelScheduledRetryMutation(issueId);
 
   if (!scheduledRetry || !issueId) return null;
   if (scheduledRetry.status !== "scheduled_retry") return null;
@@ -63,8 +65,12 @@ export function IssueScheduledRetryCard({
     ? "Pulls continuation forward immediately"
     : "Pulls retry forward immediately";
   const isError = retryNow.isError || retryNow.lastError !== null;
+  const isCancelError = cancelRetry.isError || cancelRetry.lastError !== null;
   const isSuccessTransient = retryNow.isSuccess
     && (retryNow.data?.outcome === "promoted" || retryNow.data?.outcome === "already_promoted");
+  const isCancelSuccess = cancelRetry.isSuccess
+    && (cancelRetry.data?.outcome === "cancelled" || cancelRetry.data?.outcome === "already_cancelled");
+  const controlsSettled = isSuccessTransient || isCancelSuccess;
 
   return (
     <div
@@ -117,41 +123,86 @@ export function IssueScheduledRetryCard({
               }}
             />
           ) : null}
+          {isCancelError ? (
+            <RetryErrorBand
+              error={cancelRetry.lastError}
+              title="Couldn't cancel retry"
+              testId="issue-scheduled-retry-cancel-error-band"
+              onRetry={() => {
+                cancelRetry.reset();
+                cancelRetry.mutate();
+              }}
+            />
+          ) : null}
         </div>
         <div className="flex flex-col items-stretch gap-1 sm:items-end">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0 shadow-none"
-            onClick={() => retryNow.mutate()}
-            disabled={retryNow.isPending || isSuccessTransient}
-            data-testid="issue-scheduled-retry-card-retry-now"
-          >
-            {retryNow.isPending ? (
-              <span className="inline-flex items-center gap-1.5">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-                Retrying…
-              </span>
-            ) : isSuccessTransient ? (
-              <span className="inline-flex items-center gap-1.5">
-                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
-                {retryNow.data?.outcome === "already_promoted" ? "Already promoted" : "Promoted"}
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1.5">
-                <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
-                Retry now
-              </span>
-            )}
-          </Button>
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0 shadow-none"
+              onClick={() => retryNow.mutate()}
+              disabled={retryNow.isPending || cancelRetry.isPending || controlsSettled}
+              data-testid="issue-scheduled-retry-card-retry-now"
+            >
+              {retryNow.isPending ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                  Retrying…
+                </span>
+              ) : isSuccessTransient ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  {retryNow.data?.outcome === "already_promoted" ? "Already promoted" : "Promoted"}
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1.5">
+                  <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+                  Retry now
+                </span>
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0 border-rose-500/30 text-rose-700 shadow-none hover:bg-rose-500/10 dark:text-rose-300"
+              onClick={() => cancelRetry.mutate()}
+              disabled={retryNow.isPending || cancelRetry.isPending || controlsSettled}
+              data-testid="issue-scheduled-retry-card-cancel"
+            >
+              {cancelRetry.isPending ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                  Cancelling…
+                </span>
+              ) : isCancelSuccess ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  {cancelRetry.data?.outcome === "already_cancelled" ? "Already cancelled" : "Cancelled"}
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1.5">
+                  <Ban className="h-3.5 w-3.5" aria-hidden="true" />
+                  Cancel retry
+                </span>
+              )}
+            </Button>
+          </div>
           <span className="text-right text-xs text-muted-foreground sm:max-w-[12rem]">
             {retryNow.isPending
               ? "Promoting scheduled retry"
+              : cancelRetry.isPending
+                ? "Cancelling scheduled retry"
               : isSuccessTransient
                 ? retryNow.data?.outcome === "already_promoted"
                   ? "Already promoted — run starting"
                   : "Promoted — run starting"
+                : isCancelSuccess
+                  ? cancelRetry.data?.outcome === "already_cancelled"
+                    ? "Already cancelled — retry will not start"
+                    : "Cancelled — retry will not start"
                 : helperIdle}
           </span>
         </div>
@@ -161,12 +212,20 @@ export function IssueScheduledRetryCard({
 }
 
 interface RetryErrorBandProps {
-  error: RetryNowError | null;
+  error: { message: string } | null;
   onRetry: () => void;
   className?: string;
+  title?: string;
+  testId?: string;
 }
 
-export function RetryErrorBand({ error, onRetry, className }: RetryErrorBandProps) {
+export function RetryErrorBand({
+  error,
+  onRetry,
+  className,
+  title = "Couldn't retry now",
+  testId = "issue-scheduled-retry-error-band",
+}: RetryErrorBandProps) {
   if (!error) return null;
   return (
     <div
@@ -175,11 +234,11 @@ export function RetryErrorBand({ error, onRetry, className }: RetryErrorBandProp
         className,
       )}
       role="alert"
-      data-testid="issue-scheduled-retry-error-band"
+      data-testid={testId}
     >
       <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
       <div className="min-w-0 flex-1">
-        <div className="font-medium">Couldn't retry now</div>
+        <div className="font-medium">{title}</div>
         <div className="mt-0.5 text-muted-foreground">{error.message}</div>
       </div>
       <button

--- a/ui/src/hooks/useCancelScheduledRetryMutation.ts
+++ b/ui/src/hooks/useCancelScheduledRetryMutation.ts
@@ -1,0 +1,110 @@
+import { useCallback } from "react";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+import type {
+  IssueCancelScheduledRetryOutcome,
+  IssueCancelScheduledRetryResponse,
+} from "@paperclipai/shared";
+import { ApiError } from "../api/client";
+import { issuesApi } from "../api/issues";
+import { useToastActions } from "../context/ToastContext";
+import { queryKeys } from "../lib/queryKeys";
+
+export type CancelScheduledRetryError = {
+  message: string;
+  outcomeMessage: string | null;
+  status: number | null;
+};
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (typeof error.message === "string" && error.message.trim().length > 0) return error.message;
+    return `Request failed (${error.status})`;
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return "The request failed. Try again in a moment.";
+}
+
+export const CANCEL_SCHEDULED_RETRY_OUTCOME_HEADLINE: Record<IssueCancelScheduledRetryOutcome, string> = {
+  cancelled: "Retry cancelled",
+  already_cancelled: "Retry already cancelled",
+  already_promoted: "Retry already running",
+  no_scheduled_retry: "No scheduled retry",
+};
+
+export function useCancelScheduledRetryMutation(
+  issueId: string | null | undefined,
+): UseMutationResult<IssueCancelScheduledRetryResponse, unknown, void, unknown> & {
+  lastError: CancelScheduledRetryError | null;
+} {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToastActions();
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!issueId) throw new Error("Missing issue id");
+      return issuesApi.cancelScheduledRetry(issueId);
+    },
+    onSuccess: (response) => {
+      if (issueId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.detail(issueId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.activity(issueId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.runs(issueId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.liveRuns(issueId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.issues.activeRun(issueId) });
+      }
+      if (response.outcome === "cancelled" || response.outcome === "already_cancelled") {
+        pushToast({
+          title: CANCEL_SCHEDULED_RETRY_OUTCOME_HEADLINE[response.outcome],
+          body: response.message,
+          tone: "success",
+        });
+      } else if (response.outcome === "already_promoted" || response.outcome === "no_scheduled_retry") {
+        pushToast({
+          title: CANCEL_SCHEDULED_RETRY_OUTCOME_HEADLINE[response.outcome],
+          body: response.message,
+          tone: "error",
+        });
+      }
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Couldn't cancel retry",
+        body: readErrorMessage(error),
+        tone: "error",
+      });
+    },
+  });
+
+  const reset = mutation.reset;
+  const wrappedReset = useCallback(() => reset(), [reset]);
+
+  const lastError: CancelScheduledRetryError | null = (() => {
+    if (mutation.error) {
+      const apiError = mutation.error instanceof ApiError ? mutation.error : null;
+      return {
+        message: readErrorMessage(mutation.error),
+        outcomeMessage: null,
+        status: apiError?.status ?? null,
+      };
+    }
+    if (
+      mutation.data
+      && (mutation.data.outcome === "already_promoted" || mutation.data.outcome === "no_scheduled_retry")
+    ) {
+      return {
+        message: mutation.data.message,
+        outcomeMessage: mutation.data.message,
+        status: null,
+      };
+    }
+    return null;
+  })();
+
+  return {
+    ...mutation,
+    reset: wrappedReset,
+    lastError,
+  } as UseMutationResult<IssueCancelScheduledRetryResponse, unknown, void, unknown> & {
+    lastError: CancelScheduledRetryError | null;
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue/run view already surfaces scheduled retry state so human operators can see when an agent will retry after a transient failure or continuation stop.
> - The existing UI exposed `Retry now`, but it did not give operators a symmetric way to cancel the pending scheduled retry from the same issue-scoped surface.
> - Cancelling a retry should be narrower than cancelling active work: if the retry already promoted to queued/running, the cancel control should report that race instead of killing the active run.
> - This pull request adds an issue-scoped scheduled retry cancel route and wires it into the existing scheduled retry card and properties popover.
> - The benefit is that operators can choose either `Retry now` or `Cancel retry` directly from the run/issue view, with behavior covered by route and UI tests.

## Linked Issues or Issue Description

No public issue currently tracks this exact UI gap, so describing the issue in-PR.

Problem or motivation:
When an issue has a live `scheduled_retry`, the UI lets a board user inspect the next retry and trigger it immediately, but it does not provide a human-facing cancel action in the scheduled-retry card. Operators who want to prevent the automatic retry have no obvious issue-scoped control.

When an agent has a 'scheduled_retry' pending it will not wake up on any new comment.

Proposed solution:
The scheduled retry surfaces should show both `Retry now` and `Cancel retry`, along with the resolved retry time and attempt count. Cancelling should only cancel a live `scheduled_retry`; if the retry has already promoted to queued/running, the endpoint should report that race without killing active work.

Alternatives considered:
One alternative was to reuse active-run cancellation, but that would make a stale click dangerous because a scheduled retry could promote before the user clicks. This PR keeps scheduled-retry cancellation intentionally narrow and reports `already_promoted` instead of cancelling queued or running work.

Roadmap alignment:
`ROADMAP.md` does not list overlapping scheduled-retry cancel work. This is a small issue-scoped follow-up to existing scheduled-retry and retry-now behavior, not a new roadmap-sized core feature.

Related public context:

- Refs #5426 — existing scheduled retry retry-now UI/backend work.
- Refs #7038 — related, closed-unmerged agent permission/retry-now work.
- Refs #7234 and #7340 — related backend scheduled-retry cancellation semantics; this PR does not claim to fix those.

Duplicate/related search performed before opening: `scheduled retry Retry now Cancel retry nextRetryAt`, `orphaned run scheduled_retry issueId null retry-now`.

## What Changed

- Added shared response types for issue-scoped scheduled retry cancellation.
- Added `POST /api/issues/:id/scheduled-retry/cancel`, guarded like the existing human `retry-now` route.
- Implemented narrow backend cancellation semantics for live `scheduled_retry` rows: cancel the retry run, cancel its wakeup request, clear the matching issue execution lock, and record activity/run events.
- Return explicit no-op/race outcomes for `no_scheduled_retry`, `already_cancelled`, and `already_promoted`.
- Limit `already_cancelled` to retries cancelled by this board cancel path so older cancellations from other paths do not look like duplicate clicks.
- Added a UI API method and `useCancelScheduledRetryMutation` hook.
- Added `Cancel retry` controls beside `Retry now` in `IssueScheduledRetryCard` and the issue properties scheduled-retry popover.
- Added focused route and UI tests for success, idempotence, already-promoted races, auth/scoping, and mutation states.

## Verification

- `corepack pnpm exec vitest run ui/src/components/IssueScheduledRetryCard.test.tsx ui/src/components/IssueProperties.test.tsx` — 48 passed.
- `runuser -u vaque -- corepack pnpm exec vitest run server/src/__tests__/issue-scheduled-retry-routes.test.ts --reporter verbose` — 18 passed.
- `corepack pnpm --filter @paperclipai/shared typecheck` — passed.
- `corepack pnpm --filter @paperclipai/ui typecheck` — passed.
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.
- `git diff --check` — passed.

Note: the embedded Postgres route suite was run as non-root locally because embedded Postgres refuses to start as root.

## Screenshots

Captured from Storybook's `Product/Issue Scheduled retry surfaces` story.

Issue scheduled retry card, idle state:

![Issue scheduled retry card idle state](https://raw.githubusercontent.com/hawikk/paperclip/pr-8552-screenshots/pr-8552/scheduled-retry-card-idle.png)

Issue scheduled retry card, cancelled state:

![Issue scheduled retry card cancelled state](https://raw.githubusercontent.com/hawikk/paperclip/pr-8552-screenshots/pr-8552/scheduled-retry-card-cancelled.png)

Issue scheduled retry card, already-promoted race/error state:

![Issue scheduled retry card already-promoted state](https://raw.githubusercontent.com/hawikk/paperclip/pr-8552-screenshots/pr-8552/scheduled-retry-card-already-promoted.png)

Issue properties scheduled-retry popover:

![Issue properties scheduled retry popover](https://raw.githubusercontent.com/hawikk/paperclip/pr-8552-screenshots/pr-8552/issue-properties-scheduled-retry-popover.png)

## Risks

Medium-low. This adds a new issue-scoped control-plane transition, but keeps the behavior deliberately narrow: it only cancels rows still in `scheduled_retry` status and returns `already_promoted` for queued/running retries instead of cancelling active work. No migration is required.

The main behavioral risk is stale UI: a retry may promote between render and click. The route handles that race explicitly and the UI surfaces the returned outcome.

## Model Used

OpenAI Codex coding agent, GPT-5.5 xhigh, tool-enabled local repository workflow using shell, filesystem, and GitHub tooling. Context window size and internal reasoning mode are not exposed by this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation changes were needed)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
