### PR TITLE
feat(dashboard): Daily Brief widget — decisions, executions, spend, blocked/stalled (CMP-162)

### DIFF
--- a/ui/src/components/DailyBriefWidget.tsx
+++ b/ui/src/components/DailyBriefWidget.tsx
@@ -1,0 +1,82 @@
+import type { DashboardSummary } from "@paperclipai/shared";
+import { Activity, AlertTriangle, ClipboardCheck, ReceiptText } from "lucide-react";
+import { MetricCard } from "./MetricCard";
+import { formatCents } from "../lib/utils";
+
+interface DailyBriefWidgetProps {
+  data: DashboardSummary;
+  stalledCount?: number;
+}
+
+export function DailyBriefWidget({ data, stalledCount = 0 }: DailyBriefWidgetProps) {
+  const decisions = data.pendingApprovals + data.budgets.pendingApprovals;
+  const blockedAndStalled = data.tasks.blocked + stalledCount;
+
+  return (
+    <div className="space-y-2.5">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        Daily Brief
+      </p>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <MetricCard
+          icon={ClipboardCheck}
+          value={decisions}
+          label="결정 필요"
+          to="/approvals"
+          description={
+            decisions > 0 ? (
+              <span className="text-amber-500 dark:text-amber-400">
+                {decisions} item{decisions === 1 ? "" : "s"} awaiting decision
+              </span>
+            ) : (
+              <span>No pending decisions</span>
+            )
+          }
+        />
+        <MetricCard
+          icon={Activity}
+          value={data.tasks.inProgress}
+          label="실행 중"
+          to="/issues"
+          description={
+            <span>
+              {data.tasks.open} open · {data.tasks.done} done
+            </span>
+          }
+        />
+        <MetricCard
+          icon={ReceiptText}
+          value={formatCents(data.costs.monthSpendCents)}
+          label="이번달 비용"
+          to="/costs"
+          description={
+            data.costs.monthBudgetCents > 0 ? (
+              <span>
+                {data.costs.monthUtilizationPercent}% /{" "}
+                {formatCents(data.costs.monthBudgetCents)} budget
+              </span>
+            ) : (
+              <span>무제한 예산</span>
+            )
+          }
+        />
+        <MetricCard
+          icon={AlertTriangle}
+          value={blockedAndStalled}
+          label="Blocked / Stalled"
+          to="/issues"
+          description={
+            blockedAndStalled > 0 ? (
+              <span className="text-amber-500 dark:text-amber-400">
+                {data.tasks.blocked} blocked
+                {stalledCount > 0 ? ` · ${stalledCount} stalled` : ""}
+              </span>
+            ) : (
+              <span>No blockers</span>
+            )
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { useDialogActions } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { MetricCard } from "../components/MetricCard";
+import { DailyBriefWidget } from "../components/DailyBriefWidget";
 import { EmptyState } from "../components/EmptyState";
 import { StatusIcon } from "../components/StatusIcon";
 
@@ -90,6 +91,16 @@ export function Dashboard() {
 
   const recentIssues = issues ? getRecentIssues(issues) : [];
   const recentActivity = useMemo(() => (activity ?? []).slice(0, 10), [activity]);
+
+  const stalledCount = useMemo(() => {
+    if (!issues) return 0;
+    return issues.filter(
+      (i) =>
+        i.status !== "blocked" &&
+        (i.blockerAttention?.state === "stalled" ||
+          i.blockerAttention?.state === "needs_attention"),
+    ).length;
+  }, [issues]);
 
   useEffect(() => {
     for (const timer of activityAnimationTimersRef.current) {
@@ -218,6 +229,8 @@ export function Dashboard() {
 
       {data && (
         <>
+          <DailyBriefWidget data={data} stalledCount={stalledCount} />
+
           {data.budgets.activeIncidents > 0 ? (
             <div className="flex items-start justify-between gap-3 rounded-xl border border-red-500/20 bg-[linear-gradient(180deg,rgba(255,80,80,0.12),rgba(255,255,255,0.02))] px-4 py-3">
               <div className="flex items-start gap-2.5">


### PR DESCRIPTION
## Summary

- Adds a `DailyBriefWidget` component (new file) that renders 4 `MetricCard` tiles at the top of the Executive Overview dashboard: **결정 필요** (pending decisions), **실행 중** (tasks in progress), **이번달 비용** (monthly spend), and **Blocked / Stalled** (blocked + stalled count).
- Updates `Dashboard.tsx` to import and render `DailyBriefWidget` as the first section inside the data-loaded block (above the existing budget incident banner and detailed metric grid).
- Computes `stalledCount` from the issues list (`blockerAttention.state === "stalled" | "needs_attention"`, excluding already-blocked issues) so blocked and stalled are reported separately in the card description.
- Blocked/Stalled and Decisions cards highlight with amber text when non-zero, making actionable states immediately visible.

## Files

- `ui/src/components/DailyBriefWidget.tsx` — new component, reuses `MetricCard`
- `ui/src/pages/Dashboard.tsx` — import + render widget; add `stalledCount` memo

## Test plan

- [ ] Load dashboard with active issues → verify 4 metric tiles appear above the existing grid
- [ ] With `tasks.blocked > 0` → Blocked / Stalled card description shows amber text
- [ ] With `pendingApprovals > 0` → Decisions card shows amber text
- [ ] With `monthBudgetCents > 0` → monthly spend card shows utilization %
- [ ] With zero budget → shows "무제한 예산"
- [ ] Click each tile → navigates to correct route (/approvals, /issues, /costs)
- [ ] `stalledCount` computation: issues with `blockerAttention.state === "stalled"` and `status !== "blocked"` count separately in description

Fixes: CMP-162 (P1-1 Daily Brief 위젯 — 약점 W1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)