### PR TITLE
Fix stale source-scoped recovery resolution authority for historical sweeps

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1357,6 +1357,34 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueRecoveryActionService.resolveActiveForIssue).toHaveBeenCalled();
   });
 
+  it("allows the recorded return owner to resolve a source-scoped recovery action on another agent's blocked issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: peerAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: peerAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId: peerAgentId,
+      previousOwnerAgentId: ownerAgentId,
+      returnOwnerAgentId: ownerAgentId,
+    });
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/recovery-actions/resolve`)
+      .send({
+        actionId: recoveryActionId,
+        outcome: "restored",
+        sourceIssueStatus: "done",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+    expect(mockIssueRecoveryActionService.resolveActiveForIssue).toHaveBeenCalled();
+  });
+
   it("wakes the assigned agent when recovery resolution restores a source issue to todo", async () => {
     mockIssueService.getById.mockResolvedValue(
       makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2661,6 +2661,20 @@ export function issueRoutes(
     ) {
       return true;
     }
+    if (activeRecoveryAction.previousOwnerAgentId === actorAgentId) return true;
+    if (
+      activeRecoveryAction.previousOwnerAgentId &&
+      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, activeRecoveryAction.previousOwnerAgentId)
+    ) {
+      return true;
+    }
+    if (activeRecoveryAction.returnOwnerAgentId === actorAgentId) return true;
+    if (
+      activeRecoveryAction.returnOwnerAgentId &&
+      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, activeRecoveryAction.returnOwnerAgentId)
+    ) {
+      return true;
+    }
 
     res.status(403).json({
       error: "Agent cannot resolve another owner's recovery action",
@@ -3556,7 +3570,6 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id);
     if (
       !(await assertRecoveryActionAuthority(


### PR DESCRIPTION
## Thinking Path
Historical bounded CEO sweep issues can retain source-scoped recovery actions after the underlying lane is already historical/parked. Sentinel reproduced that the documented recovery-resolution API path returned `403 Issue is outside this actor's authorization boundary` before the route considered the recovery metadata that names the previous/return owner. The narrow fix is to authorize the recovery-resolution action from the recovery action itself, not from generic issue mutation ownership.

## What Changed
- Let source-scoped recovery resolution rely on recovery-action authority instead of generic issue mutation ownership.
- Allow the recorded previous/return owner of a recovery action to resolve it, including historical sweep artifacts handed back from CEO coordination to CTO ownership.
- Cover the return-owner path with route authorization tests.

## Risks
- Low/medium control-plane authorization risk: this changes who can resolve recovery actions, so the implementation is intentionally scoped to agents already recorded on the recovery action (`previousOwnerAgentId` / `returnOwnerAgentId`) instead of broad issue mutation rights.
- Operational risk if merged without review: stale recovery cleanup could affect agent inbox visibility, so Ravi/maintainer review is still required before merge.

## Model Used
Codex local agent for implementation; Sentinel CEO used Paperclip/GitHub live checks for coordination.

## Summary
- let source-scoped recovery resolution rely on recovery-action authority instead of generic issue mutation ownership
- allow the recorded previous/return owner of a recovery action to resolve it, including historical sweep artifacts handed back from CEO coordination to CTO ownership
- cover the return-owner path with route authorization tests

## Why
Historical bounded sweep issues such as `TEC-1318` can retain active source-scoped recovery actions after the lane is effectively historical. Sentinel reproduced a `403 Issue is outside this actor's authorization boundary` from `POST /api/issues/{id}/recovery-actions/resolve` because the route enforced generic issue mutation before considering recovery metadata that still names the prior/return owner.

Inline issue description: Paperclip's recovery-resolution route should allow the agents explicitly recorded on a source-scoped recovery action to resolve that recovery action, so historical parked bounded-sweep artifacts do not keep polluting manager/CTO recovery inboxes when no live implementation lane remains.

## Dedup Search
- [x] Searched the open PR list for similar PRs before continuing; no duplicate PR for stale source-scoped recovery-action authority was found in the current queue.

## How To Test
- Reproduction before fix:
  - `POST /api/issues/TEC-1318/recovery-actions/resolve` with `{"outcome":"restored","sourceIssueStatus":"done"}` returned `403 Issue is outside this actor's authorization boundary` for Sentinel.
- Verification in this branch:
  - `./node_modules/.bin/vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-recovery-actions.test.ts`

## Verification Notes
- This repo does not have a repository-local `bin/ci`, so I ran the targeted Vitest suites directly.
- `pnpm install --frozen-lockfile` failed on this host because `sharp` fell back to a source build and Python 3.14 lacks `distutils`; `pnpm install --frozen-lockfile --ignore-scripts` was enough to run the route-level tests above.
