### PR TITLE
fix(issues): reclaim execution lock from abandoned scheduled_retry holder (IRO-45 remediation B)

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -19,6 +19,41 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
+import {
+  isStaleExecutionLockHeartbeatRun,
+  SCHEDULED_RETRY_EXECUTION_LOCK_STALE_AFTER_MS,
+} from "../services/issues.js";
+
+// Pure predicate coverage (IRO-45 remediation B): a `scheduled_retry` holder
+// with no live heartbeat is a stale, adoptable execution lock once it is overdue
+// past the grace window, but a freshly-scheduled retry that still owns the lock
+// it must reclaim is NOT stale.
+describe("isStaleExecutionLockHeartbeatRun", () => {
+  const now = new Date("2026-06-24T12:00:00.000Z");
+  const overdue = new Date(now.getTime() - SCHEDULED_RETRY_EXECUTION_LOCK_STALE_AFTER_MS - 1_000);
+  const pending = new Date(now.getTime() + 30_000);
+  const justDue = new Date(now.getTime() - 1_000);
+
+  it("treats missing, terminal, and overdue scheduled_retry holders as stale", () => {
+    expect(isStaleExecutionLockHeartbeatRun(null, now)).toBe(true);
+    expect(isStaleExecutionLockHeartbeatRun(undefined, now)).toBe(true);
+    for (const status of ["succeeded", "failed", "cancelled", "timed_out"]) {
+      expect(isStaleExecutionLockHeartbeatRun({ status, scheduledRetryAt: null }, now)).toBe(true);
+    }
+    expect(isStaleExecutionLockHeartbeatRun({ status: "scheduled_retry", scheduledRetryAt: overdue }, now)).toBe(true);
+    // A scheduled_retry holder with no recorded due time can never fire to reclaim itself.
+    expect(isStaleExecutionLockHeartbeatRun({ status: "scheduled_retry", scheduledRetryAt: null }, now)).toBe(true);
+  });
+
+  it("keeps live and not-yet-overdue scheduled_retry holders non-stale", () => {
+    expect(isStaleExecutionLockHeartbeatRun({ status: "running", scheduledRetryAt: null }, now)).toBe(false);
+    expect(isStaleExecutionLockHeartbeatRun({ status: "queued", scheduledRetryAt: null }, now)).toBe(false);
+    // Retry still pending its fire window — owns the lock it must reclaim.
+    expect(isStaleExecutionLockHeartbeatRun({ status: "scheduled_retry", scheduledRetryAt: pending }, now)).toBe(false);
+    // Just barely due, still inside the grace window.
+    expect(isStaleExecutionLockHeartbeatRun({ status: "scheduled_retry", scheduledRetryAt: justDue }, now)).toBe(false);
+  });
+});
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -417,6 +452,151 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     expect(row).toEqual({
       status: "in_progress",
       assigneeAgentId: otherAgentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+  });
+
+  // IRO-45 remediation B: a transient retry that parks the run in `scheduled_retry`
+  // owns the execution lock so it can reclaim on fire. If that retry never fires
+  // (orphaned holder / dead promoter) the lock used to be permanently
+  // unreclaimable because `scheduled_retry` is not a TERMINAL status. These tests
+  // pin the new dedicated execution-lock-staleness predicate.
+  async function insertScheduledRetryRun(
+    companyId: string,
+    agentId: string,
+    scheduledRetryAt: Date,
+  ): Promise<string> {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "scheduled_retry",
+      invocationSource: "automation",
+      scheduledRetryAt,
+      scheduledRetryAttempt: 1,
+      scheduledRetryReason: "transient_failure",
+    });
+    return runId;
+  }
+
+  it("recovers an overdue scheduled_retry executionRunId that never fired (PATCH)", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    // Due to fire well outside the grace window — the retry is abandoned.
+    const overdue = new Date(Date.now() - SCHEDULED_RETRY_EXECUTION_LOCK_STALE_AFTER_MS - 60_000);
+    const scheduledRetryRunId = await insertScheduledRetryRun(companyId, agentId, overdue);
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Scheduled-retry stale execution lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: scheduledRetryRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Recovered scheduled-retry lock" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.title).toBe("Recovered scheduled-retry lock");
+
+    const row = await db
+      .select({
+        title: issues.title,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      title: "Recovered scheduled-retry lock",
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+  });
+
+  it("does NOT steal a still-pending scheduled_retry execution lock (PATCH 409)", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    // Retry still inside its fire window — it owns the lock it must reclaim.
+    const pending = new Date(Date.now() + 5 * 60_000);
+    const scheduledRetryRunId = await insertScheduledRetryRun(companyId, agentId, pending);
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Pending scheduled-retry lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: scheduledRetryRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Should not steal" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body?.error).toBe("Issue run ownership conflict");
+
+    const row = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row?.executionRunId).toBe(scheduledRetryRunId);
+  });
+
+  it("adopts an overdue scheduled_retry execution lock on checkout when a new run takes over", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const overdue = new Date(Date.now() - SCHEDULED_RETRY_EXECUTION_LOCK_STALE_AFTER_MS - 60_000);
+    const scheduledRetryRunId = await insertScheduledRetryRun(companyId, agentId, overdue);
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Scheduled-retry lock reclaimed on checkout",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: scheduledRetryRunId,
+      executionRunId: scheduledRetryRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({
+        agentId,
+        expectedStatuses: ["todo", "backlog", "blocked", "in_review", "in_progress"],
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      status: "in_progress",
+      assigneeAgentId: agentId,
       checkoutRunId: currentRunId,
       executionRunId: currentRunId,
     });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -415,6 +415,42 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 }
 
 export const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
+
+// Grace window after a scheduled retry's due time before its held execution
+// lock is considered abandoned. A healthy promoter flips a due `scheduled_retry`
+// run to `queued` within seconds, so a holder still sitting in `scheduled_retry`
+// well past its due time has no live process to fire it and reclaim the lock.
+export const SCHEDULED_RETRY_EXECUTION_LOCK_STALE_AFTER_MS = 5 * 60 * 1000;
+
+// Dedicated execution-lock-staleness predicate (IRO-45 remediation B).
+//
+// A heartbeat run holds no real execution/checkout claim once it is terminal,
+// missing, OR parked in `scheduled_retry` past its due grace window with no live
+// process to fire it. The `scheduled_retry` case is the livelock: when a
+// transient retry is scheduled the lock is handed to the new `scheduled_retry`
+// run atomically so it can reclaim on fire, but if that retry never fires
+// (promoter died, the holder was orphaned, double-execution) the lock stays
+// permanently unreclaimable because `scheduled_retry` is not a TERMINAL status.
+//
+// We deliberately keep this separate from TERMINAL_HEARTBEAT_RUN_STATUSES, which
+// is reused for cancellation/promotion semantics that must NOT treat a
+// scheduled_retry run as terminal.
+export function isStaleExecutionLockHeartbeatRun(
+  run: { status: string; scheduledRetryAt: Date | string | null } | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!run) return true;
+  if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+  if (run.status === "scheduled_retry") {
+    // No recorded due time → the retry can never fire to reclaim its own lock.
+    if (!run.scheduledRetryAt) return true;
+    const dueAt = new Date(run.scheduledRetryAt).getTime();
+    if (Number.isNaN(dueAt)) return true;
+    return now.getTime() - dueAt >= SCHEDULED_RETRY_EXECUTION_LOCK_STALE_AFTER_MS;
+  }
+  return false;
+}
+
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
 
@@ -3829,14 +3865,16 @@ export function issueService(db: Db) {
     );
   }
 
-  async function isTerminalOrMissingHeartbeatRun(runId: string, dbOrTx: DbReader = db) {
+  // Resolves whether the run holding an execution/checkout lock is stale: terminal,
+  // missing, or an abandoned `scheduled_retry` holder (see
+  // isStaleExecutionLockHeartbeatRun / IRO-45 remediation B).
+  async function isStaleExecutionLockRun(runId: string, dbOrTx: DbReader = db) {
     const run = await dbOrTx
-      .select({ status: heartbeatRuns.status })
+      .select({ status: heartbeatRuns.status, scheduledRetryAt: heartbeatRuns.scheduledRetryAt })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
-    if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    return isStaleExecutionLockHeartbeatRun(run);
   }
 
   async function adoptStaleCheckoutRun(input: {
@@ -3880,7 +3918,7 @@ export function issueService(db: Db) {
       ]);
       const [existingRun, actorRun] = await Promise.all([
         tx
-          .select({ status: heartbeatRuns.status })
+          .select({ status: heartbeatRuns.status, scheduledRetryAt: heartbeatRuns.scheduledRetryAt })
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, input.expectedCheckoutRunId))
           .then((rows) => rows[0] ?? null),
@@ -3890,7 +3928,7 @@ export function issueService(db: Db) {
           .where(eq(heartbeatRuns.id, input.actorRunId))
           .then((rows) => rows[0] ?? null),
       ]);
-      const stale = !existingRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(existingRun.status);
+      const stale = isStaleExecutionLockHeartbeatRun(existingRun);
       const actorLive = actorRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status);
       if (!stale || !actorLive) {
         return { adopted: null, latest: lockedIssue };
@@ -4003,11 +4041,11 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select({ status: heartbeatRuns.status, scheduledRetryAt: heartbeatRuns.scheduledRetryAt })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.executionRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (run && !isStaleExecutionLockHeartbeatRun(run)) return false;
 
       const updated = await tx
         .update(issues)
@@ -4051,22 +4089,22 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.checkoutRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select({ status: heartbeatRuns.status, scheduledRetryAt: heartbeatRuns.scheduledRetryAt })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.checkoutRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (run && !isStaleExecutionLockHeartbeatRun(run)) return false;
 
       if (issue.executionRunId && issue.executionRunId !== issue.checkoutRunId) {
         await tx.execute(
           sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
         );
         const executionRun = await tx
-          .select({ status: heartbeatRuns.status })
+          .select({ status: heartbeatRuns.status, scheduledRetryAt: heartbeatRuns.scheduledRetryAt })
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, issue.executionRunId))
           .then((rows) => rows[0] ?? null);
-        if (executionRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)) return false;
+        if (executionRun && !isStaleExecutionLockHeartbeatRun(executionRun)) return false;
       }
 
       const updated = await tx
@@ -5671,7 +5709,7 @@ export function issueService(db: Db) {
         current.executionRunId !== checkoutRunId &&
         (current.assigneeAgentId === agentId || current.assigneeAgentId == null)
       ) {
-        const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
+        const stale = await isStaleExecutionLockRun(current.executionRunId);
         if (stale) {
           const now = new Date();
           const adoptionSet: Record<string, unknown> = {
@@ -5893,7 +5931,7 @@ export function issueService(db: Db) {
           existing.checkoutRunId &&
           !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
         ) {
-          const stale = await isTerminalOrMissingHeartbeatRun(existing.checkoutRunId, tx);
+          const stale = await isStaleExecutionLockRun(existing.checkoutRunId, tx);
           if (!stale) {
             throw conflict("Only checkout run can release issue", {
               issueId: existing.id,


### PR DESCRIPTION
## Summary

Fixes the IRO-45 execution-lock livelock: stale-execution-lock recovery only adopted a held lock when the holder run was **terminal** (`TERMINAL_HEARTBEAT_RUN_STATUSES` = succeeded/failed/cancelled/timed_out). A holder parked in **`scheduled_retry`** is never terminal, so once a transient retry stopped firing (dead promoter, orphaned holder, double-execution) the execution lock became permanently unreclaimable. This reproduced as concurrent double-execution + duplicate child-task sets on 2026-06-22.

This is **remediation B** of the board-authorized IRO-45 fix (decision accepted 2026-06-20).

## Changes

1. **Dedicated execution-lock-staleness predicate** — new `isStaleExecutionLockHeartbeatRun(run, now?)` in `server/src/services/issues.ts`. It treats a `scheduled_retry` holder with **no live heartbeat** (overdue past a 5-minute grace window, or with no recorded `scheduledRetryAt`) as a stale, adoptable lock. We deliberately **do not** add `scheduled_retry` to `TERMINAL_HEARTBEAT_RUN_STATUSES` — that set is reused for cancellation/promotion semantics that must not see a scheduled retry as terminal (as the issue required).
2. **Applied consistently** across every lock-staleness check: the checkout/PATCH execution-lock adoption path (`isTerminalOrMissingHeartbeatRun` → renamed `isStaleExecutionLockRun`, now also selects `scheduledRetryAt`), the `release` checkout-lock check, `adoptStaleCheckoutRun`, and the `clearExecutionRunIfTerminal` / `clearCheckoutRunIfTerminal` self-heal helpers.
3. **Grace window preserves the atomic handoff.** A still-pending retry keeps owning the lock it must reclaim, so a healthy retry is never robbed. The atomic `executionRunId` handoff on retry scheduling already exists in `heartbeat.ts` (commit 09d067884, applied across the missing-comment / process-loss / transient + max-turn-continuation paths) — verified present; **requirement 2 needed no code change**, and the new "does NOT steal a pending lock" test pins that guarantee.

## Tests

`server/src/__tests__/issue-stale-execution-lock-routes.test.ts` (alongside the existing failed/timed_out coverage):
- pure predicate cases — terminal / missing / overdue scheduled_retry / no-due → stale; running / queued / pending / just-due (grace) → not stale;
- PATCH recovers an overdue `scheduled_retry` execution lock that never fired;
- PATCH still returns **409** on a not-yet-due `scheduled_retry` holder (no lock theft);
- checkout adopts an overdue `scheduled_retry` execution lock for a new run.

**All 11 tests in the suite pass** (2 predicate + 5 pre-existing + 3 new + 1 existing checkout self-heal), embedded Postgres on. `tsc --noEmit` clean for the touched files.

## Follow-up (out of scope)

The 2026-06-22 repro also noted a "self-created child issues not writable by their creating run" authorization-boundary gap — not addressed here; recommend a separate issue.

Tracking: IronSec IRO-134 / IRO-45 remediation B.