### PR TITLE
Add idempotency to approvals create endpoint (Refs #8556)

### DIFF
--- a/packages/db/src/migrations/0111_approvals_idempotency.sql
+++ b/packages/db/src/migrations/0111_approvals_idempotency.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "approvals" ADD COLUMN IF NOT EXISTS "idempotency_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "approvals_company_idempotency_uq"
+  ON "approvals" USING btree ("company_id","idempotency_key")
+  WHERE "approvals"."idempotency_key" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1781902400000,
       "tag": "0110_document_company_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1781902500000,
+      "tag": "0111_approvals_idempotency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/approvals.ts
+++ b/packages/db/src/schema/approvals.ts
@@ -1,4 +1,5 @@
-import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
 
@@ -11,6 +12,7 @@ export const approvals = pgTable(
     requestedByAgentId: uuid("requested_by_agent_id").references(() => agents.id),
     requestedByUserId: text("requested_by_user_id"),
     status: text("status").notNull().default("pending"),
+    idempotencyKey: text("idempotency_key"),
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
     decisionNote: text("decision_note"),
     decidedByUserId: text("decided_by_user_id"),
@@ -24,5 +26,8 @@ export const approvals = pgTable(
       table.status,
       table.type,
     ),
+    companyIdempotencyUq: uniqueIndex("approvals_company_idempotency_uq")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
   }),
 );

--- a/packages/shared/src/validators/approval.ts
+++ b/packages/shared/src/validators/approval.ts
@@ -5,6 +5,7 @@ import { multilineTextSchema } from "./text.js";
 export const createApprovalSchema = z.object({
   type: z.enum(APPROVAL_TYPES),
   requestedByAgentId: z.string().uuid().optional().nullable(),
+  idempotencyKey: z.string().trim().max(255).nullable().optional(),
   payload: z.record(z.string(), z.unknown()),
   issueIds: z.array(z.string().uuid()).optional(),
 });

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockApprovalService = vi.hoisted(() => ({
   list: vi.fn(),
   getById: vi.fn(),
+  findByIdempotencyKey: vi.fn(),
   create: vi.fn(),
   approve: vi.fn(),
   reject: vi.fn(),
@@ -120,6 +121,8 @@ describe("approval routes idempotent retries", () => {
     vi.clearAllMocks();
     mockApprovalService.list.mockReset();
     mockApprovalService.getById.mockReset();
+    mockApprovalService.findByIdempotencyKey.mockReset();
+    mockApprovalService.findByIdempotencyKey.mockResolvedValue(null);
     mockApprovalService.create.mockReset();
     mockApprovalService.approve.mockReset();
     mockApprovalService.reject.mockReset();
@@ -366,6 +369,72 @@ describe("approval routes idempotent retries", () => {
         actorId: "agent-1",
         action: "approval.created",
       }),
+    );
+  });
+
+  it("returns the existing approval and skips side effects when the idempotency key was already used", async () => {
+    const existing = {
+      id: "approval-existing",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve hosting spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    };
+    mockApprovalService.findByIdempotencyKey.mockResolvedValue(existing);
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        idempotencyKey: "retry-key-1",
+        issueIds: ["00000000-0000-0000-0000-000000000001"],
+        payload: { title: "Approve hosting spend" },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ id: "approval-existing", status: "pending" });
+    expect(mockApprovalService.findByIdempotencyKey).toHaveBeenCalledWith("company-1", "retry-key-1");
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+    expect(mockIssueApprovalService.linkManyForApproval).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("creates a fresh approval and persists the idempotency key on first use", async () => {
+    mockApprovalService.create.mockResolvedValue({
+      id: "approval-1",
+      companyId: "company-1",
+      type: "request_board_approval",
+      requestedByAgentId: "agent-1",
+      requestedByUserId: null,
+      status: "pending",
+      payload: { title: "Approve hosting spend" },
+      decisionNote: null,
+      decidedByUserId: null,
+      decidedAt: null,
+      createdAt: new Date("2026-04-06T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-06T00:00:00.000Z"),
+    });
+
+    const res = await request(await createAgentApp())
+      .post("/api/companies/company-1/approvals")
+      .send({
+        type: "request_board_approval",
+        idempotencyKey: "fresh-key-1",
+        payload: { title: "Approve hosting spend" },
+      });
+
+    expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
+    expect(mockApprovalService.findByIdempotencyKey).toHaveBeenCalledWith("company-1", "fresh-key-1");
+    expect(mockApprovalService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ idempotencyKey: "fresh-key-1" }),
     );
   });
 

--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -136,6 +136,103 @@ describe("approvalService resolution idempotency", () => {
   });
 });
 
+describe("approvalService.create idempotency", () => {
+  function createIdempotencyDbStub(options: {
+    existingByKey?: ApprovalRecord[];
+    insertResult?: ApprovalRecord[];
+    insertError?: unknown;
+    existingAfterConflict?: ApprovalRecord[];
+  }) {
+    const selectResults = [
+      options.existingByKey ?? [],
+      options.existingAfterConflict ?? [],
+    ];
+    let selectCall = 0;
+    const selectWhere = vi.fn(async () => selectResults[selectCall++] ?? []);
+    const from = vi.fn(() => ({ where: selectWhere }));
+    const select = vi.fn(() => ({ from }));
+
+    const returning = vi.fn(async () => {
+      if (options.insertError) throw options.insertError;
+      return options.insertResult ?? [];
+    });
+    const values = vi.fn(() => ({ returning }));
+    const insert = vi.fn(() => ({ values }));
+
+    return { db: { select, insert } as any, selectWhere, values, returning };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inserts a new approval when no row shares the idempotency key", async () => {
+    const created = { ...createApproval("pending"), id: "approval-new" };
+    const dbStub = createIdempotencyDbStub({ insertResult: [created] });
+
+    const svc = approvalService(dbStub.db);
+    const result = await svc.create("company-1", {
+      type: "hire_agent",
+      idempotencyKey: "key-1",
+      payload: { agentId: "agent-1" },
+      status: "pending",
+    } as any);
+
+    expect(result.id).toBe("approval-new");
+    expect(dbStub.values).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the existing approval instead of creating a duplicate for a repeated key", async () => {
+    const existing = { ...createApproval("pending"), id: "approval-existing" };
+    const dbStub = createIdempotencyDbStub({ existingByKey: [existing] });
+
+    const svc = approvalService(dbStub.db);
+    const result = await svc.create("company-1", {
+      type: "hire_agent",
+      idempotencyKey: "key-1",
+      payload: { agentId: "agent-1" },
+      status: "pending",
+    } as any);
+
+    expect(result.id).toBe("approval-existing");
+    expect(dbStub.values).not.toHaveBeenCalled();
+  });
+
+  it("recovers the winning row when a concurrent insert hits the unique constraint", async () => {
+    const winner = { ...createApproval("pending"), id: "approval-winner" };
+    const dbStub = createIdempotencyDbStub({
+      insertError: { code: "23505", constraint: "approvals_company_idempotency_uq" },
+      existingAfterConflict: [winner],
+    });
+
+    const svc = approvalService(dbStub.db);
+    const result = await svc.create("company-1", {
+      type: "hire_agent",
+      idempotencyKey: "key-1",
+      payload: { agentId: "agent-1" },
+      status: "pending",
+    } as any);
+
+    expect(result.id).toBe("approval-winner");
+  });
+
+  it("rethrows unique-constraint errors unrelated to the idempotency key", async () => {
+    const dbStub = createIdempotencyDbStub({
+      insertError: { code: "23505", constraint: "approvals_pkey" },
+    });
+
+    const svc = approvalService(dbStub.db);
+    await expect(
+      svc.create("company-1", {
+        type: "hire_agent",
+        idempotencyKey: "key-1",
+        payload: {},
+        status: "pending",
+      } as any),
+    ).rejects.toMatchObject({ code: "23505" });
+  });
+});
+
 describe("approvalService.findOpenHireApprovalForAgent", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -136,6 +136,21 @@ export function approvalRoutes(
       : [];
     const uniqueIssueIds = Array.from(new Set(issueIds));
     const { issueIds: _issueIds, ...approvalInput } = req.body;
+
+    const idempotencyKey =
+      typeof approvalInput.idempotencyKey === "string" && approvalInput.idempotencyKey.length > 0
+        ? approvalInput.idempotencyKey
+        : null;
+    if (idempotencyKey) {
+      const existing = await svc.findByIdempotencyKey(companyId, idempotencyKey);
+      if (existing) {
+        // Idempotent reuse: return the original approval without re-running
+        // side effects (issue links, activity log) or minting a duplicate card.
+        res.status(200).json(redactApprovalPayload(existing));
+        return;
+      }
+    }
+
     const normalizedPayload =
       approvalInput.type === "hire_agent"
         ? await secretsSvc.normalizeHireApprovalPayloadForPersistence(

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -8,6 +8,15 @@ import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
 
+const APPROVAL_IDEMPOTENCY_CONSTRAINT = "approvals_company_idempotency_uq";
+
+function isApprovalIdempotencyConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const err = error as { code?: string; constraint?: string; constraint_name?: string };
+  const constraint = err.constraint ?? err.constraint_name;
+  return err.code === "23505" && constraint === APPROVAL_IDEMPOTENCY_CONSTRAINT;
+}
+
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
   const budgets = budgetService(db);
@@ -16,6 +25,14 @@ export function approvalService(db: Db) {
   const resolvableStatuses = Array.from(canResolveStatuses);
   type ApprovalRecord = typeof approvals.$inferSelect;
   type ResolutionResult = { approval: ApprovalRecord; applied: boolean };
+
+  function getIdempotentApproval(companyId: string, idempotencyKey: string) {
+    return db
+      .select()
+      .from(approvals)
+      .where(and(eq(approvals.companyId, companyId), eq(approvals.idempotencyKey, idempotencyKey)))
+      .then((rows) => rows[0] ?? null);
+  }
 
   function redactApprovalComment<T extends { body: string }>(comment: T, censorUsernameInLogs: boolean): T {
     return {
@@ -92,6 +109,9 @@ export function approvalService(db: Db) {
         .where(eq(approvals.id, id))
         .then((rows) => rows[0] ?? null),
 
+    findByIdempotencyKey: (companyId: string, idempotencyKey: string) =>
+      getIdempotentApproval(companyId, idempotencyKey),
+
     findOpenHireApprovalForAgent: async (companyId: string, agentId: string) => {
       const rows = await db
         .select()
@@ -107,12 +127,30 @@ export function approvalService(db: Db) {
       return rows[0] ?? null;
     },
 
-    create: (companyId: string, data: Omit<typeof approvals.$inferInsert, "companyId">) =>
-      db
-        .insert(approvals)
-        .values({ ...data, companyId })
-        .returning()
-        .then((rows) => rows[0]),
+    create: async (companyId: string, data: Omit<typeof approvals.$inferInsert, "companyId">) => {
+      const idempotencyKey = data.idempotencyKey ?? null;
+
+      if (idempotencyKey) {
+        const existing = await getIdempotentApproval(companyId, idempotencyKey);
+        if (existing) return existing;
+      }
+
+      try {
+        const [created] = await db
+          .insert(approvals)
+          .values({ ...data, companyId, idempotencyKey })
+          .returning();
+        return created;
+      } catch (error) {
+        if (!idempotencyKey || !isApprovalIdempotencyConflict(error)) {
+          throw error;
+        }
+        // Lost a race against a concurrent identical create: return the winner's row.
+        const existing = await getIdempotentApproval(companyId, idempotencyKey);
+        if (!existing) throw error;
+        return existing;
+      }
+    },
 
     approve: async (id: string, decidedByUserId: string, decisionNote?: string | null) => {
       const { approval: updated, applied } = await resolveApproval(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The approvals subsystem lets the board approve agent actions via `POST /api/companies/{companyId}/approvals`
> - That endpoint has no server-side idempotency, so a retried or duplicated POST mints a second approval card — even though confirmations / `issue_thread_interactions` already guard against this with an `idempotencyKey`
> - Duplicate cards force the board to manually clear leftovers and add noise to the approval flow
> - This PR adds an optional `idempotencyKey` to the approvals create path, mirroring the existing `issue_thread_interactions` idempotency pattern
> - The benefit is exactly-once approval creation under retries and races, with zero change to existing callers (the key is optional)

## Linked Issues or Issue Description

Refs #8556

## What Changed

- **`packages/db/src/schema/approvals.ts`** — nullable `idempotency_key` column + partial unique index `approvals_company_idempotency_uq` on `(company_id, idempotency_key) WHERE idempotency_key IS NOT NULL` (mirrors `issue_thread_interactions_company_issue_idempotency_uq`).
- **`packages/db/src/migrations/0111_approvals_idempotency.sql`** (+ `meta/_journal.json` entry) — idempotent DDL: `ADD COLUMN IF NOT EXISTS` + `CREATE UNIQUE INDEX IF NOT EXISTS` (same style as `0064`).
- **`packages/shared/src/validators/approval.ts`** — optional nullable `idempotencyKey` (trimmed, max 255), matching the interaction validators.
- **`server/src/services/approvals.ts`** — `create()` pre-checks by key and returns the existing approval; on a concurrent insert it catches the `23505` unique violation (constraint-name guarded) and re-fetches the winning row. New `findByIdempotencyKey()`.
- **`server/src/routes/approvals.ts`** — the create handler returns **200** with the existing approval and **skips side effects** (issue links, activity log, duplicate card) on key reuse.
- **Tests** — service: fresh insert, repeat-key reuse, concurrent-conflict recovery, unrelated-23505 rethrow; route: repeat key → 200 + no side effects, fresh key → create called with the key.

## Default-shape decisions (the open questions from #8556 — flagged for maintainer confirmation)

- **(a) Uniqueness scope:** `(companyId, idempotencyKey)`, partial (null keys exempt) — directly mirrors the interactions table.
- **(b) Terminal-state reuse:** a key maps to one approval row for its lifetime **regardless of status** — a retry with the same key after approve/reject/revision returns the original (now-terminal) approval rather than minting a new card. Matches the interactions pattern; this is the most likely point you may want to revisit.
- **(c) Duplicate behavior:** **200 + existing approval (idempotent reuse), not 409.** I diverged from the interactions service's `409 on different-request-same-key` because approvals have no cheap field-by-field equivalence check; permissive reuse is the safer default. Flagged for confirmation.

## Verification

- Self-reviewed; mirrors the established `issue_thread_interactions` idempotency pattern end-to-end (schema → migration → validator → service → route → tests).
- **Honesty note:** I could **not** run `pnpm` typecheck/tests in my environment, so CI is the first full run. Migration DDL is idempotent and the change is additive.
- I did **not** generate `meta/0111_snapshot.json` (not consumed by `build`/`typecheck`/`migrate`/`check:migrations`); a maintainer running `drizzle-kit generate` should regenerate snapshots.

## Risks

Additive + backward-compatible: the column is nullable, existing callers are unaffected, the unique index is partial (does not constrain null-key rows), and the migration uses `IF NOT EXISTS` (safe re-run).

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`).

## Checklist

- [x] Mirrors an existing in-repo pattern (`issue_thread_interactions` idempotency)
- [x] Backward-compatible (optional key)
- [x] Tests added (service + route)
- [ ] Full local typecheck/test run — blocked in author environment (see Verification); deferred to CI
