### PR TITLE
Make agent concurrency default configurable

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -19,6 +19,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS` | `1` | Default `runtimeConfig.heartbeat.maxConcurrentRuns` for new/imported agents and for existing agents whose heartbeat policy omits a value. Values are floored and clamped to `1..50`. |
 
 ## Secrets
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -73,7 +73,7 @@ export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   general: "General",
 };
 
-export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 20;
+export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 1;
 export const WORKSPACE_BRANCH_ROUTINE_VARIABLE = "workspaceBranch";
 
 export const MODEL_PROFILE_KEYS = ["cheap"] as const;

--- a/server/src/__tests__/agent-concurrency-defaults.test.ts
+++ b/server/src/__tests__/agent-concurrency-defaults.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV,
+  normalizeAgentMaxConcurrentRuns,
+  resolveAgentDefaultMaxConcurrentRuns,
+} from "../services/agent-concurrency-defaults.js";
+
+describe("agent concurrency defaults", () => {
+  it("uses the shared default when the environment override is unset or invalid", () => {
+    expect(resolveAgentDefaultMaxConcurrentRuns({})).toBe(1);
+    expect(resolveAgentDefaultMaxConcurrentRuns({ [AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]: "" })).toBe(1);
+    expect(resolveAgentDefaultMaxConcurrentRuns({ [AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]: "not-a-number" })).toBe(1);
+  });
+
+  it("reads and clamps PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS", () => {
+    expect(resolveAgentDefaultMaxConcurrentRuns({ [AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]: "3" })).toBe(3);
+    expect(resolveAgentDefaultMaxConcurrentRuns({ [AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]: "3.9" })).toBe(3);
+    expect(resolveAgentDefaultMaxConcurrentRuns({ [AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]: "0" })).toBe(1);
+    expect(resolveAgentDefaultMaxConcurrentRuns({ [AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]: "100" })).toBe(50);
+  });
+
+  it("normalizes explicit heartbeat values with a supplied fallback", () => {
+    expect(normalizeAgentMaxConcurrentRuns(undefined, 4)).toBe(4);
+    expect(normalizeAgentMaxConcurrentRuns("2", 4)).toBe(2);
+    expect(normalizeAgentMaxConcurrentRuns("invalid", 4)).toBe(4);
+  });
+});

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -981,7 +981,7 @@ describe.sequential("agent permission routes", () => {
           heartbeat: {
             enabled: false,
             intervalSec: 3600,
-            maxConcurrentRuns: 20,
+            maxConcurrentRuns: 1,
           },
         },
       }),
@@ -1091,7 +1091,7 @@ describe.sequential("agent permission routes", () => {
           heartbeat: {
             enabled: false,
             intervalSec: 3600,
-            maxConcurrentRuns: 20,
+            maxConcurrentRuns: 1,
           },
         },
       }),

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -2652,7 +2652,7 @@ describe("company portability", () => {
       runtimeConfig: {
         heartbeat: {
           enabled: false,
-          maxConcurrentRuns: 20,
+          maxConcurrentRuns: 1,
         },
       },
     });
@@ -2731,7 +2731,7 @@ describe("company portability", () => {
       runtimeConfig: {
         heartbeat: {
           enabled: false,
-          maxConcurrentRuns: 20,
+          maxConcurrentRuns: 1,
         },
       },
     }));

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -344,7 +344,10 @@ async function seedLowTrustFixture(db: Db) {
     role: "engineer",
     adapterType: "process",
     adapterConfig: { token: canaries.agentConfig },
-    runtimeConfig: { env: { SECRET_MARKER: canaries.agentConfig } },
+    runtimeConfig: {
+      env: { SECRET_MARKER: canaries.agentConfig },
+      heartbeat: { maxConcurrentRuns: 20 },
+    },
     permissions: {},
   }).returning();
   const [cto] = await db.insert(agents).values({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -7,7 +7,6 @@ import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
 import {
   agentSkillSyncSchema,
   agentMineInboxQuerySchema,
-  AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   createAgentKeySchema,
   createAgentHireSchema,
   createAgentSchema,
@@ -51,6 +50,7 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
+import { resolveAgentDefaultMaxConcurrentRuns } from "../services/agent-concurrency-defaults.js";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import {
@@ -1027,7 +1027,7 @@ export function agentRoutes(
       heartbeat.enabled = false;
     }
     if (parseNumberLike(heartbeat.maxConcurrentRuns) == null) {
-      heartbeat.maxConcurrentRuns = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
+      heartbeat.maxConcurrentRuns = resolveAgentDefaultMaxConcurrentRuns();
     }
 
     normalizedRuntimeConfig.heartbeat = heartbeat;

--- a/server/src/services/agent-concurrency-defaults.ts
+++ b/server/src/services/agent-concurrency-defaults.ts
@@ -1,0 +1,20 @@
+import { AGENT_DEFAULT_MAX_CONCURRENT_RUNS } from "@paperclipai/shared";
+
+export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV = "PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS";
+export const AGENT_MAX_CONCURRENT_RUNS_MIN = 1;
+export const AGENT_MAX_CONCURRENT_RUNS_MAX = 50;
+
+export function normalizeAgentMaxConcurrentRuns(value: unknown, fallback = AGENT_DEFAULT_MAX_CONCURRENT_RUNS) {
+  const parsed = typeof value === "number"
+    ? value
+    : typeof value === "string" && value.trim().length > 0
+      ? Number(value.trim())
+      : fallback;
+  const floored = Math.floor(parsed);
+  const normalized = Number.isFinite(floored) ? floored : fallback;
+  return Math.max(AGENT_MAX_CONCURRENT_RUNS_MIN, Math.min(AGENT_MAX_CONCURRENT_RUNS_MAX, normalized));
+}
+
+export function resolveAgentDefaultMaxConcurrentRuns(env: NodeJS.ProcessEnv = process.env) {
+  return normalizeAgentMaxConcurrentRuns(env[AGENT_DEFAULT_MAX_CONCURRENT_RUNS_ENV]);
+}

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -17,7 +17,6 @@ import {
   issueComments,
 } from "@paperclipai/db";
 import {
-  AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   getAgentWorkEligibility,
   isUuidLike,
   normalizeAgentUrlKey,
@@ -28,6 +27,7 @@ import { syncAgentAdapterEnvBindings } from "./agent-secret-bindings.js";
 import { normalizeAgentPermissions } from "./agent-permissions.js";
 import { REDACTED_EVENT_VALUE, sanitizeRecord } from "../redaction.js";
 import { secretService } from "./secrets.js";
+import { resolveAgentDefaultMaxConcurrentRuns } from "./agent-concurrency-defaults.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
@@ -137,7 +137,7 @@ function normalizeRuntimeConfigForNewAgent(runtimeConfig: unknown): Record<strin
     ? { ...normalizedRuntimeConfig.heartbeat }
     : {};
   if (parseFiniteNumberLike(heartbeat.maxConcurrentRuns) == null) {
-    heartbeat.maxConcurrentRuns = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
+    heartbeat.maxConcurrentRuns = resolveAgentDefaultMaxConcurrentRuns();
   }
   normalizedRuntimeConfig.heartbeat = heartbeat;
   return normalizedRuntimeConfig;

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -32,7 +32,6 @@ import type {
   RoutineVariable,
 } from "@paperclipai/shared";
 import {
-  AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
   PROJECT_ICON_NAMES,
@@ -53,6 +52,7 @@ import {
   readPaperclipSkillSyncPreference,
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
+import { resolveAgentDefaultMaxConcurrentRuns } from "./agent-concurrency-defaults.js";
 import { requireOpenCodeModelId } from "@paperclipai/adapter-opencode-local/server";
 import { findServerAdapter } from "../adapters/index.js";
 import { forbidden, notFound, unprocessable } from "../errors.js";
@@ -662,17 +662,21 @@ const COMPANY_LOGO_CONTENT_TYPE_EXTENSIONS: Record<string, string> = {
 
 const COMPANY_LOGO_FILE_NAME = "company-logo";
 
-const RUNTIME_DEFAULT_RULES: Array<{ path: string[]; value: unknown }> = [
+type DefaultRuleStaticValue = null | boolean | number | string | readonly unknown[] | Record<string, unknown>;
+
+type DefaultRule = { path: string[]; value: DefaultRuleStaticValue | (() => DefaultRuleStaticValue) };
+
+const RUNTIME_DEFAULT_RULES: DefaultRule[] = [
   { path: ["heartbeat", "cooldownSec"], value: 10 },
   { path: ["heartbeat", "intervalSec"], value: 3600 },
   { path: ["heartbeat", "wakeOnOnDemand"], value: true },
   { path: ["heartbeat", "wakeOnAssignment"], value: true },
   { path: ["heartbeat", "wakeOnAutomation"], value: true },
   { path: ["heartbeat", "wakeOnDemand"], value: true },
-  { path: ["heartbeat", "maxConcurrentRuns"], value: AGENT_DEFAULT_MAX_CONCURRENT_RUNS },
+  { path: ["heartbeat", "maxConcurrentRuns"], value: () => resolveAgentDefaultMaxConcurrentRuns() },
 ];
 
-const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, Array<{ path: string[]; value: unknown }>> = {
+const ADAPTER_DEFAULT_RULES_BY_TYPE: Record<string, DefaultRule[]> = {
   codex_local: [
     { path: ["timeoutSec"], value: 0 },
     { path: ["graceSec"], value: 15 },
@@ -922,7 +926,7 @@ function disableImportedTimerHeartbeat(runtimeConfig: unknown) {
   const heartbeat = isPlainRecord(next.heartbeat) ? { ...next.heartbeat } : {};
   heartbeat.enabled = false;
   if (parseFiniteNumberLike(heartbeat.maxConcurrentRuns) == null) {
-    heartbeat.maxConcurrentRuns = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
+    heartbeat.maxConcurrentRuns = resolveAgentDefaultMaxConcurrentRuns();
   }
   next.heartbeat = heartbeat;
   return next;
@@ -1815,8 +1819,11 @@ function jsonEqual(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-function isPathDefault(pathSegments: string[], value: unknown, rules: Array<{ path: string[]; value: unknown }>) {
-  return rules.some((rule) => jsonEqual(rule.path, pathSegments) && jsonEqual(rule.value, value));
+function isPathDefault(pathSegments: string[], value: unknown, rules: DefaultRule[]) {
+  return rules.some((rule) => {
+    const defaultValue = typeof rule.value === "function" ? rule.value() : rule.value;
+    return jsonEqual(rule.path, pathSegments) && jsonEqual(defaultValue, value);
+  });
 }
 
 function pruneDefaultLikeValue(
@@ -1824,7 +1831,7 @@ function pruneDefaultLikeValue(
   opts: {
     dropFalseBooleans: boolean;
     path?: string[];
-    defaultRules?: Array<{ path: string[]; value: unknown }>;
+    defaultRules?: DefaultRule[];
   },
 ): unknown {
   const pathSegments = opts.path ?? [];

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6,7 +6,6 @@ import { randomUUID } from "node:crypto";
 import { and, asc, desc, eq, getTableColumns, gt, gte, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
-  AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   MODEL_PROFILE_KEYS,
   envBindingSchema,
@@ -23,6 +22,10 @@ import {
   type RunLivenessState,
   type SourceTrustMetadata,
 } from "@paperclipai/shared";
+import {
+  normalizeAgentMaxConcurrentRuns,
+  resolveAgentDefaultMaxConcurrentRuns,
+} from "./agent-concurrency-defaults.js";
 import {
   agents,
   agentRuntimeState,
@@ -217,9 +220,6 @@ export function redactDetectedSuccessfulRunProgressSummaryForBoard(
 
 const MAX_RUN_EVENT_PAYLOAD_OBJECT_KEYS = 100;
 const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
-const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
-const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
-const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -1643,9 +1643,7 @@ export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_C
 }
 
 function normalizeMaxConcurrentRuns(value: unknown) {
-  const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
-  if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
-  return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_MIN, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+  return normalizeAgentMaxConcurrentRuns(value, resolveAgentDefaultMaxConcurrentRuns());
 }
 
 interface WakeupOptions {

--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -175,6 +175,11 @@ async function setupCompany(boardRequest: APIRequestContext): Promise<TestContex
           command: process.execPath,
           args: ["-e", "process.stdout.write('done\\n')"],
         },
+        runtimeConfig: {
+          heartbeat: {
+            maxConcurrentRuns: 20,
+          },
+        },
       },
     });
     expect(agentRes.ok()).toBe(true);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent heartbeats are the server-side orchestration path that turns queued work into live adapter runs.
> - `runtimeConfig.heartbeat.maxConcurrentRuns` already controls per-agent concurrency, but its default was high enough to surprise local deployments using shared provider credentials.
> - Codex/OpenAI sessions can experience provider-side pressure when many agents inherit the same default and launch parallel sessions.
> - This PR makes the safer default one concurrent run per agent while preserving an operator override for instances that intentionally want more throughput.
> - The benefit is lower surprise concurrency by default without removing configurability for larger or better-provisioned deployments.

## Linked Issues or Issue Description

Feature request inline description:

### Subsystem affected

server/ — REST API & orchestration services; packages/shared — constants; docs — deployment environment reference.

### Problem or motivation

Operators using shared Codex/OpenAI credentials can hit provider-side concurrency pressure when many agents inherit a high default heartbeat concurrency. Requiring every agent to be manually edited is error-prone, especially after company imports or bulk agent creation.

### Proposed solution

Default new/imported agents to one concurrent heartbeat run and add `PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS` so operators can raise the default instance-wide. If an existing agent omits `runtimeConfig.heartbeat.maxConcurrentRuns`, scheduling also falls back through this resolver.

### Alternatives considered

Only changing local data or only changing the static constant would not let deployments tune the default. A provider-global limiter would be useful later, but this PR keeps the existing per-agent concurrency model and only makes its default safer/configurable.

### Roadmap alignment

Checked `ROADMAP.md`; this does not duplicate a planned core roadmap item. It is a small operations/configurability improvement for the existing heartbeat runtime.

### Additional context

Duplicate PR search for `concurrency maxConcurrentRuns PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS` returned no existing PRs.

## What Changed

- Added `server/src/services/agent-concurrency-defaults.ts` to resolve and clamp the agent concurrency default.
- Changed the shared fallback default from `20` to `1`.
- Wired the resolver into agent creation, agent service creation, company import/export default pruning, and heartbeat scheduling fallback behavior.
- Added unit coverage for env parsing/clamping and updated existing default assertions.
- Documented `PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS` in the deployment environment variable reference.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-concurrency-defaults.test.ts server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/company-portability.test.ts`
- `pnpm exec vitest run server/src/__tests__/low-trust-red-team-routes.test.ts -t "redacts quarantined low-trust output"`
- `pnpm exec vitest run server/src/__tests__/agent-concurrency-defaults.test.ts server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/company-portability.test.ts server/src/__tests__/low-trust-red-team-routes.test.ts`
- `pnpm --filter @paperclipai/plugin-sdk build && pnpm exec tsc --noEmit --project server/tsconfig.json`
- `pnpm exec tsc --noEmit --project server/tsconfig.json`

## Risks

- Behavioral shift: new/imported agents now default to one concurrent run instead of twenty.
- Low migration risk: existing persisted agent configs are not migrated by this PR; operators can set explicit per-agent values or `PAPERCLIP_AGENT_DEFAULT_MAX_CONCURRENT_RUNS` for omitted values.
- The env override is clamped to the existing scheduler range of `1..50`, so invalid or excessive values fall back safely.

## Model Used

- OpenAI Codex CLI coding agent; exact backend model identifier is not exposed in this CLI session. Used tool-assisted code search, patching, tests, typecheck, and GitHub CLI operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


