### PR TITLE
fix(recovery): fold detached no-source late output

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -128,6 +128,10 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     ageMs: number;
     withOutput?: boolean;
     logChunk?: string;
+    processPid?: number | null;
+    processGroupId?: number | null;
+    runErrorCode?: string | null;
+    runError?: string | null;
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
@@ -195,10 +199,14 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       companyId,
       agentId: coderId,
       status: "running",
+      errorCode: opts.runErrorCode ?? null,
+      error: opts.runError ?? null,
       invocationSource: "assignment",
       triggerDetail: "system",
       startedAt,
       processStartedAt: startedAt,
+      processPid: opts.processPid ?? null,
+      processGroupId: opts.processGroupId ?? null,
       lastOutputAt,
       lastOutputSeq: opts.withOutput ? 3 : 0,
       lastOutputStream: opts.withOutput ? "stdout" : null,
@@ -453,6 +461,77 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
     expect(allEvaluations).toHaveLength(1);
+  });
+
+  it("auto-folds no-source detached evaluations after late run-local output and re-arms the watchdog", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      processPid: 12_345,
+      processGroupId: 12_345,
+      runErrorCode: "process_detached",
+      runError: "Lost in-memory process handle, but child pid 12345 is still alive",
+    });
+    await db.update(heartbeatRuns).set({ contextSnapshot: {} }).where(eq(heartbeatRuns.id, runId));
+    await db.update(issues).set({ executionRunId: null }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first).toMatchObject({ created: 1 });
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation).toBeTruthy();
+    expect(evaluation?.parentId).toBeNull();
+
+    const evaluationOpenedAt = new Date(now.getTime() + 1_000);
+    const outputAt = new Date(evaluationOpenedAt.getTime() + 60_000);
+    await db
+      .update(issues)
+      .set({ createdAt: evaluationOpenedAt, updatedAt: evaluationOpenedAt })
+      .where(eq(issues.id, evaluation!.id));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastOutputAt: outputAt,
+        lastOutputSeq: 7,
+        lastOutputStream: "stdout",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const secondNow = new Date(outputAt.getTime() + ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000);
+    const second = await heartbeat.scanSilentActiveRuns({ now: secondNow, companyId });
+
+    expect(second).toMatchObject({ created: 0, folded: 1 });
+    const [storedEvaluation] = await db.select().from(issues).where(eq(issues.id, evaluation!.id));
+    expect(storedEvaluation?.status).toBe("done");
+
+    const decisions = await db
+      .select()
+      .from(heartbeatRunWatchdogDecisions)
+      .where(eq(heartbeatRunWatchdogDecisions.runId, runId));
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      evaluationIssueId: evaluation!.id,
+      decision: "continue",
+    });
+    expect(decisions[0]?.reason).toContain("detached no-source run emitted durable output");
+    expect(decisions[0]?.snoozedUntil?.getTime()).toBeGreaterThan(secondNow.getTime());
+
+    const [event] = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(event?.message).toContain("Detached no-source watchdog fold");
+
+    const beforeRearm = await heartbeat.scanSilentActiveRuns({
+      now: new Date(secondNow.getTime() + 5 * 60_000),
+      companyId,
+    });
+    expect(beforeRearm).toMatchObject({ created: 0, snoozed: 1 });
   });
 
   it("folds terminal source issues with same-run durable evidence instead of creating watchdog work", async () => {

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -534,6 +534,80 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(beforeRearm).toMatchObject({ created: 0, snoozed: 1 });
   });
 
+  it("keeps detached no-source evaluations open when re-arm decision insertion fails", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      processPid: 12_345,
+      processGroupId: 12_345,
+      runErrorCode: "process_detached",
+      runError: "Lost in-memory process handle, but child pid 12345 is still alive",
+    });
+    await db.update(heartbeatRuns).set({ contextSnapshot: {} }).where(eq(heartbeatRuns.id, runId));
+    await db.update(issues).set({ executionRunId: null }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first).toMatchObject({ created: 1 });
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation).toBeTruthy();
+
+    const evaluationOpenedAt = new Date(now.getTime() + 1_000);
+    const outputAt = new Date(evaluationOpenedAt.getTime() + 60_000);
+    await db
+      .update(issues)
+      .set({ createdAt: evaluationOpenedAt, updatedAt: evaluationOpenedAt })
+      .where(eq(issues.id, evaluation!.id));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastOutputAt: outputAt,
+        lastOutputSeq: 7,
+        lastOutputStream: "stdout",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    await db.execute(sql.raw("DROP TRIGGER IF EXISTS paperclip_test_fail_watchdog_decision_insert ON heartbeat_run_watchdog_decisions"));
+    await db.execute(sql.raw("DROP FUNCTION IF EXISTS paperclip_test_fail_watchdog_decision_insert_fn()"));
+    await db.execute(sql.raw(`
+      CREATE FUNCTION paperclip_test_fail_watchdog_decision_insert_fn()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'forced watchdog decision insert failure';
+      END;
+      $$ LANGUAGE plpgsql
+    `));
+    await db.execute(sql.raw(`
+      CREATE TRIGGER paperclip_test_fail_watchdog_decision_insert
+      BEFORE INSERT ON heartbeat_run_watchdog_decisions
+      FOR EACH ROW EXECUTE FUNCTION paperclip_test_fail_watchdog_decision_insert_fn()
+    `));
+
+    try {
+      const secondNow = new Date(outputAt.getTime() + ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000);
+      await expect(heartbeat.scanSilentActiveRuns({ now: secondNow, companyId }))
+        .rejects.toThrow("heartbeat_run_watchdog_decisions");
+    } finally {
+      await db.execute(sql.raw("DROP TRIGGER IF EXISTS paperclip_test_fail_watchdog_decision_insert ON heartbeat_run_watchdog_decisions"));
+      await db.execute(sql.raw("DROP FUNCTION IF EXISTS paperclip_test_fail_watchdog_decision_insert_fn()"));
+    }
+
+    const [storedEvaluation] = await db.select().from(issues).where(eq(issues.id, evaluation!.id));
+    expect(storedEvaluation?.status).not.toBe("done");
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, evaluation!.id));
+    expect(comments).toHaveLength(0);
+    const decisions = await db
+      .select()
+      .from(heartbeatRunWatchdogDecisions)
+      .where(eq(heartbeatRunWatchdogDecisions.runId, runId));
+    expect(decisions).toHaveLength(0);
+  });
+
   it("folds terminal source issues with same-run durable evidence instead of creating watchdog work", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, coderId, issueId, runId } = await seedRunningRun({

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -11,6 +11,7 @@ import type { PluginEventBus } from "./plugin-event-bus.js";
 import { instanceSettingsService } from "./instance-settings.js";
 
 const PLUGIN_EVENT_SET: ReadonlySet<string> = new Set(PLUGIN_EVENT_TYPES);
+type ActivityLogDb = Pick<Db, "insert" | "select" | "update">;
 const ACTIVITY_ACTION_TO_PLUGIN_EVENT: Readonly<Record<string, PluginEventType>> = {
   issue_comment_added: "issue.comment.created",
   issue_comment_created: "issue.comment.created",
@@ -62,7 +63,7 @@ export interface LogActivityInput {
   details?: Record<string, unknown> | null;
 }
 
-export async function logActivity(db: Db, input: LogActivityInput) {
+export async function logActivity(db: ActivityLogDb, input: LogActivityInput) {
   const currentUserRedactionOptions = {
     enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
   };

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -18,6 +18,8 @@ import { eq } from "drizzle-orm";
 const DEFAULT_SINGLETON_KEY = "default";
 const instanceGeneralSettingsStorageSchema = instanceGeneralSettingsSchema.strip();
 const instanceExperimentalSettingsStorageSchema = instanceExperimentalSettingsSchema.strip();
+type InstanceSettingsDb = Pick<Db, "insert" | "select" | "update">;
+
 const TRUTHY_RUNTIME_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 
 interface InstanceSettingsServiceOptions {
@@ -269,7 +271,7 @@ function toInstanceSettings(row: typeof instanceSettings.$inferSelect): Instance
   } as InstanceSettings;
 }
 
-export function instanceSettingsService(db: Db, options: InstanceSettingsServiceOptions = {}) {
+export function instanceSettingsService(db: InstanceSettingsDb, options: InstanceSettingsServiceOptions = {}) {
   async function getOrCreateRow() {
     const existing = await db
       .select()

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -131,6 +131,9 @@ type ResolvedDependencyWakeBackstopOptions = {
   source?: ResolvedDependencyWakeBackstopSource;
 };
 
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type DbOrTransaction = Db | DbTransaction;
+
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
   "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
@@ -1291,8 +1294,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return null;
   }
 
-  async function nextRunEventSeq(runId: string) {
-    const [row] = await db
+  async function nextRunEventSeq(runId: string, dbOrTx: DbOrTransaction = db) {
+    const [row] = await dbOrTx
       .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
       .from(heartbeatRunEvents)
       .where(eq(heartbeatRunEvents.runId, runId));
@@ -1306,12 +1309,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       message: string;
       payload?: Record<string, unknown>;
     },
+    dbOrTx: DbOrTransaction = db,
   ) {
-    await db.insert(heartbeatRunEvents).values({
+    await dbOrTx.insert(heartbeatRunEvents).values({
       companyId: run.companyId,
       runId: run.id,
       agentId: run.agentId,
-      seq: await nextRunEventSeq(run.id),
+      seq: await nextRunEventSeq(run.id, dbOrTx),
       eventType: "lifecycle",
       stream: "system",
       level: event.level,
@@ -1562,13 +1566,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     if (!input.run.lastOutputAt) return null;
 
     const latestDecisionAt = await latestWatchdogDecisionCreatedAt(input.run.companyId, input.run.id);
-    const cutoffCandidates = [
-      input.existingEvaluation.createdAt,
-      latestDecisionAt,
-    ].filter((value): value is Date => value instanceof Date);
-    if (cutoffCandidates.length === 0) return null;
-
-    const cutoff = new Date(Math.max(...cutoffCandidates.map((value) => value.getTime())));
+    const cutoff = latestDecisionAt && latestDecisionAt > input.existingEvaluation.createdAt
+      ? latestDecisionAt
+      : input.existingEvaluation.createdAt;
     if (input.run.lastOutputAt <= cutoff) return null;
 
     return {
@@ -1587,60 +1587,65 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     evidence: NonNullable<Awaited<ReturnType<typeof resolveDetachedNoSourceLateOutput>>>;
     now: Date;
   }) {
-    await issuesSvc.update(input.existingEvaluation.id, { status: "done" });
-    await issuesSvc.addComment(input.existingEvaluation.id, [
-      "Detached no-source watchdog fold.",
-      "",
-      `- Run: \`${input.run.id}\``,
-      `- Late output at: ${input.evidence.outputAt.toISOString()}`,
-      `- Late output sequence: ${input.evidence.outputSeq}`,
-      `- Late output stream: ${input.evidence.outputStream ?? "unknown"}`,
-      `- Evaluation opened at: ${input.existingEvaluation.createdAt.toISOString()}`,
-      "- Outcome: false positive; the detached no-source run emitted durable output after review opened.",
-    ].join("\n"), { runId: input.run.id });
-
     const snoozedUntil = new Date(input.now.getTime() + ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS);
-    const [decision] = await db
-      .insert(heartbeatRunWatchdogDecisions)
-      .values({
-        companyId: input.run.companyId,
-        runId: input.run.id,
-        evaluationIssueId: input.existingEvaluation.id,
-        decision: "continue",
-        reason: "Recovered detached no-source run emitted durable output after the watchdog evaluation opened.",
-        snoozedUntil,
-        createdByRunId: input.run.id,
-      })
-      .returning();
+    await db.transaction(async (tx) => {
+      await issuesSvc.update(input.existingEvaluation.id, { status: "done" }, tx);
+      await issuesSvc.addComment(input.existingEvaluation.id, [
+        "Detached no-source watchdog fold.",
+        "",
+        `- Run: \`${input.run.id}\``,
+        `- Late output at: ${input.evidence.outputAt.toISOString()}`,
+        `- Late output sequence: ${input.evidence.outputSeq}`,
+        `- Late output stream: ${input.evidence.outputStream ?? "unknown"}`,
+        `- Evaluation opened at: ${input.existingEvaluation.createdAt.toISOString()}`,
+        "- Outcome: false positive; the detached no-source run emitted durable output after review opened.",
+      ].join("\n"), { runId: input.run.id }, undefined, tx);
 
-    const payload = {
-      evaluationIssueId: input.existingEvaluation.id,
-      evaluationIssueIdentifier: input.existingEvaluation.identifier,
-      outputAt: input.evidence.outputAt.toISOString(),
-      outputSeq: input.evidence.outputSeq,
-      outputStream: input.evidence.outputStream,
-      cutoffAt: input.evidence.cutoff.toISOString(),
-      snoozedUntil: snoozedUntil.toISOString(),
-      watchdogDecisionId: decision.id,
-    };
-    await appendRecoveryRunEvent(input.run, {
-      level: "info",
-      message: "Detached no-source watchdog fold re-armed after late output",
-      payload,
-    });
-    await logActivity(db, {
-      companyId: input.run.companyId,
-      actorType: "system",
-      actorId: "system",
-      agentId: input.run.agentId,
-      runId: input.run.id,
-      action: "heartbeat.output_stale_detached_no_source_rearmed",
-      entityType: "heartbeat_run",
-      entityId: input.run.id,
-      details: {
-        source: "recovery.scan_silent_active_runs",
-        ...payload,
-      },
+      const [decision] = await tx
+        .insert(heartbeatRunWatchdogDecisions)
+        .values({
+          companyId: input.run.companyId,
+          runId: input.run.id,
+          evaluationIssueId: input.existingEvaluation.id,
+          decision: "continue",
+          reason: "Recovered detached no-source run emitted durable output after the watchdog evaluation opened.",
+          snoozedUntil,
+          createdByRunId: input.run.id,
+        })
+        .returning();
+      if (!decision) {
+        throw new Error("Failed to record detached no-source watchdog re-arm decision");
+      }
+
+      const payload = {
+        evaluationIssueId: input.existingEvaluation.id,
+        evaluationIssueIdentifier: input.existingEvaluation.identifier,
+        outputAt: input.evidence.outputAt.toISOString(),
+        outputSeq: input.evidence.outputSeq,
+        outputStream: input.evidence.outputStream,
+        cutoffAt: input.evidence.cutoff.toISOString(),
+        snoozedUntil: snoozedUntil.toISOString(),
+        watchdogDecisionId: decision.id,
+      };
+      await appendRecoveryRunEvent(input.run, {
+        level: "info",
+        message: "Detached no-source watchdog fold re-armed after late output",
+        payload,
+      }, tx);
+      await logActivity(tx, {
+        companyId: input.run.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: input.run.agentId,
+        runId: input.run.id,
+        action: "heartbeat.output_stale_detached_no_source_rearmed",
+        entityType: "heartbeat_run",
+        entityId: input.run.id,
+        details: {
+          source: "recovery.scan_silent_active_runs",
+          ...payload,
+        },
+      });
     });
 
     return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation.id };

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -78,6 +78,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON = "execution_review_participant_recovery";
 const RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT = 500;
@@ -1101,6 +1102,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         status: issues.status,
         priority: issues.priority,
         assigneeAgentId: issues.assigneeAgentId,
+        createdAt: issues.createdAt,
         updatedAt: issues.updatedAt,
       })
       .from(issues)
@@ -1160,6 +1162,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       )
       .limit(1);
     return row != null;
+  }
+
+  async function latestWatchdogDecisionCreatedAt(companyId: string, runId: string) {
+    const [row] = await db
+      .select({ createdAt: heartbeatRunWatchdogDecisions.createdAt })
+      .from(heartbeatRunWatchdogDecisions)
+      .where(and(eq(heartbeatRunWatchdogDecisions.companyId, companyId), eq(heartbeatRunWatchdogDecisions.runId, runId)))
+      .orderBy(desc(heartbeatRunWatchdogDecisions.createdAt))
+      .limit(1);
+    return row?.createdAt ?? null;
   }
 
   async function buildRunOutputSilence(
@@ -1540,6 +1552,100 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation?.id ?? null };
   }
 
+  async function resolveDetachedNoSourceLateOutput(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    existingEvaluation: Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>;
+  }) {
+    if (input.sourceIssue || !input.existingEvaluation) return null;
+    if (input.run.errorCode !== DETACHED_PROCESS_ERROR_CODE) return null;
+    if (!input.run.lastOutputAt) return null;
+
+    const latestDecisionAt = await latestWatchdogDecisionCreatedAt(input.run.companyId, input.run.id);
+    const cutoffCandidates = [
+      input.existingEvaluation.createdAt,
+      latestDecisionAt,
+    ].filter((value): value is Date => value instanceof Date);
+    if (cutoffCandidates.length === 0) return null;
+
+    const cutoff = new Date(Math.max(...cutoffCandidates.map((value) => value.getTime())));
+    if (input.run.lastOutputAt <= cutoff) return null;
+
+    return {
+      outputAt: input.run.lastOutputAt,
+      outputSeq: input.run.lastOutputSeq ?? 0,
+      outputStream: input.run.lastOutputStream === "stdout" || input.run.lastOutputStream === "stderr"
+        ? input.run.lastOutputStream
+        : null,
+      cutoff,
+    };
+  }
+
+  async function foldDetachedNoSourceLateOutput(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    existingEvaluation: NonNullable<Awaited<ReturnType<typeof findOpenStaleRunEvaluation>>>;
+    evidence: NonNullable<Awaited<ReturnType<typeof resolveDetachedNoSourceLateOutput>>>;
+    now: Date;
+  }) {
+    await issuesSvc.update(input.existingEvaluation.id, { status: "done" });
+    await issuesSvc.addComment(input.existingEvaluation.id, [
+      "Detached no-source watchdog fold.",
+      "",
+      `- Run: \`${input.run.id}\``,
+      `- Late output at: ${input.evidence.outputAt.toISOString()}`,
+      `- Late output sequence: ${input.evidence.outputSeq}`,
+      `- Late output stream: ${input.evidence.outputStream ?? "unknown"}`,
+      `- Evaluation opened at: ${input.existingEvaluation.createdAt.toISOString()}`,
+      "- Outcome: false positive; the detached no-source run emitted durable output after review opened.",
+    ].join("\n"), { runId: input.run.id });
+
+    const snoozedUntil = new Date(input.now.getTime() + ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS);
+    const [decision] = await db
+      .insert(heartbeatRunWatchdogDecisions)
+      .values({
+        companyId: input.run.companyId,
+        runId: input.run.id,
+        evaluationIssueId: input.existingEvaluation.id,
+        decision: "continue",
+        reason: "Recovered detached no-source run emitted durable output after the watchdog evaluation opened.",
+        snoozedUntil,
+        createdByRunId: input.run.id,
+      })
+      .returning();
+
+    const payload = {
+      evaluationIssueId: input.existingEvaluation.id,
+      evaluationIssueIdentifier: input.existingEvaluation.identifier,
+      outputAt: input.evidence.outputAt.toISOString(),
+      outputSeq: input.evidence.outputSeq,
+      outputStream: input.evidence.outputStream,
+      cutoffAt: input.evidence.cutoff.toISOString(),
+      snoozedUntil: snoozedUntil.toISOString(),
+      watchdogDecisionId: decision.id,
+    };
+    await appendRecoveryRunEvent(input.run, {
+      level: "info",
+      message: "Detached no-source watchdog fold re-armed after late output",
+      payload,
+    });
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_detached_no_source_rearmed",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        ...payload,
+      },
+    });
+
+    return { kind: "folded" as const, evaluationIssueId: input.existingEvaluation.id };
+  }
+
   async function resolveStaleRunOwnerAgentId(input: {
     run: typeof heartbeatRuns.$inferSelect;
     runningAgent: typeof agents.$inferSelect;
@@ -1828,6 +1934,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
     }
+    const detachedNoSourceLateOutput = await resolveDetachedNoSourceLateOutput({
+      run: input.run,
+      sourceIssue,
+      existingEvaluation: existing,
+    });
+    if (existing && detachedNoSourceLateOutput) {
+      return foldDetachedNoSourceLateOutput({
+        run: input.run,
+        existingEvaluation: existing,
+        evidence: detachedNoSourceLateOutput,
+        now: input.now,
+      });
+    }
 
     // Idle output is expected when the source issue is blocked — skip ticket creation entirely.
     if (sourceIssue?.status === "blocked") return { kind: "skipped" as const };
@@ -2012,7 +2131,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string; issueCreatedAtGte?: Date | null }) {
     const now = opts?.now ?? new Date();
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
-    let candidates = await db
+    const staleCandidates = await db
       .select()
       .from(heartbeatRuns)
       .where(
@@ -2024,6 +2143,37 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       )
       .orderBy(asc(heartbeatRuns.createdAt))
       .limit(100);
+    const evaluationCandidates = await db
+      .select({ run: heartbeatRuns })
+      .from(issues)
+      .innerJoin(
+        heartbeatRuns,
+        and(
+          eq(issues.companyId, heartbeatRuns.companyId),
+          sql`${issues.originId} = ${heartbeatRuns.id}::text`,
+        ),
+      )
+      .where(
+        and(
+          opts?.companyId ? eq(issues.companyId, opts.companyId) : undefined,
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+          eq(heartbeatRuns.status, "running"),
+        ),
+      )
+      .orderBy(asc(issues.createdAt))
+      .limit(100);
+    const candidatesById = new Map<string, typeof heartbeatRuns.$inferSelect>();
+    for (const run of staleCandidates) {
+      candidatesById.set(run.id, run);
+    }
+    for (const { run } of evaluationCandidates) {
+      if (!candidatesById.has(run.id)) {
+        candidatesById.set(run.id, run);
+      }
+    }
+    let candidates = [...candidatesById.values()];
 
     if (opts?.issueCreatedAtGte) {
       const issueIds = [...new Set(candidates.flatMap((run) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates AI agents through issue state, run records, and recovery workflows.
> - The active-run output watchdog protects users from silent runs by opening stale-run evaluation work when an active run has stopped producing visible progress.
> - Detached runs are a special recovery case because the in-memory handle can be gone while the child process may still emit useful output later.
> - When a detached run has no source issue and emits output after watchdog evaluation, the recovery workflow should fold that output back into the existing evaluation instead of leaving the parent issue silent.
> - This pull request adds a narrow late-output fold for that detached no-source path and covers it with the watchdog regression suite.
> - The benefit is fewer false silent-run stalls while preserving the existing manual-continue and source-backed finalization behavior.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Inline bug description:

- What happened: a detached `process_detached` active run with no source issue can emit output after the stale-run watchdog has already opened an evaluation issue. The recovery path can leave that evaluation open even though useful output arrived later.
- Expected behavior: late output that arrives after the watchdog evaluation/latest decision should be folded into recovery, close the evaluation issue, and record the continuation/snooze metadata needed for follow-up.
- Steps to reproduce: seed a stale detached no-source active run, let the watchdog open an evaluation issue, update the run with output after the evaluation decision point, then scan silent active runs again.
- Version or commit: observed against `paperclipai/paperclip` `master` at `ef37203a4805b8712bef4582492df0fff8eda76f`; fixed by commit `d056a5cb14e03c42b3284965e5e045e7e37bba9e`.
- Deployment mode: server-side Paperclip control-plane heartbeat and recovery services.
- Related PR: supersedes #8590, which used the same fix commit but was closed while moving the public branch to a contribution-guide-compliant name.

## What Changed

- Added a detached no-source late-output recovery fold in the recovery service, guarded to the stale evaluation path and detached-process error state.
- Included open evaluation candidates in the silent active-run scan so late output can be folded after the original stale candidate window.
- Added regression coverage for the late-output fold path and its watchdog decision/snooze behavior.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts --silent` passed: 1 file, 19 tests.
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check origin/master...HEAD`
- Duplicate search: searched open paperclip PRs/issues for `detached no-source late output` and `active-run output watchdog detached`; only the superseded #8590 matched.

## Risks

- Low-risk two-file change: recovery service logic plus targeted watchdog regression tests.
- The fold path is intentionally narrow: no-source issue, open stale-run evaluation, detached processing, and output after the evaluation/latest watchdog decision.
- Full monorepo suite was not run locally; targeted watchdog coverage and server typecheck passed.

## Model Used

OpenAI GPT-5 via Codex, tool-assisted patch workflow with terminal-based verification and GitHub CLI operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
