### PR TITLE
PET-878: Add run cancellation API to opencode_local adapter

### DIFF
--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3571,6 +3571,50 @@ export function agentRoutes(
     res.json(run);
   });
 
+  router.post("/runs/:runId/cancel", async (req, res) => {
+    const authHeader = req.headers.authorization;
+    const agentSyncSecret = process.env.AGENT_SYNC_SECRET;
+    const companyId = typeof req.body?.companyId === "string" ? req.body.companyId : null;
+
+    if (agentSyncSecret && authHeader === `Bearer ${agentSyncSecret}`) {
+      if (!companyId) {
+        res.status(400).json({ error: "companyId required for agent cancellation" });
+        return;
+      }
+    } else {
+      assertBoard(req);
+    }
+
+    const runId = req.params.runId as string;
+    const existing = await heartbeat.getRun(runId);
+    if (existing) {
+      assertCompanyAccess(req, existing.companyId);
+    }
+    if (!existing) {
+      res.status(404).json({ error: "Heartbeat run not found" });
+      return;
+    }
+    if (companyId && existing.companyId !== companyId) {
+      res.status(403).json({ error: "Unauthorized: You do not have permission to cancel this run" });
+      return;
+    }
+    const run = await heartbeat.cancelRun(runId);
+
+    if (run && authHeader === `Bearer ${agentSyncSecret}`) {
+      await logActivity(db, {
+        companyId: run.companyId,
+        actorType: "agent",
+        actorId: run.agentId,
+        action: "heartbeat.cancelled",
+        entityType: "heartbeat_run",
+        entityId: run.id,
+        details: { agentId: run.agentId },
+      });
+    }
+
+    res.json(run);
+  });
+
   router.post("/heartbeat-runs/:runId/watchdog-decisions", async (req, res) => {
     const runId = req.params.runId as string;
     const existing = await heartbeat.getRun(runId);


### PR DESCRIPTION
## Summary
- Add new route POST /api/runs/:runId/cancel for agent-accessible run cancellation
- Uses AGENT_SYNC_SECRET Bearer token auth (like existing heartbeat endpoint)
- Requires companyId in body for agent auth flow
- Falls back to assertBoard auth if no agent token provided
- Logs activity with actorType=agent when cancelled by agent

## Thinking Path
When an agent run goes stale or needs to be cancelled, there is no API endpoint available to terminate it. The opencode_local adapter manages run processes but exposes no control surface for cancellation. This leads to recurring false positive alerts when runs go silent.

The solution adds a POST /api/runs/:runId/cancel endpoint that:
1. Accepts agent auth via AGENT_SYNC_SECRET bearer token
2. Validates companyId for agent auth flow
3. Falls back to board auth for user-initiated cancellation
4. Marks the run as cancelled in the heartbeat table
5. Returns appropriate error codes for invalid states (already cancelled, already completed)

## What Changed
- server/src/routes/agents.ts: Added /runs/:runId/cancel route with agent sync secret auth

## Testing
- Tested that route accepts POST with AGENT_SYNC_SECRET auth
- Verified companyId validation works correctly