### PR TITLE
fix: prevent double company prefix when prefix shadows a route root (/ORG/ORG/dashboard)

### DIFF
--- a/ui/src/lib/company-routes.test.ts
+++ b/ui/src/lib/company-routes.test.ts
@@ -72,6 +72,24 @@ describe("company routes", () => {
     expect(toCompanyRelativePath("/PAP/artifacts")).toBe("/artifacts");
   });
 
+  // Regression: a company whose issue prefix collides with a reserved board
+  // route root (e.g. "ORG" shadows the `org` org-chart route) was double
+  // prefixed. `App.tsx` redirects to `/ORG/dashboard`; `extractCompanyPrefixFromPath`
+  // reported no prefix (first segment "org" is a board root), so `applyCompanyPrefix`
+  // re-prepended the prefix and produced `/ORG/ORG/dashboard` → "Page not found".
+  it("does not double-prefix paths for a company whose prefix shadows a route root", () => {
+    // Already-prefixed board paths are left untouched (the bug).
+    expect(applyCompanyPrefix("/ORG/dashboard", "ORG")).toBe("/ORG/dashboard");
+    expect(applyCompanyPrefix("/ORG/board-chat", "ORG")).toBe("/ORG/board-chat");
+    expect(applyCompanyPrefix("/org/dashboard", "ORG")).toBe("/org/dashboard");
+    // Company-relative paths still get the prefix applied.
+    expect(applyCompanyPrefix("/dashboard", "ORG")).toBe("/ORG/dashboard");
+    // The bare org-chart route is company-relative and must still be prefixed.
+    expect(applyCompanyPrefix("/org", "ORG")).toBe("/ORG/org");
+    // Idempotent once prefixed: no triple prefix on the org-chart route.
+    expect(applyCompanyPrefix("/ORG/org", "ORG")).toBe("/ORG/org");
+  });
+
   it("preserves artifact deep-link anchors when applying the company prefix", () => {
     expect(applyCompanyPrefix("/issues/PAP-10205#work-product-wp-1", "PAP")).toBe(
       "/PAP/issues/PAP-10205#work-product-wp-1",

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -79,6 +79,24 @@ export function applyCompanyPrefix(path: string, companyPrefix: string | null | 
   const activePrefix = extractCompanyPrefixFromPath(pathname);
   if (activePrefix) return path;
 
+  // `extractCompanyPrefixFromPath` cannot see a prefix that collides with a
+  // reserved route root (e.g. a company whose issue prefix is "ORG", which
+  // shadows the `org` board route). In that case the path may already be
+  // prefixed — `/ORG/dashboard` — and re-prepending would yield
+  // `/ORG/ORG/dashboard`. Detect this when the first segment matches the prefix
+  // we are about to apply and is followed by a known route root.
+  const segments = pathname.split("/").filter(Boolean);
+  const firstSegment = segments[0];
+  const secondSegment = segments[1]?.toLowerCase();
+  if (
+    firstSegment &&
+    normalizeCompanyPrefix(firstSegment) === prefix &&
+    secondSegment &&
+    (BOARD_ROUTE_ROOTS.has(secondSegment) || GLOBAL_ROUTE_ROOTS.has(secondSegment))
+  ) {
+    return path;
+  }
+
   return `/${prefix}${pathname}${search}${hash}`;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The web UI namespaces every company's board under a URL prefix derived from the company's issue prefix (e.g. `/PAP/dashboard`), and a routing helper (`applyCompanyPrefix`) adds that prefix to company-relative paths during navigation
> - To avoid mistaking a board route for a company prefix, the helper treats a fixed set of first-segment words (`dashboard`, `org`, `agents`, …) as reserved route roots that are never company prefixes
> - This breaks down when a company's issue prefix *equals* one of those reserved words — most easily reproduced with a company whose prefix is `ORG`, which shadows the `org` org-chart route
> - On that company, post-onboarding the app redirects to `/ORG/dashboard`, but `applyCompanyPrefix` fails to recognize the already-present prefix and prepends it again, producing `/ORG/ORG/dashboard` → "Page not found. This route does not exist."
> - This pull request makes `applyCompanyPrefix` idempotent for the collision case so the prefix is never doubled
> - The benefit is that companies whose issue prefix collides with a reserved route word can complete onboarding and navigate the board normally

## Linked Issues or Issue Description

No existing issue — describing the bug here (bug report form):

**What happened:** After completing onboarding for a company whose issue prefix is `ORG`, the app redirects to `http://127.0.0.1:3100/ORG/ORG/dashboard` and shows:

> Page not found
> This route does not exist.
> Requested path: /ORG/ORG/dashboard

**What I expected:** Redirect to `/ORG/dashboard` and land on the company dashboard.

**Root cause:** `ui/src/lib/company-routes.ts` keeps a `BOARD_ROUTE_ROOTS` set used to tell company prefixes apart from board routes. `org` is in that set (the org-chart route). When the company's issue prefix is `ORG`, `extractCompanyPrefixFromPath("/ORG/dashboard")` sees the first segment `org` as a reserved route root and returns `null`, so `applyCompanyPrefix` concludes the path is not yet prefixed and prepends `/ORG` a second time → `/ORG/ORG/dashboard`. The redirect originates at `ui/src/App.tsx` (`<Navigate to={`/${targetCompany.issuePrefix}/dashboard`} replace />`) routed through the prefix-applying `Navigate`/`useNavigate` wrappers in `ui/src/lib/router.tsx`.

**Reproduction:** Create/onboard a company whose issue prefix collides with a reserved route word (e.g. `ORG`), then complete onboarding. The general class also covers `AGENTS`, `GOALS`, `SETTINGS`, etc.

## What Changed

- `ui/src/lib/company-routes.ts`: `applyCompanyPrefix` now returns the path unchanged when the first segment already equals the prefix being applied **and** is followed by a known board/global route root (e.g. `/ORG/dashboard`, `/ORG/board-chat`). Genuinely company-relative paths — including the bare `/org` org-chart route — are still prefixed as before, and the guard does not trip for non-colliding prefixes (those are already handled by the existing `extractCompanyPrefixFromPath` early return).
- `ui/src/lib/company-routes.test.ts`: added a regression test covering the double-prefix bug, the company-relative cases that must still be prefixed, and idempotency.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/lib/company-routes.test.ts` → 7/7 pass (incl. new regression test).
- `pnpm --filter @paperclipai/ui typecheck` → clean.
- Manual: with a company whose issue prefix is `ORG`, completing onboarding now lands on `/ORG/dashboard` instead of `/ORG/ORG/dashboard`.

## Risks

Low risk. The change is purely additive within `applyCompanyPrefix` and only activates in the previously-broken collision case: first segment equals the prefix being applied AND the next segment is a recognized route root. Non-colliding prefixes (e.g. `PAP`) are unaffected because they return earlier via `extractCompanyPrefixFromPath`. No migrations, no API or schema changes.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, used via Claude Code with extended thinking and tool use (code search, edits, running tests/typecheck). Human-reviewed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge
