### PR TITLE
[codex] Add operator-facing comment gate

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -685,6 +685,7 @@ export interface IssueCommentMetadataSection {
 export interface IssueCommentMetadata {
   version: 1;
   sourceRunId?: string | null;
+  operatorFacing?: boolean;
   sections: IssueCommentMetadataSection[];
 }
 

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -4,6 +4,7 @@ import {
   addIssueCommentSchema,
   createIssueSchema,
   issueBlockedInboxAttentionSchema,
+  issueCommentMetadataSchema,
   resolveIssueRecoveryActionSchema,
   respondIssueThreadInteractionSchema,
   suggestedTaskDraftSchema,
@@ -143,6 +144,7 @@ describe("issue validators", () => {
     const parsed = addIssueCommentSchema.parse({
       body: "Paperclip needs a disposition before this issue can continue.",
       authorType: "system",
+      operatorFacing: true,
       presentation: {
         kind: "system_notice",
         tone: "warning",
@@ -151,6 +153,7 @@ describe("issue validators", () => {
       metadata: {
         version: 1,
         sourceRunId: "11111111-1111-4111-8111-111111111111",
+        operatorFacing: true,
         sections: [
           {
             title: "Evidence",
@@ -165,8 +168,27 @@ describe("issue validators", () => {
     });
 
     expect(parsed.presentation?.detailsDefaultOpen).toBe(false);
+    expect(parsed.operatorFacing).toBe(true);
     expect(parsed.metadata?.sourceRunId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(parsed.metadata?.operatorFacing).toBe(true);
     expect(parsed.metadata?.sections[0]?.rows).toHaveLength(3);
+  });
+
+  it("accepts operator-facing issue comment metadata", () => {
+    const parsed = issueCommentMetadataSchema.parse({
+      version: 1,
+      operatorFacing: true,
+      sections: [
+        {
+          title: "Audience",
+          rows: [
+            { type: "key_value", label: "Audience", value: "operator" },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed.operatorFacing).toBe(true);
   });
 
   it("rejects arbitrary issue comment metadata", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -548,6 +548,7 @@ export const issueCommentMetadataSectionSchema = z.object({
 export const issueCommentMetadataSchema = z.object({
   version: z.literal(1),
   sourceRunId: z.string().uuid().nullable().optional(),
+  operatorFacing: z.boolean().optional(),
   sections: z.array(issueCommentMetadataSectionSchema).min(1).max(20),
 }).strict();
 
@@ -558,6 +559,7 @@ export const addIssueCommentSchema = z.object({
   authorType: issueCommentAuthorTypeSchema.optional(),
   presentation: issueCommentPresentationSchema.nullable().optional(),
   metadata: issueCommentMetadataSchema.nullable().optional(),
+  operatorFacing: z.boolean().optional(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),

--- a/packages/teams-catalog/catalog/bundled/company-defaults/core-exec-team/agents/ceo/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/core-exec-team/agents/ceo/AGENTS.md
@@ -36,6 +36,24 @@ You MUST delegate work rather than doing it yourself. When a task is assigned to
 - Hire new agents when the team needs capacity
 - Unblock your direct reports when they escalate
 
+## Operator-facing responses
+
+When you write a substantive comment or message to the board/operator, end it with an operator menu. Use this exact shape:
+
+```text
+МЕНЮ
+1. First concrete next action. [who will do it]
+2. Second concrete next action. [who will do it]
+3. Third concrete next action. [who will do it]
+
+Рекомендую выбрать: [1, 2, or 3]
+
+Почему: [short reason this option is the most effective now]
+```
+
+Only use this menu for board/operator-facing communication. Do not add it to agent-to-agent handoffs, reviewer notes, internal documents, structured output, JSON, logs, or tool payloads.
+When posting a board/operator-facing comment through the Paperclip API, set top-level `operatorFacing: true`. Do not set `operatorFacing` for agent-to-agent handoffs, reviewer notes, internal documents, structured output, JSON, logs, or tool payloads.
+
 ## Keeping work moving
 
 - Don't let tasks sit idle. If you delegate something, check that it is progressing.

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -678,6 +678,7 @@ describe.sequential("agent skill routes", () => {
 
     expect([200, 201], JSON.stringify(res.body)).toContain(res.status);
     const createdAgentId = expectResponseId(res.body.id);
+    const materializeCall = mockAgentInstructionsService.materializeManagedBundle.mock.calls.at(-1);
     expect(mockAgentInstructionsService.materializeManagedBundle).toHaveBeenCalledWith(
       expect.objectContaining({
         id: createdAgentId,
@@ -692,6 +693,13 @@ describe.sequential("agent skill routes", () => {
       }),
       { entryFile: "AGENTS.md", replaceExisting: false },
     );
+    const materializedBundle = materializeCall?.[1] as Record<string, string>;
+    expect(materializedBundle["AGENTS.md"]).toContain("Operator-facing responses");
+    expect(materializedBundle["AGENTS.md"]).toContain("МЕНЮ");
+    expect(materializedBundle["AGENTS.md"]).toContain("operatorFacing: true");
+    expect(materializedBundle["AGENTS.md"]).toContain("Do not add it to agent-to-agent handoffs");
+    expect(materializedBundle["HEARTBEAT.md"]).toContain("operator menu");
+    expect(materializedBundle["HEARTBEAT.md"]).toContain("operatorFacing: true");
   });
 
   it("materializes the bundled default instruction set for non-CEO agents with no prompt template", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -771,6 +771,53 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("rejects operator-facing comments without the required operator menu", async () => {
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({
+        body: "Готово, можно продолжать.",
+        operatorFacing: true,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toBe("operatorFacing comments must include the required operator menu");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("persists operator-facing comments with the required operator menu marker", async () => {
+    const body = [
+      "Готово, можно продолжать.",
+      "",
+      "МЕНЮ",
+      "1. Передать задачу в проверку. [CEO]",
+      "2. Вернуть на доработку CTO. [operator]",
+      "3. Закрыть задачу без дополнительных действий. [operator]",
+      "",
+      "Рекомендую выбрать: 1",
+      "",
+      "Почему: это быстрее всего подтверждает результат и сохраняет контроль качества.",
+    ].join("\n");
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({
+        body,
+        operatorFacing: true,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      body,
+      expect.any(Object),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          operatorFacing: true,
+        }),
+      }),
+    );
+  });
+
   it("rejects non-mentioned peer agents from posting comments", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read",

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -27,6 +27,24 @@ You MUST delegate work rather than doing it yourself. When a task is assigned to
 - Hire new agents when the team needs capacity
 - Unblock your direct reports when they escalate to you
 
+## Operator-facing responses
+
+When you write a substantive comment or message to the board/operator, end it with an operator menu. Use this exact shape:
+
+```text
+МЕНЮ
+1. First concrete next action. [who will do it]
+2. Second concrete next action. [who will do it]
+3. Third concrete next action. [who will do it]
+
+Рекомендую выбрать: [1, 2, or 3]
+
+Почему: [short reason this option is the most effective now]
+```
+
+Only use this menu for board/operator-facing communication. Do not add it to agent-to-agent handoffs, reviewer notes, internal documents, structured output, JSON, logs, or tool payloads.
+When posting a board/operator-facing comment through the Paperclip API, set top-level `operatorFacing: true`. Do not set `operatorFacing` for agent-to-agent handoffs, reviewer notes, internal documents, structured output, JSON, logs, or tool payloads.
+
 ## Keeping work moving
 
 - Don't let tasks sit idle. If you delegate something, check that it's progressing.

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -82,4 +82,5 @@ Status quick guide:
 - Always use the Paperclip skill for coordination.
 - Always include `X-Paperclip-Run-Id` header on mutating API calls.
 - Comment in concise markdown: status line + bullets + links.
+- Before posting a substantive board/operator-facing comment, verify it ends with the operator menu from `AGENTS.md` and set top-level `operatorFacing: true` in the comment request. Do not add that menu or flag to agent-to-agent or reviewer-facing comments.
 - Self-assign via checkout only when explicitly @-mentioned.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -60,6 +60,7 @@ import {
   type CompanySearchQuery,
   type CompanySearchResponse,
   type ExecutionWorkspace,
+  type IssueCommentMetadata,
   type IssueRelationIssueSummary,
   type IssueWatchdogDiscoveryKind,
   type SourceTrustMetadata,
@@ -2557,6 +2558,64 @@ export function issueRoutes(
       },
     });
     return false;
+  }
+
+  function validateOperatorFacingCommentBody(body: string) {
+    const missing: string[] = [];
+
+    if (!/(^|\n)\s*МЕНЮ\s*(\n|$)/.test(body)) {
+      missing.push("МЕНЮ");
+    }
+    for (const index of [1, 2, 3]) {
+      const itemPattern = new RegExp(`(^|\\n)\\s*${index}\\.\\s+.+\\[[^\\]\\n]+\\]\\s*(\\n|$)`);
+      if (!itemPattern.test(body)) {
+        missing.push(`${index}. action [owner]`);
+      }
+    }
+    if (!/(^|\n)\s*Рекомендую выбрать:\s*[1-3]\s*(\n|$)/.test(body)) {
+      missing.push("Рекомендую выбрать: 1-3");
+    }
+    if (!/(^|\n)\s*Почему:\s*\S.*\s*$/.test(body)) {
+      missing.push("Почему");
+    }
+
+    return missing;
+  }
+
+  function assertOperatorFacingCommentBodyAllowed(
+    res: Response,
+    input: { body: string; operatorFacing: boolean },
+  ) {
+    if (!input.operatorFacing) return true;
+    const missing = validateOperatorFacingCommentBody(input.body);
+    if (missing.length === 0) return true;
+    res.status(422).json({
+      error: "operatorFacing comments must include the required operator menu",
+      details: {
+        missing,
+      },
+    });
+    return false;
+  }
+
+  function withOperatorFacingMetadata(
+    metadata: IssueCommentMetadata | null | undefined,
+    operatorFacing: boolean,
+  ): IssueCommentMetadata | null {
+    if (!operatorFacing) return metadata ?? null;
+    if (metadata) return { ...metadata, operatorFacing: true };
+    return {
+      version: 1,
+      operatorFacing: true,
+      sections: [
+        {
+          title: "Audience",
+          rows: [
+            { type: "key_value", label: "Audience", value: "operator" },
+          ],
+        },
+      ],
+    };
   }
 
   async function assertExplicitResumeIntentAllowed(
@@ -7485,6 +7544,12 @@ export function issueRoutes(
       presentation: req.body.presentation,
       metadata: req.body.metadata,
     })) return;
+    const operatorFacing = req.body.operatorFacing === true || req.body.metadata?.operatorFacing === true;
+    if (!assertOperatorFacingCommentBodyAllowed(res, {
+      body: req.body.body,
+      operatorFacing,
+    })) return;
+    const commentMetadata = withOperatorFacingMetadata(req.body.metadata ?? null, operatorFacing);
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(issue);
     if (closedExecutionWorkspace) {
       respondClosedIssueExecutionWorkspace(res, closedExecutionWorkspace);
@@ -7703,7 +7768,7 @@ export function issueRoutes(
       const commentOptions = {
         authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
         presentation: req.body.presentation ?? null,
-        metadata: req.body.metadata ?? null,
+        metadata: commentMetadata,
         sourceTrust,
       };
       let txResult: { comment: Awaited<ReturnType<typeof svc.addComment>>; issue: NonNullable<Awaited<ReturnType<typeof svc.update>>> };
@@ -7787,7 +7852,7 @@ export function issueRoutes(
       }, {
         authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
         presentation: req.body.presentation ?? null,
-        metadata: req.body.metadata ?? null,
+        metadata: commentMetadata,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
       });
     }


### PR DESCRIPTION
## Summary
- add top-level `operatorFacing` support to issue comment requests
- enforce the operator menu only for `operatorFacing: true` comments
- persist an operator-facing metadata marker and update CEO instructions/tests

## Why
CEO/operator-facing responses need the menu contract, but reviewer-facing and agent-to-agent comments should remain free of operator menus. The explicit `operatorFacing` flag gives agents a narrow way to opt into the operator gate without allowing arbitrary structured metadata writes.

## Validation
- `npm test`

## Notes
- Built from a clean branch off `master` with only the operator-facing comment gate commit.
- Existing local heartbeat/recovery working-tree changes are not part of this PR.