### PR TITLE
fix(recovery): skip handoff for permanent watchers

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5248,6 +5248,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: issues.status,
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
+        executionPolicy: issues.executionPolicy,
         executionState: issues.executionState,
         projectId: issues.projectId,
       })

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -29,6 +29,7 @@ const issue = {
   status: "in_progress",
   assigneeAgentId: "agent-1",
   assigneeUserId: null,
+  executionPolicy: null,
   executionState: null,
 } as any;
 
@@ -151,6 +152,24 @@ describe("successful run handoff decision", () => {
     })).toEqual({
       kind: "skip",
       reason: "active routine continuation owns the next action",
+    });
+  });
+
+  it("does not queue for permanent watcher registry issues", () => {
+    expect(decide({
+      issue: {
+        ...issue,
+        title: "Discord Notification Dedup Registry (permanent, do not complete)",
+        executionPolicy: {
+          mode: "normal",
+          stages: [],
+          commentRequired: true,
+          permanentWatcher: true,
+        },
+      } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "permanent watcher policy owns the continuation path",
     });
   });
 

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -45,7 +45,15 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "title"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionPolicy"
+  | "executionState"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -311,6 +319,11 @@ function isProductiveSuccessfulRun(input: {
   return Boolean(input.detectedProgressSummary);
 }
 
+function isPermanentWatcherIssue(issue: IssueRow) {
+  const policy = readRecord(issue.executionPolicy);
+  return policy.permanentWatcher === true;
+}
+
 export function buildSuccessfulRunHandoffInstruction(input: {
   issueIdentifier: string | null;
   sourceRunId: string;
@@ -373,6 +386,7 @@ export function decideSuccessfulRunHandoff(input: {
   }
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
+  if (isPermanentWatcherIssue(issue)) return { kind: "skip", reason: "permanent watcher policy owns the continuation path" };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The recovery subsystem watches successful agent runs and queues corrective handoffs when an issue is left in progress without an explicit next path.
> - Some long-lived registry/watchdog issues are intentionally in progress forever and already declare that behavior through `executionPolicy.permanentWatcher`.
> - The successful-run handoff path fetched execution state, blockers, pending interactions, and routine parents, but it did not fetch or honor the permanent watcher policy.
> - That caused permanent registry issues to look like missing-disposition failures after otherwise successful watcher runs.
> - This pull request treats `permanentWatcher: true` as a valid continuation path and adds regression coverage for that issue shape.
> - The benefit is fewer false recovery loops while preserving missing-disposition recovery for ordinary in-progress work.

## Linked Issues or Issue Description

Bug description:

- A successful agent run can leave an issue in `in_progress` and trigger the missing-disposition handoff detector.
- Permanent watcher or registry issues intentionally remain in `in_progress` because their job is ongoing stewardship rather than completion.
- These issues already declare that contract via `executionPolicy.permanentWatcher: true`.
- The recovery detector ignored that policy, so it could queue corrective recovery for a valid permanent watcher issue.
- Expected behavior: successful-run handoff detection should skip permanent watcher issues because the policy itself is the continuation path.

## What Changed

- Include `executionPolicy` in the issue projection used by successful-run handoff detection.
- Add a permanent-watcher policy check before missing-disposition recovery is queued.
- Add unit coverage for a permanent watcher registry issue that remains intentionally in progress.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/successful-run-handoff.test.ts` passed in the dependency-installed checkout.
- `pnpm --filter @paperclipai/server typecheck` passed in the dependency-installed checkout.
- `git diff --check` passed in the clean PR worktree.

## Risks

- Low risk: this only skips recovery for issues that explicitly declare `executionPolicy.permanentWatcher: true`.
- Ordinary in-progress issues without that policy still go through the existing missing-disposition recovery path.
- If an issue is incorrectly marked as a permanent watcher, recovery will trust that policy and skip the corrective handoff.

## Model Used

OpenAI GPT-5 Codex with tool use for repository inspection, patching, local command execution, and GitHub/Paperclip coordination.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge