### PR TITLE
[codex] Add bundled Paperclip capsules skill

### DIFF
--- a/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/SKILL.md
+++ b/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: paperclip-capsules
+description: Generate, implement, or review Paperclip capsule visuals. Use when the user asks for Paperclip capsule art, capsule banks, agent capsule visuals, heartbeat status capsules, capsule identicons, capsule graphic-generator output, or validation of Paperclip capsule brand usage.
+key: paperclipai/bundled/product/paperclip-capsules
+recommendedForRoles:
+  - designer
+  - product
+  - engineer
+  - marketing
+tags:
+  - paperclip
+  - brand
+  - capsules
+  - agents
+  - visual-design
+  - hyperframes
+---
+
+# Paperclip Capsules
+
+Use this skill when creating or checking Paperclip capsule visuals. The central rule is simple: **the capsule is the agent**. A capsule is not generic chrome, a button shape, a random status pill, or background decoration.
+
+The one approved decorative exception is the canonical hero capsule bank. Treat it as a specific Paperclip brand surface, not a license to make arbitrary capsule wallpaper.
+
+## When to Use
+
+- Generating Paperclip capsule art, agent avatars, capsule fields, hero capsule banks, or seeded capsule identicons.
+- Implementing an individual agent capsule in product UI.
+- Rendering heartbeat status capsules for agent status.
+- Building Paperclip feature videos or marketing graphics that use the capsule motif.
+- Reviewing a design for capsule brand correctness.
+
+## When Not to Use
+
+- Generic rounded pills, badges, buttons, tags, nav items, or decorative blobs.
+- Non-agent illustrations where capsules would only be visual texture.
+- Product UI color choices unrelated to agents or heartbeat status.
+- Replacing the app's existing `AgentCapsule` or status-color helpers from memory.
+
+## Non-Negotiable Rules
+
+- **Capsules represent agents.** If the surface does not involve agents, do not add capsules.
+- **Do not use the agent capsule palette outside capsules.** Never apply agent gradients to buttons, text, page backgrounds, cards, or generic UI chrome.
+- **Keep capsule families separate.** App individual capsules, heartbeat status capsules, website marketing capsules, video capsules, seeded identicons, and the hero bank have different data.
+- **Hero bank is the only decorative exception.** Use the canonical bank spec; do not hand-roll a new bank.
+- **Record reproducibility data.** For generated assets, record seed, template, palette, dimensions, and source workflow.
+- **Respect reduced motion.** Any pulsing, blinking, breathing, wave, or fill-rise animation needs a static reduced-motion fallback.
+
+## Choose the Right Capsule Surface
+
+Use **individual agent capsules** when one capsule equals one agent in product UI, onboarding, org surfaces, or avatars. Read `references/individual-status-capsules.md` before implementing or changing UI behavior.
+
+Use **heartbeat status capsules** for small solid status markers: idle/active gray, running blue pulse, paused amber, error red blink. These are not tall gradient identity capsules.
+
+Use the **hero capsule bank** only for brand hero imagery, feature-video hero scenes, or approved marketing motif work. Read `references/hero-capsule-bank.md` before drawing it.
+
+Use **graphic-generator layouts** when the task asks for capsule graphics such as blend rows, chains, grids, icon marks, or hero compositions. Prefer seeded tools and exportable workflows; read `references/generator-workflows.md`.
+
+Use **seeded identicons/profile pills** when an agent needs a reproducible personal capsule mark. Keep the seed/config with the output.
+
+## Implementation Workflow
+
+1. Identify which capsule family you are working in: individual agent, status capsule, hero bank, generator layout, or identicon.
+2. Load the matching reference file from this skill.
+3. Prefer existing source implementations:
+   - Product UI: `ui/src/components/AgentCapsule.tsx`, `ui/src/index.css`, and `ui/src/lib/status-colors.ts`.
+   - Hero bank: canonical spec in `references/hero-capsule-bank.md`.
+   - Video work: pair this skill with the Paperclip feature-video HyperFrames skill when available.
+4. If generating an artifact, choose a reproducible workflow and write down the seed/config.
+5. Verify that the result still reads as agent-related. Remove capsules if they became decoration.
+6. Attach or otherwise expose generated deliverables when doing issue work, and name the exact workflow used.
+
+## Output Expectations
+
+For any generated capsule asset, include:
+
+- Capsule family: `individual-agent`, `heartbeat-status`, `hero-bank`, `graphic-generator`, or `identicon`.
+- Source workflow or implementation path.
+- Seed and config where available.
+- Dimensions, format, and renderer.
+- Any divergence from canonical Paperclip rendering.
+
+For code changes, include targeted checks that exercise the edited surface. For visuals, include screenshots or inspectable SVG/PNG/HTML when possible.
+
+## Validation Checklist
+
+- Does each capsule represent an agent, agent state, or the canonical hero-bank exception?
+- Are gradients confined to capsule shapes?
+- Are app, website, video, identicon, and hero-bank palettes kept separate?
+- Is motion reduced or removed under reduced-motion settings?
+- Is the source path or reproducible seed/config recorded?
+- Are generated files attached or linked as inspectable deliverables for issue work?
+
+## References
+
+- `references/individual-status-capsules.md` - product app capsules, heartbeat status capsules, palette caveats, and reduced-motion rules.
+- `references/hero-capsule-bank.md` - canonical hero-bank geometry, palette, grain, wave, crop, and rendering checklist.
+- `references/generator-workflows.md` - website generator, external graphic-generator, and seeded identicon/profile-pill workflows.

--- a/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/generator-workflows.md
+++ b/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/generator-workflows.md
@@ -12,11 +12,9 @@ Use this reference when the request is to generate Paperclip capsule graphics, c
 3. Website embedded generator:
    - `paperclip-website/public/brand/generator.js`
    - `paperclip-website/src/components/brand/sections/08-imagery.html`
-4. External generator repo:
-   - `https://github.com/scotttong/paperclip-graphic-generator`
-   - Verified source-mining commit: `36a8a092c6ea6aa85bd0862bafb35ff9b9fab852`
+4. Mirrored graphic-generator contract in this file.
 
-The external repo is a production/advanced workflow reference, not stronger brand authority than the Paperclip app, website guide, video references, or hero-bank spec.
+The mirrored contract below was source-mined from the external prototype at commit `36a8a092c6ea6aa85bd0862bafb35ff9b9fab852`, but this skill must not depend on that personal repository being reachable. Treat the mode, palette, and control lists in this reference as the durable workflow contract.
 
 ## Choose a Workflow
 
@@ -55,11 +53,11 @@ Behavior:
 - Good for understanding public brand-guide templates and palettes.
 - Weaker for issue deliverables because the UI does not expose seed/config as a first-class copyable control.
 
-## External Graphic Generator
+## Mirrored Graphic Generator Contract
 
-Use this when the task needs reproducible generated capsule art beyond the small embedded website tool.
+Use this when the task needs reproducible generated capsule art beyond the small embedded website tool. The contract here is intentionally mirrored into Paperclip so agents can proceed if the original prototype repository is renamed, deleted, or private.
 
-Known modes/templates from source mining:
+Known modes/templates:
 
 - `blendRow`
 - `icon`
@@ -79,6 +77,8 @@ Useful controls:
 - Logo overlay panel.
 - Background controls including images.
 - PNG and SVG export.
+
+If an implementation needs source code, prefer the Paperclip website embedded generator or a Paperclip-owned tool. Use any external prototype link only as optional historical context, not as required task input.
 
 Palette caution:
 

--- a/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/generator-workflows.md
+++ b/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/generator-workflows.md
@@ -1,0 +1,151 @@
+# Generator Workflows
+
+Use this reference when the request is to generate Paperclip capsule graphics, capsule identicons, or reusable visual assets.
+
+## Source Precedence
+
+1. Brand authority: app, website brand guide, feature-video references, and hero-bank spec.
+2. Deterministic identicon/profile-pill prototype:
+   - `paperclip-content/design/PAP-11825/paperclip-capsule-identicon-prototyper/README.md`
+   - `src/identicon.ts`
+   - `src/App.tsx`
+3. Website embedded generator:
+   - `paperclip-website/public/brand/generator.js`
+   - `paperclip-website/src/components/brand/sections/08-imagery.html`
+4. External generator repo:
+   - `https://github.com/scotttong/paperclip-graphic-generator`
+   - Verified source-mining commit: `36a8a092c6ea6aa85bd0862bafb35ff9b9fab852`
+
+The external repo is a production/advanced workflow reference, not stronger brand authority than the Paperclip app, website guide, video references, or hero-bank spec.
+
+## Choose a Workflow
+
+| Need | Preferred workflow |
+| --- | --- |
+| Canonical hero brand image | Hero capsule bank reference |
+| One agent's profile mark | Seeded identicon/profile-pill prototype |
+| Repeatable marketing motif | External graphic-generator with explicit seed |
+| Quick public-doc example | Website embedded generator |
+| Product UI state | Existing `AgentCapsule` and status helpers |
+
+## Website Embedded Generator
+
+Templates:
+
+- `blend-row`
+- `chain`
+- `bar-stack`
+- `grid`
+- `hero`
+- `icon`
+
+Palettes:
+
+- `rainbow`
+- `warm`
+- `cool`
+- `mono`
+- `signal`
+- `duotone`
+
+Behavior:
+
+- Uses a Mulberry32 seeded PRNG internally.
+- Supports count, width, height, jitter, gap, and background parameters.
+- Good for understanding public brand-guide templates and palettes.
+- Weaker for issue deliverables because the UI does not expose seed/config as a first-class copyable control.
+
+## External Graphic Generator
+
+Use this when the task needs reproducible generated capsule art beyond the small embedded website tool.
+
+Known modes/templates from source mining:
+
+- `blendRow`
+- `icon`
+- `chainLinks`
+- `hero`
+- `barStack`
+- `grid`
+- `wildcard`
+- `manualBlend`
+- `2d` and `3d` modes
+
+Useful controls:
+
+- Explicit numeric seed and reroll controls.
+- Anchor palette override panel.
+- Dither panel.
+- Logo overlay panel.
+- Background controls including images.
+- PNG and SVG export.
+
+Palette caution:
+
+- The `duotones` palette matches the website 12-preset capsule palette.
+- Experimental palettes such as vaporwave, cyberpunk, ocean, and jewel are generator options, not canonical Paperclip brand palettes.
+- Do not use experimental palettes when the request asks for strict Paperclip brand work.
+
+## Deterministic Identicon / Profile Pill
+
+Use this when generating a reproducible capsule identity for one agent.
+
+Determinism key:
+
+```txt
+seed + variant + density + theme
+```
+
+Variant families:
+
+- Gradient: `Smooth`, `Soft Sheen`, `Mesh`, `Aurora`
+- Dither: `Floyd-Steinberg`, `Atkinson`, `Jarvis-Judice-Ninke`, `Bayer 4x4`, `Bayer 8x8`, `Blue Noise`
+
+Color spaces and themes:
+
+- Color spaces: `hsl`, `oklch`
+- Themes: `charcoal`, `paper`, `ink`
+- Gradient angle can be seeded or manually overridden.
+
+Export/share affordances:
+
+- SVG
+- PNG
+- data URI
+- React snippet
+- standalone card view
+- URL hash restore
+- clipboard sharing
+
+Smoke checks to perform when using the prototype:
+
+- Same seed/config produces the same output.
+- Changing the seed visibly changes the output.
+- SVG or PNG export is non-empty and inspectable.
+
+## Artifact Record Template
+
+When generating assets for issue work, record this next to the attachment or deliverable:
+
+```md
+Capsule artifact
+
+- Family: identicon | graphic-generator | hero-bank | individual-agent | heartbeat-status
+- Workflow: website-generator | external-graphic-generator | identicon-prototype | hand-coded-svg | app-component
+- Source path or tool commit:
+- Seed:
+- Template / variant:
+- Palette / theme:
+- Density / count / dimensions:
+- Output: SVG | PNG | HTML | MP4 | WebM
+- Divergence from canonical Paperclip rendering:
+```
+
+## Review Checklist
+
+- Is the output agent-related or the canonical hero-bank exception?
+- Does the palette match the selected surface?
+- Is the seed/config sufficient to reproduce the result?
+- Are exports non-empty and inspectable?
+- Are generated gradients confined to capsule shapes?
+- If motion is included, is there a static/reduced-motion alternative?

--- a/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/hero-capsule-bank.md
+++ b/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/hero-capsule-bank.md
@@ -1,0 +1,189 @@
+# Hero Capsule Bank
+
+The hero capsule bank is the one approved decorative exception to the rule that capsules represent individual agents. It is a canonical Paperclip brand surface. Do not improvise a different capsule bank.
+
+## Source Precedence
+
+1. `paperclip-content/td/capsules.md` - byte-accurate technical source for geometry, gradients, grain, crop, and wave.
+2. Paperclip feature-video HyperFrames skill:
+   - `references/capsule-bank-spec.md`
+   - `references/brand-tokens.md`
+   - `references/composition-recipes.md`
+3. `paperclip-content/videos/wireframe-skill-launch/src/HeroCapsuleBank.tsx` - working Remotion implementation.
+
+## Coordinate System
+
+| Property | Value |
+| --- | --- |
+| ViewBox | `0 0 1200 675` |
+| Background | `#141413` |
+| Square crop | `viewBox="250 -19 700 700"` |
+| Columns | 8 |
+| Capsules per column | 12 |
+| Total capsules | 96 |
+
+## Capsule Shape
+
+| Property | Value |
+| --- | --- |
+| Width | 70 |
+| Height | 170 |
+| Radius | 35 |
+| Rect anchor | `x=-35`, `y=-85` |
+| Positioning | translate each rect to center `(cx, cy)` |
+
+The capsule body is rigid. Never deform the capsule shape for wave motion.
+
+## Layout
+
+| Column | `tx` | `ty0` |
+| --- | --- | --- |
+| 0 | 355 | 154.464 |
+| 1 | 425 | 161.240 |
+| 2 | 495 | 101.067 |
+| 3 | 565 | 111.908 |
+| 4 | 635 | 137.808 |
+| 5 | 705 | 181.764 |
+| 6 | 775 | 150.630 |
+| 7 | 845 | 123.362 |
+
+Formula:
+
+```txt
+STRIDE_Y = 380 / 11
+cx = tx[column]
+cy = ty0[column] + slot * STRIDE_Y
+```
+
+Drawing order is column order 0..7, and within each column slot order 0..11. Higher slot indices draw later and cover lower ones.
+
+## Gradient Palette
+
+Each gradient is a two-stop linear gradient with a rotation angle in degrees.
+
+| id | angle | top | bottom |
+| --- | --- | --- | --- |
+| g0 | 90.000 | `#3c23fb` | `#fb8b24` |
+| g1 | 90.000 | `#6721fa` | `#f85f1c` |
+| g2 | 90.000 | `#921ff8` | `#f53215` |
+| g3 | 90.000 | `#bd1df7` | `#f10e18` |
+| g4 | 90.000 | `#e81bf5` | `#e4103e` |
+| g5 | 90.000 | `#f419d3` | `#d7135f` |
+| g6 | 90.000 | `#f217a4` | `#ca147b` |
+| g7 | 90.000 | `#f11575` | `#be1692` |
+| g8 | 90.000 | `#ef1346` | `#b217a4` |
+| g9 | 90.000 | `#ec1217` | `#9919a6` |
+| g10 | 90.000 | `#e83913` | `#79199a` |
+| g11 | 90.000 | `#e36414` | `#5c1a8f` |
+| g12 | 118.000 | `#9a031e` | `#ced51c` |
+| g13 | 118.727 | `#9a0547` | `#d2bd1c` |
+| g14 | 119.455 | `#9a0770` | `#ce9f1c` |
+| g15 | 120.182 | `#9a0997` | `#cb821c` |
+| g16 | 120.909 | `#770b9a` | `#c8661c` |
+| g17 | 121.636 | `#520d9a` | `#c44b1c` |
+| g18 | 122.364 | `#2e0f9a` | `#c1311c` |
+| g19 | 123.091 | `#12189a` | `#be1c1f` |
+| g20 | 123.818 | `#143e9a` | `#bb1b37` |
+| g21 | 124.545 | `#16629a` | `#b71b4e` |
+| g22 | 125.273 | `#198599` | `#b41b64` |
+| g23 | 126.000 | `#1b998b` | `#b11b79` |
+| g24 | 127.818 | `#940540` | `#dbd81a` |
+| g25 | 137.636 | `#8e065f` | `#e1d419` |
+| g26 | 147.455 | `#88077a` | `#e7cf17` |
+| g27 | 157.273 | `#720982` | `#ebc817` |
+| g28 | 167.091 | `#520a7c` | `#edbf19` |
+| g29 | 176.909 | `#360b77` | `#f0b71a` |
+| g30 | 186.727 | `#1c0c71` | `#f2ae1c` |
+| g31 | 196.545 | `#0d146c` | `#f4a51e` |
+| g32 | 206.364 | `#0e2a66` | `#f79d20` |
+| g33 | 216.182 | `#0e3c61` | `#f99422` |
+| g34 | 226.000 | `#0f4c5c` | `#fb8b24` |
+| g35 | 93.273 | `#dc8f15` | `#671a92` |
+| g36 | 96.545 | `#d5b716` | `#721a95` |
+| g37 | 99.818 | `#c1ce17` | `#7d1a98` |
+| g38 | 103.091 | `#93c718` | `#891b9b` |
+| g39 | 106.364 | `#68c018` | `#951b9e` |
+| g40 | 109.636 | `#41b919` | `#a11ba1` |
+| g41 | 112.909 | `#1db31a` | `#a41b9a` |
+| g42 | 116.182 | `#1aac38` | `#a81b92` |
+| g43 | 119.455 | `#1aa657` | `#ab1b8a` |
+| g44 | 122.727 | `#1b9f72` | `#ae1b82` |
+
+SVG template:
+
+```xml
+<linearGradient id="g0" gradientUnits="objectBoundingBox"
+  x1="0" y1="0" x2="1" y2="0"
+  gradientTransform="rotate(90 0.5 0.5)">
+  <stop offset="0%" stop-color="#3c23fb" />
+  <stop offset="100%" stop-color="#fb8b24" />
+</linearGradient>
+```
+
+## Per-Column Gradient Sequences
+
+Each sequence lists slots 0..11.
+
+| Column | Sequence |
+| --- | --- |
+| 0 | `g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 g10 g11` |
+| 1 | `g12 g13 g14 g15 g16 g17 g18 g19 g20 g21 g22 g23` |
+| 2 | `g11 g10 g9 g8 g7 g6 g5 g4 g3 g2 g1 g0` |
+| 3 | `g23 g22 g21 g20 g19 g18 g17 g16 g15 g14 g13 g12` |
+| 4 | `g12 g24 g25 g26 g27 g28 g29 g30 g31 g32 g33 g34` |
+| 5 | `g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 g10 g11` |
+| 6 | `g11 g35 g36 g37 g38 g39 g40 g41 g42 g43 g44 g23` |
+| 7 | `g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 g10 g11` |
+
+## Grain Overlay
+
+Grain is part of the motif. Do not omit it for canonical hero-bank renders unless the output medium cannot support it.
+
+| Property | Value |
+| --- | --- |
+| SVG primitive | `feTurbulence type="fractalNoise"` |
+| Base frequency | `2.95` |
+| Octaves | 5 |
+| Seed | 9 |
+| Opacity | 0.86 |
+| Blend mode | `overlay` |
+| Mask | union of capsule shapes only |
+
+Overlay formula per channel:
+
+```txt
+overlay(b, o) = 2 * b * o                     if b < 0.5
+overlay(b, o) = 1 - 2 * (1 - b) * (1 - o)     otherwise
+final = mix(b, overlay(b, o), 0.86)
+```
+
+Background pixels stay clean `#141413`; grain is masked inside capsules.
+
+## Optional Wave Motion
+
+For motion, translate each capsule rigidly on y. Do not scale, bend, or morph the capsule.
+
+| Property | Value |
+| --- | --- |
+| Wave amplitude | 9 |
+| Per-capsule phase step | `PI / 3` |
+| Per-column phase factor | `2 * PI / 280` |
+| Loop period | 4 seconds |
+
+Formula:
+
+```txt
+dy(column, slot, t) =
+  9 * sin((2 * PI * t / 4) - (2 * PI / 280) * tx[column] - slot * (PI / 3))
+```
+
+For a static still that matches the captured spec, set amplitude to 0 and use the `ty0` values verbatim.
+
+## Rendering Checklist
+
+1. Paint background `#141413`.
+2. Draw 8 columns x 12 capsules using the layout and gradient sequence tables.
+3. Apply the grain overlay, masked to capsule shapes.
+4. For square exports, crop to `250 -19 700 700`.
+5. If animated, loop the wave over exactly 4 seconds and provide reduced-motion/static output.
+6. Do not add strokes, shadows, glow, extra gradients, or additional capsule rows.

--- a/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/individual-status-capsules.md
+++ b/packages/skills-catalog/catalog/bundled/product/paperclip-capsules/references/individual-status-capsules.md
@@ -1,0 +1,113 @@
+# Individual and Status Capsules
+
+Use this reference for product UI, onboarding, org surfaces, and heartbeat status indicators.
+
+## Source Precedence
+
+1. `ui/src/components/AgentCapsule.tsx` - React API, states, sizes, accessibility, gradient wrapping.
+2. `ui/src/index.css` - animation timings, reduced-motion behavior, agent gradient token values.
+3. `ui/src/lib/status-colors.ts` - heartbeat status color/motion mapping.
+4. `ui/src/components/OnboardingWizard.tsx` and `ui/src/pages/DesignGuide.tsx` - accepted usage examples.
+5. Website brand guide files under `paperclip-website/src/components/brand/sections/*` - marketing rules and the 12-preset website palette.
+
+## Individual Agent Capsule
+
+One tall capsule represents one agent. Do not use this component for decoration or generic status chips.
+
+States:
+
+| State | Meaning | Rendering |
+| --- | --- | --- |
+| `slot` | Empty agent slot | Dashed outline, gentle pulse |
+| `configured` | Agent named/model picked, not live | Solid stroke, no fill |
+| `online` | Agent online | Gradient liquid rise, then breathing pulse |
+
+Implementation rules:
+
+- Keep the same DOM node through lifecycle flows when the story is "this agent comes to life".
+- Use stacked layers with opacity transitions for dashed-to-solid; CSS cannot animate `border-style`.
+- Online default pulse is green. The blue pulse is a specific onboarding wizard variant, not the default app-wide live state.
+- Product sizes are `sm` 24x60, `md` 34x84, `lg` 46x116. Custom sizes should keep height at least twice width.
+- The capsule radius is full stadium/pill radius.
+- Accessibility label should describe the represented agent or state.
+
+Motion:
+
+| Motion | Timing |
+| --- | --- |
+| Slot pulse | `1.6s ease-in-out infinite` |
+| Liquid rise | `1.4s cubic-bezier(0.16, 1, 0.3, 1) forwards` |
+| Online pulse | `1.8s ease-in-out infinite` |
+| Layer transition | `opacity 0.5s ease` |
+
+Reduced motion:
+
+- Remove slot pulse and online pulse.
+- Remove layer transition.
+- Render the online liquid at full height without rise animation.
+
+## App Agent Gradient Tokens
+
+The app component currently exposes 10 gradient pairs. `AgentCapsule` wraps out-of-range gradient indexes back into `1..10`.
+
+| Index | Top token | Top | Bottom token | Bottom |
+| --- | --- | --- | --- | --- |
+| 1 | `--agent-1a` | `#f7cfdc` | `--agent-1b` | `#1f7a3a` |
+| 2 | `--agent-2a` | `#c9a9e8` | `--agent-2b` | `#ee79a1` |
+| 3 | `--agent-3a` | `#28164b` | `--agent-3b` | `#7a1530` |
+| 4 | `--agent-4a` | `#f3e6c4` | `--agent-4b` | `#e3a21a` |
+| 5 | `--agent-5a` | `#1f4dd6` | `--agent-5b` | `#3aa35c` |
+| 6 | `--agent-6a` | `#e94b27` | `--agent-6b` | `#5a1122` |
+| 7 | `--agent-7a` | `#7eb6e3` | `--agent-7b` | `#ee79a1` |
+| 8 | `--agent-8a` | `#9ce8a7` | `--agent-8b` | `#bd7ff0` |
+| 9 | `--agent-9a` | `#f3b49e` | `--agent-9b` | `#1f4ed4` |
+| 10 | `--agent-10a` | `#f2d95f` | `--agent-10b` | `#4fbcba` |
+
+Do not treat these as the universal Paperclip capsule palette. The website brand guide exposes 12 presets, the video references have a separate 12-gradient palette, and the hero bank has 45 gradients.
+
+## Website Marketing Capsule Palette
+
+The website palette extends the app's first 10 gradients with two more presets:
+
+| Index | Top | Bottom | Description |
+| --- | --- | --- | --- |
+| 11 | `#C2C2E8` | `#5E3450` | peri -> mauve |
+| 12 | `#4DB9B7` | `#3AA35C` | teal -> green |
+
+Marketing capsule rules:
+
+- Capsule visuals are reserved for agent representation: capsule fields, org-chart nodes, status indicators, avatars.
+- Never use capsules on chrome, buttons, or generic pills.
+- Use a `1 : >= 2` proportion and a top-to-bottom gradient for gradient capsules.
+- Flat single-color capsules are allowed only where a solid mark is needed.
+- The guide names a semantic `--r-capsule`, but current `brand.css` does not export a concrete `--r-capsule` variable. Do not cite it as a live CSS token without checking.
+
+## Heartbeat Status Capsule
+
+Heartbeat status capsules are small solid pills. They are a different surface from individual gradient capsules.
+
+Status mapping:
+
+| Agent status | Color | Fill | Motion |
+| --- | --- | --- | --- |
+| `idle` | gray | `#A8AEB2` light, `#6E6960` dark | none |
+| `active` | gray | same as idle | none |
+| `running` | blue | `#2563EB` | `hb-pulse` |
+| `paused` | amber | `#F59E0B` | none |
+| `error` | red | `#DC2626` | `hb-blink` |
+
+Motion timings:
+
+- `hb-pulse`: `1.6s ease-in-out infinite`
+- `hb-blink`: `1.2s step-end infinite`
+- Reduced motion removes both.
+
+Website guide geometry for the heartbeat pill is 8x16 with radius 4. Larger brand-page display examples may use 14x28.
+
+## Common Mistakes
+
+- Using capsule gradients for generic badges or buttons.
+- Using a full gradient agent capsule where a small status capsule is required.
+- Treating the onboarding blue glow as the default online state.
+- Merging the 10 app gradients, 12 website gradients, 12 video gradients, and 45 hero-bank gradients into one palette.
+- Animating status or lifecycle motion without reduced-motion fallbacks.

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-06-26T02:58:28.981Z",
+  "generatedAt": "2026-06-26T10:57:05.518Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -146,8 +146,8 @@
         {
           "path": "references/generator-workflows.md",
           "kind": "reference",
-          "sizeBytes": 4387,
-          "sha256": "a69e59335bb18e9b28fb192c5b2bf69c728919d50f0a72e8915df96b7aca255a"
+          "sizeBytes": 4753,
+          "sha256": "26f2eb9b58187351cc064f9af02c2e75f9c9512d0f5f5b80c8a9079019a48ec7"
         },
         {
           "path": "references/hero-capsule-bank.md",
@@ -162,7 +162,7 @@
           "sha256": "be1f2eccf96b4d2deefe45b3bc1dd0a3597278472c2ffedadc43c57161e9103d"
         }
       ],
-      "contentHash": "sha256:c2dac99868971240800aa6923ff7754cb226b60cd0d7569fce4f820db7ba1c46"
+      "contentHash": "sha256:1a573063759019928d591f29ad1c32029939058ec652880c7f41c58c7ebe0f4e"
     },
     {
       "id": "paperclipai:bundled:product:wireframe",

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-06-04T19:57:14.020Z",
+  "generatedAt": "2026-06-26T02:58:28.981Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -102,11 +102,67 @@
         {
           "path": "SKILL.md",
           "kind": "skill",
-          "sizeBytes": 4649,
-          "sha256": "2ff61e12dfaa4cf8cc548529fd176f55f1b1f5292ff9dd3eb2cb331417ab5e4e"
+          "sizeBytes": 4938,
+          "sha256": "9c52a44a30ec8d306119da51bf298e9e3e6c382a9a9559ffd3054bf5e0c75f36"
         }
       ],
-      "contentHash": "sha256:4fb46a4bcefad4fd46fae48c433ee497112509a8e19fb8a7745ead44d219b498"
+      "contentHash": "sha256:487c3116eead89fef4f71c984329c41836bd69951b7ef9ed8736c69435e02438"
+    },
+    {
+      "id": "paperclipai:bundled:product:paperclip-capsules",
+      "key": "paperclipai/bundled/product/paperclip-capsules",
+      "kind": "bundled",
+      "category": "product",
+      "slug": "paperclip-capsules",
+      "name": "paperclip-capsules",
+      "description": "Generate, implement, or review Paperclip capsule visuals. Use when the user asks for Paperclip capsule art, capsule banks, agent capsule visuals, heartbeat status capsules, capsule identicons, capsule graphic-generator output, or validation of Paperclip capsule brand usage.",
+      "path": "catalog/bundled/product/paperclip-capsules",
+      "entrypoint": "SKILL.md",
+      "trustLevel": "markdown_only",
+      "compatibility": "compatible",
+      "defaultInstall": false,
+      "recommendedForRoles": [
+        "designer",
+        "product",
+        "engineer",
+        "marketing"
+      ],
+      "requires": [],
+      "tags": [
+        "paperclip",
+        "brand",
+        "capsules",
+        "agents",
+        "visual-design",
+        "hyperframes"
+      ],
+      "files": [
+        {
+          "path": "SKILL.md",
+          "kind": "skill",
+          "sizeBytes": 5657,
+          "sha256": "fdc53ec7e35fc49d6c9f909a4a5c5a6da1563c6d2ab0b1e1a15c524bd890211b"
+        },
+        {
+          "path": "references/generator-workflows.md",
+          "kind": "reference",
+          "sizeBytes": 4387,
+          "sha256": "a69e59335bb18e9b28fb192c5b2bf69c728919d50f0a72e8915df96b7aca255a"
+        },
+        {
+          "path": "references/hero-capsule-bank.md",
+          "kind": "reference",
+          "sizeBytes": 5981,
+          "sha256": "ec3d34113aa7bb527560d1eb4d8ab7667c73e18284c85a2019122743a767525a"
+        },
+        {
+          "path": "references/individual-status-capsules.md",
+          "kind": "reference",
+          "sizeBytes": 5031,
+          "sha256": "be1f2eccf96b4d2deefe45b3bc1dd0a3597278472c2ffedadc43c57161e9103d"
+        }
+      ],
+      "contentHash": "sha256:c2dac99868971240800aa6923ff7754cb226b60cd0d7569fce4f820db7ba1c46"
     },
     {
       "id": "paperclipai:bundled:product:wireframe",

--- a/packages/skills-catalog/src/shipped-catalog.test.ts
+++ b/packages/skills-catalog/src/shipped-catalog.test.ts
@@ -5,6 +5,7 @@ const EXPECTED_BUNDLED_KEYS = [
   "paperclipai/bundled/docs/doc-maintenance",
   "paperclipai/bundled/paperclip-operations/issue-triage",
   "paperclipai/bundled/paperclip-operations/task-planning",
+  "paperclipai/bundled/product/paperclip-capsules",
   "paperclipai/bundled/product/wireframe",
   "paperclipai/bundled/quality/qa-acceptance",
   "paperclipai/bundled/software-development/github-pr-workflow",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Skills make repeatable agent workflows easier to install, discover, and reuse across Paperclip companies.
> - The bundled skills catalog is where core Paperclip-authored skills can be shipped with manifest coverage and catalog tests.
> - Paperclip content work needs a reusable capsule-generation playbook for concise social/video/status narratives.
> - Without a bundled skill, agents must recreate the same capsule guidance from scattered local context.
> - This pull request adds a bundled Paperclip capsules skill and its supporting references to the shipped skills catalog.
> - The benefit is a reusable, discoverable content workflow that can be installed through the normal skills catalog path.

## Linked Issues or Issue Description

No public GitHub issue exists for this local-work extraction, so the issue is described inline using the feature request shape.

### Problem or motivation

Paperclip content agents need repeatable guidance for producing concise capsules, but that guidance was not available as a bundled, catalog-discoverable skill. Without a bundled skill, similar content work has to recreate the same workflow and examples from local context.

### Proposed solution

Add a bundled `paperclip-capsules` skill with frontmatter, generator workflow guidance, and reference examples, then update the generated catalog manifest and shipped catalog test coverage.

### Alternatives considered

Leaving the guidance as ad hoc local files would avoid catalog churn, but it would not make the workflow discoverable or reusable through the skills manager. Adding it as an external-only skill would also make the core Paperclip content workflow harder to bootstrap.

### Roadmap alignment

This aligns with the shipped Skills Manager direction by making a reusable Paperclip-authored workflow available through the normal bundled catalog path.

## What Changed

- Added the `paperclip-capsules` bundled product skill with frontmatter and usage guidance.
- Added supporting reference files for generator workflows, hero capsule examples, and individual status capsule examples.
- Mirrored the graphic-generator workflow contract into the bundled reference so the skill does not depend on a personal external repository staying reachable.
- Updated the generated skills catalog manifest.
- Updated shipped catalog coverage so the new skill is expected by tests.
- Note: the `task-planning` entry in `generated/catalog.json` also updates because `origin/master` already has the 4938-byte `task-planning/SKILL.md` source hash, while the generated manifest still carried the older 4649-byte metadata. This PR regenerates the manifest from the current source tree.

## Verification

- `pnpm --filter @paperclipai/skills-catalog build:manifest`: wrote generated catalog with 11 catalog skills.
- `pnpm --filter @paperclipai/skills-catalog validate`: catalog manifest is valid with 11 catalog skills.
- `pnpm --filter @paperclipai/skills-catalog test`: 3 files passed, 14 tests passed.
- `pnpm --filter @paperclipai/skills-catalog typecheck`: passed.

## Risks

Low risk. This adds static bundled skill content and manifest/test coverage. The main risk is catalog metadata drift, covered by the catalog manifest build, validator, shipped catalog tests, and typecheck.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex using GPT-5, tool-enabled local coding session with git, shell, and test execution. Exact context window is not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
