### PR TITLE
fix(recovery): fold detached no-source late output

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -128,6 +128,10 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     ageMs: number;
     withOutput?: boolean;
     logChunk?: string;
+    processPid?: number | null;
+    processGroupId?: number | null;
+    runErrorCode?: string | null;
+    runError?: string | null;
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
@@ -194,10 +198,14 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       companyId,
       agentId: coderId,
       status: "running",
+      errorCode: opts.runErrorCode ?? null,
+      error: opts.runError ?? null,
       invocationSource: "assignment",
       triggerDetail: "system",
       startedAt,
       processStartedAt: startedAt,
+      processPid: opts.processPid ?? null,
+      processGroupId: opts.processGroupId ?? null,
       lastOutputAt,
       lastOutputSeq: opts.withOutput ? 3 : 0,
       lastOutputStream: opts.withOutput ? "stdout" : null,
@@ -452,6 +460,77 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
     expect(allEvaluations).toHaveLength(1);
+  });
+
+  it("auto-folds no-source detached evaluations after late run-local output and re-arms the watchdog", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      processPid: 12_345,
+      processGroupId: 12_345,
+      runErrorCode: "process_detached",
+      runError: "Lost in-memory process handle, but child pid 12345 is still alive",
+    });
+    await db.update(heartbeatRuns).set({ contextSnapshot: {} }).where(eq(heartbeatRuns.id, runId));
+    await db.update(issues).set({ executionRunId: null }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first).toMatchObject({ created: 1 });
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation).toBeTruthy();
+    expect(evaluation?.parentId).toBeNull();
+
+    const evaluationOpenedAt = new Date(now.getTime() + 1_000);
+    const outputAt = new Date(evaluationOpenedAt.getTime() + 60_000);
+    await db
+      .update(issues)
+      .set({ createdAt: evaluationOpenedAt, updatedAt: evaluationOpenedAt })
+      .where(eq(issues.id, evaluation!.id));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastOutputAt: outputAt,
+        lastOutputSeq: 7,
+        lastOutputStream: "stdout",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const secondNow = new Date(outputAt.getTime() + ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000);
+    const second = await heartbeat.scanSilentActiveRuns({ now: secondNow, companyId });
+
+    expect(second).toMatchObject({ created: 0, folded: 1 });
+    const [storedEvaluation] = await db.select().from(issues).where(eq(issues.id, evaluation!.id));
+    expect(storedEvaluation?.status).toBe("done");
+
+    const decisions = await db
+      .select()
+      .from(heartbeatRunWatchdogDecisions)
+      .where(eq(heartbeatRunWatchdogDecisions.runId, runId));
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      evaluationIssueId: evaluation!.id,
+      decision: "continue",
+    });
+    expect(decisions[0]?.reason).toContain("detached no-source run emitted durable output");
+    expect(decisions[0]?.snoozedUntil?.getTime()).toBeGreaterThan(secondNow.getTime());
+
+    const [event] = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(event?.message).toContain("Detached no-source watchdog fold");
+
+    const beforeRearm = await heartbeat.scanSilentActiveRuns({
+      now: new Date(secondNow.getTime() + 5 * 60_000),
+      companyId,
+    });
+    expect(beforeRearm).toMatchObject({ created: 0, snoozed: 1 });
   });
 
   it("folds terminal source issues with same-run durable evidence instead of creating watchdog work", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -71,6 +71,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
@@ -905,6 +906,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         status: issues.status,
         priority: issues.priority,
         assigneeAgentId: issues.assigneeAgentId,
+        createdAt: issues.createdAt,
         updatedAt: issues.updatedAt,
       })
       .from(issues)
@@ -964,6 +966,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       )
       .limit(1);
     return row != null;
+  }
+
+  async function latestWatchdogDecisionCreatedAt(companyId: string, runId: string) {
+    const [row] = await db
+      .select({ createdAt: heartbeatRunWatchdogDecisions.createdAt })
+      .from(heartbeatRunWatchdogDecisions)
+      .where(and(eq(heartbeatRunWatchdogDecisions.companyId, companyId), eq(heartbeatRunWatchdogDecisions.runId, runId)))
+      .orderBy(desc(heartbeatRunWatchdogDecisions.createdAt))
+      .limit(1);
+    return row?.createdAt ?? null;
   }
 
   async function buildRunOutputSilence(
@@ -1344,6 +1356,100 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation?.id ?? null };
   }
 
+  async function resolveDetachedNoSourceLateOutput(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    existingEvaluation: Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>;
+  }) {
+    if (input.sourceIssue || !input.existingEvaluation) return null;
+    if (input.run.errorCode !== DETACHED_PROCESS_ERROR_CODE) return null;
+    if (!input.run.lastOutputAt) return null;
+
+    const latestDecisionAt = await latestWatchdogDecisionCreatedAt(input.run.companyId, input.run.id);
+    const cutoffCandidates = [
+      input.existingEvaluation.createdAt,
+      latestDecisionAt,
+    ].filter((value): value is Date => value instanceof Date);
+    if (cutoffCandidates.length === 0) return null;
+
+    const cutoff = new Date(Math.max(...cutoffCandidates.map((value) => value.getTime())));
+    if (input.run.lastOutputAt <= cutoff) return null;
+
+    return {
+      outputAt: input.run.lastOutputAt,
+      outputSeq: input.run.lastOutputSeq ?? 0,
+      outputStream: input.run.lastOutputStream === "stdout" || input.run.lastOutputStream === "stderr"
+        ? input.run.lastOutputStream
+        : null,
+      cutoff,
+    };
+  }
+
+  async function foldDetachedNoSourceLateOutput(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    existingEvaluation: NonNullable<Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>>;
+    evidence: NonNullable<Awaited<ReturnType<typeof resolveDetachedNoSourceLateOutput>>>;
+    now: Date;
+  }) {
+    await issuesSvc.update(input.existingEvaluation.id, { status: "done" });
+    await issuesSvc.addComment(input.existingEvaluation.id, [
+      "Detached no-source watchdog fold.",
+      "",
+      `- Run: \`${input.run.id}\``,
+      `- Late output at: ${input.evidence.outputAt.toISOString()}`,
+      `- Late output sequence: ${input.evidence.outputSeq}`,
+      `- Late output stream: ${input.evidence.outputStream ?? "unknown"}`,
+      `- Evaluation opened at: ${input.existingEvaluation.createdAt.toISOString()}`,
+      "- Outcome: false positive; the detached no-source run emitted durable output after review opened.",
+    ].join("\n"), { runId: input.run.id });
+
+    const snoozedUntil = new Date(input.now.getTime() + ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS);
+    const [decision] = await db
+      .insert(heartbeatRunWatchdogDecisions)
+      .values({
+        companyId: input.run.companyId,
+        runId: input.run.id,
+        evaluationIssueId: input.existingEvaluation.id,
+        decision: "continue",
+        reason: "Recovered detached no-source run emitted durable output after the watchdog evaluation opened.",
+        snoozedUntil,
+        createdByRunId: input.run.id,
+      })
+      .returning();
+
+    const payload = {
+      evaluationIssueId: input.existingEvaluation.id,
+      evaluationIssueIdentifier: input.existingEvaluation.identifier,
+      outputAt: input.evidence.outputAt.toISOString(),
+      outputSeq: input.evidence.outputSeq,
+      outputStream: input.evidence.outputStream,
+      cutoffAt: input.evidence.cutoff.toISOString(),
+      snoozedUntil: snoozedUntil.toISOString(),
+      watchdogDecisionId: decision.id,
+    };
+    await appendRecoveryRunEvent(input.run, {
+      level: "info",
+      message: "Detached no-source watchdog fold re-armed after late output",
+      payload,
+    });
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_detached_no_source_rearmed",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        ...payload,
+      },
+    });
+
+    return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation.id };
+  }
+
   async function resolveStaleRunOwnerAgentId(input: {
     run: typeof heartbeatRuns.$inferSelect;
     runningAgent: typeof agents.$inferSelect;
@@ -1632,6 +1738,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
     }
+    const detachedNoSourceLateOutput = await resolveDetachedNoSourceLateOutput({
+      run: input.run,
+      sourceIssue,
+      existingEvaluation: existing,
+    });
+    if (existing && detachedNoSourceLateOutput) {
+      return foldDetachedNoSourceLateOutput({
+        run: input.run,
+        existingEvaluation: existing,
+        evidence: detachedNoSourceLateOutput,
+        now: input.now,
+      });
+    }
 
     // Idle output is expected when the source issue is blocked — skip ticket creation entirely.
     if (sourceIssue?.status === "blocked") return { kind: "skipped" as const };
@@ -1816,7 +1935,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string }) {
     const now = opts?.now ?? new Date();
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
-    const candidates = await db
+    const staleCandidates = await db
       .select()
       .from(heartbeatRuns)
       .where(
@@ -1828,6 +1947,37 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       )
       .orderBy(asc(heartbeatRuns.createdAt))
       .limit(100);
+    const evaluationCandidates = await db
+      .select({ run: heartbeatRuns })
+      .from(issues)
+      .innerJoin(
+        heartbeatRuns,
+        and(
+          eq(issues.companyId, heartbeatRuns.companyId),
+          sql`${issues.originId} = ${heartbeatRuns.id}::text`,
+        ),
+      )
+      .where(
+        and(
+          opts?.companyId ? eq(issues.companyId, opts.companyId) : undefined,
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+          eq(heartbeatRuns.status, "running"),
+        ),
+      )
+      .orderBy(asc(issues.createdAt))
+      .limit(100);
+    const candidatesById = new Map<string, typeof heartbeatRuns.$inferSelect>();
+    for (const run of staleCandidates) {
+      candidatesById.set(run.id, run);
+    }
+    for (const { run } of evaluationCandidates) {
+      if (!candidatesById.has(run.id)) {
+        candidatesById.set(run.id, run);
+      }
+    }
+    const candidates = [...candidatesById.values()];
 
     const result = {
       scanned: candidates.length,


### PR DESCRIPTION
## Summary
- Fold late output from detached no-source active runs back into the recovery path after the watchdog has evaluated the run.
- Add regression coverage for the detached late-output case in the active-run output watchdog suite.

## Linked Issue
- Internal issue: BOU-2855, detached-run late-output recovery.

## Problem
Detached `process_detached` runs can produce usable output after the stale-run/no-source watchdog has already evaluated the run. Without folding that late output, the parent issue can remain silent even though the detached run produced actionable final output.

## Fix
- Guard the recovery fold to no-source issues, open stale-run evaluation state, detached processing, and output that arrived after the evaluation/latest watchdog decision.
- Keep the change scoped to the recovery service and watchdog regression test.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts --silent` passed: 1 file, 19 tests.
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check origin/master...HEAD`
- `artifacts/bountyops-control/board-tracker/verify-git-identity.sh repos/paperclip-BOU-2855-detached-late-output`

## Risk Notes
- Low-risk two-file change: watchdog test plus recovery service.
- No dependency, lockfile, generated-file, or unrelated formatting changes.
- Full monorepo suite was not run; targeted watchdog coverage and server typecheck passed.
