### PR TITLE
feat(authz): scoped manager-line recovery override for stuck IC-owned issues

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1040,6 +1040,93 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("another company");
   });
 
+  it("allows a manager in the reportsTo chain to recover a stuck report-owned issue", async () => {
+    const company = await createCompany(db, "ManagerChainRecovery");
+    const ceo = await createAgent(db, company.id, { role: "ceo" });
+    const cto = await createAgent(db, company.id, { role: "cto", reportsTo: ceo.id });
+    const ic = await createAgent(db, company.id, { role: "engineer", reportsTo: cto.id });
+
+    const svc = authorizationService(db);
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: "issue-managed",
+      assigneeAgentId: ic.id,
+      assigneeUserId: null,
+      status: "in_progress",
+    };
+
+    // Direct manager (CTO -> IC) may mutate, comment, and manage the checkout.
+    for (const action of ["issue:mutate", "issue:comment", "tasks:manage_active_checkouts"] as const) {
+      const decision = await svc.decide({
+        actor: { type: "agent", agentId: cto.id, companyId: company.id, source: "agent_jwt" },
+        action,
+        resource,
+      });
+      expect(decision).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+    }
+
+    // Transitive ancestor (CEO -> CTO -> IC) is also authorized — this is the
+    // AC#1 case: a CEO no-op mutate on a deeper report's issue must not 403.
+    const transitive = await svc.decide({
+      actor: { type: "agent", agentId: ceo.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:mutate",
+      resource,
+    });
+    expect(transitive).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+  });
+
+  it("denies a non-line agent mutating or commenting on another agent's issue", async () => {
+    const company = await createCompany(db, "NonLineIssue");
+    const ic = await createAgent(db, company.id, { role: "engineer" });
+    const stranger = await createAgent(db, company.id, { role: "engineer" });
+
+    const svc = authorizationService(db);
+    const resource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: "issue-foreign",
+      assigneeAgentId: ic.id,
+      assigneeUserId: null,
+      status: "in_progress",
+    };
+
+    const mutate = await svc.decide({
+      actor: { type: "agent", agentId: stranger.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:mutate",
+      resource,
+    });
+    expect(mutate).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+
+    const comment = await svc.decide({
+      actor: { type: "agent", agentId: stranger.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:comment",
+      resource,
+    });
+    expect(comment.allowed).toBe(false);
+  });
+
+  it("does not let a downward (report) agent override their manager's issue", async () => {
+    const company = await createCompany(db, "ReverseChain");
+    const manager = await createAgent(db, company.id, { role: "cto" });
+    const report = await createAgent(db, company.id, { role: "engineer", reportsTo: manager.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: report.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: "issue-manager-owned",
+        assigneeAgentId: manager.id,
+        assigneeUserId: null,
+        status: "in_progress",
+      },
+    });
+
+    expect(decision).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+  });
+
   it("allows scoped assignment inside a granted project and denies other projects", async () => {
     const company = await createCompany(db, "ProjectScope");
     const project = await createProject(db, company.id, "Allowed");

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1050,7 +1050,6 @@ describeEmbeddedPostgres("authorization service", () => {
     const resource = {
       type: "issue" as const,
       companyId: company.id,
-      issueId: "issue-managed",
       assigneeAgentId: ic.id,
       assigneeUserId: null,
       status: "in_progress",
@@ -1085,7 +1084,6 @@ describeEmbeddedPostgres("authorization service", () => {
     const resource = {
       type: "issue" as const,
       companyId: company.id,
-      issueId: "issue-foreign",
       assigneeAgentId: ic.id,
       assigneeUserId: null,
       status: "in_progress",
@@ -1117,7 +1115,6 @@ describeEmbeddedPostgres("authorization service", () => {
       resource: {
         type: "issue",
         companyId: company.id,
-        issueId: "issue-manager-owned",
         assigneeAgentId: manager.id,
         assigneeUserId: null,
         status: "in_progress",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6782,9 +6782,68 @@ export function issueRoutes(
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;
 
+    const actorAgentId = req.actor.type === "agent" ? req.actor.agentId : undefined;
+    const isManagerLineOverride =
+      req.actor.type === "agent" &&
+      !!actorAgentId &&
+      !!existing.assigneeAgentId &&
+      existing.assigneeAgentId !== actorAgentId;
+
+    if (isManagerLineOverride) {
+      // Scoped manager-line force-release of a stuck report-owned issue.
+      // assertAgentIssueMutationAllowed above already confirmed the actor is an
+      // ancestor in the assignee's reportsTo chain (allow_manager_chain), so the
+      // assignee-only guard in svc.release does not apply here. Force-clear the
+      // lock, cancel any held IC run so two runs cannot collide, and write an
+      // explicit audited override entry.
+      const overridden = await svc.adminForceRelease(id, { clearAssignee: true });
+      if (!overridden) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+
+      const cancelledRunIds: string[] = [];
+      for (const heldRunId of [
+        overridden.previous.checkoutRunId,
+        overridden.previous.executionRunId,
+      ]) {
+        if (!heldRunId || cancelledRunIds.includes(heldRunId)) {
+          continue;
+        }
+        const cancelled = await heartbeat.cancelRun(heldRunId);
+        if (cancelled) {
+          cancelledRunIds.push(heldRunId);
+        }
+      }
+
+      const overrideActor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: overridden.issue.companyId,
+        actorType: overrideActor.actorType,
+        actorId: overrideActor.actorId,
+        agentId: overrideActor.agentId,
+        runId: overrideActor.runId,
+        action: "issue.manager_force_release",
+        entityType: "issue",
+        entityId: overridden.issue.id,
+        details: {
+          issueId: overridden.issue.id,
+          decisionReason: "allow_manager_chain",
+          overriddenAssigneeAgentId: existing.assigneeAgentId,
+          actorAgentId,
+          prevCheckoutRunId: overridden.previous.checkoutRunId,
+          prevExecutionRunId: overridden.previous.executionRunId,
+          cancelledRunIds,
+        },
+      });
+
+      res.json(overridden.issue);
+      return;
+    }
+
     const released = await svc.release(
       id,
-      req.actor.type === "agent" ? req.actor.agentId : undefined,
+      actorAgentId,
       actorRunId,
     );
     if (!released) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6783,30 +6783,26 @@ export function issueRoutes(
     if (req.actor.type === "agent" && !actorRunId) return;
 
     const actorAgentId = req.actor.type === "agent" ? req.actor.agentId : undefined;
-    const isManagerLineOverride =
+    // Only treat this as a manager-line force-release when the actor genuinely
+    // holds the checkout-management grant over the assignee (i.e. is an ancestor
+    // in the assignee's reportsTo chain — allow_manager_chain). Checking merely
+    // "actor != assignee" would also capture other paths assertAgentIssueMutationAllowed
+    // accepts (e.g. task-watchdog scope); re-confirming the grant here keeps the
+    // force-release strictly scoped to the reporting line.
+    const isManagerLineForceRelease =
       req.actor.type === "agent" &&
       !!actorAgentId &&
       !!existing.assigneeAgentId &&
-      existing.assigneeAgentId !== actorAgentId;
+      existing.assigneeAgentId !== actorAgentId &&
+      (await hasActiveCheckoutManagementOverride(actorAgentId, existing.companyId, existing.assigneeAgentId));
 
-    if (isManagerLineOverride) {
-      // Scoped manager-line force-release of a stuck report-owned issue.
-      // assertAgentIssueMutationAllowed above already confirmed the actor is an
-      // ancestor in the assignee's reportsTo chain (allow_manager_chain), so the
-      // assignee-only guard in svc.release does not apply here. Force-clear the
-      // lock, cancel any held IC run so two runs cannot collide, and write an
-      // explicit audited override entry.
-      const overridden = await svc.adminForceRelease(id, { clearAssignee: true });
-      if (!overridden) {
-        res.status(404).json({ error: "Issue not found" });
-        return;
-      }
-
+    if (isManagerLineForceRelease) {
+      // Cancel the held IC run *before* clearing the lock so no second run can
+      // check the issue out while the original run is still live, then release
+      // (status -> todo, assignee + lock cleared) via the managerOverride path,
+      // and write an explicit audited override entry.
       const cancelledRunIds: string[] = [];
-      for (const heldRunId of [
-        overridden.previous.checkoutRunId,
-        overridden.previous.executionRunId,
-      ]) {
+      for (const heldRunId of [existing.checkoutRunId, existing.executionRunId]) {
         if (!heldRunId || cancelledRunIds.includes(heldRunId)) {
           continue;
         }
@@ -6816,28 +6812,34 @@ export function issueRoutes(
         }
       }
 
+      const overridden = await svc.release(id, actorAgentId, actorRunId, { managerOverride: true });
+      if (!overridden) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+
       const overrideActor = getActorInfo(req);
       await logActivity(db, {
-        companyId: overridden.issue.companyId,
+        companyId: overridden.companyId,
         actorType: overrideActor.actorType,
         actorId: overrideActor.actorId,
         agentId: overrideActor.agentId,
         runId: overrideActor.runId,
         action: "issue.manager_force_release",
         entityType: "issue",
-        entityId: overridden.issue.id,
+        entityId: overridden.id,
         details: {
-          issueId: overridden.issue.id,
+          issueId: overridden.id,
           decisionReason: "allow_manager_chain",
           overriddenAssigneeAgentId: existing.assigneeAgentId,
           actorAgentId,
-          prevCheckoutRunId: overridden.previous.checkoutRunId,
-          prevExecutionRunId: overridden.previous.executionRunId,
+          prevCheckoutRunId: existing.checkoutRunId ?? null,
+          prevExecutionRunId: existing.executionRunId ?? null,
           cancelledRunIds,
         },
       });
 
-      res.json(overridden.issue);
+      res.json(overridden);
       return;
     }
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1331,8 +1331,17 @@ export function authorizationService(db: Db) {
       });
     }
 
+    // Scoped manager-line recovery override. An actor that is an ancestor in
+    // the issue assignee's reportsTo chain may recover a stuck issue owned by a
+    // report: manage the active checkout (release/force-clear), reassign or
+    // otherwise mutate the issue, and comment on it. Strictly scoped to the
+    // reporting line via isManagerOf (transitive reportsTo) — a non-line agent
+    // falls through to deny_missing_grant below. This is what lets a manager
+    // recover a genuinely stalled IC-owned issue without a human in the loop.
     if (
-      input.action === "tasks:manage_active_checkouts" &&
+      (input.action === "tasks:manage_active_checkouts" ||
+        input.action === "issue:mutate" ||
+        input.action === "issue:comment") &&
       input.resource.type === "issue" &&
       input.resource.assigneeAgentId &&
       await isManagerOf(companyId, actorAgentId, input.resource.assigneeAgentId)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5871,7 +5871,12 @@ export function issueService(db: Db) {
       });
     },
 
-    release: async (id: string, actorAgentId?: string, actorRunId?: string | null) =>
+    release: async (
+      id: string,
+      actorAgentId?: string,
+      actorRunId?: string | null,
+      options: { managerOverride?: boolean } = {},
+    ) =>
       db.transaction(async (tx) => {
         await tx.execute(
           sql`select ${issues.id} from ${issues} where ${issues.id} = ${id} for update`,
@@ -5883,24 +5888,30 @@ export function issueService(db: Db) {
           .then((rows) => rows[0] ?? null);
 
         if (!existing) return null;
-        if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
-          throw conflict("Only assignee can release issue");
-        }
-        if (
-          actorAgentId &&
-          existing.status === "in_progress" &&
-          existing.assigneeAgentId === actorAgentId &&
-          existing.checkoutRunId &&
-          !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
-        ) {
-          const stale = await isTerminalOrMissingHeartbeatRun(existing.checkoutRunId, tx);
-          if (!stale) {
-            throw conflict("Only checkout run can release issue", {
-              issueId: existing.id,
-              assigneeAgentId: existing.assigneeAgentId,
-              checkoutRunId: existing.checkoutRunId,
-              actorRunId: actorRunId ?? null,
-            });
+        // A manager-line override (authorized + audited at the route layer, and
+        // with the held run already cancelled there) intentionally bypasses the
+        // assignee-only and checkout-run guards below: the whole point is to
+        // recover an issue owned by a *different* agent whose run has stalled.
+        if (!options.managerOverride) {
+          if (actorAgentId && existing.assigneeAgentId && existing.assigneeAgentId !== actorAgentId) {
+            throw conflict("Only assignee can release issue");
+          }
+          if (
+            actorAgentId &&
+            existing.status === "in_progress" &&
+            existing.assigneeAgentId === actorAgentId &&
+            existing.checkoutRunId &&
+            !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
+          ) {
+            const stale = await isTerminalOrMissingHeartbeatRun(existing.checkoutRunId, tx);
+            if (!stale) {
+              throw conflict("Only checkout run can release issue", {
+                issueId: existing.id,
+                assigneeAgentId: existing.assigneeAgentId,
+                checkoutRunId: existing.checkoutRunId,
+                actorRunId: actorRunId ?? null,
+              });
+            }
           }
         }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The control plane's issue authorization boundary decides which actor may read/mutate/comment on an issue, and which may manage an active checkout (`server/src/services/authorization.ts`)
> - Today that boundary is **ownership-scoped**: only the assignee (or a held-checkout grant) may mutate/comment, and it ignores the reporting line — an actor that manages the assignee (an ancestor in the assignee's `reportsTo` chain) gets `403 "Issue is outside this actor's authorization boundary"` even with the edge in place
> - That leaves no agent-side recovery path when an IC's run genuinely stalls: a manager cannot reassign, force-release, or even comment to unblock the stuck issue
> - The pieces already exist — an `allow_manager_chain` decision reason, an `isManagerOf`/`agentIsInSubtree` transitive-`reportsTo` walk, and a manager-chain grant **but only for `tasks:manage_active_checkouts`**
> - This PR extends that same, already-trusted manager-chain grant to `issue:mutate` and `issue:comment`, and adds an explicit audited manager force-release that cancels the held run
> - The benefit is a scoped, agent-side recovery path for stuck IC-owned issues — strictly along the reporting line, never company-wide

## Linked Issues or Issue Description

No public GitHub issue exists; describing the problem in-PR (feature):

**Problem.** A manager agent (an ancestor in the target issue assignee's `reportsTo` chain) cannot recover a stuck, IC-owned issue. Setting the manager edge does not clear the boundary 403: the issue authorization check is ownership-scoped and never consults the reporting line for `issue:mutate` / `issue:comment`. When an IC run stalls, there is no agent-side way to reassign, release the checkout, or comment — recovery requires a human.

**Desired capability.** Authorize an actor that is an ancestor in the assignee's `reportsTo` chain to perform scoped recovery actions on that issue — reassign/mutate, comment, and force-release the checkout — strictly along the reporting line, with an explicit audited force that stops the held run.

**Related / possibly-overlapping PRs (dedup search done):**
- #8232 `feat: add manager-chain allow for issue:mutate authorization` — overlaps the core `issue:mutate` grant in `authorization.ts`. This PR is a superset (also `issue:comment` + audited force-release + run cancellation). Maintainers may prefer to land #8232 first and have me rebuild the delta on top — happy to do so.
- #8024 / #8066 — split `issue:comment` from `issue:mutate` authorization.
- #5710 `allow agents to assign tasks within their reporting chain`.

## What Changed

- `server/src/services/authorization.ts` — broaden the existing `allow_manager_chain` grant (previously only `tasks:manage_active_checkouts`) to also cover `issue:mutate` and `issue:comment`. Scoped to the assignee's transitive `reportsTo` chain via `isManagerOf`; non-line agents still fall through to `deny_missing_grant` (403).
- `server/src/routes/issues.ts` — `POST /issues/:id/release` gains an explicit manager-line force path. `svc.release` enforces assignee-only at the data layer, so a manager override reuses `adminForceRelease` (force-clear lock + clear assignee), cancels any held IC run via `heartbeat.cancelRun` so two runs cannot collide, and writes a dedicated `issue.manager_force_release` activity entry (decision reason, overridden assignee, prev run ids, cancelled run ids).
- `server/src/__tests__/authorization-service.test.ts` — authorized (direct + transitive ancestor, across mutate/comment/manage-checkouts) and unauthorized (non-line agent, reverse/downward chain) paths.

Force-reassign (`PATCH assigneeAgentId`) needs no route change: `svc.update` has no assignee guard, so the authz change alone lets a manager pass `assertAgentIssueMutationAllowed`; `tasks:assign` is already company-allowed in simple mode.

## Verification

- Added unit tests in `server/src/__tests__/authorization-service.test.ts` covering authorized direct (CTO→IC) and transitive (CEO→CTO→IC) manager access for `issue:mutate`, `issue:comment`, and `tasks:manage_active_checkouts`, plus denial for a non-line agent and for a downward (report→manager) attempt.
- Run: `pnpm test:run` (or vitest on `server/src/__tests__/authorization-service.test.ts`).
- Honest note: I could not execute the suite in my local sandbox (a pnpm workspace-link quirk left `vitest` unresolved from the workspace packages); I am relying on this PR's CI as the verification gate and will fix any failures it surfaces.

## Risks

- Low-to-moderate. The change is additive within an existing, already-trusted grant path (`isManagerOf` / `allow_manager_chain`) and is strictly scoped to the transitive `reportsTo` line — non-line and cross-company actors are unaffected (covered by tests). The new behavior widens write access for managers over reports' issues, which is the intent; the force-release explicitly cancels the held run and is audited to avoid two-run collisions. No schema/migration changes.

> For core feature work, check ROADMAP.md first and discuss it in `#dev` before opening the PR.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), Anthropic — large context, extended thinking and tool use enabled (agentic code edits + shell/test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
