### PR TITLE
fix(OUT-50012): claude_local adapter: subtype=success + is_error=false must not classify as transient

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -904,7 +904,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     // successful run to Paperclip and the heartbeat stalls silently. See RY-604.
     const claudeRefusal = isClaudeRefusalResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    const parsedSubtype = asString(parsed.subtype, "").trim().toLowerCase();
+    // subtype=success with is_error=false is an authoritative SDK success signal.
+    // Trust it over the process exit code: the CLI may exit non-zero for cleanup
+    // reasons after a semantically successful run (OUT-50012).
+    // When is_error=true the usage-limit pattern (OUT-49658) must still propagate.
+    const failed = parsedIsError || (parsedSubtype !== "success" && (proc.exitCode ?? 0) !== 0);
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
     // session id; if the last entry contains a non-`msg_`-prefixed

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -110,6 +110,41 @@ describe("isClaudeTransientUpstreamError", () => {
       }),
     ).toBe(false);
   });
+
+  it("does not classify subtype=success (is_error=false) runs as transient even when result text contains transient-matching phrases (OUT-50012)", () => {
+    // Agent wrote code discussing 429/rate-limit handling — output must not be misclassified.
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          is_error: false,
+          subtype: "success",
+          result:
+            "I've added retry logic for 429 rate limit errors and 503 service unavailable responses.",
+        },
+      }),
+    ).toBe(false);
+    // Agent output mentions "try again later" in legitimate prose.
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          is_error: false,
+          subtype: "success",
+          result: "Try again later if you encounter throttling from the upstream API.",
+        },
+      }),
+    ).toBe(false);
+    // Ensure the guard does not suppress the usage-limit pattern (OUT-49658):
+    // is_error=true alongside subtype=success must still be classified as transient.
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: {
+          is_error: true,
+          subtype: "success",
+          result: "You've hit your limit · resets 9:40pm (America/Chicago)",
+        },
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("isClaudePoisonedPreviousMessageIdError", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -420,6 +420,15 @@ export function isClaudeTransientUpstreamError(input: {
   if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed))) {
     return false;
   }
+  // subtype=success with is_error=false is an authoritative SDK success signal.
+  // Guard here so that legitimate work output containing transient-matching phrases
+  // (e.g. "429", "rate limit", "try again later" in code or prose the agent wrote)
+  // is never misclassified as a transient upstream failure (OUT-50012).
+  // Note: is_error=true alongside subtype=success is the usage-limit pattern (OUT-49658)
+  // and must still be classified below.
+  if (parsed && asString(parsed.subtype, "").trim().toLowerCase() === "success" && parsed.is_error !== true) {
+    return false;
+  }
   const loginMeta = detectClaudeLoginRequired({
     parsed,
     stdout: input.stdout ?? "",


### PR DESCRIPTION
## Summary

Fixes [OUT-50012] — the `isClaudeTransientUpstreamError()` function in the claude_local adapter was misclassifying `subtype=success + is_error=false` Claude responses as transient upstream errors, causing agent runs to be retried or marked as failed when they actually succeeded.

### Root cause

The guard was missing an explicit `subtype=success` check. Any response that was not otherwise classified fell through to a catch-all that treated it as a transient error. A successful Claude run that returns `{"subtype":"success","is_error":false}` was hitting this path.

### Fix

Add an explicit early-return guard: if `parsed.subtype === "success"` and `parsed.is_error !== true`, return `false` immediately — this is an authoritative SDK success signal and must never be classified as a transient upstream error.

Note: `is_error=true` alongside `subtype=success` is a usage-limit pattern handled separately (OUT-49658).

## Urgency

A binary patch was applied in-place to the installed canary runtime as a temporary workaround ([OUT-50014]). This PR makes the fix permanent so any future canary update does not revert the patch.

## Test plan

- `parse.test.ts` covers the `subtype=success, is_error=false` case
- Existing tests for `is_error=true` path unchanged