### PR TITLE
Guard ignored/no-PR Sentry family lifecycle reopens

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1201,6 +1201,51 @@ describe.sequential("issue comment reopen routes", () => {
       });
 
     expect(res.status).toBe(201);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { order: "desc" },
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
+  it("still suppresses POST lifecycle heartbeat reopen when the no-PR ignore decision is older than 25 later comments", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      title: "[Sentry] Grouped family follow-up",
+      description: "SentryFamily:abc123",
+    });
+    mockIssueService.listComments.mockResolvedValue([
+      ...Array.from({ length: 30 }, (_value, index) => ({
+        id: `comment-recent-${index + 1}`,
+        body: `Lifecycle note ${index + 1}`,
+      })),
+      {
+        id: "comment-old-ignore",
+        body: "Explicit ignore. No merged fix PR is expected for this grouped family. Reopen this grouped family only if new evidence shows contradictory recurrence.",
+      },
+    ]);
+
+    const res = await request(await installActor(createApp(), {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      runId: "run-different",
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({
+        body: "## Sentry lifecycle heartbeat\n\nNo merged fix PR was found for this Sentry family yet.\n\nReason: stale > 24h without merged fix PR.",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { order: "desc" },
+    );
     expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
@@ -1269,6 +1314,56 @@ describe.sequential("issue comment reopen routes", () => {
       });
 
     expect(res.status).toBe(200);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { order: "desc" },
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
+  it("still suppresses PATCH lifecycle heartbeat reopen when the no-PR ignore decision is older than 25 later comments", async () => {
+    const issue = {
+      ...makeIssue("done"),
+      title: "[Sentry] Grouped family follow-up",
+      description: "SentryFamily:abc123",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.listComments.mockResolvedValue([
+      ...Array.from({ length: 30 }, (_value, index) => ({
+        id: `comment-recent-${index + 1}`,
+        body: `Lifecycle note ${index + 1}`,
+      })),
+      {
+        id: "comment-old-ignore",
+        body: "Ignored with reason. No PR is expected for this grouped family. Reopen only if contradictory recurrence or new evidence appears.",
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      runId: "run-different",
+    }))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "## Sentry lifecycle heartbeat\n\nNo merged fix PR was found for this Sentry family yet.\n\nReason: stale > 24h without merged fix PR.",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.listComments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { order: "desc" },
+    );
     expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -7,6 +7,7 @@ const mockIssueService = vi.hoisted(() => ({
   assertCheckoutOwner: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
+  listComments: vi.fn(),
   getDependencyReadiness: vi.fn(),
   getCurrentScheduledRetry: vi.fn(),
   findMentionedAgents: vi.fn(),
@@ -205,6 +206,7 @@ function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progr
     createdByUserId: "local-board",
     identifier: "PAP-580",
     title: "Comment reopen default",
+    description: null,
   };
 }
 
@@ -229,6 +231,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockIssueService.assertCheckoutOwner.mockReset();
     mockIssueService.update.mockReset();
     mockIssueService.addComment.mockReset();
+    mockIssueService.listComments.mockReset();
     mockIssueService.getDependencyReadiness.mockReset();
     mockIssueService.getCurrentScheduledRetry.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
@@ -305,6 +308,7 @@ describe.sequential("issue comment reopen routes", () => {
       authorUserId: "local-board",
     });
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listComments.mockResolvedValue([]);
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
       blockerIssueIds: [],
@@ -1170,6 +1174,39 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("does not implicitly reopen ignored no-PR sentry families via POST lifecycle heartbeat comments", async () => {
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      title: "[Sentry] Grouped family follow-up",
+      description: "SentryFamily:abc123",
+    });
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-prior-1",
+        body: "Explicit ignore. No merged fix PR is expected for this grouped family. Reopen this grouped family only if new evidence shows contradictory recurrence.",
+      },
+    ]);
+
+    const res = await request(await installActor(createApp(), {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      runId: "run-different",
+    }))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({
+        body: "## Sentry lifecycle heartbeat\n\nNo merged fix PR was found for this Sentry family yet.\n\nReason: stale > 24h without merged fix PR.",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
   it("does not implicitly reopen done issues via the PATCH comment path when actor runId matches the issue's checkout run", async () => {
     const issue = {
       ...makeIssue("done"),
@@ -1192,6 +1229,44 @@ describe.sequential("issue comment reopen routes", () => {
     }))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "Done — final note from the run that owns the issue" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+  });
+
+  it("does not implicitly reopen ignored no-PR sentry families via the PATCH lifecycle heartbeat comment path", async () => {
+    const issue = {
+      ...makeIssue("done"),
+      title: "[Sentry] Grouped family follow-up",
+      description: "SentryFamily:abc123",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "comment-prior-1",
+        body: "Ignored with reason. No PR is expected for this grouped family. Reopen only if contradictory recurrence or new evidence appears.",
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp(), {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+      runId: "run-different",
+    }))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        comment: "## Sentry lifecycle heartbeat\n\nNo merged fix PR was found for this Sentry family yet.\n\nReason: stale > 24h without merged fix PR.",
+      });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.update).not.toHaveBeenCalledWith(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -879,7 +879,7 @@ async function shouldSuppressImplicitReopenForSentryLifecycleHeartbeat(input: {
 }) {
   if (!isSentryLifecycleMissingFixHeartbeatComment(input.commentBody)) return false;
   if (!issueLooksLikeSentryFamily(input.issue)) return false;
-  const priorComments = await input.svc.listComments(input.issue.id, { order: "desc", limit: 25 });
+  const priorComments = await input.svc.listComments(input.issue.id, { order: "desc" });
   const priorText = [
     input.issue.description ?? "",
     ...priorComments.map((comment) => comment.body ?? ""),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -823,6 +823,70 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   return true;
 }
 
+function normalizeIssueReopenGuardText(value: string | null | undefined) {
+  return (value ?? "").toLowerCase();
+}
+
+function isSentryLifecycleMissingFixHeartbeatComment(body: string | null | undefined) {
+  const normalized = normalizeIssueReopenGuardText(body);
+  return (
+    normalized.includes("## sentry lifecycle heartbeat")
+    && normalized.includes("no merged fix pr was found for this sentry family yet")
+    && normalized.includes("stale > 24h without merged fix pr")
+  );
+}
+
+function issueLooksLikeSentryFamily(input: {
+  title: string | null | undefined;
+  description: string | null | undefined;
+}) {
+  const title = normalizeIssueReopenGuardText(input.title);
+  const description = normalizeIssueReopenGuardText(input.description);
+  return title.includes("[sentry]") || description.includes("sentryfamily:");
+}
+
+function priorSentryIssueTextSignalsNoPrIgnoreDecision(text: string) {
+  const hasNoPrExpected =
+    text.includes("no merged fix pr is expected")
+    || text.includes("no pr is expected");
+  if (!hasNoPrExpected) return false;
+  const hasExplicitIgnoreSignal =
+    text.includes("explicit ignore")
+    || text.includes("ignored with reason")
+    || text.includes("ignore/no-action")
+    || text.includes("resolved/no-action")
+    || text.includes("no-action decision");
+  const hasReopenOnlyOnNewEvidenceSignal =
+    text.includes("reopen this grouped family only if")
+    || text.includes("reopen only if")
+    || (text.includes("new evidence") && text.includes("recurrence") && text.includes("contradictory"));
+  return hasExplicitIgnoreSignal || hasReopenOnlyOnNewEvidenceSignal;
+}
+
+async function shouldSuppressImplicitReopenForSentryLifecycleHeartbeat(input: {
+  svc: {
+    listComments: (
+      issueId: string,
+      opts?: { afterCommentId?: string | null; order?: "asc" | "desc"; limit?: number | null },
+    ) => Promise<Array<{ body?: string | null }>>;
+  };
+  issue: {
+    id: string;
+    title: string | null | undefined;
+    description: string | null | undefined;
+  };
+  commentBody: string | null | undefined;
+}) {
+  if (!isSentryLifecycleMissingFixHeartbeatComment(input.commentBody)) return false;
+  if (!issueLooksLikeSentryFamily(input.issue)) return false;
+  const priorComments = await input.svc.listComments(input.issue.id, { order: "desc", limit: 25 });
+  const priorText = [
+    input.issue.description ?? "",
+    ...priorComments.map((comment) => comment.body ?? ""),
+  ].join("\n");
+  return priorSentryIssueTextSignalsNoPrIgnoreDecision(normalizeIssueReopenGuardText(priorText));
+}
+
 function shouldHumanCommentResumeInProgressScheduledRetry(input: {
   hasComment: boolean;
   issueStatus: string | null | undefined;
@@ -5643,10 +5707,19 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
     });
+    const suppressImplicitReopenForLifecycleHeartbeat =
+      !explicitMoveToTodoRequested &&
+      !assigneeSelfCommentOnTerminal &&
+      await shouldSuppressImplicitReopenForSentryLifecycleHeartbeat({
+        svc,
+        issue: existing,
+        commentBody,
+      });
     const effectiveMoveToTodoRequested =
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
         (!!commentBody &&
+          !suppressImplicitReopenForLifecycleHeartbeat &&
           shouldImplicitlyMoveCommentedIssueToTodo({
             issueStatus: existing.status,
             assigneeAgentId: requestedAssigneeAgentId,
@@ -7453,18 +7526,27 @@ export function issueRoutes(
       actorType: actor.actorType,
       actorId: actor.actorId,
     });
+    const suppressImplicitReopenForLifecycleHeartbeat =
+      !explicitMoveToTodoRequested &&
+      !assigneeSelfCommentOnTerminal &&
+      await shouldSuppressImplicitReopenForSentryLifecycleHeartbeat({
+        svc,
+        issue,
+        commentBody: req.body.body,
+      });
     const effectiveMoveToTodoRequested =
       !assigneeSelfCommentOnTerminal &&
       (explicitMoveToTodoRequested ||
-        shouldImplicitlyMoveCommentedIssueToTodo({
-          issueStatus: issue.status,
-          assigneeAgentId: issue.assigneeAgentId,
-          actorType: actor.actorType,
-          actorId: actor.actorId,
-          actorRunId: actor.runId,
-          checkoutRunId: issue.checkoutRunId,
-          executionRunId: issue.executionRunId,
-        }) ||
+        (!suppressImplicitReopenForLifecycleHeartbeat &&
+          shouldImplicitlyMoveCommentedIssueToTodo({
+            issueStatus: issue.status,
+            assigneeAgentId: issue.assigneeAgentId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            actorRunId: actor.runId,
+            checkoutRunId: issue.checkoutRunId,
+            executionRunId: issue.executionRunId,
+          })) ||
         shouldResumeInProgressScheduledRetry);
     const hasUnresolvedFirstClassBlockers =
       isBlocked && effectiveMoveToTodoRequested


### PR DESCRIPTION
## Thinking Path
Paperclip is the open source app people use to manage AI agents for work.
Grouped Sentry-family issues are part of the control-plane lifecycle automation that keeps incident work accurate over time.
Some grouped Sentry families are intentionally closed with an explicit ignore or no-action decision when no fix PR is expected.
The lifecycle heartbeat should respect that terminal decision and only reopen on real recurrence or contradictory evidence.
This pull request tightens the implicit reopen guard so an old ignore/no-PR decision cannot age out behind later status comments.
The benefit is that Sentry-family issues stay closed when they were intentionally closed, while explicit `reopen` and `resume` paths still work.

## Linked Issues or Issue Description
### What happened?
Grouped Sentry family issues that were explicitly closed as ignored or no-action could be reopened later by a lifecycle heartbeat that only checked for the no-PR rationale in a limited slice of recent comments. Once enough later comments accumulated, the old ignore decision could fall outside that window and the family would reopen even though there was no new incident evidence.

### Expected behavior
If an issue history already contains an explicit ignore/no-action decision that says no fix PR is expected and the family should reopen only on recurrence or contradictory evidence, lifecycle heartbeat comments alone should not move that issue back to `todo`.

### Steps to reproduce
1. Close a grouped Sentry family issue with explicit ignore/no-PR rationale.
2. Add more than 25 later lifecycle or status comments.
3. Post another `## Sentry lifecycle heartbeat` comment that says no merged fix PR was found.
4. Observe that the issue should stay closed rather than implicitly reopening.

### Paperclip version or commit
`250f498a4bf44a5cf59aa6a535d01e385592d2a1` before this fix.

### Deployment mode
Self-hosted server.

## What Changed
- removed the 25-comment cap from the Sentry lifecycle reopen guard so it can inspect the full issue comment history before deciding whether to suppress an implicit reopen
- added POST and PATCH regression coverage for cases where the ignore/no-PR decision is older than 25 later comments
- kept the existing explicit `reopen` and `resume` behavior unchanged

## Verification
- [x] Searched existing PRs for similar work before opening this PR
- `pnpm exec vitest server/src/__tests__/issue-comment-reopen-routes.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `bin/ci` is not present in this repo, so I ran the closest safe CI-equivalent commands for the touched route/test surface

## Risks
- the guard still relies on issue/comment text markers rather than a first-class closure reason, so future lifecycle copy changes may still require matcher updates
- reading full issue comment history is a slightly broader query, but it only runs for the specific Sentry lifecycle heartbeat shape on Sentry-family issues

## Model Used
- GPT-5 Codex via Paperclip worker

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
