### PR TITLE
fix(recovery): keep recovered cadence trackers idle

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2342,6 +2342,231 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("keeps a manually recovered cadence tracker idle instead of re-dispatching assignment recovery", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+      runError: "stream disconnected before completion",
+    });
+    await db
+      .update(issues)
+      .set({
+        description: [
+          "Long-lived tracking issue for the Reporter daily programme digest cadence (14:00 BST every day). Do not close.",
+          "",
+          "Operational status convention: keep this issue assigned to Reporter and `todo` while idle between scheduled cadence comments; use `in_progress` only while a cadence trigger is actively being handled. After posting a digest or an explicit no-duplicate acknowledgement, return it to `todo` so productivity monitoring does not read the tracker as stalled long-running execution.",
+        ].join("\n"),
+        checkoutRunId: runId,
+        executionRunId: runId,
+      })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorType: "agent",
+      body: "Recovered the missed daily digest and restored this rolling tracker to Reporter-owned `todo` while idle.",
+      createdAt: new Date("2026-03-19T00:06:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:06:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue).toMatchObject({
+      status: "todo",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(runId);
+    expect(runs[0]?.status).toBe("failed");
+    expect(runs[0]?.errorCode).toBe("adapter_failed");
+    expect(runs[0]?.error).toBe("stream disconnected before completion");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+  });
+
+  it("does not let an older manual recovery comment suppress a later cadence trigger", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+      runError: "stream disconnected before completion",
+    });
+    await db
+      .update(issues)
+      .set({
+        description: [
+          "Long-lived tracking issue for the Reporter daily programme digest cadence (14:00 BST every day). Do not close.",
+          "",
+          "Operational status convention: keep this issue assigned to Reporter and `todo` while idle between scheduled cadence comments; use `in_progress` only while a cadence trigger is actively being handled. After posting a digest or an explicit no-duplicate acknowledgement, return it to `todo` so productivity monitoring does not read the tracker as stalled long-running execution.",
+        ].join("\n"),
+      })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: "Recovered the missed daily digest and restored this rolling tracker to Reporter-owned `todo` while idle.",
+        createdAt: new Date("2026-03-19T00:06:00.000Z"),
+        updatedAt: new Date("2026-03-19T00:06:00.000Z"),
+      },
+      {
+        companyId,
+        issueId,
+        body:
+          "Cadence trigger fired at 2026-03-20T13:00:00Z (2026-03-20 14:00 BST). Produce the daily-digest report. (cadence=daily-digest)",
+        createdAt: new Date("2026-03-20T13:00:00.000Z"),
+        updatedAt: new Date("2026-03-20T13:00:00.000Z"),
+      },
+    ]);
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.dispatchRequeued).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.contextSnapshot).toMatchObject({
+      issueId,
+      retryReason: "assignment_recovery",
+      source: "issue.assignment_recovery",
+    });
+    if (retryRun?.id) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  it("does not treat generic recovered progress comments as cadence recovery dispositions", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+      runError: "stream disconnected before completion",
+    });
+    await db
+      .update(issues)
+      .set({
+        description: [
+          "Long-lived tracking issue for the Reporter daily programme digest cadence (14:00 BST every day). Do not close.",
+          "",
+          "Operational status convention: keep this issue assigned to Reporter and `todo` while idle between scheduled cadence comments; use `in_progress` only while a cadence trigger is actively being handled. After posting a digest or an explicit no-duplicate acknowledgement, return it to `todo` so productivity monitoring does not read the tracker as stalled long-running execution.",
+        ].join("\n"),
+      })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorType: "agent",
+      body: "Successfully recovered from the network error and retried the fetch.",
+      createdAt: new Date("2026-03-19T00:06:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:06:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.dispatchRequeued).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.contextSnapshot).toMatchObject({
+      issueId,
+      retryReason: "assignment_recovery",
+      source: "issue.assignment_recovery",
+    });
+    if (retryRun?.id) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
+  });
+
+  it("finds a manual cadence recovery comment beyond the newest twenty comments", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+      runError: "stream disconnected before completion",
+    });
+    await db
+      .update(issues)
+      .set({
+        description: [
+          "Long-lived tracking issue for the Reporter daily programme digest cadence (14:00 BST every day). Do not close.",
+          "",
+          "Operational status convention: keep this issue assigned to Reporter and `todo` while idle between scheduled cadence comments; use `in_progress` only while a cadence trigger is actively being handled. After posting a digest or an explicit no-duplicate acknowledgement, return it to `todo` so productivity monitoring does not read the tracker as stalled long-running execution.",
+        ].join("\n"),
+        checkoutRunId: runId,
+        executionRunId: runId,
+      })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueComments).values([
+      {
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        authorType: "agent",
+        body: "Recovery note: posted the missing daily digest and returned this rolling tracker to `todo` while idle.",
+        createdAt: new Date("2026-03-19T00:06:00.000Z"),
+        updatedAt: new Date("2026-03-19T00:06:00.000Z"),
+      },
+      ...Array.from({ length: 25 }, (_, index) => ({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        authorType: "agent" as const,
+        body: `Operator follow-up note ${index + 1}: no new cadence trigger.`,
+        createdAt: new Date(Date.UTC(2026, 2, 19, 0, 7 + index, 0)),
+        updatedAt: new Date(Date.UTC(2026, 2, 19, 0, 7 + index, 0)),
+      })),
+    ]);
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue).toMatchObject({
+      status: "todo",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(runId);
+  });
+
   it("does not duplicate initial assigned todo dispatch when a queued wake already exists", async () => {
     const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
     await db.insert(agentWakeupRequests).values({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -112,7 +112,16 @@ type RecoveryWakeup = (
 
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
-  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
+  | "id"
+  | "agentId"
+  | "status"
+  | "error"
+  | "errorCode"
+  | "contextSnapshot"
+  | "livenessState"
+  | "finishedAt"
+  | "updatedAt"
+  | "createdAt"
 > | null;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
@@ -175,6 +184,39 @@ function didAutomaticRecoveryFail(
     UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
       latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
     );
+}
+
+function isTodoIdleCadenceTracker(issue: Pick<typeof issues.$inferSelect, "title" | "description">) {
+  const text = `${issue.title}\n${issue.description ?? ""}`.toLowerCase();
+  if (!text.includes("cadence")) return false;
+  if (
+    !text.includes("long-lived tracking issue") &&
+    !text.includes("long-lived tracker") &&
+    !text.includes("rolling tracker")
+  ) {
+    return false;
+  }
+  return /todo`?\s+while idle/.test(text) ||
+    /while idle[\s\S]{0,120}`?todo`?/.test(text) ||
+    /return (it|this issue|the tracker)[\s\S]{0,120}`?todo`?/.test(text);
+}
+
+const MANUAL_CADENCE_RECOVERY_COMMENT_SCAN_LIMIT = 50;
+
+function isManualCadenceRecoveryDispositionComment(body: string) {
+  return [
+    /\brecovery note\b[\s\S]{0,160}\b(todo|idle|digest|report|no-duplicate|acknowledg)/i,
+    /\bmanual\b[\s\S]{0,80}\brecovery\b[\s\S]{0,160}\b(todo|idle|digest|report)/i,
+    /\brecovered\b[\s\S]{0,160}\b(todo|idle|digest|report)/i,
+    /\b(digest|report)\b[\s\S]{0,160}\brecovered\b/i,
+    /\b(restored|returned)\b[\s\S]{0,80}\b(todo|idle)\b/i,
+    /\bno-duplicate\b[\s\S]{0,80}\backnowledg/i,
+    /^#{1,6}\s+.*\b(digest|report)\b[\s\S]{0,160}\b(recovered|recovery|returned|restored|todo|idle|no-duplicate|acknowledg)/im,
+  ].some((pattern) => pattern.test(body));
+}
+
+function isCadenceTriggerComment(body: string) {
+  return /\bCadence trigger fired\b/.test(body) && /\(cadence=/.test(body);
 }
 
 const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
@@ -497,6 +539,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        finishedAt: heartbeatRuns.finishedAt,
+        updatedAt: heartbeatRuns.updatedAt,
+        createdAt: heartbeatRuns.createdAt,
       })
       .from(heartbeatRuns)
       .where(
@@ -508,6 +553,90 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
       .limit(1)
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function findManualCadenceRecoveryCommentAfterRun(
+    issue: typeof issues.$inferSelect,
+    latestRun: NonNullable<LatestIssueRun>,
+  ) {
+    const after = latestRun.finishedAt ?? latestRun.updatedAt ?? latestRun.createdAt;
+    const rows = await db
+      .select({
+        id: issueComments.id,
+        body: issueComments.body,
+        authorType: issueComments.authorType,
+        createdByRunId: issueComments.createdByRunId,
+        createdAt: issueComments.createdAt,
+      })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, issue.companyId),
+          eq(issueComments.issueId, issue.id),
+          isNull(issueComments.deletedAt),
+          gt(issueComments.createdAt, after),
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt))
+      .limit(MANUAL_CADENCE_RECOVERY_COMMENT_SCAN_LIMIT);
+
+    const recoveryComment = rows.find((comment) =>
+      comment.authorType !== "system" &&
+      comment.createdByRunId !== latestRun.id &&
+      isManualCadenceRecoveryDispositionComment(comment.body)
+    ) ?? null;
+    if (!recoveryComment) return null;
+
+    const hasLaterCadenceTrigger = rows.some((comment) =>
+      comment.createdAt > recoveryComment.createdAt &&
+      isCadenceTriggerComment(comment.body)
+    );
+    return hasLaterCadenceTrigger ? null : recoveryComment;
+  }
+
+  async function returnManuallyRecoveredCadenceTrackerToIdleIfNeeded(
+    issue: typeof issues.$inferSelect,
+    latestRun: LatestIssueRun,
+  ) {
+    if (!latestRun) return false;
+    if (!isTodoIdleCadenceTracker(issue)) return false;
+
+    const recoveryComment = await findManualCadenceRecoveryCommentAfterRun(issue, latestRun);
+    if (!recoveryComment) return false;
+
+    if (
+      issue.status !== "todo" ||
+      issue.checkoutRunId ||
+      issue.executionRunId ||
+      issue.executionAgentNameKey ||
+      issue.executionLockedAt
+    ) {
+      const updated = await issuesSvc.update(issue.id, { status: "todo" });
+      if (!updated) return false;
+
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          identifier: issue.identifier,
+          status: "todo",
+          previousStatus: issue.status,
+          source: "recovery.reconcile_cadence_tracker_manual_recovery",
+          latestRunId: latestRun.id,
+          latestRunStatus: latestRun.status,
+          latestRunErrorCode: latestRun.errorCode,
+          recoveryCommentId: recoveryComment.id,
+        },
+      });
+    }
+
+    return true;
   }
 
   async function summarizeRecentContinuationRetries(
@@ -2778,6 +2907,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         } else {
           result.skipped += 1;
         }
+        continue;
+      }
+
+      if (await returnManuallyRecoveredCadenceTrackerToIdleIfNeeded(issue, latestRun)) {
+        result.skipped += 1;
         continue;
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The recovery subsystem reconciles assigned issues whose execution path disappeared or ended unexpectedly.
> - Standing cadence trackers can intentionally sit assigned and `todo` while idle between scheduled report triggers.
> - A failed adapter run can remain the latest run even after a later manual report/recovery comment restored the tracker to idle.
> - The generic assigned `todo` recovery path treated that state as lost work and re-dispatched the tracker.
> - This pull request adds a narrow cadence-tracker idle guard while preserving ordinary assigned-work recovery.
> - The benefit is fewer self-inflicted reruns for recovered cadence trackers without hiding failed adapter evidence.

## Linked Issues or Issue Description

No public GitHub issue matched this bug in the duplicate search.

### What happened?

A long-lived cadence tracker whose own description documents `todo` as the idle posture could be re-dispatched by stranded assigned-issue recovery after a failed adapter run, even after a later non-system recovery/disposition comment showed the missed report had been recovered.

### Expected behavior

When the tracker has a later manual recovery/disposition comment and no newer cadence trigger, recovery should clear stale execution locks and leave it assigned `todo` while idle.

### Steps to reproduce

1. Create an assigned `todo` issue with a cadence-tracker idle convention in its description.
2. Record a failed `adapter_failed` run as the latest issue run.
3. Add a later recovery comment from the assignee.
4. Run `reconcileStrandedAssignedIssues()`.

### Paperclip version or commit

Reproduced and fixed against current `master` at the time of this PR.

### Deployment mode

Local runtime recovery service; no schema or deployment-mode specific behavior.

### Installation method

Built from source.

### Agent adapter(s) involved

Not adapter-specific. The reproduction uses a failed adapter run as evidence that generic recovery previously retried too broadly.

### Database mode

Not database-mode specific.

## What Changed

- Added cadence-tracker detection based on the issue's documented long-lived cadence and `todo` idle convention.
- Added a recovery-comment check that only suppresses generic recovery after a later non-system recovery/disposition comment, while allowing a newer `Cadence trigger fired` comment to become actionable again.
- Clears stale checkout/execution locks by returning matched trackers to `todo` through the issue service.
- Added regression tests for the recovered-idle case, the later-trigger case, and preserved adapter failure evidence.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "keeps a manually recovered cadence tracker idle"`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "assigned todo|cadence tracker|cadence trigger|adapter_failed continuation|failed/adapter_failed|continuation for stranded in-progress"`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- `git diff --check`

## Risks

- Low to medium risk: this changes an automatic recovery sweep, so an overly broad detector could skip legitimate work. The guard is constrained to issues that document a long-lived cadence tracker and `todo` idle posture, requires a later recovery/disposition comment, and explicitly stops suppressing recovery after a newer cadence trigger.
- No database migration.
- No lockfile or package manifest changes.

## Model Used

OpenAI Codex coding agent based on GPT-5, with shell, git, GitHub CLI, local test execution, and repository editing tools. Reasoning mode: medium. The harness did not expose an exact context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched for similar open/closed PRs and confirmed this is not a duplicate
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge