### PR TITLE
fix(heartbeat): suppress scheduled retries on blocked issues (NOV-1623)

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -516,7 +516,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
       expect(scheduled).toMatchObject({
         outcome: "not_scheduled",
-        errorCode: "issue_not_in_progress",
+        errorCode: issueStatus === "blocked" ? "issue_blocked" : "issue_not_in_progress",
         issueId,
       });
 
@@ -563,7 +563,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         .then((rows) => rows[0] ?? null);
       expect(retryRun).toMatchObject({
         status: "cancelled",
-        errorCode: "issue_not_in_progress",
+        errorCode: issueStatus === "blocked" ? "issue_blocked" : "issue_not_in_progress",
       });
 
       const wakeupRequest = await db
@@ -597,12 +597,20 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         .where(eq(heartbeatRunEvents.runId, scheduled.run.id))
         .orderBy(sql`${heartbeatRunEvents.seq} desc`)
         .then((rows) => rows[0] ?? null);
-      expect(event?.message).toContain("no longer in_progress");
-      expect(event?.payload).toMatchObject({
-        currentStatus: issueStatus,
-        requiredStatus: "in_progress",
-        scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
-      });
+      if (issueStatus === "blocked") {
+        expect(event?.message).toContain("is blocked");
+        expect(event?.payload).toMatchObject({
+          currentStatus: issueStatus,
+          scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+        });
+      } else {
+        expect(event?.message).toContain("no longer in_progress");
+        expect(event?.payload).toMatchObject({
+          currentStatus: issueStatus,
+          requiredStatus: "in_progress",
+          scheduledRetryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
+        });
+      }
     },
   );
 
@@ -1189,6 +1197,105 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(oldRetry).toEqual({
       status: "cancelled",
       errorCode: "issue_cancelled",
+    });
+
+    const issue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.executionRunId).toBeNull();
+  });
+
+  it("does not promote a scheduled retry after the issue is blocked", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const sourceRunId = randomUUID();
+    const now = new Date("2026-04-20T15:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      error: "upstream overload",
+      errorCode: "adapter_failed",
+      finishedAt: now,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Retry promotion blocked",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: sourceRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: now,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-4`,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    await db.update(issues).set({
+      status: "blocked",
+      updatedAt: now,
+    }).where(eq(issues.id, issueId));
+
+    const promotion = await heartbeat.promoteDueScheduledRetries(scheduled.dueAt);
+    expect(promotion).toEqual({ promoted: 0, runIds: [] });
+
+    const oldRetry = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, scheduled.run.id))
+      .then((rows) => rows[0] ?? null);
+    expect(oldRetry).toEqual({
+      status: "cancelled",
+      errorCode: "issue_blocked",
     });
 
     const issue = await db

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6015,6 +6015,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_not_found"
           | "issue_reassigned"
           | "issue_cancelled"
+          | "issue_blocked"
           | "issue_terminal_status"
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
@@ -6108,11 +6109,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (issue.status === "cancelled" || issue.status === "done") {
+    if (issue.status === "cancelled" || issue.status === "done" || issue.status === "blocked") {
       return {
         allowed: false,
-        reason: `Scheduled retry suppressed because issue reached terminal status (${issue.status})`,
-        errorCode: issue.status === "cancelled" ? "issue_cancelled" : "issue_terminal_status",
+        reason:
+          issue.status === "blocked"
+            ? "Scheduled retry suppressed because the target issue is blocked"
+            : `Scheduled retry suppressed because issue reached terminal status (${issue.status})`,
+        errorCode:
+          issue.status === "cancelled"
+            ? "issue_cancelled"
+            : issue.status === "blocked"
+            ? "issue_blocked"
+            : "issue_terminal_status",
         issueId,
         details: { issueId, currentStatus: issue.status },
       };
@@ -6530,6 +6539,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             | "issue_not_found"
             | "issue_reassigned"
             | "issue_cancelled"
+            | "issue_blocked"
             | "issue_terminal_status"
             | "issue_not_in_progress"
             | "issue_execution_lock_changed";


### PR DESCRIPTION
Fixes NOV-1623 — Suppress scheduled retries on blocked issues to prevent heartbeat loop.

## Thinking Path
We want to prevent agent heartbeat loops when target issues are blocked.
We achieve this by validating issue status in evaluateScheduledRetryGate and returning issue_blocked errorCode, which cancels the scheduled retry.

## What Changed
- Added issue_blocked to ScheduledRetryGate and ScheduledRetryTransactionResult types.
- Evaluated status 'blocked' in evaluateScheduledRetryGate to suppress retries.
- Updated tests to cover this scenario.

## Verification
- Ran vitest on server/src/__tests__/heartbeat-retry-scheduling.test.ts. All tests passed.