### PR TITLE
Label synced env secret bindings

### DIFF
--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -112,6 +112,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
       configPath: "env.ANTHROPIC_API_KEY",
       versionSelector: "latest",
       required: true,
+      label: "ANTHROPIC_API_KEY",
     });
   });
 
@@ -164,6 +165,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     expect(bindings[0]).toMatchObject({
       secretId: nextSecret.id,
       configPath: "env.NEW_KEY",
+      label: "NEW_KEY",
     });
   });
 

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -2250,6 +2250,7 @@ export function secretService(db: Db) {
         secretId: string;
         configPath: string;
         versionSelector: SecretVersionSelector;
+        label: string;
       }> = [];
       const pathPrefix = target.pathPrefix ?? "env";
       const bindingDb = options?.db ?? db;
@@ -2263,6 +2264,7 @@ export function secretService(db: Db) {
           secretId: binding.secretId,
           configPath: `${pathPrefix}.${key}`,
           versionSelector: binding.version,
+          label: key,
         });
       }
 
@@ -2287,6 +2289,7 @@ export function secretService(db: Db) {
             configPath: ref.configPath,
             versionSelector: String(ref.versionSelector),
             required: true,
+            label: ref.label,
           })),
         );
       };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agent/runtime configuration can bind stored secrets into process environment variables.
> - The env binding runtime path stores the actual env key in `adapterConfig.env` and syncs a matching `company_secret_bindings` row for audit and UI surfaces.
> - Synced env secret bindings were storing the config path (`env.KEY`) but leaving the human label null, so UI surfaces that render binding labels can appear blank even though runtime resolution still works.
> - This pull request teaches env binding sync to derive the label from the env key it is syncing.
> - The benefit is that synced agent/project/routine env secret bindings remain legible in configuration and secret-reference UI after imports or updates.

## Linked Issues or Issue Description

### What happened?

Synced environment secret bindings can have an empty display label. Creating or syncing an env binding through `syncEnvBindingsForTarget` stores a functional `configPath` such as `env.ANTHROPIC_API_KEY`, but leaves `label` null. Label-based UI surfaces can then render an empty env var name even though runtime resolution still works.

### Expected behavior

A synced env secret binding should preserve its runtime `configPath` and also store a readable label derived from the env key, for example `ANTHROPIC_API_KEY`.

### Steps to reproduce

1. Create or sync an agent env binding such as `ANTHROPIC_API_KEY: { type: "secret_ref", ... }` through `syncEnvBindingsForTarget`.
2. Inspect the resulting `company_secret_bindings` row.
3. Observe that `configPath` is populated as `env.ANTHROPIC_API_KEY`, while `label` is null.

### Paperclip version or commit

Reproducible on current `master` before this change.

### Deployment mode

Any deployment using synced env secret bindings.

## What Changed

- Set synced env secret binding labels to the env key while preserving `configPath` as `env.KEY`.
- Updated agent secret-binding sync tests for create and replace paths to assert labels are populated.

## Verification

- `NODE_ENV=development pnpm exec vitest run server/src/__tests__/agents-service-secret-bindings.test.ts`

## Risks

- Low risk. Runtime secret resolution still uses `configPath` and `adapterConfig.env`; this only populates an existing optional display/audit field during sync.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Hermes Agent with tool use for code inspection, database verification, testing, git, and GitHub operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

