### PR TITLE
feat(heartbeat): rotate persisted session after an invisible 0-token run death

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1500,6 +1500,122 @@ describe("resolveNextSessionState", () => {
 
     expect(result.legacySessionId).toBe("from");
   });
+
+  it("rotates the persisted session when a succeeded run emitted zero tokens", () => {
+    const result = resolveNextSessionState({
+      adapterType: "hermes_local",
+      codec: truncatingHermesSessionCodec,
+      adapterResult: {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+      },
+      outcome: "succeeded",
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+      previousParams: {
+        sessionId: "20260601_141558_c861e4",
+      },
+      previousDisplayId: "20260601_141558_c861e4",
+      previousLegacySessionId: "20260601_141558_c861e4",
+    });
+
+    // Without rotation this succeeded run would resume the previous valid
+    // session; the 0-token death means that session is stale and must be dropped.
+    expect(result).toEqual({
+      params: null,
+      displayId: null,
+      legacySessionId: null,
+    });
+  });
+
+  it("does not rotate a zero-token run that did not classify as succeeded", () => {
+    const result = resolveNextSessionState({
+      adapterType: "hermes_local",
+      codec: truncatingHermesSessionCodec,
+      adapterResult: {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "adapter failed",
+      },
+      outcome: "failed",
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+      previousParams: {
+        sessionId: "20260601_141558_c861e4",
+      },
+      previousDisplayId: "20260601_141558_c861e4",
+      previousLegacySessionId: "20260601_141558_c861e4",
+    });
+
+    // Only the invisible succeeded-but-0-token death triggers rotation; an
+    // already-visible failed run keeps its resumable previous session.
+    expect(result).toEqual({
+      params: {
+        sessionId: "20260601_141558_c861e4",
+      },
+      displayId: "20260601_141558_c861e4",
+      legacySessionId: "20260601_141558_c861e4",
+    });
+  });
+
+  it("does not rotate a healthy succeeded run that produced real token usage", () => {
+    const result = resolveNextSessionState({
+      adapterType: "hermes_local",
+      codec: truncatingHermesSessionCodec,
+      adapterResult: {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        sessionParams: {
+          sessionId: "20260601_141558_c861e4",
+        },
+        sessionDisplayId: "20260601_141558_",
+      },
+      outcome: "succeeded",
+      usage: { inputTokens: 4200, cachedInputTokens: 0, outputTokens: 37 },
+      previousParams: null,
+      previousDisplayId: null,
+      previousLegacySessionId: null,
+    });
+
+    expect(result).toEqual({
+      params: {
+        sessionId: "20260601_141558_c861e4",
+      },
+      displayId: "20260601_141558_c861e4",
+      legacySessionId: "20260601_141558_c861e4",
+    });
+  });
+
+  it("does not rotate a succeeded run whose usage was not reported", () => {
+    const result = resolveNextSessionState({
+      adapterType: "hermes_local",
+      codec: truncatingHermesSessionCodec,
+      adapterResult: {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        sessionParams: {
+          sessionId: "20260601_141558_c861e4",
+        },
+        sessionDisplayId: "20260601_141558_",
+      },
+      outcome: "succeeded",
+      usage: null,
+      previousParams: null,
+      previousDisplayId: null,
+      previousLegacySessionId: null,
+    });
+
+    // Missing usage is ambiguous; normal session continuity must be preserved.
+    expect(result).toEqual({
+      params: {
+        sessionId: "20260601_141558_c861e4",
+      },
+      displayId: "20260601_141558_c861e4",
+      legacySessionId: "20260601_141558_c861e4",
+    });
+  });
 });
 
 describe("formatRuntimeWorkspaceWarningLog", () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2113,6 +2113,18 @@ function normalizeUsageTotals(usage: UsageSummary | null | undefined): UsageTota
   };
 }
 
+/**
+ * True only when a *reported* usage shows the run produced nothing — both input
+ * and output tokens are zero. A missing (`null`/`undefined`) usage object is
+ * intentionally NOT treated as zero-token: it is ambiguous (usage may simply
+ * not have been captured) and must not trigger a session rotation. Used by
+ * {@link resolveNextSessionState} to rotate the persisted session after an
+ * invisible 0-token run death.
+ */
+function isZeroTokenUsage(usage: UsageTotals | null | undefined): boolean {
+  return !!usage && usage.inputTokens === 0 && usage.outputTokens === 0;
+}
+
 function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
   const parsed = parseObject(usageJson);
   if (Object.keys(parsed).length === 0) return null;
@@ -3350,10 +3362,33 @@ export function resolveNextSessionState(input: {
   previousParams: Record<string, unknown> | null;
   previousDisplayId: string | null;
   previousLegacySessionId: string | null;
+  usage?: UsageTotals | null;
 }) {
   const { adapterType, codec, adapterResult, previousParams, previousDisplayId, previousLegacySessionId } = input;
 
   if (adapterResult.clearSession) {
+    return {
+      params: null as Record<string, unknown> | null,
+      displayId: null as string | null,
+      legacySessionId: null as string | null,
+    };
+  }
+
+  // A run the gateway classified as "succeeded" yet emitted zero input and
+  // output tokens is the invisible 0-token death (typically a 529 / provider
+  // overload that returned exit 0 with no error message). The session it would
+  // leave behind is stale or poisoned, so rotate it: return the same
+  // cleared-state contract as `clearSession` above, which the downstream caller
+  // translates into a task-session clear (params + displayId both null). The
+  // next run then starts a fresh session instead of resuming the dead one.
+  //
+  // Safety net only — this fixes stale-session failures, NOT a gateway-wide
+  // outage (only provider recovery / failover does). It never fires for a
+  // healthy run: any real work emits >0 tokens, and runs whose usage was simply
+  // not reported (`usage` null) are left untouched so normal session continuity
+  // is preserved. Mirrors the zero-token predicate in
+  // heartbeat-zero-token-diagnostic.ts.
+  if (input.outcome === "succeeded" && isZeroTokenUsage(input.usage)) {
     return {
       params: null as Record<string, unknown> | null,
       displayId: null as string | null,
@@ -9790,6 +9825,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         outcome = "failed";
       }
 
+      const rawUsage = normalizeUsageTotals(adapterResult.usage);
       const nextSessionState = resolveNextSessionState({
         adapterType: agent.adapterType,
         codec: sessionCodec,
@@ -9798,8 +9834,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         previousParams: previousSessionParams,
         previousDisplayId: runtimeForAdapter.sessionDisplayId,
         previousLegacySessionId: runtimeForAdapter.sessionId,
+        usage: rawUsage,
       });
-      const rawUsage = normalizeUsageTotals(adapterResult.usage);
       const sessionUsageResolution = await resolveNormalizedUsageForSession({
         agentId: agent.id,
         runId: run.id,


### PR DESCRIPTION
## Problem

A run the gateway classifies as **succeeded** yet emits **zero input and output tokens** (typically a `529` / provider-overload response returning exit 0 with no error) is an *invisible* death. Its outcome looks healthy, so the persisted session is resumed by the next run — even though that session is now stale or poisoned. The next run then resumes from a dead session instead of starting fresh.

## Change

Extend `resolveNextSessionState` to detect this case and return the **same cleared-state contract as adapter `clearSession`** (`params` + `displayId` both `null`), which the downstream caller (`heartbeatService`) already translates into a task-session clear. The next run then starts a fresh session.

- New optional `usage?: UsageTotals | null` input to `resolveNextSessionState`.
- New helper `isZeroTokenUsage()` — true only when *reported* usage is all-zero.
- Wired at the single call site by passing the already-computed `normalizeUsageTotals(adapterResult.usage)`.

## Why it's safe (session continuity)

Narrowly scoped so normal runs are unaffected:

- Fires **only** when `outcome === "succeeded"` **and** reported usage is all-zero. Failed / timed-out / cancelled runs keep their existing resume behavior.
- A **missing** usage object (`null`/`undefined`) is treated as ambiguous and does **not** trigger rotation — preserves continuity when usage wasn't captured.
- Normal runs always produce `>0` tokens, so they never match.

Safety net for stale-session failures only. It does **not** cure a gateway-wide outage — only provider recovery / failover does.

## Tests

Adds 4 cases to the existing `resolveNextSessionState` describe block in `heartbeat-workspace-session.test.ts`:

1. rotates the persisted session when a succeeded run emitted zero tokens
2. does not rotate a zero-token run that did not classify as succeeded (gate)
3. does not rotate a healthy succeeded run that produced real token usage
4. does not rotate a succeeded run whose usage was not reported (missing-usage guard)

All 92 tests in the file pass.

## Related

Part of a 0-token crash-hardening set:
- #8624 — posts a diagnostic comment when a run finalizes with zero tokens (defines the canonical zero-token predicate in `heartbeat-zero-token-diagnostic.ts`; this PR mirrors that definition inline so it stays independently mergeable).
- #8623 — tunable no-comment-streak escalation threshold.

Touches `server/src/services/heartbeat.ts` — `resolveNextSessionState` (~L3362) and its call site (~L9825).
