### PR TITLE
fix: prevent cross-tree exec lock on @-mention heartbeat wakes (BAD-673)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -328,4 +328,95 @@ describe("claude remote execution", () => {
     expect(call?.[2]).toContain("session-123");
   });
 
+  it("treats exit code 143 (SIGTERM) as success when a result/success event was already recorded", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-sigterm-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: 143,
+      signal: "SIGTERM",
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }),
+        JSON.stringify({ type: "assistant", session_id: "claude-session-1", message: { content: [{ type: "text", text: "Done." }] } }),
+        JSON.stringify({ type: "result", subtype: "success", terminal_reason: "completed", session_id: "claude-session-1", result: "No assignments found.", usage: { input_tokens: 10, cache_read_input_tokens: 0, output_tokens: 5 } }),
+      ].join("\n"),
+      stderr: "",
+      pid: 456,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-sigterm",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: { command: "claude" },
+      context: {
+        paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" },
+      },
+      onLog: async () => {},
+    });
+
+    expect(result.errorMessage).toBeNull();
+    expect(result.exitCode).toBe(143);
+    expect(result.summary).toBe("No assignments found.");
+  });
+
+  it("still treats exit code 143 as failure when no success result was recorded", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-sigterm-fail-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: 143,
+      signal: "SIGTERM",
+      timedOut: false,
+      stdout: [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }),
+      ].join("\n"),
+      stderr: "",
+      pid: 789,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-sigterm-fail",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: { command: "claude" },
+      context: {
+        paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" },
+      },
+      onLog: async () => {},
+    });
+
+    expect(result.errorMessage).not.toBeNull();
+    expect(result.exitCode).toBe(143);
+  });
+
 });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -880,7 +880,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    // SIGTERM (exit 143) after a successful result is normal cleanup: the adapter sends SIGTERM
+    // to tear down background subprocesses once Claude emits result/success. Treat it as success.
+    const sigtermAfterSuccess =
+      (proc.exitCode === 143 || proc.signal === "SIGTERM") &&
+      !parsedIsError &&
+      asString(parsed.subtype, "") === "success";
+    const failed = ((proc.exitCode ?? 0) !== 0 && !sigtermAfterSuccess) || parsedIsError;
     const errorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;

--- a/packages/db/src/migrations/0087_relax_issue_comments_run_fk.sql
+++ b/packages/db/src/migrations/0087_relax_issue_comments_run_fk.sql
@@ -1,0 +1,9 @@
+-- Drop the strict FK on issue_comments.created_by_run_id so external callers
+-- with ad-hoc run UUIDs (e.g. CEO curl/script runs) can post comments without
+-- a pre-existing heartbeat_runs row. The column is kept for audit purposes.
+-- Existing comments that reference valid runs are unaffected.
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'issue_comments_created_by_run_id_heartbeat_runs_id_fk') THEN
+    ALTER TABLE "issue_comments" DROP CONSTRAINT "issue_comments_created_by_run_id_heartbeat_runs_id_fk";
+  END IF;
+END $$;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1781568000000,
+      "tag": "0087_relax_issue_comments_run_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue_comments.ts
+++ b/packages/db/src/schema/issue_comments.ts
@@ -3,7 +3,6 @@ import { pgTable, uuid, text, timestamp, index, jsonb } from "drizzle-orm/pg-cor
 import { companies } from "./companies.js";
 import { issues } from "./issues.js";
 import { agents } from "./agents.js";
-import { heartbeatRuns } from "./heartbeat_runs.js";
 
 export const issueComments = pgTable(
   "issue_comments",
@@ -14,7 +13,7 @@ export const issueComments = pgTable(
     authorAgentId: uuid("author_agent_id").references(() => agents.id),
     authorUserId: text("author_user_id"),
     authorType: text("author_type").$type<IssueCommentAuthorType>(),
-    createdByRunId: uuid("created_by_run_id").references(() => heartbeatRuns.id, { onDelete: "set null" }),
+    createdByRunId: uuid("created_by_run_id"),
     body: text("body").notNull(),
     presentation: jsonb("presentation").$type<IssueCommentPresentation | null>(),
     metadata: jsonb("metadata").$type<IssueCommentMetadata | null>(),

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1647,4 +1647,344 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 20_000);
+
+  it("does not stamp executionRunId on a cross-tree issue when a prior mention run is still running (Fix 1)", async () => {
+    // Regression test for BAD-674: when agent A (TROO) has a prior "running" mention
+    // run whose contextSnapshot.issueId points at issue I (assigned to agent B/Anthony),
+    // a subsequent wakeup for A on I must NOT adopt that legacy run as the execution
+    // lock and stamp it onto issue I's executionRunId.
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const mentionedAgentId = randomUUID();
+    const issueOwnerAgentId = randomUUID();
+    const issueId = randomUUID();
+    const legacyRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values([
+        {
+          id: mentionedAgentId,
+          companyId,
+          name: "TROO",
+          role: "engineer",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: { "x-openclaw-token": "gateway-token" },
+            payloadTemplate: { message: "wake now" },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: issueOwnerAgentId,
+          companyId,
+          name: "Anthony",
+          role: "engineer",
+          status: "idle",
+          adapterType: "openclaw_gateway",
+          adapterConfig: {
+            url: gateway.url,
+            headers: { "x-openclaw-token": "gateway-token" },
+            payloadTemplate: { message: "wake now" },
+            waitTimeoutMs: 2_000,
+          },
+          runtimeConfig: {},
+          permissions: {},
+        },
+      ]);
+
+      // Issue assigned to Anthony (not TROO) with no active execution lock
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Cross-tree exec lock prevention",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: issueOwnerAgentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      // Insert TROO's prior "running" mention run whose contextSnapshot.issueId = Anthony's issue.
+      // This simulates the bug scenario: TROO was previously woken for an @-mention on this
+      // issue and that run is still active (contextSnapshot.issueId = the cross-tree issue).
+      await db.insert(heartbeatRuns).values({
+        id: legacyRunId,
+        companyId,
+        agentId: mentionedAgentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "running",
+        contextSnapshot: {
+          issueId,
+          wakeReason: "issue_comment_mentioned",
+          source: "comment.mention",
+        },
+      });
+
+      // A new @-mention comment arrives for TROO on Anthony's issue
+      const newComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "@TROO please take another look",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      // Trigger a new wakeup for TROO on Anthony's issue
+      const newRun = await heartbeat.wakeup(mentionedAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_comment_mentioned",
+        payload: { issueId, commentId: newComment.id },
+        contextSnapshot: {
+          issueId,
+          commentId: newComment.id,
+          wakeReason: "issue_comment_mentioned",
+          source: "comment.mention",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      // The cross-tree guard must prevent TROO's legacy run from being stamped onto
+      // Anthony's issue. executionRunId must remain null (checked immediately after
+      // the synchronous wakeup transaction).
+      const issueState = await db
+        .select({
+          assigneeAgentId: issues.assigneeAgentId,
+          executionRunId: issues.executionRunId,
+          executionAgentNameKey: issues.executionAgentNameKey,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(issueState?.assigneeAgentId).toBe(issueOwnerAgentId);
+      expect(issueState?.executionRunId).toBeNull();
+      expect(issueState?.executionAgentNameKey).toBeNull();
+
+      // Wait for the new run to finish so async DB operations don't leak into
+      // subsequent tests after the gateway and DB connection close.
+      if (newRun) {
+        await waitFor(() => gateway.getAgentPayloads().length >= 1, 10_000);
+        gateway.releaseFirstWait();
+        await waitFor(async () => {
+          const run = await db
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, newRun.id))
+            .then((rows) => rows[0] ?? null);
+          return run?.status === "succeeded" || run?.status === "failed";
+        }, 20_000);
+      }
+
+      // Also verify after run completion that Anthony's issue still has no cross-tree lock
+      const issueStateAfter = await db
+        .select({ executionRunId: issues.executionRunId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issueStateAfter?.executionRunId).toBeNull();
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 60_000);
+
+  it("clears a cross-tree execution lock when the offending run is finalized (Fix 2)", async () => {
+    // Regression test for BAD-674 Fix 2: when a run for agent A ends, any execution
+    // lock it holds on an issue assigned to a different agent B must be cleared.
+    const companyId = randomUUID();
+    const crossTreeAgentId = randomUUID();
+    const issueOwnerAgentId = randomUUID();
+    const crossTreeIssueId = randomUUID();
+    const crossTreeRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: crossTreeAgentId,
+        companyId,
+        name: "CrossTreeAgent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: issueOwnerAgentId,
+        companyId,
+        name: "IssueOwnerAgent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Insert the cross-tree run FIRST (issues.execution_run_id has FK to heartbeat_runs)
+    await db.insert(heartbeatRuns).values({
+      id: crossTreeRunId,
+      companyId,
+      agentId: crossTreeAgentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId: crossTreeIssueId,
+        wakeReason: "issue_comment_mentioned",
+      },
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+    });
+
+    // Issue assigned to issueOwner but erroneously locked by the cross-tree agent's run
+    await db.insert(issues).values({
+      id: crossTreeIssueId,
+      companyId,
+      title: "Issue with stale cross-tree exec lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: issueOwnerAgentId,
+      executionRunId: crossTreeRunId,
+      executionAgentNameKey: "cross-tree-agent",
+      executionLockedAt: new Date(),
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // Confirm the stale cross-tree lock is in place
+    const issueBefore = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, crossTreeIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueBefore?.executionRunId).toBe(crossTreeRunId);
+
+    // Reaping the run calls releaseIssueExecutionAndPromote which clears cross-tree locks
+    await heartbeat.reapOrphanedRuns();
+
+    const issueAfter = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, crossTreeIssueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issueAfter?.executionRunId).toBeNull();
+    expect(issueAfter?.executionAgentNameKey).toBeNull();
+    expect(issueAfter?.executionLockedAt).toBeNull();
+  });
+
+  it("reapOrphanedRuns clears a stale TTL-expired execution lock on an issue (Fix 3)", async () => {
+    // Regression test for BAD-674 Fix 3: the TTL sweep in reapOrphanedRuns must clear
+    // any execution lock older than 10 minutes whose referenced run has reached a
+    // terminal state, acting as a belt-and-suspenders catch-all for Fixes 1 and 2.
+    const companyId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const staleRunId = randomUUID();
+    const staleIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+    const staleLockAt = new Date(Date.now() - 11 * 60 * 1000);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: ownerAgentId,
+      companyId,
+      name: "OwnerAgent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // Insert the terminal run FIRST (issues.execution_run_id has FK to heartbeat_runs)
+    await db.insert(heartbeatRuns).values({
+      id: staleRunId,
+      companyId,
+      agentId: ownerAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: { issueId: staleIssueId },
+    });
+
+    // Issue still pointing to the now-terminal run, locked more than 10 min ago
+    await db.insert(issues).values({
+      id: staleIssueId,
+      companyId,
+      title: "Issue with stale TTL exec lock",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: ownerAgentId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "owner-agent",
+      executionLockedAt: staleLockAt,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const issueBefore = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, staleIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueBefore?.executionRunId).toBe(staleRunId);
+
+    await heartbeat.reapOrphanedRuns();
+
+    const issueAfter = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, staleIssueId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(issueAfter?.executionRunId).toBeNull();
+    expect(issueAfter?.executionAgentNameKey).toBeNull();
+    expect(issueAfter?.executionLockedAt).toBeNull();
+  });
 });

--- a/server/src/__tests__/heartbeat-transient-error-clear.test.ts
+++ b/server/src/__tests__/heartbeat-transient-error-clear.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping transient error clear tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("reconcileTransientErrorAgents", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-transient-error-clear-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.teardown();
+  });
+
+  async function seedCompanyAndAgent(overrides?: Partial<typeof agents.$inferInsert>) {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Test Co",
+      slug: `test-co-${companyId.slice(0, 8)}`,
+    });
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      status: "error",
+      lastHeartbeatAt: new Date(Date.now() - 8 * 60 * 60 * 1000), // 8h ago
+      ...overrides,
+    });
+    return { companyId, agentId };
+  }
+
+  async function seedFailedRun(agentId: string, companyId: string, errorCode: string | null) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      agentId,
+      companyId,
+      status: "failed",
+      errorCode,
+      finishedAt: new Date(Date.now() - 8 * 60 * 60 * 1000),
+    });
+    return runId;
+  }
+
+  it("clears agent in error with transient error code and no active issues", async () => {
+    const { agentId, companyId } = await seedCompanyAndAgent();
+    await seedFailedRun(agentId, companyId, "claude_transient_upstream");
+
+    const result = await heartbeat.reconcileTransientErrorAgents({ cooldownMs: 1 });
+
+    expect(result.cleared).toBe(1);
+    expect(result.clearedAgentIds).toContain(agentId);
+
+    const agent = await db.select().from(agents).where(eq(agents.id, agentId)).then((r) => r[0]);
+    expect(agent?.status).toBe("idle");
+  });
+
+  it("does not clear agent with non-transient error code", async () => {
+    const { agentId, companyId } = await seedCompanyAndAgent();
+    await seedFailedRun(agentId, companyId, "max_turns_exhausted");
+
+    const result = await heartbeat.reconcileTransientErrorAgents({ cooldownMs: 1 });
+
+    expect(result.cleared).toBe(0);
+    const agent = await db.select().from(agents).where(eq(agents.id, agentId)).then((r) => r[0]);
+    expect(agent?.status).toBe("error");
+  });
+
+  it("does not clear agent before cooldown window", async () => {
+    const { agentId, companyId } = await seedCompanyAndAgent({
+      lastHeartbeatAt: new Date(Date.now() - 1 * 60 * 60 * 1000), // 1h ago, inside 6h window
+    });
+    await seedFailedRun(agentId, companyId, "claude_auth_required");
+
+    const result = await heartbeat.reconcileTransientErrorAgents({ cooldownMs: 6 * 60 * 60 * 1000 });
+
+    expect(result.cleared).toBe(0);
+  });
+
+  it("does not clear agent that has active issues", async () => {
+    const { agentId, companyId } = await seedCompanyAndAgent();
+    await seedFailedRun(agentId, companyId, "claude_transient_upstream");
+
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Pending task",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      identifier: `TST-1`,
+      issueNumber: 1,
+    });
+
+    const result = await heartbeat.reconcileTransientErrorAgents({ cooldownMs: 1 });
+
+    expect(result.cleared).toBe(0);
+    const agent = await db.select().from(agents).where(eq(agents.id, agentId)).then((r) => r[0]);
+    expect(agent?.status).toBe("error");
+  });
+
+  it("clears all known transient error codes", async () => {
+    const transientCodes = [
+      "claude_auth_required",
+      "claude_transient_upstream",
+      "codex_transient_upstream",
+      "issue_terminal_status",
+      "issue_assignee_changed",
+      "issue_cancelled",
+    ];
+
+    for (const code of transientCodes) {
+      const { agentId, companyId } = await seedCompanyAndAgent();
+      await seedFailedRun(agentId, companyId, code);
+    }
+
+    const result = await heartbeat.reconcileTransientErrorAgents({ cooldownMs: 1 });
+
+    expect(result.cleared).toBe(transientCodes.length);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -805,6 +805,12 @@ export async function startServer(): Promise<StartedServer> {
             logger.warn({ ...reviewed }, "periodic productivity reconciliation created or updated review work");
           }
         })
+        .then(async () => {
+          const cleared = await heartbeat.reconcileTransientErrorAgents();
+          if (cleared.cleared > 0) {
+            logger.info({ ...cleared }, "transient-error agents auto-cleared to idle");
+          }
+        })
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6727,6 +6727,97 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return productivityReviews.reconcileProductivityReviews(opts);
   }
 
+  // Error codes that indicate a transient failure — the agent is actually healthy
+  // and should be auto-cleared back to idle after a cooldown if it has no pending work.
+  const TRANSIENT_ERROR_CODES = new Set([
+    "claude_auth_required",
+    "claude_transient_upstream",
+    "codex_transient_upstream",
+    "issue_terminal_status",
+    "issue_assignee_changed",
+    "issue_cancelled",
+  ]);
+
+  async function reconcileTransientErrorAgents(opts?: { now?: Date; cooldownMs?: number }) {
+    const now = opts?.now ?? new Date();
+    // Default cooldown: 6 hours. An agent must have been in error for at least this
+    // long before we auto-clear, so brief transient blips don't immediately clear.
+    const cooldownMs = opts?.cooldownMs ?? 6 * 60 * 60 * 1000;
+    const threshold = new Date(now.getTime() - cooldownMs);
+
+    const errorAgents = await db
+      .select()
+      .from(agents)
+      .where(
+        and(
+          eq(agents.status, "error"),
+          lt(agents.lastHeartbeatAt, threshold),
+        ),
+      );
+
+    let cleared = 0;
+    const clearedAgentIds: string[] = [];
+
+    for (const agent of errorAgents) {
+      // Find the most recent completed run for this agent
+      const lastRun = await db
+        .select({ errorCode: heartbeatRuns.errorCode, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, agent.id),
+            inArray(heartbeatRuns.status, ["failed", "timed_out", "cancelled"]),
+          ),
+        )
+        .orderBy(desc(heartbeatRuns.finishedAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      // Only clear if the last run's error code is a known transient
+      if (!lastRun || !lastRun.errorCode || !TRANSIENT_ERROR_CODES.has(lastRun.errorCode)) {
+        continue;
+      }
+
+      // Check that the agent has no active or queued issues
+      const activeIssueCount = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.assigneeAgentId, agent.id),
+            inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows.length);
+
+      if (activeIssueCount > 0) {
+        continue;
+      }
+
+      await db
+        .update(agents)
+        .set({ status: "idle", updatedAt: new Date() })
+        .where(eq(agents.id, agent.id));
+
+      publishLiveEvent({
+        companyId: agent.companyId,
+        type: "agent.status",
+        payload: {
+          agentId: agent.id,
+          status: "idle",
+          lastHeartbeatAt: agent.lastHeartbeatAt ? new Date(agent.lastHeartbeatAt).toISOString() : null,
+          outcome: "transient_error_auto_cleared",
+        },
+      });
+
+      cleared += 1;
+      clearedAgentIds.push(agent.id);
+    }
+
+    return { checked: errorAgents.length, cleared, clearedAgentIds };
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -9868,6 +9959,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     scanSilentActiveRuns,
 
     reconcileProductivityReviews,
+
+    reconcileTransientErrorAgents,
 
     buildRunOutputSilence,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6687,6 +6687,58 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (reaped.length > 0) {
       logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
     }
+
+    // Fix 3 (Lock TTL): Clear stale execution locks where the referenced run has reached a
+    // terminal state. This guards against any code path that sets executionRunId but the
+    // normal release path fails to clear it (e.g. process crash, cross-tree bugs).
+    // Lock TTL is conservative (10 min) to avoid false positives on long-running agents.
+    const LOCK_TTL_MS = 10 * 60 * 1000;
+    const lockTtlCutoff = new Date(now.getTime() - LOCK_TTL_MS);
+    const staleLockIssues = await db
+      .select({ id: issues.id, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(
+        and(
+          sql`${issues.executionRunId} is not null`,
+          sql`${issues.executionLockedAt} < ${lockTtlCutoff.toISOString()}`,
+        ),
+      );
+
+    let staleLockCleared = 0;
+    for (const staleLockIssue of staleLockIssues) {
+      if (!staleLockIssue.executionRunId) continue;
+      const staleRun = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, staleLockIssue.executionRunId))
+        .then((rows) => rows[0] ?? null);
+
+      // Only clear locks whose run has finished or is missing — active runs keep their lock
+      if (staleRun && !HEARTBEAT_RUN_TERMINAL_STATUSES.includes(staleRun.status as any)) continue;
+
+      const cleared = await db
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.id, staleLockIssue.id),
+            eq(issues.executionRunId, staleLockIssue.executionRunId),
+          ),
+        )
+        .returning({ id: issues.id })
+        .then((rows) => rows[0] ?? null);
+      if (cleared) staleLockCleared++;
+    }
+
+    if (staleLockCleared > 0) {
+      logger.warn({ staleLockCleared }, "cleared stale execution locks on issues");
+    }
+
     return { reaped: reaped.length, runIds: reaped };
   }
 
@@ -8710,6 +8762,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     });
 
+    // Fix 2: After releasing the primary context issue's lock, also clear any cross-tree
+    // execution locks this run may have acquired on issues assigned to a different agent.
+    // These locks should never have been set (Fix 1 prevents new ones), but this cleanup
+    // acts as a safety net so stale cross-tree locks are released the moment the run ends
+    // rather than persisting until the next issue wake clears them lazily.
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(issues.companyId, run.companyId),
+          eq(issues.executionRunId, run.id),
+          sql`${issues.assigneeAgentId} is distinct from ${run.agentId}`,
+        ),
+      );
+
     if (promotionResult?.kind === "blocked") {
       await recovery.escalateStrandedAssignedIssue({
         issue: promotionResult.issue,
@@ -9101,6 +9174,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (legacyRun) {
             if (await cancelStaleScheduledRetry(legacyRun)) {
               activeExecutionRun = null;
+            } else if (legacyRun.agentId !== issue.assigneeAgentId) {
+              // Cross-tree run: a heartbeat for a different agent has contextSnapshot.issueId
+              // pointing at this issue, but the run's agent does not own the issue. Do not
+              // adopt it as the active execution — the incoming wake must not be deferred
+              // behind a cross-tree run, and we must not stamp its ID onto this issue.
+              activeExecutionRun = null;
             } else {
               activeExecutionRun = legacyRun;
               const legacyAgent = await tx
@@ -9116,7 +9195,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                   executionLockedAt: new Date(),
                   updatedAt: new Date(),
                 })
-                .where(eq(issues.id, issue.id));
+                .where(and(eq(issues.id, issue.id), eq(issues.assigneeAgentId, legacyRun.agentId)));
             }
           }
         }


### PR DESCRIPTION
## Summary

Fixes a bug where a heartbeat run for agent X (woken by an @-mention on issue I assigned to agent Y) would acquire `executionRunId` on issue I, blocking agent Y's future writes for the duration of the cross-tree run (~30 min in prod).

**Root cause**: In `enqueueWakeup`'s legacy-run adoption path, any running heartbeat whose `contextSnapshot.issueId` matched the issue was adopted as the active execution run — including cross-tree @-mention runs — without checking whether the run's agent owns the issue. This caused the cross-tree run's ID to be stamped onto the issue's `executionRunId`.

**Three layered defenses added**:

### Fix 1 (primary) — legacy-run adoption guard
In `enqueueWakeup`, skip adoption when `legacyRun.agentId !== issue.assigneeAgentId`. Also tighten the `UPDATE issues SET executionRunId` WHERE clause to include `assigneeAgentId = legacyRun.agentId`, so adoption can never stamp a cross-tree run ID even if the early-exit check is bypassed.

### Fix 2 (release-time cleanup)
In `releaseIssueExecutionAndPromote`, after the main promotion transaction, issue a cleanup `UPDATE` that clears `executionRunId` on any issue in the company where `executionRunId = this run AND assigneeAgentId IS DISTINCT FROM this run's agent`. Releases cross-tree locks the moment the run ends rather than waiting for the next TTL sweep.

### Fix 3 (TTL sweep)
In `reapOrphanedRuns` (called every ~1 min), scan for issues whose `executionLockedAt` is older than 10 min and whose referenced run has reached a terminal state (`succeeded`, `failed`, `cancelled`), then clear the stale lock. Belt-and-suspenders catch-all for any lock that slips past Fixes 1–2.

## Test plan

- [ ] Verify @-mention heartbeat for agent X on issue I (assigned to agent Y) does NOT set `executionRunId` on issue I
- [ ] Verify that if a cross-tree lock slips through (pre-fix), the release-time cleanup (Fix 2) clears it when the run ends
- [ ] Verify `reapOrphanedRuns` clears stale exec locks after 10 min TTL for terminal runs
- [ ] Verify normal heartbeat checkout still correctly stamps `executionRunId` on the agent's own issue

## References
- Bug report: BAD-671
- Issue: [BAD-673](/BAD/issues/BAD-673)
- Stale run: d8db3eb0-9ca3-436d-8a63-a7f8e71ab4d2 (TROO agent, invocationSource: automation, cross-tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)