### PR TITLE
feat(inbox): unified Decisions tab — single inbox for all actionable items (CMP-166)

### DIFF
--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -36,6 +36,17 @@ export type ResolveRecoveryActionResponse = {
   recoveryAction: IssueRecoveryAction;
 };
 
+export type PendingInteractionItem = {
+  issue: {
+    id: string;
+    identifier: string;
+    title: string;
+    status: Issue["status"];
+    projectId: string | null;
+  };
+  interaction: IssueThreadInteraction;
+};
+
 export const issuesApi = {
   list: (
     companyId: string,
@@ -212,6 +223,8 @@ export const issuesApi = {
   },
   listInteractions: (id: string) =>
     api.get<IssueThreadInteraction[]>(`/issues/${id}/interactions`),
+  listPendingInteractions: (companyId: string) =>
+    api.get<PendingInteractionItem[]>(`/companies/${companyId}/pending-interactions`),
   listAcceptedPlanDecompositions: (id: string) =>
     api.get<AcceptedPlanDecompositionSummary[]>(`/issues/${id}/accepted-plan-decompositions`),
   createInteraction: (id: string, data: Record<string, unknown>) =>

--- a/ui/src/hooks/useInboxBadge.ts
+++ b/ui/src/hooks/useInboxBadge.ts
@@ -200,6 +200,14 @@ export function useInboxBadge(companyId: string | null | undefined) {
     staleTime: INBOX_BADGE_HOT_PATH_STALE_MS,
   });
 
+  const { data: pendingInteractionsData = [] } = useQuery({
+    queryKey: queryKeys.pendingInteractions(companyId!),
+    queryFn: () => issuesApi.listPendingInteractions(companyId!),
+    enabled: !!companyId,
+    refetchOnWindowFocus: true,
+    staleTime: INBOX_BADGE_HOT_PATH_STALE_MS,
+  });
+
   return useMemo(
     () =>
       computeInboxBadgeData({
@@ -211,7 +219,8 @@ export function useInboxBadge(companyId: string | null | undefined) {
         dismissedAlerts,
         dismissedAtByKey,
         currentUserId,
+        pendingInteractions: pendingInteractionsData.length,
       }),
-    [approvals, joinRequests, dashboard, heartbeatRuns, mineIssues, dismissedAlerts, dismissedAtByKey, currentUserId],
+    [approvals, joinRequests, dashboard, heartbeatRuns, mineIssues, dismissedAlerts, dismissedAtByKey, currentUserId, pendingInteractionsData.length],
   );
 }

--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -26,7 +26,7 @@ export const INBOX_NESTING_KEY = "paperclip:inbox:nesting";
 export const INBOX_GROUP_BY_KEY = "paperclip:inbox:group-by";
 export const INBOX_FILTER_PREFERENCES_KEY_PREFIX = "paperclip:inbox:filters";
 export const INBOX_COLLAPSED_GROUPS_KEY_PREFIX = "paperclip:inbox:collapsed-groups";
-export type InboxTab = "mine" | "recent" | "unread" | "blocked" | "all";
+export type InboxTab = "mine" | "recent" | "unread" | "blocked" | "all" | "decisions";
 export type InboxCategoryFilter =
   | "everything"
   | "issues_i_touched"
@@ -82,6 +82,7 @@ export interface InboxBadgeData {
   joinRequests: number;
   mineIssues: number;
   alerts: number;
+  pendingInteractions: number;
 }
 
 export interface InboxWorkItemGroup {
@@ -1230,6 +1231,7 @@ export function computeInboxBadgeData({
   dismissedAlerts,
   dismissedAtByKey,
   currentUserId,
+  pendingInteractions = 0,
 }: {
   approvals: Approval[];
   joinRequests: JoinRequest[];
@@ -1239,6 +1241,7 @@ export function computeInboxBadgeData({
   dismissedAlerts: Set<string>;
   dismissedAtByKey: ReadonlyMap<string, number>;
   currentUserId?: string | null;
+  pendingInteractions?: number;
 }): InboxBadgeData {
   const actionableApprovals = approvals.filter(
     (approval) =>
@@ -1268,11 +1271,12 @@ export function computeInboxBadgeData({
 
   return {
     // The inbox badge reflects personal/actionable work, not company-wide health alerts.
-    inbox: actionableApprovals + visibleJoinRequests + failedRuns + visibleMineIssues,
+    inbox: actionableApprovals + visibleJoinRequests + failedRuns + visibleMineIssues + pendingInteractions,
     approvals: actionableApprovals,
     failedRuns,
     joinRequests: visibleJoinRequests,
     mineIssues: visibleMineIssues,
     alerts,
+    pendingInteractions,
   };
 }

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -224,6 +224,7 @@ export const queryKeys = {
   dashboard: (companyId: string) => ["dashboard", companyId] as const,
   userProfile: (companyId: string, userSlug: string) =>
     ["user-profile", companyId, userSlug] as const,
+  pendingInteractions: (companyId: string) => ["pending-interactions", companyId] as const,
   sidebarBadges: (companyId: string) => ["sidebar-badges", companyId] as const,
   inboxDismissals: (companyId: string) => ["inbox-dismissals", companyId] as const,
   activity: (companyId: string) => ["activity", companyId] as const,

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -63,6 +63,15 @@ import { IssueFiltersPopover } from "../components/IssueFiltersPopover";
 import { IssueRow } from "../components/IssueRow";
 import { BlockedInboxView } from "../components/BlockedInboxView";
 import { SwipeToArchive } from "../components/SwipeToArchive";
+import { IssueThreadInteractionCard } from "../components/IssueThreadInteractionCard";
+import type { PendingInteractionItem } from "../api/issues";
+import type {
+  AskUserQuestionsAnswer,
+  AskUserQuestionsInteraction,
+  RequestCheckboxConfirmationInteraction,
+  RequestConfirmationInteraction,
+  SuggestTasksInteraction,
+} from "../lib/issue-thread-interactions";
 
 import { StatusIcon } from "../components/StatusIcon";
 import { cn } from "../lib/utils";
@@ -102,6 +111,7 @@ import {
   UserPlus,
   Search,
   ListTree,
+  CheckCircle2,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { PageTabBar } from "../components/PageTabBar";
@@ -662,6 +672,149 @@ function JoinRequestInboxRow({
   );
 }
 
+type AcceptableInteraction =
+  | SuggestTasksInteraction
+  | RequestConfirmationInteraction
+  | RequestCheckboxConfirmationInteraction;
+
+function DecisionsView({
+  pendingInteractions,
+  isLoading,
+  actionableApprovals,
+  joinRequests,
+  onAcceptInteraction,
+  onRejectInteraction,
+  onRespondInteraction,
+  onCancelInteraction,
+  onApproveApproval,
+  onRejectApproval,
+  isApprovalPending,
+  onApproveJoin,
+  onRejectJoin,
+  isJoinPending,
+  agentNameById,
+}: {
+  pendingInteractions: PendingInteractionItem[];
+  isLoading: boolean;
+  actionableApprovals: Approval[];
+  joinRequests: JoinRequest[];
+  onAcceptInteraction: (item: PendingInteractionItem, interaction: AcceptableInteraction, selectedClientKeys?: string[], selectedOptionIds?: string[]) => void;
+  onRejectInteraction: (item: PendingInteractionItem, interaction: AcceptableInteraction, reason?: string) => void;
+  onRespondInteraction: (item: PendingInteractionItem, interaction: AskUserQuestionsInteraction, answers: AskUserQuestionsAnswer[]) => void;
+  onCancelInteraction: (item: PendingInteractionItem, interaction: AskUserQuestionsInteraction) => void;
+  onApproveApproval: (id: string) => void;
+  onRejectApproval: (id: string) => void;
+  isApprovalPending: boolean;
+  onApproveJoin: (jr: JoinRequest) => void;
+  onRejectJoin: (jr: JoinRequest) => void;
+  isJoinPending: boolean;
+  agentNameById: Map<string, string>;
+}) {
+  const isEmpty =
+    !isLoading &&
+    pendingInteractions.length === 0 &&
+    actionableApprovals.length === 0 &&
+    joinRequests.length === 0;
+
+  if (isLoading && pendingInteractions.length === 0) {
+    return <PageSkeleton variant="inbox" />;
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-border bg-card p-12 text-center">
+        <CheckCircle2 className="h-10 w-10 text-emerald-500" />
+        <p className="text-base font-medium">No pending decisions</p>
+        <p className="text-sm text-muted-foreground">
+          Confirmations, questions, and approvals from agents will appear here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {pendingInteractions.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Agent requests ({pendingInteractions.length})
+          </h3>
+          <div className="space-y-3">
+            {pendingInteractions.map((item) => (
+              <div key={item.interaction.id} className="overflow-hidden rounded-xl border border-border">
+                <div className="flex items-center gap-2 border-b border-border bg-muted/30 px-4 py-2">
+                  <Link
+                    to={`/issues/${item.issue.identifier ?? item.issue.id}`}
+                    className="flex min-w-0 items-center gap-1.5 text-sm no-underline text-inherit hover:underline"
+                  >
+                    <span className="font-mono text-xs text-muted-foreground">{item.issue.identifier}</span>
+                    <span className="truncate font-medium">{item.issue.title}</span>
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  </Link>
+                </div>
+                <div className="p-4">
+                  <IssueThreadInteractionCard
+                    interaction={item.interaction}
+                    onAcceptInteraction={(interaction, selectedClientKeys, selectedOptionIds) =>
+                      onAcceptInteraction(item, interaction as AcceptableInteraction, selectedClientKeys, selectedOptionIds)
+                    }
+                    onRejectInteraction={(interaction, reason) =>
+                      onRejectInteraction(item, interaction as AcceptableInteraction, reason)
+                    }
+                    onSubmitInteractionAnswers={(interaction, answers) =>
+                      onRespondInteraction(item, interaction, answers)
+                    }
+                    onCancelInteraction={(interaction) => onCancelInteraction(item, interaction)}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {actionableApprovals.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Approvals ({actionableApprovals.length})
+          </h3>
+          <div className="overflow-hidden rounded-xl border border-border">
+            {actionableApprovals.map((approval) => (
+              <ApprovalInboxRow
+                key={approval.id}
+                approval={approval}
+                requesterName={agentNameById.get(approval.requestedByAgentId ?? "") ?? null}
+                onApprove={() => onApproveApproval(approval.id)}
+                onReject={() => onRejectApproval(approval.id)}
+                isPending={isApprovalPending}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {joinRequests.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Join requests ({joinRequests.length})
+          </h3>
+          <div className="overflow-hidden rounded-xl border border-border">
+            {joinRequests.map((jr) => (
+              <JoinRequestInboxRow
+                key={jr.id}
+                joinRequest={jr}
+                onApprove={() => onApproveJoin(jr)}
+                onReject={() => onRejectJoin(jr)}
+                isPending={isJoinPending}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function Inbox() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
@@ -699,6 +852,7 @@ export function Inbox() {
     || pathSegment === "all"
     || pathSegment === "unread"
     || pathSegment === "blocked"
+    || pathSegment === "decisions"
       ? pathSegment
       : "mine";
   const canArchiveFromTab = isMineInboxTab(tab);
@@ -856,6 +1010,12 @@ export function Inbox() {
     refetchInterval: 5000,
   });
   const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
+  const { data: pendingInteractions = [], isLoading: isPendingInteractionsLoading } = useQuery({
+    queryKey: queryKeys.pendingInteractions(selectedCompanyId!),
+    queryFn: () => issuesApi.listPendingInteractions(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchOnWindowFocus: true,
+  });
   const { data: companyMembers } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
     queryFn: () => accessApi.listUserDirectory(selectedCompanyId!),
@@ -1510,6 +1670,50 @@ export function Inbox() {
     },
   });
 
+  const invalidatePendingInteractions = () => {
+    if (!selectedCompanyId) return;
+    queryClient.invalidateQueries({ queryKey: queryKeys.pendingInteractions(selectedCompanyId) });
+  };
+
+  const acceptInteractionMutation = useMutation({
+    mutationFn: (a: { issueId: string; interactionId: string; selectedClientKeys?: string[]; selectedOptionIds?: string[] }) =>
+      issuesApi.acceptInteraction(a.issueId, a.interactionId, {
+        selectedClientKeys: a.selectedClientKeys,
+        selectedOptionIds: a.selectedOptionIds,
+      }),
+    onSuccess: invalidatePendingInteractions,
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to accept");
+    },
+  });
+
+  const rejectInteractionMutation = useMutation({
+    mutationFn: (a: { issueId: string; interactionId: string; reason?: string }) =>
+      issuesApi.rejectInteraction(a.issueId, a.interactionId, a.reason),
+    onSuccess: invalidatePendingInteractions,
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to reject");
+    },
+  });
+
+  const respondInteractionMutation = useMutation({
+    mutationFn: (a: { issueId: string; interactionId: string; answers: AskUserQuestionsAnswer[] }) =>
+      issuesApi.respondToInteraction(a.issueId, a.interactionId, { answers: a.answers }),
+    onSuccess: invalidatePendingInteractions,
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to respond");
+    },
+  });
+
+  const cancelInteractionMutation = useMutation({
+    mutationFn: (a: { issueId: string; interactionId: string }) =>
+      issuesApi.cancelInteraction(a.issueId, a.interactionId),
+    onSuccess: invalidatePendingInteractions,
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to cancel");
+    },
+  });
+
   const [fadingOutIssues, setFadingOutIssues] = useState<Set<string>>(new Set());
   const [showMarkAllReadConfirm, setShowMarkAllReadConfirm] = useState(false);
   const [archivingIssueIds, setArchivingIssueIds] = useState<Set<string>>(new Set());
@@ -1976,12 +2180,12 @@ export function Inbox() {
     .map((issue) => issue.id);
   const canMarkAllRead = unreadIssueIds.length > 0;
   const activeIssueFilterCount = countActiveIssueFilters(issueFilters, true);
-  const showGeneralIssueToolbarControls = tab !== "blocked";
+  const showGeneralIssueToolbarControls = tab !== "blocked" && tab !== "decisions";
   return (
     <div className="space-y-6">
       <div className="space-y-2">
         {/* Search — full-width row on mobile, inline on desktop */}
-        <div className="relative sm:hidden">
+        <div className={cn("relative sm:hidden", tab === "decisions" && "hidden")}>
           <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             type="search"
@@ -2024,6 +2228,19 @@ export function Inbox() {
               { value: "unread", label: "Unread" },
               { value: "blocked", label: "Blocked" },
               { value: "all", label: "All" },
+              {
+                value: "decisions",
+                label: (
+                  <span className="flex items-center gap-1.5">
+                    Decisions
+                    {pendingInteractions.length > 0 && (
+                      <span className="inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground">
+                        {pendingInteractions.length}
+                      </span>
+                    )}
+                  </span>
+                ),
+              },
             ]}
           />
         </Tabs>
@@ -2319,11 +2536,44 @@ export function Inbox() {
         />
       ) : null}
 
-      {tab !== "blocked" && !allLoaded && visibleSections.length === 0 && (
+      {tab === "decisions" ? (
+        <DecisionsView
+          pendingInteractions={pendingInteractions}
+          isLoading={isPendingInteractionsLoading}
+          actionableApprovals={approvalsToRender.filter((a) => ACTIONABLE_APPROVAL_STATUSES.has(a.status))}
+          joinRequests={joinRequestsForTab}
+          onAcceptInteraction={(item, interaction, selectedClientKeys, selectedOptionIds) =>
+            acceptInteractionMutation.mutate({
+              issueId: item.issue.id,
+              interactionId: interaction.id,
+              selectedClientKeys,
+              selectedOptionIds,
+            })
+          }
+          onRejectInteraction={(item, interaction, reason) =>
+            rejectInteractionMutation.mutate({ issueId: item.issue.id, interactionId: interaction.id, reason })
+          }
+          onRespondInteraction={(item, interaction, answers) =>
+            respondInteractionMutation.mutate({ issueId: item.issue.id, interactionId: interaction.id, answers })
+          }
+          onCancelInteraction={(item, interaction) =>
+            cancelInteractionMutation.mutate({ issueId: item.issue.id, interactionId: interaction.id })
+          }
+          onApproveApproval={(id) => approveMutation.mutate(id)}
+          onRejectApproval={(id) => rejectMutation.mutate(id)}
+          isApprovalPending={approveMutation.isPending || rejectMutation.isPending}
+          onApproveJoin={(jr) => approveJoinMutation.mutate(jr)}
+          onRejectJoin={(jr) => rejectJoinMutation.mutate(jr)}
+          isJoinPending={approveJoinMutation.isPending || rejectJoinMutation.isPending}
+          agentNameById={agentById}
+        />
+      ) : null}
+
+      {tab !== "blocked" && tab !== "decisions" && !allLoaded && visibleSections.length === 0 && (
         <PageSkeleton variant="inbox" />
       )}
 
-      {tab !== "blocked" && allLoaded && visibleSections.length === 0 && (
+      {tab !== "blocked" && tab !== "decisions" && allLoaded && visibleSections.length === 0 && (
         <EmptyState
           icon={searchQuery.trim() ? Search : InboxIcon}
           message={
@@ -2340,7 +2590,7 @@ export function Inbox() {
         />
       )}
 
-      {tab !== "blocked" && showWorkItemsSection && (
+      {tab !== "blocked" && tab !== "decisions" && showWorkItemsSection && (
         <>
           {showSeparatorBefore("work_items") && <Separator />}
           <div>
@@ -2771,7 +3021,7 @@ export function Inbox() {
         </>
       )}
 
-      {showAlertsSection && (
+      {tab !== "decisions" && showAlertsSection && (
         <>
           {showSeparatorBefore("alerts") && <Separator />}
           <div>


### PR DESCRIPTION
## Summary

Implements CMP-166 "P2-5 Unified Decision Inbox": merges the separate `/review` surface into a new **Decisions** tab inside the Inbox, giving users one place for all items requiring their action.

**What changed:**
- `lib/queryKeys.ts` — added `pendingInteractions` query key
- `lib/inbox.ts` — added `"decisions"` to `InboxTab` union; `pendingInteractions` count added to `InboxBadgeData` and `computeInboxBadgeData` (backward-compatible optional param, defaults to 0)
- `hooks/useInboxBadge.ts` — queries pending interactions endpoint; count included in sidebar badge total
- `api/issues.ts` — added `PendingInteractionItem` type and `listPendingInteractions` API method (endpoint: `GET /companies/:id/pending-interactions`)
- `pages/Inbox.tsx` — new "Decisions" tab with inline badge count; `DecisionsView` component with three sections (Agent requests, Approvals, Join requests); interaction accept/reject/respond/cancel mutations; issue-list guards updated for decisions tab

**Behaviour:**
- Decisions tab groups all actionable items: pending `request_confirmation` / `ask_user_questions` / `suggest_tasks` interactions, actionable approvals, and pending join requests
- Tab label shows a badge count when items are present; sidebar badge total includes pending interactions
- Search bar and general issue toolbar controls are hidden for the Decisions tab (no free-text search needed)
- `/review` route continues to work unchanged (no regression)

## Test plan

- [ ] Navigate to `/inbox/decisions` — verify all three sections render (or empty states if no items)
- [ ] Confirm sidebar badge count updates when pending interactions exist
- [ ] Accept / reject a `request_confirmation` interaction inline — card dismisses, query invalidated
- [ ] Approve / reject an approval inline
- [ ] Approve / reject a join request inline
- [ ] Verify switching between Decisions and other tabs (Mine, All, etc.) works correctly
- [ ] Confirm `/review` route still loads without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)