### PR TITLE
fix(plugins): scope config and secret refs by company

### DIFF
--- a/packages/db/src/migrations/0087_plugin_config_company_scope.sql
+++ b/packages/db/src/migrations/0087_plugin_config_company_scope.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "plugin_config" ADD COLUMN IF NOT EXISTS "company_id" uuid;--> statement-breakpoint
+UPDATE "plugin_config"
+SET "company_id" = (
+  SELECT "id" FROM "companies" ORDER BY "created_at" ASC LIMIT 1
+)
+WHERE "company_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "plugin_config" ALTER COLUMN "company_id" SET NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'plugin_config_company_id_companies_id_fk') THEN
+    ALTER TABLE "plugin_config" ADD CONSTRAINT "plugin_config_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DROP INDEX IF EXISTS "plugin_config_plugin_id_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "plugin_config_plugin_company_idx" ON "plugin_config" USING btree ("plugin_id", "company_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1779235200000,
+      "tag": "0087_plugin_config_company_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/plugin_config.ts
+++ b/packages/db/src/schema/plugin_config.ts
@@ -1,10 +1,11 @@
 import { pgTable, uuid, text, timestamp, jsonb, uniqueIndex } from "drizzle-orm/pg-core";
 import { plugins } from "./plugins.js";
+import { companies } from "./companies.js";
 
 /**
  * `plugin_config` table — stores operator-provided instance configuration
- * for each plugin (one row per plugin, enforced by a unique index on
- * `plugin_id`).
+ * for each plugin and company (one row per plugin/company pair, enforced
+ * by a unique index on `plugin_id, company_id`).
  *
  * The `config_json` column holds the values that the operator enters in the
  * plugin settings UI. These values are validated at runtime against the
@@ -19,12 +20,15 @@ export const pluginConfig = pgTable(
     pluginId: uuid("plugin_id")
       .notNull()
       .references(() => plugins.id, { onDelete: "cascade" }),
+    companyId: uuid("company_id")
+      .notNull()
+      .references(() => companies.id, { onDelete: "cascade" }),
     configJson: jsonb("config_json").$type<Record<string, unknown>>().notNull().default({}),
     lastError: text("last_error"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    pluginIdIdx: uniqueIndex("plugin_config_plugin_id_idx").on(table.pluginId),
+    pluginCompanyIdx: uniqueIndex("plugin_config_plugin_company_idx").on(table.pluginId, table.companyId),
   }),
 );

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -87,7 +87,7 @@ export class CapabilityDeniedError extends Error {
 export interface HostServices {
   /** Provides `config.get`. */
   config: {
-    get(): Promise<Record<string, unknown>>;
+    get(params: WorkerToHostMethods["config.get"][0]): Promise<Record<string, unknown>>;
   };
 
   /** Provides trusted company-scoped local folder helpers. */
@@ -497,8 +497,8 @@ export function createHostClientHandlers(
 
   return {
     // Config
-    "config.get": gated("config.get", async () => {
-      return services.config.get();
+    "config.get": gated("config.get", async (params) => {
+      return services.config.get(params);
     }),
 
     "localFolders.declarations": gated("localFolders.declarations", async (params) => {

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -576,7 +576,7 @@ export const HOST_TO_WORKER_OPTIONAL_METHODS: readonly HostToWorkerMethodName[] 
  */
 export interface WorkerToHostMethods {
   // Config
-  "config.get": [params: Record<string, never>, result: Record<string, unknown>];
+  "config.get": [params: { companyId?: string }, result: Record<string, unknown>];
 
   // Trusted local folders
   "localFolders.declarations": [
@@ -713,7 +713,7 @@ export interface WorkerToHostMethods {
 
   // Secrets
   "secrets.resolve": [
-    params: { secretRef: string },
+    params: { companyId?: string; secretRef: string },
     result: string,
   ];
 

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -412,7 +412,7 @@ export interface PluginConfigClient {
    * Values are validated against the plugin's `instanceConfigSchema` by the
    * host before being passed to the worker.
    */
-  get(): Promise<Record<string, unknown>>;
+  get(companyId?: string): Promise<Record<string, unknown>>;
 }
 
 export interface PluginLocalFolderProblem {
@@ -644,6 +644,7 @@ export interface PluginSecretsClient {
    * @returns The resolved secret value
    */
   resolve(secretRef: string): Promise<string>;
+  resolve(companyId: string, secretRef: string): Promise<string>;
 }
 
 /**

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -396,8 +396,8 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
       },
 
       config: {
-        async get() {
-          return callHost("config.get", {} as Record<string, never>);
+        async get(companyId?: string) {
+          return callHost("config.get", { companyId });
         },
       },
 
@@ -547,8 +547,10 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
       },
 
       secrets: {
-        async resolve(secretRef: string): Promise<string> {
-          return callHost("secrets.resolve", { secretRef });
+        async resolve(companyIdOrSecretRef: string, maybeSecretRef?: string): Promise<string> {
+          const companyId = maybeSecretRef ? companyIdOrSecretRef : undefined;
+          const secretRef = maybeSecretRef ?? companyIdOrSecretRef;
+          return callHost("secrets.resolve", { companyId, secretRef });
         },
       },
 

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -666,8 +666,10 @@ export interface PluginStateRecord {
 export interface PluginConfig {
   /** UUID primary key. */
   id: string;
-  /** FK to `plugins.id`. Unique — each plugin has at most one config row. */
+  /** FK to `plugins.id`. */
   pluginId: string;
+  /** Company that owns this configuration row. */
+  companyId: string;
   /** Operator-provided configuration values (validated against `instanceConfigSchema`). */
   configJson: Record<string, unknown>;
   /** Most recent config validation error, if any. */

--- a/packages/shared/src/validators/plugin.ts
+++ b/packages/shared/src/validators/plugin.ts
@@ -993,6 +993,7 @@ export type InstallPlugin = z.infer<typeof installPluginSchema>;
  * the plugin's instanceConfigSchema is done at the service layer.
  */
 export const upsertPluginConfigSchema = z.object({
+  companyId: z.string().uuid(),
   configJson: z.record(z.string(), z.unknown()),
 });
 
@@ -1003,6 +1004,7 @@ export type UpsertPluginConfig = z.infer<typeof upsertPluginConfigSchema>;
  * Allows a partial merge of config values.
  */
 export const patchPluginConfigSchema = z.object({
+  companyId: z.string().uuid(),
   configJson: z.record(z.string(), z.unknown()),
 });
 

--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockRegistry = vi.hoisted(() => ({
   getById: vi.fn(),
   getByKey: vi.fn(),
+  getConfig: vi.fn(),
   upsertConfig: vi.fn(),
   getCompanySettings: vi.fn(),
   upsertCompanySettings: vi.fn(),
@@ -17,6 +18,8 @@ const mockLifecycle = vi.hoisted(() => ({
   enable: vi.fn(),
   disable: vi.fn(),
 }));
+
+const mockSyncSecretRefsForTarget = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/plugin-registry.js", () => ({
   pluginRegistryService: () => mockRegistry,
@@ -32,6 +35,12 @@ vi.mock("../services/activity-log.js", () => ({
 
 vi.mock("../services/live-events.js", () => ({
   publishGlobalLiveEvent: vi.fn(),
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: () => ({
+    syncSecretRefsForTarget: mockSyncSecretRefsForTarget,
+  }),
 }));
 
 async function createApp(
@@ -120,6 +129,14 @@ function readyPlugin() {
     pluginKey: "paperclip.example",
     version: "1.0.0",
     status: "ready",
+    manifestJson: {
+      instanceConfigSchema: {
+        type: "object",
+        properties: {
+          apiKeyRef: { type: "string", format: "secret-ref" },
+        },
+      },
+    },
   });
 }
 
@@ -275,7 +292,42 @@ describe.sequential("plugin install and upgrade authz", () => {
     expect(mockLifecycle.unload).toHaveBeenCalledWith(pluginId, true);
   }, 20_000);
 
-  it("rejects plugin config saves that contain secret refs even for instance admins", async () => {
+  it("saves plugin secret-ref config under an explicit company scope", async () => {
+    readyPlugin();
+    mockRegistry.upsertConfig.mockResolvedValue({ id: "cfg-1", pluginId, companyId: companyA, configJson: {} });
+
+    const { app } = await createApp({
+      type: "board",
+      userId: "admin-1",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: [companyA],
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/config`)
+      .send({
+        companyId: companyA,
+        configJson: {
+          apiKeyRef: "77777777-7777-4777-8777-777777777777",
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockRegistry.upsertConfig).toHaveBeenCalledWith(pluginId, companyA, {
+      companyId: companyA,
+      configJson: {
+        apiKeyRef: "77777777-7777-4777-8777-777777777777",
+      },
+    });
+    expect(mockSyncSecretRefsForTarget).toHaveBeenCalledWith(
+      companyA,
+      { targetType: "plugin", targetId: pluginId },
+      [{ secretId: "77777777-7777-4777-8777-777777777777", configPath: "apiKeyRef" }],
+    );
+  }, 20_000);
+
+  it("rejects plugin config saves for another company", async () => {
     readyPlugin();
 
     const { app } = await createApp({
@@ -289,13 +341,11 @@ describe.sequential("plugin install and upgrade authz", () => {
     const res = await request(app)
       .post(`/api/plugins/${pluginId}/config`)
       .send({
-        configJson: {
-          apiKeyRef: "77777777-7777-4777-8777-777777777777",
-        },
+        companyId: companyB,
+        configJson: { apiKeyRef: "77777777-7777-4777-8777-777777777777" },
       });
 
-    expect(res.status).toBe(422);
-    expect(res.body.error).toMatch(/secret references are disabled/i);
+    expect(res.status).toBe(403);
     expect(mockRegistry.upsertConfig).not.toHaveBeenCalled();
   }, 20_000);
 

--- a/server/src/__tests__/plugin-secrets-handler.test.ts
+++ b/server/src/__tests__/plugin-secrets-handler.test.ts
@@ -1,19 +1,59 @@
-import { describe, expect, it } from "vitest";
-import {
-  createPluginSecretsHandler,
-  PLUGIN_SECRET_REFS_DISABLED_MESSAGE,
-} from "../services/plugin-secrets-handler.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginSecretsHandler } from "../services/plugin-secrets-handler.js";
+
+const mockResolveSecretValue = vi.fn();
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: () => ({
+    resolveSecretValue: mockResolveSecretValue,
+  }),
+}));
 
 describe("createPluginSecretsHandler", () => {
-  it("fails closed for plugin secret resolution until company scoping lands", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves secret refs only with explicit company scope", async () => {
+    mockResolveSecretValue.mockResolvedValue("resolved-token");
     const handler = createPluginSecretsHandler({
       db: {} as never,
       pluginId: "11111111-1111-4111-8111-111111111111",
     });
 
     await expect(
-      handler.resolve({ secretRef: "77777777-7777-4777-8777-777777777777" }),
-    ).rejects.toThrow(PLUGIN_SECRET_REFS_DISABLED_MESSAGE);
+      handler.resolve({
+        companyId: "22222222-2222-4222-8222-222222222222",
+        secretRef: "77777777-7777-4777-8777-777777777777",
+      }),
+    ).resolves.toBe("resolved-token");
+
+    expect(mockResolveSecretValue).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      "77777777-7777-4777-8777-777777777777",
+      "latest",
+      { consumerType: "plugin", consumerId: "11111111-1111-4111-8111-111111111111" },
+    );
+  });
+
+  it("fails closed when company scope is missing", async () => {
+    const handler = createPluginSecretsHandler({
+      db: {
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({
+              then: (resolve: (rows: unknown[]) => unknown) => resolve([]),
+            })),
+          })),
+        })),
+      } as never,
+      pluginId: "11111111-1111-4111-8111-111111111111",
+    });
+
+    await expect(
+      handler.resolve({ secretRef: "77777777-7777-4777-8777-777777777777" } as never),
+    ).rejects.toThrow(/companyId is required/i);
+    expect(mockResolveSecretValue).not.toHaveBeenCalled();
   });
 
   it("still rejects malformed secret refs before the feature-disable guard", async () => {
@@ -23,7 +63,7 @@ describe("createPluginSecretsHandler", () => {
     });
 
     await expect(
-      handler.resolve({ secretRef: "not-a-uuid" }),
+      handler.resolve({ companyId: "22222222-2222-4222-8222-222222222222", secretRef: "not-a-uuid" }),
     ).rejects.toThrow(/invalid secret reference/i);
   });
 });

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -73,10 +73,8 @@ import {
   requireLocalFolderDeclaration,
   setStoredLocalFolder,
 } from "../services/plugin-local-folders.js";
-import {
-  extractSecretRefPathsFromConfig,
-  PLUGIN_SECRET_REFS_DISABLED_MESSAGE,
-} from "../services/plugin-secrets-handler.js";
+import { extractSecretRefPathsFromConfig } from "../services/plugin-secrets-handler.js";
+import { secretService } from "../services/secrets.js";
 import { badRequest, forbidden, notFound, unauthorized, unprocessable } from "../errors.js";
 
 /** UI slot declaration extracted from plugin manifest */
@@ -1952,7 +1950,14 @@ export function pluginRoutes(
       return;
     }
 
-    const config = await registry.getConfig(plugin.id);
+    const companyId = typeof req.query.companyId === "string" ? req.query.companyId : null;
+    if (!companyId) {
+      res.status(400).json({ error: '"companyId" query parameter is required' });
+      return;
+    }
+    assertCompanyAccess(req, companyId);
+
+    const config = await registry.getConfig(plugin.id, companyId);
     res.json(config);
   });
 
@@ -1982,8 +1987,14 @@ export function pluginRoutes(
       return;
     }
 
-    const body = req.body as { configJson?: Record<string, unknown> } | undefined;
-    if (!body?.configJson || typeof body.configJson !== "object") {
+    const body = req.body as { companyId?: string; configJson?: Record<string, unknown> } | undefined;
+    if (!body?.companyId || typeof body.companyId !== "string") {
+      res.status(400).json({ error: '"companyId" is required and must be a string' });
+      return;
+    }
+    assertCompanyAccess(req, body.companyId);
+
+    if (!body.configJson || typeof body.configJson !== "object") {
       res.status(400).json({ error: '"configJson" is required and must be an object' });
       return;
     }
@@ -2014,12 +2025,16 @@ export function pluginRoutes(
 
     try {
       const secretRefsByPath = extractSecretRefPathsFromConfig(body.configJson, schema);
-      if (secretRefsByPath.size > 0) {
-        res.status(422).json({ error: PLUGIN_SECRET_REFS_DISABLED_MESSAGE });
-        return;
-      }
+      await secretService(db).syncSecretRefsForTarget(
+        body.companyId,
+        { targetType: "plugin", targetId: plugin.id },
+        [...secretRefsByPath.entries()].flatMap(([secretId, paths]) =>
+          [...paths].map((configPath) => ({ secretId, configPath })),
+        ),
+      );
 
-      const result = await registry.upsertConfig(plugin.id, {
+      const result = await registry.upsertConfig(plugin.id, body.companyId, {
+        companyId: body.companyId,
         configJson: body.configJson,
       });
       await logPluginMutationActivity(req, "plugin.config.updated", plugin.id, {

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -843,8 +843,10 @@ export function buildHostServices(
 
   return {
     config: {
-      async get() {
-        const configRow = await registry.getConfig(pluginId);
+      async get(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        const configRow = await registry.getConfig(pluginId, companyId);
         return configRow?.configJson ?? {};
       },
     },

--- a/server/src/services/plugin-registry.ts
+++ b/server/src/services/plugin-registry.ts
@@ -280,27 +280,32 @@ export function pluginRegistryService(db: Db) {
 
     // ----- Config ---------------------------------------------------------
 
-    /** Retrieve a plugin's instance configuration. */
-    getConfig: (pluginId: string) =>
-      db
+    /** Retrieve a plugin's company-scoped configuration. */
+    getConfig: (pluginId: string, companyId?: string) => {
+      const query = db
         .select()
         .from(pluginConfig)
-        .where(eq(pluginConfig.pluginId, pluginId))
-        .then((rows) => rows[0] ?? null),
+        .where(companyId
+          ? and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId))
+          : eq(pluginConfig.pluginId, pluginId));
+
+      return (companyId ? query : query.orderBy(asc(pluginConfig.createdAt)))
+        .then((rows) => rows[0] ?? null);
+    },
 
     /**
-     * Create or fully replace a plugin's instance configuration.
-     * If a config row already exists for the plugin it is replaced;
+     * Create or fully replace a plugin's company-scoped configuration.
+     * If a config row already exists for the plugin/company it is replaced;
      * otherwise a new row is inserted.
      */
-    upsertConfig: async (pluginId: string, input: UpsertPluginConfig) => {
+    upsertConfig: async (pluginId: string, companyId: string, input: UpsertPluginConfig) => {
       const plugin = await getById(pluginId);
       if (!plugin) throw notFound("Plugin not found");
 
       const existing = await db
         .select()
         .from(pluginConfig)
-        .where(eq(pluginConfig.pluginId, pluginId))
+        .where(and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId)))
         .then((rows) => rows[0] ?? null);
 
       if (existing) {
@@ -311,7 +316,7 @@ export function pluginRegistryService(db: Db) {
             lastError: null,
             updatedAt: new Date(),
           })
-          .where(eq(pluginConfig.pluginId, pluginId))
+          .where(and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId)))
           .returning()
           .then((rows) => rows[0]);
       }
@@ -320,6 +325,7 @@ export function pluginRegistryService(db: Db) {
         .insert(pluginConfig)
         .values({
           pluginId,
+          companyId,
           configJson: input.configJson,
         })
         .returning()
@@ -330,14 +336,14 @@ export function pluginRegistryService(db: Db) {
      * Partially update a plugin's instance configuration via shallow merge.
      * If no config row exists yet one is created with the supplied values.
      */
-    patchConfig: async (pluginId: string, input: PatchPluginConfig) => {
+    patchConfig: async (pluginId: string, companyId: string, input: PatchPluginConfig) => {
       const plugin = await getById(pluginId);
       if (!plugin) throw notFound("Plugin not found");
 
       const existing = await db
         .select()
         .from(pluginConfig)
-        .where(eq(pluginConfig.pluginId, pluginId))
+        .where(and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId)))
         .then((rows) => rows[0] ?? null);
 
       if (existing) {
@@ -349,7 +355,7 @@ export function pluginRegistryService(db: Db) {
             lastError: null,
             updatedAt: new Date(),
           })
-          .where(eq(pluginConfig.pluginId, pluginId))
+          .where(and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId)))
           .returning()
           .then((rows) => rows[0]);
       }
@@ -358,6 +364,7 @@ export function pluginRegistryService(db: Db) {
         .insert(pluginConfig)
         .values({
           pluginId,
+          companyId,
           configJson: input.configJson,
         })
         .returning()
@@ -368,11 +375,11 @@ export function pluginRegistryService(db: Db) {
      * Record an error against a plugin's config (e.g. validation failure
      * against the plugin's instanceConfigSchema).
      */
-    setConfigError: async (pluginId: string, lastError: string | null) => {
+    setConfigError: async (pluginId: string, companyId: string, lastError: string | null) => {
       const rows = await db
         .update(pluginConfig)
         .set({ lastError, updatedAt: new Date() })
-        .where(eq(pluginConfig.pluginId, pluginId))
+        .where(and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId)))
         .returning();
 
       if (rows.length === 0) throw notFound("Plugin config not found");
@@ -380,10 +387,10 @@ export function pluginRegistryService(db: Db) {
     },
 
     /** Delete a plugin's config row. */
-    deleteConfig: async (pluginId: string) => {
+    deleteConfig: async (pluginId: string, companyId: string) => {
       const rows = await db
         .delete(pluginConfig)
-        .where(eq(pluginConfig.pluginId, pluginId))
+        .where(and(eq(pluginConfig.pluginId, pluginId), eq(pluginConfig.companyId, companyId)))
         .returning();
 
       return rows[0] ?? null;

--- a/server/src/services/plugin-secrets-handler.ts
+++ b/server/src/services/plugin-secrets-handler.ts
@@ -2,8 +2,9 @@
  * Plugin secrets host-side handler — resolves secret references through the
  * Paperclip secret provider system.
  *
- * When a plugin worker calls `ctx.secrets.resolve(secretRef)`, the JSON-RPC
- * request arrives at the host with `{ secretRef }`. This module provides the
+ * When a plugin worker calls `ctx.secrets.resolve(companyId, secretRef)` (or
+ * the backward-compatible `ctx.secrets.resolve(secretRef)` form), the JSON-RPC
+ * request arrives at the host with `{ companyId?, secretRef }`. This module provides the
  * concrete `HostServices.secrets` adapter that:
  *
  * 1. Parses the `secretRef` string to identify the secret.
@@ -17,7 +18,7 @@
  * A `secretRef` is a **secret UUID** — the primary key (`id`) of a row in
  * the `company_secrets` table. Operators place these UUIDs into plugin
  * config values; plugin workers resolve them at execution time via
- * `ctx.secrets.resolve(secretId)`.
+ * `ctx.secrets.resolve(companyId, secretId)`.
  *
  * ## Security Invariants
  *
@@ -34,14 +35,14 @@
  */
 
 import type { Db } from "@paperclipai/db";
+import { companySecretBindings } from "@paperclipai/db";
+import { and, eq } from "drizzle-orm";
 import {
   collectSecretRefPaths,
   isUuidSecretRef,
   readConfigValueAtPath,
 } from "./json-schema-secret-refs.js";
-
-export const PLUGIN_SECRET_REFS_DISABLED_MESSAGE =
-  "Plugin secret references are disabled until company-scoped plugin config lands";
+import { secretService } from "./secrets.js";
 
 // ---------------------------------------------------------------------------
 // Error helpers
@@ -123,6 +124,8 @@ export function extractSecretRefPathsFromConfig(
  * Matches `WorkerToHostMethods["secrets.resolve"][0]` from `protocol.ts`.
  */
 export interface PluginSecretsResolveParams {
+  /** Company that owns the secret binding. */
+  companyId?: string;
   /** The secret reference string (a secret UUID). */
   secretRef: string;
 }
@@ -200,13 +203,14 @@ export function createPluginSecretsHandler(
   options: PluginSecretsHandlerOptions,
 ): PluginSecretsService {
   const { pluginId } = options;
+  const secrets = secretService(options.db);
 
   // Rate limit: max 30 resolution attempts per plugin per minute
   const rateLimiter = createRateLimiter(30, 60_000);
 
   return {
     async resolve(params: PluginSecretsResolveParams): Promise<string> {
-      const { secretRef } = params;
+      const { companyId, secretRef } = params;
 
       // ---------------------------------------------------------------
       // 0. Rate limiting — prevent brute-force UUID enumeration
@@ -230,9 +234,28 @@ export function createPluginSecretsHandler(
         throw invalidSecretRef(trimmedRef);
       }
 
-      // Fail closed until plugin config and worker runtime both carry an
-      // explicit company scope for secret bindings and resolution.
-      throw new Error(PLUGIN_SECRET_REFS_DISABLED_MESSAGE);
+      let resolvedCompanyId = companyId?.trim();
+      if (!resolvedCompanyId) {
+        const binding = await options.db
+          .select({ companyId: companySecretBindings.companyId })
+          .from(companySecretBindings)
+          .where(and(
+            eq(companySecretBindings.targetType, "plugin"),
+            eq(companySecretBindings.targetId, pluginId),
+            eq(companySecretBindings.secretId, trimmedRef),
+          ))
+          .then((rows) => rows[0] ?? null);
+        resolvedCompanyId = binding?.companyId;
+      }
+
+      if (!resolvedCompanyId) {
+        throw new Error("companyId is required for plugin secret resolution");
+      }
+
+      return secrets.resolveSecretValue(resolvedCompanyId, trimmedRef, "latest", {
+        consumerType: "plugin",
+        consumerId: pluginId,
+      });
     },
   };
 }

--- a/ui/src/api/plugins.ts
+++ b/ui/src/api/plugins.ts
@@ -356,8 +356,8 @@ export const pluginsApi = {
    *
    * @param pluginId - UUID of the plugin.
    */
-  getConfig: (pluginId: string) =>
-    api.get<PluginConfig | null>(`/plugins/${pluginId}/config`),
+  getConfig: (pluginId: string, companyId: string) =>
+    api.get<PluginConfig | null>(`/plugins/${pluginId}/config?companyId=${encodeURIComponent(companyId)}`),
 
   /**
    * Save (create or update) the configuration for a plugin.
@@ -368,8 +368,8 @@ export const pluginsApi = {
    * @param pluginId - UUID of the plugin.
    * @param configJson - Configuration values matching the plugin's `instanceConfigSchema`.
    */
-  saveConfig: (pluginId: string, configJson: Record<string, unknown>) =>
-    api.post<PluginConfig>(`/plugins/${pluginId}/config`, { configJson }),
+  saveConfig: (pluginId: string, companyId: string, configJson: Record<string, unknown>) =>
+    api.post<PluginConfig>(`/plugins/${pluginId}/config`, { companyId, configJson }),
 
   /**
    * Call the plugin's `validateConfig` RPC method to test the configuration

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -185,7 +185,7 @@ export const queryKeys = {
     detail: (pluginId: string) => ["plugins", pluginId] as const,
     health: (pluginId: string) => ["plugins", pluginId, "health"] as const,
     uiContributions: ["plugins", "ui-contributions"] as const,
-    config: (pluginId: string) => ["plugins", pluginId, "config"] as const,
+    config: (pluginId: string, companyId?: string | null) => ["plugins", pluginId, "config", companyId ?? "__no_company__"] as const,
     localFolders: (pluginId: string, companyId: string) =>
       ["plugins", pluginId, "companies", companyId, "local-folders"] as const,
     dashboard: (pluginId: string) => ["plugins", pluginId, "dashboard"] as const,

--- a/ui/src/pages/PluginSettings.tsx
+++ b/ui/src/pages/PluginSettings.tsx
@@ -97,9 +97,9 @@ export function PluginSettings() {
   const hasConfigSchema = configSchema && configSchema.properties && Object.keys(configSchema.properties).length > 0;
 
   const { data: configData, isLoading: configLoading } = useQuery({
-    queryKey: queryKeys.plugins.config(pluginId!),
-    queryFn: () => pluginsApi.getConfig(pluginId!),
-    enabled: !!pluginId && !!hasConfigSchema,
+    queryKey: queryKeys.plugins.config(pluginId!, selectedCompanyId),
+    queryFn: () => pluginsApi.getConfig(pluginId!, selectedCompanyId!),
+    enabled: !!pluginId && !!selectedCompanyId && !!hasConfigSchema,
   });
 
   const { slots } = usePluginSlots({
@@ -245,6 +245,7 @@ export function PluginSettings() {
               ) : hasConfigSchema ? (
                 <PluginConfigForm
                   pluginId={pluginId!}
+                  companyId={selectedCompanyId}
                   schema={configSchema!}
                   initialValues={configData?.configJson}
                   isLoading={configLoading}
@@ -919,6 +920,7 @@ function isLikelyAbsolutePath(pathValue: string) {
 
 interface PluginConfigFormProps {
   pluginId: string;
+  companyId?: string | null;
   schema: JsonSchemaNode;
   initialValues?: Record<string, unknown>;
   isLoading?: boolean;
@@ -935,7 +937,7 @@ interface PluginConfigFormProps {
  * Separated from PluginSettings to isolate re-render scope — only the form
  * re-renders on field changes, not the entire page.
  */
-function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginStatus, supportsConfigTest }: PluginConfigFormProps) {
+function PluginConfigForm({ pluginId, companyId, schema, initialValues, isLoading, pluginStatus, supportsConfigTest }: PluginConfigFormProps) {
   const queryClient = useQueryClient();
 
   // Form values: start with saved values, fall back to schema defaults
@@ -971,11 +973,11 @@ function PluginConfigForm({ pluginId, schema, initialValues, isLoading, pluginSt
   // Save mutation
   const saveMutation = useMutation({
     mutationFn: (configJson: Record<string, unknown>) =>
-      pluginsApi.saveConfig(pluginId, configJson),
+      pluginsApi.saveConfig(pluginId, companyId!, configJson),
     onSuccess: () => {
       setSaveMessage({ type: "success", text: "Configuration saved." });
       setTestResult(null);
-      queryClient.invalidateQueries({ queryKey: queryKeys.plugins.config(pluginId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.plugins.config(pluginId, companyId) });
       // Clear success message after 3s
       setTimeout(() => setSaveMessage(null), 3000);
     },


### PR DESCRIPTION
## Summary
- Scope plugin config rows by company and require company context for plugin config reads/writes
- Re-enable `format: "secret-ref"` plugin config fields by syncing company-scoped secret bindings
- Allow plugin workers to resolve secrets with `ctx.secrets.resolve(companyId, secretRef)` while keeping the one-argument form backward compatible through binding lookup
- Thread selected company through the plugin settings UI config fetch/save path

## Why
This unblocks Slack plugin setup: Slack bot/signing-secret refs cannot be saved or resolved safely while plugin config is global and secret refs are disabled.

## Verification
- `pnpm exec vitest run server/src/__tests__/plugin-routes-authz.test.ts server/src/__tests__/plugin-secrets-handler.test.ts`
- `pnpm --filter @paperclipai/plugin-sdk typecheck`
- `pnpm --filter @paperclipai/plugin-sdk build`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/db typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `git diff --check`

## Notes
- I intentionally left the unrelated `cli/README.md` change out of this branch.
- The isolated worktree did not have `node_modules`, so verification was run in the existing development checkout before applying the same patch onto `origin/master` and committing it.
