### PR TITLE
Prevent heartbeat churn on pending interaction gates

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -10,6 +10,7 @@ import {
   createDb,
   heartbeatRuns,
   issueComments,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -1169,6 +1170,126 @@ describe("heartbeat comment wake batching", () => {
         retryReason: "missing_issue_comment",
         modelProfile: "cheap",
       });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 20_000);
+
+  it("does not queue a missing-comment follow-up when a pending interaction owns assignee continuation", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Await board gate",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      await db.insert(issueThreadInteractions).values({
+        companyId,
+        issueId,
+        kind: "ask_user_questions",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        title: "Need board answer",
+        payload: {
+          questions: [
+            {
+              id: "scope",
+              header: "Scope",
+              question: "Which scope should continue?",
+              options: [
+                { label: "Narrow", description: "Continue the narrow implementation." },
+                { label: "Broad", description: "Expand the implementation." },
+              ],
+            },
+          ],
+        },
+      });
+
+      const run = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(run).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const rows = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId));
+        return rows.length === 1 && rows[0]?.status === "succeeded";
+      });
+
+      const [completedRun] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+      expect(completedRun?.issueCommentStatus).toBe("not_applicable");
+
+      const wakeups = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)));
+      expect(wakeups.some((wakeup) => wakeup.reason === "missing_issue_comment")).toBe(false);
+
+      const comments = await db
+        .select()
+        .from(issueComments)
+        .where(eq(issueComments.issueId, issueId));
+      expect(comments).toHaveLength(0);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -412,7 +412,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(escalations).toHaveLength(0);
   });
 
-  it("does not treat non-continuation pending interactions as scheduled liveness waiting paths", async () => {
+  it("treats non-continuation pending interactions as review liveness waiting paths", async () => {
     await enableAutoRecovery();
     const { companyId, blockerIssueId } = await seedBlockedChain({
       blockerStatus: "in_review",
@@ -443,8 +443,14 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
 
     const result = await heartbeatService(db).reconcileIssueGraphLiveness();
 
-    expect(result.findings).toBe(1);
-    expect(result.escalationsCreated).toBe(1);
+    expect(result.findings).toBe(0);
+    expect(result.escalationsCreated).toBe(0);
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(0);
   });
 
   it("keeps active invalid_review_participant recoveries from being retired", async () => {

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -12,6 +12,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueRelations,
+  issueThreadInteractions,
   issueTreeHolds,
   issues,
   projects,
@@ -368,6 +369,82 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
     expect(escalations).toHaveLength(1);
+  });
+
+  it("treats pending assignee-continuation interactions as scheduled liveness waiting paths", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockerIssueId } = await seedBlockedChain({
+      blockerStatus: "in_review",
+      blockerAssigneeAgentId: "coder",
+    });
+
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId: blockerIssueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Need board input",
+      payload: {
+        questions: [
+          {
+            id: "decision",
+            header: "Decision",
+            question: "What should happen next?",
+            options: [
+              { label: "Continue", description: "Resume the assignee after the answer." },
+              { label: "Stop", description: "Do not continue this path." },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.findings).toBe(0);
+    expect(result.escalationsCreated).toBe(0);
+
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(0);
+  });
+
+  it("does not treat non-continuation pending interactions as scheduled liveness waiting paths", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockerIssueId } = await seedBlockedChain({
+      blockerStatus: "in_review",
+      blockerAssigneeAgentId: "coder",
+    });
+
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId: blockerIssueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Informational question",
+      payload: {
+        questions: [
+          {
+            id: "decision",
+            header: "Decision",
+            question: "What should happen next?",
+            options: [
+              { label: "Continue", description: "Resume manually if needed." },
+              { label: "Stop", description: "Do not continue this path." },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+    expect(result.findings).toBe(1);
+    expect(result.escalationsCreated).toBe(1);
   });
 
   it("keeps active invalid_review_participant recoveries from being retired", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4792,6 +4792,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
   }
 
+  async function hasPendingAssigneeContinuationInteraction(companyId: string, issueId: string) {
+    return db
+      .select({ id: issueThreadInteractions.id })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, companyId),
+          eq(issueThreadInteractions.issueId, issueId),
+          eq(issueThreadInteractions.status, "pending"),
+          inArray(issueThreadInteractions.continuationPolicy, [
+            "wake_assignee",
+            "wake_assignee_on_accept",
+          ]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeIssueCommentPolicy(
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
@@ -4841,6 +4860,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           issueCommentRetryQueuedAt: null,
         });
       }
+      return { outcome: "not_applicable" as const, queuedRun: null };
+    }
+
+    const pendingContinuationInteraction = await hasPendingAssigneeContinuationInteraction(run.companyId, issueId);
+    if (pendingContinuationInteraction) {
+      await patchRunIssueCommentStatus(run.id, {
+        issueCommentStatus: "not_applicable",
+        issueCommentSatisfiedByCommentId: null,
+        issueCommentRetryQueuedAt: null,
+      });
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Run ended without an issue comment; pending issue interaction owns the next wake",
+        payload: {
+          interactionId: pendingContinuationInteraction.id,
+        },
+      });
       return { outcome: "not_applicable" as const, queuedRun: null };
     }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2839,10 +2839,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .where(
           and(
             eq(issueThreadInteractions.status, "pending"),
-            inArray(issueThreadInteractions.continuationPolicy, [
-              "wake_assignee",
-              "wake_assignee_on_accept",
-            ]),
           ),
         ),
       db

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2836,7 +2836,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           status: issueThreadInteractions.status,
         })
         .from(issueThreadInteractions)
-        .where(eq(issueThreadInteractions.status, "pending")),
+        .where(
+          and(
+            eq(issueThreadInteractions.status, "pending"),
+            inArray(issueThreadInteractions.continuationPolicy, [
+              "wake_assignee",
+              "wake_assignee_on_accept",
+            ]),
+          ),
+        ),
       db
         .select({
           companyId: issueApprovals.companyId,


### PR DESCRIPTION
## Summary
- suppress missing-comment follow-up wakes when a pending issue-thread interaction with assignee continuation already owns the next action
- restrict scheduled graph-liveness pending interaction waiting paths to wake-capable continuation policies
- add regression coverage for pending gate suppression and non-continuation interaction escalation

## Verification
- pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts
- pnpm exec vitest run server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts --no-file-parallelism --maxWorkers=1 --minWorkers=1
- pnpm --filter @paperclipai/server typecheck

## Source of Truth
- VEN-1201 / VEN-1200 issue requirements and CTO routing comment
