### PR TITLE
feat(claude-local): per-stream idle watchdog to reap wedged CLI streams

### DIFF
--- a/packages/adapter-utils/src/execution-target.test.ts
+++ b/packages/adapter-utils/src/execution-target.test.ts
@@ -280,6 +280,46 @@ describe("runAdapterExecutionTargetProcess", () => {
       }),
     );
   });
+
+  it("forwards streamIdleWatchdogMs to runChildProcess on the local path", async () => {
+    // Regression guard: the local execution wrapper must thread the per-stream
+    // idle watchdog through to runChildProcess. If it silently drops the option
+    // the watchdog ships disabled on the claude-local path while still appearing
+    // configured.
+    const runChildProcessSpy = vi.spyOn(serverUtils, "runChildProcess").mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+      pid: null,
+      startedAt: new Date().toISOString(),
+    });
+
+    await runAdapterExecutionTargetProcess(
+      "run-local-process",
+      null,
+      "agent-cli",
+      ["--json"],
+      {
+        cwd: "/tmp/local",
+        env: { SAFE_VALUE: "visible" },
+        timeoutSec: 5,
+        graceSec: 1,
+        streamIdleWatchdogMs: 60_000,
+        onLog: async () => {},
+      },
+    );
+
+    expect(runChildProcessSpy).toHaveBeenCalledWith(
+      "run-local-process",
+      "agent-cli",
+      ["--json"],
+      expect.objectContaining({
+        streamIdleWatchdogMs: 60_000,
+      }),
+    );
+  });
 });
 
 describe("ensureAdapterExecutionTargetRuntimeCommandInstalled", () => {

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -82,6 +82,12 @@ export interface AdapterExecutionTargetProcessOptions {
   stdin?: string;
   timeoutSec: number;
   graceSec: number;
+  /**
+   * Per-stream idle watchdog (ms). Forwarded to `runChildProcess` on the local
+   * execution path; remote (SSH/sandbox) transports rely on their own timeouts
+   * and ignore it. Omitted/<=0 disables the watchdog.
+   */
+  streamIdleWatchdogMs?: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onRuntimeProgress?: RuntimeStatusSink;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
@@ -437,6 +443,7 @@ export async function runAdapterExecutionTargetProcess(
     stdin: options.stdin,
     timeoutSec: options.timeoutSec,
     graceSec: options.graceSec,
+    streamIdleWatchdogMs: options.streamIdleWatchdogMs,
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -595,6 +595,83 @@ describe("runChildProcess", () => {
       }
     }
   });
+
+  it("reaps a stdout-silent subprocess once the idle watchdog elapses", async () => {
+    const watchdogMs = 300;
+    const startedAt = Date.now();
+
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      // Emit one early chunk, then go silent well past the watchdog window.
+      ["-e", "process.stdout.write('starting');setTimeout(() => {}, 10000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 30,
+        graceSec: 1,
+        streamIdleWatchdogMs: watchdogMs,
+        onLog: async () => {},
+        onSpawn: async () => {},
+      },
+    );
+    const elapsed = Date.now() - startedAt;
+
+    expect(result.idleWatchdogFired).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.silenceAgeMs).not.toBeNull();
+    expect(result.silenceAgeMs!).toBeGreaterThanOrEqual(watchdogMs - 50);
+    // Fired off the idle window, not the 30s wall-clock cap.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("re-arms the idle watchdog on each stdout chunk so a chatty subprocess survives", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        // Write every 100ms for ~600ms (under the 300ms watchdog each gap), then exit.
+        "let n=0;const t=setInterval(()=>{process.stdout.write('tick'+n);if(++n>=6){clearInterval(t);process.exit(0);}},100);",
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 30,
+        graceSec: 1,
+        streamIdleWatchdogMs: 300,
+        onLog: async () => {},
+        onSpawn: async () => {},
+      },
+    );
+
+    expect(result.idleWatchdogFired).toBe(false);
+    expect(result.silenceAgeMs ?? null).toBeNull();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("tick5");
+  });
+
+  it("disables the idle watchdog when streamIdleWatchdogMs is not positive", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      // Silent for 500ms — would trip a 200ms watchdog if one were armed.
+      ["-e", "setTimeout(() => process.exit(0), 500);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 30,
+        graceSec: 1,
+        streamIdleWatchdogMs: 0,
+        onLog: async () => {},
+        onSpawn: async () => {},
+      },
+    );
+
+    expect(result.idleWatchdogFired).toBe(false);
+    expect(result.silenceAgeMs ?? null).toBeNull();
+    expect(result.exitCode).toBe(0);
+  });
 });
 
 describe("renderPaperclipWakePrompt", () => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -15,6 +15,19 @@ export interface RunProcessResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  /**
+   * True when the per-stream idle watchdog reaped the subprocess because no
+   * stdout was observed for `streamIdleWatchdogMs`. Distinct from `timedOut`
+   * (the wall-clock `timeoutSec` cap), which stays false in this case.
+   * Optional: only the local `runChildProcess` path arms the watchdog; remote
+   * (SSH/sandbox) result producers leave it undefined.
+   */
+  idleWatchdogFired?: boolean;
+  /**
+   * Silence (in ms) since the last stdout chunk at the moment the idle
+   * watchdog fired. `null`/undefined when the watchdog did not fire.
+   */
+  silenceAgeMs?: number | null;
   stdout: string;
   stderr: string;
   pid: number | null;
@@ -2313,6 +2326,12 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
+    /**
+     * Per-stream idle watchdog. When > 0, the subprocess is SIGTERM'd (then
+     * SIGKILL'd after `graceSec`) if no stdout chunk arrives for this many ms.
+     * Independent of `timeoutSec` (the wall-clock cap). Omitted/<=0 disables it.
+     */
+    streamIdleWatchdogMs?: number;
     onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
@@ -2369,6 +2388,8 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let idleWatchdogFired = false;
+        let silenceAgeMs: number | null = null;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -2433,11 +2454,40 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
+        // Per-stream idle watchdog: independent of the wall-clock `timeout`
+        // above, this reaps a subprocess whose stdout has gone silent (e.g. a
+        // half-open SSE socket after laptop sleep) long before the Claude CLI's
+        // own ~11h idle timeout would. Re-armed on every stdout chunk.
+        const idleWatchdogMs = opts.streamIdleWatchdogMs ?? 0;
+        let lastStdoutAt = Date.now();
+        let idleTimer: NodeJS.Timeout | null = null;
+        const clearIdleTimer = () => {
+          if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+          }
+        };
+        const armIdleWatchdog = () => {
+          if (idleWatchdogMs <= 0) return;
+          clearIdleTimer();
+          idleTimer = setTimeout(() => {
+            idleWatchdogFired = true;
+            silenceAgeMs = Date.now() - lastStdoutAt;
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            setTimeout(() => {
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }, idleWatchdogMs);
+        };
+        armIdleWatchdog();
+
         child.stdout?.on("data", (chunk: unknown) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
           const text = String(chunk);
+          lastStdoutAt = Date.now();
+          armIdleWatchdog();
           stdout = appendWithCap(stdout, text);
           maybeArmTerminalResultCleanup();
           logChain = logChain
@@ -2477,6 +2527,7 @@ export async function runChildProcess(
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearIdleTimer();
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -2495,6 +2546,7 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearIdleTimer();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()
@@ -2504,6 +2556,8 @@ export async function runChildProcess(
                 exitCode: code,
                 signal,
                 timedOut,
+                idleWatchdogFired,
+                silenceAgeMs,
                 stdout,
                 stderr,
                 pid: child.pid ?? null,

--- a/packages/adapter-utils/vitest.config.ts
+++ b/packages/adapter-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -90,6 +90,7 @@ interface ClaudeRuntimeConfig {
   loggedEnv: Record<string, string>;
   timeoutSec: number;
   graceSec: number;
+  streamIdleWatchdogMs: number;
   extraArgs: string[];
 }
 
@@ -100,6 +101,23 @@ export function claudeSessionCwdMatchesExecutionTarget(input: {
 }): boolean {
   if (input.executionTargetIsRemote || input.runtimeSessionCwd.length === 0) return true;
   return path.resolve(input.runtimeSessionCwd) === path.resolve(input.effectiveExecutionCwd);
+}
+
+const DEFAULT_STREAM_IDLE_WATCHDOG_MS = 30 * 60 * 1000;
+
+// Resolve the per-stream idle watchdog window. Env override
+// (CLAUDE_STREAM_IDLE_WATCHDOG_MS) wins over adapter config so it can be tuned
+// on a running host without a redeploy. <= 0 disables the watchdog entirely.
+function resolveStreamIdleWatchdogMs(
+  config: Record<string, unknown>,
+  runtimeEnv: Record<string, string | undefined>,
+): number {
+  const rawEnv = runtimeEnv.CLAUDE_STREAM_IDLE_WATCHDOG_MS;
+  if (typeof rawEnv === "string" && rawEnv.trim().length > 0) {
+    const parsed = Number(rawEnv);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return asNumber(config.streamIdleWatchdogMs, DEFAULT_STREAM_IDLE_WATCHDOG_MS);
 }
 
 function buildLoginResult(input: {
@@ -305,6 +323,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     resolvedCommand,
   });
 
+  const streamIdleWatchdogMs = resolveStreamIdleWatchdogMs(config, runtimeEnv);
   const extraArgs = (() => {
     const fromExtraArgs = asStringArray(config.extraArgs);
     if (fromExtraArgs.length > 0) return fromExtraArgs;
@@ -322,6 +341,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     loggedEnv,
     timeoutSec,
     graceSec,
+    streamIdleWatchdogMs,
     extraArgs,
   };
 }
@@ -422,6 +442,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     loggedEnv: initialLoggedEnv,
     timeoutSec,
     graceSec,
+    streamIdleWatchdogMs,
     extraArgs,
   } = runtimeConfig;
   let loggedEnv = initialLoggedEnv;
@@ -790,6 +811,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stdin: prompt,
       timeoutSec,
       graceSec,
+      streamIdleWatchdogMs,
       onSpawn,
       onRuntimeProgress: ctx.onRuntimeProgress,
       onLog,
@@ -833,6 +855,31 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorMessage: `Timed out after ${timeoutSec}s`,
         errorCode: "timeout",
         errorMeta,
+        clearSession: Boolean(opts.clearSessionOnMissingSession),
+      };
+    }
+
+    if (proc.idleWatchdogFired) {
+      const silenceAgeMs = proc.silenceAgeMs ?? streamIdleWatchdogMs;
+      const silenceMin = Math.round(silenceAgeMs / 60000);
+      return {
+        exitCode: proc.exitCode,
+        signal: proc.signal,
+        timedOut: false,
+        errorMessage: `Claude stream idle for ~${silenceMin}m with no stdout; reaped by idle watchdog (threshold ${streamIdleWatchdogMs}ms)`,
+        errorCode: "stream_idle_watchdog",
+        errorMeta: { ...errorMeta, silenceAgeMs, streamIdleWatchdogMs },
+        // Persisted into heartbeat_runs.result_json so the silence age is
+        // durably attached to the run payload (errorMeta has no column).
+        resultJson: {
+          streamIdleWatchdog: {
+            silenceAgeMs,
+            streamIdleWatchdogMs,
+            terminatedSignal: proc.signal,
+          },
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+        },
         clearSession: Boolean(opts.clearSessionOnMissingSession),
       };
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run via local CLI adapters (e.g. `claude-local`) that spawn a CLI subprocess and stream its stdout back to the server
> - When that stream goes silent mid-run — a half-open SSE socket after a laptop sleeps on battery (Wi-Fi suspended), or a stalled backend — nothing at the adapter layer notices
> - The only backstop today is the Claude CLI's own idle timeout (~11h), so a wedged run can occupy a slot for most of a day and trigger false-positive stale-active-run alerts at the 1h recovery mark
> - This pull request adds a per-stream stdout idle watchdog at the local subprocess runner, reaping a silent run within a configurable window (default 30m)
> - The benefit is wedged streams fail fast and cleanly with a structured reason instead of hanging for hours

## Linked Issues or Issue Description

No public GitHub issue exists — describing the underlying problem inline, following the feature issue template:

**Problem**

Local CLI adapter runs can wedge when the child process stops producing stdout (a half-open SSE socket after network suspension on laptop sleep, or a stalled backend). There is no idle detection at the adapter layer, so the run hangs until the Claude CLI's own ~11h idle timeout fires — occupying a slot for most of a day and tripping false-positive stale-active-run alerts at the 1h mark.

**Solution**

A per-run watchdog in the local subprocess runner that resets on every stdout chunk and, after a configurable silence window (default 30m), SIGTERMs the subprocess (SIGKILL after the grace period) and marks the run failed with a structured `stream_idle_watchdog` reason plus the observed `silenceAgeMs`.

**Alternatives considered**

Keep relying on the CLI's ~11h idle timeout (status quo — far too slow, wastes a slot for hours). Lower the server-side `ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS` (1h) instead — that only changes alerting, it does not reap the wedged process. Power-state hooks for laptop sleep — narrower and more brittle than watching the stream directly; left as a possible follow-up.

**Roadmap alignment**

Operational reliability hardening of the local adapter runtime; not a new product surface and does not overlap planned core feature work in ROADMAP.md.

## What Changed

- `packages/adapter-utils/src/server-utils.ts` — `runChildProcess` gains `streamIdleWatchdogMs`. A timer is armed on spawn and re-armed on every stdout chunk; on expiry it `SIGTERM`s the subprocess (process-group aware) and escalates to `SIGKILL` after `graceSec`. The result reports `idleWatchdogFired` + `silenceAgeMs`. Cleared on `close`/`error`. Independent of `timeoutSec` (the wall-clock cap), which is unchanged.
- `packages/adapter-utils/src/execution-target.ts` — threads `streamIdleWatchdogMs` through `runAdapterExecutionTargetProcess` to the local path (remote transports ignore it). Without this the watchdog would ship silently disabled on the local execution path.
- `packages/adapters/claude-local/src/server/execute.ts` — resolves the window from `CLAUDE_STREAM_IDLE_WATCHDOG_MS` (env, wins) → `config.streamIdleWatchdogMs` → default **30 min**; `<= 0` disables it (escape hatch). A tripped watchdog yields a failed run with `errorCode: "stream_idle_watchdog"` and `silenceAgeMs` in both `errorMeta` and `resultJson.streamIdleWatchdog` (durable column).
- CI — registered `adapter-utils` as a vitest project (`packages/adapter-utils/vitest.config.ts` + root `vitest.config.ts`) so its suite runs in CI; it was not wired in before.

## Verification

- `cd packages/adapter-utils && npx vitest run src/server-utils.test.ts` → **53 passed**, including 3 new cases: fires on a stdout-silent subprocess (asserts `idleWatchdogFired` + `silenceAgeMs`), re-arms on a chatty subprocess (survives, exits 0), stays disabled when `<= 0`.
- `npx tsc --noEmit` clean in `packages/adapter-utils` and `packages/adapters/claude-local`.

## Risks

Low risk. The watchdog is opt-in by value and fully disabled when `<= 0`; it does not change `timeoutSec` semantics. Worst case of a too-tight window is an early termination of a legitimately slow-but-alive run — mitigated by the 30m default and the env override for hot-tuning without redeploy. Only the local execution path is affected; remote transports are untouched.

## Model Used

Claude (Anthropic), `claude-opus-4-8` (Opus 4.8), 1M context, extended thinking + tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
